### PR TITLE
Sprint run.log appends across restarts — no single coherent audit record

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -176,6 +176,7 @@ def cmd_sprint(args: object) -> int:
             notify=not args.no_notify,
             resume=resume,
             no_pull=no_pull,
+            run_id=run_id,
         )
     except Exception as exc:
         import traceback
@@ -355,6 +356,7 @@ def _run_query_mode(
             notify=not args.no_notify,
             resume=resume,
             no_pull=no_pull,
+            run_id=run_id,
         )
     except Exception as exc:
         import traceback

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -168,21 +168,23 @@ def read_run_status(run_id: str, slug: str, project_root: Path) -> dict:
 def _find_log_path(slug: str, run_id: str, project_root: Path) -> Path | None:
     """Find the log file for a run.
 
-    Checks .forge/logs/<slug>/run.log first (new-style from daemonization),
-    then falls back to searching for run-<run_id>.log in any log subdirectory.
+    Checks .forge/logs/<slug>/run-<run_id>.log first, then falls back to
+    searching for the same filename in any log subdirectory. Finally, falls
+    back to the legacy shared run.log path for pre-migration runs.
     """
-    # New-style log path (written by daemonize_run)
-    new_style = project_root / ".forge" / "logs" / slug / "run.log"
+    new_style = project_root / ".forge" / "logs" / slug / f"run-{run_id}.log"
     if new_style.exists():
         return new_style
 
-    # Fallback: search for run-<run_id>.log
     logs_dir = project_root / ".forge" / "logs"
     if logs_dir.exists():
         for match in logs_dir.rglob(f"run-{run_id}.log"):
             return match
 
-    # Return the expected new-style path even if it doesn't exist yet
+    legacy = project_root / ".forge" / "logs" / slug / "run.log"
+    if legacy.exists():
+        return legacy
+
     return new_style
 
 
@@ -247,7 +249,7 @@ def daemonize_run(run_id: str, slug: str, project_root: Path) -> None:
 
     Raises RuntimeError if os.fork() is unavailable (Windows).
     """
-    log_file = project_root / ".forge" / "logs" / slug / "run.log"
+    log_file = project_root / ".forge" / "logs" / slug / f"run-{run_id}.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Save original stdout for the pre-fork print

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -173,6 +173,7 @@ def _write_sprint_summary(
     story_times: "dict[str, tuple[datetime.datetime, datetime.datetime]] | None" = None,
     batch_assignments: "dict[str, int] | None" = None,
     slug_map: "dict[str, str] | None" = None,
+    run_id: str | None = None,
 ) -> None:
     """Write sprint-summary.yaml to <project_root>/.forge/logs/<sprint-name>/."""
     story_times = story_times or {}
@@ -233,6 +234,8 @@ def _write_sprint_summary(
             "name": manifest.name,
             "budget_usd": manifest.budget_usd,
             "max_parallel": manifest.max_parallel,
+            "run_id": run_id,
+            "run_log": f"run-{run_id}.log" if run_id else None,
             "total_cost_usd": round(result.total_cost_usd, 4),
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -444,6 +444,7 @@ def run_sprint(
     resume: bool = False,
     state_update_fn: "Callable[[dict], None] | None" = None,
     no_pull: bool = False,
+    run_id: str | None = None,
 ) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -520,6 +521,7 @@ def run_sprint(
     _log("⚠ Budget tracks Claude costs only (Codex/Gemini report $0.00)")
 
     # Sprint-level structured logger
+    _cli_run_id = run_id
     _sprint_run_id = _generate_run_id()
     _sprint_logger = StructuredLogger(
         run_id=_sprint_run_id,
@@ -1085,6 +1087,7 @@ def run_sprint(
             story_times=story_times,
             batch_assignments=batch_assignments,
             slug_map=slug_map,
+            run_id=_cli_run_id,
         )
 
     # ── POST_SPRINT hook ──────────────────────────────────────────────

--- a/tests/test_detach.py
+++ b/tests/test_detach.py
@@ -157,6 +157,8 @@ class TestDaemonizeRun:
             patch("theforge.detach.os.dup2"),
             patch("theforge.detach.os.waitpid"),
             patch("theforge.detach.os.devnull", "/dev/null"),
+            patch("theforge.detach.os.open", side_effect=[10, 11]) as mock_os_open,
+            patch("theforge.detach.os.close"),
             patch("theforge.detach.write_pid") as mock_write_pid,
             patch(
                 "builtins.open",
@@ -180,8 +182,26 @@ class TestDaemonizeRun:
             detach.daemonize_run("run123", "my-slug", tmp_path)
 
         mock_write_pid.assert_called_once_with("run123", "my-slug", tmp_path)
+        log_path = tmp_path / ".forge" / "logs" / "my-slug" / "run-run123.log"
+        assert mock_os_open.call_args_list[1].args[0] == str(log_path)
 
     def test_raises_on_no_fork(self, tmp_path):
         with patch("theforge.detach.os.fork", side_effect=AttributeError):
             with pytest.raises(RuntimeError, match="os.fork"):
                 detach.daemonize_run("run123", "slug", tmp_path)
+
+
+def test_find_log_path_prefers_per_run_log(tmp_path):
+    log_path = tmp_path / ".forge" / "logs" / "my-slug" / "run-run123.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("hello")
+
+    assert detach._find_log_path("my-slug", "run123", tmp_path) == log_path
+
+
+def test_find_log_path_falls_back_to_legacy_run_log(tmp_path):
+    legacy_path = tmp_path / ".forge" / "logs" / "my-slug" / "run.log"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text("legacy")
+
+    assert detach._find_log_path("my-slug", "run123", tmp_path) == legacy_path

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -236,3 +236,54 @@ def test_is_branch_merged_not_ancestor(tmp_path: Path) -> None:
     with patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_git_not_ancestor):
         result = _is_branch_merged("forge/story-a", "main", tmp_path, slug="story-a")
     assert result is False
+
+
+def test_run_sprint_summary_records_run_log(tmp_path: Path) -> None:
+    from types import SimpleNamespace
+
+    from theforge.sprint.audit import _write_sprint_summary
+
+    manifest = SimpleNamespace(name="demo-sprint", budget_usd=12.5, max_parallel=1)
+    state = SimpleNamespace(
+        preflight_verdict="PROCEED",
+        review_results=[],
+        total_cost=1.25,
+        error=None,
+        error_type=None,
+    )
+    result = SimpleNamespace(
+        results=[
+            (
+                "issue:123",
+                SimpleNamespace(
+                    state=state, phase=SimpleNamespace(name="DONE"), success=True, merge=None
+                ),
+            )
+        ],
+        total_cost_usd=1.25,
+        specs_total=1,
+        specs_succeeded=1,
+        specs_failed=0,
+        specs_skipped=0,
+        stopped_reason=None,
+    )
+    started_at = finished_at = __import__("datetime").datetime(
+        2024, 1, 1, tzinfo=__import__("datetime").timezone.utc
+    )
+    sprint_log_dir = tmp_path / ".forge" / "logs" / "demo-sprint"
+
+    _write_sprint_summary(
+        manifest=manifest,
+        result=result,
+        canonical_refs=["issue:123"],
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=0.0,
+        sprint_log_dir=sprint_log_dir,
+        slug_map={"issue:123": "story-123"},
+        run_id="run-abc",
+    )
+
+    summary = __import__("yaml").safe_load((sprint_log_dir / "sprint-summary.yaml").read_text())
+    assert summary["sprint"]["run_id"] == "run-abc"
+    assert summary["sprint"]["run_log"] == "run-run-abc.log"


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation correctly isolates per-run logs and records run_id and run_log in summary | [gemini-reviewer] The implementation correctly isolates sprint run logs by using a unique run_id for each detached sprint's log file. The sprint summary is also updated to reference this run_id and log file, ensuring a coherent audit record for each run. The changes are well-tested, covering the new log naming convention, fallback logic for legacy logs, and the metadata in the sprint summary.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.59
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint run.log appends across restarts — no single coherent audit record (GitHub Issue #441)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #441