### PR TITLE
Dev prompt relaxes plan-obedience for note-driven and refactor stories

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -130,6 +130,7 @@ def _run_dev_phase(
             escalation_note=state.escalation_note,
             cycle_history=state.cycle_history or None,
             handoff_file=config.validation.handoff_file,
+            preflight_sufficiency=state.preflight_sufficiency,
         )
         state.escalation_note = None  # consumed
     state.retry_reason = None  # consumed

--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -24,6 +24,7 @@ def build_dev_prompt(
     escalation_note: str | None = None,
     cycle_history: list[CycleHistory] | None = None,
     handoff_file: str = "handoff.yaml",
+    preflight_sufficiency: str | None = None,
 ) -> str:
     """Build the complete dev agent prompt.
 
@@ -86,6 +87,13 @@ def build_dev_prompt(
             {human_feedback}
         """)
 
+    _relaxed = preflight_sufficiency == "implementation_ready"
+    _obedience_text = (
+        "Use the plan as a guide — adapt freely if you discover the approach needs adjustment."
+        if _relaxed
+        else "Follow it closely — do not re-derive the approach from scratch."
+    )
+
     plan_section = ""
     if plan_output:
         if isinstance(plan_output, dict):
@@ -94,8 +102,7 @@ def build_dev_prompt(
                 "## Implementation Plan (from planning agent)",
                 "",
                 "The planning agent has already analysed this codebase and produced a",
-                "detailed implementation plan. Follow it closely — do not re-derive the",
-                "approach from scratch.",
+                f"detailed implementation plan. {_obedience_text}",
                 "",
                 f"**Approach:** {plan_output.get('approach', '')}",
                 "",
@@ -116,8 +123,7 @@ def build_dev_prompt(
                 ## Implementation Plan (from planning agent)
 
                 The planning agent has already analysed this codebase and produced a
-                detailed implementation plan. Follow it closely — do not re-derive the
-                approach from scratch.
+                detailed implementation plan. {_obedience_text}
 
                 {plan_output}
             """)

--- a/tests/test_dev_prompts.py
+++ b/tests/test_dev_prompts.py
@@ -1,0 +1,129 @@
+"""Tests for plan-obedience framing in build_dev_prompt."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.task import TaskStory, build_dev_prompt
+
+
+def _make_task(tmp_path: Path) -> TaskStory:
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n\nDo the thing.", encoding="utf-8")
+    return TaskStory(name="Test Task", story_path=spec, slug="test-task")
+
+
+PLAN_DICT = {
+    "approach": "Do it this way",
+    "steps": [
+        {"id": 1, "description": "First step", "action": "edit", "details": "Edit the file"},
+    ],
+}
+
+PLAN_STR = "1. Do the first thing\n2. Do the second thing"
+
+
+class TestPlanObedienceFraming:
+    """Verify strict vs relaxed plan-obedience language in the dev prompt."""
+
+    # ── Strict (default / feature stories) ──────────────────────────────
+
+    def test_strict_framing_dict_plan_no_signal(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            plan_output=PLAN_DICT,
+        )
+        assert "Follow it closely" in prompt
+        assert "adapt freely" not in prompt
+
+    def test_strict_framing_str_plan_no_signal(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            plan_output=PLAN_STR,
+        )
+        assert "Follow it closely" in prompt
+        assert "adapt freely" not in prompt
+
+    def test_strict_framing_explicit_needs_planning(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            plan_output=PLAN_DICT,
+            preflight_sufficiency="needs_planning",
+        )
+        assert "Follow it closely" in prompt
+        assert "adapt freely" not in prompt
+
+    # ── Relaxed (implementation_ready / note-driven / refactor stories) ─
+
+    def test_relaxed_framing_dict_plan_implementation_ready(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            plan_output=PLAN_DICT,
+            preflight_sufficiency="implementation_ready",
+        )
+        assert "adapt freely" in prompt
+        assert "Follow it closely" not in prompt
+
+    def test_relaxed_framing_str_plan_implementation_ready(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            plan_output=PLAN_STR,
+            preflight_sufficiency="implementation_ready",
+        )
+        assert "adapt freely" in prompt
+        assert "Follow it closely" not in prompt
+
+    # ── No plan — obedience text irrelevant ─────────────────────────────
+
+    def test_no_plan_section_absent(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            preflight_sufficiency="implementation_ready",
+        )
+        assert "Implementation Plan" not in prompt
+
+    # ── Default backward-compat: no preflight_sufficiency → strict ──────
+
+    def test_default_no_signal_is_strict(self, tmp_path):
+        """When preflight_sufficiency is not passed, strict framing must be used."""
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            plan_output=PLAN_DICT,
+            # preflight_sufficiency intentionally omitted
+        )
+        assert "Follow it closely" in prompt


### PR DESCRIPTION
## Summary

[codex-reviewer] No correctness issues found; the prompt framing is selected from pipeline state, defaults to strict when absent, and is wired into the coordinator runtime path. | [gemini-reviewer] The plan-obedience language in the dev prompt correctly varies based on the `preflight_sufficiency` signal, meeting all acceptance criteria. | [deepseek-reviewer] Implementation correctly varies plan-obedience language based on preflight_sufficiency signal with proper pipeline integration and comprehensive tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** codex-reviewer, gemini-reviewer, deepseek-reviewer
- **Cost:** $0.70
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Dev prompt relaxes plan-obedience for note-driven and refactor stories (`/Users/pwickersham/src/theforge/stories/backlog/dev-prompt-plan-obedience.md`)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*