### PR TITLE
fix: deduplicate findings in review merge

### DIFF
--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -77,6 +77,7 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                     "file": f.file,
                     "line": f.line,
                     "description": f.description,
+                    "reviewers": list(f.reviewers),
                 }
                 for f in r.findings
             ]

--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -24,6 +24,7 @@ class ReviewFinding:
     line: int | None
     description: str
     suggestion: str | None
+    reviewers: tuple[str, ...] = ()  # reviewers who raised this finding (audit attribution)
 
 
 @dataclass(frozen=True)
@@ -586,6 +587,43 @@ def review_to_dev_handoff(result: ReviewResult) -> str:
     return "\n\n".join(parts)
 
 
+def _normalize_description(description: str) -> str:
+    """Normalize a finding description for duplicate detection: lowercase + stripped."""
+    return description.strip().lower()
+
+
+def _dedup_findings(reviewer_findings: list[tuple[str, ReviewFinding]]) -> list[ReviewFinding]:
+    """Deduplicate findings by (file, line, normalized description).
+
+    First occurrence of each unique (file, line, normalized_description) key wins
+    for all fields.  All reviewers who raised the same finding are collected into
+    the ``reviewers`` attribution tuple on the canonical finding.
+    """
+    seen_reviewers: dict[tuple[str, int | None, str], list[str]] = {}
+    canonical: dict[tuple[str, int | None, str], ReviewFinding] = {}
+
+    for reviewer_name, finding in reviewer_findings:
+        key = (finding.file, finding.line, _normalize_description(finding.description))
+        if key not in canonical:
+            canonical[key] = finding
+            seen_reviewers[key] = []
+        seen_reviewers[key].append(reviewer_name)
+
+    result: list[ReviewFinding] = []
+    for key, finding in canonical.items():
+        result.append(
+            ReviewFinding(
+                severity=finding.severity,
+                file=finding.file,
+                line=finding.line,
+                description=finding.description,
+                suggestion=finding.suggestion,
+                reviewers=tuple(seen_reviewers[key]),
+            )
+        )
+    return result
+
+
 def merge_review_results(results: list[ReviewResult], names: list[str]) -> ReviewResult:
     """Merge multiple ReviewResults into one without an LLM call.
 
@@ -594,7 +632,7 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
       so the parse-retry loop in coord_phases can fire.
     - Verdict: REQUEST_CHANGES if any valid reviewer says so, else APPROVE
     - Summary: one line per valid reviewer labelled by name
-    - Findings: union of all valid findings (preserves duplicates)
+    - Findings: union of all valid findings, deduplicated by (file, line, description)
     - story_matches: False if any valid reviewer says False
     - test_adequate: False if any valid reviewer says False
     """
@@ -634,9 +672,11 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
     summary_parts = [f"[{name}] {r.summary}" for name, r in valid]
     summary = " | ".join(summary_parts)
 
-    all_findings: list[ReviewFinding] = []
-    for _, r in valid:
-        all_findings.extend(r.findings)
+    reviewer_findings: list[tuple[str, ReviewFinding]] = []
+    for name, r in valid:
+        for f in r.findings:
+            reviewer_findings.append((name, f))
+    all_findings = _dedup_findings(reviewer_findings)
 
     story_matches = all(r.story_matches for _, r in valid)
     story_mismatches: list[str] = []

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -4,8 +4,10 @@ from theforge.review import (
     ReviewFinding,
     ReviewResult,
     _best_individual_result,
+    _dedup_findings,
     _try_parse_review,
     findings_to_markdown,
+    merge_review_results,
     parse_plan_review_output,
     parse_review_output,
 )
@@ -374,3 +376,134 @@ class TestBestIndividualResult:
     def test_single_p1_result(self):
         with_p1 = _make_review_result("REQUEST_CHANGES", findings=[_p1_finding()])
         assert _best_individual_result([with_p1]) is with_p1
+
+
+# ── Tests: _dedup_findings ───────────────────────────────────────────
+
+
+def _rf(severity: str, file: str, line: int | None, description: str) -> ReviewFinding:
+    return ReviewFinding(
+        severity=severity, file=file, line=line, description=description, suggestion=None
+    )
+
+
+class TestDedupFindings:
+    """Tests for _dedup_findings helper."""
+
+    def test_no_duplicates_unchanged(self):
+        f1 = _rf("P1", "foo.py", 1, "Bug A")
+        f2 = _rf("P2", "bar.py", 2, "Bug B")
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 2
+
+    def test_exact_duplicate_collapsed(self):
+        f = _rf("P1", "foo.py", 1, "Bug A")
+        result = _dedup_findings([("r1", f), ("r2", f)])
+        assert len(result) == 1
+
+    def test_case_insensitive_description_dedup(self):
+        f1 = _rf("P1", "foo.py", 1, "Bug A")
+        f2 = _rf("P1", "foo.py", 1, "bug a")
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 1
+
+    def test_whitespace_normalized_description_dedup(self):
+        f1 = _rf("P1", "foo.py", 1, "  Bug A  ")
+        f2 = _rf("P1", "foo.py", 1, "Bug A")
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 1
+
+    def test_different_line_not_deduped(self):
+        f1 = _rf("P1", "foo.py", 1, "Bug A")
+        f2 = _rf("P1", "foo.py", 2, "Bug A")
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 2
+
+    def test_different_file_not_deduped(self):
+        f1 = _rf("P1", "foo.py", 1, "Bug A")
+        f2 = _rf("P1", "bar.py", 1, "Bug A")
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 2
+
+    def test_different_description_not_deduped(self):
+        f1 = _rf("P1", "foo.py", 1, "Bug A")
+        f2 = _rf("P1", "foo.py", 1, "Bug B")
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 2
+
+    def test_first_occurrence_wins(self):
+        f1 = _rf("P1", "foo.py", 1, "Bug A")
+        f2 = _rf("P2", "foo.py", 1, "bug a")  # different severity, same location/desc
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 1
+        assert result[0].severity == "P1"  # first wins
+
+    def test_reviewers_attributed_on_duplicate(self):
+        f = _rf("P1", "foo.py", 1, "Bug A")
+        result = _dedup_findings([("reviewer-a", f), ("reviewer-b", f)])
+        assert len(result) == 1
+        assert set(result[0].reviewers) == {"reviewer-a", "reviewer-b"}
+
+    def test_single_reviewer_attribution(self):
+        f = _rf("P1", "foo.py", 1, "Bug A")
+        result = _dedup_findings([("reviewer-a", f)])
+        assert result[0].reviewers == ("reviewer-a",)
+
+    def test_triple_duplicate_all_attributed(self):
+        f = _rf("P1", "foo.py", 1, "Bug A")
+        result = _dedup_findings([("r1", f), ("r2", f), ("r3", f)])
+        assert len(result) == 1
+        assert set(result[0].reviewers) == {"r1", "r2", "r3"}
+
+    def test_null_line_deduplication(self):
+        f1 = _rf("P1", "foo.py", None, "Bug A")
+        f2 = _rf("P1", "foo.py", None, "bug a")
+        result = _dedup_findings([("r1", f1), ("r2", f2)])
+        assert len(result) == 1
+        assert set(result[0].reviewers) == {"r1", "r2"}
+
+
+# ── Tests: merge_review_results deduplication ────────────────────────
+
+
+class TestMergeReviewResultsDedup:
+    """Tests for deduplication in merge_review_results."""
+
+    def test_duplicate_p1_across_reviewers_counted_once(self):
+        finding = _rf("P1", "foo.py", 1, "Off-by-one error")
+        r1 = _make_review_result("REQUEST_CHANGES", findings=[finding])
+        r2 = _make_review_result("REQUEST_CHANGES", findings=[finding])
+        r3 = _make_review_result("REQUEST_CHANGES", findings=[finding])
+        merged = merge_review_results([r1, r2, r3], ["a", "b", "c"])
+        p1_count = sum(1 for f in merged.findings if f.severity == "P1")
+        assert p1_count == 1  # unique issue, not reviewer_count * issues
+
+    def test_unique_findings_all_preserved(self):
+        f1 = _rf("P1", "foo.py", 1, "Bug A")
+        f2 = _rf("P1", "bar.py", 2, "Bug B")
+        r1 = _make_review_result("REQUEST_CHANGES", findings=[f1])
+        r2 = _make_review_result("REQUEST_CHANGES", findings=[f2])
+        merged = merge_review_results([r1, r2], ["a", "b"])
+        assert len(merged.findings) == 2
+
+    def test_duplicate_finding_carries_reviewer_attribution(self):
+        finding = _rf("P1", "foo.py", 1, "Same issue")
+        r1 = _make_review_result("REQUEST_CHANGES", findings=[finding])
+        r2 = _make_review_result("REQUEST_CHANGES", findings=[finding])
+        merged = merge_review_results([r1, r2], ["reviewer-a", "reviewer-b"])
+        assert len(merged.findings) == 1
+        assert set(merged.findings[0].reviewers) == {"reviewer-a", "reviewer-b"}
+
+    def test_all_parse_errors_propagated(self):
+        r1 = _make_review_result("REQUEST_CHANGES", parse_errors=["bad yaml"])
+        r2 = _make_review_result("REQUEST_CHANGES", parse_errors=["bad yaml"])
+        merged = merge_review_results([r1, r2], ["a", "b"])
+        assert merged.parse_errors  # propagated for retry loop
+
+    def test_mixed_valid_and_parse_error(self):
+        finding = _rf("P1", "foo.py", 1, "Bug")
+        valid = _make_review_result("REQUEST_CHANGES", findings=[finding])
+        invalid = _make_review_result("REQUEST_CHANGES", parse_errors=["bad"])
+        merged = merge_review_results([valid, invalid], ["a", "b"])
+        assert not merged.parse_errors
+        assert len(merged.findings) == 1


### PR DESCRIPTION
## Summary

[openai-reviewer] Deduplication is implemented in merge_review_results, reviewer attribution is surfaced in audit output, and tests cover the new behavior. | [gemini-reviewer] The implementation correctly deduplicates findings and attributes them to reviewers.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.78
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: deduplicate findings in review merge (GitHub Issue #605)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #605