### PR TITLE
fix(preflight): match api profiles in model registry (#496)

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -190,18 +190,27 @@ def _parse_preflight_sufficiency(output: str) -> str:
 def _find_registry_info_for_profile(profile: ModelProfile) -> tuple[int, int]:
     """Return (cost_rank, capability) for a profile using the model registry.
 
+    CLI profiles match by cli+model. API profiles match by provider+model against
+    the registry key because registry entries are keyed by provider/model while
+    storing the corresponding CLI transport.
+
     Falls back to (2, 5) for unknown models.
     """
-    for info in MODEL_REGISTRY.values():
-        if info.cli == profile.cli and info.model == profile.model:
-            return info.cost_rank, info.capability
-    return 2, 5
+    registry_key = _find_registry_key_for_profile(profile)
+    if registry_key is None:
+        return 2, 5
+    info = MODEL_REGISTRY[registry_key]
+    return info.cost_rank, info.capability
 
 
 def _find_registry_key_for_profile(profile: ModelProfile) -> str | None:
     """Return the MODEL_REGISTRY key for a profile, or None if unknown."""
     for key, info in MODEL_REGISTRY.items():
-        if info.cli == profile.cli and info.model == profile.model:
+        if profile.cli is not None:
+            if info.cli == profile.cli and info.model == profile.model:
+                return key
+            continue
+        if profile.provider is not None and key == f"{profile.provider}/{profile.model}":
             return key
     return None
 

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -477,6 +477,34 @@ class TestComplexityAdaptation:
         assert adapted.dev_profile.model == "opus"
         assert adapted.dev_profile.cli == "claude"
 
+    def test_large_api_dev_uses_provider_model_registry_match(self, tmp_path):
+        """large complexity ranks API profiles by provider/model instead of defaulting."""
+        config = _make_smart_config(tmp_path)
+        api_dev = replace(
+            config.dev_profile,
+            cli=None,
+            provider="openai",
+            model="gpt-5.4",
+        )
+        api_review = replace(
+            config.review_pool[0],
+            cli=None,
+            provider="anthropic",
+            model="opus",
+        )
+        reviewer = replace(
+            config.review_pool[1],
+            cli=None,
+            provider="openai",
+            model="gpt-5.4",
+        )
+        api_config = replace(config, dev_profile=api_dev, review_pool=[api_review, reviewer])
+
+        adapted = _apply_complexity_adaptation(api_config, "large")
+
+        assert adapted.dev_profile.model == "opus"
+        assert adapted.dev_profile.cli == "claude"
+
     def test_complexity_ignored_with_explicit_profiles(self, tmp_path):
         """No smart_config_models → complexity is a no-op."""
         config = _make_config(tmp_path)  # classic config, smart_config_models=None


### PR DESCRIPTION
Closes #496

Recovered from orphaned PR — original was approved but never merged due to the auto-merge bug (#459, fixed in #511).