### PR TITLE
bug: merge-pr treats auto-merge queue as completed state transition

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -361,8 +361,17 @@ def _merge_pr(
             _pr_log.warning("remote branch cleanup failed (non-fatal): %s", exc)
 
     pr_url: str | None = None
-    auto_merge_queued = False
+    merge_queued = False
     merge_retry_error = "base branch was modified"
+    branch_protection_signals = (
+        "required status checks",
+        "protected branch",
+        "approval required",
+        "waiting for status",
+        "merging is blocked",
+        "cannot be merged",
+        "review required",
+    )
 
     for attempt in range(MAX_MERGE_RETRIES):
         # Step 1: defensively scrub tracked forge artifacts before rebase.
@@ -441,7 +450,7 @@ def _merge_pr(
         # feature worktree can trip worktree branch checkout constraints.
         try:
             merge_proc = subprocess.run(
-                ["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
+                ["gh", "pr", "merge", pr_url, f"--{merge_strategy}"],
                 capture_output=True,
                 text=True,
                 cwd=str(config.project_root),
@@ -457,7 +466,7 @@ def _merge_pr(
                 for part in (merge_proc.stdout, merge_proc.stderr)
                 if part and part.strip()
             ).lower()
-            auto_merge_queued = (
+            merge_queued = (
                 "auto-merge enabled" in merge_output
                 or "pull request is not mergeable" in merge_output
             )
@@ -468,8 +477,9 @@ def _merge_pr(
             for part in (merge_proc.stderr, merge_proc.stdout)
             if part and part.strip()
         )
+        err_lower = err.lower()
         _pr_log.warning("gh pr merge failed (exit %d): %s", merge_proc.returncode, err)
-        if merge_retry_error in err.lower():
+        if merge_retry_error in err_lower:
             if attempt < MAX_MERGE_RETRIES - 1:
                 _pr_log.warning(
                     "base branch changed during PR merge attempt %d/%d; retrying",
@@ -478,9 +488,44 @@ def _merge_pr(
                 )
                 continue
             return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
+
+        if not any(signal in err_lower for signal in branch_protection_signals):
+            return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
+
+        _pr_log.info("gh pr merge blocked by branch protection; falling back to --auto: %s", err)
+        try:
+            merge_proc = subprocess.run(
+                ["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
+                capture_output=True,
+                text=True,
+                cwd=str(config.project_root),
+                timeout=120,
+            )
+        except Exception as exc:
+            _pr_log.warning("gh pr merge --auto failed: %s", exc)
+            return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
+
+        if merge_proc.returncode == 0:
+            merge_output = "\n".join(
+                part.strip()
+                for part in (merge_proc.stdout, merge_proc.stderr)
+                if part and part.strip()
+            ).lower()
+            merge_queued = (
+                "auto-merge enabled" in merge_output
+                or "pull request is not mergeable" in merge_output
+            )
+            break
+
+        err = "\n".join(
+            part.strip()
+            for part in (merge_proc.stderr, merge_proc.stdout)
+            if part and part.strip()
+        )
+        _pr_log.warning("gh pr merge --auto failed (exit %d): %s", merge_proc.returncode, err)
         return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
 
-    if auto_merge_queued:
+    if merge_queued:
         _log(f"  ✓ PR queued for auto-merge: {pr_url}")
     else:
         _log(f"  ✓ PR merged: {pr_url}")
@@ -488,15 +533,15 @@ def _merge_pr(
     # Step 6: sync local state and clean up the merged feature worktree/branch.
     # Preserve the remote branch when GitHub only queued auto-merge; branch
     # protection still needs that ref until the hosted merge completes.
-    _cleanup_after_merge(delete_remote_branch=not auto_merge_queued)
+    _cleanup_after_merge(delete_remote_branch=not merge_queued)
 
     return {
         "action": "merge-pr",
         "pr_url": pr_url,
-        "merged": True,
+        "merged": not merge_queued,
+        "merge_queued": merge_queued,
         "success": True,
         "error": None,
-        "auto_merge_queued": auto_merge_queued,
     }
 
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import subprocess
 import sys
 import threading
+import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from pathlib import Path
@@ -43,6 +45,28 @@ from .manifest import (
 )
 from .query import normalize_dependency_plan
 from .sources import StorySource
+
+QUEUED_MERGE_TIMEOUT_SECONDS = 3600
+
+
+def _poll_pr_merge_state(pr_url: str, project_root: Path) -> str:
+    """Return GitHub PR state for a queued merge, or UNKNOWN on CLI failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", pr_url, "--json", "state", "--jq", ".state"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return "UNKNOWN"
+
+    if proc.returncode != 0:
+        return "UNKNOWN"
+
+    state = proc.stdout.strip().upper()
+    return state if state in {"MERGED", "CLOSED", "OPEN"} else "UNKNOWN"
 
 
 def _log(msg: str) -> None:
@@ -442,6 +466,7 @@ def _classify_and_record(
     result: CoordinatorResult,
     dag: StoryDAG,
     merged_slugs: set[str],
+    queued_prs: dict[str, tuple[TaskStory, str]],
 ) -> tuple[int, int, int]:
     """Classify result and update DAG state. Returns (succeeded, failed, skipped) deltas."""
     preflight_verdict = result.state.preflight_verdict
@@ -462,6 +487,11 @@ def _classify_and_record(
     ):
         merged_slugs.add(task.slug)
         dag.mark_complete(task.slug)
+    elif result.merge is not None and result.merge.get("merge_queued", False):
+        pr_url = result.merge.get("pr_url")
+        if isinstance(pr_url, str) and pr_url:
+            queued_prs[task.slug] = (task, pr_url)
+        dag.mark_skipped(task.slug)
     else:
         # Story finished but deps not satisfied for downstream scheduling
         dag.mark_skipped(task.slug)
@@ -599,6 +629,8 @@ def run_sprint(
     stopped_reason: str | None = None
     ci_halt_slug: str | None = None
     merged_slugs: set[str] = set()
+    queued_prs: dict[str, tuple[TaskStory, str]] = {}
+    queued_pr_deadlines: dict[str, datetime.datetime] = {}
 
     # Derive slug_to_spec from unified context mapping
     slug_to_spec: dict[str, str] = {slug: ctx[2] for slug, ctx in slug_to_context.items()}
@@ -702,7 +734,7 @@ def run_sprint(
     use_plan_gates = max_parallel > 1  # only for parallel mode
 
     with ThreadPoolExecutor(max_workers=max_parallel) as pool:
-        while not dag.is_done():
+        while not dag.is_done() or queued_prs:
             _log(f"[debug] loop: active={list(active.keys())} fin={dag._finished}")
             ready = [t for t in dag.ready() if t.slug not in active]
 
@@ -784,7 +816,7 @@ def run_sprint(
                 active[task.slug] = fut
 
             _log(f"[debug] post-submit: active={list(active.keys())}")
-            if not active:
+            if not active and not queued_prs:
                 # Deadlock: remaining tasks have unmet or budget-blocked deps
                 # Release any pending plan gates so worker threads can exit
                 for g_slug, _gate in plan_gates.items():
@@ -914,7 +946,7 @@ def run_sprint(
                 dur = _fmt_duration(elapsed)
                 _log(f"{icon} {slug}   ${spec_cost:.2f}  {dur}")
 
-                ds, df, dsk = _classify_and_record(task, result, dag, merged_slugs)
+                ds, df, dsk = _classify_and_record(task, result, dag, merged_slugs, queued_prs)
                 specs_succeeded += ds
                 specs_failed += df
                 specs_skipped += dsk
@@ -939,7 +971,7 @@ def run_sprint(
                     and config.workspace.on_approve == "merge-pr"
                     and result.merge
                     and result.merge.get("merged")
-                    and not result.merge.get("auto_merge_queued", False)
+                    and not result.merge.get("merge_queued", False)
                 ):
                     ci_result = poll_required_checks(
                         config.project_root,
@@ -1016,7 +1048,7 @@ def run_sprint(
                                     if merge_info.get("merged"):
                                         merged_slugs.add(slug)
                                         dag.mark_complete(slug)
-                                        if not merge_info.get("auto_merge_queued", False):
+                                        if not merge_info.get("merge_queued", False):
                                             ci_result = poll_required_checks(
                                                 config.project_root,
                                                 config.workspace.base_branch,
@@ -1043,6 +1075,17 @@ def run_sprint(
                                                 f"INFO {slug}: PR auto-merge queued; "
                                                 "skipping CI gate until GitHub lands the merge"
                                             )
+                                    elif merge_info.get("merge_queued"):
+                                        queued_prs[slug] = (task, merge_info["pr_url"])
+                                        queued_pr_deadlines[slug] = datetime.datetime.now(
+                                            datetime.timezone.utc
+                                        ) + datetime.timedelta(
+                                            seconds=QUEUED_MERGE_TIMEOUT_SECONDS
+                                        )
+                                        _log(
+                                            f"INFO {slug}: PR auto-merge queued; "
+                                            "will poll for completion"
+                                        )
                                     else:
                                         result.success = False
                                         result.phase = Phase.ESCALATE
@@ -1097,6 +1140,69 @@ def run_sprint(
                                 specs_skipped += 1
                                 _log(f"SKIPPED {t.slug} ({stopped_reason})")
                         pending_merges.clear()
+
+            if queued_prs:
+                now = datetime.datetime.now(datetime.timezone.utc)
+                for slug in list(queued_prs):
+                    task, pr_url = queued_prs[slug]
+                    deadline = queued_pr_deadlines.setdefault(
+                        slug,
+                        now + datetime.timedelta(seconds=QUEUED_MERGE_TIMEOUT_SECONDS),
+                    )
+                    state = _poll_pr_merge_state(pr_url, config.project_root)
+                    if state == "MERGED":
+                        merged_slugs.add(slug)
+                        dag.mark_complete(slug)
+                        queued_prs.pop(slug, None)
+                        queued_pr_deadlines.pop(slug, None)
+                        _log(f"✓ {slug}: auto-merge landed — marking complete")
+                        if config.workspace.on_approve == "merge-pr":
+                            ci_result = poll_required_checks(
+                                config.project_root,
+                                config.workspace.base_branch,
+                                config.workspace.ci_check_timeout_seconds,
+                            )
+                            if ci_result["status"] in {"fail", "timeout"}:
+                                failing = (
+                                    ", ".join(ci_result["failing_checks"])
+                                    or "pending required checks"
+                                )
+                                stopped_reason = (
+                                    "Required CI checks "
+                                    f"{ci_result['status']} after merging {slug} "
+                                    f"at {ci_result['sha']}: {failing}"
+                                )
+                                ci_halt_slug = slug
+                                _log(
+                                    f"HALT {slug}: required CI checks {ci_result['status']} "
+                                    f"for {ci_result['sha']} ({failing})"
+                                )
+                    elif state == "CLOSED" or now > deadline:
+                        reason = "PR closed" if state == "CLOSED" else "auto-merge timeout"
+                        _log(f"✗ {slug}: {reason} — escalating")
+                        queued_prs.pop(slug, None)
+                        queued_pr_deadlines.pop(slug, None)
+                        for spec_str, existing_result in results:
+                            if spec_str != slug_to_spec[slug]:
+                                continue
+                            if existing_result.success:
+                                existing_result.success = False
+                                existing_result.phase = Phase.ESCALATE
+                                existing_result.state.phase = Phase.ESCALATE
+                                existing_result.state.error = reason
+                                specs_succeeded -= 1
+                                specs_failed += 1
+                                _write_story_audit(config, task, existing_result)
+                                ctx = slug_to_context.get(slug)
+                                if ctx:
+                                    _ctx_task, source, _ctx_ref = ctx
+                                    try:
+                                        source.on_escalate(task, existing_result.state, config)
+                                    except Exception as exc:
+                                        _log(f"WARN on_escalate callback failed for {slug}: {exc}")
+                            break
+                if queued_prs and not active:
+                    time.sleep(5)
 
     finished_at = datetime.datetime.now(datetime.timezone.utc)
     set_worker_slug("")

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -410,8 +410,8 @@ class TestMergePrFunction:
         assert "branch protection" in result["error"]
         assert call_counts == {"fetch": 1, "rebase": 1, "push": 1, "merge": 1}
 
-    def test_auto_flag_passed_to_gh_merge(self, tmp_path: Path) -> None:
-        """Verify --auto is passed so branch protection can queue the merge."""
+    def test_sync_merge_attempted_before_auto_fallback(self, tmp_path: Path) -> None:
+        """Verify merge-pr tries a synchronous gh merge before any --auto fallback."""
         config = _make_merge_pr_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
@@ -443,7 +443,15 @@ class TestMergePrFunction:
             _merge_pr(config, task, "forge/test-task", review, state)
 
         assert gh_calls
-        assert all("--auto" in c for c in gh_calls)
+        assert gh_calls[0] == [
+            "gh",
+            "pr",
+            "merge",
+            "https://github.com/fuzzypete/theforge/pull/auto",
+            "--squash",
+        ]
+        assert all("--squash" in c for c in gh_calls)
+        assert all("--auto" not in c for c in gh_calls)
 
     def test_merge_strategy_squash_passed_to_gh(self, tmp_path: Path) -> None:
         """Verify --squash is passed to gh pr merge."""
@@ -547,8 +555,78 @@ class TestMergePrFunction:
             result = _merge_pr(config, task, "forge/test-task", review, state)
 
         assert result["success"] is True
-        assert result["merged"] is True
+        assert result["merged"] is False
+        assert result["merge_queued"] is True
+        assert [
+            "gh",
+            "pr",
+            "merge",
+            "https://github.com/fuzzypete/theforge/pull/queued",
+            "--squash",
+        ] in commands
+        assert [
+            "gh",
+            "pr",
+            "merge",
+            "https://github.com/fuzzypete/theforge/pull/queued",
+            "--auto",
+            "--squash",
+        ] not in commands
         assert ["git", "push", "origin", "--delete", "forge/test-task"] not in commands
+
+    def test_branch_protection_falls_back_to_auto_merge_queue(self, tmp_path: Path) -> None:
+        """Branch protection errors should retry with --auto and report queued state."""
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        commands: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list):
+                commands.append(cmd)
+                if cmd[:3] == ["gh", "pr", "merge"] and "--auto" not in cmd:
+                    return _make_subprocess_result(1, stderr="required status checks are expected")
+                if cmd[:3] == ["gh", "pr", "merge"] and "--auto" in cmd:
+                    return _make_subprocess_result(0, stdout="Auto-merge enabled for pull request")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/queued-auto",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        assert result["merged"] is False
+        assert result["merge_queued"] is True
+        assert [
+            "gh",
+            "pr",
+            "merge",
+            "https://github.com/fuzzypete/theforge/pull/queued-auto",
+            "--squash",
+        ] in commands
+        assert [
+            "gh",
+            "pr",
+            "merge",
+            "https://github.com/fuzzypete/theforge/pull/queued-auto",
+            "--auto",
+            "--squash",
+        ] in commands
 
     def test_immediate_merge_still_deletes_remote_branch(self, tmp_path: Path) -> None:
         """Completed merges should still perform remote branch cleanup."""

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -23,7 +24,7 @@ from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phas
 from theforge.review import ReviewResult
 from theforge.sprint import load_sprint_manifest, run_sprint
 from theforge.sprint.dag import StoryDAG, build_dag
-from theforge.sprint.runner import _classify_and_record
+from theforge.sprint.runner import _classify_and_record, _poll_pr_merge_state
 from theforge.task import TaskStory
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -120,6 +121,8 @@ def _make_coordinator_result(
     preflight_verdict: str = "PROCEED",
     phase: Phase = Phase.DONE,
     merged: bool = False,
+    merge_queued: bool = False,
+    pr_url: str = "https://example.test/pr/1",
 ) -> CoordinatorResult:
     state = CoordinatorState()
     state.preflight_verdict = preflight_verdict
@@ -132,7 +135,13 @@ def _make_coordinator_result(
         phase=phase,
         state=state,
         message="Done." if success else "Failed.",
-        merge={"merged": True} if merged else None,
+        merge=(
+            {"merged": True, "pr_url": pr_url}
+            if merged
+            else (
+                {"merged": False, "merge_queued": True, "pr_url": pr_url} if merge_queued else None
+            )
+        ),
     )
 
 
@@ -557,9 +566,10 @@ class TestClassifyAndRecord:
         b = _make_task("b", depends_on=["a"])
         dag = StoryDAG([a, b])
         merged_slugs: set[str] = set()
+        queued_prs: dict[str, tuple[TaskStory, str]] = {}
 
         result = _make_coordinator_result(success=True, cost=1.0, merged=False)
-        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs, queued_prs)
 
         assert ds == 1
         assert df == 0
@@ -574,9 +584,10 @@ class TestClassifyAndRecord:
         b = _make_task("b", depends_on=["a"])
         dag = StoryDAG([a, b])
         merged_slugs: set[str] = set()
+        queued_prs: dict[str, tuple[TaskStory, str]] = {}
 
         result = _make_coordinator_result(success=True, cost=1.0, merged=True)
-        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs, queued_prs)
 
         assert ds == 1
         assert "a" in merged_slugs
@@ -589,11 +600,12 @@ class TestClassifyAndRecord:
         b = _make_task("b", depends_on=["a"])
         dag = StoryDAG([a, b])
         merged_slugs: set[str] = set()
+        queued_prs: dict[str, tuple[TaskStory, str]] = {}
 
         result = _make_coordinator_result(
             success=True, cost=0.0, preflight_verdict="ALREADY_DONE", phase=Phase.DONE
         )
-        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs, queued_prs)
 
         assert ds == 0
         assert dsk == 1
@@ -606,13 +618,104 @@ class TestClassifyAndRecord:
         b = _make_task("b", depends_on=["a"])
         dag = StoryDAG([a, b])
         merged_slugs: set[str] = set()
+        queued_prs: dict[str, tuple[TaskStory, str]] = {}
 
         result = _make_coordinator_result(success=False, cost=1.0, phase=Phase.ESCALATE)
-        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs, queued_prs)
 
         assert df == 1
         assert "a" not in merged_slugs
         assert dag.ready() == []
+
+    def test_merge_queued_does_not_complete_for_dag(self) -> None:
+        """Queued merges stay blocked until polling promotes them."""
+        a = _make_task("a")
+        b = _make_task("b", depends_on=["a"])
+        dag = StoryDAG([a, b])
+        merged_slugs: set[str] = set()
+        queued_prs: dict[str, tuple[TaskStory, str]] = {}
+
+        result = _make_coordinator_result(success=True, cost=1.0, merge_queued=True)
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs, queued_prs)
+
+        assert ds == 1
+        assert df == 0
+        assert dsk == 0
+        assert "a" not in merged_slugs
+        assert queued_prs["a"][1] == "https://example.test/pr/1"
+        assert dag.ready() == []
+
+
+class TestQueuedMergePolling:
+    def test_poll_pr_merge_state_returns_unknown_on_error(self, tmp_path: Path) -> None:
+        with patch(
+            "theforge.sprint.runner.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="boom"
+            ),
+        ):
+            assert _poll_pr_merge_state("https://example.test/pr/1", tmp_path) == "UNKNOWN"
+
+    def test_run_sprint_promotes_queued_merge_when_pr_lands(self, tmp_path: Path) -> None:
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b", depends_on=["story-a"])
+        manifest_path = _make_manifest_parallel(
+            tmp_path, ["story-a.md", "story-b.md"], max_parallel=1
+        )
+        config = _make_config(tmp_path)
+        config = dataclasses.replace(
+            config, workspace=dataclasses.replace(config.workspace, on_approve="merge-pr")
+        )
+
+        result_a = _make_coordinator_result(
+            success=True, merge_queued=True, pr_url="https://example.test/pr/a"
+        )
+        result_b = _make_coordinator_result(
+            success=True, merged=True, pr_url="https://example.test/pr/b"
+        )
+
+        with (
+            patch("theforge.sprint.runner.run_task", side_effect=[result_a, result_b]) as mock_run,
+            patch("theforge.sprint.runner._poll_pr_merge_state", side_effect=["MERGED"]),
+            patch(
+                "theforge.sprint.runner.poll_required_checks",
+                return_value={"status": "pass", "sha": "abc", "failing_checks": []},
+            ),
+            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.sprint.runner._write_story_audit"),
+            patch("theforge.sprint.runner._write_sprint_audit"),
+            patch("theforge.sprint.runner._write_sprint_summary"),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        assert mock_run.call_count == 2
+        assert sprint.specs_succeeded == 2
+        assert sprint.specs_failed == 0
+
+    def test_run_sprint_escalates_when_queued_pr_closes(self, tmp_path: Path) -> None:
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(tmp_path, ["story-a.md"], max_parallel=1)
+        config = _make_config(tmp_path)
+        config = dataclasses.replace(
+            config, workspace=dataclasses.replace(config.workspace, on_approve="merge-pr")
+        )
+
+        result_a = _make_coordinator_result(
+            success=True, merge_queued=True, pr_url="https://example.test/pr/a"
+        )
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result_a),
+            patch("theforge.sprint.runner._poll_pr_merge_state", return_value="CLOSED"),
+            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.sprint.runner._write_story_audit"),
+            patch("theforge.sprint.runner._write_sprint_audit"),
+            patch("theforge.sprint.runner._write_sprint_summary"),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
 
 
 class TestMergeOrdering:


### PR DESCRIPTION
## Summary

[openai-reviewer] The implementation correctly satisfies all acceptance criteria; minor test coverage gaps exist for timeout and independent-story scheduling. | [gemini-reviewer] The implementation correctly defers story completion for auto-queued PRs by introducing a polling mechanism, satisfying all acceptance criteria with robust logic and thorough tests.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.85
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:1144`** No test covers escalation of a queued PR when it exceeds the timeout threshold.
- **[P2] `src/theforge/sprint/runner.py:736`** No explicit test verifies that independent stories continue running while merges are queued.

## Story

bug: merge-pr treats auto-merge queue as completed state transition (GitHub Issue #459)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #459