### PR TITLE
Bug: preflight prompt missing likely_files — collision scheduling blind

### DIFF
--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -151,6 +151,8 @@ def build_preflight_prompt(
             description: "<what conflicts or is unclear>"
         warnings:
           - "<missing file path or other non-blocking advisory>"
+        likely_files:
+          - "<repo-relative file path likely to be edited if implementation proceeds>"
         criteria_checked:
           - criterion: "<acceptance criterion text>"
             satisfied: true | false
@@ -159,6 +161,8 @@ def build_preflight_prompt(
 
         Use `spec_issues: []` if the spec is clean.
         Use `warnings: []` if there are no non-blocking advisories.
+        Use `likely_files: []` when no likely edit targets can be identified.
+        Include repo-relative paths only; do not invent nonexistent files just to fill the list.
         Always include `sufficiency` and `sufficiency_reason` when verdict is PROCEED.
 
         ## Rules

--- a/tests/test_task_preflight_prompt.py
+++ b/tests/test_task_preflight_prompt.py
@@ -1,0 +1,12 @@
+from theforge.task import build_preflight_prompt
+from theforge.task.story import TaskStory
+
+
+def test_build_preflight_prompt_requests_likely_files() -> None:
+    task = TaskStory(name="Bug fix", slug="bug-fix")
+
+    prompt = build_preflight_prompt(task, story_content="## Spec\n\n- Example")
+
+    assert "likely_files:" in prompt
+    assert "repo-relative file path likely to be edited if implementation proceeds" in prompt
+    assert "Use `likely_files: []` when no likely edit targets can be identified." in prompt


### PR DESCRIPTION
## Summary

[openai-reviewer] Preflight prompt now explicitly requests likely_files in the YAML schema, satisfying the acceptance criterion and covered by a regression test. | [gemini-reviewer] The preflight prompt now correctly requests likely_files in its output schema.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.17
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Bug: preflight prompt missing likely_files — collision scheduling blind (GitHub Issue #548)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #548