### PR TITLE
Hardening bug bundle — six fixes for release readiness

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -568,6 +568,9 @@ def run_task(
         if start_phase is not None and start_phase.value > Phase.PREFLIGHT.value:
             state.preflight_verdict = "SKIPPED"
             _log("  ⚡ PREFLIGHT   skipped (--from phase)")
+            # When starting at REVIEW (or later), skip DEV on the first iteration
+            # so the existing worktree is reviewed before the dev agent is invoked.
+            _skip_dev_first = start_phase.value >= Phase.REVIEW.value
             result = _coordinator_loop(
                 state,
                 config,
@@ -576,6 +579,7 @@ def run_task(
                 _task_start,
                 interactive=interactive,
                 auto_merge=auto_merge,
+                skip_dev_first_iter=_skip_dev_first,
                 notify=notify,
                 logger=logger,
                 state_update_fn=state_update_fn,

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1194,3 +1194,40 @@ class TestAssignmentReviewerAuthCrossCheck:
         ):
             with pytest.raises(ValueError, match="no reviewer-eligible agents have auth"):
                 load_config(config_path)
+
+
+class TestDefaultFlags:
+    """Tests for plan_model_is_default and review_pool_is_default flags."""
+
+    def test_plan_model_is_default_when_no_plan_key(self, tmp_path):
+        """plan_model_is_default is True when forge.yaml has no plan key."""
+        config_path = _write_config({"profiles": {}}, tmp_path)
+        config = load_config(config_path)
+        assert config.plan_model_is_default is True
+
+    def test_plan_model_is_default_false_when_plan_model_set(self, tmp_path):
+        """plan_model_is_default is False when plan.model is explicitly configured."""
+        config_path = _write_config({"plan": {"model": "claude-opus-4-5"}}, tmp_path)
+        config = load_config(config_path)
+        assert config.plan_model_is_default is False
+
+    def test_plan_model_is_default_false_when_plan_cli_set(self, tmp_path):
+        """plan_model_is_default is False when plan.cli is explicitly configured."""
+        config_path = _write_config({"plan": {"cli": "claude"}}, tmp_path)
+        config = load_config(config_path)
+        assert config.plan_model_is_default is False
+
+    def test_review_pool_is_default_when_no_review_pool(self, tmp_path):
+        """review_pool_is_default is True when forge.yaml has no review_pool configured."""
+        config_path = _write_config({"profiles": {}}, tmp_path)
+        config = load_config(config_path)
+        assert config.review_pool_is_default is True
+
+    def test_review_pool_is_default_false_when_explicitly_configured(self, tmp_path):
+        """review_pool_is_default is False when review_pool is explicitly configured."""
+        config_path = _write_config(
+            {"profiles": {"review_pool": [{"name": "my-reviewer", "cli": "claude"}]}},
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.review_pool_is_default is False

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -740,3 +740,63 @@ class TestWorkspaceBranchCollision:
         captured = capsys.readouterr()
         assert "⚠ WORKSPACE" in captured.err
         assert "stale branch" in captured.err
+
+
+class TestRunSetupSplit:
+    """Unit tests for _run_setup_split in workspace.py."""
+
+    def test_verbatim_fallback_when_pattern_not_matched(self, tmp_path):
+        """When command doesn't match the venv guard pattern, runs it verbatim."""
+        from theforge.coordinator.workspace import _run_setup_split
+
+        calls = []
+
+        def fake_shell(cmd, cwd, **kw):
+            calls.append(cmd)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split("pip install -e .", tmp_path)
+
+        assert ok is True
+        assert calls == ["pip install -e ."]
+
+    def test_venv_guard_pattern_splits_correctly(self, tmp_path):
+        """When command matches venv guard, venv creation and install run separately."""
+        from theforge.coordinator.workspace import _run_setup_split
+
+        cmd = "test -d .venv || (python -m venv .venv && pip install -e .)"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kw):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert len(calls) == 2
+        assert "test -d .venv" in calls[0]
+        assert "python -m venv" in calls[0]
+        # Second call is just the install command, not the venv creation
+        assert "pip install -e ." in calls[1]
+        assert "python -m venv" not in calls[1]
+
+    def test_venv_creation_failure_stops_early(self, tmp_path):
+        """If venv creation fails, the install command is not run."""
+        from theforge.coordinator.workspace import _run_setup_split
+
+        cmd = "test -d .venv || (python -m venv .venv && pip install -e .)"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kw):
+            calls.append(cmd_arg)
+            return (False, "venv error")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is False
+        assert out == "venv error"
+        assert len(calls) == 1  # install was not called

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -854,3 +854,145 @@ class TestFromPhaseSkip:
         assert result.phase == Phase.VALIDATE
         assert result.state.preflight_verdict == "SKIPPED"
         mock_pool.assert_not_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_from_review_skips_dev_on_first_iter(
+        self, mock_shell, mock_dev_agent, mock_pool, tmp_path
+    ):
+        """--from review: DEV must NOT run before the first REVIEW iteration."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        plan_path = workspace / ".forge" / "plan.md"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        plan_path.write_text("# Plan\n- step 1", encoding="utf-8")
+
+        def shell_side(cmd, cwd=None, **kw):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            return _shell_with_gate(workspace, "PASS")(cmd, cwd, **kw)
+
+        mock_shell.side_effect = shell_side
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task, start_phase=Phase.REVIEW)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.preflight_verdict == "SKIPPED"
+        # DEV must NOT have been called — we started at REVIEW
+        mock_dev_agent.assert_not_called()
+        # REVIEW pool must have run exactly once
+        assert mock_pool.call_count == 1
+
+
+class TestHandoffPersistence:
+    """Test that handoff.yaml is copied to .forge/logs after VALIDATE."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_handoff_copied_to_log_dir(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """handoff.yaml is copied to .forge/logs/<slug>/ after a passing gate."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev_agent.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        log_dir = tmp_path / ".forge" / "logs" / "test-task"
+        assert log_dir.exists(), "log directory was not created"
+        handoff_copies = list(log_dir.glob("handoff-iter-*.yaml"))
+        assert len(handoff_copies) >= 1, "handoff was not copied to log dir"
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_handoff_copy_failure_does_not_block_pipeline(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """A failure writing handoff to logs must not cause the pipeline to fail."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev_agent.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        with patch(
+            "theforge.coordinator.engine.resolve_handoff_path",
+            side_effect=OSError("disk full"),
+        ):
+            result = run_task(config, task)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+
+
+class TestStartupFailureEscalation:
+    """Test that a dev agent startup failure escalates immediately."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_startup_failure_escalates(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """Dev startup_failure escalates; VALIDATE/REVIEW must not run."""
+        from theforge.runners import AgentResult
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+
+        def shell_side(cmd, cwd=None, **kw):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            return _shell_with_gate(workspace, "PASS")(cmd, cwd, **kw)
+
+        mock_shell.side_effect = shell_side
+        mock_dev_agent.return_value = AgentResult(
+            success=False,
+            output="command not found: claude",
+            session_id=None,
+            cost_usd=None,
+            exit_code=127,
+            raw={},
+            startup_failure=True,
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert "no agent available" in result.message
+        # dev_agent called once; no VALIDATE or REVIEW
+        assert mock_dev_agent.call_count == 1
+        mock_pool.assert_not_called()


### PR DESCRIPTION
## Summary

[codex-reviewer] Prior REVIEW-start fix remains resolved, and I found no new P1 regressions; --from plan and --from validate remain an untested P2 stage-aware gap. | [gemini-reviewer] All previous P1 findings are resolved, and no regressions or new issues were introduced. | [deepseek-reviewer] All prior P1 findings resolved, no regressions introduced, and all acceptance criteria met.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** codex-reviewer, gemini-reviewer, deepseek-reviewer
- **Cost:** $2.72
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/engine.py:567`** run_task routes every start_phase after PREFLIGHT straight into _coordinator_loop. In a direct repro, start_phase=Phase.PLAN skipped PLAN entirely and invoked DEV, and start_phase=Phase.VALIDATE also invoked DEV instead of starting at VALIDATE, so general --from phase wiring is still incomplete beyond the fixed REVIEW case.

## Story

Hardening bug bundle — six fixes for release readiness (`/Users/pwickersham/src/theforge/stories/backlog/hardening-bug-bundle.md`)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*