### PR TITLE
fix: double-fork daemonize race causes self-conflict on fresh sprint launch (#475)

### DIFF
--- a/src/theforge/sprint/preflight.py
+++ b/src/theforge/sprint/preflight.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
-from theforge.sprint.lock import acquire_story_locks, check_active_worktrees
+from theforge.sprint.lock import check_active_worktrees
 
 _ACTIVE_WORKTREE_ABORT_PREFIX = "[forge] Stories already have active worktrees"
 _RUNNING_STORIES_ABORT_PREFIX = "[forge] Stories already running"
@@ -56,11 +57,18 @@ def reacquire_story_locks_in_daemon(
     project_root: Path,
     locked_fds: list,
 ) -> list:
-    """Close inherited lock FDs and re-acquire locks in the daemon process."""
+    """Update lock file PIDs to the daemon PID without releasing the inherited flocks.
+
+    The parent process acquired the story locks before double-fork daemonizing.
+    After fork(), the daemon inherits the same open file descriptions — and therefore
+    the same flocks — so no re-acquisition is needed.  We only need to overwrite the
+    PID recorded in each lock file so that stale-lock cleanup uses the daemon's PID
+    rather than the (soon-dead) parent's PID.
+    """
+    daemon_pid = str(os.getpid())
     for fd in locked_fds:
-        fd.close()
-    refreshed_fds, conflicted = acquire_story_locks(slugs, project_root)
-    if conflicted:
-        abort_for_running_stories(conflicted)
-        sys.exit(1)
-    return refreshed_fds
+        fd.seek(0)
+        fd.truncate(0)
+        fd.write(daemon_pid)
+        fd.flush()
+    return locked_fds

--- a/tests/test_sprint_preflight.py
+++ b/tests/test_sprint_preflight.py
@@ -45,25 +45,44 @@ def test_check_active_worktrees_returns_abort_when_active(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_reacquire_story_locks_in_daemon_aborts_on_conflict(capsys) -> None:
+def test_reacquire_story_locks_in_daemon_updates_pid_in_place() -> None:
+    # Simulate two inherited lock FDs (StringIO-like objects with seek/truncate/write/flush)
+    import io
+
+    fd_a = io.StringIO()
+    fd_a.write("11111")  # parent PID written before fork
+    fd_b = io.StringIO()
+    fd_b.write("11111")
+
+    import os
+
+    returned = reacquire_story_locks_in_daemon(
+        ["story-a", "story-b"],
+        Path("/tmp/project"),
+        [fd_a, fd_b],
+    )
+
+    # Same FD objects returned — no close, no re-acquire
+    assert returned == [fd_a, fd_b]
+
+    # Each FD now contains the daemon's PID
+    daemon_pid = str(os.getpid())
+    fd_a.seek(0)
+    assert fd_a.read() == daemon_pid
+    fd_b.seek(0)
+    assert fd_b.read() == daemon_pid
+
+
+def test_reacquire_story_locks_in_daemon_does_not_close_fds() -> None:
+    # Regression: before fix, the inherited FDs were closed, which dropped the
+    # flock and caused a self-conflict race with the still-alive parent process.
     inherited_fd = MagicMock()
+    inherited_fd.read.return_value = ""
 
-    with patch(
-        "theforge.sprint.preflight.acquire_story_locks",
-        return_value=([], ["story-a", "story-b"]),
-    ):
-        try:
-            reacquire_story_locks_in_daemon(
-                ["story-a", "story-b"],
-                Path("/tmp/project"),
-                [inherited_fd],
-            )
-        except SystemExit as exc:
-            assert exc.code == 1
-        else:
-            raise AssertionError("expected SystemExit")
+    reacquire_story_locks_in_daemon(
+        ["story-a"],
+        Path("/tmp/project"),
+        [inherited_fd],
+    )
 
-    inherited_fd.close.assert_called_once()
-    captured = capsys.readouterr()
-    assert "Stories already running" in captured.err
-    assert "story-a, story-b" in captured.err
+    inherited_fd.close.assert_not_called()


### PR DESCRIPTION
## Summary

- `reacquire_story_locks_in_daemon` no longer closes inherited FDs and re-acquires — instead updates the PID in-place on the existing locked FDs
- Eliminates the race where the daemon's re-acquire attempt conflicts with the still-alive parent process holding the same OFD
- Regression introduced by #469 (commit ac421b0, merged today)

## Root cause

After double-fork daemonization, the parent, intermediate child, and grandchild all share the same open file description (OFD) and therefore the same flock. The grandchild (daemon) closed its inherited FDs and tried to re-acquire, but the parent was still alive printing run info — so the flock was still held via the parent's copy of the OFD. `BlockingIOError` → conflict → abort → stale lock left behind.

## Test plan

- [x] `test_reacquire_story_locks_in_daemon_updates_pid_in_place` — verifies PID is written to inherited FDs
- [x] `test_reacquire_story_locks_in_daemon_does_not_close_fds` — regression guard: `fd.close()` never called
- [x] Full suite: 2224 passed, 1 pre-existing failure (unrelated Python 3.12 assertion in `test_assignment.py`)

Closes #475