### PR TITLE
bug: sprint resumes stale worktrees without rebasing onto main first

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -189,7 +189,7 @@ from .dev_phase import _run_dev_phase  # noqa: E402
 from .path_setup import prepend_worktree_src  # noqa: E402
 from .review_context import _parse_dev_handoff  # noqa: E402
 from .review_phase import _ReviewOutcome, _run_review_only_phase, _run_review_phase  # noqa: E402
-from .run_setup import _setup_resume_entry  # noqa: E402
+from .run_setup import _rebase_onto_main, _setup_resume_entry  # noqa: E402
 from .validate_phase import _run_validate_phase, _ValidateOutcome  # noqa: E402
 
 
@@ -782,6 +782,24 @@ def _run_resume_coordinator(
     prepend_worktree_src(workspace_path)
 
     with _run_log_context(config, logger, task, state, _task_start):
+        base_branch = config.workspace.base_branch
+        rebase_ok, rebase_err = _rebase_onto_main(str(state.workspace_path), base_branch, logger)
+        if not rebase_ok:
+            state.phase = Phase.ESCALATE
+            state.escalate_reason = (
+                f"pre-dev rebase onto {base_branch} failed — conflicts must be resolved manually: "
+                f"{rebase_err}"
+            )
+            state.error = state.escalate_reason
+            logger._safe_emit("escalate", reason=state.escalate_reason, phase="RESUME_REBASE")
+            _escalate_notify(task, state, notify, config)
+            return CoordinatorResult(
+                success=False,
+                phase=Phase.ESCALATE,
+                state=state,
+                message=state.escalate_reason,
+            )
+        logger._safe_emit("rebase", phase="RESUME_REBASE", base_branch=base_branch, outcome="ok")
         result = _coordinator_loop(
             state,
             config,

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import datetime
 import logging
 import shutil
+import subprocess
 import time
 from pathlib import Path
 
@@ -91,6 +92,46 @@ def load_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
         ]
     if "surviving_families" in data and isinstance(data["surviving_families"], list):
         state.surviving_families = data["surviving_families"]
+
+
+def _rebase_onto_main(worktree_path: str, base_branch: str, logger) -> tuple[bool, str]:
+    """Fetch and rebase the resumed worktree onto origin/base_branch."""
+    git_dir = Path(worktree_path) / ".git"
+    if not git_dir.exists():
+        return True, ""
+
+    try:
+        fetch_proc = subprocess.run(
+            ["git", "fetch", "origin", base_branch],
+            capture_output=True,
+            text=True,
+            cwd=worktree_path,
+        )
+        if fetch_proc.returncode != 0:
+            err = fetch_proc.stderr.strip() or fetch_proc.stdout.strip()
+            return False, err
+
+        rebase_proc = subprocess.run(
+            ["git", "rebase", f"origin/{base_branch}"],
+            capture_output=True,
+            text=True,
+            cwd=worktree_path,
+        )
+        if rebase_proc.returncode != 0:
+            err = rebase_proc.stderr.strip() or rebase_proc.stdout.strip()
+            subprocess.run(
+                ["git", "rebase", "--abort"],
+                capture_output=True,
+                text=True,
+                cwd=worktree_path,
+            )
+            return False, err
+    except Exception as exc:  # noqa: BLE001
+        if logger is not None:
+            logger.warning("resume rebase step failed: %s", exc)
+        return False, str(exc)
+
+    return True, ""
 
 
 def _setup_resume_entry(

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -1,12 +1,13 @@
 """Tests for _setup_resume_entry in coordinator/run_setup.py."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from coord_test_helpers import _make_config, _make_task
 
+from theforge.coordinator.engine import _run_resume_coordinator
 from theforge.coordinator.path_setup import prepend_worktree_src
 from theforge.coordinator.run_setup import _setup_resume_entry
-from theforge.coordinator.state import Phase
+from theforge.coordinator.state import CoordinatorResult, Phase
 
 
 def _call_setup(config, task, workspace_path):
@@ -64,8 +65,6 @@ def test_forge_yaml_sync_skipped_when_root_missing(tmp_path):
 
 def test_setup_returns_escalate_when_workspace_missing(tmp_path):
     """Returns CoordinatorResult when workspace_path doesn't exist."""
-    from theforge.coordinator.state import CoordinatorResult
-
     config = _make_config(tmp_path)
     task = _make_task(tmp_path)
     missing = tmp_path / "nonexistent"
@@ -131,3 +130,104 @@ def test_setup_resume_entry_prepends_worktree_src(tmp_path):
         assert sys.path[0] == str((workspace / "src").resolve())
     finally:
         sys.path[:] = original_sys_path
+
+
+def test_run_resume_coordinator_rebases_before_loop_and_continues(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    state = MagicMock()
+    state.workspace_path = workspace
+    state.log_dir = None
+    logger = MagicMock()
+    setup = (state, logger, "forge/test-task", "story", 123.0)
+    loop_result = CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="done")
+
+    with (
+        patch("theforge.coordinator.engine._ensure_runners"),
+        patch("theforge.coordinator.engine._check_behind_origin"),
+        patch("theforge.coordinator.engine._setup_resume_entry", return_value=setup),
+        patch("theforge.coordinator.engine._make_story_log_dir", return_value=tmp_path / "logs"),
+        patch("theforge.coordinator.engine.prepend_worktree_src"),
+        patch("theforge.coordinator.engine._run_log_context") as mock_ctx,
+        patch("theforge.coordinator.engine._rebase_onto_main", return_value=(True, "")),
+        patch(
+            "theforge.coordinator.engine._coordinator_loop", return_value=loop_result
+        ) as mock_loop,
+        patch("theforge.coordinator.engine._fire_post_run_hook"),
+    ):
+        mock_ctx.return_value.__enter__.return_value = None
+        mock_ctx.return_value.__exit__.return_value = None
+        result = _run_resume_coordinator(
+            config,
+            task,
+            workspace,
+            initial_phase=Phase.DEV,
+            skip_dev_first_iter=False,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            run_id="run-1",
+            sprint_name=None,
+            state_update_fn=None,
+        )
+
+    assert result is loop_result
+    mock_loop.assert_called_once()
+    logger._safe_emit.assert_any_call(
+        "rebase", phase="RESUME_REBASE", base_branch=config.workspace.base_branch, outcome="ok"
+    )
+
+
+def test_run_resume_coordinator_escalates_when_rebase_fails(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    state = MagicMock()
+    state.workspace_path = workspace
+    state.log_dir = None
+    setup = (state, MagicMock(), "forge/test-task", "story", 123.0)
+
+    with (
+        patch("theforge.coordinator.engine._ensure_runners"),
+        patch("theforge.coordinator.engine._check_behind_origin"),
+        patch("theforge.coordinator.engine._setup_resume_entry", return_value=setup),
+        patch("theforge.coordinator.engine._make_story_log_dir", return_value=tmp_path / "logs"),
+        patch("theforge.coordinator.engine.prepend_worktree_src"),
+        patch("theforge.coordinator.engine._run_log_context") as mock_ctx,
+        patch(
+            "theforge.coordinator.engine._rebase_onto_main",
+            return_value=(False, "merge conflict"),
+        ),
+        patch("theforge.coordinator.engine._coordinator_loop") as mock_loop,
+        patch("theforge.coordinator.engine._fire_post_run_hook"),
+        patch("theforge.coordinator.engine._escalate_notify") as mock_notify,
+    ):
+        mock_ctx.return_value.__enter__.return_value = None
+        mock_ctx.return_value.__exit__.return_value = None
+        result = _run_resume_coordinator(
+            config,
+            task,
+            workspace,
+            initial_phase=Phase.DEV,
+            skip_dev_first_iter=False,
+            interactive=False,
+            auto_merge=False,
+            notify=True,
+            run_id="run-1",
+            sprint_name=None,
+            state_update_fn=None,
+        )
+
+    assert result.success is False
+    assert result.phase == Phase.ESCALATE
+    assert "pre-dev rebase" in result.message
+    assert "pre-dev rebase" in state.escalate_reason
+    mock_loop.assert_not_called()
+    mock_notify.assert_called_once()


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation correctly performs early resume-time rebase and escalates on failure per spec | [gemini-reviewer] The change correctly implements the resume-time rebase logic, satisfying all acceptance criteria with robust error handling and focused tests for both success and failure paths.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.90
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: sprint resumes stale worktrees without rebasing onto main first (GitHub Issue #471)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #471