### PR TITLE
fix: re-exec forge process after git pull so new code takes effect before sprint runs

### DIFF
--- a/bin_script
+++ b/bin_script
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "reexec":
+    print("Re-execed successfully!")
+    sys.exit(0)
+
+print(f"sys.executable: {sys.executable}")
+print(f"sys.argv: {sys.argv}")
+os.execv(sys.executable, [sys.executable] + sys.argv + ["reexec"])

--- a/bin_script2
+++ b/bin_script2
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "reexec":
+    print("Re-execed successfully!")
+    sys.exit(0)
+
+print(f"sys.executable: {sys.executable}")
+print(f"sys.argv: {sys.argv}")
+os.execv(sys.executable, sys.argv + ["reexec"])

--- a/fake_forge
+++ b/fake_forge
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "sprint":
+    if len(sys.argv) > 2 and sys.argv[2] == "reexec":
+        print("Re-execed successfully!")
+        sys.exit(0)
+    print(f"sys.executable: {sys.executable}")
+    print(f"sys.argv: {sys.argv}")
+    os.execv(sys.executable, sys.argv + ["reexec"])

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 import subprocess
@@ -447,8 +448,16 @@ def pull_base_branch(config: ForgeConfig) -> bool:
 
     - If base_branch is checked out: git pull --ff-only (updates working tree)
     - If base_branch is not checked out: git fetch origin base:base (updates ref)
+
+    If the pull updates src/theforge source files, re-execs the process so the
+    sprint runs with fresh imports rather than stale bytecode.
     """
     base_branch = config.workspace.base_branch
+
+    ok_before, tree_before = _cu._run_shell("git rev-parse HEAD:src/theforge", config.project_root)
+    if not ok_before:
+        tree_before = ""
+
     _, current_branch = _cu._run_shell("git rev-parse --abbrev-ref HEAD", config.project_root)
     if current_branch.strip() == base_branch:
         ok_pull, pull_out = _cu._run_shell(
@@ -462,7 +471,24 @@ def pull_base_branch(config: ForgeConfig) -> bool:
         _cu._log(f"✓ WORKSPACE  pulled latest {base_branch}")
     else:
         _cu._log(f"⚠ WORKSPACE  pull failed (non-ff / offline): {pull_out.strip()}")
-    return ok_pull
+        return False
+
+    ok_after, tree_after = _cu._run_shell("git rev-parse HEAD:src/theforge", config.project_root)
+    if not ok_after:
+        tree_after = ""
+
+    if tree_before and tree_after and tree_before.strip() != tree_after.strip():
+        _cu._log("Source updated after pull — re-execing to load new code")
+        os.chdir(str(config.project_root))
+        try:
+            os.execv(sys.executable, [sys.executable] + sys.argv)
+        except OSError:
+            raise SystemExit(
+                "Source files changed after git pull"
+                " — re-run forge sprint to pick up the new code."
+            )
+
+    return True
 
 
 def _create_workspace(

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -66,16 +66,9 @@ def _write_last_setup_command(workspace_path: Path, cmd: str) -> None:
 def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, str]:
     """Run workspace setup, always running pip install even if .venv exists.
 
-    When setup_command contains the {forge_python} placeholder, the template is
-    matched BEFORE substitution so the regex never has to parse shlex.quote()
-    output (which varies with the interpreter path and cannot be reliably matched
-    by a single regex pattern).  sys.executable is then injected directly into
-    the constructed shell strings via shlex.quote().
-
-    For legacy commands without {forge_python}, falls back to matching the bare
-    executable token after resolving any other substitutions.
-
-    Falls back to running setup_command verbatim when neither pattern matches.
+    Matches the {forge_python} template BEFORE substitution to avoid parsing
+    shlex.quote() output; falls back to the legacy bare-token form; then runs
+    setup_command verbatim if neither pattern matches.
     """
     last_setup_command = _read_last_setup_command(workspace_path)
     if last_setup_command is not None and last_setup_command != setup_command:

--- a/test_exec.py
+++ b/test_exec.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "reexec":
+    print("Re-execed successfully!")
+    sys.exit(0)
+
+print(f"sys.executable: {sys.executable}")
+print(f"sys.argv: {sys.argv}")
+os.execv(sys.executable, sys.argv + ["reexec"])

--- a/test_exec2.py
+++ b/test_exec2.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "reexec":
+    print("Re-execed successfully!")
+    sys.exit(0)
+
+print(f"sys.executable: {sys.executable}")
+print(f"sys.argv: {sys.argv}")
+os.execv(sys.executable, [sys.executable] + sys.argv + ["reexec"])

--- a/test_exec3.py
+++ b/test_exec3.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "reexec":
+    print("Re-execed successfully!")
+    sys.exit(0)
+
+print(f"sys.executable: {sys.executable}")
+print(f"sys.argv: {sys.argv}")
+os.execv(sys.executable, sys.argv + ["reexec"])

--- a/tests/test_coord_workspace_reexec.py
+++ b/tests/test_coord_workspace_reexec.py
@@ -1,0 +1,90 @@
+"""Tests for pull_base_branch re-exec behavior after source changes.
+
+Covers:
+- No re-exec when tree hash is unchanged after pull
+- Re-exec (os.execv) when tree hash changes after pull
+- SystemExit raised when os.execv itself raises OSError
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+from coord_test_helpers import _make_config
+
+from theforge.coordinator.workspace import pull_base_branch
+
+_HASH_BEFORE = "abc123def456abc123def456abc123def456abc123"
+_HASH_AFTER_SAME = "abc123def456abc123def456abc123def456abc123"
+_HASH_AFTER_CHANGED = "999999999999999999999999999999999999999999"
+
+
+def _make_shell_side_effect(tree_before: str, tree_after: str, pull_ok: bool = True):
+    """Build a _run_shell side_effect for pull_base_branch tests."""
+    calls = {"count": 0}
+
+    def side_effect(cmd, cwd, **kwargs):
+        if "rev-parse HEAD:src/theforge" in cmd:
+            if calls["count"] == 0:
+                calls["count"] += 1
+                return (True, tree_before)
+            else:
+                return (True, tree_after)
+        if "rev-parse --abbrev-ref HEAD" in cmd:
+            return (True, "feat/other-branch")
+        if "fetch origin" in cmd:
+            return (pull_ok, "")
+        return (True, "")
+
+    return side_effect
+
+
+class TestPullBaseReexec:
+    @patch("theforge.coordinator.workspace._cu._log")
+    @patch("theforge.coordinator.workspace.os.execv")
+    @patch("theforge.coordinator.workspace.os.chdir")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_no_reexec_when_tree_unchanged(
+        self, mock_shell, mock_chdir, mock_execv, mock_log, tmp_path
+    ):
+        """When tree hash is identical before and after pull, os.execv is NOT called."""
+        config = _make_config(tmp_path)
+        mock_shell.side_effect = _make_shell_side_effect(_HASH_BEFORE, _HASH_AFTER_SAME)
+
+        result = pull_base_branch(config)
+
+        assert result is True
+        mock_execv.assert_not_called()
+        mock_chdir.assert_not_called()
+
+    @patch("theforge.coordinator.workspace._cu._log")
+    @patch("theforge.coordinator.workspace.os.execv")
+    @patch("theforge.coordinator.workspace.os.chdir")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_reexec_when_tree_changed(
+        self, mock_shell, mock_chdir, mock_execv, mock_log, tmp_path
+    ):
+        """When tree hash differs after pull, os.execv is called with sys.executable + sys.argv."""
+        config = _make_config(tmp_path)
+        mock_shell.side_effect = _make_shell_side_effect(_HASH_BEFORE, _HASH_AFTER_CHANGED)
+
+        pull_base_branch(config)
+
+        mock_chdir.assert_called_once_with(str(config.project_root))
+        mock_execv.assert_called_once_with(sys.executable, [sys.executable] + sys.argv)
+
+    @patch("theforge.coordinator.workspace._cu._log")
+    @patch("theforge.coordinator.workspace.os.execv", side_effect=OSError("exec failed"))
+    @patch("theforge.coordinator.workspace.os.chdir")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_abort_when_execv_raises(self, mock_shell, mock_chdir, mock_execv, mock_log, tmp_path):
+        """When os.execv raises OSError, SystemExit is raised with the re-run message."""
+        config = _make_config(tmp_path)
+        mock_shell.side_effect = _make_shell_side_effect(_HASH_BEFORE, _HASH_AFTER_CHANGED)
+
+        with pytest.raises(SystemExit) as exc_info:
+            pull_base_branch(config)
+
+        assert "re-run forge sprint" in str(exc_info.value)


### PR DESCRIPTION
## Summary

[openai-reviewer] Workspace pull now detects source updates and re-execs before sprint execution, with focused tests covering the new behavior. | [gemini-reviewer] Implementation correctly re-execs the process after source changes, but includes junk test files.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.95
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

- **[P2] `bin_script:1`** Junk test files (`bin_script`, `bin_script2`, `fake_forge`, `test_exec.py`, `test_exec2.py`, `test_exec3.py`) were accidentally committed to the root of the repository.

## Story

fix: re-exec forge process after git pull so new code takes effect before sprint runs (GitHub Issue #646)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #646