### PR TITLE
Resumed stories bypass PLAN and never register file footprints for collision detection

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -181,6 +181,40 @@ def _extract_plan_footprint(workspace_path: Path) -> set[str]:
         return set()
 
 
+def _populate_resumed_story_footprint(
+    slug: str,
+    state: CoordinatorState,
+    workspace_path: Path,
+) -> CoordinatorState:
+    """Populate preflight_likely_files from an existing plan.md for resumed stories."""
+    if state.preflight_likely_files:
+        return state
+
+    files = sorted(_extract_plan_footprint(workspace_path))
+    state.preflight_likely_files = files
+    _log(
+        f"Resumed story {slug}: registered {len(files)} file(s) from plan.md "
+        f"for collision detection: {files}"
+    )
+    return state
+
+
+def _register_resumed_story_footprints(
+    triages: dict[str, StoryTriage],
+    preflight_states: dict[str, CoordinatorState],
+) -> dict[str, CoordinatorState]:
+    """Ensure resumed dev/review stories contribute likely_files to collision detection."""
+    for triage in triages.values():
+        if triage.action not in {"review", "dev"} or triage.worktree_path is None:
+            continue
+        state = preflight_states.get(triage.slug)
+        if state is None:
+            state = CoordinatorState()
+            preflight_states[triage.slug] = state
+        _populate_resumed_story_footprint(triage.slug, state, triage.worktree_path)
+    return preflight_states
+
+
 def _run_fresh(
     config: ForgeConfig,
     task: TaskStory,
@@ -606,6 +640,8 @@ def run_sprint(
         max_parallel=max_parallel,
         notify=notify,
     )
+    if resume:
+        _register_resumed_story_footprints(triages, preflight_states)
     synthetic_edges = compute_synthetic_edges(preflight_states, normalized.tasks)
     if synthetic_edges:
         _log(f"Injected synthetic dependency constraints for {len(synthetic_edges)} stories")

--- a/tests/test_sprint_collision.py
+++ b/tests/test_sprint_collision.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 from theforge.coordinator.state import CoordinatorState
 from theforge.sprint.collision import compute_synthetic_edges, inject_synthetic_deps
+from theforge.sprint.dag import StoryTriage
+from theforge.sprint.runner import _register_resumed_story_footprints
 from theforge.task import TaskStory
 
 
@@ -65,3 +67,40 @@ def test_compute_synthetic_edges_falls_back_to_slug_order_when_issue_missing() -
     }
 
     assert compute_synthetic_edges(states, tasks) == {"b-story": ["a-story"]}
+
+
+def test_register_resumed_story_footprints_reads_plan_md(tmp_path: Path) -> None:
+    slug = "story-12"
+    workspace_path = tmp_path / slug
+    plan_dir = workspace_path / ".forge"
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "plan.md").write_text(
+        """---
+plan:
+  approach: Resume implementation
+  steps:
+    - id: 1
+      description: Update API
+      files:
+        - src/foo.py
+        - tests/test_foo.py
+      action: modify
+      details: Continue the resumed story
+""",
+        encoding="utf-8",
+    )
+
+    preflight_states = {slug: CoordinatorState()}
+    triages = {
+        slug: StoryTriage(
+            story_path="stories/story-12.md",
+            action="dev",
+            reason="resume",
+            worktree_path=workspace_path,
+            slug=slug,
+        )
+    }
+
+    _register_resumed_story_footprints(triages, preflight_states)
+
+    assert preflight_states[slug].preflight_likely_files == ["src/foo.py", "tests/test_foo.py"]


### PR DESCRIPTION
## Summary

[openai-reviewer] Resumed story plan footprints are correctly registered for collision detection | [gemini-reviewer] The implementation correctly registers file footprints for resumed stories from their existing plan.md, ensuring they participate in collision detection as required by the spec. The logic is sound, placed correctly in the sprint runner's control flow, and includes a new unit test that verifies the behavior.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.34
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Resumed stories bypass PLAN and never register file footprints for collision detection (GitHub Issue #443)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #443