### PR TITLE
refactor: break _merge_pr into resumable steps

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -3,7 +3,7 @@ project: theforge
 
 workspace:
   create_command: "git worktree add .forge/worktrees/{slug} -b feat/{slug} {base_branch}"
-  setup_command: "test -d .venv || ({forge_python} -m venv .venv && .venv/bin/pip install -e '.[all]' pytest pytest-xdist pytest-timeout -q)"
+  setup_command: "test -d .venv || ({forge_python} -m venv .venv && .venv/bin/pip install -e '.[all,dev]' -q)"
   path_pattern: ".forge/worktrees/{slug}"
   branch_pattern: "feat/{slug}"
   on_approve: merge-pr
@@ -14,7 +14,7 @@ workspace:
   merge_wait_timeout_seconds: 3600
 
 validation:
-  gate_command: ".venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
+  gate_command: ".venv/bin/ruff check src/ tests/ && .venv/bin/ruff format --check src/ tests/ && .venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
   gate_debug_command: ".venv/bin/python -m pytest tests/ -x -v -n 0 --timeout=10"
   handoff_file: ".forge/handoff.yaml"
   gate_decision_key: "gate_decision"

--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -657,33 +657,53 @@ def _merge_pr(
 
     # Retry loop: handles transient "base branch was modified" errors from GitHub.
     for attempt in range(MAX_MERGE_RETRIES):
-        # fetch + rebase — always run per attempt (idempotent, needed for freshness).
-        fetch_rebase_result = _step_fetch_rebase(push_cwd, base_branch)
-        _pr_log.info(
-            "merge step fetch_rebase (attempt %d): success=%s error=%s",
-            attempt,
-            fetch_rebase_result["success"],
-            fetch_rebase_result.get("error"),
-        )
-        if not fetch_rebase_result["success"]:
-            return _fail(fetch_rebase_result["error"], merge_state=merge_state)
+        # fetch + rebase and force-push are only needed before the merge command runs.
+        # If merge already completed (resuming after a crash post-merge), skip them:
+        # force-pushing after auto-merge is queued can dismiss approvals and cancel it.
+        if "merge" not in merge_state.completed_steps:
+            fetch_rebase_result = _step_fetch_rebase(push_cwd, base_branch)
+            _pr_log.info(
+                "merge step fetch_rebase (attempt %d): success=%s error=%s",
+                attempt,
+                fetch_rebase_result["success"],
+                fetch_rebase_result.get("error"),
+            )
+            if not fetch_rebase_result["success"]:
+                return _fail(fetch_rebase_result["error"], merge_state=merge_state)
 
-        # force-push — always run per attempt.
-        force_push_result = _step_force_push(push_cwd, branch_name)
-        _pr_log.info(
-            "merge step force_push (attempt %d): success=%s error=%s",
-            attempt,
-            force_push_result["success"],
-            force_push_result.get("error"),
-        )
-        if not force_push_result["success"]:
-            return _fail(force_push_result["error"], merge_state=merge_state)
+            force_push_result = _step_force_push(push_cwd, branch_name)
+            _pr_log.info(
+                "merge step force_push (attempt %d): success=%s error=%s",
+                attempt,
+                force_push_result["success"],
+                force_push_result.get("error"),
+            )
+            if not force_push_result["success"]:
+                return _fail(force_push_result["error"], merge_state=merge_state)
 
         # create PR — only once; skip on resume if already completed.
         if "create_pr" not in merge_state.completed_steps:
             create_result = _step_create_pr(config, task, branch_name, parsed_review, state)
             if not create_result["success"]:
                 return _fail(create_result["error"], merge_state=merge_state)
+            if create_result["pr_url"] is None:
+                # Zero-delta branch: no commits ahead of base, nothing to merge.
+                _log(
+                    f"  Skipping merge: branch {branch_name} has no commits ahead of "
+                    f"origin/{base_branch}"
+                )
+                delete_merge_state(worktree_path)
+                return {
+                    "action": "merge-pr",
+                    "pr_url": None,
+                    "merged": False,
+                    "merge_queued": False,
+                    "auto_merge_queued": False,
+                    "success": True,
+                    "error": None,
+                    "skipped": True,
+                    "skip_reason": "zero-delta branch",
+                }
             merge_state.pr_url = create_result["pr_url"]
             _complete_step(merge_state, "create_pr", pr_url=merge_state.pr_url)
 

--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -17,7 +17,8 @@ from .gate import _parse_dirty_files
 from .github_integration import assign_pr_reviewers, post_findings_comment
 from .logging import StructuredLogger
 from .notify import _ntfy_done_notify
-from .state import CoordinatorResult, CoordinatorState, CycleHistory, Phase
+from .run_setup import delete_merge_state, load_merge_state, save_merge_state
+from .state import CoordinatorResult, CoordinatorState, CycleHistory, MergeStepState, Phase
 from .util import _fmt_duration, _log, _log_verbose, _run_shell
 from .workspace import _deindex_forge_artifacts, _merge_branch
 
@@ -309,6 +310,240 @@ def _create_pr(
         return {"action": "pr", "pr_url": None, "success": False, "error": str(exc)}
 
 
+def _step_fetch_rebase(push_cwd: Path, base_branch: str) -> dict:
+    """Fetch origin/{base_branch} and rebase the worktree onto it.
+
+    Returns ``{"success": True}`` or ``{"success": False, "error": ...}``.
+    """
+    _deindex_forge_artifacts(push_cwd)
+    try:
+        fetch_proc = subprocess.run(
+            ["git", "fetch", "origin", base_branch],
+            capture_output=True,
+            text=True,
+            cwd=str(push_cwd),
+            timeout=60,
+        )
+        if fetch_proc.returncode != 0:
+            err = fetch_proc.stderr.strip() or fetch_proc.stdout.strip()
+            _pr_log.warning("git fetch failed (exit %d): %s", fetch_proc.returncode, err)
+            return {"success": False, "error": f"git fetch failed: {err}"}
+
+        rebase_proc = subprocess.run(
+            ["git", "rebase", f"origin/{base_branch}"],
+            capture_output=True,
+            text=True,
+            cwd=str(push_cwd),
+            timeout=120,
+        )
+        if rebase_proc.returncode != 0:
+            err = rebase_proc.stderr.strip() or rebase_proc.stdout.strip()
+            _pr_log.warning("git rebase failed (exit %d): %s", rebase_proc.returncode, err)
+            subprocess.run(
+                ["git", "rebase", "--abort"],
+                capture_output=True,
+                cwd=str(push_cwd),
+                timeout=30,
+            )
+            return {
+                "success": False,
+                "error": f"rebase onto {base_branch} failed — escalating: {err}",
+            }
+    except Exception as exc:
+        _pr_log.warning("rebase step failed: %s", exc)
+        return {"success": False, "error": f"rebase step failed: {exc}"}
+
+    return {"success": True}
+
+
+def _step_force_push(push_cwd: Path, branch_name: str) -> dict:
+    """Force-push the rebased branch to origin.
+
+    Returns ``{"success": True}`` or ``{"success": False, "error": ...}``.
+    A missing remote branch is treated as success (already cleaned up).
+    """
+    try:
+        push_proc = subprocess.run(
+            ["git", "push", "-f", "origin", branch_name],
+            capture_output=True,
+            text=True,
+            cwd=str(push_cwd),
+            timeout=60,
+        )
+        if push_proc.returncode != 0:
+            err = push_proc.stderr.strip() or push_proc.stdout.strip()
+            if "does not match any" in err.lower():
+                _pr_log.info(
+                    "force-push skipped because remote branch %s is already gone: %s",
+                    branch_name,
+                    err,
+                )
+                return {"success": True}
+            _pr_log.warning("force-push failed (exit %d): %s", push_proc.returncode, err)
+            return {"success": False, "error": f"force-push after rebase failed: {err}"}
+    except Exception as exc:
+        _pr_log.warning("force-push failed: %s", exc)
+        return {"success": False, "error": f"force-push after rebase failed: {exc}"}
+
+    return {"success": True}
+
+
+def _step_create_pr(
+    config: ForgeConfig,
+    task: TaskStory,
+    branch_name: str,
+    parsed_review: ReviewResult,
+    state: CoordinatorState,
+) -> dict:
+    """Create the GitHub PR (archives story, pushes branch).
+
+    Returns ``{"success": True, "pr_url": ...}`` or
+    ``{"success": False, "error": ..., "pr_url": ...}``.
+    """
+    pr_result = _create_pr(config, task, branch_name, parsed_review, state)
+    if not pr_result.get("success"):
+        return {
+            "success": False,
+            "error": pr_result.get("error") or "PR creation failed",
+            "pr_url": pr_result.get("pr_url"),
+        }
+    return {"success": True, "pr_url": pr_result["pr_url"]}
+
+
+def _step_merge(project_root: Path, pr_url: str, merge_strategy: str) -> dict:
+    """Execute ``gh pr merge --auto --{strategy}``.
+
+    Returns ``{"success": True}`` or
+    ``{"success": False, "error": ..., "retryable": bool}``.
+    """
+    merge_retry_error = "base branch was modified"
+    try:
+        merge_proc = subprocess.run(
+            ["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=120,
+        )
+    except Exception as exc:
+        _pr_log.warning("gh pr merge --auto failed: %s", exc)
+        return {"success": False, "error": f"gh pr merge failed: {exc}", "retryable": False}
+
+    if merge_proc.returncode != 0:
+        err = "\n".join(
+            part.strip()
+            for part in (merge_proc.stderr, merge_proc.stdout)
+            if part and part.strip()
+        )
+        _pr_log.warning("gh pr merge --auto failed (exit %d): %s", merge_proc.returncode, err)
+        return {
+            "success": False,
+            "error": f"gh pr merge failed: {err}",
+            "retryable": merge_retry_error in err.lower(),
+        }
+
+    return {"success": True}
+
+
+def _step_await_merge_state(project_root: Path, pr_url: str) -> dict:
+    """Check whether GitHub merged the PR immediately or queued it for checks.
+
+    Returns ``{"success": True, "merge_queued": bool, "auto_merge_queued": bool}``
+    or ``{"success": False, "error": ...}``.
+    """
+    try:
+        state_proc = subprocess.run(
+            ["gh", "pr", "view", pr_url, "--json", "state", "-q", ".state"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception as exc:
+        _pr_log.warning("gh pr view failed after auto-merge queue: %s", exc)
+        return {"success": False, "error": f"gh pr view failed after auto-merge queue: {exc}"}
+
+    if state_proc.returncode != 0:
+        state_err = state_proc.stderr.strip() or state_proc.stdout.strip()
+        _pr_log.warning(
+            "gh pr view failed after auto-merge queue (exit %d): %s",
+            state_proc.returncode,
+            state_err,
+        )
+        return {
+            "success": False,
+            "error": f"gh pr view failed after auto-merge queue: {state_err}",
+        }
+
+    pr_state = state_proc.stdout.strip()
+    queued = pr_state != "MERGED"
+    return {"success": True, "merge_queued": queued, "auto_merge_queued": queued}
+
+
+def _step_cleanup(
+    project_root: Path,
+    worktree_path: Path,
+    branch_name: str,
+    base_branch: str,
+    *,
+    delete_remote_branch: bool,
+) -> None:
+    """Best-effort local cleanup after a successful remote PR merge."""
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=60,
+        )
+        subprocess.run(
+            ["git", "merge", "--ff-only", f"origin/{base_branch}"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception as exc:
+        _pr_log.warning("local base_branch fast-forward failed (non-fatal): %s", exc)
+
+    try:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception as exc:
+        _pr_log.warning("worktree cleanup failed (non-fatal): %s", exc)
+
+    try:
+        subprocess.run(
+            ["git", "branch", "-D", branch_name],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception as exc:
+        _pr_log.warning("local branch cleanup failed (non-fatal): %s", exc)
+
+    if not delete_remote_branch:
+        return
+
+    try:
+        subprocess.run(
+            ["git", "push", "origin", "--delete", branch_name],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=60,
+        )
+    except Exception as exc:
+        _pr_log.warning("remote branch cleanup failed (non-fatal): %s", exc)
+
+
 def _merge_pr(
     config: ForgeConfig,
     task: TaskStory,
@@ -319,13 +554,17 @@ def _merge_pr(
     """Create a PR and immediately merge it via gh pr merge.
 
     Sequence:
-    1. Fetch + rebase onto latest origin/{base_branch} (escalate on conflict).
-    2. Force-push rebased branch so _create_pr's push is a fast-forward.
-    3. Call _create_pr() to archive story, push, and open the PR.
-    4. Merge via `gh pr merge --{strategy}` from the project root.
-    5. Best-effort local cleanup: fast-forward local base_branch, remove the
-       feature worktree, and delete the feature branch locally. Remote branch
-       deletion is deferred unless the PR is already merged.
+    1. Check if PR is already merged (fast-exit).
+    2. Fetch + rebase onto latest origin/{base_branch} (escalate on conflict).
+    3. Force-push rebased branch so _step_create_pr's push is a fast-forward.
+    4. Call _step_create_pr() to archive story, push, and open the PR (once only).
+    5. Merge via ``gh pr merge --auto --{strategy}`` from the project root.
+    6. Confirm PR state (MERGED or queued for auto-merge).
+    7. Best-effort local cleanup.
+
+    Each step's outcome is persisted to merge_state.yaml so a crash mid-merge
+    can be resumed from the last committed step.  Each step logs its outcome via
+    _pr_log so failures are independently auditable in the run log.
 
     Returns a result dict with keys: action, pr_url, merged, success, error.
     Never raises.
@@ -336,78 +575,28 @@ def _merge_pr(
     worktree_path = config.project_root / worktree_dir
     push_cwd = worktree_path if worktree_path.is_dir() else config.project_root
 
-    def _fail(error: str, *, pr_url: str | None = None, merged: bool = False) -> dict:
+    def _fail(error: str, *, merge_state: MergeStepState) -> dict:
+        merge_state.error = error
+        save_merge_state(worktree_path, merge_state)
         return {
             "action": "merge-pr",
-            "pr_url": pr_url,
-            "merged": merged,
+            "pr_url": merge_state.pr_url,
+            "merged": False,
             "merge_queued": False,
             "auto_merge_queued": False,
             "success": False,
             "error": error,
         }
 
-    def _cleanup_after_merge(*, delete_remote_branch: bool) -> None:
-        """Best-effort local cleanup after a successful remote PR merge."""
-        try:
-            subprocess.run(
-                ["git", "fetch", "origin"],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=60,
-            )
-            subprocess.run(
-                ["git", "merge", "--ff-only", f"origin/{base_branch}"],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=30,
-            )
-        except Exception as exc:
-            _pr_log.warning("local base_branch fast-forward failed (non-fatal): %s", exc)
+    def _complete_step(merge_state: MergeStepState, step: str, **log_kwargs: object) -> None:
+        merge_state.completed_steps.append(step)
+        save_merge_state(worktree_path, merge_state)
+        _pr_log.info("merge step %s completed: %s", step, log_kwargs)
 
-        try:
-            subprocess.run(
-                ["git", "worktree", "remove", "--force", str(worktree_path)],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=30,
-            )
-        except Exception as exc:
-            _pr_log.warning("worktree cleanup failed (non-fatal): %s", exc)
+    # Load any persisted step state (enables crash-resume).
+    merge_state = load_merge_state(worktree_path)
 
-        try:
-            subprocess.run(
-                ["git", "branch", "-D", branch_name],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=30,
-            )
-        except Exception as exc:
-            _pr_log.warning("local branch cleanup failed (non-fatal): %s", exc)
-
-        if not delete_remote_branch:
-            return
-
-        try:
-            subprocess.run(
-                ["git", "push", "origin", "--delete", branch_name],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=60,
-            )
-        except Exception as exc:
-            _pr_log.warning("remote branch cleanup failed (non-fatal): %s", exc)
-
-    pr_url: str | None = None
-    merge_queued = False
-    auto_merge_queued = False
-    merge_retry_error = "base branch was modified"
-
+    # Check if the PR is already merged (always runs — external state may have changed).
     try:
         merged_pr_proc = subprocess.run(
             [
@@ -436,7 +625,16 @@ def _merge_pr(
                     branch_name,
                     pr_url,
                 )
-                _cleanup_after_merge(delete_remote_branch=False)
+                if "cleanup" not in merge_state.completed_steps:
+                    _step_cleanup(
+                        config.project_root,
+                        worktree_path,
+                        branch_name,
+                        base_branch,
+                        delete_remote_branch=False,
+                    )
+                    _complete_step(merge_state, "cleanup", pr_url=pr_url)
+                delete_merge_state(worktree_path)
                 return {
                     "action": "merge-pr",
                     "pr_url": pr_url,
@@ -457,163 +655,103 @@ def _merge_pr(
     except Exception as exc:
         _pr_log.warning("Merged PR lookup failed for %s: %s", branch_name, exc)
 
+    # Retry loop: handles transient "base branch was modified" errors from GitHub.
     for attempt in range(MAX_MERGE_RETRIES):
-        # Step 1: defensively scrub tracked forge artifacts before rebase.
+        # fetch + rebase — always run per attempt (idempotent, needed for freshness).
+        fetch_rebase_result = _step_fetch_rebase(push_cwd, base_branch)
+        _pr_log.info(
+            "merge step fetch_rebase (attempt %d): success=%s error=%s",
+            attempt,
+            fetch_rebase_result["success"],
+            fetch_rebase_result.get("error"),
+        )
+        if not fetch_rebase_result["success"]:
+            return _fail(fetch_rebase_result["error"], merge_state=merge_state)
+
+        # force-push — always run per attempt.
+        force_push_result = _step_force_push(push_cwd, branch_name)
+        _pr_log.info(
+            "merge step force_push (attempt %d): success=%s error=%s",
+            attempt,
+            force_push_result["success"],
+            force_push_result.get("error"),
+        )
+        if not force_push_result["success"]:
+            return _fail(force_push_result["error"], merge_state=merge_state)
+
+        # create PR — only once; skip on resume if already completed.
+        if "create_pr" not in merge_state.completed_steps:
+            create_result = _step_create_pr(config, task, branch_name, parsed_review, state)
+            if not create_result["success"]:
+                return _fail(create_result["error"], merge_state=merge_state)
+            merge_state.pr_url = create_result["pr_url"]
+            _complete_step(merge_state, "create_pr", pr_url=merge_state.pr_url)
+
+        # Scrub forge artifacts before merge consumes the rewritten commit graph.
         _deindex_forge_artifacts(push_cwd)
 
-        # Step 2: fetch + rebase onto latest base_branch
-        try:
-            fetch_proc = subprocess.run(
-                ["git", "fetch", "origin", base_branch],
-                capture_output=True,
-                text=True,
-                cwd=str(push_cwd),
-                timeout=60,
+        # merge — skip on resume if already completed.
+        if "merge" not in merge_state.completed_steps:
+            merge_result = _step_merge(config.project_root, merge_state.pr_url, merge_strategy)
+            _pr_log.info(
+                "merge step merge (attempt %d): success=%s error=%s",
+                attempt,
+                merge_result["success"],
+                merge_result.get("error"),
             )
-            if fetch_proc.returncode != 0:
-                err = fetch_proc.stderr.strip() or fetch_proc.stdout.strip()
-                _pr_log.warning("git fetch failed (exit %d): %s", fetch_proc.returncode, err)
-                return _fail(f"git fetch failed: {err}", pr_url=pr_url)
-
-            rebase_proc = subprocess.run(
-                ["git", "rebase", f"origin/{base_branch}"],
-                capture_output=True,
-                text=True,
-                cwd=str(push_cwd),
-                timeout=120,
-            )
-            if rebase_proc.returncode != 0:
-                err = rebase_proc.stderr.strip() or rebase_proc.stdout.strip()
-                _pr_log.warning("git rebase failed (exit %d): %s", rebase_proc.returncode, err)
-                subprocess.run(
-                    ["git", "rebase", "--abort"],
-                    capture_output=True,
-                    cwd=str(push_cwd),
-                    timeout=30,
-                )
-                return _fail(
-                    f"rebase onto {base_branch} failed — escalating: {err}",
-                    pr_url=pr_url,
-                )
-        except Exception as exc:
-            _pr_log.warning("rebase step failed: %s", exc)
-            return _fail(f"rebase step failed: {exc}", pr_url=pr_url)
-
-        # Step 3: force-push the rebased branch so _create_pr's push is a fast-forward
-        try:
-            push_proc = subprocess.run(
-                ["git", "push", "-f", "origin", branch_name],
-                capture_output=True,
-                text=True,
-                cwd=str(push_cwd),
-                timeout=60,
-            )
-            if push_proc.returncode != 0:
-                err = push_proc.stderr.strip() or push_proc.stdout.strip()
-                err_lower = err.lower()
-                if "does not match any" in err_lower:
-                    _pr_log.info(
-                        "force-push skipped because remote branch %s is already gone: %s",
-                        branch_name,
-                        err,
-                    )
-                else:
-                    _pr_log.warning("force-push failed (exit %d): %s", push_proc.returncode, err)
-                    return _fail(f"force-push after rebase failed: {err}", pr_url=pr_url)
-        except Exception as exc:
-            _pr_log.warning("force-push failed: %s", exc)
-            return _fail(f"force-push after rebase failed: {exc}", pr_url=pr_url)
-
-        # Step 3: create the PR only once (also archives story + pushes archive commit)
-        if attempt == 0:
-            pr_result = _create_pr(config, task, branch_name, parsed_review, state)
-            if not pr_result.get("success"):
-                return _fail(
-                    pr_result.get("error") or "PR creation failed",
-                    pr_url=pr_result.get("pr_url"),
-                )
-            pr_url = pr_result["pr_url"]
-
-        # Step 4: defensively scrub tracked forge artifacts again after rebase,
-        # before any push/merge consumes the rewritten commit graph.
-        _deindex_forge_artifacts(push_cwd)
-
-        # Step 5: merge the PR via --auto so GitHub queues the merge and applies
-        # it only after all required checks pass. Running gh from the repo root
-        # avoids worktree branch checkout constraints.
-        try:
-            merge_proc = subprocess.run(
-                ["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=120,
-            )
-        except Exception as exc:
-            _pr_log.warning("gh pr merge --auto failed: %s", exc)
-            return _fail(f"gh pr merge failed: {exc}", pr_url=pr_url)
-
-        if merge_proc.returncode != 0:
-            err = "\n".join(
-                part.strip()
-                for part in (merge_proc.stderr, merge_proc.stdout)
-                if part and part.strip()
-            )
-            err_lower = err.lower()
-            _pr_log.warning("gh pr merge --auto failed (exit %d): %s", merge_proc.returncode, err)
-            if merge_retry_error in err_lower:
-                if attempt < MAX_MERGE_RETRIES - 1:
+            if not merge_result["success"]:
+                if merge_result.get("retryable") and attempt < MAX_MERGE_RETRIES - 1:
                     _pr_log.warning(
                         "base branch changed during PR merge attempt %d/%d; retrying",
                         attempt + 1,
                         MAX_MERGE_RETRIES,
                     )
                     continue
-            return _fail(f"gh pr merge failed: {err}", pr_url=pr_url)
+                return _fail(merge_result["error"], merge_state=merge_state)
+            _complete_step(merge_state, "merge")
 
         # Determine whether GitHub merged immediately or queued for checks.
-        try:
-            state_proc = subprocess.run(
-                ["gh", "pr", "view", pr_url, "--json", "state", "-q", ".state"],
-                capture_output=True,
-                text=True,
-                cwd=str(config.project_root),
-                timeout=30,
+        if "await_merge_state" not in merge_state.completed_steps:
+            await_result = _step_await_merge_state(config.project_root, merge_state.pr_url)
+            if not await_result["success"]:
+                return _fail(await_result["error"], merge_state=merge_state)
+            merge_state.merge_queued = await_result["merge_queued"]
+            merge_state.auto_merge_queued = await_result["auto_merge_queued"]
+            _complete_step(
+                merge_state,
+                "await_merge_state",
+                merge_queued=merge_state.merge_queued,
+                pr_url=merge_state.pr_url,
             )
-        except Exception as exc:
-            _pr_log.warning("gh pr view failed after auto-merge queue: %s", exc)
-            return _fail(f"gh pr view failed after auto-merge queue: {exc}", pr_url=pr_url)
 
-        if state_proc.returncode != 0:
-            state_err = state_proc.stderr.strip() or state_proc.stdout.strip()
-            _pr_log.warning(
-                "gh pr view failed after auto-merge queue (exit %d): %s",
-                state_proc.returncode,
-                state_err,
-            )
-            return _fail(f"gh pr view failed after auto-merge queue: {state_err}", pr_url=pr_url)
+        break  # success — exit retry loop
 
-        pr_state = state_proc.stdout.strip()
-        if pr_state == "MERGED":
-            break
-
-        merge_queued = True
-        auto_merge_queued = True
-        break
+    merge_queued = merge_state.merge_queued
+    auto_merge_queued = merge_state.auto_merge_queued
 
     if merge_queued:
-        _log(f"  ✓ PR queued for auto-merge: {pr_url}")
+        _log(f"  ✓ PR queued for auto-merge: {merge_state.pr_url}")
     else:
-        _log(f"  ✓ PR merged: {pr_url}")
+        _log(f"  ✓ PR merged: {merge_state.pr_url}")
 
-    # Step 6: sync local state and clean up the merged feature worktree/branch.
+    # Sync local state and clean up the merged feature worktree/branch.
     # Preserve the remote branch when GitHub only queued auto-merge; branch
     # protection still needs that ref until the hosted merge completes.
-    _cleanup_after_merge(delete_remote_branch=not merge_queued)
+    if "cleanup" not in merge_state.completed_steps:
+        _step_cleanup(
+            config.project_root,
+            worktree_path,
+            branch_name,
+            base_branch,
+            delete_remote_branch=not merge_queued,
+        )
+        _complete_step(merge_state, "cleanup", pr_url=merge_state.pr_url)
+
+    delete_merge_state(worktree_path)
 
     return {
         "action": "merge-pr",
-        "pr_url": pr_url,
+        "pr_url": merge_state.pr_url,
         "merged": not merge_queued,
         "merge_queued": merge_queued,
         "success": True,

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -23,7 +23,7 @@ from theforge.task import TaskStory, load_story
 from . import util as _cu
 from .logging import StructuredLogger
 from .notify import _escalate_notify
-from .state import CoordinatorResult, CoordinatorState, Phase
+from .state import CoordinatorResult, CoordinatorState, MergeStepState, Phase
 
 _logger = logging.getLogger(__name__)
 
@@ -91,6 +91,63 @@ def load_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
         ]
     if "surviving_families" in data and isinstance(data["surviving_families"], list):
         state.surviving_families = data["surviving_families"]
+
+
+def save_merge_state(workspace_path: Path, merge_state: MergeStepState) -> None:
+    """Persist merge step state to <workspace_path>/.forge/merge_state.yaml.
+
+    Called after each step in _merge_pr so a crash can be resumed from the last
+    committed step.  Follows the same sidecar pattern as save_trajectory_state.
+    """
+    sidecar = workspace_path / ".forge" / "merge_state.yaml"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "completed_steps": list(merge_state.completed_steps),
+        "pr_url": merge_state.pr_url,
+        "merge_queued": merge_state.merge_queued,
+        "auto_merge_queued": merge_state.auto_merge_queued,
+        "error": merge_state.error,
+        "last_updated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    sidecar.write_text(yaml.dump(data, allow_unicode=True), encoding="utf-8")
+
+
+def load_merge_state(workspace_path: Path) -> MergeStepState:
+    """Restore merge step state from <workspace_path>/.forge/merge_state.yaml.
+
+    Returns a fresh MergeStepState if the sidecar is missing or corrupt.
+    """
+    sidecar = workspace_path / ".forge" / "merge_state.yaml"
+    if not sidecar.exists():
+        return MergeStepState()
+    try:
+        raw = sidecar.read_text(encoding="utf-8")
+        if not raw.strip():
+            return MergeStepState()
+        data = yaml.safe_load(raw)
+        if not isinstance(data, dict):
+            _logger.warning("merge_state.yaml: expected a dict, got %s — ignoring", type(data))
+            return MergeStepState()
+        completed = data.get("completed_steps")
+        return MergeStepState(
+            completed_steps=list(completed) if isinstance(completed, list) else [],
+            pr_url=data.get("pr_url"),
+            merge_queued=bool(data.get("merge_queued", False)),
+            auto_merge_queued=bool(data.get("auto_merge_queued", False)),
+            error=data.get("error"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("merge_state.yaml: failed to parse (%s) — ignoring", exc)
+        return MergeStepState()
+
+
+def delete_merge_state(workspace_path: Path) -> None:
+    """Remove the merge step state sidecar on clean completion."""
+    sidecar = workspace_path / ".forge" / "merge_state.yaml"
+    try:
+        sidecar.unlink(missing_ok=True)
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("merge_state.yaml: failed to delete (%s) — ignoring", exc)
 
 
 def _rebase_onto_main(worktree_path: str, base_branch: str, logger) -> tuple[bool, str]:

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -102,6 +102,21 @@ Disposition = Literal[
 
 
 @dataclass
+class MergeStepState:
+    """Persistent step-state for a resumable _merge_pr execution.
+
+    Written to <workspace_path>/.forge/merge_state.yaml after each step so a
+    crash mid-merge can be resumed from the last committed step.
+    """
+
+    completed_steps: list[str] = field(default_factory=list)
+    pr_url: str | None = None
+    merge_queued: bool = False
+    auto_merge_queued: bool = False
+    error: str | None = None
+
+
+@dataclass
 class FindingRecord:
     """Persistent record of a finding across review cycles.
 

--- a/tests/test_coord_merge_step_state.py
+++ b/tests/test_coord_merge_step_state.py
@@ -558,3 +558,94 @@ class TestMergePrStepStateResume:
         assert "merge" in logged_steps
         assert "await_merge_state" in logged_steps
         assert "cleanup" in logged_steps
+
+    def test_zero_delta_branch_returns_success_without_merge(self, tmp_path: Path) -> None:
+        """Zero-delta skip path: return success immediately, do not persist pr_url=None."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        zero_delta_pr_result = {
+            "action": "pr",
+            "pr_url": None,
+            "success": True,
+            "error": None,
+            "skipped": True,
+            "skip_reason": "zero-delta branch",
+            "ahead_commit_count": 0,
+        }
+
+        merge_calls: list = []
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                merge_calls.append(cmd)
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value=zero_delta_pr_result,
+            ),
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        # Zero-delta: success but no merge attempted.
+        assert result["success"] is True
+        assert result["pr_url"] is None
+        assert result.get("skipped") is True
+        assert result.get("skip_reason") == "zero-delta branch"
+        assert merge_calls == []
+
+        # merge_state.yaml must be cleaned up (not persisted with pr_url=None).
+        sidecar = self._worktree_path(tmp_path) / ".forge" / "merge_state.yaml"
+        assert not sidecar.exists()
+
+    def test_resume_after_merge_skips_fetch_rebase_and_force_push(self, tmp_path: Path) -> None:
+        """Resuming after merge is complete must not force-push, which could cancel auto-merge."""
+        self._write_state(
+            tmp_path,
+            completed_steps=["create_pr", "merge"],
+            pr_url=PR_URL,
+            merge_queued=False,
+            auto_merge_queued=False,
+        )
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        git_push_calls: list = []
+        git_fetch_rebase_calls: list = []
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            if isinstance(cmd, list) and cmd[:4] == ["git", "push", "-f", "origin"]:
+                git_push_calls.append(cmd)
+            if isinstance(cmd, list) and "rebase" in cmd:
+                git_fetch_rebase_calls.append(cmd)
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch("theforge.coordinator.completion._create_pr") as mock_create_pr,
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        # force-push must NOT run after merge is already complete.
+        assert git_push_calls == [], "force-push must not run when resuming after merge"
+        assert git_fetch_rebase_calls == [], "rebase must not run when resuming after merge"
+        mock_create_pr.assert_not_called()

--- a/tests/test_coord_merge_step_state.py
+++ b/tests/test_coord_merge_step_state.py
@@ -1,0 +1,560 @@
+"""Tests for merge step-state persistence and crash-resume in _merge_pr."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.coordinator.completion import (
+    _merge_pr,
+    _step_await_merge_state,
+    _step_fetch_rebase,
+    _step_force_push,
+    _step_merge,
+)
+from theforge.coordinator.run_setup import (
+    delete_merge_state,
+    load_merge_state,
+    save_merge_state,
+)
+from theforge.coordinator.state import MergeStepState
+
+# ── MergeStepState persistence helpers ────────────────────────────────
+
+
+class TestMergeStatePersistence:
+    def test_load_returns_fresh_state_when_no_sidecar(self, tmp_path: Path) -> None:
+        state = load_merge_state(tmp_path)
+        assert state.completed_steps == []
+        assert state.pr_url is None
+        assert state.merge_queued is False
+        assert state.auto_merge_queued is False
+        assert state.error is None
+
+    def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
+        ms = MergeStepState(
+            completed_steps=["create_pr", "merge"],
+            pr_url="https://github.com/owner/repo/pull/99",
+            merge_queued=True,
+            auto_merge_queued=True,
+            error=None,
+        )
+        save_merge_state(tmp_path, ms)
+        loaded = load_merge_state(tmp_path)
+        assert loaded.completed_steps == ["create_pr", "merge"]
+        assert loaded.pr_url == "https://github.com/owner/repo/pull/99"
+        assert loaded.merge_queued is True
+        assert loaded.auto_merge_queued is True
+        assert loaded.error is None
+
+    def test_save_writes_last_updated(self, tmp_path: Path) -> None:
+        import yaml
+
+        ms = MergeStepState(completed_steps=["create_pr"])
+        save_merge_state(tmp_path, ms)
+        sidecar = tmp_path / ".forge" / "merge_state.yaml"
+        data = yaml.safe_load(sidecar.read_text())
+        assert "last_updated" in data
+        assert data["last_updated"]  # non-empty ISO timestamp
+
+    def test_delete_removes_sidecar(self, tmp_path: Path) -> None:
+        save_merge_state(tmp_path, MergeStepState(completed_steps=["create_pr"]))
+        sidecar = tmp_path / ".forge" / "merge_state.yaml"
+        assert sidecar.exists()
+        delete_merge_state(tmp_path)
+        assert not sidecar.exists()
+
+    def test_delete_is_idempotent_when_no_sidecar(self, tmp_path: Path) -> None:
+        # Should not raise even if file doesn't exist.
+        delete_merge_state(tmp_path)
+
+    def test_load_returns_fresh_state_on_corrupt_sidecar(self, tmp_path: Path) -> None:
+        sidecar = tmp_path / ".forge" / "merge_state.yaml"
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
+        sidecar.write_text("not: valid: yaml: [[[", encoding="utf-8")
+        state = load_merge_state(tmp_path)
+        assert state.completed_steps == []
+
+    def test_load_returns_fresh_state_on_empty_sidecar(self, tmp_path: Path) -> None:
+        sidecar = tmp_path / ".forge" / "merge_state.yaml"
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
+        sidecar.write_text("", encoding="utf-8")
+        state = load_merge_state(tmp_path)
+        assert state.completed_steps == []
+
+    def test_load_handles_non_dict_sidecar(self, tmp_path: Path) -> None:
+        sidecar = tmp_path / ".forge" / "merge_state.yaml"
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
+        sidecar.write_text("- a\n- b\n", encoding="utf-8")
+        state = load_merge_state(tmp_path)
+        assert state.completed_steps == []
+
+    def test_load_handles_invalid_completed_steps(self, tmp_path: Path) -> None:
+        import yaml
+
+        sidecar = tmp_path / ".forge" / "merge_state.yaml"
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
+        sidecar.write_text(yaml.dump({"completed_steps": "not-a-list"}), encoding="utf-8")
+        state = load_merge_state(tmp_path)
+        assert state.completed_steps == []
+
+
+# ── Step function unit tests ──────────────────────────────────────────
+
+
+def _ok(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+class TestStepFetchRebase:
+    def test_success(self, tmp_path: Path) -> None:
+        with patch("theforge.coordinator.completion.subprocess.run", return_value=_ok()):
+            with patch("theforge.coordinator.completion._deindex_forge_artifacts"):
+                result = _step_fetch_rebase(tmp_path, "main")
+        assert result["success"] is True
+
+    def test_fetch_failure(self, tmp_path: Path) -> None:
+        fetch_fail = _ok(1, stderr="network error")
+
+        def fake_run(cmd, **kw):
+            if "fetch" in cmd:
+                return fetch_fail
+            return _ok()
+
+        with patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run):
+            with patch("theforge.coordinator.completion._deindex_forge_artifacts"):
+                result = _step_fetch_rebase(tmp_path, "main")
+        assert result["success"] is False
+        assert "fetch" in result["error"].lower()
+
+    def test_rebase_failure_aborts_and_returns_error(self, tmp_path: Path) -> None:
+        def fake_run(cmd, **kw):
+            if "rebase" in cmd and "--abort" not in cmd:
+                return _ok(1, stderr="conflict!")
+            return _ok()
+
+        with patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run):
+            with patch("theforge.coordinator.completion._deindex_forge_artifacts"):
+                result = _step_fetch_rebase(tmp_path, "main")
+        assert result["success"] is False
+        assert "rebase" in result["error"].lower() or "escalat" in result["error"].lower()
+
+
+class TestStepForcePush:
+    def test_success(self, tmp_path: Path) -> None:
+        with patch("theforge.coordinator.completion.subprocess.run", return_value=_ok()):
+            result = _step_force_push(tmp_path, "feat/my-branch")
+        assert result["success"] is True
+
+    def test_missing_refspec_is_success(self, tmp_path: Path) -> None:
+        gone = _ok(1, stderr="error: src refspec feat/my-branch does not match any")
+        with patch("theforge.coordinator.completion.subprocess.run", return_value=gone):
+            result = _step_force_push(tmp_path, "feat/my-branch")
+        assert result["success"] is True
+
+    def test_push_failure(self, tmp_path: Path) -> None:
+        with patch(
+            "theforge.coordinator.completion.subprocess.run", return_value=_ok(1, stderr="denied")
+        ):
+            result = _step_force_push(tmp_path, "feat/my-branch")
+        assert result["success"] is False
+        assert "push" in result["error"].lower()
+
+
+class TestStepMerge:
+    def test_success(self, tmp_path: Path) -> None:
+        with patch("theforge.coordinator.completion.subprocess.run", return_value=_ok()):
+            result = _step_merge(tmp_path, "https://github.com/o/r/pull/1", "squash")
+        assert result["success"] is True
+        assert "retryable" not in result
+
+    def test_retryable_error(self, tmp_path: Path) -> None:
+        err = _ok(1, stderr="GraphQL: Base branch was modified. Review and try the merge again.")
+        with patch("theforge.coordinator.completion.subprocess.run", return_value=err):
+            result = _step_merge(tmp_path, "https://github.com/o/r/pull/1", "squash")
+        assert result["success"] is False
+        assert result["retryable"] is True
+
+    def test_non_retryable_error(self, tmp_path: Path) -> None:
+        err = _ok(1, stderr="some other unrelated merge error")
+        with patch("theforge.coordinator.completion.subprocess.run", return_value=err):
+            result = _step_merge(tmp_path, "https://github.com/o/r/pull/1", "squash")
+        assert result["success"] is False
+        assert result["retryable"] is False
+
+
+class TestStepAwaitMergeState:
+    def test_merged_immediately(self, tmp_path: Path) -> None:
+        with patch(
+            "theforge.coordinator.completion.subprocess.run", return_value=_ok(0, stdout="MERGED")
+        ):
+            result = _step_await_merge_state(tmp_path, "https://github.com/o/r/pull/1")
+        assert result["success"] is True
+        assert result["merge_queued"] is False
+        assert result["auto_merge_queued"] is False
+
+    def test_queued_for_checks(self, tmp_path: Path) -> None:
+        with patch(
+            "theforge.coordinator.completion.subprocess.run", return_value=_ok(0, stdout="OPEN")
+        ):
+            result = _step_await_merge_state(tmp_path, "https://github.com/o/r/pull/1")
+        assert result["success"] is True
+        assert result["merge_queued"] is True
+        assert result["auto_merge_queued"] is True
+
+    def test_gh_view_failure(self, tmp_path: Path) -> None:
+        with patch(
+            "theforge.coordinator.completion.subprocess.run",
+            return_value=_ok(1, stderr="not found"),
+        ):
+            result = _step_await_merge_state(tmp_path, "https://github.com/o/r/pull/1")
+        assert result["success"] is False
+        assert "error" in result
+
+
+# ── _merge_pr crash-resume tests ─────────────────────────────────────
+
+PR_URL = "https://github.com/fuzzypete/theforge/pull/42"
+
+
+def _make_config(tmp_path: Path):
+    from theforge.config import (
+        DEFAULT_DEV_PROFILE,
+        DEFAULT_PREFLIGHT_PROFILE,
+        DEFAULT_REVIEW_PROFILE,
+        DEFAULT_VALIDATION,
+        ForgeConfig,
+        LogConfig,
+        RetryPolicy,
+        WorkspaceConfig,
+    )
+
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+            on_approve="merge-pr",
+            auto_push=True,
+            merge_strategy="squash",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _make_task(tmp_path: Path):
+    from theforge.task import TaskStory
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Test", encoding="utf-8")
+    return TaskStory(name="Test Task", story_path=spec, slug="test-task")
+
+
+def _make_review():
+    from theforge.review import ReviewResult
+
+    return ReviewResult(
+        verdict="APPROVE",
+        summary="Looks good.",
+        findings=[],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+class TestMergePrStepStateResume:
+    """Tests that _merge_pr correctly resumes from persisted step state."""
+
+    def _worktree_path(self, tmp_path: Path) -> Path:
+        return tmp_path / "test-task"
+
+    def _write_state(self, tmp_path: Path, **kwargs) -> None:
+        ms = MergeStepState(**kwargs)
+        save_merge_state(self._worktree_path(tmp_path), ms)
+
+    def _patches(self):
+        """Return context managers that stub out subprocess and _create_pr."""
+        return (
+            patch(
+                "theforge.coordinator.completion.subprocess.run",
+                return_value=_ok(0, stdout="MERGED"),
+            ),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={"action": "pr", "pr_url": PR_URL, "success": True, "error": None},
+            ),
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        )
+
+    def _run(self, tmp_path: Path, *, gh_list_stdout: str = "[]"):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout=gh_list_stdout)
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={"action": "pr", "pr_url": PR_URL, "success": True, "error": None},
+            ) as mock_create_pr,
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        return result, mock_create_pr
+
+    def test_fresh_run_writes_and_deletes_sidecar(self, tmp_path: Path) -> None:
+        result, _ = self._run(tmp_path)
+        assert result["success"] is True
+        # Sidecar should be cleaned up on success.
+        sidecar = self._worktree_path(tmp_path) / ".forge" / "merge_state.yaml"
+        assert not sidecar.exists()
+
+    def test_resume_skips_create_pr_when_already_completed(self, tmp_path: Path) -> None:
+        # Pre-populate state as if create_pr already succeeded.
+        self._write_state(
+            tmp_path,
+            completed_steps=["create_pr"],
+            pr_url=PR_URL,
+        )
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch("theforge.coordinator.completion._create_pr") as mock_create_pr,
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        assert result["pr_url"] == PR_URL
+        # _create_pr must NOT be called again on resume.
+        mock_create_pr.assert_not_called()
+
+    def test_resume_skips_merge_when_already_completed(self, tmp_path: Path) -> None:
+        # Pre-populate state as if merge already succeeded.
+        self._write_state(
+            tmp_path,
+            completed_steps=["create_pr", "merge"],
+            pr_url=PR_URL,
+        )
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        merge_calls: list = []
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                merge_calls.append(cmd)
+                return _ok(0)
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch("theforge.coordinator.completion._create_pr") as mock_create_pr,
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        # merge command must NOT be called again.
+        assert merge_calls == []
+        mock_create_pr.assert_not_called()
+
+    def test_resume_skips_await_merge_state_when_already_completed(self, tmp_path: Path) -> None:
+        # Pre-populate state as if await_merge_state already ran (queued).
+        self._write_state(
+            tmp_path,
+            completed_steps=["create_pr", "merge", "await_merge_state"],
+            pr_url=PR_URL,
+            merge_queued=True,
+            auto_merge_queued=True,
+        )
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        view_calls: list = []
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                view_calls.append(cmd)
+                return _ok(0, stdout="MERGED")
+            return _ok(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch("theforge.coordinator.completion._create_pr") as mock_create_pr,
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        # merge_queued restored from state, not from a fresh gh pr view call.
+        assert result["merge_queued"] is True
+        assert view_calls == []
+        mock_create_pr.assert_not_called()
+
+    def test_resume_skips_cleanup_when_already_completed(self, tmp_path: Path) -> None:
+        # Pre-populate state as if cleanup already ran.
+        self._write_state(
+            tmp_path,
+            completed_steps=["create_pr", "merge", "await_merge_state", "cleanup"],
+            pr_url=PR_URL,
+            merge_queued=False,
+            auto_merge_queued=False,
+        )
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        cleanup_related: list = []
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            if isinstance(cmd, list) and "worktree" in cmd:
+                cleanup_related.append("worktree")
+            if isinstance(cmd, list) and cmd[:3] == ["git", "branch", "-D"]:
+                cleanup_related.append("branch-delete")
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch("theforge.coordinator.completion._create_pr") as mock_create_pr,
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        assert cleanup_related == []  # cleanup was skipped
+        mock_create_pr.assert_not_called()
+
+    def test_failure_persists_error_to_sidecar(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            if isinstance(cmd, list) and "fetch" in cmd:
+                return _ok(1, stderr="network failure")
+            return _ok(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch("theforge.coordinator.completion._create_pr"),
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is False
+        # Error should be persisted so humans can inspect mid-merge state.
+        worktree_path = tmp_path / "test-task"
+        loaded = load_merge_state(worktree_path)
+        assert loaded.error is not None
+        assert "fetch" in loaded.error.lower() or "network" in loaded.error.lower()
+
+    def test_step_outcomes_logged_via_pr_log(self, tmp_path: Path) -> None:
+        """Each step should log its outcome via _pr_log.info for independent auditability."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        logged_steps: list[str] = []
+
+        def capture_info(msg, *args, **kw):
+            if "merge step" in str(msg):
+                # Render the format string so we see the actual step name.
+                try:
+                    rendered = str(msg) % args if args else str(msg)
+                except Exception:
+                    rendered = str(msg)
+                parts = rendered.split()
+                if len(parts) >= 3:
+                    logged_steps.append(parts[2])
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={"action": "pr", "pr_url": PR_URL, "success": True, "error": None},
+            ),
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+            patch("theforge.coordinator.completion._pr_log") as mock_log,
+        ):
+            mock_log.info.side_effect = capture_info
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        # Each major step should log its outcome.
+        assert "fetch_rebase" in logged_steps
+        assert "force_push" in logged_steps
+        assert "create_pr" in logged_steps
+        assert "merge" in logged_steps
+        assert "await_merge_state" in logged_steps
+        assert "cleanup" in logged_steps


### PR DESCRIPTION
## Summary

[openai-reviewer] Prior P1 issues are fixed, and I did not find any new blocking regressions in the refactor to resumable merge steps. | [gemini-reviewer] The refactoring of _merge_pr into resumable steps is complete and addresses all previous findings.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.91
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

refactor: break _merge_pr into resumable steps (GitHub Issue #607)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #607