### PR TITLE
fix: DeepSeek json_object, Gemini 3.1-pro-customtools, forge version dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ MagicMock/
 # OS
 .DS_Store
 .forge/.env
+forge_audit.yaml

--- a/forge.yaml
+++ b/forge.yaml
@@ -41,19 +41,13 @@ profiles:
       timeout_seconds: 300
       reasoning_effort: high
       max_iterations: 20
-    - name: codex-patterns-reviewer
-      cli: codex
-      model: gpt-5.4
-      review_role: patterns
+    - name: gemini-reviewer
+      provider: google
+      model: gemini-3.1-pro-preview-customtools
+      review_role: edge-cases
       budget_usd: 2.00
       timeout_seconds: 300
       max_iterations: 20
-    - name: gemini-reviewer
-      provider: google
-      model: gemini-2.5-flash
-      review_role: edge-cases
-      budget_usd: 1.00
-      timeout_seconds: 300
     - name: deepseek-reviewer
       provider: deepseek
       model: deepseek-chat

--- a/src/theforge/cli.py
+++ b/src/theforge/cli.py
@@ -2401,6 +2401,7 @@ def main() -> None:
         "logs": cmd_logs,
         "stop": cmd_stop,
         "decide": cmd_decide,
+        "version": cmd_version,
     }
 
     try:

--- a/src/theforge/runner_api.py
+++ b/src/theforge/runner_api.py
@@ -858,19 +858,28 @@ def _run_openai_chat(
     secrets: dict[str, str] | None = None,
     client: Any = None,
     provider: str = "openai",
+    response_format: dict[str, Any] | None = None,
 ) -> AgentResult:
-    """Run via OpenAI Chat Completions (/v1/chat/completions)."""
+    """Run via OpenAI Chat Completions (/v1/chat/completions).
+
+    Args:
+        response_format: Override the default response_format. Pass
+            ``{"type": "json_object"}`` for providers that don't support
+            ``json_schema`` (e.g. DeepSeek).
+    """
     if client is None:
         client = _openai_client(profile, secrets)
     schema = review_json_schema()
+    if response_format is None:
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "review_output", "schema": schema, "strict": True},
+        }
     try:
         create_kwargs: dict[str, Any] = {
             "model": profile.model,
             "messages": [{"role": "user", "content": prompt}],
-            "response_format": {
-                "type": "json_schema",
-                "json_schema": {"name": "review_output", "schema": schema, "strict": True},
-            },
+            "response_format": response_format,
         }
         if not _is_reasoning_model(profile.model):
             create_kwargs["temperature"] = 0
@@ -949,9 +958,19 @@ def _run_openai(
 def _run_deepseek(
     prompt: str, profile: "ModelProfile", secrets: dict[str, str] | None = None
 ) -> AgentResult:
-    """Run via DeepSeek API (OpenAI-compatible Chat Completions)."""
+    """Run via DeepSeek API (OpenAI-compatible Chat Completions).
+
+    DeepSeek supports json_object but not json_schema structured output.
+    """
     client = _deepseek_client(profile, secrets)
-    return _run_openai_chat(prompt, profile, secrets, client=client, provider="deepseek")
+    return _run_openai_chat(
+        prompt,
+        profile,
+        secrets,
+        client=client,
+        provider="deepseek",
+        response_format={"type": "json_object"},
+    )
 
 
 def _run_anthropic(


### PR DESCRIPTION
## Summary

- **DeepSeek stateless runner**: was sending `response_format: json_schema` which DeepSeek doesn't support → HTTP 400 on every review. Now sends `json_object` to match the existing loop-path finalizer behavior.
- **Gemini reviewer**: upgraded from `gemini-2.5-flash` (two generations old, garbled output) to `gemini-3.1-pro-preview-customtools` (current flagship, tuned for custom tool use — exactly the theforge reviewer pattern). Dropped duplicate `codex-patterns-reviewer` (same model as `codex-reviewer`, double cost for no benefit).
- **`forge version` dispatch**: `cmd_version` was registered in argparse but missing from the dispatch dict since PR #171 — command was silently broken.
- **`.gitignore`**: add `forge_audit.yaml` to suppress root-level runtime artifact.

## Test plan
- [ ] `pytest tests/test_runner_api.py -q -k deepseek` — verify DeepSeek path passes
- [ ] `forge version` — verify command now works
- [ ] Run a review cycle and confirm Gemini reviewer participates with findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)