### PR TITLE
Soft conventions — prompt-injected project standards for plan/dev/review

### DIFF
--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -141,6 +141,7 @@ def _cmd_dry_run(config: ForgeConfig, task: TaskStory, story_path: Path) -> int:
         branch_name=branch_name,
         story_content=story_content,
         gate_command=config.validation.gate_command,
+        conventions=config.conventions_soft,
     )
     review_prompt = build_review_prompt(
         task,
@@ -149,6 +150,7 @@ def _cmd_dry_run(config: ForgeConfig, task: TaskStory, story_path: Path) -> int:
         workspace_path=str(workspace_path),
         branch=branch_name,
         handoff_content="(dry run — no handoff available)",
+        conventions=config.conventions_soft,
     )
 
     sep = "=" * 60

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -360,7 +360,19 @@ def load_config(config_path: Path) -> ForgeConfig:
         )
     sprint_cfg = SprintConfig(max_parallel=sprint_max_parallel_raw)
 
-    # Conventions config
+    # Conventions config — soft
+    conventions_soft_raw = raw.get("conventions", {}).get("soft", [])
+    if not isinstance(conventions_soft_raw, list):
+        raise ValueError(
+            "forge.yaml 'conventions.soft' must be a list of strings,"
+            f" got {conventions_soft_raw!r}"
+        )
+    for _item in conventions_soft_raw:
+        if not isinstance(_item, str):
+            raise ValueError(f"forge.yaml 'conventions.soft' items must be strings, got {_item!r}")
+    conventions_soft_list: list[str] = conventions_soft_raw
+
+    # Conventions config — hard
     conventions_hard_raw = raw.get("conventions", {}).get("hard", None)
     if conventions_hard_raw is None:
         conventions_hard_cfg: HardConventionsConfig | None = None
@@ -420,4 +432,5 @@ def load_config(config_path: Path) -> ForgeConfig:
         review_pool_is_default=_review_pool_is_default,
         plan_model_is_default=_plan_model_is_default,
         conventions_hard=conventions_hard_cfg,
+        conventions_soft=conventions_soft_list,
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -294,6 +294,7 @@ class ForgeConfig:
     review_pool_is_default: bool = False  # True when review_pool was not explicitly configured
     plan_model_is_default: bool = False  # True when plan.cli/model were not explicitly configured
     conventions_hard: HardConventionsConfig | None = None  # None = no section = no checks
+    conventions_soft: list[str] = field(default_factory=list)  # [] = no soft conventions
 
     @property
     def review_profile(self) -> ModelProfile:

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -486,5 +486,6 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             for r in state.finding_registry
             if r.severity == "P1" and r.disposition == "net_new"
         ],
+        "conventions": {"soft": config.conventions_soft} if config.conventions_soft else None,
         **_build_phases_block(state, config),
     }

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -109,6 +109,7 @@ def _run_dev_phase(
             else state.plan_output,
             classified_p1s=[r for r in state.finding_registry if r.severity == "P1"] or None,
             surviving_families=state.surviving_families or None,
+            conventions=config.conventions_soft,
         )
         state.escalation_note = None  # consumed
     else:
@@ -131,6 +132,7 @@ def _run_dev_phase(
             cycle_history=state.cycle_history or None,
             handoff_file=config.validation.handoff_file,
             preflight_sufficiency=state.preflight_sufficiency,
+            conventions=config.conventions_soft,
         )
         state.escalation_note = None  # consumed
     state.retry_reason = None  # consumed

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -216,6 +216,7 @@ def _run_plan_phase(
         preflight_output=(
             preflight_result.output if preflight_result and preflight_result.success else None
         ),
+        conventions=config.conventions_soft,
     )
 
     _plan_start = time.monotonic()

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -809,6 +809,7 @@ def _run_review_only_phase(
         mode=config.review_pool[0].mode,
         dev_notes=dev_notes,
         cycle_history=None,
+        conventions=config.conventions_soft,
     )
 
     meta = ReviewCycleMetadata(

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -130,6 +130,7 @@ def _run_review_pool(
                     review_role=p.review_role,
                     dev_notes=dev_notes,
                     cycle_history=state.cycle_history if state.cycle_history else None,
+                    conventions=config.conventions_soft,
                 )
                 for p in config.review_pool
             ]
@@ -144,6 +145,7 @@ def _run_review_pool(
                 mode=config.review_pool[0].mode,
                 dev_notes=dev_notes,
                 cycle_history=state.cycle_history if state.cycle_history else None,
+                conventions=config.conventions_soft,
             )
         )
     _log_verbose(f"Running {pool_size} reviewer(s): {[p.name for p in config.review_pool]}")

--- a/src/theforge/task/__init__.py
+++ b/src/theforge/task/__init__.py
@@ -1,3 +1,4 @@
+from .conventions import render_conventions_block
 from .dev_prompts import build_dev_prompt
 from .fix_prompts import build_fix_prompt, build_handoff_fix_prompt
 from .plan_parser import PlanData, PlanStep, parse_plan_output
@@ -13,6 +14,7 @@ from .story import (
 )
 
 __all__ = [
+    "render_conventions_block",
     "build_dev_prompt",
     "build_fix_prompt",
     "build_handoff_fix_prompt",

--- a/src/theforge/task/conventions.py
+++ b/src/theforge/task/conventions.py
@@ -1,0 +1,14 @@
+def render_conventions_block(conventions: list[str] | None) -> str:
+    """Render the soft conventions prompt block.
+
+    Returns an empty string when conventions is None or empty.
+    """
+    if not conventions:
+        return ""
+    items = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(conventions))
+    return (
+        "\n## Project Conventions\n\n"
+        "The following conventions apply to this project. Respect them in your work"
+        " and flag violations you observe.\n\n"
+        f"{items}\n"
+    )

--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 from theforge.coordinator.state import CycleHistory
 
+from .conventions import render_conventions_block
 from .plan_parser import PlanData
 from .story import TaskStory
 
@@ -25,6 +26,7 @@ def build_dev_prompt(
     cycle_history: list[CycleHistory] | None = None,
     handoff_file: str = "handoff.yaml",
     preflight_sufficiency: str | None = None,
+    conventions: list[str] | None = None,
 ) -> str:
     """Build the complete dev agent prompt.
 
@@ -189,7 +191,7 @@ def build_dev_prompt(
         > most reasonable interpretation and flag the ambiguity in `dev_notes`.
 
         {story_content}
-        {feedback_section}{preflight_section}
+        {feedback_section}{preflight_section}{render_conventions_block(conventions)}
         ## Workflow
 
         1. Implement the spec. Write tests for new functionality.

--- a/src/theforge/task/fix_prompts.py
+++ b/src/theforge/task/fix_prompts.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 from theforge.coordinator.state import CycleHistory
 
+from .conventions import render_conventions_block
 from .story import TaskStory
 
 
@@ -123,6 +124,7 @@ def build_fix_prompt(
     plan_output: str | dict | None = None,
     classified_p1s: list | None = None,  # list[FindingRecord]
     surviving_families: list[dict] | None = None,
+    conventions: list[str] | None = None,
 ) -> str:
     """Build a minimal fix prompt for review iteration 2+.
 
@@ -202,6 +204,10 @@ def build_fix_prompt(
             ## Previous Review Cycles
 
         """) + "\n".join(history_lines)
+
+    _conventions_block = render_conventions_block(conventions)
+    if _conventions_block:
+        context_sections += _conventions_block
 
     if surviving_families:
         traj_lines: list[str] = []

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
+from .conventions import render_conventions_block
 from .plan_parser import PlanData
 from .story import TaskStory
 
@@ -306,6 +307,7 @@ def build_plan_prompt(
     *,
     story_content: str,
     preflight_output: str | None = None,
+    conventions: list[str] | None = None,
 ) -> str:
     """Build the planning agent prompt.
 
@@ -388,4 +390,4 @@ def build_plan_prompt(
           against the actual codebase before relying on it.
         - If something in the spec is ambiguous or contradictory, say so
           explicitly in risks rather than guessing.
-    """)
+    """) + render_conventions_block(conventions)

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 
 from theforge.coordinator.state import CycleHistory
 
+from .conventions import render_conventions_block
 from .story import TaskStory
 
 _REVIEW_ROLE_SECTIONS: dict[str, str] = {
@@ -138,6 +139,7 @@ def build_review_prompt(
     review_role: str | None = None,
     dev_notes: str | None = None,
     cycle_history: list[CycleHistory] | None = None,
+    conventions: list[str] | None = None,
 ) -> str:
     """Build the review agent prompt.
 
@@ -257,7 +259,7 @@ def build_review_prompt(
         ## Spec
 
         {story_content}
-        {dev_notes_section}
+        {dev_notes_section}{render_conventions_block(conventions)}
         ## Commits
 
         The following commits implement the spec on branch `{branch}`.
@@ -286,9 +288,12 @@ def build_review_prompt(
           to satisfy the criterion — not if the approach differs from what you'd
           prefer.
         - **P2** (non-blocking): Style, minor improvement, non-critical missing
-          test, suggestion for future work. Does NOT block merge. **Pre-existing
-          issues in code not modified by these commits are always P2** — they are
-          valuable signal but they do not block this change.
+          test, suggestion for future work, or a project convention violation.
+          Does NOT block merge. **Pre-existing issues in code not modified by
+          these commits are always P2** — they are valuable signal but they do
+          not block this change. Convention violations (from ## Project
+          Conventions, if present) are P2 findings — cite the convention by
+          name in the description.
 
         ## Rules
 

--- a/tests/test_soft_conventions.py
+++ b/tests/test_soft_conventions.py
@@ -1,0 +1,318 @@
+"""Tests for soft conventions feature.
+
+Covers: config parsing, render_conventions_block, prompt builder injection,
+review-only path, dry-run path, and audit inclusion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    ForgeConfig,
+    RetryPolicy,
+    ValidationConfig,
+    WorkspaceConfig,
+    load_config,
+)
+from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.state import (
+    CoordinatorResult,
+    CoordinatorState,
+    Phase,
+)
+from theforge.task import (
+    TaskStory,
+    build_dev_prompt,
+    build_fix_prompt,
+    build_plan_prompt,
+    build_review_prompt,
+    render_conventions_block,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _write_config(data: dict, tmp_dir: Path) -> Path:
+    config_path = tmp_dir / "forge.yaml"
+    config_path.write_text(yaml.dump(data), encoding="utf-8")
+    return config_path
+
+
+def _make_task(tmp_path: Path) -> TaskStory:
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n\nDo the thing.", encoding="utf-8")
+    return TaskStory(name="Test Task", story_path=spec, slug="test-task")
+
+
+def _make_config(tmp_path: Path, conventions_soft: list[str] | None = None) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=ValidationConfig(
+            gate_command="make gate",
+            handoff_file="handoff.yaml",
+            gate_decision_key="gate_result",
+        ),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        conventions_soft=conventions_soft or [],
+    )
+
+
+# ── Config parsing ────────────────────────────────────────────────────────
+
+
+class TestConfigParsing:
+    def test_conventions_soft_list_parsed(self, tmp_path):
+        """forge.yaml with conventions.soft list produces correct ForgeConfig."""
+        conventions = [
+            "Single concern per module",
+            "Separate IO from logic",
+        ]
+        config_path = _write_config({"conventions": {"soft": conventions}}, tmp_path)
+        with patch("importlib.import_module"):
+            cfg = load_config(config_path)
+        assert cfg.conventions_soft == conventions
+
+    def test_missing_conventions_section_produces_empty_list(self, tmp_path):
+        """No conventions section → conventions_soft is []."""
+        config_path = _write_config({}, tmp_path)
+        with patch("importlib.import_module"):
+            cfg = load_config(config_path)
+        assert cfg.conventions_soft == []
+
+    def test_missing_soft_key_produces_empty_list(self, tmp_path):
+        """conventions: without soft key → conventions_soft is []."""
+        config_path = _write_config({"conventions": {"hard": None}}, tmp_path)
+        with patch("importlib.import_module"):
+            cfg = load_config(config_path)
+        assert cfg.conventions_soft == []
+
+    def test_invalid_type_raises_value_error(self, tmp_path):
+        """conventions.soft that is not a list raises ValueError."""
+        config_path = _write_config({"conventions": {"soft": "not-a-list"}}, tmp_path)
+        with patch("importlib.import_module"), pytest.raises(ValueError, match="list of strings"):
+            load_config(config_path)
+
+    def test_invalid_item_type_raises_value_error(self, tmp_path):
+        """conventions.soft with non-string item raises ValueError."""
+        config_path = _write_config({"conventions": {"soft": [1, "valid"]}}, tmp_path)
+        with (
+            patch("importlib.import_module"),
+            pytest.raises(ValueError, match="items must be strings"),
+        ):
+            load_config(config_path)
+
+
+# ── render_conventions_block ──────────────────────────────────────────────
+
+
+class TestRenderConventionsBlock:
+    def test_empty_list_returns_empty_string(self):
+        assert render_conventions_block([]) == ""
+
+    def test_none_returns_empty_string(self):
+        assert render_conventions_block(None) == ""
+
+    def test_single_item_numbered(self):
+        result = render_conventions_block(["Do one thing"])
+        assert "## Project Conventions" in result
+        assert "1. Do one thing" in result
+
+    def test_multiple_items_numbered(self):
+        conventions = ["Rule A", "Rule B", "Rule C"]
+        result = render_conventions_block(conventions)
+        assert "1. Rule A" in result
+        assert "2. Rule B" in result
+        assert "3. Rule C" in result
+
+    def test_contains_preamble(self):
+        result = render_conventions_block(["Some rule"])
+        assert "Respect them in your work" in result
+        assert "flag violations you observe" in result
+
+
+# ── Prompt builder integration ────────────────────────────────────────────
+
+
+_CONVENTIONS = ["Single concern per module", "Separate IO from logic"]
+
+
+class TestBuildPlanPromptConventions:
+    def test_conventions_block_included(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_plan_prompt(task, story_content="# Spec", conventions=_CONVENTIONS)
+        assert "## Project Conventions" in prompt
+        assert "Single concern per module" in prompt
+
+    def test_no_conventions_no_block(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_plan_prompt(task, story_content="# Spec")
+        assert "## Project Conventions" not in prompt
+
+    def test_empty_conventions_no_block(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_plan_prompt(task, story_content="# Spec", conventions=[])
+        assert "## Project Conventions" not in prompt
+
+
+class TestBuildDevPromptConventions:
+    def test_conventions_block_included(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+            conventions=_CONVENTIONS,
+        )
+        assert "## Project Conventions" in prompt
+        assert "Separate IO from logic" in prompt
+
+    def test_no_conventions_no_block(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+        )
+        assert "## Project Conventions" not in prompt
+
+
+class TestBuildFixPromptConventions:
+    def test_conventions_block_included(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_fix_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            review_findings="P1: something is wrong",
+            gate_command="make gate",
+            conventions=_CONVENTIONS,
+        )
+        assert "## Project Conventions" in prompt
+        assert "Single concern per module" in prompt
+
+    def test_no_conventions_no_block(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_fix_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            review_findings="P1: something is wrong",
+            gate_command="make gate",
+        )
+        assert "## Project Conventions" not in prompt
+
+
+class TestBuildReviewPromptConventions:
+    def test_conventions_block_included(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat: thing",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+            conventions=_CONVENTIONS,
+        )
+        assert "## Project Conventions" in prompt
+        assert "Single concern per module" in prompt
+
+    def test_no_conventions_no_block(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat: thing",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+        )
+        assert "## Project Conventions" not in prompt
+
+    def test_p2_convention_violation_note_present(self, tmp_path):
+        """Review prompt mentions convention violations are P2 findings."""
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat: thing",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+            conventions=_CONVENTIONS,
+        )
+        # The P2 severity definition should mention convention violations
+        assert "convention" in prompt.lower()
+
+
+# ── Audit inclusion ───────────────────────────────────────────────────────
+
+
+class TestAuditConventions:
+    def _make_result(self) -> CoordinatorResult:
+        state = CoordinatorState()
+        state.phase = Phase.DONE
+        return CoordinatorResult(
+            success=True,
+            phase=Phase.DONE,
+            state=state,
+            message="done",
+            merge=None,
+        )
+
+    def test_conventions_soft_included_in_audit(self, tmp_path):
+        cfg = _make_config(tmp_path, conventions_soft=["Rule A", "Rule B"])
+        task = _make_task(tmp_path)
+        result = self._make_result()
+        audit = generate_audit_log(cfg, task, result)
+        assert audit["conventions"] == {"soft": ["Rule A", "Rule B"]}
+
+    def test_no_conventions_produces_none(self, tmp_path):
+        cfg = _make_config(tmp_path, conventions_soft=[])
+        task = _make_task(tmp_path)
+        result = self._make_result()
+        audit = generate_audit_log(cfg, task, result)
+        assert audit["conventions"] is None
+
+
+# ── No-op: empty conventions leave prompts unchanged ─────────────────────
+
+
+class TestNoConventionsNoOp:
+    def test_plan_prompt_unchanged_without_conventions(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt_without = build_plan_prompt(task, story_content="# Spec")
+        prompt_empty = build_plan_prompt(task, story_content="# Spec", conventions=[])
+        assert prompt_without == prompt_empty
+
+    def test_dev_prompt_unchanged_without_conventions(self, tmp_path):
+        task = _make_task(tmp_path)
+        kwargs = dict(
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+        )
+        assert build_dev_prompt(task, **kwargs) == build_dev_prompt(task, **kwargs, conventions=[])


### PR DESCRIPTION
## Summary

- `forge.yaml` accepts `conventions.soft` as a list of freeform strings
- Conventions injected into plan, dev, review, and fix prompts via `build_*_prompt()` functions
- Review agents can cite convention violations as P2 findings (no schema change)
- Projects without soft conventions see no prompt changes
- Conventions list included in audit YAML for traceability

Closes #188

*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*