### PR TITLE
Document bug report convention

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,36 +6,16 @@ labels: bug
 
 ## What happened
 
-<!-- A clear description of the bug -->
+<!-- Describe the observed behavior. Include evidence: log lines, audit trail
+     entries, run IDs, or error messages. -->
 
-## What I expected
+## What was expected
 
-<!-- What should have happened instead -->
+<!-- Describe the correct behavior. -->
 
-## Steps to reproduce
+## Evidence
 
-1.
-2.
-3.
-
-## Environment
-
-- **OS:** <!-- macOS / Linux / Windows -->
-- **Python:** <!-- e.g., 3.12.1 -->
-- **TheForge version:** <!-- `forge --version` or commit hash -->
-- **Provider(s):** <!-- Claude CLI, Codex CLI, OpenAI API, etc. -->
-
-## Configuration
-
-<!-- Paste relevant forge.yaml sections (redact API keys) -->
-
-```yaml
-
-```
-
-## Audit/log output
-
-<!-- If available, paste relevant sections from forge_audit.yaml or forge.log -->
+<!-- Paste relevant log output, audit YAML, or screenshots. -->
 
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,18 @@ Stories describe WHAT and WHY — never HOW. The plan phase produces the HOW.
 - The primary term is "story" throughout the codebase. `TaskSpec` is a
   backward-compat alias for `TaskStory`; prefer `TaskStory` in new code.
 
+### Writing bug reports
+Bug reports contain exactly two things:
+
+1. **What happened** — the observed behavior, with evidence (log lines, audit
+   trail entries, run IDs).
+2. **What was expected** — the correct behavior.
+
+That's it. No acceptance criteria, no implementation hints, no file paths, no
+suggestions about which module or function to fix. The dev agent should discover
+the fix from the codebase. Over-constraining the report biases the agent toward
+a specific fix path that may not be the right one.
+
 ### Dogfooding config
 `forge.yaml` at the project root configures theforge to develop itself. Worktrees
 land in `.forge/worktrees/<slug>/` on branch `feat/<slug>`.


### PR DESCRIPTION
## Summary
- Adds `### Writing bug reports` section to CLAUDE.md: observed + expected only, no ACs or implementation hints
- Simplifies GH issue template to match: stripped environment/config/steps-to-reproduce sections that encouraged over-constraining

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)