### PR TITLE
fix: audit iteration counts must match actual invocations

### DIFF
--- a/src/theforge/cli/audit.py
+++ b/src/theforge/cli/audit.py
@@ -125,8 +125,14 @@ def cmd_audit(args: object) -> int:
     # Iterations
     print()
     print("  Iterations")
-    print(f"    Dev iterations: {iterations.get('dev_iterations', '?')}")
-    print(f"    Review cycles:  {iterations.get('review_cycles', '?')}")
+    dev_productive = iterations.get(
+        "dev_iterations_productive", iterations.get("dev_iterations", "?")
+    )
+    dev_total = iterations.get("dev_attempts_total", "?")
+    review_cycles = iterations.get("review_cycles_total", iterations.get("review_cycles", "?"))
+    print(f"    Dev iterations (productive): {dev_productive}")
+    print(f"    Dev attempts (total):        {dev_total}")
+    print(f"    Review cycles:               {review_cycles}")
     print(f"    Gate decisions: {iterations.get('gate_decisions', [])}")
 
     # Cost summary

--- a/src/theforge/cli/telemetry.py
+++ b/src/theforge/cli/telemetry.py
@@ -98,11 +98,17 @@ def cmd_telemetry(args: object) -> int:
             totals = rec.get("totals") or {}
             cost = totals.get("cost_usd") or (rec.get("cost") or {}).get("total_usd")
             dur = totals.get("duration_s") or (rec.get("timing") or {}).get("duration_seconds")
-            dev_iters = totals.get("dev_iterations") or (rec.get("iterations") or {}).get(
-                "dev_iterations", "?"
+            dev_iters = (
+                totals.get("dev_iterations_productive")
+                or totals.get("dev_iterations")
+                or (rec.get("iterations") or {}).get("dev_iterations_productive")
+                or (rec.get("iterations") or {}).get("dev_iterations", "?")
             )
-            rev_cycles = totals.get("review_cycles") or (rec.get("iterations") or {}).get(
-                "review_cycles", "?"
+            rev_cycles = (
+                totals.get("review_cycles_total")
+                or totals.get("review_cycles")
+                or (rec.get("iterations") or {}).get("review_cycles_total")
+                or (rec.get("iterations") or {}).get("review_cycles", "?")
             )
             print(
                 f"{slug_short:<30} {_fmt_cost_s(cost):>8}  {_fmt_dur_s(dur):>8}  "

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -205,10 +205,10 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
         "cost_usd": round(state.total_cost, 6),
         "duration_s": round(sum(all_durations), 2),
         "dev_attempts_total": len(state.dev_results) + len(state.dev_handoff_fix_results),
-        "dev_iterations_productive": state.dev_iteration,
+        "dev_iterations_productive": len(state.dev_results),
         "review_cycles_total": state.review_cycle,
         # kept for backward compatibility with older audit readers
-        "dev_iterations": state.dev_iteration,
+        "dev_iterations": len(state.dev_results),
         "review_cycles": state.review_cycle,
     }
 
@@ -366,11 +366,11 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
         },
         "iterations": {
             "dev_attempts_total": len(state.dev_results) + len(state.dev_handoff_fix_results),
-            "dev_iterations_productive": state.dev_iteration,
+            "dev_iterations_productive": len(state.dev_results),
             "review_cycles_total": state.review_cycle,
             # kept for backward compatibility with older audit readers
             "review_cycles": state.review_cycle,
-            "dev_iterations": state.dev_iteration,
+            "dev_iterations": len(state.dev_results),
             "gate_decisions": state.gate_decisions,
             "dev_loop": _serialize_dev_iteration_metrics(state),
             "review_loop": _serialize_review_iteration_metrics(state),

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -204,6 +204,10 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
     totals = {
         "cost_usd": round(state.total_cost, 6),
         "duration_s": round(sum(all_durations), 2),
+        "dev_attempts_total": len(state.dev_results) + len(state.dev_handoff_fix_results),
+        "dev_iterations_productive": state.dev_iteration,
+        "review_cycles_total": state.review_cycle,
+        # kept for backward compatibility with older audit readers
         "dev_iterations": state.dev_iteration,
         "review_cycles": state.review_cycle,
     }
@@ -253,6 +257,7 @@ def _build_iteration_usage_summary(state: CoordinatorState, config: ForgeConfig)
 def _serialize_dev_iteration_metrics(state: CoordinatorState) -> list[dict]:
     return [
         {
+            "cycle": item.cycle,
             "iteration": item.iteration,
             "max_iterations": item.max_iterations,
             "gate_result": item.gate_result,
@@ -360,6 +365,10 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             "branch": state.branch_name,
         },
         "iterations": {
+            "dev_attempts_total": len(state.dev_results) + len(state.dev_handoff_fix_results),
+            "dev_iterations_productive": state.dev_iteration,
+            "review_cycles_total": state.review_cycle,
+            # kept for backward compatibility with older audit readers
             "review_cycles": state.review_cycle,
             "dev_iterations": state.dev_iteration,
             "gate_decisions": state.gate_decisions,
@@ -371,7 +380,9 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             "total_usd": state.total_cost,
             "dev_usd": state.total_dev_cost,
             "review_usd": state.total_review_cost,
-            "dev_invocations": len(state.dev_results),
+            "dev_invocations": len(state.dev_results) + len(state.dev_handoff_fix_results),
+            "dev_productive_invocations": len(state.dev_results),
+            "dev_handoff_fix_invocations": len(state.dev_handoff_fix_results),
             "review_invocations": len(state.review_agent_results),
             "agents": agents,
         },

--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -31,6 +31,26 @@ def build_agent_entries(state: CoordinatorState, config: ForgeConfig) -> list[di
                 for u in r.model_usage
             ]
         agents.append(entry)
+    for r in state.dev_handoff_fix_results:
+        entry = {
+            "role": "dev/handoff-fix",
+            "profile": r.profile_name or config.dev_profile.name,
+            "cost_usd": r.cost_usd,
+            "duration_seconds": None,
+        }
+        if r.model_usage:
+            entry["model_usage"] = [
+                {
+                    "model": u.model,
+                    "input_tokens": u.input_tokens,
+                    "output_tokens": u.output_tokens,
+                    "cache_read_tokens": u.cache_read_tokens,
+                    "cache_creation_tokens": u.cache_creation_tokens,
+                    "cost_usd": u.cost_usd,
+                }
+                for u in r.model_usage
+            ]
+        agents.append(entry)
     for i, r in enumerate(state.review_agent_results):
         dur = state.review_durations[i] if i < len(state.review_durations) else None
         role = "synthesis" if r.profile_name == "synthesis" else "review"

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -151,6 +151,7 @@ def record_dev_iteration_telemetry(
             max_iterations=max_iterations,
             cost_usd=dev_result.cost_usd,
             duration_s=duration_s,
+            cycle=state.review_cycle,
             gate_result=gate_result,
             failed_tests=failed_tests,
             existing_test_failures=False,

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -403,7 +403,7 @@ def _coordinator_loop(
                     session_id=state.dev_session_id,
                     secrets=config.secrets,
                 )
-                state.dev_results.append(_hf_result)
+                state.dev_handoff_fix_results.append(_hf_result)
                 state.dev_session_id = _hf_result.session_id or state.dev_session_id
                 save_sessions(
                     workspace_path,

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -126,6 +126,7 @@ class DevIterationTelemetry:
     max_iterations: int
     cost_usd: float | None
     duration_s: float
+    cycle: int = 0  # which review cycle this dev iteration belongs to
     gate_result: str | None = None
     failed_tests: list[str] = field(default_factory=list)
     existing_test_failures: bool = False
@@ -191,6 +192,9 @@ class CoordinatorState:
     dev_iteration: int = 0  # retries within the current review cycle
     dev_trace_count: int = 0  # monotonically increasing across all cycles; never reset
     dev_results: list[AgentResult] = field(default_factory=list)
+    dev_handoff_fix_results: list[AgentResult] = field(
+        default_factory=list
+    )  # handoff-fix retries, separate from productive dev calls
     dev_durations: list[float] = field(default_factory=list)  # wall-clock seconds per dev call
     review_agent_results: list[AgentResult] = field(default_factory=list)
     review_durations: list[float] = field(
@@ -319,7 +323,9 @@ class CoordinatorState:
 
     @property
     def total_dev_cost(self) -> float:
-        return sum(r.cost_usd or 0.0 for r in self.dev_results)
+        return sum(r.cost_usd or 0.0 for r in self.dev_results) + sum(
+            r.cost_usd or 0.0 for r in self.dev_handoff_fix_results
+        )
 
     @property
     def total_review_cost(self) -> float:

--- a/tests/test_coord_audit_iteration_counts.py
+++ b/tests/test_coord_audit_iteration_counts.py
@@ -1,0 +1,243 @@
+"""Tests for audit iteration count accuracy (issue-601).
+
+Verifies:
+- dev_attempts_total counts all invocations including handoff-fix retries
+- dev_iterations_productive counts only productive dev calls (no handoff-fix)
+- review_cycles_total is a separate distinct field
+- Each dev telemetry entry carries a (cycle, iteration) tuple
+- Handoff-fix retries are tagged with role="dev/handoff-fix" in cost.agents
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.state import (
+    CoordinatorResult,
+    CoordinatorState,
+    DevIterationTelemetry,
+    Phase,
+)
+from theforge.runners import AgentResult
+
+
+def _make_config(tmp_path: Path):
+    from theforge.config import (
+        DEFAULT_DEV_PROFILE,
+        DEFAULT_PREFLIGHT_PROFILE,
+        DEFAULT_REVIEW_PROFILE,
+        ForgeConfig,
+        RetryPolicy,
+        ValidationConfig,
+        WorkspaceConfig,
+    )
+
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=ValidationConfig(
+            gate_command="make gate",
+            handoff_file="handoff.yaml",
+            gate_decision_key="gate_result",
+        ),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+    )
+
+
+def _make_task(tmp_path: Path):
+    from theforge.task import TaskStory
+
+    spec_path = tmp_path / "spec.md"
+    spec_path.write_text("# Test spec", encoding="utf-8")
+    return TaskStory(name="Test Task", slug="test-task", story_path=spec_path)
+
+
+def _agent_result(cost: float = 0.10, profile: str = "dev") -> AgentResult:
+    return AgentResult(
+        success=True,
+        output="done",
+        session_id=None,
+        cost_usd=cost,
+        exit_code=0,
+        raw={},
+        profile_name=profile,
+    )
+
+
+def _make_result(state: CoordinatorState) -> CoordinatorResult:
+    return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="done")
+
+
+class TestIterationCountFields:
+    """AC1: audit records dev_attempts_total, dev_iterations_productive, review_cycles_total."""
+
+    def test_no_calls_all_zero(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        assert log["iterations"]["dev_attempts_total"] == 0
+        assert log["iterations"]["dev_iterations_productive"] == 0
+        assert log["iterations"]["review_cycles_total"] == 0
+        assert log["totals"]["dev_attempts_total"] == 0
+        assert log["totals"]["dev_iterations_productive"] == 0
+        assert log["totals"]["review_cycles_total"] == 0
+
+    def test_productive_dev_only_no_handoff_fix(self, tmp_path: Path) -> None:
+        """When no handoff-fix retries occur, dev_attempts_total == dev_iterations_productive."""
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result())
+        state.dev_results.append(_agent_result())
+        state.dev_durations.extend([10.0, 12.0])
+        state.dev_iteration = 2  # 2 productive iterations
+        state.review_cycle = 1
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        assert log["iterations"]["dev_attempts_total"] == 2
+        assert log["iterations"]["dev_iterations_productive"] == 2
+        assert log["iterations"]["review_cycles_total"] == 1
+        assert log["totals"]["dev_attempts_total"] == 2
+        assert log["totals"]["dev_iterations_productive"] == 2
+        assert log["totals"]["review_cycles_total"] == 1
+
+    def test_handoff_fix_inflates_attempts_total(self, tmp_path: Path) -> None:
+        """dev_attempts_total = productive + handoff-fix; productive count is unchanged."""
+        state = CoordinatorState()
+        # 2 productive dev calls
+        state.dev_results.append(_agent_result(cost=0.50))
+        state.dev_results.append(_agent_result(cost=0.50))
+        state.dev_durations.extend([10.0, 12.0])
+        state.dev_iteration = 2
+        # 3 handoff-fix retries
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.05))
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.05))
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.05))
+        state.review_cycle = 1
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        assert log["iterations"]["dev_attempts_total"] == 5  # 2 + 3
+        assert log["iterations"]["dev_iterations_productive"] == 2
+        assert log["iterations"]["review_cycles_total"] == 1
+        assert log["totals"]["dev_attempts_total"] == 5
+        assert log["totals"]["dev_iterations_productive"] == 2
+
+    def test_cost_counts_include_handoff_fix(self, tmp_path: Path) -> None:
+        """cost.dev_invocations counts all invocations; dev_productive_invocations excludes fix."""
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(cost=1.00))
+        state.dev_durations.append(10.0)
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.10))
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.10))
+        state.dev_iteration = 1
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        assert log["cost"]["dev_invocations"] == 3  # 1 productive + 2 handoff-fix
+        assert log["cost"]["dev_productive_invocations"] == 1
+        assert log["cost"]["dev_handoff_fix_invocations"] == 2
+
+    def test_total_dev_cost_includes_handoff_fix(self, tmp_path: Path) -> None:
+        """total_dev_cost property sums both productive and handoff-fix costs."""
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(cost=1.00))
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.25))
+
+        assert state.total_dev_cost == pytest.approx(1.25)
+
+
+class TestCycleIterationTuple:
+    """AC2: each dev telemetry entry has (cycle, iteration) tuple."""
+
+    def test_cycle_field_present_in_dev_loop(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.dev_iteration_telemetry.append(
+            DevIterationTelemetry(
+                iteration=1,
+                max_iterations=3,
+                cost_usd=0.50,
+                duration_s=10.0,
+                cycle=0,
+                gate_result="FAIL",
+            )
+        )
+        state.dev_iteration_telemetry.append(
+            DevIterationTelemetry(
+                iteration=1,
+                max_iterations=3,
+                cost_usd=0.60,
+                duration_s=12.0,
+                cycle=1,
+                gate_result="PASS",
+            )
+        )
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        dev_loop = log["iterations"]["dev_loop"]
+        assert len(dev_loop) == 2
+        assert dev_loop[0]["cycle"] == 0
+        assert dev_loop[0]["iteration"] == 1
+        assert dev_loop[1]["cycle"] == 1
+        assert dev_loop[1]["iteration"] == 1
+
+    def test_cycle_defaults_to_zero(self, tmp_path: Path) -> None:
+        """DevIterationTelemetry.cycle defaults to 0 for backward compat."""
+        t = DevIterationTelemetry(iteration=1, max_iterations=3, cost_usd=None, duration_s=5.0)
+        assert t.cycle == 0
+
+
+class TestHandoffFixTagging:
+    """AC3: handoff-fix retries are tagged distinctly in cost.agents."""
+
+    def test_handoff_fix_role_in_agents(self, tmp_path: Path) -> None:
+        """cost.agents entries for handoff-fix retries use role='dev/handoff-fix'."""
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(cost=1.00))
+        state.dev_durations.append(10.0)
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.05, profile="dev"))
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.05, profile="dev"))
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        agents = log["cost"]["agents"]
+        roles = [a["role"] for a in agents]
+        assert "dev" in roles
+        assert "dev/handoff-fix" in roles
+        fix_entries = [a for a in agents if a["role"] == "dev/handoff-fix"]
+        assert len(fix_entries) == 2
+
+    def test_productive_dev_entries_precede_handoff_fix(self, tmp_path: Path) -> None:
+        """In cost.agents, productive dev entries come before handoff-fix entries."""
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(cost=1.00))
+        state.dev_durations.append(10.0)
+        state.dev_handoff_fix_results.append(_agent_result(cost=0.05))
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        agents = log["cost"]["agents"]
+        assert agents[0]["role"] == "dev"
+        assert agents[1]["role"] == "dev/handoff-fix"
+
+    def test_no_handoff_fix_means_no_fix_entries(self, tmp_path: Path) -> None:
+        """When no handoff-fix retries occur, no dev/handoff-fix entries in agents."""
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result())
+        state.dev_durations.append(10.0)
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        agents = log["cost"]["agents"]
+        assert all(a["role"] != "dev/handoff-fix" for a in agents)

--- a/tests/test_coord_audit_iteration_counts.py
+++ b/tests/test_coord_audit_iteration_counts.py
@@ -111,6 +111,33 @@ class TestIterationCountFields:
         assert log["totals"]["dev_iterations_productive"] == 2
         assert log["totals"]["review_cycles_total"] == 1
 
+    def test_productive_count_survives_cycle_reset(self, tmp_path: Path) -> None:
+        """dev_iterations_productive counts across ALL review cycles, not just the last.
+
+        Regression test: state.dev_iteration resets to 0 on REQUEST_CHANGES; using it
+        as the productive count would report 0 (or N from the final cycle) instead of
+        the true cumulative total.  len(state.dev_results) is the correct source.
+        """
+        state = CoordinatorState()
+        # Simulate 2 productive dev calls in cycle 1 + 1 productive call in cycle 2
+        state.dev_results.append(_agent_result(cost=0.50))
+        state.dev_results.append(_agent_result(cost=0.50))
+        state.dev_results.append(_agent_result(cost=0.50))
+        state.dev_durations.extend([10.0, 12.0, 9.0])
+        # dev_iteration is reset to 0 by review_phase on REQUEST_CHANGES, then
+        # incremented once for cycle 2's single dev call — final value is 1, not 3.
+        state.dev_iteration = 1
+        state.review_cycle = 2
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+
+        # Must reflect all 3 productive calls, not just the last cycle's counter
+        assert log["iterations"]["dev_iterations_productive"] == 3
+        assert log["totals"]["dev_iterations_productive"] == 3
+        # Backward-compat alias must also be correct
+        assert log["iterations"]["dev_iterations"] == 3
+        assert log["totals"]["dev_iterations"] == 3
+
     def test_handoff_fix_inflates_attempts_total(self, tmp_path: Path) -> None:
         """dev_attempts_total = productive + handoff-fix; productive count is unchanged."""
         state = CoordinatorState()


### PR DESCRIPTION
## Summary

Verified the prior P1 count bug is fixed and found no blocking regressions in the touched files.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $5.71
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: audit iteration counts must match actual invocations (GitHub Issue #601)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #601