### PR TITLE
Add directory-level CLAUDE.md files for major subsystems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,12 @@
 TheForge is a deterministic multi-LLM development orchestrator. This file provides
 conventions for any Claude agent working in this codebase.
 
+Directory-level `CLAUDE.md` files under `src/theforge/` provide subsystem-local
+context. When working inside `coordinator/`, `runners/`, `sprint/`, `task/`,
+`config/`, or `cli/`, read the nearest local `CLAUDE.md` in addition to this
+root guide. Treat local `Invariants` sections as hard constraints and `Context`
+sections as navigational guidance.
+
 ---
 
 ## Current State — Start Here

--- a/src/theforge/cli/CLAUDE.md
+++ b/src/theforge/cli/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLI subsystem guidance
+
+## Purpose
+
+The CLI subsystem exposes operator-facing commands for running TheForge,
+inspecting audits, managing daemon behavior, checking configuration, and working
+with sprint and review flows.
+
+## Invariants
+
+- CLI commands should remain thin orchestration layers over underlying modules;
+  avoid embedding core business logic directly in command handlers.
+- Preserve stable, comprehensible command behavior and error reporting. Prefer
+  explicit user-facing failures over silent fallback behavior.
+- Keep command-specific concerns separated so `main.py` and shared helpers do not
+  become catch-all modules.
+- CLI wiring must respect deterministic coordinator behavior rather than adding
+  alternate process policy at the command layer.
+- When commands surface structured run data, do not hide details that operators
+  need for debugging or audit review.
+
+## Context
+
+- `main.py` is the primary entry point that assembles the command tree.
+- Modules such as `run.py`, `review.py`, `sprint.py`, `daemon.py`, and
+  `status.py` implement major command families.
+- `shared.py` and `overrides.py` contain reusable CLI plumbing and option
+  handling.
+- `audit.py`, `check_config.py`, and `providers.py` are useful reference points
+  for commands that inspect system state rather than launching work.
+- If a change mostly affects terminal UX, argument parsing, or command dispatch,
+  it likely belongs here; if it changes execution semantics, inspect the
+  underlying subsystem first.

--- a/src/theforge/config/CLAUDE.md
+++ b/src/theforge/config/CLAUDE.md
@@ -1,0 +1,31 @@
+# Config subsystem guidance
+
+## Purpose
+
+The config subsystem loads, validates, and normalizes TheForge configuration,
+including defaults, profiles, model selection data, authentication settings,
+and secrets handling.
+
+## Invariants
+
+- Configuration loading is an integrity boundary. Prefer explicit validation
+  errors over permissive fallback behavior that hides bad config.
+- Keep secrets handling narrow and deliberate; do not log secret values or make
+  them easier to leak through convenience helpers.
+- Preserve clear separation between raw loading, defaults application, and typed
+  normalization so configuration behavior stays understandable.
+- Foundational config types should remain low-dependency and broadly reusable.
+- Changes to model/profile configuration must not quietly undermine coordinator
+  assumptions about assignment or provider capabilities.
+
+## Context
+
+- `load.py` and `_loaders.py` are the entry points for reading configuration from
+  disk and environment.
+- `defaults.py`, `profiles.py`, and `models.py` define how omitted values are
+  filled and how model/provider capabilities are represented.
+- `types.py` contains typed config structures used throughout the codebase.
+- `auth.py` and `secrets.py` are the main places to inspect when credentials or
+  provider authentication behavior changes.
+- Misconfigurations often surface far from their source, so preserving precise
+  validation messages here saves debugging time elsewhere.

--- a/src/theforge/coordinator/CLAUDE.md
+++ b/src/theforge/coordinator/CLAUDE.md
@@ -1,0 +1,40 @@
+# Coordinator subsystem guidance
+
+## Purpose
+
+The coordinator owns deterministic process control for TheForge. It advances work
+through the state machine, prepares workspaces, invokes runners, validates phase
+outputs, records audit data, and decides whether a run proceeds, retries,
+escalates, or completes.
+
+## Invariants
+
+- Coordinator control flow is pure Python. Do not introduce LLM-driven routing,
+  retry, escalation, or state-transition decisions here.
+- State transitions must remain explicit and auditable. When phase inputs or
+  outputs change, preserve or extend audit visibility so reviewers can inspect
+  the real values that drove coordinator behavior.
+- Schema and validation boundaries are load-bearing. Do not weaken checks just to
+  accept malformed runner output or make tests pass.
+- Keep coordinator modules focused by phase or concern. Extract helpers instead
+  of growing `engine.py` or phase modules into mixed-responsibility monoliths.
+- Workspace and gate handling must be conservative: prefer failing closed over
+  silently continuing with an invalid repository, branch, or validation result.
+
+## Context
+
+- `engine.py` is the orchestration center for the run lifecycle and state
+  machine.
+- `preflight.py` and `preflight_flow.py` classify readiness and complexity before
+  downstream work begins; these decisions affect model assignment and whether
+  planning runs.
+- `plan_flow.py`, `dev_phase.py`, `validate_phase.py`, and `review_phase.py`
+  implement the major execution phases.
+- `audit.py`, `audit_render.py`, and `review_context.py` shape the traceability
+  story for runs; changes that hide intermediate values make sprint failures much
+  harder to diagnose.
+- `workspace.py`, `run_setup.py`, and related helpers manage repository state and
+  should be treated as safety-critical because mistakes can invalidate the whole
+  run.
+- If a change feels like prompt construction or output parsing rather than
+  process control, it probably belongs in `task/` or `runners/`, not here.

--- a/src/theforge/runners/CLAUDE.md
+++ b/src/theforge/runners/CLAUDE.md
@@ -1,0 +1,34 @@
+# Runners subsystem guidance
+
+## Purpose
+
+The runners subsystem is the execution boundary between the deterministic
+coordinator and external agent providers. It normalizes runner APIs, CLI-backed
+invocations, provider adapters, tool runtime behavior, and finalization of agent
+results.
+
+## Invariants
+
+- Runners execute work; they do not decide process policy. Keep routing,
+  escalation, retry, and verdict logic in the coordinator.
+- Preserve a clean separation between prompt input, provider invocation, and
+  output normalization/parsing so provider-specific behavior does not leak across
+  the subsystem.
+- Provider adapters must maintain schema integrity. Do not silently coerce or
+  discard malformed outputs in ways that hide contract violations.
+- Tests for runner behavior must mock subprocesses and external CLIs; never make
+  real provider calls part of the test suite.
+- Keep provider-specific code isolated to adapters or dedicated runner modules
+  rather than spreading conditional logic throughout shared APIs.
+
+## Context
+
+- `api.py` defines the common runner-facing interface used by the coordinator.
+- `cli.py` and `runner_*.py` modules wrap concrete agent execution paths.
+- `adapters/` contains provider-specific translation layers for Anthropic,
+  DeepSeek, Google, and OpenAI.
+- `schema_utils.py` and `finalizers.py` are where output normalization and
+  completion shaping happen; bugs here often surface later as validation or
+  review failures.
+- `tool_runtime.py` is the place to look when agent tool execution semantics or
+  environment wiring are involved.

--- a/src/theforge/sprint/CLAUDE.md
+++ b/src/theforge/sprint/CLAUDE.md
@@ -1,0 +1,33 @@
+# Sprint subsystem guidance
+
+## Purpose
+
+The sprint subsystem manages multi-story execution concerns: sprint manifests,
+issue sourcing, DAG scheduling, launch safety, collision avoidance, CI checks,
+and sprint-level audit/display behavior.
+
+## Invariants
+
+- Sprint orchestration must preserve dependency order and launch safety; do not
+  bypass DAG, collision, or guard checks for convenience.
+- Locking and concurrency behavior must remain deterministic and testable.
+  Changes here can create deadlocks or duplicate work if safety checks are
+  weakened.
+- Sprint logic should coordinate stories and repositories, not absorb unrelated
+  coordinator or CLI responsibilities.
+- CI and preflight checks should fail closed when required information is
+  missing or inconsistent.
+- Be careful with lock-related tests: avoid patterns that combine real
+  `fcntl.flock` usage with threaded tests under xdist.
+
+## Context
+
+- `dag.py` models dependency ordering and is central to launch sequencing.
+- `runner.py` coordinates sprint execution across stories once scheduling is
+  resolved.
+- `manifest.py`, `sources.py`, and `query.py` define how sprint work is
+  discovered and represented.
+- `launch_guard.py`, `collision.py`, `lock.py`, and `ci_checks.py` are the main
+  safety rails for concurrent or repeated execution.
+- `display.py` and `audit.py` shape operator-facing visibility into sprint
+  progress and outcomes.

--- a/src/theforge/task/CLAUDE.md
+++ b/src/theforge/task/CLAUDE.md
@@ -1,0 +1,31 @@
+# Task subsystem guidance
+
+## Purpose
+
+The task subsystem defines story data structures and builds the prompts and
+parsers used for planning, development, fixes, and review. It is the prompt
+construction layer, not the coordinator.
+
+## Invariants
+
+- Keep prompt construction separate from coordinator control flow and separate
+  from runner/provider execution details.
+- Preserve the distinction between story requirements and advisory notes.
+  Acceptance criteria are authoritative; notes are hints that must not be
+  promoted into hard requirements by default.
+- Story and plan parsing should remain strict enough to surface malformed agent
+  output instead of papering over ambiguity.
+- Keep low-dependency data definitions lightweight; avoid pulling heavy runtime
+  dependencies into foundational story or convention modules.
+- Prompt changes that alter data exchanged between phases should be reflected in
+  audit-visible structures upstream so the resulting values remain traceable.
+
+## Context
+
+- `story.py` defines the story/task representation consumed across the system.
+- `dev_prompts.py`, `fix_prompts.py`, `plan_prompts.py`, and
+  `review_prompts.py` hold phase-specific prompt builders.
+- `plan_parser.py` is the main parsing boundary for structured planning output.
+- `conventions.py` centralizes project conventions injected into prompts.
+- If a change is about what agents are told or how their structured text is
+  interpreted, this directory is usually the right home.

--- a/tests/test_claude_docs.py
+++ b/tests/test_claude_docs.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SUBSYSTEMS = ["coordinator", "runners", "sprint", "task", "config", "cli"]
+REQUIRED_SECTIONS = ["## Purpose", "## Invariants", "## Context"]
+
+
+def test_major_subsystems_have_claude_docs() -> None:
+    for subsystem in SUBSYSTEMS:
+        path = ROOT / "src" / "theforge" / subsystem / "CLAUDE.md"
+        assert path.exists(), f"missing CLAUDE.md for {subsystem}"
+
+
+def test_subsystem_claude_docs_have_required_sections() -> None:
+    for subsystem in SUBSYSTEMS:
+        text = (ROOT / "src" / "theforge" / subsystem / "CLAUDE.md").read_text()
+        for section in REQUIRED_SECTIONS:
+            assert section in text, f"{subsystem} missing section {section}"
+
+
+def test_root_claude_mentions_directory_level_convention() -> None:
+    text = (ROOT / "CLAUDE.md").read_text()
+    assert "Directory-level `CLAUDE.md` files under `src/theforge/`" in text
+    for subsystem in SUBSYSTEMS:
+        assert f"`{subsystem}/`" in text


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation satisfies the documentation story acceptance criteria with no blocking correctness issues. | [gemini-reviewer] Added directory-level CLAUDE.md files for major subsystems with required sections and tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.04
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Add directory-level CLAUDE.md files for major subsystems (GitHub Issue #417)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #417