### PR TITLE
fix(sprint): detect merge fallback via audit trail (#478)

### DIFF
--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -87,6 +87,13 @@ def _is_branch_merged(
                     # Regular merge: base has moved past branch and branch had
                     # unique work of its own.
                     return True
+                # ahead_count > 0 with no unique commits is ambiguous in git state
+                # alone: it can be an abandoned empty branch or a regular merge
+                # commit whose branch tip is already reachable from base. Use the
+                # audit trail as the tiebreaker when the slug is known.
+                if slug is not None:
+                    return has_review_approve(project_root, slug, base_branch, branch)
+                return False
             # Fast-forward merge: branch and base at the same tip (count == 0).
             # Fall back to the audit trail when the slug is known.
             if slug is not None:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -212,6 +212,28 @@ def test_is_branch_merged_regular_merge(tmp_path: Path) -> None:
     assert result is True
 
 
+def test_is_branch_merged_regular_merge_falls_back_to_audit(tmp_path: Path) -> None:
+    """Regular merge fallback: ahead > 0, unique == 0, audit APPROVE → True."""
+
+    def _mock_regular_fallback(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        m.returncode = 0
+        if cmd[:2] == ["git", "rev-list"] and cmd[2] == "forge/story-a..main":
+            m.stdout = b"3"
+        elif cmd[:2] == ["git", "rev-list"] and cmd[2] == "main..forge/story-a":
+            m.stdout = b"0"
+        else:
+            m.stdout = b""
+        return m
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_regular_fallback),
+        patch("theforge.sprint.dag.has_review_approve", return_value=True),
+    ):
+        result = _is_branch_merged("forge/story-a", "main", tmp_path, slug="story-a")
+    assert result is True
+
+
 def test_is_branch_merged_stale_empty_branch(tmp_path: Path) -> None:
     """Base moving past an empty branch must not count as merged."""
 


### PR DESCRIPTION
Closes #478

Recovered from orphaned PR — original was approved but never merged due to the auto-merge bug (#459, fixed in #511).