### PR TITLE
Bug: preflight ALREADY_DONE evaluates stale worktree instead of clean baseline

### DIFF
--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -54,7 +54,7 @@ def _prepare_preflight_working_dir(
     project_root: Path, base_branch: str
 ) -> tuple[Path, Callable[[], None]]:
     """Materialize a clean baseline checkout for deterministic preflight evaluation."""
-    temp_dir = Path(tempfile.mkdtemp(prefix="forge-preflight-", dir=project_root))
+    temp_dir = Path(tempfile.mkdtemp(prefix="forge-preflight-"))
     git_dir = project_root / ".git"
     if not git_dir.exists():
         return temp_dir, lambda: shutil.rmtree(temp_dir, ignore_errors=True)

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -18,6 +18,9 @@ Called from run_task(); returns (updated_config, result, already_done_loop):
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+import tempfile
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -45,6 +48,42 @@ from .preflight import (
 )
 from .state import CoordinatorResult, CoordinatorState, Phase
 from .util import _fmt_duration, _log_phase
+
+
+def _prepare_preflight_working_dir(
+    project_root: Path, base_branch: str
+) -> tuple[Path, Callable[[], None]]:
+    """Materialize a clean baseline checkout for deterministic preflight evaluation."""
+    temp_dir = Path(tempfile.mkdtemp(prefix="forge-preflight-", dir=project_root))
+    git_dir = project_root / ".git"
+    if not git_dir.exists():
+        return temp_dir, lambda: shutil.rmtree(temp_dir, ignore_errors=True)
+
+    try:
+        archive = subprocess.run(
+            ["git", "archive", base_branch],
+            cwd=project_root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["tar", "-xmf", "-"],
+            cwd=temp_dir,
+            input=archive.stdout,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise RuntimeError(f"Failed to archive baseline branch {base_branch!r}") from exc
+
+    def cleanup() -> None:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return temp_dir, cleanup
+
 
 if TYPE_CHECKING:
     from theforge.coordinator.logging import StructuredLogger
@@ -118,14 +157,20 @@ def _run_preflight_phase(
         assembled_context=preflight_context,
     )
 
-    _preflight_start = time.monotonic()
-    preflight_result = run_agent(
-        prompt=preflight_prompt,
-        profile=preflight_profile,
-        working_dir=workspace_path,
-        secrets=config.secrets,
+    baseline_working_dir, cleanup_preflight_dir = _prepare_preflight_working_dir(
+        config.project_root, config.workspace.base_branch
     )
-    _preflight_elapsed = time.monotonic() - _preflight_start
+    try:
+        _preflight_start = time.monotonic()
+        preflight_result = run_agent(
+            prompt=preflight_prompt,
+            profile=preflight_profile,
+            working_dir=baseline_working_dir,
+            secrets=config.secrets,
+        )
+        _preflight_elapsed = time.monotonic() - _preflight_start
+    finally:
+        cleanup_preflight_dir()
     state.preflight_duration_s = _preflight_elapsed
     state.preflight_result = preflight_result
     log_agent_result(preflight_result, "PREFLIGHT")
@@ -204,6 +249,7 @@ def _run_preflight_phase(
         "likely_files": state.preflight_likely_files,
         "bundle_candidate": state.preflight_bundle_candidate,
         "branch_merged": branch_merged,
+        "evaluation_base_branch": config.workspace.base_branch,
     }
     _write_log_artifact(state.log_dir, "preflight-raw.log", preflight_result.output or "")
     _write_log_artifact(

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -98,7 +98,12 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
     """Best-effort kill for a spawned shell process group."""
     try:
         os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    except ProcessLookupError:
+        return
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        proc.terminate()
+    except (ProcessLookupError, PermissionError):
         pass
 
 
@@ -128,14 +133,8 @@ def _run_shell(
         output = (stdout + stderr).strip()
         return proc.returncode == 0, output
     except subprocess.TimeoutExpired as te:
-        # Kill first, then drain — reading pipes while the process is
-        # still alive can block indefinitely (the process holds the
-        # write end open, so read() waits for EOF that never comes).
         _kill_process_group(proc)
         proc.wait()
-        # Collect partial output: TimeoutExpired may carry buffered
-        # data, and any remaining bytes are still in the kernel pipe
-        # buffer now that the write end is closed.
         partial_out = ""
         try:
             chunks: list[str] = []
@@ -147,7 +146,7 @@ def _run_shell(
             if proc.stderr:
                 chunks.append(proc.stderr.read())
             partial_out = "".join(chunks).strip()
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
         header = f"TIMEOUT after {timeout}s: {cmd}"
         if partial_out:

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -133,6 +133,9 @@ def _run_shell(
         output = (stdout + stderr).strip()
         return proc.returncode == 0, output
     except subprocess.TimeoutExpired as te:
+        # Kill the whole process group before draining pipes so grandchildren
+        # such as pytest-xdist workers cannot keep writing indefinitely after
+        # the shell itself has timed out.
         _kill_process_group(proc)
         proc.wait()
         partial_out = ""

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -50,13 +50,14 @@ def build_preflight_prompt(
 
         ## Classification
 
-        Evaluate the spec against the current code and output ONE of these verdicts:
+        Evaluate the spec against the target baseline branch content
+        and output ONE of these verdicts:
 
         - **PROCEED** — The spec describes unfinished work. The acceptance criteria
           are clear, non-contradictory, and testable. Implementation should begin.
 
         - **ALREADY_DONE** — Every acceptance criterion is ALREADY satisfied by
-          the current code. You MUST verify each criterion individually.
+          the target baseline branch content. You MUST verify each criterion individually.
 
         - **BLOCKED** — The spec cannot be implemented as written. This includes:
           - References to functions or APIs that do not exist
@@ -72,6 +73,13 @@ def build_preflight_prompt(
         on disk, do NOT set verdict to BLOCKED for this reason alone. Instead,
         list the missing paths in the `warnings` field and proceed normally.
         The plan agent will discover the correct paths.
+
+        **Baseline for evaluation**: Use the configured target baseline branch as the
+        source of truth for ALREADY_DONE decisions, not branch-local or resumed
+        worktree changes. In this workspace flow, that baseline is
+        `config.workspace.base_branch` checked out from the project root
+        repository. Code that exists only in the current worktree is not proof
+        that the story is already implemented.
 
         ## Spec Quality Check
 
@@ -169,6 +177,8 @@ def build_preflight_prompt(
 
         - Check EVERY acceptance criterion individually. Do not shortcut.
         - "Related code exists" is NOT the same as "criterion is satisfied."
+        - Evaluate ALREADY_DONE against the configured baseline branch
+          content, not the resumed worktree contents.
         - If even ONE criterion is unsatisfied, the verdict cannot be ALREADY_DONE.
         - If the spec has internal contradictions or untestable criteria, verdict is BLOCKED.
         - If the spec contains a **Notes** section, treat it as informal hints that

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -50,8 +50,8 @@ def build_preflight_prompt(
 
         ## Classification
 
-        Evaluate the spec against the target baseline branch content
-        and output ONE of these verdicts:
+        Evaluate the spec against the repository content you can inspect in the
+        provided working directory and output ONE of these verdicts:
 
         - **PROCEED** — The spec describes unfinished work. The acceptance criteria
           are clear, non-contradictory, and testable. Implementation should begin.
@@ -73,13 +73,6 @@ def build_preflight_prompt(
         on disk, do NOT set verdict to BLOCKED for this reason alone. Instead,
         list the missing paths in the `warnings` field and proceed normally.
         The plan agent will discover the correct paths.
-
-        **Baseline for evaluation**: Use the configured target baseline branch as the
-        source of truth for ALREADY_DONE decisions, not branch-local or resumed
-        worktree changes. In this workspace flow, that baseline is
-        `config.workspace.base_branch` checked out from the project root
-        repository. Code that exists only in the current worktree is not proof
-        that the story is already implemented.
 
         ## Spec Quality Check
 
@@ -177,8 +170,8 @@ def build_preflight_prompt(
 
         - Check EVERY acceptance criterion individually. Do not shortcut.
         - "Related code exists" is NOT the same as "criterion is satisfied."
-        - Evaluate ALREADY_DONE against the configured baseline branch
-          content, not the resumed worktree contents.
+        - Evaluate ALREADY_DONE against the configured target baseline branch
+          content from `config.workspace.base_branch`, not the resumed worktree contents.
         - If even ONE criterion is unsatisfied, the verdict cannot be ALREADY_DONE.
         - If the spec has internal contradictions or untestable criteria, verdict is BLOCKED.
         - If the spec contains a **Notes** section, treat it as informal hints that

--- a/tests/test_coord_logging.py
+++ b/tests/test_coord_logging.py
@@ -797,3 +797,4 @@ def test_preflight_yaml_includes_branch_merged(tmp_path):
 
     data = _yaml.safe_load((state.log_dir / "preflight.yaml").read_text())
     assert "branch_merged" in data
+    assert "evaluation_base_branch" in data

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -46,45 +46,80 @@ class TestCoordinatorPreflight:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_preflight_already_done_prompt_targets_configured_base_branch(
+    def test_preflight_already_done_uses_clean_baseline_not_resumed_worktree(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """Preflight prompt targets config.workspace.base_branch for ALREADY_DONE."""
-        config = replace(
-            _make_config(tmp_path),
-            workspace=WorkspaceConfig(
-                create_command="mkdir -p {slug}",
-                path_pattern="{slug}",
-                branch_pattern="forge/{slug}",
-                base_branch="release",
-            ),
-        )
+        """Resumed-worktree-only implementation must not trigger ALREADY_DONE."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        (workspace / "resumed_only.py").write_text("implemented = True\n", encoding="utf-8")
+
+        captured = {}
+
+        def preflight_side_effect(**kwargs):
+            working_dir = Path(kwargs["working_dir"])
+            captured["working_dir"] = working_dir
+            captured["has_resumed_only"] = (working_dir / "resumed_only.py").exists()
+            return _make_agent_result(success=True, output=_PREFLIGHT_RESULT.output, cost_usd=0.08)
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.side_effect = preflight_side_effect
+        mock_agent.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.preflight_verdict == "PROCEED"
+        assert captured["working_dir"] != workspace
+        assert captured["has_resumed_only"] is False
+        mock_pool.assert_called_once()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow.has_review_approve", return_value=True)
+    def test_preflight_already_done_allows_clean_baseline_match(
+        self,
+        mock_approve,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """Baseline content satisfying the story may still return ALREADY_DONE."""
+        config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
 
-        captured_prompt = {}
+        captured = {}
 
         def preflight_side_effect(**kwargs):
-            captured_prompt["prompt"] = kwargs["prompt"]
+            working_dir = Path(kwargs["working_dir"])
+            captured["working_dir"] = working_dir
+            captured["exists"] = working_dir.exists()
             return _make_agent_result(success=True, output=PREFLIGHT_ALREADY_DONE, cost_usd=0.08)
 
-        def shell_side_effect(cmd, cwd, **kwargs):
-            if "git log release..forge/test-task --oneline" in cmd:
-                return (True, "")
-            return (True, "OK")
-
-        mock_shell.side_effect = shell_side_effect
+        mock_shell.return_value = (True, "OK")
         mock_preflight.side_effect = preflight_side_effect
 
         result = run_task(config, task)
 
         assert result.success is True
+        assert result.phase == Phase.DONE
         assert result.state.preflight_verdict == "ALREADY_DONE"
-        prompt = captured_prompt["prompt"]
-        assert "configured target baseline branch" in prompt
-        assert "`config.workspace.base_branch`" in prompt
-        assert "not the resumed worktree contents" in prompt
+        assert captured["working_dir"] != workspace
+        assert captured["exists"] is True
         mock_pool.assert_not_called()
 
     """Test the PREFLIGHT phase: classify spec before expensive dev cycles."""

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -46,6 +46,54 @@ class TestCoordinatorPreflight:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
+    def test_preflight_already_done_prompt_targets_configured_base_branch(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Preflight prompt targets config.workspace.base_branch for ALREADY_DONE."""
+        config = replace(
+            _make_config(tmp_path),
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+                base_branch="release",
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        captured_prompt = {}
+
+        def preflight_side_effect(**kwargs):
+            captured_prompt["prompt"] = kwargs["prompt"]
+            return _make_agent_result(success=True, output=PREFLIGHT_ALREADY_DONE, cost_usd=0.08)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "git log release..forge/test-task --oneline" in cmd:
+                return (True, "")
+            return (True, "OK")
+
+        mock_shell.side_effect = shell_side_effect
+        mock_preflight.side_effect = preflight_side_effect
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.preflight_verdict == "ALREADY_DONE"
+        prompt = captured_prompt["prompt"]
+        assert "configured target baseline branch" in prompt
+        assert "`config.workspace.base_branch`" in prompt
+        assert "not the resumed worktree contents" in prompt
+        mock_pool.assert_not_called()
+
+    """Test the PREFLIGHT phase: classify spec before expensive dev cycles."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
     def test_preflight_proceed_continues_to_dev(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -39,8 +39,6 @@ from theforge.coordinator.state import CoordinatorState, Phase
 
 
 class TestCoordinatorPreflight:
-    """Test the PREFLIGHT phase: classify spec before expensive dev cycles."""
-
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
     @patch("theforge.coordinator.preflight_flow.run_agent")
@@ -121,8 +119,6 @@ class TestCoordinatorPreflight:
         assert captured["working_dir"] != workspace
         assert captured["exists"] is True
         mock_pool.assert_not_called()
-
-    """Test the PREFLIGHT phase: classify spec before expensive dev cycles."""
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")

--- a/tests/test_task_preflight_prompt.py
+++ b/tests/test_task_preflight_prompt.py
@@ -10,3 +10,13 @@ def test_build_preflight_prompt_requests_likely_files() -> None:
     assert "likely_files:" in prompt
     assert "repo-relative file path likely to be edited if implementation proceeds" in prompt
     assert "Use `likely_files: []` when no likely edit targets can be identified." in prompt
+
+
+def test_build_preflight_prompt_requires_baseline_branch_for_already_done() -> None:
+    task = TaskStory(name="Bug fix", slug="bug-fix")
+
+    prompt = build_preflight_prompt(task, story_content="## Spec\n\n- Example")
+
+    assert "configured target baseline branch" in prompt
+    assert "`config.workspace.base_branch`" in prompt
+    assert "not the resumed worktree contents" in prompt


### PR DESCRIPTION
## Summary

[openai-reviewer] Coordinator now runs preflight against a clean checkout of config.workspace.base_branch outside the repo tree, and the added regression tests cover both required baseline scenarios. | [gemini-reviewer] All prior P1 findings have been addressed and the implementation correctly evaluates the baseline branch.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $7.98
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Bug: preflight ALREADY_DONE evaluates stale worktree instead of clean baseline (GitHub Issue #588)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #588