### PR TITLE
bug: merge-pr race — base branch modified during parallel sprint

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -18,6 +18,7 @@ from .util import _fmt_duration, _log, _log_verbose
 from .workspace import _merge_branch
 
 _pr_log = logging.getLogger(__name__)
+MAX_MERGE_RETRIES = 3
 
 
 def _archive_story_to_done(
@@ -284,84 +285,108 @@ def _merge_pr(
         except Exception as exc:
             _pr_log.warning("remote branch cleanup failed (non-fatal): %s", exc)
 
-    # Step 1: fetch + rebase onto latest base_branch
-    try:
-        fetch_proc = subprocess.run(
-            ["git", "fetch", "origin", base_branch],
-            capture_output=True,
-            text=True,
-            cwd=str(push_cwd),
-            timeout=60,
-        )
-        if fetch_proc.returncode != 0:
-            err = fetch_proc.stderr.strip() or fetch_proc.stdout.strip()
-            _pr_log.warning("git fetch failed (exit %d): %s", fetch_proc.returncode, err)
-            return _fail(f"git fetch failed: {err}")
+    pr_url: str | None = None
+    merge_retry_error = "base branch was modified"
 
-        rebase_proc = subprocess.run(
-            ["git", "rebase", f"origin/{base_branch}"],
-            capture_output=True,
-            text=True,
-            cwd=str(push_cwd),
-            timeout=120,
-        )
-        if rebase_proc.returncode != 0:
-            err = rebase_proc.stderr.strip() or rebase_proc.stdout.strip()
-            _pr_log.warning("git rebase failed (exit %d): %s", rebase_proc.returncode, err)
-            subprocess.run(
-                ["git", "rebase", "--abort"],
+    for attempt in range(MAX_MERGE_RETRIES):
+        # Step 1: fetch + rebase onto latest base_branch
+        try:
+            fetch_proc = subprocess.run(
+                ["git", "fetch", "origin", base_branch],
                 capture_output=True,
+                text=True,
                 cwd=str(push_cwd),
-                timeout=30,
+                timeout=60,
             )
-            return _fail(f"rebase onto {base_branch} failed — escalating: {err}")
-    except Exception as exc:
-        _pr_log.warning("rebase step failed: %s", exc)
-        return _fail(f"rebase step failed: {exc}")
+            if fetch_proc.returncode != 0:
+                err = fetch_proc.stderr.strip() or fetch_proc.stdout.strip()
+                _pr_log.warning("git fetch failed (exit %d): %s", fetch_proc.returncode, err)
+                return _fail(f"git fetch failed: {err}", pr_url=pr_url)
 
-    # Step 2: force-push the rebased branch so _create_pr's push is a fast-forward
-    try:
-        push_proc = subprocess.run(
-            ["git", "push", "-f", "origin", branch_name],
-            capture_output=True,
-            text=True,
-            cwd=str(push_cwd),
-            timeout=60,
-        )
-        if push_proc.returncode != 0:
-            err = push_proc.stderr.strip() or push_proc.stdout.strip()
-            _pr_log.warning("force-push failed (exit %d): %s", push_proc.returncode, err)
-            return _fail(f"force-push after rebase failed: {err}")
-    except Exception as exc:
-        _pr_log.warning("force-push failed: %s", exc)
-        return _fail(f"force-push after rebase failed: {exc}")
+            rebase_proc = subprocess.run(
+                ["git", "rebase", f"origin/{base_branch}"],
+                capture_output=True,
+                text=True,
+                cwd=str(push_cwd),
+                timeout=120,
+            )
+            if rebase_proc.returncode != 0:
+                err = rebase_proc.stderr.strip() or rebase_proc.stdout.strip()
+                _pr_log.warning("git rebase failed (exit %d): %s", rebase_proc.returncode, err)
+                subprocess.run(
+                    ["git", "rebase", "--abort"],
+                    capture_output=True,
+                    cwd=str(push_cwd),
+                    timeout=30,
+                )
+                return _fail(
+                    f"rebase onto {base_branch} failed — escalating: {err}",
+                    pr_url=pr_url,
+                )
+        except Exception as exc:
+            _pr_log.warning("rebase step failed: %s", exc)
+            return _fail(f"rebase step failed: {exc}", pr_url=pr_url)
 
-    # Step 3: create the PR (also archives story + pushes archive commit)
-    pr_result = _create_pr(config, task, branch_name, parsed_review, state)
-    if not pr_result.get("success"):
-        return _fail(
-            pr_result.get("error") or "PR creation failed",
-            pr_url=pr_result.get("pr_url"),
-        )
-    pr_url = pr_result["pr_url"]
+        # Step 2: force-push the rebased branch so _create_pr's push is a fast-forward
+        try:
+            push_proc = subprocess.run(
+                ["git", "push", "-f", "origin", branch_name],
+                capture_output=True,
+                text=True,
+                cwd=str(push_cwd),
+                timeout=60,
+            )
+            if push_proc.returncode != 0:
+                err = push_proc.stderr.strip() or push_proc.stdout.strip()
+                _pr_log.warning("force-push failed (exit %d): %s", push_proc.returncode, err)
+                return _fail(f"force-push after rebase failed: {err}", pr_url=pr_url)
+        except Exception as exc:
+            _pr_log.warning("force-push failed: %s", exc)
+            return _fail(f"force-push after rebase failed: {exc}", pr_url=pr_url)
 
-    # Step 4: merge the PR remotely from the repo root. Running gh from the
-    # feature worktree can trip worktree branch checkout constraints.
-    try:
-        merge_proc = subprocess.run(
-            ["gh", "pr", "merge", pr_url, f"--{merge_strategy}"],
-            capture_output=True,
-            text=True,
-            cwd=str(config.project_root),
-            timeout=120,
+        # Step 3: create the PR only once (also archives story + pushes archive commit)
+        if attempt == 0:
+            pr_result = _create_pr(config, task, branch_name, parsed_review, state)
+            if not pr_result.get("success"):
+                return _fail(
+                    pr_result.get("error") or "PR creation failed",
+                    pr_url=pr_result.get("pr_url"),
+                )
+            pr_url = pr_result["pr_url"]
+
+        # Step 4: merge the PR remotely from the repo root. Running gh from the
+        # feature worktree can trip worktree branch checkout constraints.
+        try:
+            merge_proc = subprocess.run(
+                ["gh", "pr", "merge", pr_url, f"--{merge_strategy}"],
+                capture_output=True,
+                text=True,
+                cwd=str(config.project_root),
+                timeout=120,
+            )
+        except Exception as exc:
+            _pr_log.warning("gh pr merge failed: %s", exc)
+            return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
+
+        if merge_proc.returncode == 0:
+            break
+
+        err = "\n".join(
+            part.strip()
+            for part in (merge_proc.stderr, merge_proc.stdout)
+            if part and part.strip()
         )
-        if merge_proc.returncode != 0:
-            err = merge_proc.stderr.strip() or merge_proc.stdout.strip()
-            _pr_log.warning("gh pr merge failed (exit %d): %s", merge_proc.returncode, err)
+        _pr_log.warning("gh pr merge failed (exit %d): %s", merge_proc.returncode, err)
+        if merge_retry_error in err.lower():
+            if attempt < MAX_MERGE_RETRIES - 1:
+                _pr_log.warning(
+                    "base branch changed during PR merge attempt %d/%d; retrying",
+                    attempt + 1,
+                    MAX_MERGE_RETRIES,
+                )
+                continue
             return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
-    except Exception as exc:
-        _pr_log.warning("gh pr merge failed: %s", exc)
-        return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
+        return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
 
     _log(f"  ✓ PR merged: {pr_url}")
 

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -21,7 +21,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
-from theforge.coordinator.completion import _merge_pr
+from theforge.coordinator.completion import MAX_MERGE_RETRIES, _merge_pr
 from theforge.review import ReviewResult
 
 # ── Helpers ───────────────────────────────────────────────────────
@@ -135,6 +135,7 @@ class TestMergePrFunction:
         push_ok: bool = True,
         create_pr_result: dict | None = None,
         gh_merge_ok: bool = True,
+        gh_merge_results: list[MagicMock] | None = None,
         fetch_after_ok: bool = True,
     ) -> dict:
         """Run _merge_pr with mocked subprocess.run and _create_pr."""
@@ -180,6 +181,10 @@ class TestMergePrFunction:
         def _fake_gh_run(cmd, **kwargs):
             cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
             if "gh" in cmd_str and "pr" in cmd_str and "merge" in cmd_str:
+                if gh_merge_results is not None:
+                    if gh_merge_results:
+                        return gh_merge_results.pop(0)
+                    return _make_subprocess_result(0)
                 rc = 0 if gh_merge_ok else 1
                 err = "" if gh_merge_ok else "merge failed"
                 return _make_subprocess_result(rc, stderr=err)
@@ -240,6 +245,170 @@ class TestMergePrFunction:
         assert result["success"] is False
         assert result["pr_url"] == "https://github.com/fuzzypete/theforge/pull/42"
         assert "merge failed" in result["error"] or "gh pr merge" in result["error"].lower()
+
+    def test_base_branch_modified_retries_then_succeeds(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        call_counts = {"fetch": 0, "rebase": 0, "push": 0}
+        merge_results = [
+            _make_subprocess_result(
+                1,
+                stderr="GraphQL: Base branch was modified. Review and try the merge again.",
+            ),
+            _make_subprocess_result(0),
+        ]
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:4] == [
+                "git",
+                "fetch",
+                "origin",
+                config.workspace.base_branch,
+            ]:
+                call_counts["fetch"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:2] == ["git", "rebase"] and "--abort" not in cmd:
+                call_counts["rebase"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:4] == ["git", "push", "-f", "origin"]:
+                call_counts["push"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                return merge_results.pop(0)
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/42",
+                    "success": True,
+                    "error": None,
+                },
+            ) as mock_create_pr,
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        assert result["merged"] is True
+        assert mock_create_pr.call_count == 1
+        assert call_counts == {"fetch": 2, "rebase": 2, "push": 2}
+
+    def test_base_branch_modified_exhausts_retry_limit(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        call_counts = {"fetch": 0, "rebase": 0, "push": 0, "merge": 0}
+        merge_error = "GraphQL: Base branch was modified. Review and try the merge again."
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:4] == [
+                "git",
+                "fetch",
+                "origin",
+                config.workspace.base_branch,
+            ]:
+                call_counts["fetch"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:2] == ["git", "rebase"] and "--abort" not in cmd:
+                call_counts["rebase"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:4] == ["git", "push", "-f", "origin"]:
+                call_counts["push"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                call_counts["merge"] += 1
+                return _make_subprocess_result(1, stderr=merge_error)
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/42",
+                    "success": True,
+                    "error": None,
+                },
+            ) as mock_create_pr,
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is False
+        assert result["merged"] is False
+        assert result["pr_url"] == "https://github.com/fuzzypete/theforge/pull/42"
+        assert merge_error in result["error"]
+        assert mock_create_pr.call_count == 1
+        assert call_counts == {
+            "fetch": MAX_MERGE_RETRIES,
+            "rebase": MAX_MERGE_RETRIES,
+            "push": MAX_MERGE_RETRIES,
+            "merge": MAX_MERGE_RETRIES,
+        }
+
+    def test_non_retryable_merge_failure_does_not_retry(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        call_counts = {"fetch": 0, "rebase": 0, "push": 0, "merge": 0}
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:4] == [
+                "git",
+                "fetch",
+                "origin",
+                config.workspace.base_branch,
+            ]:
+                call_counts["fetch"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:2] == ["git", "rebase"] and "--abort" not in cmd:
+                call_counts["rebase"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:4] == ["git", "push", "-f", "origin"]:
+                call_counts["push"] += 1
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                call_counts["merge"] += 1
+                return _make_subprocess_result(1, stderr="merge blocked by branch protection")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/42",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is False
+        assert result["merged"] is False
+        assert "branch protection" in result["error"]
+        assert call_counts == {"fetch": 1, "rebase": 1, "push": 1, "merge": 1}
 
     def test_merge_strategy_squash_passed_to_gh(self, tmp_path: Path) -> None:
         """Verify --squash is passed to gh pr merge."""


### PR DESCRIPTION
## Summary

[codex-reviewer] Implementation matches the merge-pr race spec and the retry path is exercised in runtime callers and tests | [gemini-reviewer] The implementation correctly adds a bounded retry loop to the merge process, specifically for the 'base branch was modified' error, and includes comprehensive unit tests for the new logic.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** codex-reviewer, gemini-reviewer
- **Cost:** $0.33
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: merge-pr race — base branch modified during parallel sprint (GitHub Issue #394)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #394