### PR TITLE
bug: gate timeout leaves orphaned pytest worker processes

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import datetime
 import signal
-import subprocess
 import time
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -119,50 +118,6 @@ def _ensure_runners() -> None:
         log_agent_result = _r.log_agent_result
     if LogLevel is None:
         LogLevel = _r.LogLevel
-
-
-def _run_shell(cmd: str, cwd: Path, timeout: int = 120) -> tuple[bool, str]:
-    """Run a shell command. Returns (success, combined output).
-
-    Defined here (not re-exported from coord_util) so that
-    ``patch('theforge.coordinator._run_shell')`` intercepts calls made
-    directly within this module.  Sub-modules (coord_workspace, coord_gate)
-    call coord_util._run_shell; patch that symbol when testing those paths.
-
-    On timeout, kills the entire process group so child processes don't
-    outlive the shell and consume unbounded memory.
-    """
-    import os  # noqa: PLC0415
-
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=str(cwd),
-            start_new_session=True,
-        )
-    except Exception as e:
-        return False, f"ERROR: {e}"
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-        output = (stdout + stderr).strip()
-        return proc.returncode == 0, output
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        proc.wait()
-        return False, f"TIMEOUT after {timeout}s: {cmd}"
-    except Exception as e:
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        return False, f"ERROR: {e}"
 
 
 # ── Log-tee / SIGTERM context manager ────────────────────────────────

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -94,12 +94,20 @@ def resolve_timeout(
     return base
 
 
+def _kill_process_group(proc: subprocess.Popen[str]) -> None:
+    """Best-effort kill for a spawned shell process group."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
 def _run_shell(
     cmd: str, cwd: Path, timeout: int = 120, env: dict[str, str] | None = None
 ) -> tuple[bool, str]:
     """Run a shell command. Returns (success, combined output).
 
-    On timeout, kills the entire process group so child processes (e.g.
+    On abnormal exit, kills the entire process group so child processes (e.g.
     pytest-xdist workers) don't outlive the shell and consume unbounded memory.
     """
     try:
@@ -120,15 +128,18 @@ def _run_shell(
         output = (stdout + stderr).strip()
         return proc.returncode == 0, output
     except subprocess.TimeoutExpired:
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+        _kill_process_group(proc)
         proc.wait()
         return False, f"TIMEOUT after {timeout}s: {cmd}"
-    except Exception as e:
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        return False, f"ERROR: {e}"
+    except BaseException:
+        _kill_process_group(proc)
+        proc.wait()
+        raise
+    finally:
+        for stream_name in ("stdout", "stderr"):
+            stream = getattr(proc, stream_name, None)
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass

--- a/tests/test_coord_gate_exec.py
+++ b/tests/test_coord_gate_exec.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import patch
 
+import pytest
 import yaml
 from coord_test_helpers import (
     _PREFLIGHT_RESULT,
@@ -875,5 +876,40 @@ def test_run_shell_timeout_ignores_missing_process_group(tmp_path):
 
     assert ok is False
     assert output == "TIMEOUT after 1s: pytest -n auto --dist worksteal"
+    mock_killpg.assert_not_called()
+    proc.wait.assert_called_once_with()
+
+
+def test_run_shell_kills_process_group_on_keyboard_interrupt(tmp_path):
+    proc = mock.MagicMock()
+    proc.pid = 4321
+    proc.communicate.side_effect = KeyboardInterrupt
+
+    with (
+        patch("theforge.coordinator.util.subprocess.Popen", return_value=proc),
+        patch("theforge.coordinator.util.os.getpgid", return_value=9876) as mock_getpgid,
+        patch("theforge.coordinator.util.os.killpg") as mock_killpg,
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            _cu._run_shell("pytest -n auto --dist worksteal", tmp_path, timeout=1)
+
+    mock_getpgid.assert_called_once_with(4321)
+    mock_killpg.assert_called_once_with(9876, signal.SIGKILL)
+    proc.wait.assert_called_once_with()
+
+
+def test_run_shell_keyboard_interrupt_ignores_missing_process_group(tmp_path):
+    proc = mock.MagicMock()
+    proc.pid = 4321
+    proc.communicate.side_effect = KeyboardInterrupt
+
+    with (
+        patch("theforge.coordinator.util.subprocess.Popen", return_value=proc),
+        patch("theforge.coordinator.util.os.getpgid", side_effect=ProcessLookupError),
+        patch("theforge.coordinator.util.os.killpg") as mock_killpg,
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            _cu._run_shell("pytest -n auto --dist worksteal", tmp_path, timeout=1)
+
     mock_killpg.assert_not_called()
     proc.wait.assert_called_once_with()


### PR DESCRIPTION
## Summary

[openai-reviewer] Gate timeout cleanup fix is correctly wired through the runtime path and the prior KeyboardInterrupt orphan-process bug is resolved. | [gemini-reviewer] Fixes the KeyboardInterrupt handling and correctly cleans up process groups on timeout.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.37
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/util.py:101`** `_kill_process_group` catches `ProcessLookupError`, but if the PID was rapidly reused by a process owned by another user, `os.getpgid` or `os.killpg` could raise `PermissionError`. Catching `OSError` would be slightly safer for a best-effort cleanup function.

## Story

bug: gate timeout leaves orphaned pytest worker processes (GitHub Issue #523)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #523