### PR TITLE
fix: make invalid/failed preflight a hard stop, not normalize to PROCEED

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -667,7 +667,11 @@ def run_task(
             state.preflight_work_type = cached_preflight_state.preflight_work_type
             state.preflight_bundle_candidate = cached_preflight_state.preflight_bundle_candidate
             state.preflight_warnings = list(cached_preflight_state.preflight_warnings)
-            state.preflight_likely_files = list(cached_preflight_state.preflight_likely_files)
+            state.preflight_likely_files = (
+                None
+                if cached_preflight_state.preflight_likely_files is None
+                else list(cached_preflight_state.preflight_likely_files)
+            )
             state.preflight_duration_s = cached_preflight_state.preflight_duration_s
             state.preflight_cached = True
             state.preflight_cached_original_verdict = cached_preflight_state.preflight_verdict

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -244,7 +244,7 @@ def _run_plan_phase(
     plan_context = ContextAssembler.from_config(config).assemble(
         phase="plan",
         story_text=story_content,
-        file_list=state.preflight_likely_files or None,
+        file_list=state.preflight_likely_files,
     )
 
     state.context_manifests.append({"phase": "plan", "manifest": plan_context})

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -20,9 +20,9 @@ _VALID_PREFLIGHT_VERDICTS = frozenset({"PROCEED", "ALREADY_DONE", "BLOCKED"})
 def _parse_preflight_verdict(output: str) -> tuple[str, str]:
     """Extract verdict and reason from preflight agent output.
 
-    Returns (verdict, reason). Parse failures still fail open to PROCEED, but
-    unrecognized verdict values are treated as BLOCKED because downstream
-    classifications from a confused preflight are unreliable.
+    Returns (verdict, reason). Parse failures and invalid verdicts are treated
+    as BLOCKED because downstream classifications from a confused preflight are
+    unreliable.
     """
     # Extract YAML block from markdown fences
     yaml_text = output
@@ -38,10 +38,10 @@ def _parse_preflight_verdict(output: str) -> tuple[str, str]:
     try:
         parsed = yaml.safe_load(yaml_text)
     except yaml.YAMLError:
-        return "PROCEED", f"Failed to parse preflight YAML; proceeding anyway. Raw: {output[:200]}"
+        return "BLOCKED", f"Failed to parse preflight YAML; blocking. Raw: {output[:200]}"
 
     if not isinstance(parsed, dict):
-        return "PROCEED", "Preflight output is not a dict; proceeding anyway."
+        return "BLOCKED", "Preflight output is not a dict; blocking."
 
     verdict = str(parsed.get("verdict", "PROCEED")).upper()
     reason = str(parsed.get("reason", "(no reason provided)"))
@@ -133,8 +133,12 @@ def _parse_preflight_warnings(output: str) -> list[str]:
     return []
 
 
-def _parse_preflight_likely_files(output: str) -> list[str]:
-    """Extract likely_files list from preflight agent output. Returns [] if absent."""
+def _parse_preflight_likely_files(output: str) -> list[str] | None:
+    """Extract likely_files list from preflight agent output.
+
+    Returns None when the agent did not explicitly provide a valid list so that
+    zero-footprint remains an explicit assertion rather than a parser default.
+    """
     yaml_text = output
     if "```yaml" in output:
         start = output.index("```yaml") + len("```yaml")
@@ -148,13 +152,15 @@ def _parse_preflight_likely_files(output: str) -> list[str]:
     try:
         parsed = yaml.safe_load(yaml_text)
         if isinstance(parsed, dict):
-            raw = parsed.get("likely_files", [])
+            if "likely_files" not in parsed:
+                return None
+            raw = parsed.get("likely_files")
             if isinstance(raw, list):
                 return [str(path) for path in raw if path]
     except yaml.YAMLError:
         pass
 
-    return []
+    return None
 
 
 def _parse_preflight_complexity(output: str) -> str:

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -179,45 +179,43 @@ def _run_preflight_phase(
         verdict, reason = _parse_preflight_verdict(preflight_result.output)
     else:
         verdict, reason = (
-            "PROCEED",
-            f"Preflight agent failed (exit={preflight_result.exit_code}); proceeding anyway.",
+            "BLOCKED",
+            f"Preflight agent failed (exit={preflight_result.exit_code}); blocking execution.",
         )
-        state.preflight_complexity = "large"
-        state.preflight_sufficiency = "needs_planning"
-        state.preflight_work_type = "feature"
-        _log("  ⚠ PREFLIGHT failed — defaulting complexity to large")
+        _log("  ⚠ PREFLIGHT failed — blocking execution")
 
     state.preflight_verdict = verdict
     state.preflight_reason = reason
 
-    # ── Warnings parsing (non-blocking advisories) ─────────────────────
+    # ── Parsed preflight signals ────────────────────────────────────────
     if preflight_result.success:
         _warnings = _parse_preflight_warnings(preflight_result.output)
         state.preflight_warnings = _warnings
         _likely_files = _parse_preflight_likely_files(preflight_result.output)
-        state.preflight_likely_files = _likely_files
-        if _warnings:
-            _log(f"  ⚠ PREFLIGHT warnings: {'; '.join(_warnings)}")
-        if _likely_files:
-            _log(f"  Likely files: {', '.join(_likely_files)}")
-
-    # ── Complexity parsing + adaptive model swapping ───────────────────
-    if preflight_result.success:
+        if _likely_files is not None:
+            state.preflight_likely_files = _likely_files
         complexity = _parse_preflight_complexity(preflight_result.output)
         state.preflight_complexity = complexity
-        _log(f"  Complexity: {complexity} (from preflight)")
         sufficiency = _parse_preflight_sufficiency(preflight_result.output)
         state.preflight_sufficiency = sufficiency
-        _log(f"  Sufficiency: {sufficiency}")
         work_type = _parse_preflight_work_type(preflight_result.output)
         state.preflight_work_type = work_type
-        _log(f"  Work type: {work_type}")
         bundle_candidate = _parse_preflight_bundle_candidate(preflight_result.output)
         state.preflight_bundle_candidate = bundle_candidate
+        _log(f"  Complexity: {complexity} (from preflight)")
+        _log(f"  Sufficiency: {sufficiency}")
+        _log(f"  Work type: {work_type}")
         _log(f"  Bundle candidate: {bundle_candidate}")
+        if _warnings:
+            _log(f"  ⚠ PREFLIGHT warnings: {'; '.join(_warnings)}")
+        if _likely_files is not None:
+            _log(f"  Likely files: {', '.join(_likely_files)}")
     else:
-        complexity = state.preflight_complexity
-        _log(f"  Complexity: {complexity} (preflight failed — using fallback)")
+        complexity = state.preflight_complexity or "medium"
+        state.preflight_complexity = complexity
+        state.preflight_sufficiency = state.preflight_sufficiency or "needs_planning"
+        state.preflight_work_type = state.preflight_work_type or "feature"
+        state.preflight_bundle_candidate = False
 
     config = _apply_preflight_config(config, state, log=_log, log_verbose=_log_verbose)
 

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -192,8 +192,7 @@ def _run_preflight_phase(
         _warnings = _parse_preflight_warnings(preflight_result.output)
         state.preflight_warnings = _warnings
         _likely_files = _parse_preflight_likely_files(preflight_result.output)
-        if _likely_files is not None:
-            state.preflight_likely_files = _likely_files
+        state.preflight_likely_files = _likely_files
         complexity = _parse_preflight_complexity(preflight_result.output)
         state.preflight_complexity = complexity
         sufficiency = _parse_preflight_sufficiency(preflight_result.output)

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -223,7 +223,7 @@ class CoordinatorState:
     preflight_work_type: str | None = None  # "feature" | "refactor" | "mechanical" | "bug"
     preflight_bundle_candidate: bool = False
     preflight_warnings: list[str] = field(default_factory=list)  # non-blocking advisories
-    preflight_likely_files: list[str] = field(default_factory=list)
+    preflight_likely_files: list[str] | None = None
     preflight_result: AgentResult | None = None
     preflight_cached: bool = False
     preflight_cached_from_run_id: str | None = None

--- a/src/theforge/sprint/collision.py
+++ b/src/theforge/sprint/collision.py
@@ -55,7 +55,7 @@ def build_bundle_hint(task: TaskStory, state: CoordinatorState) -> BundleHint:
         slug=task.slug,
         work_type=work_type,
         complexity=complexity,
-        likely_files=tuple(sorted(set(state.preflight_likely_files))),
+        likely_files=tuple(sorted(set(state.preflight_likely_files or []))),
         bundle_candidate=bundle_candidate,
         area=_extract_area_label(task),
     )
@@ -201,7 +201,7 @@ def compute_synthetic_edges(
     synthetic: dict[str, set[str]] = {}
 
     for slug, state in preflight_states.items():
-        for path in state.preflight_likely_files:
+        for path in state.preflight_likely_files or []:
             file_to_slugs.setdefault(path, []).append(slug)
 
     def _sort_key(slug: str) -> tuple[int, str]:

--- a/src/theforge/sprint/collision.py
+++ b/src/theforge/sprint/collision.py
@@ -21,7 +21,7 @@ class BundleHint:
     slug: str
     work_type: str | None
     complexity: str | None
-    likely_files: tuple[str, ...]
+    likely_files: tuple[str, ...] | None
     bundle_candidate: bool
     area: str | None
 
@@ -55,7 +55,11 @@ def build_bundle_hint(task: TaskStory, state: CoordinatorState) -> BundleHint:
         slug=task.slug,
         work_type=work_type,
         complexity=complexity,
-        likely_files=tuple(sorted(set(state.preflight_likely_files or []))),
+        likely_files=(
+            None
+            if state.preflight_likely_files is None
+            else tuple(sorted(set(state.preflight_likely_files)))
+        ),
         bundle_candidate=bundle_candidate,
         area=_extract_area_label(task),
     )
@@ -68,6 +72,8 @@ def _bundle_sort_key(task: TaskStory) -> tuple[int, str]:
 
 def _tasks_overlap_by_signal(left: BundleHint, right: BundleHint) -> bool:
     if left.area is not None and left.area == right.area:
+        return True
+    if left.likely_files is None or right.likely_files is None:
         return True
     return bool(set(left.likely_files) & set(right.likely_files))
 
@@ -177,7 +183,7 @@ def run_batch_preflight(
                     f"{task.slug}: {type(exc).__name__}: {exc}; "
                     "excluding from collision detection"
                 )
-                states[task.slug] = CoordinatorState(preflight_likely_files=[])
+                states[task.slug] = CoordinatorState(preflight_likely_files=None)
                 continue
 
             if not result.success:
@@ -185,7 +191,7 @@ def run_batch_preflight(
                     "WARNING: batch preflight returned failure for "
                     f"{task.slug}: {result.message}; excluding from collision detection"
                 )
-                states[task.slug] = CoordinatorState(preflight_likely_files=[])
+                states[task.slug] = CoordinatorState(preflight_likely_files=None)
                 continue
 
             states[task.slug] = result.state
@@ -201,7 +207,9 @@ def compute_synthetic_edges(
     synthetic: dict[str, set[str]] = {}
 
     for slug, state in preflight_states.items():
-        for path in state.preflight_likely_files or []:
+        if state.preflight_likely_files is None:
+            continue
+        for path in state.preflight_likely_files:
             file_to_slugs.setdefault(path, []).append(slug)
 
     def _sort_key(slug: str) -> tuple[int, str]:

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -859,3 +859,72 @@ criteria_checked: []
         assert result.state.dev_results[0].success  # dev ran normally
         # Pool called with original single reviewer (no synthesis was added)
         assert len(pool_profiles_used) == 1
+
+
+def test_preflight_missing_likely_files_preserved_as_unknown(tmp_path):
+    from theforge.sprint.collision import build_bundle_hint
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+
+    with (
+        patch("theforge.coordinator.util._run_shell") as mock_shell,
+        patch("theforge.coordinator.dev_phase.run_agent") as mock_agent,
+        patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+        patch("theforge.coordinator.plan_flow.run_agent") as mock_plan_agent,
+        patch("theforge.coordinator.review_pool.run_agent_pool") as mock_pool,
+    ):
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True,
+            output="""```yaml
+verdict: PROCEED
+reason: \"Need planning before implementation.\"
+complexity: small
+work_type: bug
+bundle_candidate: true
+criteria_checked: []
+```\n""",
+            cost_usd=0.05,
+            profile_name="review",
+        )
+        mock_agent.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+    assert result.success is True
+    assert result.state.preflight_likely_files is None
+
+    hint = build_bundle_hint(task, result.state)
+    assert hint.likely_files is None
+
+
+def test_collision_unknown_likely_files_not_treated_as_zero_footprint(tmp_path):
+    from theforge.coordinator.state import CoordinatorState
+    from theforge.sprint.collision import build_bundle_hint
+
+    task = _make_task(tmp_path)
+    unknown_state = CoordinatorState(
+        preflight_work_type="bug",
+        preflight_complexity="small",
+        preflight_bundle_candidate=True,
+        preflight_likely_files=None,
+    )
+    zero_state = CoordinatorState(
+        preflight_work_type="bug",
+        preflight_complexity="small",
+        preflight_bundle_candidate=True,
+        preflight_likely_files=[],
+    )
+
+    unknown_hint = build_bundle_hint(task, unknown_state)
+    zero_hint = build_bundle_hint(task, zero_state)
+
+    assert unknown_hint.likely_files is None
+    assert zero_hint.likely_files == ()

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -221,10 +221,10 @@ class TestCoordinatorPreflight:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_preflight_agent_failure_proceeds(
+    def test_preflight_agent_failure_blocks(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """If the preflight agent itself fails, fail-open to PROCEED."""
+        """If the preflight agent itself fails, execution is blocked."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -242,20 +242,21 @@ class TestCoordinatorPreflight:
 
         result = run_task(config, task)
 
-        assert result.success is True
-        assert result.phase == Phase.DONE
-        assert result.state.preflight_verdict == "PROCEED"
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.preflight_verdict == "BLOCKED"
         assert "failed" in result.state.preflight_reason.lower()
+        assert len(result.state.dev_results) == 0
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_preflight_unparseable_proceeds(
+    def test_preflight_unparseable_blocks(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """If preflight output is not valid YAML, fail-open to PROCEED."""
+        """If preflight output is not valid YAML, execution is blocked."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -275,9 +276,10 @@ class TestCoordinatorPreflight:
 
         result = run_task(config, task)
 
-        assert result.success is True
-        assert result.phase == Phase.DONE
-        assert result.state.preflight_verdict == "PROCEED"
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.preflight_verdict == "BLOCKED"
+        assert len(result.state.dev_results) == 0
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
@@ -382,6 +384,27 @@ likely_files:
         assert len(result.state.preflight_warnings) == 2
         assert "src/theforge/old_module.py" in result.state.preflight_warnings[0]
         assert len(result.state.dev_results) == 1
+
+    def test_parse_preflight_likely_files_requires_explicit_field(self):
+        """Missing likely_files stays unknown instead of defaulting to zero-footprint."""
+        from coord_test_helpers import PREFLIGHT_PROCEED
+
+        from theforge.coordinator.preflight import _parse_preflight_likely_files
+
+        assert _parse_preflight_likely_files(PREFLIGHT_PROCEED) is None
+
+    def test_parse_preflight_likely_files_allows_explicit_zero_footprint(self):
+        """An explicit empty likely_files list is preserved as zero-footprint."""
+        from theforge.coordinator.preflight import _parse_preflight_likely_files
+
+        output = """```yaml
+verdict: PROCEED
+reason: \"No file edits expected.\"
+likely_files: []
+```
+"""
+
+        assert _parse_preflight_likely_files(output) == []
 
     def test_parse_preflight_warnings_extracts_paths(self):
         """_parse_preflight_warnings returns the warnings list from YAML."""


### PR DESCRIPTION
## Summary

[openai-reviewer] The fail-closed preflight behavior and explicit likely_files handling now match the acceptance criteria, and I found no blocking regressions in the touched code. | [gemini-reviewer] The implementation correctly resolves the prior P1 findings by preserving missing likely_files as None and avoiding normalization to an empty list.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $4.51
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: make invalid/failed preflight a hard stop, not normalize to PROCEED (GitHub Issue #597)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #597