### PR TITLE
forge sprint --issues: select stories by issue number without a label or manifest

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -23,32 +23,47 @@ def cmd_sprint(args: object) -> int:
 
     milestone: str | None = getattr(args, "milestone", None)
     label: str | None = getattr(args, "label", None)
-    query_mode = bool(milestone or label)
+    issues_arg: str | None = getattr(args, "issues", None)
+    query_mode = bool(milestone or label or issues_arg)
     manifest_arg: str | None = getattr(args, "manifest", None)
 
     # ── Validate argument combinations ──────────────────────────────────
     if not query_mode and not manifest_arg:
         print(
-            "forge sprint: provide a manifest path or use --milestone/--label",
+            "forge sprint: provide a manifest path or use --milestone/--label/--issues",
             file=sys.stderr,
         )
         return 1
 
     if query_mode and manifest_arg:
         print(
-            "forge sprint: --milestone/--label and a manifest path are mutually exclusive",
+            "forge sprint: --milestone/--label/--issues and a manifest path "
+            "are mutually exclusive",
             file=sys.stderr,
         )
         return 1
 
-    if milestone and label:
-        print("forge sprint: --milestone and --label are mutually exclusive", file=sys.stderr)
+    selected_queries = [
+        flag
+        for flag, value in (
+            ("--milestone", milestone),
+            ("--label", label),
+            ("--issues", issues_arg),
+        )
+        if value
+    ]
+    if len(selected_queries) > 1:
+        print(
+            f"forge sprint: {', '.join(selected_queries)} are mutually exclusive",
+            file=sys.stderr,
+        )
         return 1
 
     budget_str: str | None = getattr(args, "budget", None)
     if query_mode and budget_str is None:
         print(
-            "forge sprint: --budget <usd> is required when using --milestone or --label",
+            "forge sprint: --budget <usd> is required when using "
+            "--milestone, --label, or --issues",
             file=sys.stderr,
         )
         return 1
@@ -92,6 +107,7 @@ def cmd_sprint(args: object) -> int:
             config_path=config_path,
             milestone=milestone,
             label=label,
+            issues_arg=issues_arg,
             budget_str=budget_str,
             dry_run=dry_run,
             max_parallel=max_parallel,
@@ -182,6 +198,7 @@ def _run_query_mode(
     config_path: Path,
     milestone: str | None,
     label: str | None,
+    issues_arg: str | None = None,
     budget_str: str | None,
     dry_run: bool,
     max_parallel: int | None,
@@ -193,11 +210,12 @@ def _run_query_mode(
     _detach: object,
     _generate_run_id: object,
 ) -> int:
-    """Handle --milestone / --label query mode."""
+    """Handle --milestone / --label / --issues query mode."""
     from theforge.sprint.dag import resolve_satisfied_dependencies
     from theforge.sprint.query import (
         assign_dependency_batches_with_satisfied,
         build_resolved_sprint,
+        fetch_issues_by_numbers,
         fetch_issues_for_label,
         fetch_issues_for_milestone,
     )
@@ -214,14 +232,25 @@ def _run_query_mode(
     # Query mode is sequential by default unless the caller explicitly opts in.
     effective_max_parallel = 1 if max_parallel is None else max_parallel
 
-    query_desc = f"milestone '{milestone}'" if milestone else f"label '{label}'"
+    query_desc = (
+        f"milestone '{milestone}'"
+        if milestone
+        else f"label '{label}'"
+        if label
+        else f"issues '{issues_arg}'"
+    )
 
     # Fetch issue list (lightweight — just numbers and titles)
     try:
         if milestone:
             issues = fetch_issues_for_milestone(milestone, config.project_root)
-        else:
+        elif label:
             issues = fetch_issues_for_label(label, config.project_root)
+        else:
+            issue_numbers = [int(part.strip()) for part in issues_arg.split(",") if part.strip()]
+            if not issue_numbers:
+                raise RuntimeError("No issue numbers provided")
+            issues = fetch_issues_by_numbers(issue_numbers, config.project_root)
     except RuntimeError as exc:
         print(f"[forge] GitHub query failed for {query_desc}: {exc}", file=sys.stderr)
         return 1
@@ -233,7 +262,7 @@ def _run_query_mode(
         )
         return 0
 
-    sprint_name: str = getattr(args, "name", None) or milestone or label
+    sprint_name: str = getattr(args, "name", None) or milestone or label or f"issues-{issues_arg}"
 
     # Build full ResolvedSprint (fetches individual issue bodies via gh)
     try:
@@ -304,7 +333,7 @@ def _run_query_mode(
     if getattr(args, "detach", False) and _daemon.is_daemon_running(config.project_root):
         release_story_locks(locked_fds)
         print(
-            "[forge] --detach is not supported in query mode (--milestone/--label).\n"
+            "[forge] --detach is not supported in query mode (--milestone/--label/--issues).\n"
             "        Run with --fg or without --detach instead.",
             file=sys.stderr,
         )
@@ -340,12 +369,12 @@ def register_parser(subparsers: object) -> None:
         "sprint",
         help="Run multiple stories from a sprint manifest or GitHub query",
     )
-    # Manifest path is now optional — query mode uses --milestone/--label instead
+    # Manifest path is now optional — query mode uses --milestone/--label/--issues instead
     sprint_parser.add_argument(
         "manifest",
         nargs="?",
         default=None,
-        help="Path to sprint.yaml manifest (omit when using --milestone or --label)",
+        help="Path to sprint.yaml manifest (omit when using --milestone, --label, or --issues)",
     )
     sprint_parser.add_argument("--config", help="Path to forge.yaml (default: auto-detect)")
 
@@ -361,9 +390,15 @@ def register_parser(subparsers: object) -> None:
         help="Run all open issues with a GitHub label (requires --budget)",
     )
     sprint_parser.add_argument(
+        "--issues",
+        metavar="N[,N,...]",
+        default=None,
+        help="Run specific GitHub issues by comma-separated number (requires --budget)",
+    )
+    sprint_parser.add_argument(
         "--budget",
         metavar="USD",
-        help="Budget ceiling in USD (required for --milestone/--label)",
+        help="Budget ceiling in USD (required for --milestone/--label/--issues)",
     )
     sprint_parser.add_argument(
         "--name",

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -155,6 +155,47 @@ def fetch_issues_for_label(
     return sorted(issues, key=lambda x: x["number"])
 
 
+def fetch_issues_by_numbers(
+    numbers: list[int],
+    project_root: Path | None = None,
+) -> list[dict]:
+    """Fetch specific issues by number.
+
+    Returns a list of ``{"number": int, "title": str}`` dicts ordered by number.
+    Raises ``RuntimeError`` if any requested issue is missing or a ``gh`` call fails.
+    """
+    issues: list[dict] = []
+    found_numbers: set[int] = set()
+
+    for number in numbers:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(number), "--json", "number,title"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root) if project_root else None,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if "Could not resolve to an issue" in stderr or "not found" in stderr.lower():
+                continue
+            raise RuntimeError(f"gh issue view {number!r} failed: {stderr}")
+        try:
+            issue = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"gh issue view returned malformed JSON for #{number}: {exc}"
+            ) from exc
+        issues.append({"number": issue["number"], "title": issue["title"]})
+        found_numbers.add(issue["number"])
+
+    missing = sorted(set(numbers) - found_numbers)
+    if missing:
+        missing_str = ", ".join(str(number) for number in missing)
+        raise RuntimeError(f"Issue number(s) not found in this repository: {missing_str}")
+
+    return sorted(issues, key=lambda x: x["number"])
+
+
 def assign_dependency_batches(
     tasks: list["TaskStory"],
     max_parallel: int | None,

--- a/tests/test_sprint_issues_query.py
+++ b/tests/test_sprint_issues_query.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.cli.sprint import cmd_sprint
+from theforge.config import (
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.sprint.query import fetch_issues_by_numbers
+
+
+def _api_profile(
+    name: str, provider: str = "anthropic", model: str = "claude-opus-4-6"
+) -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        provider=provider,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=120,
+        allowed_tools=("Read", "Grep"),
+    )
+
+
+def _make_forge_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        ),
+        preflight_profile=ModelProfile(
+            name="preflight",
+            cli="claude",
+            model="sonnet",
+            budget_usd=0.5,
+            timeout_seconds=120,
+            allowed_tools=("Read",),
+        ),
+        review_pool=[_api_profile("claude-reviewer"), _api_profile("codex-reviewer", "openai")],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        plan_agent_review=PlanAgentReviewConfig(enabled=False),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _make_args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    config_path = tmp_path / "forge.yaml"
+    if not config_path.exists():
+        config_path.write_text("project:\n  root: .\n", encoding="utf-8")
+    base = dict(
+        manifest=None,
+        config=None,
+        fg=True,
+        detach=False,
+        resume=False,
+        milestone=None,
+        label=None,
+        issues="403,405",
+        budget="10",
+        parallel=1,
+        name=None,
+        dry_run=True,
+        auto_merge=False,
+        interactive=False,
+        verbose=False,
+        no_notify=True,
+        no_pull=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestFetchIssuesByNumbers:
+    def test_fetches_and_sorts_requested_issues(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0, stdout=json.dumps({"number": 405, "title": "B"}), stderr=""
+                ),
+                MagicMock(
+                    returncode=0, stdout=json.dumps({"number": 403, "title": "A"}), stderr=""
+                ),
+            ]
+            issues = fetch_issues_by_numbers([405, 403], tmp_path)
+        assert issues == [{"number": 403, "title": "A"}, {"number": 405, "title": "B"}]
+
+    def test_raises_when_any_issue_is_missing(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0, stdout=json.dumps({"number": 403, "title": "A"}), stderr=""
+                ),
+                MagicMock(returncode=1, stdout="", stderr="Could not resolve to an issue"),
+            ]
+            try:
+                fetch_issues_by_numbers([403, 405], tmp_path)
+            except RuntimeError as exc:
+                assert "405" in str(exc)
+            else:
+                raise AssertionError("Expected RuntimeError")
+
+
+class TestCmdSprintIssuesValidation:
+    def test_issues_and_milestone_are_mutually_exclusive(self, tmp_path: Path, capsys) -> None:
+        args = _make_args(tmp_path, milestone="v1")
+        rc = cmd_sprint(args)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "mutually exclusive" in err
+
+    def test_issues_and_label_are_mutually_exclusive(self, tmp_path: Path, capsys) -> None:
+        args = _make_args(tmp_path, label="bug")
+        rc = cmd_sprint(args)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "mutually exclusive" in err
+
+    def test_issues_and_manifest_are_mutually_exclusive(self, tmp_path: Path, capsys) -> None:
+        args = _make_args(tmp_path, manifest="sprint.yaml")
+        rc = cmd_sprint(args)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "mutually exclusive" in err
+
+    def test_budget_required_with_issues(self, tmp_path: Path, capsys) -> None:
+        args = _make_args(tmp_path, budget=None)
+        rc = cmd_sprint(args)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "--budget <usd> is required" in err
+
+    def test_query_mode_uses_requested_issue_numbers(self, tmp_path: Path) -> None:
+        config = _make_forge_config(tmp_path)
+        args = _make_args(tmp_path)
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.sprint.query.fetch_issues_by_numbers",
+                return_value=[{"number": 403, "title": "A"}, {"number": 405, "title": "B"}],
+            ) as mock_fetch,
+            patch("theforge.sprint.query.build_resolved_sprint") as mock_build,
+        ):
+            mock_build.return_value = MagicMock(stories=[])
+            rc = cmd_sprint(args)
+        assert rc == 0
+        mock_fetch.assert_called_once_with([403, 405], tmp_path)


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation correctly adds --issues option with mutual exclusion, budget enforcement, error handling, and help documentation | [gemini-reviewer] The implementation correctly adds the `--issues` flag with proper validation, error handling, and testing, fully meeting all acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.56
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge sprint --issues: select stories by issue number without a label or manifest (GitHub Issue #406)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #406