### PR TITLE
fix(workspace): rerun setup on reused worktrees (#353)

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -46,6 +46,22 @@ def _resolve_setup_command(cmd: str) -> str:
     return cmd.replace("{forge_python}", shlex.quote(sys.executable))
 
 
+def _read_last_setup_command(workspace_path: Path) -> str | None:
+    """Read the last setup_command run in this workspace, if any."""
+    path = workspace_path / ".forge" / "last_setup_command"
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+
+def _write_last_setup_command(workspace_path: Path, cmd: str) -> None:
+    """Persist the last setup_command run in this workspace."""
+    forge_dir = workspace_path / ".forge"
+    forge_dir.mkdir(parents=True, exist_ok=True)
+    (forge_dir / "last_setup_command").write_text(cmd, encoding="utf-8")
+
+
 def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, str]:
     """Run workspace setup, always running pip install even if .venv exists.
 
@@ -60,6 +76,10 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
 
     Falls back to running setup_command verbatim when neither pattern matches.
     """
+    last_setup_command = _read_last_setup_command(workspace_path)
+    if last_setup_command is not None and last_setup_command != setup_command:
+        _cu._log("⚠ WORKSPACE  setup_command changed — re-running install")
+
     # --- template form: match before substitution ---
     m = _VENV_GUARD_TEMPLATE_RE.search(setup_command)
     if m:
@@ -68,19 +88,28 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
         ok, out = _cu._run_shell(f"test -d .venv || {python_exe} -m venv .venv", workspace_path)
         if not ok:
             return ok, out
-        return _cu._run_shell(install_cmd, workspace_path)
+        ok, out = _cu._run_shell(install_cmd, workspace_path)
+        if ok:
+            _write_last_setup_command(workspace_path, setup_command)
+        return ok, out
 
     # --- legacy form: resolve then match ---
     cmd = _resolve_setup_command(setup_command)
     m = _VENV_GUARD_RE.search(cmd)
     if not m:
-        return _cu._run_shell(cmd, workspace_path)
+        ok, out = _cu._run_shell(cmd, workspace_path)
+        if ok:
+            _write_last_setup_command(workspace_path, setup_command)
+        return ok, out
     python_exe = m.group(1)
     install_cmd = m.group(2).strip()
     ok, out = _cu._run_shell(f"test -d .venv || {python_exe} -m venv .venv", workspace_path)
     if not ok:
         return ok, out
-    return _cu._run_shell(install_cmd, workspace_path)
+    ok, out = _cu._run_shell(install_cmd, workspace_path)
+    if ok:
+        _write_last_setup_command(workspace_path, setup_command)
+    return ok, out
 
 
 def _resolve_merge_conflicts(
@@ -378,7 +407,7 @@ def _check_behind_origin(config: ForgeConfig) -> None:
         _cu._log(f"ℹ WORKSPACE  {base_branch} is {count} commit(s) behind origin/{base_branch}")
 
 
-_FORGE_ARTIFACTS = (".forge/handoff.yaml", ".forge/trajectory.yaml")
+_FORGE_ARTIFACTS = (".forge/handoff.yaml", ".forge/trajectory.yaml", ".forge/last_setup_command")
 
 
 def _deindex_forge_artifacts(workspace_path: Path) -> None:
@@ -446,6 +475,11 @@ def _create_workspace(
             _cu._log(f"↻ WORKSPACE  reusing existing worktree: {workspace_path}")
             if not no_pull:
                 _check_behind_origin(config)
+            if config.workspace.setup_command:
+                _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
+                ok_s, out_s = _run_setup_split(config.workspace.setup_command, workspace_path)
+                if not ok_s:
+                    return None, None, f"Workspace setup command failed: {out_s}"
             _deindex_forge_artifacts(workspace_path)
             return workspace_path, branch_name, None
 

--- a/tests/test_coord_workspace_venv.py
+++ b/tests/test_coord_workspace_venv.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.coordinator.workspace import _FORGE_ARTIFACTS, _create_workspace, _run_setup_split
+
+
+class TestRunSetupSplitVenvBehavior:
+    def test_template_guard_always_runs_install_even_when_venv_exists(self, tmp_path):
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e '.[all]')"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kwargs):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert len(calls) == 2
+        assert "-m venv .venv" in calls[0]
+        assert calls[1] == "pip install -e '.[all]'"
+
+    def test_legacy_guard_always_runs_install_even_when_venv_exists(self, tmp_path):
+        cmd = "test -d .venv || (python -m venv .venv && pip install -e '.[all]')"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kwargs):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert len(calls) == 2
+        assert calls[0] == "test -d .venv || python -m venv .venv"
+        assert calls[1] == "pip install -e '.[all]'"
+
+
+class TestRunSetupSplitCommandTracking:
+    @patch("theforge.coordinator.workspace._cu._log")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_logs_and_records_changed_setup_command(self, mock_shell, mock_log, tmp_path):
+        forge_dir = tmp_path / ".forge"
+        forge_dir.mkdir()
+        (forge_dir / "last_setup_command").write_text("pip install -e .", encoding="utf-8")
+        mock_shell.return_value = (True, "ok")
+
+        cmd = "pip install -e '.[all]'"
+        ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert any("setup_command changed" in str(call) for call in mock_log.call_args_list)
+        assert (forge_dir / "last_setup_command").read_text(encoding="utf-8") == cmd
+
+    @patch("theforge.coordinator.workspace._cu._log")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_no_log_when_setup_command_unchanged(self, mock_shell, mock_log, tmp_path):
+        forge_dir = tmp_path / ".forge"
+        forge_dir.mkdir()
+        cmd = "pip install -e '.[all]'"
+        (forge_dir / "last_setup_command").write_text(cmd, encoding="utf-8")
+        mock_shell.return_value = (True, "ok")
+
+        ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert not any("setup_command changed" in str(call) for call in mock_log.call_args_list)
+        assert (forge_dir / "last_setup_command").read_text(encoding="utf-8") == cmd
+
+
+class TestCreateWorkspaceReuseRunsSetup:
+    @patch("theforge.coordinator.workspace._deindex_forge_artifacts")
+    @patch("theforge.coordinator.workspace._run_setup_split")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_non_stale_reuse_path_runs_setup(
+        self, mock_log, mock_shell, mock_setup, mock_deindex, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        config = replace(
+            config,
+            workspace=replace(config.workspace, setup_command="pip install -e '.[all]'"),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir(parents=True, exist_ok=True)
+        mock_setup.return_value = (True, "ok")
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            if "git log" in cmd and ".." in cmd:
+                return (True, "abc123 a commit\n")
+            if "rev-list" in cmd:
+                return (True, "0\n")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        workspace_path, branch_name, err = _create_workspace(config, task, no_pull=False)
+
+        assert err is None
+        assert workspace_path == workspace
+        mock_setup.assert_called_once_with(config.workspace.setup_command, workspace)
+        mock_deindex.assert_called_once_with(workspace)
+
+
+def test_last_setup_command_is_deindexed_artifact():
+    assert ".forge/last_setup_command" in _FORGE_ARTIFACTS


### PR DESCRIPTION
Closes #353

Recovered from orphaned PR — original was approved but never merged due to the auto-merge bug (#459, fixed in #511).