### PR TITLE
forge stop should wait for process exit by default

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -6,6 +6,7 @@ import datetime
 import os
 import subprocess
 import sys
+import time
 
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
@@ -144,6 +145,8 @@ def cmd_stop(args: object) -> int:
     """Send SIGTERM to a running forge process."""
     import signal as _signal
 
+    from theforge import detach as _detach
+
     config_path = _find_config()
     if config_path is None or not config_path.exists():
         print("forge.yaml not found.", file=sys.stderr)
@@ -156,8 +159,6 @@ def cmd_stop(args: object) -> int:
     if not pid_file.exists():
         print(f"No PID file found for run {run_id} — is it still running?", file=sys.stderr)
         return 1
-
-    from theforge import detach as _detach
 
     parsed = _detach._read_pid_file(pid_file)
     if parsed is None:
@@ -176,7 +177,25 @@ def cmd_stop(args: object) -> int:
         print(f"Could not signal process {pid}: {exc}", file=sys.stderr)
         return 1
 
-    return 0
+    if args.no_wait:
+        return 0
+
+    start = time.monotonic()
+    while time.monotonic() - start < args.timeout:
+        if not _detach._is_pid_alive(pid):
+            print(f"[forge] Run {run_id} has stopped.")
+            return 0
+        time.sleep(0.1)
+
+    if not _detach._is_pid_alive(pid):
+        print(f"[forge] Run {run_id} has stopped.")
+        return 0
+
+    print(
+        f"Timed out waiting for run {run_id} to stop (PID {pid} still alive)",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def cmd_decide(args: object) -> int:
@@ -237,6 +256,19 @@ def register_parsers(subparsers: object) -> None:
         help="Send SIGTERM to a running forge process",
     )
     stop_parser.add_argument("run_id", help="Run ID to stop")
+    stop_parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        default=False,
+        help="Return immediately after sending SIGTERM",
+    )
+    stop_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        metavar="N",
+        help="Seconds to wait for process exit (default 60)",
+    )
 
     # forge decide
     decide_parser = subparsers.add_parser(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -652,7 +652,7 @@ class TestCmdStop:
         forge_yaml = tmp_path / "forge.yaml"
         forge_yaml.write_text("project:\n  root: .\n")
         config = _make_forge_config(tmp_path)
-        args = argparse.Namespace(run_id=run_id)
+        args = argparse.Namespace(run_id=run_id, no_wait=True, timeout=60)
 
         with (
             patch("theforge.cli.status._find_config", return_value=forge_yaml),
@@ -664,6 +664,86 @@ class TestCmdStop:
         assert result == 0
         mock_kill.assert_called_once_with(target_pid, _signal.SIGTERM)
 
+    def test_blocks_until_process_dies(self, tmp_path):
+        """forge stop waits for the process to exit before returning 0."""
+        from theforge.cli import cmd_stop
+
+        run_id = "abc123"
+        target_pid = 54321
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nmy-slug\n")
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, no_wait=False, timeout=60)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status.os.kill"),
+            patch("theforge.cli.status.time.sleep") as mock_sleep,
+            patch("theforge.detach._is_pid_alive", side_effect=[True, False]),
+        ):
+            result = cmd_stop(args)
+
+        assert result == 0
+        mock_sleep.assert_called_once_with(0.1)
+
+    def test_timeout_returns_nonzero(self, tmp_path):
+        """forge stop returns 1 when the process does not exit before timeout."""
+        from theforge.cli import cmd_stop
+
+        run_id = "abc123"
+        target_pid = 54321
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nmy-slug\n")
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, no_wait=False, timeout=60)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status.os.kill"),
+            patch("theforge.cli.status.time.sleep"),
+            patch("theforge.cli.status.time.monotonic", side_effect=[0.0, 0.0, 61.0]),
+            patch("theforge.detach._is_pid_alive", return_value=True),
+        ):
+            result = cmd_stop(args)
+
+        assert result == 1
+
+    def test_no_wait_skips_polling(self, tmp_path):
+        """forge stop --no-wait returns immediately without polling."""
+        from theforge.cli import cmd_stop
+
+        run_id = "abc123"
+        target_pid = 54321
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nmy-slug\n")
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, no_wait=True, timeout=60)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status.os.kill"),
+            patch("theforge.detach._is_pid_alive") as mock_is_alive,
+        ):
+            result = cmd_stop(args)
+
+        assert result == 0
+        mock_is_alive.assert_not_called()
+
     def test_returns_error_when_no_pid_file(self, tmp_path):
         """forge stop returns 1 when no PID file found."""
         from theforge.cli import cmd_stop
@@ -671,7 +751,7 @@ class TestCmdStop:
         forge_yaml = tmp_path / "forge.yaml"
         forge_yaml.write_text("project:\n  root: .\n")
         config = _make_forge_config(tmp_path)
-        args = argparse.Namespace(run_id="nosuchrun")
+        args = argparse.Namespace(run_id="nosuchrun", no_wait=False, timeout=60)
 
         with (
             patch("theforge.cli.status._find_config", return_value=forge_yaml),


### PR DESCRIPTION
## Summary

[openai-reviewer] `forge stop` now correctly waits for process exit with `--timeout` and `--no-wait` flags | [gemini-reviewer] The change correctly implements the blocking `forge stop` behavior with `--no-wait` and `--timeout` options, and includes thorough tests for the new logic.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.67
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/cli/status.py:180`** Duplicate code paths for printing confirmation of run stop in both the loop and final check
- **[P2] `src/theforge/cli/status.py:172`** Printing confirmation messages to stdout while errors to stderr may be inconsistent
- **[P2] `src/theforge/cli/status.py:191`** The logic to check if the process has stopped and print the confirmation message is duplicated, once inside the `while` loop and once after it. This could be slightly refactored to remove the duplication, for example by having a single check after the loop that determines whether it was a success or a timeout.

## Story

forge stop should wait for process exit by default (GitHub Issue #412)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #412