### PR TITLE
fix: scrub tracked .forge artifacts automatically

### DIFF
--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -18,6 +18,7 @@ from .notify import _escalate_notify
 from .review_context import _get_handoff_content, _get_raw_dev_notes
 from .state import CoordinatorResult, CoordinatorState, Phase
 from .util import _log, _log_phase, _log_verbose
+from .workspace import _deindex_forge_artifacts
 
 
 class _ValidateOutcome(Enum):
@@ -118,6 +119,9 @@ def _run_validate_phase(
                 _log(f"  ⚠ Pre-validate command failed (non-fatal): {pv_out[:200]}")
             else:
                 _log_verbose(f"Pre-validate output: {pv_out[:200]}")
+        # Defensive scrub: if an agent force-added .forge artifacts, remove them
+        # from the index before dirty-worktree detection and any auto-commit.
+        _deindex_forge_artifacts(workspace_path)
         dirty_ok, dirty_out = _cu._run_shell("git status --porcelain", workspace_path)
         if dirty_ok and dirty_out.strip():
             handoff_file = config.validation.handoff_file

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -39,6 +39,13 @@ def _log(msg: str) -> None:
     print(f"[sprint] {msg}", file=sys.stderr, flush=True)
 
 
+def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:
+    """Best-effort: remove tracked .forge artifacts from the project-root index."""
+    from ..coordinator.workspace import _deindex_forge_artifacts  # noqa: PLC0415
+
+    _deindex_forge_artifacts(config.project_root)
+
+
 def _read_prior_sprint_cost(project_root: Path) -> float:
     """Read total_cost_usd from the prior sprint-audit.yaml, if it exists."""
     audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
@@ -440,6 +447,9 @@ def run_sprint(
             stories=_task_entries,
             max_parallel=_manifest.max_parallel,
         )
+
+    # Defensive scrub for the root checkout used by sprint commands.
+    _scrub_root_forge_artifacts(config)
 
     max_parallel = (
         resolved.max_parallel if resolved.max_parallel is not None else config.sprint.max_parallel

--- a/tests/test_coord_gate_exec.py
+++ b/tests/test_coord_gate_exec.py
@@ -209,9 +209,10 @@ class TestCoordinatorDirtyWorktree:
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
     @patch("theforge.coordinator.util._run_shell")
     def test_dirty_worktree_auto_commits_no_retry(
-        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+        self, mock_shell, mock_deindex, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
         """Dirty worktree after gate PASS → coordinator auto-commits, no agent retry."""
         config = _make_config(tmp_path)
@@ -245,6 +246,7 @@ class TestCoordinatorDirtyWorktree:
         assert result.success is True
         assert result.phase == Phase.DONE
         assert mock_agent.call_count == 1
+        mock_deindex.assert_called_once_with(workspace)
         assert any("git add" in c for c in shell_cmds)
         assert any(
             c[0][0] == ["git", "commit", "-m", mock.ANY] for c in mock_subprocess.call_args_list

--- a/tests/test_sprint_lifecycle.py
+++ b/tests/test_sprint_lifecycle.py
@@ -179,6 +179,21 @@ class TestLoadManifest:
 
 
 class TestRunSprint:
+    def test_root_forge_artifacts_deindexed_before_sprint(self, tmp_path: Path) -> None:
+        """run_sprint scrubs tracked .forge artifacts from the project root index first."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=10.0)
+        config = _make_config(tmp_path)
+        result_a = _make_coordinator_result(success=True, cost=1.0)
+
+        with (
+            patch("theforge.sprint.runner._scrub_root_forge_artifacts") as mock_scrub,
+            patch("theforge.sprint.runner.run_task", return_value=result_a),
+        ):
+            run_sprint(config, manifest_path)
+
+        mock_scrub.assert_called_once_with(config)
+
     def test_success_path(self, tmp_path: Path) -> None:
         """Two specs both succeed, costs accumulate, audit written."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")


### PR DESCRIPTION
## Summary

- Calls `_deindex_forge_artifacts()` in `validate_phase.py` before dirty-worktree detection and any auto-commit
- Calls it in `sprint/runner.py` at sprint start for the root checkout
- Tests cover both call sites

Defensive guard against agents force-adding `.forge` artifacts into the index, which would cause false dirty-worktree failures or pollute commits.

## Test plan
- [ ] `make test` passes
- [ ] `test_root_forge_artifacts_deindexed_before_sprint` asserts scrub called at sprint start
- [ ] `test_dirty_worktree_auto_commits_no_retry` asserts `_deindex_forge_artifacts` called before dirty check

🤖 Generated with [Claude Code](https://claude.com/claude-code)