### PR TITLE
fix: make merge-pr landing semantics authoritative and always use auto-merge

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -407,14 +407,6 @@ def _merge_pr(
     merge_queued = False
     auto_merge_queued = False
     merge_retry_error = "base branch was modified"
-    branch_protection_markers = (
-        "required status",
-        "protected branch",
-        "cannot be merged",
-        "branch protection",
-        "required check",
-        "required reviews",
-    )
 
     try:
         merged_pr_proc = subprocess.run(
@@ -546,47 +538,11 @@ def _merge_pr(
         # before any push/merge consumes the rewritten commit graph.
         _deindex_forge_artifacts(push_cwd)
 
-        # Step 5: merge the PR remotely from the repo root. Running gh from the
-        # feature worktree can trip worktree branch checkout constraints. Try a
-        # synchronous merge first; only fall back to --auto when GitHub reports
-        # branch protection / required-check gating.
+        # Step 5: merge the PR via --auto so GitHub queues the merge and applies
+        # it only after all required checks pass. Running gh from the repo root
+        # avoids worktree branch checkout constraints.
         try:
             merge_proc = subprocess.run(
-                ["gh", "pr", "merge", pr_url, f"--{merge_strategy}"],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=120,
-            )
-        except Exception as exc:
-            _pr_log.warning("gh pr merge failed: %s", exc)
-            return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
-
-        if merge_proc.returncode == 0:
-            break
-
-        err = "\n".join(
-            part.strip()
-            for part in (merge_proc.stderr, merge_proc.stdout)
-            if part and part.strip()
-        )
-        err_lower = err.lower()
-        _pr_log.warning("gh pr merge failed (exit %d): %s", merge_proc.returncode, err)
-        if merge_retry_error in err_lower:
-            if attempt < MAX_MERGE_RETRIES - 1:
-                _pr_log.warning(
-                    "base branch changed during PR merge attempt %d/%d; retrying",
-                    attempt + 1,
-                    MAX_MERGE_RETRIES,
-                )
-                continue
-            return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
-
-        if not any(marker in err_lower for marker in branch_protection_markers):
-            return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
-
-        try:
-            auto_merge_proc = subprocess.run(
                 ["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
                 capture_output=True,
                 text=True,
@@ -597,19 +553,25 @@ def _merge_pr(
             _pr_log.warning("gh pr merge --auto failed: %s", exc)
             return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
 
-        if auto_merge_proc.returncode != 0:
-            auto_err = "\n".join(
+        if merge_proc.returncode != 0:
+            err = "\n".join(
                 part.strip()
-                for part in (auto_merge_proc.stderr, auto_merge_proc.stdout)
+                for part in (merge_proc.stderr, merge_proc.stdout)
                 if part and part.strip()
             )
-            _pr_log.warning(
-                "gh pr merge --auto failed (exit %d): %s",
-                auto_merge_proc.returncode,
-                auto_err,
-            )
-            return _fail(f"gh pr merge failed: {auto_err}", pr_url=pr_url)
+            err_lower = err.lower()
+            _pr_log.warning("gh pr merge --auto failed (exit %d): %s", merge_proc.returncode, err)
+            if merge_retry_error in err_lower:
+                if attempt < MAX_MERGE_RETRIES - 1:
+                    _pr_log.warning(
+                        "base branch changed during PR merge attempt %d/%d; retrying",
+                        attempt + 1,
+                        MAX_MERGE_RETRIES,
+                    )
+                    continue
+            return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
 
+        # Determine whether GitHub merged immediately or queued for checks.
         try:
             state_proc = subprocess.run(
                 ["gh", "pr", "view", pr_url, "--json", "state", "-q", ".state"],

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -831,6 +831,11 @@ def run_task(
             elif _merge_info.get("merge_queued"):
                 result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
             elif _landing_status == "failed":
+                # merge-pr: landing IS part of the story contract — a failed
+                # PR merge means the story did not complete.  Local auto-merge
+                # failures are non-fatal (safety guards, dirty worktree, etc.).
+                if _effective_on_approve == "merge-pr":
+                    result.success = False
                 result.message += f" Merge failed: {_merge_info.get('error', 'unknown')}"
 
         _total_elapsed = time.monotonic() - _task_start
@@ -989,6 +994,8 @@ def _run_resume_coordinator(
             elif _merge_info.get("merge_queued"):
                 result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
             elif _landing_status == "failed":
+                if _effective_on_approve == "merge-pr":
+                    result.success = False
                 result.message += f" Merge failed: {_merge_info.get('error', 'unknown')}"
 
         _total_elapsed = time.monotonic() - _task_start

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -498,7 +498,10 @@ def _classify_and_record(
         dag.mark_complete(task.slug)
         return delta_succeeded, delta_failed, delta_skipped
 
-    if result.success:
+    if landing_status == "failed":
+        delta_failed = 1
+        dag.mark_skipped(task.slug)
+    elif result.success:
         delta_succeeded = 1
         if landing_status == "landed" or (
             result.merge is not None and result.merge.get("merged", False)

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -191,6 +191,9 @@ class TestMergePrFunction:
                 rc = 0 if gh_merge_ok else 1
                 err = "" if gh_merge_ok else "merge failed"
                 return _make_subprocess_result(rc, stderr=err)
+            if "gh" in cmd_str and "pr" in cmd_str and "view" in cmd_str:
+                # Default: report MERGED so merged=True in the common case.
+                return _make_subprocess_result(0, stdout="MERGED")
             return _make_subprocess_result(0)
 
         with (
@@ -341,6 +344,8 @@ class TestMergePrFunction:
                 return _make_subprocess_result(0)
             if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
                 return merge_results.pop(0)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="MERGED")
             return _make_subprocess_result(0)
 
         with (
@@ -468,10 +473,10 @@ class TestMergePrFunction:
         assert result["success"] is False
         assert result["merged"] is False
         assert "branch protection" in result["error"]
-        assert call_counts == {"fetch": 1, "rebase": 1, "push": 1, "merge": 2}
+        assert call_counts == {"fetch": 1, "rebase": 1, "push": 1, "merge": 1}
 
     def test_auto_flag_passed_to_gh_merge(self, tmp_path: Path) -> None:
-        """Verify --auto is passed so branch protection can queue the merge."""
+        """Verify --auto is unconditionally passed to gh pr merge."""
         config = _make_merge_pr_config(tmp_path)
         task = _make_task(tmp_path)
         review = _make_review_result()
@@ -485,6 +490,8 @@ class TestMergePrFunction:
         def _fake_run(cmd, **kwargs):
             if isinstance(cmd, list) and cmd and cmd[0] == "gh":
                 gh_calls.append(cmd)
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return _make_subprocess_result(0, stdout="MERGED")
                 return _make_subprocess_result(0)
             return _make_subprocess_result(0)
 
@@ -502,8 +509,9 @@ class TestMergePrFunction:
         ):
             _merge_pr(config, task, "forge/test-task", review, state)
 
-        assert gh_calls
-        assert all("--auto" not in c for c in gh_calls)
+        merge_calls = [c for c in gh_calls if len(c) >= 3 and c[1] == "pr" and c[2] == "merge"]
+        assert merge_calls, "Expected at least one gh pr merge call"
+        assert all("--auto" in c for c in merge_calls), "All gh pr merge calls must include --auto"
 
     def test_merge_strategy_squash_passed_to_gh(self, tmp_path: Path) -> None:
         """Verify --squash is passed to gh pr merge."""
@@ -637,6 +645,8 @@ class TestMergePrFunction:
                 commands.append(cmd)
                 if cmd[:3] == ["gh", "pr", "merge"]:
                     return _make_subprocess_result(0, stdout="Merged pull request")
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return _make_subprocess_result(0, stdout="MERGED")
             return _make_subprocess_result(0)
 
         with (
@@ -692,15 +702,38 @@ class TestMergePrFunction:
         assert result["merged"] is True
         assert result["merge_queued"] is False
 
-    def test_branch_protection_fallback_queued(self, tmp_path: Path) -> None:
-        result = self._run_merge_pr(
-            tmp_path,
-            gh_merge_results=[
-                _make_subprocess_result(1, stderr="protected branch hook declined"),
-                _make_subprocess_result(0),
-                _make_subprocess_result(0, stdout="", stderr="OPEN"),
-            ],
-        )
+    def test_auto_merge_queued_when_checks_pending(self, tmp_path: Path) -> None:
+        """--auto succeeds but PR is not yet MERGED → merge_queued=True."""
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                assert "--auto" in cmd, "merge call must use --auto"
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="OPEN")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/42",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
         assert result["success"] is True
         assert result["merged"] is False
         assert result["merge_queued"] is True
@@ -1364,6 +1397,8 @@ class TestFastForwardAfterMerge:
                 ff_calls.append(cmd)
                 return _make_subprocess_result(0)
             if isinstance(cmd, list) and cmd and cmd[0] == "gh":
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return _make_subprocess_result(0, stdout="MERGED")
                 return _make_subprocess_result(0)
             return _make_subprocess_result(0)
 
@@ -1406,6 +1441,8 @@ class TestFastForwardAfterMerge:
                 or cmd[:4] == ["git", "push", "origin", "--delete"]
             ):
                 cleanup_calls.append(cmd)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="MERGED")
             return _make_subprocess_result(0)
 
         with (

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -123,6 +123,7 @@ def _make_coordinator_result(
     preflight_verdict: str = "PROCEED",
     phase: Phase = Phase.DONE,
     merged: bool = False,
+    landing_status: str | None = None,
 ) -> CoordinatorResult:
     state = CoordinatorState()
     state.preflight_verdict = preflight_verdict
@@ -136,6 +137,7 @@ def _make_coordinator_result(
         state=state,
         message="Done." if success else "Failed.",
         merge={"merged": True} if merged else None,
+        landing_status=landing_status,
     )
 
 
@@ -616,6 +618,96 @@ class TestClassifyAndRecord:
         assert df == 1
         assert "a" not in merged_slugs
         assert dag.ready() == []
+
+    def test_landing_failed_counts_as_delta_failed(self) -> None:
+        """landing_status=failed is classified as a failed story, not a success."""
+        a = _make_task("a")
+        b = _make_task("b", depends_on=["a"])
+        dag = StoryDAG([a, b])
+        merged_slugs: set[str] = set()
+
+        # success=True but landing_status=failed — the merge step failed after approval.
+        result = _make_coordinator_result(success=True, cost=1.0, landing_status="failed")
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
+
+        assert ds == 0, "landing_status=failed must not increment delta_succeeded"
+        assert df == 1, "landing_status=failed must increment delta_failed"
+        assert dsk == 0
+        assert "a" not in merged_slugs
+        # B must remain blocked: a failed to land, so it cannot satisfy a's dependency.
+        assert dag.ready() == []
+
+    def test_landing_pending_integration_does_not_mark_complete(self) -> None:
+        """landing_status=pending_integration does not mark the story complete or unblock deps."""
+        a = _make_task("a")
+        b = _make_task("b", depends_on=["a"])
+        dag = StoryDAG([a, b])
+        merged_slugs: set[str] = set()
+
+        result = _make_coordinator_result(
+            success=True, cost=1.0, landing_status="pending_integration"
+        )
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
+
+        assert ds == 1
+        assert df == 0
+        assert "a" not in merged_slugs
+        # B must remain blocked: a is only queued, not landed.
+        assert dag.ready() == []
+
+    def test_landing_landed_marks_complete_and_unblocks_deps(self) -> None:
+        """landing_status=landed is the only merge-pr state that satisfies dependency gating."""
+        a = _make_task("a")
+        b = _make_task("b", depends_on=["a"])
+        dag = StoryDAG([a, b])
+        merged_slugs: set[str] = set()
+
+        result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+        ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
+
+        assert ds == 1
+        assert df == 0
+        assert "a" in merged_slugs
+        # B is now ready because a landed.
+        assert {t.slug for t in dag.ready()} == {"b"}
+
+    def test_sequential_dep_blocked_while_pending_integration(self) -> None:
+        """Story B with depends_on=[A] is not dispatched while A is pending_integration."""
+        a = _make_task("a")
+        b = _make_task("b", depends_on=["a"])
+        dag = StoryDAG([a, b])
+        merged_slugs: set[str] = set()
+
+        # A completes with pending_integration (auto-merge queued, not yet landed).
+        result_a = _make_coordinator_result(
+            success=True, cost=1.0, landing_status="pending_integration"
+        )
+        _classify_and_record(a, result_a, dag, merged_slugs)
+
+        # B must still be blocked — only a "landed" outcome satisfies the dependency.
+        assert dag.ready() == [], "B must not become ready while A is pending_integration"
+
+    def test_parallel_deps_both_blocked_until_predecessor_lands(self) -> None:
+        """Two parallel stories (C, D) depending on A both remain blocked until A lands."""
+        a = _make_task("a")
+        c = _make_task("c", depends_on=["a"])
+        d = _make_task("d", depends_on=["a"])
+        dag = StoryDAG([a, c, d])
+        merged_slugs: set[str] = set()
+
+        # A finishes with pending_integration.
+        result_a = _make_coordinator_result(
+            success=True, cost=1.0, landing_status="pending_integration"
+        )
+        _classify_and_record(a, result_a, dag, merged_slugs)
+
+        assert dag.ready() == [], "C and D must not become ready while A is pending_integration"
+
+        # Simulate A landing (a separate queued-PR completion event would update the DAG;
+        # here we directly call mark_complete to prove the gate opens).
+        dag.mark_complete("a")
+        ready_slugs = {t.slug for t in dag.ready()}
+        assert ready_slugs == {"c", "d"}, "Both C and D become ready after A lands"
 
 
 class TestMergeOrdering:


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the merge-pr landing semantics spec and the updated tests cover the required landed, pending, failed, and dependency-gating paths. | [gemini-reviewer] The implementation correctly updates merge-pr to unconditionally use auto-merge and properly handles landing statuses.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $3.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: make merge-pr landing semantics authoritative and always use auto-merge (GitHub Issue #632)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #632