### PR TITLE
bug: preflight returning invalid verdict (APPROVE) silently falls through with empty likely_files

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -20,9 +20,9 @@ _VALID_PREFLIGHT_VERDICTS = frozenset({"PROCEED", "ALREADY_DONE", "BLOCKED"})
 def _parse_preflight_verdict(output: str) -> tuple[str, str]:
     """Extract verdict and reason from preflight agent output.
 
-    Returns (verdict, reason). If parsing fails, returns ("PROCEED", reason)
-    to avoid blocking on a broken preflight — it's cheaper to try DEV than
-    to stall.
+    Returns (verdict, reason). Parse failures still fail open to PROCEED, but
+    unrecognized verdict values are treated as BLOCKED because downstream
+    classifications from a confused preflight are unreliable.
     """
     # Extract YAML block from markdown fences
     yaml_text = output
@@ -47,7 +47,11 @@ def _parse_preflight_verdict(output: str) -> tuple[str, str]:
     reason = str(parsed.get("reason", "(no reason provided)"))
 
     if verdict not in _VALID_PREFLIGHT_VERDICTS:
-        return "PROCEED", f"Unknown preflight verdict {verdict!r}; proceeding anyway. {reason}"
+        return (
+            "BLOCKED",
+            "Unknown preflight verdict "
+            f"{verdict!r}; escalating because preflight output is invalid. {reason}",
+        )
 
     return verdict, reason
 

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -205,6 +205,47 @@ class TestCoordinatorPreflight:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
+    def test_preflight_unknown_verdict_escalates(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Unknown preflight verdicts are treated as hard failures."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.return_value = (True, "OK")
+        mock_preflight.return_value = _make_agent_result(
+            success=True,
+            output="""```yaml
+verdict: APPROVE
+complexity: small
+reason: \"Model returned a review verdict during preflight.\"
+likely_files:
+  - src/theforge/coordinator/preflight_flow.py
+```
+""",
+            cost_usd=0.05,
+            profile_name="review",
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.preflight_verdict == "BLOCKED"
+        assert "unknown preflight verdict" in result.state.preflight_reason.lower()
+        assert result.state.preflight_likely_files == [
+            "src/theforge/coordinator/preflight_flow.py"
+        ]
+        assert len(result.state.dev_results) == 0
+        mock_pool.assert_not_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
     def test_preflight_cost_in_audit(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):


### PR DESCRIPTION
## Summary

Preflight unknown verdict handling is correct and matches acceptance criteria

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer
- **Cost:** $0.59
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: preflight returning invalid verdict (APPROVE) silently falls through with empty likely_files (GitHub Issue #435)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #435