### PR TITLE
bug: dev agent re-commits .forge/handoff.yaml after workspace deindex

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -16,7 +16,7 @@ from .logging import StructuredLogger
 from .notify import _ntfy_done_notify
 from .state import CoordinatorResult, CoordinatorState, CycleHistory, Phase
 from .util import _fmt_duration, _log, _log_verbose
-from .workspace import _merge_branch
+from .workspace import _deindex_forge_artifacts, _merge_branch
 
 _pr_log = logging.getLogger(__name__)
 MAX_MERGE_RETRIES = 3
@@ -304,7 +304,10 @@ def _merge_pr(
     merge_retry_error = "base branch was modified"
 
     for attempt in range(MAX_MERGE_RETRIES):
-        # Step 1: fetch + rebase onto latest base_branch
+        # Step 1: defensively scrub tracked forge artifacts before rebase.
+        _deindex_forge_artifacts(push_cwd)
+
+        # Step 2: fetch + rebase onto latest base_branch
         try:
             fetch_proc = subprocess.run(
                 ["git", "fetch", "origin", base_branch],
@@ -342,7 +345,7 @@ def _merge_pr(
             _pr_log.warning("rebase step failed: %s", exc)
             return _fail(f"rebase step failed: {exc}", pr_url=pr_url)
 
-        # Step 2: force-push the rebased branch so _create_pr's push is a fast-forward
+        # Step 3: force-push the rebased branch so _create_pr's push is a fast-forward
         try:
             push_proc = subprocess.run(
                 ["git", "push", "-f", "origin", branch_name],
@@ -369,7 +372,11 @@ def _merge_pr(
                 )
             pr_url = pr_result["pr_url"]
 
-        # Step 4: merge the PR remotely from the repo root. Running gh from the
+        # Step 4: defensively scrub tracked forge artifacts again after rebase,
+        # before any push/merge consumes the rewritten commit graph.
+        _deindex_forge_artifacts(push_cwd)
+
+        # Step 5: merge the PR remotely from the repo root. Running gh from the
         # feature worktree can trip worktree branch checkout constraints.
         try:
             merge_proc = subprocess.run(
@@ -405,7 +412,7 @@ def _merge_pr(
 
     _log(f"  ✓ PR merged: {pr_url}")
 
-    # Step 5: sync local state and clean up the merged feature worktree/branch.
+    # Step 6: sync local state and clean up the merged feature worktree/branch.
     _cleanup_after_merge()
 
     return {

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -149,6 +149,7 @@ def _run_validate_phase(
                         f"wip: uncommitted changes from dev iteration {state.dev_iteration}"
                     )
                 _cu._run_shell("git add -A", workspace_path)
+                _deindex_forge_artifacts(workspace_path)
                 # Use subprocess.run directly to avoid shell injection
                 # from model-authored dev_notes (quotes, backticks, $()).
                 try:

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -182,6 +182,8 @@ def _merge_branch(
         _cu._log(f"Auto-merge skipped: {info['error']}")
         return info
 
+    _deindex_forge_artifacts(workspace_path)
+
     ok, out = _cu._run_shell(f"git checkout {base_branch}", project_root)
     if not ok:
         info["error"] = f"Failed to checkout {base_branch!r}: {out}"
@@ -344,9 +346,12 @@ def _deindex_forge_artifacts(workspace_path: Path) -> None:
 
     Uses -f so removal succeeds even when the index entry has staged content that
     differs from both HEAD and the working tree (the agent-misbehavior state described
-    in the story).  Uses --ignore-unmatch so the call is a no-op when files are not
-    tracked.  This prevents merge conflicts and dirty-worktree noise from gitignored
+    in the story). Uses --ignore-unmatch so the call is a no-op when files are not
+    tracked. This prevents merge conflicts and dirty-worktree noise from gitignored
     files that were previously committed or accidentally staged.
+
+    This helper is intentionally safe to run repeatedly at workspace setup, after the
+    dev phase, and immediately before rebase/merge operations.
     """
     files_arg = " ".join(_FORGE_ARTIFACTS)
     ok, out = _cu._run_shell(f"git rm -f --cached --ignore-unmatch {files_arg}", workspace_path)

--- a/tests/test_coord_gate_exec.py
+++ b/tests/test_coord_gate_exec.py
@@ -246,12 +246,58 @@ class TestCoordinatorDirtyWorktree:
         assert result.success is True
         assert result.phase == Phase.DONE
         assert mock_agent.call_count == 1
-        mock_deindex.assert_called_once_with(workspace)
+        assert mock_deindex.call_count == 2
+        assert mock_deindex.call_args_list[0].args == (workspace,)
+        assert mock_deindex.call_args_list[1].args == (workspace,)
         assert any("git add" in c for c in shell_cmds)
         assert any(
             c[0][0] == ["git", "commit", "-m", mock.ANY] for c in mock_subprocess.call_args_list
         )
         assert mock_subprocess.call_args[0][0] == ["git", "commit", "-m", mock.ANY]
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dirty_worktree_deindexes_before_status_and_after_git_add(
+        self, mock_shell, mock_deindex, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """PASS path scrubs forge artifacts before status and again after staging dirty files."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        shell_cmds: list[str] = []
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            shell_cmds.append(cmd)
+            if "gate" in cmd:
+                _write_handoff(Path(cwd), "PASS")
+                return (True, "OK")
+            if "git status --porcelain" in cmd:
+                return (True, " M src/theforge/runner.py")
+            if "git add" in cmd:
+                return (True, "")
+            return (True, "OK")
+
+        mock_shell.side_effect = shell_side_effect
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.return_value = _make_agent_result(success=True, output="Done.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        with patch("theforge.coordinator.validate_phase.subprocess.run"):
+            result = run_task(config, task)
+
+        assert result.success is True
+        assert mock_deindex.call_count == 2
+        assert mock_deindex.call_args_list[0].args == (workspace,)
+        assert mock_deindex.call_args_list[1].args == (workspace,)
+        assert any("git status --porcelain" in c for c in shell_cmds)
+        assert any("git add -A" in c for c in shell_cmds)
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -409,6 +409,42 @@ class TestDeindexForgeArtifacts:
         assert cwd_used == workspace
 
 
+@patch("theforge.coordinator.workspace._deindex_forge_artifacts")
+@patch("theforge.coordinator.workspace._cu._run_shell")
+def test_merge_branch_deindexes_workspace_before_merge(mock_shell, mock_deindex, tmp_path):
+    """_merge_branch scrubs tracked forge artifacts from the workspace before merge."""
+    from theforge.coordinator.workspace import _merge_branch
+
+    workspace = tmp_path / "wt"
+    workspace.mkdir()
+
+    def shell_side_effect(cmd, cwd, **kwargs):
+        if "git branch --list" in cmd:
+            return (True, "* main")
+        if "git status --porcelain" in cmd:
+            return (True, "")
+        if "git log main..forge/issue-1 --oneline" in cmd:
+            return (True, "abc123 feat: change")
+        if "git checkout main" in cmd:
+            return (True, "")
+        if "git merge --ff-only forge/issue-1" in cmd:
+            return (True, "")
+        return (True, "")
+
+    mock_shell.side_effect = shell_side_effect
+
+    info = _merge_branch(
+        project_root=tmp_path,
+        base_branch="main",
+        branch_name="forge/issue-1",
+        slug="issue-1",
+        workspace_path=workspace,
+    )
+
+    assert info["merged"] is True
+    mock_deindex.assert_called_once_with(workspace)
+
+
 class TestDeindexRunsOnAllReturnPaths:
     """_create_workspace calls _deindex_forge_artifacts on every successful return path."""
 


### PR DESCRIPTION
## Summary

Implementation enforces deindexing of forge artifacts at validate and merge points, satisfying acceptance criteria with appropriate tests

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer
- **Cost:** $0.21
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: dev agent re-commits .forge/handoff.yaml after workspace deindex (GitHub Issue #434)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #434