### PR TITLE
Coordinator removes handoff.yaml from git index on workspace setup

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -342,12 +342,14 @@ _FORGE_ARTIFACTS = (".forge/handoff.yaml", ".forge/trajectory.yaml")
 def _deindex_forge_artifacts(workspace_path: Path) -> None:
     """Remove .forge/handoff.yaml and .forge/trajectory.yaml from the git index.
 
-    Uses --ignore-unmatch so the call is a no-op when files are not tracked.
-    This prevents merge conflicts and dirty-worktree noise from gitignored files
-    that were previously committed or accidentally staged.
+    Uses -f so removal succeeds even when the index entry has staged content that
+    differs from both HEAD and the working tree (the agent-misbehavior state described
+    in the story).  Uses --ignore-unmatch so the call is a no-op when files are not
+    tracked.  This prevents merge conflicts and dirty-worktree noise from gitignored
+    files that were previously committed or accidentally staged.
     """
     files_arg = " ".join(_FORGE_ARTIFACTS)
-    ok, out = _cu._run_shell(f"git rm --cached --ignore-unmatch {files_arg}", workspace_path)
+    ok, out = _cu._run_shell(f"git rm -f --cached --ignore-unmatch {files_arg}", workspace_path)
     if not ok:
         _cu._log(f"⚠ WORKSPACE  git rm --cached failed: {out.strip()}")
 

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -348,21 +348,41 @@ class TestDaemonNoPull:
 
 
 class TestDeindexForgeArtifacts:
-    """_deindex_forge_artifacts runs git rm --cached --ignore-unmatch on handoff + trajectory."""
+    """_deindex_forge_artifacts runs git rm -f --cached --ignore-unmatch on both artifacts."""
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_issues_git_rm_cached_ignore_unmatch(self, mock_log, mock_shell, tmp_path):
-        """The helper runs git rm --cached --ignore-unmatch for both forge artifacts."""
+    def test_issues_git_rm_force_cached_ignore_unmatch(self, mock_log, mock_shell, tmp_path):
+        """The helper runs git rm -f --cached --ignore-unmatch for both forge artifacts."""
         mock_shell.return_value = (True, "")
 
         _deindex_forge_artifacts(tmp_path)
 
         assert mock_shell.call_count == 1
         cmd_issued = mock_shell.call_args[0][0]
-        assert "git rm --cached --ignore-unmatch" in cmd_issued
+        assert "git rm" in cmd_issued
+        assert "-f" in cmd_issued
+        assert "--cached" in cmd_issued
+        assert "--ignore-unmatch" in cmd_issued
         for artifact in _FORGE_ARTIFACTS:
             assert artifact in cmd_issued
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_force_flag_present_for_diverged_index(self, mock_log, mock_shell, tmp_path):
+        """git rm -f is used so removal succeeds when index entry diverges from HEAD/worktree.
+
+        This is the agent-misbehavior state: handoff.yaml is tracked but its index
+        content differs from both HEAD and the working tree.  Without -f git rm
+        --cached refuses to remove it.  With -f it succeeds unconditionally.
+        """
+        mock_shell.return_value = (True, "rm '.forge/handoff.yaml'")
+
+        _deindex_forge_artifacts(tmp_path)
+
+        cmd_issued = mock_shell.call_args[0][0]
+        # -f must appear before --cached (or anywhere) in the command
+        assert "-f" in cmd_issued.split()
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")


### PR DESCRIPTION
## Summary

Prior P1 on missing force removal is resolved; the workspace setup now deindexes both forge artifacts on each successful setup path and I found no P1 regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** codex-reviewer
- **Cost:** $1.44
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Coordinator removes handoff.yaml from git index on workspace setup (`/Users/pwickersham/src/theforge/stories/backlog/forge-handoff-git-hygiene.md`)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*