### PR TITLE
fix: freeze auto-model-escalation behind feature flag

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -261,6 +261,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         max_plan_regen_attempts=int(retry_data.get("max_plan_regen_attempts", 3)),
         demotion_threshold=int(retry_data.get("demotion_threshold", 2)),
         escalate_policy=str(retry_data.get("escalate_policy", "prompt")),
+        auto_model_escalation=bool(retry_data.get("auto_model_escalation", False)),
     )
 
     notifications = _parse_notifications(raw.get("notifications", {}), secrets)

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -186,6 +186,7 @@ class RetryPolicy:
         2  # consecutive plan rejections before escalating planner model
     )
     escalate_policy: str = "prompt"  # "prompt" | "auto_approve" | "reject"
+    auto_model_escalation: bool = False  # escalate dev model on persistent P1; disabled by default
 
 
 @dataclass(frozen=True)

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -816,9 +816,10 @@ def _run_review_phase(
         f"  ${_review_cost:.2f}  {_fmt_duration(_review_elapsed)}"
     )
 
-    # Escalate dev model on persistent P1
+    # Escalate dev model on persistent P1 (only when explicitly enabled via forge.yaml)
     if (
-        _is_persistent_p1
+        config.retry.auto_model_escalation
+        and _is_persistent_p1
         and not state.dev_escalated
         and (state.total_dev_cost < config.dev_profile.budget_usd)
     ):

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -401,6 +401,19 @@ class TestLoadConfig:
         assert config.retry.max_dev_iterations == 5
         assert config.retry.max_review_cycles == 4
 
+    def test_auto_model_escalation_defaults_false(self, tmp_path):
+        config_path = _write_config({"retry": {}}, tmp_path)
+        config = load_config(config_path)
+        assert config.retry.auto_model_escalation is False
+
+    def test_auto_model_escalation_parsed_true(self, tmp_path):
+        config_path = _write_config(
+            {"retry": {"auto_model_escalation": True}},
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.retry.auto_model_escalation is True
+
     def test_empty_file(self, tmp_path):
         config_path = tmp_path / "forge.yaml"
         config_path.write_text("", encoding="utf-8")

--- a/tests/test_coord_preflight_cycle.py
+++ b/tests/test_coord_preflight_cycle.py
@@ -66,7 +66,11 @@ def _make_smart_config(
         preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
         review_pool=[review_profile],
         synthesis_profile=None,
-        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=max_review_cycles),
+        retry=RetryPolicy(
+            max_dev_iterations=2,
+            max_review_cycles=max_review_cycles,
+            auto_model_escalation=True,
+        ),
         smart_config_models=models,
     )
 

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -81,7 +81,11 @@ def _make_smart_config(
         preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
         review_pool=[review_profile],
         synthesis_profile=None,
-        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=max_review_cycles),
+        retry=RetryPolicy(
+            max_dev_iterations=2,
+            max_review_cycles=max_review_cycles,
+            auto_model_escalation=True,
+        ),
         smart_config_models=models,
     )
 
@@ -476,6 +480,101 @@ class TestDevModelEscalationIntegration:
         assert "budget" in result.message.lower()
         # Escalation flag never set (budget guard fired first)
         assert result.state.dev_escalated is False
+
+
+class TestAutoModelEscalationFlag:
+    """Tests that auto_model_escalation feature flag gates dev model escalation."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_escalation_disabled_by_default(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Smart config with auto_model_escalation=False (default) → no dev model swap."""
+        # _make_smart_config would set auto_model_escalation=True; build one without it
+        dev_profile = ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=30.0,
+            timeout_seconds=900,
+            allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
+        )
+        review_profile = ModelProfile(
+            name="claude-opus",
+            cli="claude",
+            model="opus",
+            budget_usd=10.0,
+            timeout_seconds=300,
+            allowed_tools=("Read", "Bash", "Glob", "Grep"),
+        )
+        config = ForgeConfig(
+            project="test",
+            project_root=tmp_path,
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+            ),
+            validation=DEFAULT_VALIDATION,
+            dev_profile=dev_profile,
+            preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+            review_pool=[review_profile],
+            synthesis_profile=None,
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=3,
+                auto_model_escalation=False,  # explicit default
+            ),
+            smart_config_models=["claude/sonnet", "claude/opus"],
+        )
+
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.side_effect = [_make_agent_result() for _ in range(4)]
+
+        pool_call = {"n": 0}
+
+        def pool_side_effect(**kwargs):
+            pool_call["n"] += 1
+            if pool_call["n"] >= 3:
+                return [
+                    _make_agent_result(
+                        success=True, output=APPROVE_REVIEW, profile_name="claude-opus"
+                    )
+                ]
+            return [
+                _make_agent_result(
+                    success=True,
+                    output=_PERSISTENT_P1_REVIEW,
+                    profile_name="claude-opus",
+                )
+            ]
+
+        mock_pool.side_effect = pool_side_effect
+
+        result = run_task(config, task)
+
+        # Escalation never fired despite persistent P1 and smart config
+        assert result.state.dev_escalated is False
+
+    def test_auto_model_escalation_defaults_to_false(self, tmp_path):
+        """RetryPolicy.auto_model_escalation defaults to False."""
+        policy = RetryPolicy()
+        assert policy.auto_model_escalation is False
+
+    def test_auto_model_escalation_can_be_enabled(self, tmp_path):
+        """RetryPolicy.auto_model_escalation can be set to True."""
+        policy = RetryPolicy(auto_model_escalation=True)
+        assert policy.auto_model_escalation is True
 
 
 def test_dev_startup_failure_message_mentions_launcher(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

[openai-reviewer] Feature flag correctly disables auto dev-model escalation by default and only enables it when explicitly configured. | [gemini-reviewer] The implementation correctly gates auto-model-escalation behind a feature flag.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.29
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: freeze auto-model-escalation behind feature flag (GitHub Issue #609)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #609