### PR TITLE
fix: revert dev profile to openai/gpt-5.4 (claude CLI blocked by sandbox)

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -38,8 +38,8 @@ retry:
 # Explicit profiles until adaptive assignment is stable
 profiles:
   dev:
-    cli: claude
-    model: claude-sonnet-4-6
+    provider: openai
+    model: gpt-5.4
     budget_usd: 50.00
     timeout_seconds: 600
     timeout_medium_seconds: 900


### PR DESCRIPTION
## Summary

Claude CLI's dev invocations have been failing immediately with exit=1 and `Not logged in · Please run /login`, causing every story in a sprint to escalate with cost=\$0. Root cause: the sandbox profile blocks Claude Code's OAuth credential lookup in the macOS keychain.

Reverting the dev profile to `openai/gpt-5.4` sidesteps the sandbox issue entirely — the OpenAI runner uses API auth, not a sandboxed subprocess.

## Root cause (for the record)

`src/theforge/runners/sandbox.py:_user_config_roots()` allowlists `~/.claude`, but Claude Code stores OAuth credentials in the macOS keychain at `~/Library/Keychains/login.keychain-db`. That path is not allowlisted, so `securityd` cannot serve credentials to the sandboxed `claude` process. The CLI reports "Not logged in" and exits 1 with zero output.

Evidence: run log `.forge/logs/issues-598,619,586,605,601,614,610/run-68a96774660f.log` shows every DEV invocation producing `Not logged in · Please run /login` with `cost=\$0.000`.

The underlying sandbox bug will be tracked in a separate issue.

## Test plan

- [ ] Verify existing tests still pass (`make test`)
- [ ] Re-run the escalated sprint — expect dev agents to actually execute and produce handoffs