### PR TITLE
bug: merge-pr treats auto-merge queue as completed state transition

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -339,6 +339,8 @@ def _merge_pr(
             "action": "merge-pr",
             "pr_url": pr_url,
             "merged": merged,
+            "merge_queued": False,
+            "auto_merge_queued": False,
             "success": False,
             "error": error,
         }
@@ -400,8 +402,17 @@ def _merge_pr(
             _pr_log.warning("remote branch cleanup failed (non-fatal): %s", exc)
 
     pr_url: str | None = None
+    merge_queued = False
     auto_merge_queued = False
     merge_retry_error = "base branch was modified"
+    branch_protection_markers = (
+        "required status",
+        "protected branch",
+        "cannot be merged",
+        "branch protection",
+        "required check",
+        "required reviews",
+    )
 
     for attempt in range(MAX_MERGE_RETRIES):
         # Step 1: defensively scrub tracked forge artifacts before rebase.
@@ -477,10 +488,12 @@ def _merge_pr(
         _deindex_forge_artifacts(push_cwd)
 
         # Step 5: merge the PR remotely from the repo root. Running gh from the
-        # feature worktree can trip worktree branch checkout constraints.
+        # feature worktree can trip worktree branch checkout constraints. Try a
+        # synchronous merge first; only fall back to --auto when GitHub reports
+        # branch protection / required-check gating.
         try:
             merge_proc = subprocess.run(
-                ["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
+                ["gh", "pr", "merge", pr_url, f"--{merge_strategy}"],
                 capture_output=True,
                 text=True,
                 cwd=str(config.project_root),
@@ -491,15 +504,6 @@ def _merge_pr(
             return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
 
         if merge_proc.returncode == 0:
-            merge_output = "\n".join(
-                part.strip()
-                for part in (merge_proc.stdout, merge_proc.stderr)
-                if part and part.strip()
-            ).lower()
-            auto_merge_queued = (
-                "auto-merge enabled" in merge_output
-                or "pull request is not mergeable" in merge_output
-            )
             break
 
         err = "\n".join(
@@ -507,8 +511,9 @@ def _merge_pr(
             for part in (merge_proc.stderr, merge_proc.stdout)
             if part and part.strip()
         )
+        err_lower = err.lower()
         _pr_log.warning("gh pr merge failed (exit %d): %s", merge_proc.returncode, err)
-        if merge_retry_error in err.lower():
+        if merge_retry_error in err_lower:
             if attempt < MAX_MERGE_RETRIES - 1:
                 _pr_log.warning(
                     "base branch changed during PR merge attempt %d/%d; retrying",
@@ -517,9 +522,65 @@ def _merge_pr(
                 )
                 continue
             return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
-        return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
 
-    if auto_merge_queued:
+        if not any(marker in err_lower for marker in branch_protection_markers):
+            return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
+
+        try:
+            auto_merge_proc = subprocess.run(
+                ["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
+                capture_output=True,
+                text=True,
+                cwd=str(config.project_root),
+                timeout=120,
+            )
+        except Exception as exc:
+            _pr_log.warning("gh pr merge --auto failed: %s", exc)
+            return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
+
+        if auto_merge_proc.returncode != 0:
+            auto_err = "\n".join(
+                part.strip()
+                for part in (auto_merge_proc.stderr, auto_merge_proc.stdout)
+                if part and part.strip()
+            )
+            _pr_log.warning(
+                "gh pr merge --auto failed (exit %d): %s",
+                auto_merge_proc.returncode,
+                auto_err,
+            )
+            return _fail(f"gh pr merge failed: {auto_err}", pr_url=pr_url)
+
+        try:
+            state_proc = subprocess.run(
+                ["gh", "pr", "view", pr_url, "--json", "state", "-q", ".state"],
+                capture_output=True,
+                text=True,
+                cwd=str(config.project_root),
+                timeout=30,
+            )
+        except Exception as exc:
+            _pr_log.warning("gh pr view failed after auto-merge queue: %s", exc)
+            return _fail(f"gh pr view failed after auto-merge queue: {exc}", pr_url=pr_url)
+
+        if state_proc.returncode != 0:
+            state_err = state_proc.stderr.strip() or state_proc.stdout.strip()
+            _pr_log.warning(
+                "gh pr view failed after auto-merge queue (exit %d): %s",
+                state_proc.returncode,
+                state_err,
+            )
+            return _fail(f"gh pr view failed after auto-merge queue: {state_err}", pr_url=pr_url)
+
+        pr_state = state_proc.stdout.strip()
+        if pr_state == "MERGED":
+            break
+
+        merge_queued = True
+        auto_merge_queued = True
+        break
+
+    if merge_queued:
         _log(f"  ✓ PR queued for auto-merge: {pr_url}")
     else:
         _log(f"  ✓ PR merged: {pr_url}")
@@ -527,12 +588,13 @@ def _merge_pr(
     # Step 6: sync local state and clean up the merged feature worktree/branch.
     # Preserve the remote branch when GitHub only queued auto-merge; branch
     # protection still needs that ref until the hosted merge completes.
-    _cleanup_after_merge(delete_remote_branch=not auto_merge_queued)
+    _cleanup_after_merge(delete_remote_branch=not merge_queued)
 
     return {
         "action": "merge-pr",
         "pr_url": pr_url,
-        "merged": True,
+        "merged": not merge_queued,
+        "merge_queued": merge_queued,
         "success": True,
         "error": None,
         "auto_merge_queued": auto_merge_queued,
@@ -624,6 +686,8 @@ def _finalize_approve(
         merge_info = _merge_pr(config, task, branch_name, parsed_review, state)
         if merge_info["merged"]:
             merge_suffix = f" PR merged: {merge_info['pr_url']}"
+        elif merge_info.get("merge_queued"):
+            merge_suffix = f" PR queued for auto-merge: {merge_info['pr_url']}"
         else:
             merge_suffix = f" merge-pr failed: {merge_info['error']}"
         if logger:
@@ -647,7 +711,7 @@ def _finalize_approve(
                 logger,
                 secrets=config.secrets,
             )
-        if not merge_info["merged"]:
+        if not merge_info["merged"] and not merge_info.get("merge_queued"):
             # PR merge failed (rebase conflict, gh error, etc.) — escalate rather than DONE.
             state.phase = Phase.ESCALATE
             state.error = merge_info.get("error") or "merge-pr failed"

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import subprocess
 import sys
 import threading
+import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from pathlib import Path
@@ -437,6 +439,33 @@ def _make_worker_phase_fn(
     return _update
 
 
+def _poll_queued_pr(pr_url: str, project_root: Path, timeout_seconds: int) -> dict[str, str]:
+    """Poll GitHub until a queued PR is merged, closed, or times out."""
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            proc = subprocess.run(
+                ["gh", "pr", "view", pr_url, "--json", "state", "-q", ".state"],
+                capture_output=True,
+                text=True,
+                cwd=str(project_root),
+                timeout=30,
+            )
+        except Exception:
+            return {"status": "timeout"}
+
+        if proc.returncode == 0:
+            state = proc.stdout.strip()
+            if state == "MERGED":
+                return {"status": "merged"}
+            if state == "CLOSED":
+                return {"status": "closed"}
+
+        if time.monotonic() >= deadline:
+            return {"status": "timeout"}
+        time.sleep(30)
+
+
 def _classify_and_record(
     task: TaskStory,
     result: CoordinatorResult,
@@ -456,7 +485,8 @@ def _classify_and_record(
     else:
         delta_failed = 1
 
-    # DAG: mark_complete (satisfies deps) only when merged or ALREADY_DONE
+    # DAG: mark_complete (satisfies deps) only when actually merged or ALREADY_DONE.
+    # Queued auto-merges report merged=False, so they stay blocked until polling confirms MERGED.
     if preflight_verdict == "ALREADY_DONE" or (
         result.merge is not None and result.merge.get("merged", False)
     ):
@@ -693,6 +723,7 @@ def run_sprint(
     worker_phases: dict[str, str] = {}
     phase_lock = threading.Lock()
     pending_merges: dict[str, tuple[TaskStory, CoordinatorResult]] = {}
+    queued_prs: dict[str, tuple[TaskStory, CoordinatorResult, str]] = {}
     _submission_counter = [0]  # mutable for closure capture; counts submitted stories
 
     # Overlap detection state (plan gates)
@@ -707,6 +738,43 @@ def run_sprint(
             ready = [t for t in dag.ready() if t.slug not in active]
 
             for task in ready:
+                blocked_by_queued = [dep for dep in task.depends_on if dep in queued_prs]
+                if blocked_by_queued:
+                    dependency_failed = False
+                    for dep in blocked_by_queued:
+                        dep_task, dep_result, dep_pr_url = queued_prs[dep]
+                        poll_result = _poll_queued_pr(
+                            dep_pr_url,
+                            config.project_root,
+                            config.workspace.ci_check_timeout_seconds,
+                        )
+                        if poll_result["status"] == "merged":
+                            merged_slugs.add(dep)
+                            dag.mark_complete(dep)
+                            del queued_prs[dep]
+                            _write_story_audit(config, dep_task, dep_result)
+                        else:
+                            dep_result.success = False
+                            dep_result.phase = Phase.ESCALATE
+                            dep_result.state.phase = Phase.ESCALATE
+                            dep_result.state.error = (
+                                f"Queued PR {poll_result['status']}: {dep_pr_url}"
+                            )
+                            specs_succeeded -= 1
+                            specs_failed += 1
+                            dag.mark_skipped(dep)
+                            del queued_prs[dep]
+                            _write_story_audit(config, dep_task, dep_result)
+                            _log(
+                                f"✗ {dep}: queued PR {poll_result['status']} "
+                                "before dependent dispatch"
+                            )
+                            dependency_failed = True
+                    if dependency_failed:
+                        continue
+                    if any(dep in queued_prs for dep in task.depends_on):
+                        continue
+
                 # Cap concurrent submissions at max_parallel
                 if len(active) >= max_parallel:
                     break
@@ -1014,6 +1082,8 @@ def run_sprint(
                                     )
                                     result.merge = merge_info
                                     if merge_info.get("merged"):
+                                        # Only actual merges satisfy DAG dependencies;
+                                        # queued auto-merges wait for polling.
                                         merged_slugs.add(slug)
                                         dag.mark_complete(slug)
                                         if not merge_info.get("auto_merge_queued", False):
@@ -1043,6 +1113,12 @@ def run_sprint(
                                                 f"INFO {slug}: PR auto-merge queued; "
                                                 "skipping CI gate until GitHub lands the merge"
                                             )
+                                    elif merge_info.get("merge_queued"):
+                                        queued_prs[slug] = (task, result, merge_info["pr_url"])
+                                        _log(
+                                            f"INFO {slug}: PR auto-merge queued; "
+                                            "waiting for GitHub to report MERGED"
+                                        )
                                     else:
                                         result.success = False
                                         result.phase = Phase.ESCALATE
@@ -1071,8 +1147,8 @@ def run_sprint(
                                 )
                                 result.merge = merge_info
                                 if merge_info.get("merged"):
+                                    # Re-classify in DAG only after an actual merge lands.
                                     merged_slugs.add(slug)
-                                    # Re-classify in DAG since we now know it merged
                                     dag.mark_complete(slug)
                                 else:
                                     result.success = False
@@ -1097,6 +1173,28 @@ def run_sprint(
                                 specs_skipped += 1
                                 _log(f"SKIPPED {t.slug} ({stopped_reason})")
                         pending_merges.clear()
+
+    if queued_prs:
+        for slug, (task, result, pr_url) in list(queued_prs.items()):
+            poll_result = _poll_queued_pr(
+                pr_url,
+                config.project_root,
+                config.workspace.ci_check_timeout_seconds,
+            )
+            if poll_result["status"] == "merged":
+                merged_slugs.add(slug)
+                dag.mark_complete(slug)
+            else:
+                result.success = False
+                result.phase = Phase.ESCALATE
+                result.state.phase = Phase.ESCALATE
+                result.state.error = f"Queued PR {poll_result['status']}: {pr_url}"
+                specs_succeeded -= 1
+                specs_failed += 1
+                dag.mark_skipped(slug)
+                _log(f"✗ {slug}: queued PR {poll_result['status']} during sprint wrap-up")
+            _write_story_audit(config, task, result)
+            del queued_prs[slug]
 
     finished_at = datetime.datetime.now(datetime.timezone.utc)
     set_worker_slug("")

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -408,7 +408,7 @@ class TestMergePrFunction:
         assert result["success"] is False
         assert result["merged"] is False
         assert "branch protection" in result["error"]
-        assert call_counts == {"fetch": 1, "rebase": 1, "push": 1, "merge": 1}
+        assert call_counts == {"fetch": 1, "rebase": 1, "push": 1, "merge": 2}
 
     def test_auto_flag_passed_to_gh_merge(self, tmp_path: Path) -> None:
         """Verify --auto is passed so branch protection can queue the merge."""
@@ -443,7 +443,7 @@ class TestMergePrFunction:
             _merge_pr(config, task, "forge/test-task", review, state)
 
         assert gh_calls
-        assert all("--auto" in c for c in gh_calls)
+        assert all("--auto" not in c for c in gh_calls)
 
     def test_merge_strategy_squash_passed_to_gh(self, tmp_path: Path) -> None:
         """Verify --squash is passed to gh pr merge."""
@@ -528,8 +528,17 @@ class TestMergePrFunction:
         def _fake_run(cmd, **kwargs):
             if isinstance(cmd, list):
                 commands.append(cmd)
-                if cmd[:3] == ["gh", "pr", "merge"]:
-                    return _make_subprocess_result(0, stdout="Auto-merge enabled for pull request")
+                if cmd[:4] == [
+                    "gh",
+                    "pr",
+                    "merge",
+                    "https://github.com/fuzzypete/theforge/pull/queued",
+                ]:
+                    if "--auto" in cmd:
+                        return _make_subprocess_result(0)
+                    return _make_subprocess_result(1, stderr="required status checks must pass")
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return _make_subprocess_result(0, stdout="", stderr="OPEN")
             return _make_subprocess_result(0)
 
         with (
@@ -547,7 +556,8 @@ class TestMergePrFunction:
             result = _merge_pr(config, task, "forge/test-task", review, state)
 
         assert result["success"] is True
-        assert result["merged"] is True
+        assert result["merged"] is False
+        assert result["merge_queued"] is True
         assert ["git", "push", "origin", "--delete", "forge/test-task"] not in commands
 
     def test_immediate_merge_still_deletes_remote_branch(self, tmp_path: Path) -> None:
@@ -586,6 +596,64 @@ class TestMergePrFunction:
         assert result["success"] is True
         assert result["merged"] is True
         assert ["git", "push", "origin", "--delete", "forge/test-task"] in commands
+
+    def test_branch_protection_fallback_immediate_merge(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                if "--auto" in cmd:
+                    return _make_subprocess_result(0)
+                return _make_subprocess_result(1, stderr="required status checks must pass")
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="MERGED")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/42",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+        assert result["success"] is True
+        assert result["merged"] is True
+        assert result["merge_queued"] is False
+
+    def test_branch_protection_fallback_queued(self, tmp_path: Path) -> None:
+        result = self._run_merge_pr(
+            tmp_path,
+            gh_merge_results=[
+                _make_subprocess_result(1, stderr="protected branch hook declined"),
+                _make_subprocess_result(0),
+                _make_subprocess_result(0, stdout="", stderr="OPEN"),
+            ],
+        )
+        assert result["success"] is True
+        assert result["merged"] is False
+        assert result["merge_queued"] is True
+        assert result["auto_merge_queued"] is True
+
+    def test_non_protection_failure_returns_fail_without_auto(self, tmp_path: Path) -> None:
+        result = self._run_merge_pr(
+            tmp_path,
+            gh_merge_results=[_make_subprocess_result(1, stderr="authentication failed")],
+        )
+        assert result["success"] is False
+        assert result["merged"] is False
+        assert result["merge_queued"] is False
 
     def test_delete_branch_not_passed_to_gh(self, tmp_path: Path) -> None:
         """gh pr merge avoids local cleanup flags that trip worktree constraints."""
@@ -1335,3 +1403,47 @@ class TestFastForwardAfterMerge:
         assert any(cmd[:4] == ["git", "worktree", "remove", "--force"] for cmd in cleanup_calls)
         assert any(cmd[:3] == ["git", "branch", "-D"] for cmd in cleanup_calls)
         assert any(cmd[:4] == ["git", "push", "origin", "--delete"] for cmd in cleanup_calls)
+
+    def test_finalize_approve_keeps_done_for_merge_queued(self, tmp_path: Path) -> None:
+        import time
+
+        from theforge.coordinator.completion import _finalize_approve
+        from theforge.coordinator.state import CoordinatorState, Phase
+
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = CoordinatorState()
+        state.phase = Phase.REVIEW
+
+        with patch(
+            "theforge.coordinator.completion._merge_pr",
+            return_value={
+                "action": "merge-pr",
+                "pr_url": "https://github.com/x/y/pull/6",
+                "merged": False,
+                "merge_queued": True,
+                "auto_merge_queued": True,
+                "success": True,
+                "error": None,
+            },
+        ):
+            result = _finalize_approve(
+                state,
+                config,
+                task,
+                review,
+                tmp_path,
+                "forge/test-task",
+                time.monotonic(),
+                auto_merge=False,
+                notify=False,
+                logger=None,
+                review_cost=0.5,
+                review_elapsed=1.0,
+                message="done. ",
+            )
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.merge["merge_queued"] is True

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1291,3 +1291,132 @@ def test_write_sprint_summary_records_ci_break_slug(tmp_path: Path) -> None:
 
     summary = __import__("yaml").safe_load((sprint_log_dir / "sprint-summary.yaml").read_text())
     assert summary["sprint"]["ci_break_slug"] == "story-123"
+
+
+class TestQueuedMergePolling:
+    def test_poll_queued_pr_merged(self, tmp_path: Path) -> None:
+        from theforge.sprint.runner import _poll_queued_pr
+
+        states = ["OPEN", "OPEN", "MERGED"]
+
+        def _fake_run(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout=states.pop(0), stderr="")
+
+        with (
+            patch("theforge.sprint.runner.subprocess.run", side_effect=_fake_run),
+            patch("theforge.sprint.runner.time.sleep"),
+        ):
+            assert _poll_queued_pr("https://github.com/x/y/pull/1", tmp_path, 90) == {
+                "status": "merged"
+            }
+
+    def test_poll_queued_pr_closed(self, tmp_path: Path) -> None:
+        from theforge.sprint.runner import _poll_queued_pr
+
+        with patch(
+            "theforge.sprint.runner.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="CLOSED", stderr=""),
+        ):
+            assert _poll_queued_pr("https://github.com/x/y/pull/1", tmp_path, 90) == {
+                "status": "closed"
+            }
+
+    def test_poll_queued_pr_timeout(self, tmp_path: Path) -> None:
+        from theforge.sprint.runner import _poll_queued_pr
+
+        monotonic_values = iter([0, 1, 31, 61])
+        with (
+            patch(
+                "theforge.sprint.runner.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="OPEN", stderr=""),
+            ),
+            patch("theforge.sprint.runner.time.sleep"),
+            patch(
+                "theforge.sprint.runner.time.monotonic", side_effect=lambda: next(monotonic_values)
+            ),
+        ):
+            assert _poll_queued_pr("https://github.com/x/y/pull/1", tmp_path, 60) == {
+                "status": "timeout"
+            }
+
+    def test_merge_queued_does_not_mark_complete_immediately(self, tmp_path: Path) -> None:
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b", depends_on=["story-a"])
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md", "story-b.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+                on_approve="merge-pr",
+                auto_push=True,
+                ci_check_timeout_seconds=60,
+            ),
+        )
+
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        mock_preflight = MagicMock()
+        mock_preflight.cost_usd = 1.0
+        state.preflight_result = mock_preflight
+        state.review_results = [
+            ReviewResult(
+                verdict="APPROVE",
+                summary="Looks good.",
+                findings=[],
+                story_matches=True,
+                story_mismatches=[],
+                test_adequate=True,
+                test_gaps=[],
+                parse_errors=[],
+                raw_yaml={},
+            )
+        ]
+        result = CoordinatorResult(
+            success=True,
+            phase=Phase.DONE,
+            state=state,
+            message="Done.",
+            merge={"action": "none", "success": True, "error": None},
+        )
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result) as mock_run,
+            patch(
+                "theforge.coordinator.completion._merge_pr",
+                return_value={
+                    "action": "merge-pr",
+                    "pr_url": "https://github.com/x/y/pull/7",
+                    "merged": False,
+                    "merge_queued": True,
+                    "auto_merge_queued": True,
+                    "success": True,
+                    "error": None,
+                },
+            ),
+            patch(
+                "theforge.sprint.runner._poll_queued_pr",
+                side_effect=[{"status": "timeout"}],
+            ),
+            patch(
+                "theforge.sprint.runner.poll_required_checks",
+                return_value={
+                    "status": "pass",
+                    "sha": "deadbeef",
+                    "failing_checks": [],
+                    "message": "ok",
+                },
+            ),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        assert mock_run.call_count == 1
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
+        assert sprint.specs_skipped == 1


### PR DESCRIPTION
## Summary

[openai-reviewer] merge-pr async state handled correctly; all acceptance criteria satisfied | [gemini-reviewer] The implementation correctly addresses the auto-merge race condition by introducing a two-phase merge process, a distinct 'merge_queued' state, and polling for final merge confirmation, all of which are well-tested.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.29
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: merge-pr treats auto-merge queue as completed state transition (GitHub Issue #459)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #459