### PR TITLE
bug: dependent stories skipped when dependency is pending_integration instead of waiting

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -968,8 +968,11 @@ def run_sprint(
                 )
                 active[task.slug] = fut
 
-            _log(f"[debug] post-submit: active={list(active.keys())}")
-            if not active:
+            _log(
+                f"[debug] post-submit: active={list(active.keys())}"
+                f" queued_prs={list(queued_prs.keys())}"
+            )
+            if not active and not queued_prs:
                 # Deadlock: remaining tasks have unmet or budget-blocked deps
                 # Release any pending plan gates so worker threads can exit
                 for g_slug, _gate in plan_gates.items():
@@ -986,6 +989,42 @@ def run_sprint(
                     dag.mark_skipped(t.slug)
                     specs_skipped += 1
                 break
+
+            # No active workers but queued PRs are still in flight.
+            # Poll each queued PR directly so dependents can be dispatched
+            # once the PR lands — do not declare deadlock while PRs are pending.
+            if not active and queued_prs:
+                for _qp_slug in list(queued_prs):
+                    _qp_task, _qp_result, _qp_pr_url = queued_prs[_qp_slug]
+                    _qp_poll = _poll_queued_pr(
+                        _qp_pr_url,
+                        config.project_root,
+                        config.workspace.merge_wait_timeout_seconds,
+                    )
+                    if _qp_poll["status"] == "merged":
+                        merged_slugs.add(_qp_slug)
+                        dag.mark_complete(_qp_slug)
+                        _qp_result.landing_status = "landed"
+                        del queued_prs[_qp_slug]
+                        _write_story_audit(config, _qp_task, _qp_result)
+                        _log(f"INFO {_qp_slug}: queued PR merged; unblocking dependents")
+                    else:
+                        specs_succeeded -= 1
+                        specs_failed += 1
+                        _qp_result.landing_status = "failed"
+                        if _qp_poll["status"] == "timeout":
+                            _qp_result.state.error = (
+                                f"Queued PR timed out after "
+                                f"{config.workspace.merge_wait_timeout_seconds}s: {_qp_pr_url}"
+                            )
+                        else:
+                            _qp_result.state.error = (
+                                f"Queued PR {_qp_poll['status']}: {_qp_pr_url}"
+                            )
+                        del queued_prs[_qp_slug]
+                        _write_story_audit(config, _qp_task, _qp_result)
+                        _log(f"✗ {_qp_slug}: queued PR {_qp_poll['status']} (no active workers)")
+                continue
 
             _log(f"[debug] calling wait() with {len(active)} active futures")
             # Use a short poll interval when plan gates are pending so the

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1899,6 +1899,107 @@ class TestQueuedMergePolling:
         assert "timed out" in (queued_result.state.error or "")
         assert sprint.specs_failed >= 1
 
+    def test_dependent_not_skipped_when_dep_has_queued_pr(self, tmp_path: Path) -> None:
+        """Dependent story must run after its dep's queued PR merges, not be skipped.
+
+        Regression for: dependent stories skipped when dependency is
+        pending_integration instead of waiting (#642).
+
+        Scenario: story-a (no deps) completes REVIEW/APPROVE, PR is queued for
+        auto-merge.  story-b depends on story-a.  When active workers are all
+        done but story-a is still in queued_prs, the scheduler must poll the PR
+        directly and dispatch story-b once it lands — not declare deadlock.
+        """
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b", depends_on=["story-a"])
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md", "story-b.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+                on_approve="merge-pr",
+                auto_push=True,
+                merge_wait_timeout_seconds=60,
+            ),
+        )
+
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        mock_preflight = MagicMock()
+        mock_preflight.cost_usd = 1.0
+        state.preflight_result = mock_preflight
+        state.review_results = [
+            ReviewResult(
+                verdict="APPROVE",
+                summary="Looks good.",
+                findings=[],
+                story_matches=True,
+                story_mismatches=[],
+                test_adequate=True,
+                test_gaps=[],
+                parse_errors=[],
+                raw_yaml={},
+            )
+        ]
+        queued_result = CoordinatorResult(
+            success=True,
+            phase=Phase.DONE,
+            state=state,
+            message="Done.",
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
+        )
+        dispatched: list[str] = []
+
+        def fake_run_task(*args, **kwargs):  # noqa: ANN001
+            task = args[1]
+            dispatched.append(task.slug)
+            if task.slug == "story-a":
+                return queued_result
+            return _make_coordinator_result(success=True, cost=1.0)
+
+        with (
+            patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+            patch(
+                "theforge.coordinator.completion._merge_pr",
+                return_value={
+                    "action": "merge-pr",
+                    "pr_url": "https://github.com/x/y/pull/11",
+                    "merged": False,
+                    "merge_queued": True,
+                    "auto_merge_queued": True,
+                    "success": True,
+                    "error": None,
+                },
+            ),
+            patch(
+                "theforge.sprint.runner._poll_queued_pr",
+                return_value={"status": "merged"},
+            ),
+            patch(
+                "theforge.sprint.runner.poll_required_checks",
+                return_value={
+                    "status": "pass",
+                    "sha": "deadbeef",
+                    "failing_checks": [],
+                    "message": "ok",
+                },
+            ),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        assert "story-b" in dispatched, "story-b was skipped due to premature deadlock"
+        assert queued_result.landing_status == "landed"
+        assert sprint.specs_succeeded == 2
+        assert sprint.specs_skipped == 0
+
 
 class TestImmediateIntegrationLanding:
     def test_immediate_landing_on_approve(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

[openai-reviewer] Scheduler now treats queued PRs as in-flight work and avoids premature deadlock skips; regression coverage matches the reported bug. | [gemini-reviewer] The fix correctly prevents premature deadlock declaration when PRs are queued and properly polls them to unblock dependents.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.59
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: dependent stories skipped when dependency is pending_integration instead of waiting (GitHub Issue #642)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #642