### PR TITLE
fix: check conventions before or parallel with gate

### DIFF
--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import dataclasses
 import subprocess
 import time
@@ -82,6 +83,43 @@ def _format_failed_test_feedback(
     return "\n".join(lines), bool(existing_failures)
 
 
+def _check_conventions_parallel(
+    config: ForgeConfig,
+    workspace_path: Path,
+) -> tuple[list, list] | None:
+    """Return (all_violations, net_new_violations) or None if conventions are not configured.
+
+    Designed to run in a thread concurrently with gate execution.
+    Gate commands are test runners; they don't write source files.
+    Convention scanner reads source, not test output. Parallel execution is safe.
+    """
+    if config.conventions_hard is None:
+        return None
+    _config_dict = dataclasses.asdict(config.conventions_hard)
+    baseline_ref = _get_convention_baseline_ref(workspace_path, config.workspace.base_branch)
+    if baseline_ref is not None:
+        result = _cu._run_worktree_eval(
+            workspace_path,
+            "check_conventions",
+            {
+                "config": _config_dict,
+                "project_root": str(workspace_path),
+                "baseline_ref": baseline_ref,
+            },
+        )
+        all_v = [types.SimpleNamespace(**d) for d in result["all_violations"]]
+        net_v = [types.SimpleNamespace(**d) for d in result["violations"]]
+    else:
+        result = _cu._run_worktree_eval(
+            workspace_path,
+            "check_conventions",
+            {"config": _config_dict, "project_root": str(workspace_path)},
+        )
+        all_v = [types.SimpleNamespace(**d) for d in result["violations"]]
+        net_v = all_v
+    return all_v, net_v
+
+
 def _run_validate_phase(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -100,6 +138,14 @@ def _run_validate_phase(
     state.phase = Phase.VALIDATE
     if logger:
         logger._safe_emit("phase_start", phase="VALIDATE", iteration=state.dev_iteration)
+
+    # Submit convention check to run in parallel with gate execution.
+    # Gate commands are test runners; they don't write source files. Convention
+    # scanner reads source, not test output. Parallel execution is safe.
+    _cv_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    _cv_future: concurrent.futures.Future = _cv_executor.submit(
+        _check_conventions_parallel, config, workspace_path
+    )
 
     _gate_start = time.monotonic()
     gate_override = task.gate_override
@@ -130,6 +176,18 @@ def _run_validate_phase(
             duration_s=round(_gate_elapsed, 2),
             output_tail=gate_output_tail[-500:] if gate_output_tail else "",
         )
+
+    # Retrieve convention check result (ran in parallel; should be done by now).
+    try:
+        _cv_result_raw = _cv_future.result(timeout=120)
+    except Exception as exc:
+        _log(f"  ⚠ Convention check failed or timed out: {exc}")
+        _cv_result_raw = None
+    finally:
+        _cv_executor.shutdown(wait=False)
+
+    _cv_all: list = _cv_result_raw[0] if _cv_result_raw is not None else []
+    _cv_violations: list = _cv_result_raw[1] if _cv_result_raw is not None else []
 
     if gate_err:
         is_timeout = "timed out" in (gate_err or "").lower()
@@ -222,6 +280,16 @@ def _run_validate_phase(
             return _ValidateOutcome.ESCALATE, CoordinatorResult(
                 success=False, phase=state.phase, state=state, message=state.error
             )
+        if _cv_violations:
+            lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _cv_violations]
+            state.human_feedback += (
+                "\n\nAdditionally, hard convention violations were detected:\n" + "\n".join(lines)
+            )
+            state.convention_violations = [
+                {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
+                for v in _cv_violations
+            ]
+            _log(f"  ✗ VALIDATE   convention violations also found ({len(_cv_violations)})")
         _log(f"  ✗ VALIDATE   FAIL  (iter={state.dev_iteration} → retrying)")
         if logger:
             logger._safe_emit("phase_end", phase="VALIDATE", outcome="fail")
@@ -365,6 +433,16 @@ def _run_validate_phase(
             return _ValidateOutcome.ESCALATE, CoordinatorResult(
                 success=False, phase=state.phase, state=state, message=state.error
             )
+        if _cv_violations:
+            lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _cv_violations]
+            state.human_feedback += (
+                "\n\nAdditionally, hard convention violations were detected:\n" + "\n".join(lines)
+            )
+            state.convention_violations = [
+                {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
+                for v in _cv_violations
+            ]
+            _log(f"  ✗ VALIDATE   convention violations also found ({len(_cv_violations)})")
         if logger:
             logger._safe_emit("phase_end", phase="VALIDATE", outcome="fail")
         return _ValidateOutcome.RETRY_DEV, None
@@ -386,33 +464,11 @@ def _run_validate_phase(
         gate_output_tail=gate_output_tail,
     )
 
-    # Hard convention checks (post-gate, only on PASS path)
-    # Run in the worktree's subprocess so self-hosting sprints evaluate the
+    # Convention check ran in parallel with gate; use pre-fetched result.
+    # Runs in the worktree's subprocess so self-hosting sprints evaluate the
     # worktree's version of conventions.py, not the coordinator's own copy.
     if config.conventions_hard is not None:
-        _config_dict = dataclasses.asdict(config.conventions_hard)
-        baseline_ref = _get_convention_baseline_ref(workspace_path, config.workspace.base_branch)
-        if baseline_ref is not None:
-            _cv_result = _cu._run_worktree_eval(
-                workspace_path,
-                "check_conventions",
-                {
-                    "config": _config_dict,
-                    "project_root": str(workspace_path),
-                    "baseline_ref": baseline_ref,
-                },
-            )
-            all_cv_violations = [types.SimpleNamespace(**d) for d in _cv_result["all_violations"]]
-            cv_violations = [types.SimpleNamespace(**d) for d in _cv_result["violations"]]
-        else:
-            _cv_result = _cu._run_worktree_eval(
-                workspace_path,
-                "check_conventions",
-                {"config": _config_dict, "project_root": str(workspace_path)},
-            )
-            all_cv_violations = [types.SimpleNamespace(**d) for d in _cv_result["violations"]]
-            cv_violations = all_cv_violations
-        if cv_violations:
+        if _cv_violations:
             state.convention_violations = [
                 {
                     "rule": v.rule,
@@ -420,14 +476,14 @@ def _run_validate_phase(
                     "detail": v.detail,
                     "blocking": v.blocking,
                 }
-                for v in cv_violations
+                for v in _cv_violations
             ]
-            lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in cv_violations]
+            lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _cv_violations]
             human_feedback = "Hard convention violations detected:\n" + "\n".join(lines)
             state.human_feedback = human_feedback
             state.retry_reason = "convention_violations"
-            _log(f"  ✗ VALIDATE   convention violations ({len(cv_violations)} found)")
-            for v in cv_violations:
+            _log(f"  ✗ VALIDATE   convention violations ({len(_cv_violations)} found)")
+            for v in _cv_violations:
                 _log(f"    [{v.rule}] {v.file}: {v.detail}")
             if dev_calls_this_cycle >= config.retry.max_dev_iterations:
                 state.phase = Phase.ESCALATE
@@ -451,7 +507,7 @@ def _run_validate_phase(
                     "detail": v.detail,
                     "blocking": False,
                 }
-                for v in all_cv_violations
+                for v in _cv_all
             ]
     else:
         state.convention_violations = []

--- a/tests/test_coord_convention_parallel.py
+++ b/tests/test_coord_convention_parallel.py
@@ -1,0 +1,166 @@
+"""Tests for convention check running in parallel with gate execution.
+
+Covers: TestConventionParallelCheck — combined gate-fail + convention violation feedback,
+PASS path with pre-fetched violations, and no-conventions-configured path.
+"""
+
+import dataclasses
+import types
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.config.types import HardConventionsConfig
+from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.coordinator.validate_phase import _run_validate_phase, _ValidateOutcome
+
+
+def _make_violation(
+    rule: str = "max_module_lines",
+    file: str = "src/foo.py",
+    detail: str = "Module exceeds 500 lines (600 found)",
+    blocking: bool = True,
+) -> types.SimpleNamespace:
+    return types.SimpleNamespace(rule=rule, file=file, detail=detail, blocking=blocking)
+
+
+def _make_state() -> CoordinatorState:
+    return CoordinatorState(phase=Phase.VALIDATE)
+
+
+class TestConventionParallelCheck:
+    """Convention check runs in parallel with gate; violations appear in combined feedback."""
+
+    @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
+    @patch("theforge.coordinator.validate_phase._get_handoff_content")
+    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
+    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    def test_gate_fail_includes_convention_violations(
+        self,
+        mock_gate,
+        mock_cv,
+        mock_handoff,
+        mock_telemetry,
+        tmp_path,
+    ):
+        """When gate FAILs, convention violations are appended to human_feedback."""
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            conventions_hard=HardConventionsConfig(max_module_lines=500),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        state = _make_state()
+
+        viol = _make_violation()
+        mock_gate.return_value = ("FAIL", None, "test output: 1 failed", "make gate")
+        mock_cv.return_value = ([viol], [viol])
+        mock_handoff.return_value = "handoff content"
+
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            workspace,
+            dev_calls_this_cycle=0,
+            notify=False,
+            logger=None,
+        )
+
+        assert outcome is _ValidateOutcome.RETRY_DEV
+        assert result is None
+        assert state.retry_reason == "gate_fail"
+        # Gate failure text is present
+        assert "test suite" in state.human_feedback
+        # Convention violation text is also present in the same feedback
+        assert "convention violations" in state.human_feedback.lower()
+        assert "max_module_lines" in state.human_feedback
+        assert "src/foo.py" in state.human_feedback
+        # Convention violations are recorded on state
+        assert len(state.convention_violations) == 1
+        assert state.convention_violations[0]["rule"] == "max_module_lines"
+
+    @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
+    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
+    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase._cu._run_shell")
+    @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
+    def test_gate_pass_convention_violation_still_blocks(
+        self,
+        mock_deindex,
+        mock_shell,
+        mock_gate,
+        mock_cv,
+        mock_telemetry,
+        tmp_path,
+    ):
+        """When gate PASSes but conventions have violations, outcome is REVIEW_CONVENTION_BLOCK."""
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            conventions_hard=HardConventionsConfig(max_module_lines=500),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        state = _make_state()
+
+        viol = _make_violation()
+        mock_gate.return_value = ("PASS", None, "", "make gate")
+        mock_cv.return_value = ([viol], [viol])
+        mock_shell.return_value = (True, "")  # clean worktree
+
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            workspace,
+            dev_calls_this_cycle=0,
+            notify=False,
+            logger=None,
+        )
+
+        assert outcome is _ValidateOutcome.REVIEW_CONVENTION_BLOCK
+        assert result is None
+        assert state.retry_reason == "convention_violations"
+        assert len(state.convention_violations) == 1
+        assert "Hard convention violations" in state.human_feedback
+
+    @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
+    @patch("theforge.coordinator.validate_phase._get_handoff_content")
+    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
+    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    def test_no_conventions_configured_unchanged(
+        self,
+        mock_gate,
+        mock_cv,
+        mock_handoff,
+        mock_telemetry,
+        tmp_path,
+    ):
+        """When conventions_hard is None, gate FAIL returns RETRY_DEV with no convention text."""
+        config = _make_config(tmp_path)  # conventions_hard is None by default
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        state = _make_state()
+
+        mock_gate.return_value = ("FAIL", None, "1 failed", "make gate")
+        mock_cv.return_value = None  # None because conventions_hard is None
+        mock_handoff.return_value = "handoff"
+
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            workspace,
+            dev_calls_this_cycle=0,
+            notify=False,
+            logger=None,
+        )
+
+        assert outcome is _ValidateOutcome.RETRY_DEV
+        assert result is None
+        assert state.retry_reason == "gate_fail"
+        assert "convention" not in state.human_feedback.lower()
+        assert state.convention_violations is None or state.convention_violations == []


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation satisfies the spec by starting convention checks before gate execution and surfacing combined feedback on gate failures. | [gemini-reviewer] The implementation correctly runs the convention check in parallel with the gate and surfaces both test failures and convention violations in a single feedback cycle.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $3.66
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: check conventions before or parallel with gate (GitHub Issue #611)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #611