### PR TITLE
fix: remove launcher_command from CLI runners (#624)

### DIFF
--- a/src/theforge/config/auth.py
+++ b/src/theforge/config/auth.py
@@ -56,32 +56,7 @@ def _sandbox_readiness(profile: ModelProfile) -> tuple[bool, str]:
 
 
 def _launcher_sandbox_readiness(profile: ModelProfile) -> tuple[bool, str]:
-    """Return whether CLI launcher sandboxing can enforce the worktree boundary."""
-    if profile.mode != "cli":
-        return (True, "")
-
-    from theforge.runners.sandbox import launcher_command
-
-    binary = "npx" if profile.cli in _NPX_CLIS else profile.cli
-    if binary is None:
-        return (True, "")
-    probe = launcher_command([binary, "--version"], Path.cwd())
-    if probe and probe[0] != binary:
-        return (True, "")
-
-    system = platform.system()
-    if system == "Darwin":
-        return (
-            False,
-            "launcher sandbox unavailable: sandbox-exec not usable; "
-            "CLI filesystem isolation will not hold",
-        )
-    if system == "Linux":
-        return (
-            False,
-            "launcher sandbox unavailable: bwrap not usable; "
-            "CLI filesystem isolation will not hold",
-        )
+    """CLI launchers are intentionally unsandboxed; always report ready."""
     return (True, "")
 
 

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -18,7 +18,6 @@ from typing import Any
 from theforge.agent_types import AgentResult, ModelUsage
 
 from ..config import ModelProfile
-from .sandbox import launcher_command
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -188,7 +187,7 @@ def _run_claude(
     timed_out = False
     try:
         proc = subprocess.Popen(
-            launcher_command(cmd, working_dir),
+            cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -20,7 +20,6 @@ from theforge.agent_types import AgentResult
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
-from .sandbox import launcher_command
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -137,7 +136,7 @@ def _run_codex(
     _codex_env = {**os.environ, **(secrets or {})}
     outcome, elapsed = _run_with_heartbeat(
         run_fn=lambda: subprocess.run(
-            launcher_command(cmd, working_dir),
+            cmd,
             input=stdin_prompt,
             capture_output=True,
             text=True,

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -142,6 +142,7 @@ def _run_codex(
             text=True,
             timeout=profile.timeout_seconds,
             env=_codex_env,
+            cwd=str(working_dir),
         ),
         label=label,
         profile=profile,

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -17,7 +17,6 @@ from theforge.agent_types import AgentResult
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
-from .sandbox import launcher_command
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -76,7 +75,7 @@ def _run_gemini(
     _gemini_env = {**os.environ, **(secrets or {})}
     outcome, elapsed = _run_with_heartbeat(
         run_fn=lambda: subprocess.run(
-            launcher_command(cmd, working_dir),
+            cmd,
             capture_output=True,
             text=True,
             cwd=str(working_dir),

--- a/src/theforge/runners/sandbox.py
+++ b/src/theforge/runners/sandbox.py
@@ -145,16 +145,6 @@ def _workspace_read_roots(allowed_root: Path) -> tuple[Path, ...]:
     return _unique_existing_paths(roots)
 
 
-def _launcher_extra_read_roots(cmd: list[str]) -> tuple[Path, ...]:
-    roots: list[Path] = []
-    if cmd:
-        executable = shutil.which(cmd[0])
-        if executable is not None:
-            roots.extend(_path_parent_roots(Path(executable)))
-    roots.extend(_user_config_roots())
-    return _unique_existing_paths(roots)
-
-
 def _macos_profile(
     allowed_root: Path,
     *,
@@ -277,35 +267,6 @@ def workspace_effect_sandbox_command(cmd: list[str], allowed_root: Path) -> list
             return _linux_command(cmd, root, masked_read_roots=blocked_worktrees)
         return cmd
     return cmd
-
-
-def launcher_command(cmd: list[str], allowed_root: Path) -> list[str]:
-    root = allowed_root.resolve()
-    blocked_worktrees = _blocked_worktree_roots(root)
-    extra_read_roots = _launcher_extra_read_roots(cmd)
-    if _SYSTEM == "Darwin":
-        profile = _macos_profile(
-            root,
-            extra_read_roots=extra_read_roots,
-            denied_read_roots=blocked_worktrees,
-        )
-        if _sandbox_available(
-            "sandbox-exec", ("sandbox-exec", "-p", "(version 1) (allow default)", "true")
-        ):
-            return ["sandbox-exec", "-p", profile, *cmd]
-        return cmd
-    if _SYSTEM == "Linux":
-        if _sandbox_available("bwrap", ("bwrap", "--ro-bind", "/", "/", "true")):
-            return _linux_command(
-                cmd,
-                root,
-                extra_read_roots=extra_read_roots,
-                masked_read_roots=blocked_worktrees,
-            )
-        return cmd
-    return cmd
-
-    # Backward-compatible alias for existing tool-runtime callers.
 
 
 def sandbox_command(cmd: list[str], allowed_root: Path) -> list[str]:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -58,13 +58,7 @@ def _neither_profile() -> ModelProfile:
 
 
 def test_cli_claude_binary_present():
-    with (
-        patch("theforge.config.auth.shutil.which", return_value="/usr/bin/claude"),
-        patch(
-            "theforge.runners.sandbox.launcher_command",
-            return_value=["sandbox-exec", "-p", "profile", "claude", "--version"],
-        ),
-    ):
+    with patch("theforge.config.auth.shutil.which", return_value="/usr/bin/claude"):
         ok, _ = check_agent_auth(_cli_profile("claude"))
         assert ok
 
@@ -84,13 +78,7 @@ def test_cli_codex_checks_npx_not_binary():
         calls.append(name)
         return "/usr/bin/npx" if name == "npx" else None
 
-    with (
-        patch("theforge.config.auth.shutil.which", side_effect=_which),
-        patch(
-            "theforge.runners.sandbox.launcher_command",
-            return_value=["bwrap", "npx", "--version"],
-        ),
-    ):
+    with patch("theforge.config.auth.shutil.which", side_effect=_which):
         result = check_agent_auth(_cli_profile("codex"))
 
     ok, _ = result
@@ -107,13 +95,7 @@ def test_cli_gemini_checks_npx_not_binary():
         calls.append(name)
         return "/usr/bin/npx" if name == "npx" else None
 
-    with (
-        patch("theforge.config.auth.shutil.which", side_effect=_which),
-        patch(
-            "theforge.runners.sandbox.launcher_command",
-            return_value=["bwrap", "npx", "--version"],
-        ),
-    ):
+    with patch("theforge.config.auth.shutil.which", side_effect=_which):
         result = check_agent_auth(_cli_profile("gemini"))
 
     ok, _ = result
@@ -279,13 +261,7 @@ def test_synthesis_profile_missing_key_returns_false(monkeypatch):
 
 
 def test_cli_binary_outside_system_paths_is_still_ready_when_present():
-    with (
-        patch("theforge.config.auth.shutil.which", return_value="/home/user/.local/bin/claude"),
-        patch(
-            "theforge.runners.sandbox.launcher_command",
-            return_value=["sandbox-exec", "-p", "x", "true"],
-        ),
-    ):
+    with patch("theforge.config.auth.shutil.which", return_value="/home/user/.local/bin/claude"):
         ok, reason = check_agent_auth(_cli_profile("claude"))
     assert ok
     assert reason == ""
@@ -319,38 +295,10 @@ def test_cli_bash_profile_does_not_report_workspace_sandbox_readiness():
         timeout_seconds=300,
         allowed_tools=("bash",),
     )
-    with (
-        patch("theforge.config.auth.shutil.which", return_value="/usr/bin/claude"),
-        patch(
-            "theforge.runners.sandbox.launcher_command",
-            return_value=["sandbox-exec", "-p", "profile", "claude", "--version"],
-        ),
-    ):
+    with patch("theforge.config.auth.shutil.which", return_value="/usr/bin/claude"):
         ok, reason = check_agent_auth(profile, {})
     assert ok is True
     assert reason == ""
-
-
-def test_cli_profile_reports_launcher_sandbox_unavailable() -> None:
-    profile = ModelProfile(
-        name="cli-dev",
-        cli="claude",
-        model="sonnet",
-        budget_usd=1.0,
-        timeout_seconds=300,
-        allowed_tools=("bash",),
-    )
-    with (
-        patch("theforge.config.auth.shutil.which", return_value="/usr/bin/claude"),
-        patch(
-            "theforge.runners.sandbox.launcher_command",
-            return_value=["claude", "--version"],
-        ),
-        patch("theforge.config.auth.platform.system", return_value="Darwin"),
-    ):
-        ok, reason = check_agent_auth(profile, {})
-    assert ok is False
-    assert "launcher sandbox unavailable" in reason
 
 
 def test_cli_profile_can_skip_sandbox_readiness_for_auth_only() -> None:

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -643,29 +643,11 @@ class TestRunAgentUnknownCli:
         assert result.profile_name == "dev"
 
 
-def test_claude_launcher_invocation_accepts_wrapped_or_direct_command(
-    dev_profile: ModelProfile, tmp_path: Path
-) -> None:
+def test_claude_launcher_invokes_cmd_directly(dev_profile: ModelProfile, tmp_path: Path) -> None:
     mock_proc = _make_stream_mock([_result_line(result="done")])
     with patch(
         "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
     ) as mock_popen:
         run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
     cmd = mock_popen.call_args[0][0]
-    assert cmd[0] == "claude" or cmd[0] in {"sandbox-exec", "bwrap"}
-
-
-def test_claude_launcher_uses_launcher_sandbox(dev_profile: ModelProfile, tmp_path: Path) -> None:
-    mock_proc = _make_stream_mock([_result_line(result="done")])
-    with (
-        patch(
-            "theforge.runners.runner_claude.launcher_command",
-            return_value=["sandbox-exec", "claude"],
-        ) as mock_launcher,
-        patch(
-            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-        ) as mock_popen,
-    ):
-        run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
-    mock_launcher.assert_called_once()
-    assert mock_popen.call_args[0][0] == ["sandbox-exec", "claude"]
+    assert cmd[0] == "claude"

--- a/tests/test_runner_providers.py
+++ b/tests/test_runner_providers.py
@@ -467,14 +467,9 @@ class TestRunGemini:
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=json_output, stderr=""
         )
-        with (
-            patch(
-                "theforge.runners.runner_gemini.launcher_command", side_effect=lambda cmd, _: cmd
-            ),
-            patch(
-                "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
-            ) as mock_run,
-        ):
+        with patch(
+            "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
+        ) as mock_run:
             run_agent(prompt="review", profile=gemini_profile, working_dir=tmp_path)
 
         cmd = mock_run.call_args[0][0]
@@ -495,14 +490,9 @@ class TestRunGemini:
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=json_output, stderr=""
         )
-        with (
-            patch(
-                "theforge.runners.runner_gemini.launcher_command", side_effect=lambda cmd, _: cmd
-            ),
-            patch(
-                "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
-            ) as mock_run,
-        ):
+        with patch(
+            "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
+        ) as mock_run:
             run_agent(prompt="my prompt", profile=gemini_profile, working_dir=tmp_path)
 
         call_kwargs = mock_run.call_args[1]

--- a/tests/test_runner_sandbox.py
+++ b/tests/test_runner_sandbox.py
@@ -103,45 +103,6 @@ def test_sandbox_command_linux_probe_uses_hashable_cache_key(tmp_path: Path) -> 
     assert wrapped[0] == "bwrap"
 
 
-def test_launcher_command_macos_adds_cli_install_root(tmp_path: Path) -> None:
-    from theforge.runners.sandbox import launcher_command
-
-    fake_bin = tmp_path / "homebrew" / "bin" / "claude"
-    fake_bin.parent.mkdir(parents=True)
-    fake_bin.write_text("", encoding="utf-8")
-
-    with (
-        patch("theforge.runners.sandbox._SYSTEM", "Darwin"),
-        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
-        patch("theforge.runners.sandbox.shutil.which", return_value=str(fake_bin)),
-    ):
-        wrapped = launcher_command(["claude", "-p"], tmp_path)
-
-    assert wrapped[:2] == ["sandbox-exec", "-p"]
-    profile = wrapped[2]
-    assert str(fake_bin.parent) in profile
-    assert str(fake_bin.parent.parent) in profile
-
-
-def test_launcher_command_linux_adds_cli_install_root(tmp_path: Path) -> None:
-    from theforge.runners.sandbox import launcher_command
-
-    fake_bin = tmp_path / "npm" / "bin" / "npx"
-    fake_bin.parent.mkdir(parents=True)
-    fake_bin.write_text("", encoding="utf-8")
-
-    with (
-        patch("theforge.runners.sandbox._SYSTEM", "Linux"),
-        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
-        patch("theforge.runners.sandbox.shutil.which", return_value=str(fake_bin)),
-    ):
-        wrapped = launcher_command(["npx", "@google/gemini-cli"], tmp_path)
-
-    assert wrapped[0] == "bwrap"
-    assert str(fake_bin.parent) in wrapped
-    assert str(fake_bin.parent.parent) in wrapped
-
-
 def test_workspace_sandbox_allows_project_root_but_blocks_sibling_worktrees(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Removes `launcher_command(...)` from `runner_claude`, `runner_codex`, and `runner_gemini` — aligns the runners with the invariant already stated in `config/auth.py`: CLI launchers are intentionally unsandboxed
- Deletes `launcher_command` and its helper `_launcher_extra_read_roots` from `sandbox.py` (no remaining callers)
- Simplifies `_launcher_sandbox_readiness` in `auth.py` to always return `(True, "")` — no sandbox probe needed
- Adds `cwd=str(working_dir)` to the Codex `subprocess.run` call (was previously provided implicitly by the bwrap `--chdir` flag; Claude and Gemini already passed `cwd=` explicitly)
- `workspace_effect_sandbox_command` / `sandbox_command` and `_handle_bash` API bash sandboxing are unchanged

Fixes #624. Supersedes #599 (original "remove sandbox from CLI launchers" whose runner edits never landed). Symptom reported in #623.

## Test plan

- [x] `make gate` — 2410 passed, 0 failed
- [x] Reviewed: `runner_claude`, `runner_codex`, `runner_gemini` all invoke subprocess directly with explicit `cwd=`
- [x] `test_claude_launcher_invokes_cmd_directly` asserts `cmd[0] == "claude"` (no sandbox wrapper)
- [x] `test_cli_profile_reports_launcher_sandbox_unavailable` removed (scenario no longer exists)
- [x] API bash sandboxing tests (`test_runner_sandbox.py`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)