### PR TITLE
fix: add identical-failure circuit breaker for gate retries

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -121,6 +121,7 @@ def record_dev_iteration_telemetry(
     max_iterations: int,
     gate_result: str | None,
     gate_output_tail: str = "",
+    is_timeout: bool = False,
 ) -> None:
     """Capture per-iteration dev telemetry after validation completes."""
     if not state.dev_results or not state.dev_durations:
@@ -153,6 +154,7 @@ def record_dev_iteration_telemetry(
             gate_result=gate_result,
             failed_tests=failed_tests,
             existing_test_failures=False,
+            is_timeout=is_timeout,
             files_changed=files_changed,
             files_changed_count=len(files_changed),
             tests_fixed_count=tests_fixed_count,

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -129,6 +129,7 @@ class DevIterationTelemetry:
     gate_result: str | None = None
     failed_tests: list[str] = field(default_factory=list)
     existing_test_failures: bool = False
+    is_timeout: bool = False
     files_changed: list[str] = field(default_factory=list)
     files_changed_count: int = 0
     tests_fixed_count: int = 0

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -18,7 +18,7 @@ from .gate import _is_gate_skip, _run_gate_full
 from .logging import StructuredLogger
 from .notify import _escalate_notify
 from .review_context import _get_handoff_content, _get_raw_dev_notes
-from .state import CoordinatorResult, CoordinatorState, Phase
+from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase
 from .util import _log, _log_phase, _log_verbose
 from .workspace import _deindex_forge_artifacts
 
@@ -28,6 +28,24 @@ class _ValidateOutcome(Enum):
     RETRY_DEV = auto()
     REVIEW_CONVENTION_BLOCK = auto()
     ESCALATE = auto()
+
+
+def _is_identical_failure(telemetry: list[DevIterationTelemetry]) -> bool:
+    """Return True if the last two recorded iterations share an identical failure signature.
+
+    Two failure signatures are identical when:
+    - Both iterations timed out, OR
+    - Both have the same non-empty set of failing tests.
+    """
+    if len(telemetry) < 2:
+        return False
+    prev = telemetry[-2]
+    curr = telemetry[-1]
+    if curr.is_timeout and prev.is_timeout:
+        return True
+    if curr.failed_tests and set(curr.failed_tests) == set(prev.failed_tests):
+        return True
+    return False
 
 
 def _test_file_exists_in_head(workspace_path: Path, test_file: str) -> bool:
@@ -114,12 +132,14 @@ def _run_validate_phase(
         )
 
     if gate_err:
+        is_timeout = "timed out" in (gate_err or "").lower()
         record_dev_iteration_telemetry(
             state,
             workspace_path,
             max_iterations=config.retry.max_dev_iterations,
             gate_result=gate_result_for_telemetry,
             gate_output_tail=gate_output_tail or gate_err,
+            is_timeout=is_timeout,
         )
         use_exit_code = not config.validation.handoff_file
         if use_exit_code:
@@ -154,7 +174,6 @@ def _run_validate_phase(
             tail_chars = config.validation.gate_output_tail_chars
             partial = f"\n\nPartial gate output (last {tail_chars} chars):\n{gate_output_tail}"
             _log(f"  Gate partial output captured ({len(gate_output_tail)} chars)")
-        is_timeout = "timed out" in (gate_err or "").lower()
         if is_timeout:
             debug_cmd = config.validation.gate_debug_command
             if debug_cmd:
@@ -186,6 +205,22 @@ def _run_validate_phase(
             state.dev_iteration_telemetry[-1] = dataclasses.replace(
                 state.dev_iteration_telemetry[-1],
                 existing_test_failures=existing_test_failures,
+            )
+        if _is_identical_failure(state.dev_iteration_telemetry):
+            remaining = config.retry.max_dev_iterations - dev_calls_this_cycle
+            state.phase = Phase.ESCALATE
+            state.error = (
+                f"Identical gate failure on consecutive iterations"
+                f" (iteration {state.dev_iteration}): {gate_err}."
+                f" Remaining retry budget: {remaining}."
+            )
+            _log(f"✗ ESCALATE   {state.error}")
+            if logger:
+                logger._safe_emit("phase_end", phase="VALIDATE", outcome="escalate")
+                logger._safe_emit("escalate", reason=state.error, phase="VALIDATE")
+            _escalate_notify(task, state, notify, config)
+            return _ValidateOutcome.ESCALATE, CoordinatorResult(
+                success=False, phase=state.phase, state=state, message=state.error
             )
         _log(f"  ✗ VALIDATE   FAIL  (iter={state.dev_iteration} → retrying)")
         if logger:
@@ -313,6 +348,22 @@ def _run_validate_phase(
             state.dev_iteration_telemetry[-1] = dataclasses.replace(
                 state.dev_iteration_telemetry[-1],
                 existing_test_failures=existing_test_failures,
+            )
+        if _is_identical_failure(state.dev_iteration_telemetry):
+            remaining = config.retry.max_dev_iterations - dev_calls_this_cycle
+            state.phase = Phase.ESCALATE
+            state.error = (
+                f"Identical gate failure on consecutive iterations"
+                f" (iteration {state.dev_iteration}): gate returned {gate_decision}."
+                f" Remaining retry budget: {remaining}."
+            )
+            _log(f"✗ ESCALATE   {state.error}")
+            if logger:
+                logger._safe_emit("phase_end", phase="VALIDATE", outcome="escalate")
+                logger._safe_emit("escalate", reason=state.error, phase="VALIDATE")
+            _escalate_notify(task, state, notify, config)
+            return _ValidateOutcome.ESCALATE, CoordinatorResult(
+                success=False, phase=state.phase, state=state, message=state.error
             )
         if logger:
             logger._safe_emit("phase_end", phase="VALIDATE", outcome="fail")

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -9,9 +9,10 @@ from unittest.mock import patch
 
 from coord_test_helpers import _make_agent_result, _make_config, _make_task
 
-from theforge.coordinator.state import CoordinatorState
+from theforge.coordinator.state import CoordinatorState, DevIterationTelemetry
 from theforge.coordinator.validate_phase import (
     _get_convention_baseline_ref,
+    _is_identical_failure,
     _run_validate_phase,
     _ValidateOutcome,
 )
@@ -306,3 +307,209 @@ def test_format_failed_test_feedback_no_contract_change_uses_default_message(
     assert "These are existing tests your changes broke" in feedback
     assert "do not edit these test files" in feedback
     assert "old behavioral contract" not in feedback
+
+
+def _make_telemetry(**kwargs) -> DevIterationTelemetry:
+    defaults = dict(
+        iteration=1,
+        max_iterations=3,
+        cost_usd=0.5,
+        duration_s=10.0,
+        gate_result="FAIL",
+        failed_tests=[],
+        existing_test_failures=False,
+        is_timeout=False,
+        files_changed=[],
+        files_changed_count=0,
+        tests_fixed_count=0,
+        meaningful_progress=False,
+    )
+    defaults.update(kwargs)
+    return DevIterationTelemetry(**defaults)
+
+
+def test_is_identical_failure_returns_false_with_fewer_than_two_entries() -> None:
+    assert _is_identical_failure([]) is False
+    assert _is_identical_failure([_make_telemetry()]) is False
+
+
+def test_is_identical_failure_same_failing_tests_escalates() -> None:
+    prev = _make_telemetry(failed_tests=["tests/test_a.py::test_one"])
+    curr = _make_telemetry(failed_tests=["tests/test_a.py::test_one"])
+    assert _is_identical_failure([prev, curr]) is True
+
+
+def test_is_identical_failure_different_failing_tests_does_not_escalate() -> None:
+    prev = _make_telemetry(failed_tests=["tests/test_a.py::test_one"])
+    curr = _make_telemetry(failed_tests=["tests/test_b.py::test_two"])
+    assert _is_identical_failure([prev, curr]) is False
+
+
+def test_is_identical_failure_empty_failed_tests_does_not_escalate() -> None:
+    prev = _make_telemetry(failed_tests=[])
+    curr = _make_telemetry(failed_tests=[])
+    assert _is_identical_failure([prev, curr]) is False
+
+
+def test_is_identical_failure_both_timeout_escalates() -> None:
+    prev = _make_telemetry(is_timeout=True, gate_result="ERROR")
+    curr = _make_telemetry(is_timeout=True, gate_result="ERROR")
+    assert _is_identical_failure([prev, curr]) is True
+
+
+def test_is_identical_failure_only_one_timeout_does_not_escalate() -> None:
+    prev = _make_telemetry(is_timeout=True, gate_result="ERROR")
+    curr = _make_telemetry(is_timeout=False, gate_result="FAIL")
+    assert _is_identical_failure([prev, curr]) is False
+
+
+def test_is_identical_failure_checks_last_two_entries() -> None:
+    """Circuit breaker compares the final two entries, not just any two."""
+    old = _make_telemetry(iteration=1, failed_tests=["tests/test_a.py::test_one"])
+    prev = _make_telemetry(iteration=2, failed_tests=["tests/test_b.py::test_two"])
+    curr = _make_telemetry(iteration=3, failed_tests=["tests/test_b.py::test_two"])
+    assert _is_identical_failure([old, prev, curr]) is True
+
+
+def test_run_validate_phase_escalates_on_identical_gate_fail(tmp_path: Path) -> None:
+    """Circuit breaker escalates when consecutive FAIL iterations have the same test failures."""
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=2)
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(2.0)
+    state.last_dev_start_commit = "HEAD"
+    # Seed prior iteration telemetry with identical failing test
+    state.dev_iteration_telemetry.append(
+        _make_telemetry(
+            iteration=1,
+            failed_tests=["tests/test_alpha.py::test_one"],
+        )
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_alpha.py").write_text(
+        "def test_one():\n    pass\n", encoding="utf-8"
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=(
+                "FAIL",
+                None,
+                "FAILED tests/test_alpha.py::test_one",
+                "pytest tests/",
+            ),
+        ),
+        patch(
+            "theforge.coordinator.validate_phase._get_handoff_content",
+            return_value="summary: pending",
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            dev_calls_this_cycle=1,  # below max_dev_iterations so circuit breaker fires first
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert "Identical gate failure" in result.message
+    assert "Remaining retry budget:" in result.message
+
+
+def test_run_validate_phase_escalates_on_consecutive_timeouts(tmp_path: Path) -> None:
+    """Circuit breaker escalates when two consecutive gate errors are both timeouts."""
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=2)
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(2.0)
+    state.last_dev_start_commit = "HEAD"
+    # Seed prior iteration telemetry with a timeout
+    state.dev_iteration_telemetry.append(
+        _make_telemetry(
+            iteration=1,
+            gate_result="ERROR",
+            is_timeout=True,
+        )
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=(None, "gate timed out after 120s", "", "pytest tests/"),
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            dev_calls_this_cycle=1,  # below max_dev_iterations so circuit breaker fires first
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert "Identical gate failure" in result.message
+    assert "Remaining retry budget:" in result.message
+
+
+def test_run_validate_phase_retries_when_failures_differ(tmp_path: Path) -> None:
+    """Circuit breaker does not fire when failure signatures change between iterations."""
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=2)
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(2.0)
+    state.last_dev_start_commit = "HEAD"
+    # Seed prior iteration telemetry with a different failing test
+    state.dev_iteration_telemetry.append(
+        _make_telemetry(
+            iteration=1,
+            failed_tests=["tests/test_alpha.py::test_one"],
+        )
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_alpha.py").write_text(
+        "def test_two():\n    pass\n", encoding="utf-8"
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=(
+                "FAIL",
+                None,
+                "FAILED tests/test_alpha.py::test_two",
+                "pytest tests/",
+            ),
+        ),
+        patch(
+            "theforge.coordinator.validate_phase._get_handoff_content",
+            return_value="summary: pending",
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            dev_calls_this_cycle=1,  # below max_dev_iterations
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.RETRY_DEV
+    assert result is None


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the identical-failure circuit breaker spec and is covered by targeted tests. | [gemini-reviewer] The implementation correctly adds an identical-failure circuit breaker for gate retries and preserves the remaining retry budget in the escalation message.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.17
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: add identical-failure circuit breaker for gate retries (GitHub Issue #598)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #598