### PR TITLE
Sprint runner swallows worker exceptions — ESCALATE with no error in audit

### DIFF
--- a/src/theforge/cli/audit.py
+++ b/src/theforge/cli/audit.py
@@ -176,7 +176,11 @@ def cmd_audit(args: object) -> int:
 
     if audit.get("error"):
         print()
-        print(f"  Error: {audit['error']}")
+        error_type = audit.get("error_type")
+        if error_type:
+            print(f"  Error: {error_type}: {audit['error']}")
+        else:
+            print(f"  Error: {audit['error']}")
 
     print(f"{sep}")
     return 0

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -447,6 +447,7 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             else None
         ),
         "error": state.error,
+        "error_type": state.error_type,
         "story_validation": (
             {
                 "verdict": state.story_validation_result.verdict,

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -211,6 +211,7 @@ class CoordinatorState:
     plan_regen_disposition: str | None = None  # "patch" | "backtrack" | "escalate"
     log_dir: Path | None = None  # per-story log directory under <project_root>/.forge/logs/
     error: str | None = None
+    error_type: str | None = None
     dev_escalated: bool = False  # True once model escalation has occurred this run
     plan_escalated: bool = False  # True once plan model escalation has occurred this run
     plan_escalation_note: str | None = None  # escalation context injected into regen prompt

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -81,6 +81,8 @@ def _write_sprint_audit(
                 "outcome": outcome,
                 "cost_usd": round(res.state.total_cost, 4),
                 "preflight": preflight,
+                "error": res.state.error,
+                "error_type": res.state.error_type,
                 "merge": res.merge is not None and res.merge.get("merged", False),
                 "reviews": reviews_summary,
                 "depends_on": task.depends_on if task else [],
@@ -107,6 +109,8 @@ def _write_sprint_audit(
                 "outcome": "SKIPPED",
                 "cost_usd": 0.0,
                 "preflight": None,
+                "error": None,
+                "error_type": None,
                 "merge": False,
                 "reviews": [],
                 "depends_on": task.depends_on if task else [],
@@ -201,6 +205,8 @@ def _write_sprint_summary(
                 "verdict": last_verdict or None,
                 "cost_usd": round(res.state.total_cost, 4),
                 "preflight": preflight,
+                "error": res.state.error,
+                "error_type": res.state.error_type,
                 "merge": res.merge is not None and res.merge.get("merged", False),
             }
             if slug in story_times:
@@ -215,6 +221,8 @@ def _write_sprint_summary(
                 "verdict": None,
                 "cost_usd": 0.0,
                 "preflight": None,
+                "error": None,
+                "error_type": None,
                 "merge": False,
                 "batch": batch_assignments.get(slug, 0),
             }

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -14,6 +14,7 @@ import yaml
 
 from ..config import ForgeConfig
 from ..coordinator.engine import run_from_dev, run_from_review, run_task
+from ..coordinator.log_tee import _make_story_log_dir
 from ..coordinator.logging import StructuredLogger
 from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
@@ -278,37 +279,52 @@ def _run_single_story(
     4. run_from_dev to continue
     """
     started_at = datetime.datetime.now(datetime.timezone.utc)
+    workspace_path = config.project_root / config.workspace.path_pattern.format(slug=task.slug)
 
     if state_update_fn is not None:
         state_update_fn({"spec": task.slug, "phase": "STARTING"})
 
-    if resume and triage is not None:
-        if triage.action == "review" and triage.worktree_path is not None:
-            result = run_from_review(
-                config,
-                task,
-                triage.worktree_path,
-                interactive=interactive,
-                auto_merge=effective_auto_merge,
-                notify=notify,
-                run_id=sprint_run_id,
-                sprint_name=sprint_name,
-                state_update_fn=state_update_fn,
-                no_pull=no_pull,
-            )
-        elif triage.action == "dev" and triage.worktree_path is not None:
-            result = run_from_dev(
-                config,
-                task,
-                triage.worktree_path,
-                interactive=interactive,
-                auto_merge=effective_auto_merge,
-                notify=notify,
-                run_id=sprint_run_id,
-                sprint_name=sprint_name,
-                state_update_fn=state_update_fn,
-                no_pull=no_pull,
-            )
+    try:
+        if resume and triage is not None:
+            if triage.action == "review" and triage.worktree_path is not None:
+                result = run_from_review(
+                    config,
+                    task,
+                    triage.worktree_path,
+                    interactive=interactive,
+                    auto_merge=effective_auto_merge,
+                    notify=notify,
+                    run_id=sprint_run_id,
+                    sprint_name=sprint_name,
+                    state_update_fn=state_update_fn,
+                    no_pull=no_pull,
+                )
+            elif triage.action == "dev" and triage.worktree_path is not None:
+                result = run_from_dev(
+                    config,
+                    task,
+                    triage.worktree_path,
+                    interactive=interactive,
+                    auto_merge=effective_auto_merge,
+                    notify=notify,
+                    run_id=sprint_run_id,
+                    sprint_name=sprint_name,
+                    state_update_fn=state_update_fn,
+                    no_pull=no_pull,
+                )
+            else:
+                result = _run_fresh(
+                    config,
+                    task,
+                    sprint_run_id,
+                    sprint_name,
+                    interactive,
+                    notify,
+                    effective_auto_merge,
+                    state_update_fn,
+                    no_pull,
+                    plan_gate,
+                )
         else:
             result = _run_fresh(
                 config,
@@ -322,18 +338,21 @@ def _run_single_story(
                 no_pull,
                 plan_gate,
             )
-    else:
-        result = _run_fresh(
-            config,
-            task,
-            sprint_run_id,
-            sprint_name,
-            interactive,
-            notify,
-            effective_auto_merge,
-            state_update_fn,
-            no_pull,
-            plan_gate,
+    except Exception as exc:
+        _log(f"ERROR {task.slug}: worker thread raised {type(exc).__name__}: {exc}")
+        failure_state = CoordinatorState(
+            phase=Phase.ESCALATE,
+            started_at=started_at.isoformat(),
+            workspace_path=workspace_path,
+            log_dir=_make_story_log_dir(config, task.slug, sprint_name),
+            error=f"Worker exception: {exc}",
+            error_type=type(exc).__name__,
+        )
+        result = CoordinatorResult(
+            success=False,
+            phase=Phase.ESCALATE,
+            state=failure_state,
+            message=f"Worker thread raised {type(exc).__name__}: {exc}",
         )
 
     finished_at = datetime.datetime.now(datetime.timezone.utc)
@@ -740,14 +759,25 @@ def run_sprint(
                     fut.cancel()
                     _log(f"TIMEOUT {slug} (worker unresponsive after 3600s — marking as failed)")
                     spec_str = slug_to_spec[slug]
-                    _timeout_state = CoordinatorState()
-                    _timeout_state.error = "Worker timeout (>3600s)"
+                    timed_out_at = datetime.datetime.now(datetime.timezone.utc)
+                    story_started_at = story_times.get(slug, (timed_out_at, timed_out_at))[0]
+                    _timeout_state = CoordinatorState(
+                        phase=Phase.ESCALATE,
+                        started_at=story_started_at.isoformat(),
+                        workspace_path=(
+                            config.project_root / config.workspace.path_pattern.format(slug=slug)
+                        ),
+                        log_dir=_make_story_log_dir(config, slug, resolved.name),
+                        error="Worker timeout (>3600s)",
+                        error_type="TimeoutError",
+                    )
                     _timeout_result = CoordinatorResult(
                         success=False,
                         phase=Phase.ESCALATE,
                         state=_timeout_state,
                         message="Worker thread timed out after 3600s",
                     )
+                    story_times[slug] = (story_started_at, timed_out_at)
                     results.append((spec_str, _timeout_result))
                     dag.mark_skipped(slug)
                     specs_failed += 1
@@ -764,15 +794,27 @@ def run_sprint(
                     _log(f"ERROR {slug}: worker thread raised {type(exc).__name__}: {exc}")
                     del active[slug]
                     spec_str = slug_to_spec[slug]
-                    _exc_state = CoordinatorState()
-                    _exc_state.error = f"Worker exception: {exc}"
+                    failed_at = datetime.datetime.now(datetime.timezone.utc)
+                    story_started_at = story_times.get(slug, (failed_at, failed_at))[0]
+                    _exc_state = CoordinatorState(
+                        phase=Phase.ESCALATE,
+                        started_at=story_started_at.isoformat(),
+                        workspace_path=(
+                            config.project_root / config.workspace.path_pattern.format(slug=slug)
+                        ),
+                        log_dir=_make_story_log_dir(config, slug, resolved.name),
+                        error=f"Worker exception: {exc}",
+                        error_type=type(exc).__name__,
+                    )
                     _exc_result = CoordinatorResult(
                         success=False,
                         phase=Phase.ESCALATE,
                         state=_exc_state,
                         message=f"Worker thread raised {type(exc).__name__}: {exc}",
                     )
+                    story_times[slug] = (story_started_at, failed_at)
                     results.append((spec_str, _exc_result))
+                    _write_story_audit(config, slug_to_context[slug][0], _exc_result)
                     dag.mark_skipped(slug)
                     specs_failed += 1
                     continue

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -763,6 +763,26 @@ class TestWorkerExceptionHandling:
         assert sprint.specs_failed == 1
         assert sprint.specs_succeeded == 1
 
+        sprint_audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+        sprint_audit = yaml.safe_load(sprint_audit_path.read_text(encoding="utf-8")) or {}
+        story_a_entry = next(
+            entry for entry in sprint_audit["specs"] if entry["path"] == "story-a.md"
+        )
+        assert story_a_entry["outcome"] == "ESCALATE"
+        assert story_a_entry["error"] == "Worker exception: agent crashed"
+        assert story_a_entry["error_type"] == "RuntimeError"
+        assert story_a_entry["started_at"] is not None
+        assert story_a_entry["finished_at"] is not None
+
+        durable_audit_path = (
+            tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a" / "audit.yaml"
+        )
+        durable_audit = yaml.safe_load(durable_audit_path.read_text(encoding="utf-8")) or {}
+        assert durable_audit["outcome"]["final_phase"] == "ESCALATE"
+        assert durable_audit["error"] == "Worker exception: agent crashed"
+        assert durable_audit["error_type"] == "RuntimeError"
+        assert durable_audit["timing"]["started_at"] is not None
+
     def test_worker_exception_dependent_is_skipped(self, tmp_path: Path) -> None:
         """When a worker raises, the story is marked skipped in the DAG so dependents skip too."""
         _make_spec_file(tmp_path, "Story A", "story-a")


### PR DESCRIPTION
## Summary

[codex-reviewer] No correctness issues found; the change persists worker exception details and start timing into sprint and per-story audits as specified. | [gemini-reviewer] Worker exceptions are now properly caught, typed, and persisted in both sprint and per-story audits.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** codex-reviewer, gemini-reviewer
- **Cost:** $0.47
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:785`** The timeout case in `run_sprint` (when workers hang for >3600s) creates a synthetic `CoordinatorResult` but does not call `_write_story_audit` to persist the per-story audit file, unlike the exception handling block which correctly calls it. This means timed-out stories won't have a durable per-story audit file.

## Story

Sprint runner swallows worker exceptions — ESCALATE with no error in audit (GitHub Issue #226)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #226