### PR TITLE
feat(scripts): release.sh — scripted release process

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -97,7 +97,7 @@ echo "    pyproject.toml updated."
 # --- 6. Commit ---
 echo "==> Committing..."
 run git add CHANGELOG.md pyproject.toml
-run git commit -m "chore: release v$VERSION (#533)"
+run git commit -m "chore: release v$VERSION"
 
 # --- 7. Tag and push ---
 echo "==> Tagging and pushing..."
@@ -118,12 +118,12 @@ if [[ "$DRY_RUN" == false ]]; then
     sed -i '' "s/^version = \"$VERSION\"/version = \"$NEXT_DEV\"/" pyproject.toml
 fi
 run git add pyproject.toml
-run git commit -m "chore: begin v$NEXT_DEV development"
+run git commit -m "chore: begin v$NEXT_DEV development [skip ci]"
 run git push origin main
 
 # --- 10. GitHub Release ---
 echo "==> Creating GitHub release..."
-RELEASE_NOTES=$(awk "/^## \[$VERSION\]/,/^## \[/" CHANGELOG.md | head -n -1)
+RELEASE_NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
 run gh release create "v$VERSION" --repo fuzzypete/theforge \
     --title "v$VERSION" \
     --notes "$RELEASE_NOTES"


### PR DESCRIPTION
## Summary

- Adds `scripts/release.sh VERSION` — executes the full documented release process from RELEASING.md as a single command
- Reads current version from `pyproject.toml`, derives next dev version automatically
- Blocks if any milestone issues are still open (milestone gate)
- `--dry-run` mode prints every step without making changes
- Closes #533

## Test plan

- [ ] `bash scripts/release.sh --dry-run 0.5.0` — verify output shows all steps without executing, and correctly errors on open milestone issues
- [ ] Verify awk correctly extracts CHANGELOG section for a given version
- [ ] Verify release and dev-bump commits have correct message format (no stale issue refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)