### PR TITLE
docs: update guides for v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml/badge.svg)](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.3.0-orange)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.4.0-orange)](CHANGELOG.md)
 
 **Deterministic multi-LLM development orchestrator.**
 
@@ -16,6 +16,14 @@ and isolated in a git worktree until you decide to merge.
 - Validation and review act as mechanical gates
 - Work happens on feature branches in managed worktrees
 - Logs, audits, and review output make every run inspectable
+
+## What's new in v0.4.0
+
+- **Gemini thinking mode** — set `thinking_budget` on a Gemini API profile to enable extended reasoning
+- **Paperless sprints** — `forge sprint --milestone "v0.4.0" --budget 50` pulls stories directly from GitHub; no local manifest required
+- **`on_approve: merge-pr`** — auto-merges approved branches via PR with a full audit trail
+
+See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
 ## Why TheForge
 

--- a/docs/guides/choose-your-provider-setup.md
+++ b/docs/guides/choose-your-provider-setup.md
@@ -127,6 +127,7 @@ profiles:
       provider: google              # API mode
       model: gemini-2.5-flash
       review_role: edge-cases       # edge cases, error handling
+      thinking_budget: 2048         # optional: enables Gemini extended reasoning
       budget_usd: 1.00
       timeout_seconds: 300
 ```

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -105,13 +105,16 @@ run review without re-running PLAN/DEV.
 
 ## `forge sprint`
 
-Run multiple stories from a sprint manifest.
+Run multiple stories from a sprint manifest or directly from a GitHub milestone or label.
 
 ```bash
-forge sprint <manifest.yaml> [flags]
+forge sprint [manifest.yaml] [flags]
+forge sprint --milestone "v0.4.0" --budget 50 [flags]
+forge sprint --label "sprint-1" --budget 20 [flags]
 ```
 
-**Use this when:** You want batch execution with shared budget and story ordering.
+**Use this when:** You want batch execution with shared budget and story ordering. The
+manifest argument is optional when using `--milestone` or `--label`.
 
 **Flags:**
 
@@ -121,6 +124,10 @@ forge sprint <manifest.yaml> [flags]
 | `--auto-merge` | Auto-merge each approved story |
 | `--interactive` | Pause at each APPROVE |
 | `--resume` | Auto-triage each story and resume from the correct phase |
+| `--milestone <name>` | Run all open issues in a GitHub milestone (requires `--budget`) |
+| `--label <name>` | Run all open issues with a GitHub label (requires `--budget`) |
+| `--budget <usd>` | Budget ceiling in USD — required when using `--milestone` or `--label` |
+| `--name <name>` | Override the sprint name (default: milestone or label value) |
 | `--config <path>` | Path to `forge.yaml` |
 | `--no-notify` | Suppress notifications |
 | `--detach` | Queue the sprint on a running daemon and return immediately |
@@ -133,11 +140,14 @@ forge sprint <manifest.yaml> [flags]
 name: "Sprint Name"
 budget_usd: 50
 auto_merge: true
-specs:
+stories:
   - stories/story-one.md
   - stories/story-two.md
-  - stories/story-three.md
+  - {issue: 123}             # source from GitHub issue #123
+  - {issue: 124, slug: my-slug, depends_on: [my-slug]}
 ```
+
+> **Note:** `specs:` is a deprecated alias for `stories:` and still works.
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -193,12 +193,14 @@ git merge forge/add-health-check
 
 ## 10. Run multiple stories as a sprint
 
-Create a sprint manifest (`sprints/my-sprint.yaml`):
+### Option A: manifest file
+
+Create `sprints/my-sprint.yaml`:
 
 ```yaml
 name: "My First Sprint"
 budget_usd: 20
-specs:
+stories:
   - stories/add-health-check.md
   - stories/add-logging.md
   - stories/fix-auth-bug.md
@@ -209,6 +211,17 @@ Run it:
 ```bash
 forge sprint sprints/my-sprint.yaml --verbose --auto-merge
 ```
+
+### Option B: paperless sprint from GitHub
+
+If your stories are GitHub issues, skip the manifest entirely:
+
+```bash
+forge sprint --milestone "v1.0" --budget 50 --verbose --auto-merge
+forge sprint --label "sprint-1" --budget 20 --verbose
+```
+
+TheForge fetches open issues from the milestone or label and runs them in order.
 
 Stories run sequentially. Each one goes through the full pipeline. Failed stories
 don't block the rest.

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -66,7 +66,9 @@ background, not as requirements.
 
 ## Sprint manifest (`sprints/*.yaml`)
 
-Bundles multiple stories into a sequential run with shared budget.
+Bundles multiple stories into a sequential run with shared budget. You can also
+run sprints without a manifest using `forge sprint --milestone` or `--label`
+(see [CLI Reference](cli-reference.md#forge-sprint)).
 
 ### Template
 
@@ -74,11 +76,14 @@ Bundles multiple stories into a sequential run with shared budget.
 name: "Sprint Name — brief description"
 budget_usd: 50
 auto_merge: true    # optional: merge each APPROVED story automatically
-specs:
-  - stories/story-one.md
+stories:
+  - stories/story-one.md           # local story file
   - stories/story-two.md
-  - stories/story-three.md
+  - {issue: 123}                   # pull from GitHub issue #123
+  - {issue: 124, slug: my-feature, depends_on: [story-one]}
 ```
+
+> **Note:** `specs:` is a deprecated alias for `stories:` and still works.
 
 ### Fields
 
@@ -87,7 +92,17 @@ specs:
 | `name` | Yes | — | Human-readable sprint name |
 | `budget_usd` | Yes | — | Total budget ceiling across all stories |
 | `auto_merge` | No | `false` | Auto-merge approved stories to main |
-| `specs` | Yes | — | Ordered list of spec file paths (relative to project root) |
+| `stories` | Yes | — | Ordered list of stories — local file paths or `{issue: N}` dicts |
+
+### Story entry formats
+
+| Format | Description |
+|--------|-------------|
+| `stories/my-feature.md` | Local story file (path relative to project root) |
+| `{issue: 123}` | Pull story body from GitHub issue #123 |
+| `{issue: 123, slug: my-slug}` | Override the slug derived from the issue title |
+| `{issue: 123, depends_on: [other-slug]}` | Declare a dependency on another story in the sprint |
+| `{issue: 123, pytest_target: tests/test_foo.py}` | Override the pytest target for this story |
 
 ### Behavior
 
@@ -149,6 +164,10 @@ workspace:
   path_pattern: ".forge/worktrees/{slug}"
   branch_pattern: "forge/{slug}"
   base_branch: "main"                 # default: "main"
+  on_approve: "none"                  # "none" | "merge" | "pr" | "merge-pr"
+  merge_strategy: "squash"            # "squash" | "merge" | "rebase" (used by merge-pr)
+  pr_labels: []                       # labels applied when on_approve is "pr" or "merge-pr"
+  pr_draft: false                     # create PR as draft when on_approve is "pr"
 
 # ── Validation gate ────────────────────────────────────────
 validation:
@@ -212,6 +231,14 @@ profiles:
       timeout_seconds: 300
       max_iterations: 50
       allowed_tools: [Read, Bash, Glob, Grep]
+
+    - name: gemini-reviewer      # Gemini with extended thinking enabled
+      provider: google
+      model: gemini-2.5-flash
+      review_role: edge-cases
+      thinking_budget: 2048      # optional: enables Gemini thinking mode (token budget)
+      budget_usd: 1.00
+      timeout_seconds: 300
 
     - name: local-reviewer       # Local model via Ollama/vLLM/LM Studio
       provider: openai


### PR DESCRIPTION
## Summary

- Bump version badge to 0.4.0 and add "What's new in v0.4.0" section to README
- `cli-reference`: document `forge sprint --milestone`/`--label` flags, optional manifest, `stories:` key with issue dict format
- `inputs-reference`: add `on_approve`/`merge_strategy`/`pr_labels`/`pr_draft` to workspace section; `thinking_budget` to profile reference; update sprint manifest to `stories:` with `{issue: N}` dict table
- `choose-your-provider-setup`: add `thinking_budget: 2048` to Pattern 3 Gemini example
- `getting-started`: use `stories:` key in sprint example; add paperless sprint Option B

Based on Gemini audit of v0.4.0 changes. One audit claim rejected: the description of `matches_spec: false` as "acting as a blocking P1 regardless of test results" is inaccurate — the actual behavior is that net-new P1s from a reviewer who flagged `matches_spec=false` are treated as AC-blocking in cycle ≥ 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)