### PR TITLE
refactor: replace retry_reason string with Enum

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -299,12 +299,13 @@ def _run_dev_phase(
             None
             | RetryReason.GATE_FAIL
             | RetryReason.CONVENTION_VIOLATIONS
+            | RetryReason.DIRTY_WORKTREE
             | RetryReason.REJECT
             | RetryReason.EXTEND
             | RetryReason.REVIEW_CHANGES
         ):
-            # None → first iteration; gate_fail/convention_violations/reject/extend(no findings)
-            # → fresh dev prompt
+            # None → first iteration; gate_fail/convention_violations/dirty_worktree/reject
+            # /extend(no findings) → fresh dev prompt
             dev_context = ContextAssembler.from_config(config).assemble(
                 phase="dev",
                 story_text=story_content,

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -19,7 +19,7 @@ from theforge.traces import write_trace
 from .gate import _is_gate_skip
 from .logging import StructuredLogger
 from .notify import _escalate_notify
-from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase
+from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase, RetryReason
 from .util import _fmt_duration, _log, _log_phase, _log_verbose, resolve_timeout
 
 # ── Sibling-worktree write detector ──────────────────────────────────
@@ -258,74 +258,88 @@ def _run_dev_phase(
         else config.validation.gate_command
     )
     _dev_entry_reason = state.retry_reason  # snapshot before consumed by prompt routing
-    if state.retry_reason == "timeout_resume":
-        prompt = (
-            state.human_feedback
-            or "You were cut off by a timeout. Continue from where you left off."
-        )
-        state.dev_prompt_injected_finding_ids.append([])
-        state.retry_reason = None
-        state.human_feedback = None
-    elif state.retry_reason in ("review_changes", "extend") and state.last_review_findings:
-        carry_forward_p1s = _prior_open_p1s_for_dev_prompt(state)
-        current_cycle_p1s = _current_cycle_p1s_for_dev_prompt(state)
-        prompt = build_fix_prompt(
-            task,
-            workspace_path=workspace_path,
-            branch_name=branch_name,
-            review_findings=state.last_review_findings,
-            gate_command=_gate_cmd,
-            gate_skipped=_is_gate_skip(task.gate_override),
-            iteration=state.dev_iteration,
-            cycle_history=state.cycle_history or None,
-            escalation_note=state.escalation_note,
-            handoff_file=config.validation.handoff_file,
-            plan_output=state.plan_structured
-            if state.plan_structured is not None
-            else state.plan_output,
-            prior_open_p1s=carry_forward_p1s or None,
-            classified_p1s=current_cycle_p1s or None,
-            surviving_families=state.surviving_families or None,
-            conventions=config.conventions_soft,
-        )
-        injected_finding_ids = [r.finding_id for r in carry_forward_p1s]
-        injected_finding_ids.extend(
-            r.finding_id for r in current_cycle_p1s if r.finding_id not in injected_finding_ids
-        )
-        state.dev_prompt_injected_finding_ids.append(injected_finding_ids)
-        state.escalation_note = None  # consumed
-    else:
-        dev_context = ContextAssembler.from_config(config).assemble(
-            phase="dev",
-            story_text=story_content,
-            file_list=plan_file_list(state.plan_structured) or None,
-        )
-        state.context_manifests.append({"phase": "dev", "manifest": dev_context})
-        prompt = build_dev_prompt(
-            task,
-            workspace_path=workspace_path,
-            branch_name=branch_name,
-            story_content=story_content,
-            gate_command=_gate_cmd,
-            gate_skipped=_is_gate_skip(task.gate_override),
-            review_findings=state.last_review_findings,
-            human_feedback=state.human_feedback,
-            preflight_output=(state.preflight_result.output if state.preflight_result else None),
-            plan_output=state.plan_structured
-            if state.plan_structured is not None
-            else state.plan_output,
-            plan_review_advisory=state.plan_agent_review_findings,
-            iteration=state.dev_iteration,
-            escalation_note=state.escalation_note,
-            cycle_history=state.cycle_history or None,
-            handoff_file=config.validation.handoff_file,
-            preflight_sufficiency=state.preflight_sufficiency,
-            contract_change=state.preflight_contract_change,
-            conventions=config.conventions_soft,
-            assembled_context=dev_context,
-        )
-        state.dev_prompt_injected_finding_ids.append([])
-        state.escalation_note = None  # consumed
+    match state.retry_reason:
+        case RetryReason.TIMEOUT_RESUME:
+            prompt = (
+                state.human_feedback
+                or "You were cut off by a timeout. Continue from where you left off."
+            )
+            state.dev_prompt_injected_finding_ids.append([])
+            state.retry_reason = None
+            state.human_feedback = None
+        case RetryReason.REVIEW_CHANGES | RetryReason.EXTEND if state.last_review_findings:
+            carry_forward_p1s = _prior_open_p1s_for_dev_prompt(state)
+            current_cycle_p1s = _current_cycle_p1s_for_dev_prompt(state)
+            prompt = build_fix_prompt(
+                task,
+                workspace_path=workspace_path,
+                branch_name=branch_name,
+                review_findings=state.last_review_findings,
+                gate_command=_gate_cmd,
+                gate_skipped=_is_gate_skip(task.gate_override),
+                iteration=state.dev_iteration,
+                cycle_history=state.cycle_history or None,
+                escalation_note=state.escalation_note,
+                handoff_file=config.validation.handoff_file,
+                plan_output=state.plan_structured
+                if state.plan_structured is not None
+                else state.plan_output,
+                prior_open_p1s=carry_forward_p1s or None,
+                classified_p1s=current_cycle_p1s or None,
+                surviving_families=state.surviving_families or None,
+                conventions=config.conventions_soft,
+            )
+            injected_finding_ids = [r.finding_id for r in carry_forward_p1s]
+            injected_finding_ids.extend(
+                r.finding_id for r in current_cycle_p1s if r.finding_id not in injected_finding_ids
+            )
+            state.dev_prompt_injected_finding_ids.append(injected_finding_ids)
+            state.escalation_note = None  # consumed
+        case (
+            None
+            | RetryReason.GATE_FAIL
+            | RetryReason.CONVENTION_VIOLATIONS
+            | RetryReason.REJECT
+            | RetryReason.EXTEND
+            | RetryReason.REVIEW_CHANGES
+        ):
+            # None → first iteration; gate_fail/convention_violations/reject/extend(no findings)
+            # → fresh dev prompt
+            dev_context = ContextAssembler.from_config(config).assemble(
+                phase="dev",
+                story_text=story_content,
+                file_list=plan_file_list(state.plan_structured) or None,
+            )
+            state.context_manifests.append({"phase": "dev", "manifest": dev_context})
+            prompt = build_dev_prompt(
+                task,
+                workspace_path=workspace_path,
+                branch_name=branch_name,
+                story_content=story_content,
+                gate_command=_gate_cmd,
+                gate_skipped=_is_gate_skip(task.gate_override),
+                review_findings=state.last_review_findings,
+                human_feedback=state.human_feedback,
+                preflight_output=(
+                    state.preflight_result.output if state.preflight_result else None
+                ),
+                plan_output=state.plan_structured
+                if state.plan_structured is not None
+                else state.plan_output,
+                plan_review_advisory=state.plan_agent_review_findings,
+                iteration=state.dev_iteration,
+                escalation_note=state.escalation_note,
+                cycle_history=state.cycle_history or None,
+                handoff_file=config.validation.handoff_file,
+                preflight_sufficiency=state.preflight_sufficiency,
+                contract_change=state.preflight_contract_change,
+                conventions=config.conventions_soft,
+                assembled_context=dev_context,
+            )
+            state.dev_prompt_injected_finding_ids.append([])
+            state.escalation_note = None  # consumed
+        case _:
+            raise ValueError(f"Unrecognized retry_reason: {state.retry_reason!r}")
     state.retry_reason = None  # consumed
 
     write_trace(

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -71,6 +71,7 @@ from .state import (
     CoordinatorResult,
     CoordinatorState,
     Phase,
+    RetryReason,
 )
 from .util import (
     _generate_run_id,
@@ -338,7 +339,7 @@ def _coordinator_loop(
                     state.dev_results
                     and state.dev_results[-1].exit_code == -9
                     and state.dev_session_id
-                    and state.retry_reason == "gate_fail"
+                    and state.retry_reason == RetryReason.GATE_FAIL
                 ):
                     gate_result = "FAIL"
                     if state.gate_decisions:

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -58,6 +58,7 @@ from .state import (
     CoordinatorState,
     FindingRecord,
     Phase,
+    RetryReason,
     ReviewCycleMetadata,
     ReviewIterationTelemetry,
 )
@@ -449,7 +450,7 @@ def _handle_interactive_review_decision(
                 review_to_dev_handoff(parsed_review) if parsed_review.findings else None
             )
         state.human_feedback = None
-        state.retry_reason = "extend"
+        state.retry_reason = RetryReason.EXTEND
         _log(
             f"Human extended — granting fresh budget "
             f"(extra_cycles={state.human_review_extra_cycles})"
@@ -460,7 +461,7 @@ def _handle_interactive_review_decision(
     _append_cycle_history(state, parsed_review)
     state.dev_iteration = 0
     state.last_review_findings = None
-    state.retry_reason = "reject"
+    state.retry_reason = RetryReason.REJECT
     if exhausted_cycles:
         # Treat as extend + reject: grant fresh budget
         state.review_cycle = 0
@@ -893,7 +894,7 @@ def _run_review_phase(
     state.last_review_findings = review_to_dev_handoff(parsed_review)
     state.dev_iteration = 0
     state.human_feedback = None
-    state.retry_reason = "review_changes"
+    state.retry_reason = RetryReason.REVIEW_CHANGES
     _log_verbose(f"Sending {len(parsed_review.findings)} findings back to dev agent")
     return _ReviewOutcome.RETRY_DEV, None, config
 

--- a/src/theforge/coordinator/signals.py
+++ b/src/theforge/coordinator/signals.py
@@ -8,6 +8,7 @@ import time
 from typing import TYPE_CHECKING
 
 from .log_tee import _end_run_log_tee, _safe_signal
+from .state import RetryReason
 
 if TYPE_CHECKING:
     from theforge.config import ForgeConfig
@@ -71,7 +72,7 @@ def _make_sigterm_handler(
 
 def _set_timeout_resume(state: "CoordinatorState", gate_result: str) -> None:
     """Mark state for a timeout-resume retry with a short continuation prompt."""
-    state.retry_reason = "timeout_resume"
+    state.retry_reason = RetryReason.TIMEOUT_RESUME
     state.human_feedback = (
         "You were cut off by a timeout. Continue from where you left off. "
         f"Gate result: {gate_result}"

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -64,6 +64,24 @@ def parse_phase_name(name: str) -> Phase:
     return result
 
 
+# ── RetryReason enum ─────────────────────────────────────────────────
+
+
+class RetryReason(str, Enum):
+    """Reason the coordinator is retrying the dev phase.
+
+    Using str mixin keeps serialization compatible with audit YAML output.
+    """
+
+    REVIEW_CHANGES = "review_changes"
+    GATE_FAIL = "gate_fail"
+    DIRTY_WORKTREE = "dirty_worktree"  # reserved; no active assignment site
+    EXTEND = "extend"
+    REJECT = "reject"
+    TIMEOUT_RESUME = "timeout_resume"
+    CONVENTION_VIOLATIONS = "convention_violations"
+
+
 # ── Disposition enum ──────────────────────────────────────────────────
 
 
@@ -260,11 +278,7 @@ class CoordinatorState:
     dev_escalated: bool = False  # True once model escalation has occurred this run
     plan_escalated: bool = False  # True once plan model escalation has occurred this run
     plan_escalation_note: str | None = None  # escalation context injected into regen prompt
-    retry_reason: str | None = (
-        None
-        # "review_changes" | "gate_fail" | "dirty_worktree" | "extend"
-        # | "reject" | "timeout_resume" | None
-    )
+    retry_reason: RetryReason | None = None  # see RetryReason enum for valid values
     last_cycle_reviewer_results: list[tuple[str, ReviewResult]] = field(
         default_factory=list
     )  # (profile_name, ReviewResult) pairs from the most recent pool run

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -19,7 +19,7 @@ from .gate import _is_gate_skip, _run_gate_full
 from .logging import StructuredLogger
 from .notify import _escalate_notify
 from .review_context import _get_handoff_content, _get_raw_dev_notes
-from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase
+from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase, RetryReason
 from .util import _log, _log_phase, _log_verbose
 from .workspace import _deindex_forge_artifacts
 
@@ -258,7 +258,7 @@ def _run_validate_phase(
                 f"{failed_test_feedback}"
                 f"{partial}"
             )
-        state.retry_reason = "gate_fail"
+        state.retry_reason = RetryReason.GATE_FAIL
         if state.dev_iteration_telemetry:
             state.dev_iteration_telemetry[-1] = dataclasses.replace(
                 state.dev_iteration_telemetry[-1],
@@ -402,7 +402,7 @@ def _run_validate_phase(
             f"Gate output (last {tail_chars} chars):\n{gate_output_tail}\n\n"
             f"Current handoff:\n{handoff_text}"
         )
-        state.retry_reason = "gate_fail"
+        state.retry_reason = RetryReason.GATE_FAIL
         _log(f"  ✗ VALIDATE   {gate_decision}  (iter={state.dev_iteration} → retrying)")
         _log(f"Retrying dev (gate={gate_decision}, iter={state.dev_iteration})")
         record_dev_iteration_telemetry(
@@ -481,7 +481,7 @@ def _run_validate_phase(
             lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _cv_violations]
             human_feedback = "Hard convention violations detected:\n" + "\n".join(lines)
             state.human_feedback = human_feedback
-            state.retry_reason = "convention_violations"
+            state.retry_reason = RetryReason.CONVENTION_VIOLATIONS
             _log(f"  ✗ VALIDATE   convention violations ({len(_cv_violations)} found)")
             for v in _cv_violations:
                 _log(f"    [{v.rule}] {v.file}: {v.detail}")

--- a/tests/test_coord_convention_parallel.py
+++ b/tests/test_coord_convention_parallel.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from coord_test_helpers import _make_config, _make_task
 
 from theforge.config.types import HardConventionsConfig
-from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.coordinator.state import CoordinatorState, Phase, RetryReason
 from theforge.coordinator.validate_phase import _run_validate_phase, _ValidateOutcome
 
 
@@ -70,7 +70,7 @@ class TestConventionParallelCheck:
 
         assert outcome is _ValidateOutcome.RETRY_DEV
         assert result is None
-        assert state.retry_reason == "gate_fail"
+        assert state.retry_reason == RetryReason.GATE_FAIL
         # Gate failure text is present
         assert "test suite" in state.human_feedback
         # Convention violation text is also present in the same feedback
@@ -122,7 +122,7 @@ class TestConventionParallelCheck:
 
         assert outcome is _ValidateOutcome.REVIEW_CONVENTION_BLOCK
         assert result is None
-        assert state.retry_reason == "convention_violations"
+        assert state.retry_reason == RetryReason.CONVENTION_VIOLATIONS
         assert len(state.convention_violations) == 1
         assert "Hard convention violations" in state.human_feedback
 
@@ -161,6 +161,6 @@ class TestConventionParallelCheck:
 
         assert outcome is _ValidateOutcome.RETRY_DEV
         assert result is None
-        assert state.retry_reason == "gate_fail"
+        assert state.retry_reason == RetryReason.GATE_FAIL
         assert "convention" not in state.human_feedback.lower()
         assert state.convention_violations is None or state.convention_violations == []


### PR DESCRIPTION
## Summary

[openai-reviewer] Prior exhaustiveness issue is fixed, and I found no new correctness regressions in the enum refactor. | [gemini-reviewer] The P1 finding from cycle 1 has been fixed and the match statement is now exhaustive.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.76
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

refactor: replace retry_reason string with Enum (GitHub Issue #602)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #602