### PR TITLE
docs: prohibit agent edits to CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,4 @@ land in `.forge/worktrees/<slug>/` on branch `feat/<slug>`.
 - Do NOT skip `make fmt` before committing
 - Do NOT relax schema validation to make tests pass
 - Do NOT suggest replacing preflight with a cheap/fast model — it is load-bearing
+- Do NOT modify CLAUDE.md or AGENTS.md unless the story explicitly requires it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,3 +137,4 @@ land in `.forge/worktrees/<slug>/` on branch `feat/<slug>`.
 - Do NOT skip `make fmt` before committing
 - Do NOT relax schema validation to make tests pass
 - Do NOT suggest replacing preflight with a cheap/fast model — it is load-bearing
+- Do NOT modify CLAUDE.md or AGENTS.md unless the story explicitly requires it


### PR DESCRIPTION
## Summary
- Adds explicit "Do NOT modify CLAUDE.md or AGENTS.md unless the story explicitly requires it" to both files
- Root cause of the #374 regression: dev agent edited guidance files unprompted from a stale worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)