### PR TITLE
fix: reset reviewer demotion counter between review cycles

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -502,6 +502,10 @@ def _run_review_phase(
     state.phase = Phase.REVIEW
     if logger:
         logger._safe_emit("phase_start", phase="REVIEW", iteration=state.review_cycle + 1)
+    # Reset per-cycle parse failure counts so transient failures from one cycle
+    # do not accumulate into the next. Permanent demotions are tracked separately
+    # in state.reviewer_demoted, which is never reset.
+    state.reviewer_parse_failure_counts = {}
     max_parse_retries = config.retry.max_review_parse_retries
     _review_pool_start = time.monotonic()
     _pool_model_names = "+".join(p.model for p in config.review_pool)

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -145,9 +145,8 @@ def _run_review_pool(
     if demotion_threshold > 0:
         active_pool: list = []
         for profile in pool:
-            failure_count = state.reviewer_parse_failure_counts.get(profile.name, 0)
-            if failure_count >= demotion_threshold:
-                _log(f"⚠ {profile.name} demoted after {failure_count} parse failures this run")
+            if profile.name in state.reviewer_demoted:
+                _log(f"⚠ {profile.name} demoted due to parse failures in a previous cycle")
                 continue
             active_pool.append(profile)
         pool = active_pool
@@ -436,6 +435,7 @@ def _run_review_pool(
             failure_count = state.reviewer_parse_failure_counts.get(name, 0) + 1
             state.reviewer_parse_failure_counts[name] = failure_count
             if failure_count >= demotion_threshold:
+                state.reviewer_demoted.add(name)
                 _log(f"⚠ {name} demoted after {failure_count} parse failures this run")
 
     # Individual parsed results (no parse errors) — used by caller for fallback

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -224,6 +224,9 @@ class CoordinatorState:
     plan_review_session_ids: dict[str, str] = field(default_factory=dict)  # keyed by profile.name
     reviewer_session_ids: dict[str, str] = field(default_factory=dict)  # keyed by profile.name
     reviewer_parse_failure_counts: dict[str, int] = field(default_factory=dict)
+    reviewer_demoted: set[str] = field(
+        default_factory=set
+    )  # reviewers permanently demoted this run
     review_cycle: int = 0  # which dev→review loop we're on
     # dev_iteration is an InitVar: accepted as a constructor kwarg for backward
     # compatibility (tests pass dev_iteration=N directly), but not stored as a

--- a/tests/test_coord_review_pool.py
+++ b/tests/test_coord_review_pool.py
@@ -213,3 +213,121 @@ class TestReviewerDemotion:
             "⚠ solo demoted after 1 parse failures this run" in str(c)
             for c in mock_log.call_args_list
         )
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_failures_below_threshold_across_cycles_not_demoted(
+        self, mock_pool, _mock_log_agent_result, tmp_path
+    ):
+        """Reviewer fails once per cycle but never reaches threshold in a cycle — not demoted."""
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = _make_pool_config(tmp_path, [r1, r2], r1)
+        config = config.__class__(
+            **{**config.__dict__, "retry": RetryPolicy(demotion_threshold=3)}
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=PARSE_ERROR_OUTPUT, profile_name="r1"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r2"),
+        ]
+
+        # Cycle 1: r1 fails once (count=1, < threshold=3)
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            _meta(),
+            notify=False,
+            enforce_budgets=False,
+        )
+        assert state.reviewer_parse_failure_counts == {"r1": 1}
+
+        # Simulate cycle boundary: _run_review_phase resets the per-cycle counter
+        state.reviewer_parse_failure_counts = {}
+
+        # Cycle 2: r1 fails again (starts fresh from 0, count=1 again, still < threshold=3)
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            _meta(),
+            notify=False,
+            enforce_budgets=False,
+        )
+        assert state.reviewer_parse_failure_counts == {"r1": 1}
+
+        # r1 never hit the threshold in any single cycle → not demoted
+        assert "r1" not in state.reviewer_demoted
+        # Both cycles used the full pool (r1 was not filtered out)
+        assert all(call.kwargs["profiles"] == [r1, r2] for call in mock_pool.call_args_list)
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_demotion_persists_across_cycle_boundary(
+        self, mock_pool, _mock_log_agent_result, tmp_path
+    ):
+        """Reviewer that hits threshold within one cycle stays demoted after counter reset."""
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = _make_pool_config(tmp_path, [r1, r2], r1)
+        config = config.__class__(
+            **{**config.__dict__, "retry": RetryPolicy(demotion_threshold=1)}
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.side_effect = [
+            # Cycle 1: r1 fails (threshold=1 → immediately demoted)
+            [
+                _make_agent_result(success=True, output=PARSE_ERROR_OUTPUT, profile_name="r1"),
+                _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r2"),
+            ],
+            # Cycle 2: only r2 should be in pool
+            [_make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r2")],
+        ]
+
+        # Cycle 1: r1 hits threshold → added to reviewer_demoted
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            _meta(),
+            notify=False,
+            enforce_budgets=False,
+        )
+        assert "r1" in state.reviewer_demoted
+
+        # Simulate cycle boundary: _run_review_phase resets the per-cycle counter
+        state.reviewer_parse_failure_counts = {}
+
+        # Cycle 2: counter is clear, but demotion set preserves r1's demotion
+        successful, _, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            _meta(),
+            notify=False,
+            enforce_budgets=False,
+        )
+        assert merged is not None
+        assert [r.profile_name for r in successful] == ["r2"]
+        assert mock_pool.call_args_list[1].kwargs["profiles"] == [r2]


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation correctly resets per-cycle reviewer parse-failure counts while preserving within-run demotions once a reviewer hits the threshold in a cycle. | [gemini-reviewer] The implementation correctly resets the reviewer demotion counter between cycles while preserving permanent demotions.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.53
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/audit.py:1`** Project Convention 6 violation: The new `reviewer_demoted` state field is not serialized in the audit log. When adding data that flows between coordinator phases, it must be instrumented in the audit trail.

## Story

fix: reset reviewer demotion counter between review cycles (GitHub Issue #610)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #610