### PR TITLE
fix(coordinator): use mergedAt for duplicate PR guard (#482)

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -167,7 +167,7 @@ def _create_pr(
                 "--state",
                 "closed",
                 "--json",
-                "number,url,merged",
+                "number,url,mergedAt",
             ],
             capture_output=True,
             text=True,
@@ -176,7 +176,7 @@ def _create_pr(
         )
         if merged_pr_proc.returncode == 0:
             merged_prs = json.loads(merged_pr_proc.stdout or "[]")
-            merged_pr = next((pr for pr in merged_prs if pr.get("merged")), None)
+            merged_pr = next((pr for pr in merged_prs if pr.get("mergedAt")), None)
             if merged_pr is not None:
                 pr_url = merged_pr.get("url")
                 message = f"PR already merged for branch {branch_name}: {pr_url}"

--- a/tests/test_coord_gate_fix.py
+++ b/tests/test_coord_gate_fix.py
@@ -574,6 +574,8 @@ class TestCreatePR:
         # First call must be merged PR lookup
         lookup_call = mock_run.call_args_list[0]
         assert lookup_call[0][0][:3] == ["gh", "pr", "list"]
+        json_idx = lookup_call[0][0].index("--json") + 1
+        assert lookup_call[0][0][json_idx] == "number,url,mergedAt"
 
         # Second call must be git push
         push_call = mock_run.call_args_list[1]
@@ -663,7 +665,8 @@ class TestCreatePR:
             {
                 "returncode": 0,
                 "stdout": (
-                    '[{"number": 222, "url": "https://github.com/test/pr/222", "merged": true}]'
+                    '[{"number": 222, "url": "https://github.com/test/pr/222", '
+                    '"mergedAt": "2024-01-02T03:04:05Z"}]'
                 ),
                 "stderr": "",
             },
@@ -677,6 +680,8 @@ class TestCreatePR:
         assert mock_run.call_count == 1
         lookup_call = mock_run.call_args_list[0]
         assert lookup_call[0][0][:3] == ["gh", "pr", "list"]
+        json_idx = lookup_call[0][0].index("--json") + 1
+        assert lookup_call[0][0][json_idx] == "number,url,mergedAt"
 
     @patch("theforge.coordinator.validate_phase.subprocess.run")
     def test_push_failure_aborts_pr(self, mock_run, tmp_path):


### PR DESCRIPTION
Closes #482

Recovered from orphaned PR — original was approved but never merged due to the auto-merge bug (#459, fixed in #511).