### PR TITLE
fix: conditional test-edit rule via contract_change preflight signal (#618)

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -380,6 +380,7 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "verdict": ("cached" if state.preflight_cached else state.preflight_verdict),
                 "reason": state.preflight_reason,
                 "work_type": state.preflight_work_type,
+                "contract_change": state.preflight_contract_change,
                 "bundle_candidate": state.preflight_bundle_candidate,
                 "cost_usd": state.preflight_result.cost_usd if state.preflight_result else 0.0,
                 "cached": state.preflight_cached,

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -262,6 +262,7 @@ def _run_dev_phase(
             cycle_history=state.cycle_history or None,
             handoff_file=config.validation.handoff_file,
             preflight_sufficiency=state.preflight_sufficiency,
+            contract_change=state.preflight_contract_change,
             conventions=config.conventions_soft,
             assembled_context=dev_context,
         )

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -688,6 +688,7 @@ def run_task(
             state.preflight_complexity = cached_preflight_state.preflight_complexity
             state.preflight_sufficiency = cached_preflight_state.preflight_sufficiency
             state.preflight_work_type = cached_preflight_state.preflight_work_type
+            state.preflight_contract_change = cached_preflight_state.preflight_contract_change
             state.preflight_bundle_candidate = cached_preflight_state.preflight_bundle_candidate
             state.preflight_warnings = list(cached_preflight_state.preflight_warnings)
             state.preflight_likely_files = (
@@ -875,6 +876,7 @@ def _run_resume_coordinator(
         state.preflight_complexity = cached_preflight_state.preflight_complexity
         state.preflight_sufficiency = cached_preflight_state.preflight_sufficiency
         state.preflight_work_type = cached_preflight_state.preflight_work_type
+        state.preflight_contract_change = cached_preflight_state.preflight_contract_change
         state.preflight_warnings = list(cached_preflight_state.preflight_warnings)
         state.preflight_likely_files = list(cached_preflight_state.preflight_likely_files)
         state.preflight_duration_s = cached_preflight_state.preflight_duration_s

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -63,6 +63,28 @@ _VALID_SUFFICIENCIES = frozenset({"implementation_ready", "needs_planning"})
 _VALID_WORK_TYPES = frozenset({"feature", "refactor", "mechanical", "bug"})
 
 
+def _parse_preflight_contract_change(output: str) -> bool:
+    """Extract contract_change from preflight agent output. Defaults to False."""
+    yaml_text = output
+    if "```yaml" in output:
+        start = output.index("```yaml") + len("```yaml")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+    elif "```" in output:
+        start = output.index("```") + len("```")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+
+    try:
+        parsed = yaml.safe_load(yaml_text)
+        if isinstance(parsed, dict):
+            return bool(parsed.get("contract_change", False))
+    except yaml.YAMLError:
+        pass
+
+    return False
+
+
 def _parse_preflight_bundle_candidate(output: str) -> bool:
     """Extract bundle_candidate from preflight agent output. Defaults to False."""
     yaml_text = output

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -78,7 +78,13 @@ def _parse_preflight_contract_change(output: str) -> bool:
     try:
         parsed = yaml.safe_load(yaml_text)
         if isinstance(parsed, dict):
-            return bool(parsed.get("contract_change", False))
+            raw = parsed.get("contract_change", False)
+            if isinstance(raw, bool):
+                return raw
+            # Normalize string representations; reject non-boolean values safely
+            if isinstance(raw, str) and raw.strip().lower() == "true":
+                return True
+            return False
     except yaml.YAMLError:
         pass
 

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -40,6 +40,7 @@ from .preflight import (
     _apply_preflight_config,
     _parse_preflight_bundle_candidate,
     _parse_preflight_complexity,
+    _parse_preflight_contract_change,
     _parse_preflight_likely_files,
     _parse_preflight_sufficiency,
     _parse_preflight_verdict,
@@ -199,11 +200,14 @@ def _run_preflight_phase(
         state.preflight_sufficiency = sufficiency
         work_type = _parse_preflight_work_type(preflight_result.output)
         state.preflight_work_type = work_type
+        contract_change = _parse_preflight_contract_change(preflight_result.output)
+        state.preflight_contract_change = contract_change
         bundle_candidate = _parse_preflight_bundle_candidate(preflight_result.output)
         state.preflight_bundle_candidate = bundle_candidate
         _log(f"  Complexity: {complexity} (from preflight)")
         _log(f"  Sufficiency: {sufficiency}")
         _log(f"  Work type: {work_type}")
+        _log(f"  Contract change: {contract_change}")
         _log(f"  Bundle candidate: {bundle_candidate}")
         if _warnings:
             _log(f"  ⚠ PREFLIGHT warnings: {'; '.join(_warnings)}")

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -245,6 +245,7 @@ def _run_preflight_phase(
         "reason": reason,
         "complexity": state.preflight_complexity,
         "sufficiency": state.preflight_sufficiency,
+        "contract_change": state.preflight_contract_change,
         "cost_usd": preflight_result.cost_usd,
         "duration_s": round(_preflight_elapsed, 2),
         "likely_files": state.preflight_likely_files,

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -221,6 +221,7 @@ class CoordinatorState:
     preflight_complexity: str | None = None  # "small" | "medium" | "large"
     preflight_sufficiency: str | None = None  # "implementation_ready" | "needs_planning"
     preflight_work_type: str | None = None  # "feature" | "refactor" | "mechanical" | "bug"
+    preflight_contract_change: bool = False  # story intentionally alters a tested contract
     preflight_bundle_candidate: bool = False
     preflight_warnings: list[str] = field(default_factory=list)  # non-blocking advisories
     preflight_likely_files: list[str] | None = None

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -35,7 +35,9 @@ def _test_file_exists_in_head(workspace_path: Path, test_file: str) -> bool:
     return workspace_path.joinpath(test_file).is_file()
 
 
-def _format_failed_test_feedback(gate_output_tail: str, workspace_path: Path) -> tuple[str, bool]:
+def _format_failed_test_feedback(
+    gate_output_tail: str, workspace_path: Path, contract_change: bool = False
+) -> tuple[str, bool]:
     """Return retry-feedback text for extracted failing tests and whether they are existing."""
     failed_tests = _extract_failed_tests(gate_output_tail)
     if not failed_tests:
@@ -49,10 +51,16 @@ def _format_failed_test_feedback(gate_output_tail: str, workspace_path: Path) ->
     lines = ["\n\nExtracted failing tests (best effort):"]
     lines.extend(f"- {test_name}" for test_name in failed_tests)
     if existing_failures:
-        lines.append(
-            "These are existing tests your changes broke — "
-            "fix your implementation, do not edit these test files."
-        )
+        if contract_change:
+            lines.append(
+                "Some of these tests may assert the old behavioral contract — "
+                "update them if they encode the behavior this story is changing."
+            )
+        else:
+            lines.append(
+                "These are existing tests your changes broke — "
+                "fix your implementation, do not edit these test files."
+            )
     return "\n".join(lines), bool(existing_failures)
 
 
@@ -140,7 +148,7 @@ def _run_validate_phase(
         gate_cmd = resolved_gate_cmd
         partial = ""
         failed_test_feedback, existing_test_failures = _format_failed_test_feedback(
-            gate_output_tail, workspace_path
+            gate_output_tail, workspace_path, contract_change=state.preflight_contract_change
         )
         if gate_output_tail and gate_output_tail != gate_err:
             tail_chars = config.validation.gate_output_tail_chars
@@ -280,7 +288,7 @@ def _run_validate_phase(
         gate_cmd = resolved_gate_cmd
         tail_chars = config.validation.gate_output_tail_chars
         failed_test_feedback, existing_test_failures = _format_failed_test_feedback(
-            gate_output_tail, workspace_path
+            gate_output_tail, workspace_path, contract_change=state.preflight_contract_change
         )
         state.human_feedback = (
             f"The full test suite (`{gate_cmd}`) failed."

--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -27,6 +27,7 @@ def build_dev_prompt(
     cycle_history: list[CycleHistory] | None = None,
     handoff_file: str = "handoff.yaml",
     preflight_sufficiency: str | None = None,
+    contract_change: bool = False,
     conventions: list[str] | None = None,
     assembled_context: ContextPack | None = None,
 ) -> str:
@@ -181,6 +182,19 @@ def build_dev_prompt(
             finished until the gate passes.
         """)
 
+    if contract_change:
+        test_rule = (
+            "- This story intentionally changes an existing behavioral contract.\n"
+            "  You MAY update test files that assert the old contract behavior.\n"
+            "  Do NOT modify tests unrelated to the contract change."
+        )
+    else:
+        test_rule = (
+            "- Do NOT modify existing test files that are not directly related to\n"
+            "  your story. If existing tests fail after your changes, your\n"
+            "  implementation is wrong — fix your code, not the tests."
+        )
+
     return dedent(f"""\
         You are implementing **{task.name}**.
 
@@ -252,9 +266,7 @@ def build_dev_prompt(
 
         - Do NOT merge to main.
         - Do NOT leave uncommitted changes.
-        - Do NOT modify existing test files that are not directly related to
-          your story. If existing tests fail after your changes, your
-          implementation is wrong — fix your code, not the tests.
+        {test_rule}
         - If you cannot finish, commit what you have and list blockers in
           `deferred_items`.
     """)

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -144,6 +144,7 @@ def build_preflight_prompt(
         verdict: PROCEED | ALREADY_DONE | BLOCKED
         complexity: small | medium | large
         work_type: feature | refactor | mechanical | bug
+        contract_change: true | false
         reason: "<1-2 sentence explanation of your classification>"
         sufficiency: implementation_ready | needs_planning
         sufficiency_reason: "<1-2 sentence explanation of the sufficiency classification>"
@@ -165,6 +166,11 @@ def build_preflight_prompt(
         Use `likely_files: []` when no likely edit targets can be identified.
         Include repo-relative paths only; do not invent nonexistent files just to fill the list.
         Always include `sufficiency` and `sufficiency_reason` when verdict is PROCEED.
+        Set `contract_change: true` when the story explicitly changes an existing behavioral
+        contract — a previously tested behavior is intentionally being altered (e.g., changing
+        an error to an escalation, changing a return value, renaming a field). When true, the
+        dev agent is permitted to update test files that assert the old behavior. Set
+        `contract_change: false` (the default) for all other stories.
 
         ## Rules
 

--- a/tests/test_dev_prompts.py
+++ b/tests/test_dev_prompts.py
@@ -160,3 +160,35 @@ def test_dev_prompt_includes_repository_context_pack(tmp_path):
 
     assert "Repository Context Pack" in prompt
     assert "keep it deterministic" in prompt
+
+
+class TestContractChangeTestRule:
+    """Verify that the test-editing rule is conditional on contract_change."""
+
+    def _make_prompt(self, tmp_path: Path, *, contract_change: bool) -> str:
+        task = _make_task(tmp_path)
+        return build_dev_prompt(
+            task,
+            workspace_path=tmp_path,
+            branch_name="feat/test",
+            story_content="# Test\n\nDo something.",
+            gate_command="make test",
+            contract_change=contract_change,
+        )
+
+    def test_default_false_uses_strict_rule(self, tmp_path: Path) -> None:
+        prompt = self._make_prompt(tmp_path, contract_change=False)
+        assert "implementation is wrong" in prompt
+        assert "fix your code, not the tests" in prompt
+        assert "intentionally changes an existing behavioral contract" not in prompt
+
+    def test_contract_change_true_uses_permissive_rule(self, tmp_path: Path) -> None:
+        prompt = self._make_prompt(tmp_path, contract_change=True)
+        assert "intentionally changes an existing behavioral contract" in prompt
+        assert "You MAY update test files" in prompt
+        assert "implementation is wrong" not in prompt
+        assert "fix your code, not the tests" not in prompt
+
+    def test_contract_change_still_restricts_unrelated_tests(self, tmp_path: Path) -> None:
+        prompt = self._make_prompt(tmp_path, contract_change=True)
+        assert "Do NOT modify tests unrelated to the contract change" in prompt

--- a/tests/test_preflight_work_type.py
+++ b/tests/test_preflight_work_type.py
@@ -28,7 +28,10 @@ from theforge.config import (
 )
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.engine import run_task
-from theforge.coordinator.preflight import _parse_preflight_work_type
+from theforge.coordinator.preflight import (
+    _parse_preflight_contract_change,
+    _parse_preflight_work_type,
+)
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.task import TaskStory, build_plan_prompt, build_preflight_prompt
 
@@ -929,3 +932,116 @@ class TestAuditLogIncludesWorkType:
         audit = generate_audit_log(config, task, result)
 
         assert audit["preflight"] is None
+
+
+# ── contract_change parser tests ─────────────────────────────────────
+
+
+class TestParsePreflightContractChange:
+    def test_true_when_set(self):
+        output = """\
+```yaml
+verdict: PROCEED
+complexity: small
+work_type: bug
+contract_change: true
+reason: "Behavioral contract change."
+sufficiency: implementation_ready
+spec_issues: []
+warnings: []
+criteria_checked: []
+```
+"""
+        assert _parse_preflight_contract_change(output) is True
+
+    def test_false_when_explicitly_false(self):
+        output = """\
+```yaml
+verdict: PROCEED
+complexity: medium
+work_type: feature
+contract_change: false
+reason: "New capability."
+sufficiency: needs_planning
+spec_issues: []
+warnings: []
+criteria_checked: []
+```
+"""
+        assert _parse_preflight_contract_change(output) is False
+
+    def test_false_when_field_absent(self):
+        output = """\
+```yaml
+verdict: PROCEED
+complexity: medium
+work_type: feature
+reason: "New capability."
+sufficiency: needs_planning
+spec_issues: []
+warnings: []
+criteria_checked: []
+```
+"""
+        assert _parse_preflight_contract_change(output) is False
+
+    def test_false_on_malformed_yaml(self):
+        assert _parse_preflight_contract_change("```yaml\n{{{ not valid\n```") is False
+
+    def test_no_fences_still_parses(self):
+        output = "verdict: PROCEED\ncontract_change: true\n"
+        assert _parse_preflight_contract_change(output) is True
+
+
+# ── Preflight prompt includes contract_change field ───────────────────
+
+
+class TestPreflightPromptContractChange:
+    def test_prompt_includes_contract_change_field(self, tmp_path: Path):
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Test\n\nDo something.", encoding="utf-8")
+        task = TaskStory(name="Test Task", story_path=spec, slug="test-task")
+        prompt = build_preflight_prompt(task, story_content="# Test\n\nDo something.")
+        assert "contract_change" in prompt
+
+    def test_audit_log_includes_contract_change(self, tmp_path: Path):
+        """generate_audit_log includes contract_change in the preflight section."""
+        spec_path = tmp_path / "spec.md"
+        spec_path.write_text("# Test spec", encoding="utf-8")
+        task = TaskStory(name="Test Task", slug="test-task", story_path=spec_path)
+
+        config = ForgeConfig(
+            project="test",
+            project_root=tmp_path,
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+            ),
+            validation=DEFAULT_VALIDATION,
+            dev_profile=DEFAULT_DEV_PROFILE,
+            preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+            review_pool=[DEFAULT_REVIEW_PROFILE],
+            synthesis_profile=None,
+            retry=RetryPolicy(),
+        )
+
+        state = CoordinatorState(
+            preflight_verdict="PROCEED",
+            preflight_reason="Contract changed.",
+            preflight_work_type="bug",
+            preflight_contract_change=True,
+            preflight_result=_make_agent_result(success=True, output="...", cost_usd=0.01),
+        )
+        result = CoordinatorResult(
+            success=True,
+            phase=Phase.DONE,
+            state=state,
+            message="Done.",
+        )
+
+        audit = generate_audit_log(config, task, result)
+
+        assert audit["preflight"] is not None
+        assert "contract_change" in audit["preflight"]
+        assert audit["preflight"]["contract_change"] is True

--- a/tests/test_preflight_work_type.py
+++ b/tests/test_preflight_work_type.py
@@ -992,6 +992,26 @@ criteria_checked: []
         output = "verdict: PROCEED\ncontract_change: true\n"
         assert _parse_preflight_contract_change(output) is True
 
+    def test_string_false_does_not_become_true(self):
+        """Quoted 'false' must not be treated as truthy via bool()."""
+        output = 'contract_change: "false"\n'
+        assert _parse_preflight_contract_change(output) is False
+
+    def test_string_zero_does_not_become_true(self):
+        """Quoted '0' must not be treated as truthy via bool()."""
+        output = 'contract_change: "0"\n'
+        assert _parse_preflight_contract_change(output) is False
+
+    def test_string_true_is_accepted(self):
+        """Quoted 'true' (unusual but possible) should be accepted."""
+        output = 'contract_change: "true"\n'
+        assert _parse_preflight_contract_change(output) is True
+
+    def test_integer_one_does_not_become_true(self):
+        """Numeric 1 should not be accepted — only boolean True."""
+        output = "contract_change: 1\n"
+        assert _parse_preflight_contract_change(output) is False
+
 
 # ── Preflight prompt includes contract_change field ───────────────────
 
@@ -1045,3 +1065,65 @@ class TestPreflightPromptContractChange:
         assert audit["preflight"] is not None
         assert "contract_change" in audit["preflight"]
         assert audit["preflight"]["contract_change"] is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_contract_change_in_preflight_artifact(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """preflight.yaml artifact includes contract_change field."""
+        import dataclasses
+
+        import yaml as _yaml
+        from coord_test_helpers import _make_plan_config
+
+        from theforge.config import LogConfig
+
+        config = _make_plan_config(tmp_path)
+        config = dataclasses.replace(config, log=LogConfig(enabled=True))
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        _preflight_output = """\
+```yaml
+verdict: PROCEED
+complexity: small
+work_type: bug
+contract_change: true
+reason: "Changes the error-to-escalation contract."
+sufficiency: implementation_ready
+sufficiency_reason: "Spec is concrete."
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "ESCALATE instead of error"
+    satisfied: false
+    evidence: "Still returns error"
+```
+"""
+        preflight_result = _make_agent_result(
+            success=True, output=_preflight_output, cost_usd=0.03
+        )
+        dev_result = _make_agent_result(success=True, output="Done.", cost_usd=0.30)
+
+        mock_preflight.return_value = preflight_result
+        mock_dev_agent.return_value = dev_result
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        log_dir = result.state.log_dir
+        assert log_dir is not None
+        preflight_yaml = log_dir / "preflight.yaml"
+        assert preflight_yaml.exists(), f"preflight.yaml not found in {log_dir}"
+        artifact = _yaml.safe_load(preflight_yaml.read_text(encoding="utf-8"))
+        assert "contract_change" in artifact
+        assert artifact["contract_change"] is True

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -264,3 +264,45 @@ def test_run_validate_phase_retry_feedback_includes_extracted_failures(tmp_path:
     assert "- tests/test_existing.py::test_breaks" in state.human_feedback
     assert "- generated/test_new.py::test_agent" in state.human_feedback
     assert "These are existing tests your changes broke" in state.human_feedback
+
+
+def test_format_failed_test_feedback_contract_change_uses_contract_message(
+    tmp_path: Path,
+) -> None:
+    from theforge.coordinator.validate_phase import _format_failed_test_feedback
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_existing.py").write_text(
+        "def test_breaks():\n    pass\n", encoding="utf-8"
+    )
+    feedback, existing = _format_failed_test_feedback(
+        "FAILED tests/test_existing.py::test_breaks",
+        tmp_path,
+        contract_change=True,
+    )
+
+    assert existing is True
+    assert "Some of these tests may assert the old behavioral contract" in feedback
+    assert "These are existing tests your changes broke" not in feedback
+    assert "do not edit these test files" not in feedback
+
+
+def test_format_failed_test_feedback_no_contract_change_uses_default_message(
+    tmp_path: Path,
+) -> None:
+    from theforge.coordinator.validate_phase import _format_failed_test_feedback
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_existing.py").write_text(
+        "def test_breaks():\n    pass\n", encoding="utf-8"
+    )
+    feedback, existing = _format_failed_test_feedback(
+        "FAILED tests/test_existing.py::test_breaks",
+        tmp_path,
+        contract_change=False,
+    )
+
+    assert existing is True
+    assert "These are existing tests your changes broke" in feedback
+    assert "do not edit these test files" in feedback
+    assert "old behavioral contract" not in feedback


### PR DESCRIPTION
## Summary

- Adds `contract_change: true | false` to the preflight output schema. Preflight sets it when the story intentionally changes a tested behavioral contract (e.g., changing an error response to an ESCALATE).
- When `contract_change` is true, the dev prompt Rules block switches from "implementation is wrong — fix your code, not the tests" to "you MAY update tests that assert the old contract; do not modify unrelated tests."
- When `contract_change` is true, validate-phase retry feedback drops "do not edit these test files" and instead says "some of these tests may assert the old behavioral contract."
- Includes explicit boolean normalization so quoted YAML strings like `"false"` or `"0"` cannot inadvertently authorize test rewrites.
- `contract_change` is included in the `preflight.yaml` artifact and the audit log for full traceability.

Fixes the root cause of #596 burning 3 iterations / $9.43: gpt-5.4 contorted a 5-line change into 57 lines to preserve old test expectations it was explicitly forbidden from updating.

Closes #618

## Test plan

- [ ] 17 new tests across `test_dev_prompts.py`, `test_validate_phase.py`, `test_preflight_work_type.py`
- [ ] Parser unit tests: `true`/`false`/absent/malformed YAML, string normalization edge cases (`"false"`, `"0"`, `"true"`, integer `1`)
- [ ] Dev prompt: default rule present when `contract_change=False`; permissive rule present when `contract_change=True`; unrelated-tests restriction always present
- [ ] Validate feedback: "fix your implementation" message when `contract_change=False`; "old behavioral contract" message when `contract_change=True`
- [ ] `preflight.yaml` artifact integration test reads the written file and asserts `contract_change` is present and correct
- [ ] Audit log unit test asserts `contract_change` in preflight section
- [ ] `make gate` PASS — 2414 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)