### PR TITLE
fix: bound pending merge-pr integration and fail closed on timeout

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -9,6 +9,9 @@ workspace:
   on_approve: merge-pr
   merge_strategy: squash
   auto_push: true
+  # Bounds queued auto-merge polling. Expiry is fail-closed: story is marked
+  # failed and dependents remain blocked. Increase for slow CI environments.
+  merge_wait_timeout_seconds: 3600
 
 validation:
   gate_command: ".venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"

--- a/src/theforge/config/_loaders.py
+++ b/src/theforge/config/_loaders.py
@@ -57,6 +57,9 @@ def _parse_workspace(ws_data: dict[str, Any]) -> WorkspaceConfig:
         ci_check_timeout_seconds=int(
             ws_data.get("ci_check_timeout_seconds", DEFAULT_WORKSPACE.ci_check_timeout_seconds)
         ),
+        merge_wait_timeout_seconds=int(
+            ws_data.get("merge_wait_timeout_seconds", DEFAULT_WORKSPACE.merge_wait_timeout_seconds)
+        ),
     )
 
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -133,6 +133,8 @@ class WorkspaceConfig:
     pr_labels: tuple[str, ...] = ()  # labels to apply when on_approve="pr" or "merge-pr"
     pr_draft: bool = False  # create PR as draft when on_approve="pr"
     ci_check_timeout_seconds: int = 300  # bounded wait for required CI checks after merge
+    merge_wait_timeout_seconds: int = 3600  # bounded wait for queued merge-pr landing; expiry is
+    # fail-closed: story is marked failed and dependents remain blocked
 
 
 @dataclass(frozen=True)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -865,7 +865,7 @@ def run_sprint(
                         poll_result = _poll_queued_pr(
                             dep_pr_url,
                             config.project_root,
-                            config.workspace.ci_check_timeout_seconds,
+                            config.workspace.merge_wait_timeout_seconds,
                         )
                         if poll_result["status"] == "merged":
                             merged_slugs.add(dep)
@@ -874,9 +874,15 @@ def run_sprint(
                             _write_story_audit(config, dep_task, dep_result)
                         else:
                             dep_result.landing_status = "failed"
-                            dep_result.state.error = (
-                                f"Queued PR {poll_result['status']}: {dep_pr_url}"
-                            )
+                            if poll_result["status"] == "timeout":
+                                dep_result.state.error = (
+                                    f"Queued PR timed out after "
+                                    f"{config.workspace.merge_wait_timeout_seconds}s: {dep_pr_url}"
+                                )
+                            else:
+                                dep_result.state.error = (
+                                    f"Queued PR {poll_result['status']}: {dep_pr_url}"
+                                )
                             del queued_prs[dep]
                             _write_story_audit(config, dep_task, dep_result)
                             _log(
@@ -1153,7 +1159,7 @@ def run_sprint(
             poll_result = _poll_queued_pr(
                 pr_url,
                 config.project_root,
-                config.workspace.ci_check_timeout_seconds,
+                config.workspace.merge_wait_timeout_seconds,
             )
             if poll_result["status"] == "merged":
                 merged_slugs.add(slug)
@@ -1163,7 +1169,13 @@ def run_sprint(
                 specs_succeeded -= 1
                 specs_failed += 1
                 result.landing_status = "failed"
-                result.state.error = f"Queued PR {poll_result['status']}: {pr_url}"
+                if poll_result["status"] == "timeout":
+                    result.state.error = (
+                        f"Queued PR timed out after "
+                        f"{config.workspace.merge_wait_timeout_seconds}s: {pr_url}"
+                    )
+                else:
+                    result.state.error = f"Queued PR {poll_result['status']}: {pr_url}"
                 _log(f"✗ {slug}: queued PR {poll_result['status']} during sprint wrap-up")
             _write_story_audit(config, task, result)
             del queued_prs[slug]

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1542,6 +1542,7 @@ class TestQueuedMergePolling:
                 on_approve="merge-pr",
                 auto_push=True,
                 ci_check_timeout_seconds=60,
+                merge_wait_timeout_seconds=60,
             ),
         )
 
@@ -1608,7 +1609,7 @@ class TestQueuedMergePolling:
             60,
         )
         assert result.landing_status == "failed"
-        assert result.state.error == "Queued PR timeout: https://github.com/x/y/pull/7"
+        assert result.state.error == "Queued PR timed out after 60s: https://github.com/x/y/pull/7"
         assert sprint.specs_succeeded == 0
         assert sprint.specs_failed == 1
         assert sprint.specs_skipped == 0
@@ -1631,6 +1632,7 @@ class TestQueuedMergePolling:
                 on_approve="merge-pr",
                 auto_push=True,
                 ci_check_timeout_seconds=60,
+                merge_wait_timeout_seconds=60,
             ),
         )
 
@@ -1723,6 +1725,179 @@ class TestQueuedMergePolling:
         assert landed_result.landing_status == "landed"
         assert queued_result.landing_status == "landed"
         assert mock_poll.call_count == 1
+
+    def test_queued_pr_closed_fail_closed_during_wrap_up(self, tmp_path: Path) -> None:
+        """Closed queued PR → failed landing, error message references 'closed'."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path, ["story-a.md"], budget=10.0, max_parallel=2
+        )
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+                on_approve="merge-pr",
+                auto_push=True,
+                merge_wait_timeout_seconds=60,
+            ),
+        )
+
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        mock_preflight = MagicMock()
+        mock_preflight.cost_usd = 1.0
+        state.preflight_result = mock_preflight
+        state.review_results = [
+            ReviewResult(
+                verdict="APPROVE",
+                summary="Looks good.",
+                findings=[],
+                story_matches=True,
+                story_mismatches=[],
+                test_adequate=True,
+                test_gaps=[],
+                parse_errors=[],
+                raw_yaml={},
+            )
+        ]
+        result = CoordinatorResult(
+            success=True,
+            phase=Phase.DONE,
+            state=state,
+            message="Done.",
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
+        )
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch(
+                "theforge.coordinator.completion._merge_pr",
+                return_value={
+                    "action": "merge-pr",
+                    "pr_url": "https://github.com/x/y/pull/9",
+                    "merged": False,
+                    "merge_queued": True,
+                    "auto_merge_queued": True,
+                    "success": True,
+                    "error": None,
+                },
+            ),
+            patch(
+                "theforge.sprint.runner._poll_queued_pr",
+                return_value={"status": "closed"},
+            ),
+            patch(
+                "theforge.sprint.runner.poll_required_checks",
+                return_value={
+                    "status": "pass",
+                    "sha": "deadbeef",
+                    "failing_checks": [],
+                    "message": "ok",
+                },
+            ),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        assert result.landing_status == "failed"
+        assert "closed" in (result.state.error or "")
+        assert "timed out" not in (result.state.error or "")
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
+
+    def test_queued_pr_timeout_blocks_dependent(self, tmp_path: Path) -> None:
+        """Timeout on queued dep PR → dependent story is not dispatched."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b", depends_on=["story-a"])
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md", "story-b.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+                on_approve="merge-pr",
+                auto_push=True,
+                merge_wait_timeout_seconds=60,
+            ),
+        )
+
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        mock_preflight = MagicMock()
+        mock_preflight.cost_usd = 1.0
+        state.preflight_result = mock_preflight
+        state.review_results = [
+            ReviewResult(
+                verdict="APPROVE",
+                summary="Looks good.",
+                findings=[],
+                story_matches=True,
+                story_mismatches=[],
+                test_adequate=True,
+                test_gaps=[],
+                parse_errors=[],
+                raw_yaml={},
+            )
+        ]
+        queued_result = CoordinatorResult(
+            success=True,
+            phase=Phase.DONE,
+            state=state,
+            message="Done.",
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
+        )
+
+        dispatched: list[str] = []
+
+        def fake_run_task(*args, **kwargs):  # noqa: ANN001
+            task = args[1]
+            dispatched.append(task.slug)
+            return queued_result
+
+        with (
+            patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+            patch(
+                "theforge.coordinator.completion._merge_pr",
+                return_value={
+                    "action": "merge-pr",
+                    "pr_url": "https://github.com/x/y/pull/10",
+                    "merged": False,
+                    "merge_queued": True,
+                    "auto_merge_queued": True,
+                    "success": True,
+                    "error": None,
+                },
+            ),
+            patch(
+                "theforge.sprint.runner._poll_queued_pr",
+                return_value={"status": "timeout"},
+            ),
+            patch(
+                "theforge.sprint.runner.poll_required_checks",
+                return_value={
+                    "status": "pass",
+                    "sha": "deadbeef",
+                    "failing_checks": [],
+                    "message": "ok",
+                },
+            ),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        # Dependent story-b must never be dispatched when story-a times out
+        assert "story-b" not in dispatched
+        assert queued_result.landing_status == "failed"
+        assert "timed out" in (queued_result.state.error or "")
+        assert sprint.specs_failed >= 1
 
 
 class TestImmediateIntegrationLanding:


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the queued merge timeout spec and applies the new bounded fail-closed behavior at both runtime call sites. | [gemini-reviewer] The changes correctly implement the configurable timeout for queued merge-pr integrations and fail closed on timeout.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $3.38
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:860`** The block `blocked_by_queued = [dep for dep in task.depends_on if dep in queued_prs]` inside the `for task in ready:` loop appears to be dead code. A task is only returned by `dag.ready()` if all its dependencies are in `dag._completed`. If a dependency is in `queued_prs`, it has not yet been marked complete, so the dependent task will never be in `ready()`. Consequently, queued PRs are only ever polled during the wrap-up phase, not during the main scheduler loop.

## Story

fix: bound pending merge-pr integration and fail closed on timeout (GitHub Issue #633)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #633