### PR TITLE
Gemini finalization applies response_schema during plain-text ideation runs

### DIFF
--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -740,6 +740,11 @@ def run_api_agent(
 
     When profile.allowed_tools is non-empty, drives an agent loop where the model
     can call tools. When empty, falls back to a single-shot stateless call.
+
+    Google Gemini plain-text calls intentionally bypass the tool loop even when
+    the profile allows tools. Ideation expects raw markdown/text output, and the
+    Google loop's review finalization path can otherwise force response_schema
+    JSON output that does not match the ideation prompt.
     """
     if not profile.provider:
         return AgentResult(
@@ -756,7 +761,20 @@ def run_api_agent(
     if not quiet:
         _log(f"  Starting {label} (model={profile.model}, timeout={profile.timeout_seconds}s)...")
 
-    if profile.allowed_tools:
+    if profile.provider == "google" and plain_text:
+        runner_fn = PROVIDER_RUNNERS.get(profile.provider)
+        if not runner_fn:
+            return AgentResult(
+                success=False,
+                output=f"Unknown API provider: {profile.provider}",
+                session_id=None,
+                cost_usd=None,
+                exit_code=1,
+                raw={},
+                profile_name=profile.name,
+            )
+        result = runner_fn(prompt, profile, secrets, plain_text=True)
+    elif profile.allowed_tools:
         loop_runner = _LOOP_RUNNERS.get(profile.provider)
         if not loop_runner:
             return AgentResult(
@@ -781,10 +799,7 @@ def run_api_agent(
                 raw={},
                 profile_name=profile.name,
             )
-        if profile.provider == "google" and plain_text:
-            result = runner_fn(prompt, profile, secrets, plain_text=True)
-        else:
-            result = runner_fn(prompt, profile, secrets)
+        result = runner_fn(prompt, profile, secrets)
 
     if not quiet:
         status = "OK" if result.success else "FAIL"

--- a/tests/test_runner_api_providers.py
+++ b/tests/test_runner_api_providers.py
@@ -274,6 +274,33 @@ class TestRunApiAgentLoopIntegration:
             )
             mock_fn.assert_called_once_with("review", profile, tmp_path, None)
 
+    def test_google_plain_text_with_tools_bypasses_loop_runner(self, tmp_path):
+        profile = _make_profile(
+            provider="google",
+            model="gemini-2.5-flash",
+            allowed_tools=("read_file",),
+        )
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.cost_usd = None
+
+        loop_runner = MagicMock()
+        single_shot_runner = MagicMock(return_value=mock_result)
+        with (
+            patch.dict("theforge.runners.api._LOOP_RUNNERS", {"google": loop_runner}),
+            patch.dict("theforge.runners.api.PROVIDER_RUNNERS", {"google": single_shot_runner}),
+        ):
+            run_api_agent(
+                prompt="ideate",
+                profile=profile,
+                working_dir=tmp_path,
+                quiet=True,
+                plain_text=True,
+            )
+
+        loop_runner.assert_not_called()
+        single_shot_runner.assert_called_once_with("ideate", profile, None, plain_text=True)
+
     def test_run_api_agent_no_provider_returns_failure(self, tmp_path):
         profile = ModelProfile(
             name="no-provider",


### PR DESCRIPTION
## Summary

The change fixes the Gemini ideation regression by routing Google plain-text API calls away from the response_schema finalization loop.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** codex-reviewer, gemini-reviewer
- **Cost:** $0.36
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Gemini finalization applies response_schema during plain-text ideation runs (GitHub Issue #220)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #220