### PR TITLE
fix: serialize landing in scheduler thread — workers must not merge

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -674,37 +674,31 @@ def _append_cycle_history(state: CoordinatorState, parsed_review: ReviewResult) 
         state.cycle_history = state.cycle_history[-3:]
 
 
-def _finalize_approve(
-    state: CoordinatorState,
+def land_story(
     config: ForgeConfig,
     task: TaskStory,
-    parsed_review: ReviewResult,
-    workspace_path: Path,
     branch_name: str,
-    task_start: float,
+    workspace_path: Path,
+    parsed_review: "ReviewResult | None",
+    state: CoordinatorState,
+    effective_on_approve: str,
     *,
-    auto_merge: bool,
-    notify: bool,
-    logger: "StructuredLogger | None",
-    review_cost: float,
-    review_elapsed: float,
-    message: str,
+    logger: "StructuredLogger | None" = None,
     run_id: str = "",
-) -> CoordinatorResult:
-    """Set DONE, optionally merge, log, notify, return CoordinatorResult.
+) -> "tuple[dict, str]":
+    """Execute the actual merge/landing for an approved story.
 
-    Pass logger=None to suppress merge_result/phase_end logger events (interactive paths).
-    Pass logger=logger to emit them (non-interactive path).
+    Returns ``(merge_info, landing_status)``.
+
+    The caller is responsible for acquiring ``integration_lock`` when needed
+    (sprint scheduler path).  Single-story ``run_task`` calls this directly
+    without a lock because there is only one worker.
+
+    ``effective_on_approve`` must be ``"merge"`` or ``"merge-pr"``; callers
+    should not invoke this function for ``"pr"`` or ``"none"`` modes.
     """
-    state.phase = Phase.DONE
-    merge_info: dict | None = None
-    merge_suffix = ""
-    landing_status: str | None = None
-
-    # Resolve effective on_approve: CLI --auto-merge flag forces "merge"
-    effective_on_approve = "merge" if auto_merge else config.workspace.on_approve
-
     if effective_on_approve == "merge":
+        # Pre-merge cleanup: commit any tracked dirty files in the worktree
         status_ok, status_out = _run_shell("git status --porcelain", workspace_path)
         if status_ok:
             tracked_dirty = _parse_dirty_files(status_out)
@@ -737,6 +731,7 @@ def _finalize_approve(
                 )
         else:
             _log(f"Warning: could not inspect worktree before merge: {status_out}")
+
         merge_info = _merge_branch(
             config.project_root,
             config.workspace.base_branch,
@@ -749,9 +744,7 @@ def _finalize_approve(
         )
         merge_info = dict(merge_info)
         merge_info["action"] = "merge"
-        merge_suffix = (
-            " Merged." if merge_info["merged"] else f" Merge failed: {merge_info['error']}"
-        )
+
         if merge_info["merged"] and task.story_path:
             _archive_story_to_done(task.story_path, config.project_root, commit=True)
         if logger:
@@ -774,14 +767,16 @@ def _finalize_approve(
                 logger,
                 secrets=config.secrets,
             )
+
+        landing_status = "landed" if merge_info["merged"] else "failed"
+        return merge_info, landing_status
+
     elif effective_on_approve == "merge-pr":
+        if parsed_review is None:
+            _log("WARN: land_story called for merge-pr but parsed_review is None — skipping")
+            return {"merged": False, "error": "no review result available"}, "failed"
+
         merge_info = _merge_pr(config, task, branch_name, parsed_review, state)
-        if merge_info["merged"]:
-            merge_suffix = f" PR merged: {merge_info['pr_url']}"
-        elif merge_info.get("merge_queued"):
-            merge_suffix = f" PR queued for auto-merge: {merge_info['pr_url']}"
-        else:
-            merge_suffix = f" merge-pr failed: {merge_info['error']}"
         if logger:
             logger._safe_emit(
                 "merge_result",
@@ -803,12 +798,59 @@ def _finalize_approve(
                 logger,
                 secrets=config.secrets,
             )
+
         if not merge_info["merged"] and not merge_info.get("merge_queued"):
             landing_status = "failed"
         elif merge_info.get("merge_queued"):
             landing_status = "pending_integration"
         else:
             landing_status = "landed"
+        return merge_info, landing_status
+
+    else:
+        raise ValueError(
+            f"land_story called for unsupported effective_on_approve={effective_on_approve!r}; "
+            "only 'merge' and 'merge-pr' are valid"
+        )
+
+
+def _finalize_approve(
+    state: CoordinatorState,
+    config: ForgeConfig,
+    task: TaskStory,
+    parsed_review: ReviewResult,
+    workspace_path: Path,
+    branch_name: str,
+    task_start: float,
+    *,
+    auto_merge: bool,
+    notify: bool,
+    logger: "StructuredLogger | None",
+    review_cost: float,
+    review_elapsed: float,
+    message: str,
+    run_id: str = "",
+) -> CoordinatorResult:
+    """Set DONE, mark landing pending, log, notify, return CoordinatorResult.
+
+    Merge/landing is deferred: callers (run_task for single-story, _attempt_integration
+    for sprint) invoke land_story() after this returns.
+
+    Pass logger=None to suppress phase_end logger events (interactive paths).
+    Pass logger=logger to emit them (non-interactive path).
+    """
+    state.phase = Phase.DONE
+    merge_info: dict | None = None
+    merge_suffix = ""
+    landing_status: str | None = None
+
+    # Resolve effective on_approve: CLI --auto-merge flag forces "merge"
+    effective_on_approve = "merge" if auto_merge else config.workspace.on_approve
+
+    if effective_on_approve in ("merge", "merge-pr"):
+        # Defer to land_story() — no git operations here.
+        merge_info = {"action": effective_on_approve, "pending": True}
+        landing_status = "pending_integration"
     elif effective_on_approve == "pr":
         merge_info = _create_pr(config, task, branch_name, parsed_review, state)
         if merge_info.get("skipped"):

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -800,6 +800,36 @@ def run_task(
             state_update_fn=state_update_fn,
             stop_phase=stop_phase,
         )
+
+        # ── Landing (single-story path) ───────────────────────────────
+        # _finalize_approve defers all git operations and sets landing_status
+        # = "pending_integration".  We perform the actual merge here, without
+        # a lock, because single-story runs have exactly one worker.
+        if result.success and result.landing_status == "pending_integration":
+            from .completion import land_story  # noqa: PLC0415
+
+            _effective_on_approve = "merge" if auto_merge else config.workspace.on_approve
+            _parsed_review = state.review_results[-1] if state.review_results else None
+            _merge_info, _landing_status = land_story(
+                config,
+                task,
+                branch_name,
+                workspace_path,
+                _parsed_review,
+                state,
+                _effective_on_approve,
+                logger=logger,
+                run_id=_run_id,
+            )
+            result.merge = _merge_info
+            result.landing_status = _landing_status
+            if _merge_info.get("merged"):
+                result.message += " Merged."
+            elif _merge_info.get("merge_queued"):
+                result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
+            elif _landing_status == "failed":
+                result.message += f" Merge failed: {_merge_info.get('error', 'unknown')}"
+
         _total_elapsed = time.monotonic() - _task_start
         _fire_post_run_hook(config, state, task, result, _run_id, _total_elapsed, logger)
         logger._safe_emit(
@@ -928,6 +958,34 @@ def _run_resume_coordinator(
             logger=logger,
             state_update_fn=state_update_fn,
         )
+
+        # ── Landing (single-story resume path) ───────────────────────
+        if result.success and result.landing_status == "pending_integration":
+            from .completion import land_story  # noqa: PLC0415
+
+            _effective_on_approve = "merge" if auto_merge else config.workspace.on_approve
+            _parsed_review = state.review_results[-1] if state.review_results else None
+            _rws = state.workspace_path or workspace_path
+            _merge_info, _landing_status = land_story(
+                config,
+                task,
+                branch_name,
+                _rws,
+                _parsed_review,
+                state,
+                _effective_on_approve,
+                logger=logger,
+                run_id=logger._run_id if logger else "",
+            )
+            result.merge = _merge_info
+            result.landing_status = _landing_status
+            if _merge_info.get("merged"):
+                result.message += " Merged."
+            elif _merge_info.get("merge_queued"):
+                result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
+            elif _landing_status == "failed":
+                result.message += f" Merge failed: {_merge_info.get('error', 'unknown')}"
+
         _total_elapsed = time.monotonic() - _task_start
         _fire_post_run_hook(config, state, task, result, logger._run_id, _total_elapsed, logger)
         logger._safe_emit(

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -508,6 +508,7 @@ def run_task(
     stop_phase: Phase | None = None,
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
+    defer_landing: bool = False,
 ) -> CoordinatorResult:
     """Execute the full coordinator state machine for a single task.
 
@@ -805,7 +806,9 @@ def run_task(
         # _finalize_approve defers all git operations and sets landing_status
         # = "pending_integration".  We perform the actual merge here, without
         # a lock, because single-story runs have exactly one worker.
-        if result.success and result.landing_status == "pending_integration":
+        # When defer_landing=True (sprint worker path), skip: the scheduler
+        # thread will call _attempt_integration under integration_lock.
+        if result.success and result.landing_status == "pending_integration" and not defer_landing:
             from .completion import land_story  # noqa: PLC0415
 
             _effective_on_approve = "merge" if auto_merge else config.workspace.on_approve
@@ -887,6 +890,7 @@ def _run_resume_coordinator(
     state_update_fn: "Callable[[dict], None] | None",
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
+    defer_landing: bool = False,
 ) -> CoordinatorResult:
     """Shared body for run_from_review and run_from_dev.
 
@@ -960,7 +964,8 @@ def _run_resume_coordinator(
         )
 
         # ── Landing (single-story resume path) ───────────────────────
-        if result.success and result.landing_status == "pending_integration":
+        # Skip when defer_landing=True (sprint worker): scheduler handles it.
+        if result.success and result.landing_status == "pending_integration" and not defer_landing:
             from .completion import land_story  # noqa: PLC0415
 
             _effective_on_approve = "merge" if auto_merge else config.workspace.on_approve
@@ -1013,6 +1018,7 @@ def run_from_review(
     state_update_fn: "Callable[[dict], None] | None" = None,
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
+    defer_landing: bool = False,
 ) -> CoordinatorResult:
     """Start at REVIEW on an existing worktree, then iterate DEV→VALIDATE→REVIEW as needed.
 
@@ -1028,6 +1034,8 @@ def run_from_review(
         workspace_path: Path to the existing worktree.
         interactive: When True, pause at HUMAN_REVIEW for operator input.
         auto_merge: When True, merge the feature branch after APPROVE.
+        defer_landing: When True, skip the landing step and leave
+            landing_status="pending_integration" for the caller (sprint scheduler).
     """
     return _run_resume_coordinator(
         config,
@@ -1043,6 +1051,7 @@ def run_from_review(
         state_update_fn=state_update_fn,
         no_pull=no_pull,
         cached_preflight_state=cached_preflight_state,
+        defer_landing=defer_landing,
     )
 
 
@@ -1059,6 +1068,7 @@ def run_from_dev(
     state_update_fn: "Callable[[dict], None] | None" = None,
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
+    defer_landing: bool = False,
 ) -> CoordinatorResult:
     """Start at DEV on an existing worktree, skipping WORKSPACE and PREFLIGHT.
 
@@ -1071,6 +1081,8 @@ def run_from_dev(
         workspace_path: Path to the existing worktree.
         interactive: When True, pause at HUMAN_REVIEW for operator input.
         auto_merge: When True, merge the feature branch after APPROVE.
+        defer_landing: When True, skip the landing step and leave
+            landing_status="pending_integration" for the caller (sprint scheduler).
     """
     return _run_resume_coordinator(
         config,
@@ -1086,6 +1098,7 @@ def run_from_dev(
         state_update_fn=state_update_fn,
         no_pull=no_pull,
         cached_preflight_state=cached_preflight_state,
+        defer_landing=defer_landing,
     )
 
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -249,6 +249,7 @@ def _run_fresh(
             state_update_fn=state_update_fn,
             no_pull=no_pull,
             cached_preflight_state=(preflight_states or {}).get(task.slug),
+            defer_landing=True,
         )
 
     # Phase 1: run through PLAN only
@@ -264,6 +265,7 @@ def _run_fresh(
         no_pull=no_pull,
         stop_phase=Phase.PLAN_REVIEW,
         cached_preflight_state=(preflight_states or {}).get(task.slug),
+        defer_landing=True,
     )
 
     if not plan_result.success:
@@ -299,6 +301,7 @@ def _run_fresh(
         state_update_fn=state_update_fn,
         no_pull=no_pull,
         cached_preflight_state=(preflight_states or {}).get(task.slug),
+        defer_landing=True,
     )
 
 
@@ -350,6 +353,7 @@ def _run_single_story(
                     state_update_fn=state_update_fn,
                     no_pull=no_pull,
                     cached_preflight_state=(preflight_states or {}).get(task.slug),
+                    defer_landing=True,
                 )
             elif triage.action == "dev" and triage.worktree_path is not None:
                 result = run_from_dev(
@@ -364,6 +368,7 @@ def _run_single_story(
                     state_update_fn=state_update_fn,
                     no_pull=no_pull,
                     cached_preflight_state=(preflight_states or {}).get(task.slug),
+                    defer_landing=True,
                 )
             else:
                 result = _run_fresh(
@@ -776,6 +781,15 @@ def run_sprint(
         # Falls back to config.workspace.on_approve for legacy/direct callers.
         effective_on_approve = (result.merge or {}).get("action") or config.workspace.on_approve
 
+        story_logger = StructuredLogger(
+            run_id=_sprint_run_id,
+            project=config.project,
+            task=task.slug,
+            log_file=config.log.log_file,
+            enabled=config.log.enabled,
+            project_root=config.project_root,
+        )
+
         with integration_lock(config.project_root):
             from ..coordinator.completion import land_story  # noqa: PLC0415
 
@@ -790,6 +804,8 @@ def run_sprint(
                 parsed_review,
                 result.state,
                 effective_on_approve,
+                logger=story_logger,
+                run_id=_sprint_run_id,
             )
 
         result.merge = merge_info

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -21,7 +21,7 @@ from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
 from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from ..coordinator.util import _fmt_duration, _generate_run_id
-from ..coordinator.workspace import _merge_branch, pull_base_branch
+from ..coordinator.workspace import pull_base_branch
 from ..task import TaskStory
 from .audit import _write_sprint_audit, _write_sprint_summary, _write_story_audit
 from .ci_checks import poll_required_checks
@@ -754,6 +754,14 @@ def run_sprint(
         task: TaskStory,
         result: CoordinatorResult,
     ) -> bool:
+        """Attempt to land an approved story under integration_lock.
+
+        Returns True when integration was attempted (success, failure, or queued).
+        Returns False when dependencies are unmet — caller should retry later.
+
+        This is the sole merge site for sprint execution.  Workers never merge;
+        they set landing_status="pending_integration" and return.
+        """
         nonlocal stopped_reason, ci_halt_slug
 
         if not all(dep in merged_slugs for dep in task.depends_on):
@@ -763,37 +771,35 @@ def run_sprint(
 
         branch = config.workspace.branch_pattern.format(slug=slug)
         wt = config.project_root / config.workspace.path_pattern.format(slug=slug)
-        with integration_lock(config.project_root):
-            if config.workspace.on_approve == "merge-pr":
-                from ..coordinator.completion import _merge_pr  # noqa: PLC0415
 
-                parsed_review = (
-                    result.state.review_results[-1] if result.state.review_results else None
-                )
-                if parsed_review is None:
-                    _log(f"WARN: no review result for {slug} — skipping merge-pr")
-                    result.landing_status = "failed"
-                    _write_story_audit(config, task, result)
-                    return True
-                merge_info = _merge_pr(config, task, branch, parsed_review, result.state)
-            else:
-                merge_info = _merge_branch(
-                    config.project_root,
-                    config.workspace.base_branch,
-                    branch,
-                    slug,
-                    wt,
-                    config=config,
-                    task_name=task.name,
-                )
+        # Read effective mode from the pending merge action stored by _finalize_approve.
+        # Falls back to config.workspace.on_approve for legacy/direct callers.
+        effective_on_approve = (result.merge or {}).get("action") or config.workspace.on_approve
+
+        with integration_lock(config.project_root):
+            from ..coordinator.completion import land_story  # noqa: PLC0415
+
+            parsed_review = (
+                result.state.review_results[-1] if result.state.review_results else None
+            )
+            merge_info, landing_status = land_story(
+                config,
+                task,
+                branch,
+                wt,
+                parsed_review,
+                result.state,
+                effective_on_approve,
+            )
 
         result.merge = merge_info
+        result.landing_status = landing_status
+
         if merge_info.get("merged"):
-            result.landing_status = "landed"
             merged_slugs.add(slug)
             dag.mark_complete(slug)
             _write_story_audit(config, task, result)
-            if config.workspace.on_approve == "merge-pr" and not merge_info.get(
+            if effective_on_approve == "merge-pr" and not merge_info.get(
                 "auto_merge_queued", False
             ):
                 ci_result = poll_required_checks(
@@ -817,12 +823,10 @@ def run_sprint(
 
         if merge_info.get("merge_queued"):
             queued_prs[slug] = (task, result, merge_info["pr_url"])
-            result.landing_status = "pending_integration"
             _write_story_audit(config, task, result)
             _log(f"INFO {slug}: PR auto-merge queued; waiting for GitHub to report MERGED")
             return True
 
-        result.landing_status = "failed"
         result.state.error = merge_info.get("error") or "integration failed"
         _log(f"WARN {slug}: integration failed: {merge_info.get('error')}")
         _write_story_audit(config, task, result)
@@ -1074,15 +1078,21 @@ def run_sprint(
                 specs_failed += df
                 specs_skipped += dsk
 
+                # Dependent stories in parallel mode need scheduler-side local merge
+                # even when on_approve is "none" and auto_merge is False.
+                if (
+                    result.success
+                    and result.landing_status is None
+                    and max_parallel > 1
+                    and slug in dependent_slugs
+                ):
+                    result.landing_status = "pending_integration"
+                    result.merge = {**(result.merge or {}), "action": "merge", "pending": True}
+
                 # The scheduler thread is the sole owner of DAG/landing state.
-                # Workers only return CoordinatorResult objects; integration and
-                # dependency satisfaction happen here after futures complete.
-                needs_parallel_integration = max_parallel > 1 and (
-                    auto_merge
-                    or config.workspace.on_approve == "merge-pr"
-                    or slug in dependent_slugs
-                )
-                if needs_parallel_integration and result.success:
+                # Workers set landing_status="pending_integration" and return;
+                # _attempt_integration is the sole merge site for all sprint execution.
+                if result.success and result.landing_status == "pending_integration":
                     integrated = _attempt_integration(slug, task, result)
                     if not integrated:
                         pending_integration[slug] = (task, result)
@@ -1112,39 +1122,6 @@ def run_sprint(
                             source.on_escalate(task, result.state, config)
                         except Exception as exc:
                             _log(f"WARN on_escalate callback failed for {slug}: {exc}")
-
-                if (
-                    max_parallel == 1
-                    and config.workspace.on_approve == "merge-pr"
-                    and result.merge
-                    and result.merge.get("merged")
-                    and not result.merge.get("auto_merge_queued", False)
-                ):
-                    ci_result = poll_required_checks(
-                        config.project_root,
-                        config.workspace.base_branch,
-                        config.workspace.ci_check_timeout_seconds,
-                    )
-                    if ci_result["status"] in {"fail", "timeout"}:
-                        failing = (
-                            ", ".join(ci_result["failing_checks"]) or "pending required checks"
-                        )
-                        stopped_reason = (
-                            "Required CI checks "
-                            f"{ci_result['status']} after merging {slug} "
-                            f"at {ci_result['sha']}: {failing}"
-                        )
-                        ci_halt_slug = slug
-                        _log(
-                            f"HALT {slug}: required CI checks {ci_result['status']} "
-                            f"for {ci_result['sha']} ({failing})"
-                        )
-                        for t in dag.ready():
-                            if t.slug not in active:
-                                dag.mark_skipped(t.slug)
-                                specs_skipped += 1
-                                _log(f"SKIPPED {t.slug} ({stopped_reason})")
-                        break
 
                 _print_worker_status(active, worker_phases, dag, total)
 

--- a/tests/test_coord_logging.py
+++ b/tests/test_coord_logging.py
@@ -390,6 +390,7 @@ class TestProjectLocalLogDir:
             state = _state
             merge = None
             message = "done"
+            landing_status = None
 
         captured_kwargs: dict = {}
 
@@ -473,6 +474,7 @@ class TestProjectLocalLogDir:
                 phase = Phase.DONE
                 merge = None
                 message = "done"
+                landing_status = None
 
             fake_result = _FakeResult()
             fake_result.state = result_state

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -817,6 +817,7 @@ class TestFinalizeApproveMergePr:
     """Test _finalize_approve routes merge-pr correctly."""
 
     def test_merge_pr_path_in_finalize_approve(self, tmp_path: Path) -> None:
+        """_finalize_approve defers landing — sets pending_integration, never calls _merge_pr."""
         from theforge.coordinator.completion import _finalize_approve
         from theforge.coordinator.state import CoordinatorState, Phase
 
@@ -829,13 +830,6 @@ class TestFinalizeApproveMergePr:
 
         with patch(
             "theforge.coordinator.completion._merge_pr",
-            return_value={
-                "action": "merge-pr",
-                "pr_url": "https://github.com/fuzzypete/theforge/pull/99",
-                "merged": True,
-                "success": True,
-                "error": None,
-            },
         ) as mock_merge_pr:
             result = _finalize_approve(
                 state,
@@ -856,11 +850,12 @@ class TestFinalizeApproveMergePr:
         assert result.success is True
         assert result.merge is not None
         assert result.merge["action"] == "merge-pr"
-        assert result.merge["merged"] is True
-        assert "PR merged" in result.message
-        mock_merge_pr.assert_called_once()
+        assert result.merge.get("pending") is True
+        assert result.landing_status == "pending_integration"
+        mock_merge_pr.assert_not_called()
 
     def test_merge_pr_failure_in_finalize_approve(self, tmp_path: Path) -> None:
+        """_finalize_approve defers landing — returns pending_integration, never fails."""
         from theforge.coordinator.completion import _finalize_approve
         from theforge.coordinator.state import CoordinatorState, Phase
 
@@ -871,37 +866,26 @@ class TestFinalizeApproveMergePr:
         state.phase = Phase.REVIEW
         import time
 
-        with patch(
-            "theforge.coordinator.completion._merge_pr",
-            return_value={
-                "action": "merge-pr",
-                "pr_url": None,
-                "merged": False,
-                "success": False,
-                "error": "gh auth failed",
-            },
-        ):
-            result = _finalize_approve(
-                state,
-                config,
-                task,
-                review,
-                tmp_path,
-                "forge/test-task",
-                time.monotonic(),
-                auto_merge=False,
-                notify=False,
-                logger=None,
-                review_cost=0.5,
-                review_elapsed=1.0,
-                message="done. ",
-            )
+        result = _finalize_approve(
+            state,
+            config,
+            task,
+            review,
+            tmp_path,
+            "forge/test-task",
+            time.monotonic(),
+            auto_merge=False,
+            notify=False,
+            logger=None,
+            review_cost=0.5,
+            review_elapsed=1.0,
+            message="done. ",
+        )
 
         assert result.success is True
         assert result.phase == Phase.DONE
-        assert result.merge["merged"] is False
-        assert result.landing_status == "failed"
-        assert "merge-pr failed" in result.message
+        assert result.landing_status == "pending_integration"
+        assert result.merge == {"action": "merge-pr", "pending": True}
 
     def test_auto_merge_overrides_merge_pr(self, tmp_path: Path) -> None:
         """When auto_merge=True is passed, merge-pr config is overridden to use local merge."""
@@ -944,17 +928,16 @@ class TestFinalizeApproveMergePr:
 
 
 class TestPreMergeDirtyWorktreeCleanup:
-    def test_tracked_dirty_worktree_is_committed_before_merge(self, tmp_path: Path) -> None:
-        import time
+    """Pre-merge worktree cleanup lives in land_story(), not _finalize_approve()."""
 
-        from theforge.coordinator.completion import _finalize_approve
-        from theforge.coordinator.state import CoordinatorState, Phase
+    def test_tracked_dirty_worktree_is_committed_before_merge(self, tmp_path: Path) -> None:
+        from theforge.coordinator.completion import land_story
+        from theforge.coordinator.state import CoordinatorState
 
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
         state = CoordinatorState()
-        state.phase = Phase.REVIEW
 
         shell_calls: list[str] = []
 
@@ -975,23 +958,11 @@ class TestPreMergeDirtyWorktreeCleanup:
                 return_value={"merged": True, "error": None},
             ) as mock_merge_branch,
         ):
-            result = _finalize_approve(
-                state,
-                config,
-                task,
-                review,
-                tmp_path,
-                "forge/test-task",
-                time.monotonic(),
-                auto_merge=True,
-                notify=False,
-                logger=None,
-                review_cost=0.5,
-                review_elapsed=1.0,
-                message="done. ",
+            merge_info, landing_status = land_story(
+                config, task, "forge/test-task", tmp_path, review, state, "merge"
             )
 
-        assert result.success is True
+        assert landing_status == "landed"
         assert shell_calls == [
             "git status --porcelain",
             "git add -- tracked.py added.py removed.py",
@@ -1000,16 +971,13 @@ class TestPreMergeDirtyWorktreeCleanup:
         mock_merge_branch.assert_called_once()
 
     def test_clean_worktree_skips_pre_merge_commit(self, tmp_path: Path) -> None:
-        import time
-
-        from theforge.coordinator.completion import _finalize_approve
-        from theforge.coordinator.state import CoordinatorState, Phase
+        from theforge.coordinator.completion import land_story
+        from theforge.coordinator.state import CoordinatorState
 
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
         state = CoordinatorState()
-        state.phase = Phase.REVIEW
 
         shell_calls: list[str] = []
 
@@ -1026,37 +994,22 @@ class TestPreMergeDirtyWorktreeCleanup:
                 return_value={"merged": True, "error": None},
             ) as mock_merge_branch,
         ):
-            result = _finalize_approve(
-                state,
-                config,
-                task,
-                review,
-                tmp_path,
-                "forge/test-task",
-                time.monotonic(),
-                auto_merge=True,
-                notify=False,
-                logger=None,
-                review_cost=0.5,
-                review_elapsed=1.0,
-                message="done. ",
+            merge_info, landing_status = land_story(
+                config, task, "forge/test-task", tmp_path, review, state, "merge"
             )
 
-        assert result.success is True
+        assert landing_status == "landed"
         assert shell_calls == ["git status --porcelain"]
         mock_merge_branch.assert_called_once()
 
     def test_untracked_files_are_warned_but_not_added(self, tmp_path: Path) -> None:
-        import time
-
-        from theforge.coordinator.completion import _finalize_approve
-        from theforge.coordinator.state import CoordinatorState, Phase
+        from theforge.coordinator.completion import land_story
+        from theforge.coordinator.state import CoordinatorState
 
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
         state = CoordinatorState()
-        state.phase = Phase.REVIEW
 
         shell_calls: list[str] = []
         log_messages: list[str] = []
@@ -1079,23 +1032,11 @@ class TestPreMergeDirtyWorktreeCleanup:
                 return_value={"merged": True, "error": None},
             ),
         ):
-            result = _finalize_approve(
-                state,
-                config,
-                task,
-                review,
-                tmp_path,
-                "forge/test-task",
-                time.monotonic(),
-                auto_merge=True,
-                notify=False,
-                logger=None,
-                review_cost=0.5,
-                review_elapsed=1.0,
-                message="done. ",
+            merge_info, landing_status = land_story(
+                config, task, "forge/test-task", tmp_path, review, state, "merge"
             )
 
-        assert result.success is True
+        assert landing_status == "landed"
         assert shell_calls == [
             "git status --porcelain",
             "git add -- tracked.py",
@@ -1308,19 +1249,17 @@ class TestPrBodyContent:
 
 
 class TestMergePrEscalate:
-    """_finalize_approve preserves approval when merge-pr landing fails."""
+    """land_story() preserves approval when merge-pr landing fails."""
 
     def test_finalize_approve_escalates_on_merge_pr_failure(self, tmp_path: Path) -> None:
-        import time
-
-        from theforge.coordinator.completion import _finalize_approve
-        from theforge.coordinator.state import CoordinatorState, Phase
+        """land_story returns landing_status='failed' when _merge_pr fails."""
+        from theforge.coordinator.completion import land_story
+        from theforge.coordinator.state import CoordinatorState
 
         config = _make_merge_pr_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
         state = CoordinatorState()
-        state.phase = Phase.REVIEW
 
         with patch(
             "theforge.coordinator.completion._merge_pr",
@@ -1332,39 +1271,22 @@ class TestMergePrEscalate:
                 "error": "rebase conflict on main",
             },
         ):
-            result = _finalize_approve(
-                state,
-                config,
-                task,
-                review,
-                tmp_path,
-                "forge/test-task",
-                time.monotonic(),
-                auto_merge=False,
-                notify=False,
-                logger=None,
-                review_cost=0.5,
-                review_elapsed=1.0,
-                message="done. ",
+            merge_info, landing_status = land_story(
+                config, task, "forge/test-task", tmp_path, review, state, "merge-pr"
             )
 
-        assert result.success is True
-        assert result.phase == Phase.DONE
-        assert result.merge["merged"] is False
-        assert result.landing_status == "failed"
-        assert state.phase == Phase.DONE
+        assert merge_info["merged"] is False
+        assert landing_status == "failed"
 
     def test_finalize_approve_done_on_merge_pr_success(self, tmp_path: Path) -> None:
-        import time
-
-        from theforge.coordinator.completion import _finalize_approve
-        from theforge.coordinator.state import CoordinatorState, Phase
+        """land_story returns landing_status='landed' when _merge_pr succeeds."""
+        from theforge.coordinator.completion import land_story
+        from theforge.coordinator.state import CoordinatorState
 
         config = _make_merge_pr_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
         state = CoordinatorState()
-        state.phase = Phase.REVIEW
 
         with patch(
             "theforge.coordinator.completion._merge_pr",
@@ -1376,25 +1298,12 @@ class TestMergePrEscalate:
                 "error": None,
             },
         ):
-            result = _finalize_approve(
-                state,
-                config,
-                task,
-                review,
-                tmp_path,
-                "forge/test-task",
-                time.monotonic(),
-                auto_merge=False,
-                notify=False,
-                logger=None,
-                review_cost=0.5,
-                review_elapsed=1.0,
-                message="done. ",
+            merge_info, landing_status = land_story(
+                config, task, "forge/test-task", tmp_path, review, state, "merge-pr"
             )
 
-        assert result.success is True
-        assert result.phase == Phase.DONE
-        assert result.merge["merged"] is True
+        assert merge_info["merged"] is True
+        assert landing_status == "landed"
 
 
 # ── Config validation: merge_strategy ────────────────────────────
@@ -1519,16 +1428,14 @@ class TestFastForwardAfterMerge:
         assert any(cmd[:4] == ["git", "push", "origin", "--delete"] for cmd in cleanup_calls)
 
     def test_finalize_approve_keeps_done_for_merge_queued(self, tmp_path: Path) -> None:
-        import time
-
-        from theforge.coordinator.completion import _finalize_approve
-        from theforge.coordinator.state import CoordinatorState, Phase
+        """land_story returns landing_status='pending_integration' when PR merge is queued."""
+        from theforge.coordinator.completion import land_story
+        from theforge.coordinator.state import CoordinatorState
 
         config = _make_merge_pr_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
         state = CoordinatorState()
-        state.phase = Phase.REVIEW
 
         with patch(
             "theforge.coordinator.completion._merge_pr",
@@ -1542,22 +1449,9 @@ class TestFastForwardAfterMerge:
                 "error": None,
             },
         ):
-            result = _finalize_approve(
-                state,
-                config,
-                task,
-                review,
-                tmp_path,
-                "forge/test-task",
-                time.monotonic(),
-                auto_merge=False,
-                notify=False,
-                logger=None,
-                review_cost=0.5,
-                review_elapsed=1.0,
-                message="done. ",
+            merge_info, landing_status = land_story(
+                config, task, "forge/test-task", tmp_path, review, state, "merge-pr"
             )
 
-        assert result.success is True
-        assert result.phase == Phase.DONE
-        assert result.merge["merge_queued"] is True
+        assert merge_info["merge_queued"] is True
+        assert landing_status == "pending_integration"

--- a/tests/test_coord_workspace_merge.py
+++ b/tests/test_coord_workspace_merge.py
@@ -29,8 +29,10 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.coordinator.completion import _finalize_approve
 from theforge.coordinator.engine import run_task
-from theforge.coordinator.state import Phase
+from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.review import ReviewResult
 
 # ── Workspace failure ─────────────────────────────────────────────
 
@@ -536,3 +538,135 @@ class TestCoordinatorAutoPush:
         assert result.phase == Phase.DONE
         assert result.merge is not None
         assert result.merge["merged"] is True
+
+
+# ── _finalize_approve no-git contract ─────────────────────────────────
+
+
+class TestFinalizeApproveNoGit:
+    """_finalize_approve must never touch git for any on_approve mode.
+
+    All landing is deferred to land_story() / _attempt_integration.
+    """
+
+    def _make_parsed_review(self) -> ReviewResult:
+        return ReviewResult(
+            verdict="APPROVE",
+            summary="Looks good.",
+            findings=[],
+            story_matches=True,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={},
+        )
+
+    @patch("theforge.coordinator.completion._run_shell")
+    def test_finalize_approve_merge_no_git_calls(self, mock_run_shell, tmp_path):
+        """auto_merge=True: _finalize_approve returns pending_integration, no git ops."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = CoordinatorState()
+        parsed_review = self._make_parsed_review()
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        result = _finalize_approve(
+            state,
+            config,
+            task,
+            parsed_review,
+            workspace,
+            "forge/test-task",
+            0.0,
+            auto_merge=True,
+            notify=False,
+            logger=None,
+            review_cost=0.1,
+            review_elapsed=1.0,
+            message="Done. ",
+        )
+
+        assert result.success is True
+        assert result.landing_status == "pending_integration"
+        assert result.merge == {"action": "merge", "pending": True}
+        mock_run_shell.assert_not_called()
+
+    @patch("theforge.coordinator.completion._run_shell")
+    def test_finalize_approve_merge_pr_no_git_calls(self, mock_run_shell, tmp_path):
+        """on_approve=merge-pr: _finalize_approve returns pending_integration, no git ops."""
+        config = ForgeConfig(
+            project="test",
+            project_root=tmp_path,
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+                on_approve="merge-pr",
+            ),
+            validation=DEFAULT_VALIDATION,
+            dev_profile=DEFAULT_DEV_PROFILE,
+            preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+            review_pool=[DEFAULT_REVIEW_PROFILE],
+            synthesis_profile=None,
+            retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        )
+        task = _make_task(tmp_path)
+        state = CoordinatorState()
+        parsed_review = self._make_parsed_review()
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        result = _finalize_approve(
+            state,
+            config,
+            task,
+            parsed_review,
+            workspace,
+            "forge/test-task",
+            0.0,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+            review_cost=0.1,
+            review_elapsed=1.0,
+            message="Done. ",
+        )
+
+        assert result.success is True
+        assert result.landing_status == "pending_integration"
+        assert result.merge == {"action": "merge-pr", "pending": True}
+        mock_run_shell.assert_not_called()
+
+    @patch("theforge.coordinator.completion._run_shell")
+    def test_finalize_approve_none_no_git_merge_calls(self, mock_run_shell, tmp_path):
+        """on_approve=none: _finalize_approve sets no landing_status, no merge git ops."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = CoordinatorState()
+        parsed_review = self._make_parsed_review()
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        result = _finalize_approve(
+            state,
+            config,
+            task,
+            parsed_review,
+            workspace,
+            "forge/test-task",
+            0.0,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+            review_cost=0.1,
+            review_elapsed=1.0,
+            message="Done. ",
+        )
+
+        assert result.success is True
+        assert result.landing_status is None
+        assert result.merge is not None
+        assert result.merge["action"] == "none"
+        mock_run_shell.assert_not_called()

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -839,7 +839,7 @@ class TestParallelDependencySafety:
 
         with (
             patch("theforge.sprint.runner.run_task", side_effect=[result_a, result_b]) as mock_run,
-            patch("theforge.sprint.runner._merge_branch", side_effect=_fake_merge),
+            patch("theforge.coordinator.completion._merge_branch", side_effect=_fake_merge),
         ):
             sprint = run_sprint(config, manifest_path, auto_merge=False)
 
@@ -871,6 +871,11 @@ class TestParallelMergeOrderingParallelMode:
         # Both complete successfully (no real merge needed in test)
         result_a = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result_b = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        # Simulate what _finalize_approve sets when auto_merge=True
+        result_a.landing_status = "pending_integration"
+        result_a.merge = {"action": "merge", "pending": True}
+        result_b.landing_status = "pending_integration"
+        result_b.merge = {"action": "merge", "pending": True}
 
         merge_calls: list[str] = []
 
@@ -880,7 +885,7 @@ class TestParallelMergeOrderingParallelMode:
 
         with (
             patch("theforge.sprint.runner.run_task", side_effect=[result_a, result_b]),
-            patch("theforge.sprint.runner._merge_branch", side_effect=_fake_merge),
+            patch("theforge.coordinator.completion._merge_branch", side_effect=_fake_merge),
         ):
             sprint = run_sprint(config, manifest_path, auto_merge=True)
 
@@ -934,7 +939,8 @@ class TestParallelMergeOrderingParallelMode:
             phase=Phase.DONE,
             state=state,
             message="Done.",
-            merge={"action": "none", "success": True, "error": None},
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
         )
 
         merge_info = {
@@ -1012,7 +1018,8 @@ class TestParallelMergeOrderingParallelMode:
             phase=Phase.DONE,
             state=state,
             message="Done.",
-            merge={"action": "none", "success": True, "error": None},
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
         )
 
         with (
@@ -1094,7 +1101,8 @@ class TestParallelMergeOrderingParallelMode:
             phase=Phase.DONE,
             state=state,
             message="Done.",
-            merge={"action": "none", "success": True, "error": None},
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
         )
 
         with (
@@ -1152,13 +1160,14 @@ class TestParallelMergeOrderingParallelMode:
             phase=Phase.DONE,
             state=state,
             message="Done.",
-            merge={"action": "none", "success": True, "error": None},
+            merge={"action": "merge", "pending": True},
+            landing_status="pending_integration",
         )
 
         with (
             patch("theforge.sprint.runner.run_task", return_value=result),
             patch(
-                "theforge.sprint.runner._merge_branch",
+                "theforge.coordinator.completion._merge_branch",
                 return_value={
                     "action": "merge",
                     "merged": False,
@@ -1467,7 +1476,8 @@ class TestQueuedMergePolling:
             phase=Phase.DONE,
             state=state,
             message="Done.",
-            merge={"action": "none", "success": True, "error": None},
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
         )
 
         with (
@@ -1533,6 +1543,8 @@ class TestQueuedMergePolling:
         )
 
         queued_result = _make_coordinator_result(success=True, cost=1.0)
+        queued_result.landing_status = "pending_integration"
+        queued_result.merge = {"action": "merge-pr", "pending": True}
         queued_result.state.review_results = [
             ReviewResult(
                 verdict="APPROVE",
@@ -1547,6 +1559,8 @@ class TestQueuedMergePolling:
             )
         ]
         landed_result = _make_coordinator_result(success=True, cost=1.0)
+        landed_result.landing_status = "pending_integration"
+        landed_result.merge = {"action": "merge-pr", "pending": True}
         landed_result.state.review_results = [
             ReviewResult(
                 verdict="APPROVE",
@@ -1633,6 +1647,11 @@ class TestImmediateIntegrationLanding:
 
         result_a = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result_b = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        # Simulate what _finalize_approve sets when auto_merge=True
+        result_a.landing_status = "pending_integration"
+        result_a.merge = {"action": "merge", "pending": True}
+        result_b.landing_status = "pending_integration"
+        result_b.merge = {"action": "merge", "pending": True}
         events: list[str] = []
 
         def fake_run_task(*args, **kwargs):  # noqa: ANN001
@@ -1646,7 +1665,7 @@ class TestImmediateIntegrationLanding:
 
         with (
             patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
-            patch("theforge.sprint.runner._merge_branch", side_effect=fake_merge),
+            patch("theforge.coordinator.completion._merge_branch", side_effect=fake_merge),
         ):
             sprint = run_sprint(config, manifest_path, auto_merge=True)
 
@@ -1673,6 +1692,11 @@ class TestImmediateIntegrationLanding:
         state_b.preflight_result = MagicMock(cost_usd=1.0)
         result_a = CoordinatorResult(True, Phase.DONE, state_a, "Done.")
         result_b = CoordinatorResult(True, Phase.DONE, state_b, "Done.")
+        # Simulate what _finalize_approve sets when auto_merge=True
+        result_a.landing_status = "pending_integration"
+        result_a.merge = {"action": "merge", "pending": True}
+        result_b.landing_status = "pending_integration"
+        result_b.merge = {"action": "merge", "pending": True}
 
         def fake_run_task(*args, **kwargs):  # noqa: ANN001
             task = args[1]
@@ -1689,7 +1713,7 @@ class TestImmediateIntegrationLanding:
 
         with (
             patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
-            patch("theforge.sprint.runner._merge_branch", side_effect=fake_merge),
+            patch("theforge.coordinator.completion._merge_branch", side_effect=fake_merge),
         ):
             sprint = run_sprint(config, manifest_path, auto_merge=True)
 
@@ -1735,6 +1759,8 @@ class TestImmediateIntegrationLanding:
             )
         ]
         result = CoordinatorResult(True, Phase.DONE, state, "Done.")
+        result.landing_status = "pending_integration"
+        result.merge = {"action": "merge-pr", "pending": True}
 
         with (
             patch("theforge.sprint.runner.run_task", return_value=result),


### PR DESCRIPTION
## Summary

Verified the worker-side merge regressions are fixed and found no new blocking correctness issues in the landing serialization changes.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $8.32
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: serialize landing in scheduler thread — workers must not merge (GitHub Issue #626)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #626