### PR TITLE
Sprint parallel mode silently skips dependent stories without auto_merge

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -621,6 +621,19 @@ def run_sprint(
                 merged_slugs.add(slug)
                 dag.mark_complete(slug)
 
+    auto_enabled_dependency_merges = dependent_slugs - satisfied_slugs - merged_slugs
+    if (
+        max_parallel > 1
+        and not auto_merge
+        and config.workspace.on_approve != "merge-pr"
+        and auto_enabled_dependency_merges
+    ):
+        listed = ", ".join(sorted(auto_enabled_dependency_merges))
+        _log(
+            "WARN: parallel dependency merging auto-enabled for "
+            f"{listed} so dependent stories are not silently skipped"
+        )
+
     # Stories blocked by unresolved external dependencies never enter the DAG.
     for slug, blocked_by in blocked_slugs.items():
         _log(f"SKIPPED {slug} (blocked: {', '.join(blocked_by)})")
@@ -878,7 +891,11 @@ def run_sprint(
                             _log(f"WARN on_escalate callback failed for {slug}: {exc}")
 
                 # In parallel mode, merge actions are serialized in the main thread.
-                needs_deferred_merge = auto_merge or config.workspace.on_approve == "merge-pr"
+                needs_deferred_merge = (
+                    auto_merge
+                    or config.workspace.on_approve == "merge-pr"
+                    or slug in dependent_slugs
+                )
                 if max_parallel > 1 and needs_deferred_merge and result.success:
                     pending_merges[slug] = (task, result)
 
@@ -889,7 +906,9 @@ def run_sprint(
                 _release_plan_gates(plan_done, file_footprints, plan_gates, active, phase_lock)
 
             # Flush pending merges in dependency order (parallel mode only)
-            needs_flush = auto_merge or config.workspace.on_approve == "merge-pr"
+            needs_flush = (
+                auto_merge or config.workspace.on_approve == "merge-pr" or bool(dependent_slugs)
+            )
             if max_parallel > 1 and needs_flush and pending_merges:
                 changed = True
                 while changed:

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -435,14 +435,15 @@ class TestParallelDependencyGating:
         )
         config = _make_config(tmp_path)
 
-        # A succeeds but does NOT merge → B should be skipped
+        # A succeeds but deferred merge fails → B should be skipped
         result_a = _make_coordinator_result(success=True, cost=1.0, merged=False)
 
         with patch("theforge.sprint.runner.run_task", side_effect=[result_a]) as mock_run:
             sprint = run_sprint(config, manifest_path)
 
         assert mock_run.call_count == 1  # only A ran
-        assert sprint.specs_succeeded == 1
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
         assert sprint.specs_skipped == 1
 
     def test_dependency_satisfied_by_merge_unlocks_dependent(self, tmp_path: Path) -> None:
@@ -807,6 +808,48 @@ class TestWorkerExceptionHandling:
 
 
 # ── TestParallelMergeOrderingParallelMode ─────────────────────────────────────
+
+
+class TestParallelDependencySafety:
+    def test_parallel_dep_without_auto_merge_runs_dependent_story_and_warns(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Parallel depends_on auto-enables deferred merges so dependents are not skipped."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b", depends_on=["story-a"])
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md", "story-b.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = _make_config(tmp_path)
+
+        result_a = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        result_b = _make_coordinator_result(success=True, cost=1.0, merged=False)
+
+        merge_calls: list[str] = []
+
+        def _fake_merge(project_root, base_branch, branch, slug, wt, **kwargs):  # noqa: ANN001
+            merge_calls.append(slug)
+            return {"merged": True}
+
+        with (
+            patch("theforge.sprint.runner.run_task", side_effect=[result_a, result_b]) as mock_run,
+            patch("theforge.sprint.runner._merge_branch", side_effect=_fake_merge),
+        ):
+            sprint = run_sprint(config, manifest_path, auto_merge=False)
+
+        assert sprint.specs_succeeded == 2
+        assert sprint.specs_failed == 0
+        assert sprint.specs_skipped == 0
+        assert mock_run.call_count == 2
+        assert [call.args[1].slug for call in mock_run.call_args_list] == ["story-a", "story-b"]
+        assert merge_calls == ["story-a"]
+
+        captured = capsys.readouterr()
+        assert "parallel dependency merging auto-enabled" in captured.err
+        assert "story-a" in captured.err
 
 
 class TestParallelMergeOrderingParallelMode:


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation auto-enables dependency merges with warning and flushes merges in parallel mode, satisfying acceptance criteria with tests covering the behavior. | [gemini-reviewer] The changes correctly address the issue of dependent stories being silently skipped in parallel mode by auto-enabling merges for dependency source stories and emitting a warning. The implementation is robust and is accompanied by a precise test case that verifies the new behavior.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.64
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint parallel mode silently skips dependent stories without auto_merge (GitHub Issue #351)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #351