### PR TITLE
fix: separate landing status from review approval in CoordinatorResult

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -487,6 +487,15 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
         ),
         "merge": result.merge,
         "landing_status": getattr(result, "landing_status", None),
+        "landing_event": (
+            {
+                "landing_status": result.landing_status,
+                "landed": result.landing_status == "landed",
+                "timestamp": finished_at_str,
+            }
+            if result.landing_status is not None
+            else None
+        ),
         "escalation": (
             {
                 "reason": state.escalate_reason,

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -989,8 +989,7 @@ def _run_resume_coordinator(
             elif _merge_info.get("merge_queued"):
                 result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
             elif _landing_status == "failed":
-                if _effective_on_approve == "merge-pr":
-                    result.success = False
+                result.success = False
                 result.message += f" Merge failed: {_merge_info.get('error', 'unknown')}"
 
         _total_elapsed = time.monotonic() - _task_start

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -830,11 +830,7 @@ def run_task(
             elif _merge_info.get("merge_queued"):
                 result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
             elif _landing_status == "failed":
-                # merge-pr: landing IS part of the story contract — a failed
-                # PR merge means the story did not complete.  Local auto-merge
-                # failures are non-fatal (safety guards, dirty worktree, etc.).
-                if _effective_on_approve == "merge-pr":
-                    result.success = False
+                result.success = False
                 result.message += f" Merge failed: {_merge_info.get('error', 'unknown')}"
 
         _total_elapsed = time.monotonic() - _task_start

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -879,6 +879,7 @@ def run_sprint(
                             _write_story_audit(config, dep_task, dep_result)
                         else:
                             dep_result.landing_status = "failed"
+                            dep_result.success = False
                             if poll_result["status"] == "timeout":
                                 dep_result.state.error = (
                                     f"Queued PR timed out after "
@@ -1017,6 +1018,7 @@ def run_sprint(
                         specs_succeeded -= 1
                         specs_failed += 1
                         _qp_result.landing_status = "failed"
+                        _qp_result.success = False
                         if _qp_poll["status"] == "timeout":
                             _qp_result.state.error = (
                                 f"Queued PR timed out after "
@@ -1221,6 +1223,7 @@ def run_sprint(
                 specs_succeeded -= 1
                 specs_failed += 1
                 result.landing_status = "failed"
+                result.success = False
                 if poll_result["status"] == "timeout":
                     result.state.error = (
                         f"Queued PR timed out after "

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -498,18 +498,21 @@ def _classify_and_record(
         dag.mark_complete(task.slug)
         return delta_succeeded, delta_failed, delta_skipped
 
-    if landing_status == "failed":
+    if landing_status == "landed":
+        delta_succeeded = 1
+        merged_slugs.add(task.slug)
+        dag.mark_complete(task.slug)
+    elif landing_status == "failed":
         delta_failed = 1
         dag.mark_skipped(task.slug)
-    elif result.success:
+    elif landing_status == "pending_integration":
+        # Approved but merge deferred or queued — counts as succeeded, not yet in DAG
         delta_succeeded = 1
-        if landing_status == "landed" or (
-            result.merge is not None and result.merge.get("merged", False)
-        ):
-            merged_slugs.add(task.slug)
-            dag.mark_complete(task.slug)
-        else:
-            dag.mark_skipped(task.slug)
+        dag.mark_skipped(task.slug)
+    elif result.success:
+        # No merge operation performed (on_approve=none or similar)
+        delta_succeeded = 1
+        dag.mark_skipped(task.slug)
     else:
         delta_failed = 1
         dag.mark_skipped(task.slug)
@@ -813,6 +816,8 @@ def run_sprint(
 
         result.merge = merge_info
         result.landing_status = landing_status
+        if landing_status == "failed":
+            result.success = False
 
         if merge_info.get("merged"):
             merged_slugs.add(slug)
@@ -1160,6 +1165,10 @@ def run_sprint(
                     integrated = _attempt_integration(slug, task, result)
                     if not integrated:
                         pending_integration[slug] = (task, result)
+                    elif result.landing_status == "failed":
+                        # Optimistic classify counted this as succeeded; landing failed.
+                        specs_succeeded -= ds
+                        specs_failed += 1
                     changed = True
                     while changed:
                         changed = False
@@ -1168,6 +1177,10 @@ def run_sprint(
                         ):
                             if _attempt_integration(pending_slug, pending_task, pending_result):
                                 del pending_integration[pending_slug]
+                                if pending_result.landing_status == "failed":
+                                    # Correct the optimistic classify for this pending story
+                                    specs_succeeded -= 1
+                                    specs_failed += 1
                                 changed = True
                 else:
                     _write_story_audit(config, task, result)

--- a/tests/test_coord_completion.py
+++ b/tests/test_coord_completion.py
@@ -1,0 +1,177 @@
+"""Tests for CoordinatorResult success/landing separation and audit landing_event.
+
+Covers:
+- result.success is False when landing_status is "failed" (engine and sprint paths)
+- generate_audit_log emits a landing_event block separate from the outcome block
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.task import TaskStory
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_task() -> TaskStory:
+    return TaskStory(name="test-story", slug="test-story", story_path="specs/test.md")
+
+
+def _make_result(
+    landing_status: str | None = None,
+    success: bool = True,
+    merge: dict | None = None,
+) -> CoordinatorResult:
+    state = CoordinatorState()
+    return CoordinatorResult(
+        success=success,
+        phase=Phase.DONE,
+        state=state,
+        message="Done." if success else "Failed.",
+        merge=merge,
+        landing_status=landing_status,
+    )
+
+
+# ── Audit landing_event block ─────────────────────────────────────────────────
+
+
+class TestAuditLandingEvent:
+    def test_landing_event_none_when_no_landing_status(self, tmp_path: Path) -> None:
+        """landing_event is None when no merge operation was attempted."""
+        result = _make_result(landing_status=None)
+        audit = generate_audit_log(_make_config(tmp_path), _make_task(), result)
+        assert audit["landing_event"] is None
+
+    def test_landing_event_failed_sets_landed_false(self, tmp_path: Path) -> None:
+        """landing_status=failed produces landing_event with landed=False."""
+        result = _make_result(landing_status="failed", success=False)
+        audit = generate_audit_log(_make_config(tmp_path), _make_task(), result)
+        assert audit["landing_event"] is not None
+        assert audit["landing_event"]["landing_status"] == "failed"
+        assert audit["landing_event"]["landed"] is False
+        assert "timestamp" in audit["landing_event"]
+
+    def test_landing_event_landed_sets_landed_true(self, tmp_path: Path) -> None:
+        """landing_status=landed produces landing_event with landed=True."""
+        result = _make_result(landing_status="landed", success=True)
+        audit = generate_audit_log(_make_config(tmp_path), _make_task(), result)
+        assert audit["landing_event"] is not None
+        assert audit["landing_event"]["landing_status"] == "landed"
+        assert audit["landing_event"]["landed"] is True
+
+    def test_landing_event_pending_integration_sets_landed_false(self, tmp_path: Path) -> None:
+        """landing_status=pending_integration produces landing_event with landed=False."""
+        result = _make_result(landing_status="pending_integration", success=True)
+        audit = generate_audit_log(_make_config(tmp_path), _make_task(), result)
+        assert audit["landing_event"] is not None
+        assert audit["landing_event"]["landing_status"] == "pending_integration"
+        assert audit["landing_event"]["landed"] is False
+
+    def test_landing_event_is_separate_from_outcome(self, tmp_path: Path) -> None:
+        """landing_event and outcome are distinct top-level keys with independent values."""
+        result = _make_result(landing_status="failed", success=False)
+        audit = generate_audit_log(_make_config(tmp_path), _make_task(), result)
+        assert "outcome" in audit
+        assert "landing_event" in audit
+        # outcome reflects overall run success
+        assert audit["outcome"]["success"] is False
+        # landing_event reflects the landing operation specifically
+        assert audit["landing_event"]["landing_status"] == "failed"
+        assert audit["landing_event"]["landed"] is False
+
+
+# ── result.success=False when landing fails ───────────────────────────────────
+
+
+class TestSuccessFalseOnLandingFailure:
+    def test_engine_path_sets_success_false_on_direct_merge_failure(self) -> None:
+        """Engine sets result.success=False when land_story returns 'failed' (merge mode).
+
+        Previously, direct-merge failures were non-fatal (success stayed True).
+        This test documents the new contract: any landing failure → success=False.
+        """
+        # Simulate the engine.py post-coordinator-loop block:
+        # result starts as success=True, pending_integration from _finalize_approve
+        result = _make_result(success=True, landing_status="pending_integration")
+        merge_info = {"merged": False, "error": "fast-forward blocked", "action": "merge"}
+        _landing_status = "failed"
+
+        # Apply the same logic as engine.py lines 826-838
+        result.merge = merge_info
+        result.landing_status = _landing_status
+        if _landing_status == "failed":
+            result.success = False
+            result.message += f" Merge failed: {merge_info.get('error', 'unknown')}"
+
+        assert result.success is False
+        assert result.landing_status == "failed"
+        assert "Merge failed" in result.message
+
+    def test_sprint_path_sets_success_false_on_landing_failure(self) -> None:
+        """Sprint _attempt_integration sets result.success=False on land_story 'failed'."""
+        # Simulate the sprint runner _attempt_integration block:
+        # result starts as success=True (worker completed, pending integration)
+        result = _make_result(success=True, landing_status="pending_integration")
+        merge_info = {"merged": False, "error": "rebase conflict", "action": "merge"}
+        landing_status = "failed"
+
+        # Apply the same logic as sprint/runner.py _attempt_integration
+        result.merge = merge_info
+        result.landing_status = landing_status
+        if landing_status == "failed":
+            result.success = False
+
+        assert result.success is False
+        assert result.landing_status == "failed"
+
+    def test_success_unchanged_when_landing_succeeds(self) -> None:
+        """result.success stays True when landing_status is 'landed'."""
+        result = _make_result(success=True, landing_status="pending_integration")
+        merge_info = {"merged": True, "action": "merge"}
+        landing_status = "landed"
+
+        result.merge = merge_info
+        result.landing_status = landing_status
+        if landing_status == "failed":
+            result.success = False
+
+        assert result.success is True
+        assert result.landing_status == "landed"
+
+    def test_audit_outcome_reflects_success_false_after_landing_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """Audit outcome.success matches result.success after landing failure."""
+        result = _make_result(landing_status="failed", success=False)
+        audit = generate_audit_log(_make_config(tmp_path), _make_task(), result)
+        assert audit["outcome"]["success"] is False
+        assert audit["landing_event"]["landing_status"] == "failed"

--- a/tests/test_coord_completion.py
+++ b/tests/test_coord_completion.py
@@ -3,11 +3,18 @@
 Covers:
 - result.success is False when landing_status is "failed" (engine and sprint paths)
 - generate_audit_log emits a landing_event block separate from the outcome block
+- Resume path (run_from_review): landing failure sets result.success=False
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+)
 
 from theforge.config import (
     DEFAULT_DEV_PROFILE,
@@ -19,6 +26,7 @@ from theforge.config import (
     WorkspaceConfig,
 )
 from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.engine import run_from_review
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.task import TaskStory
 
@@ -175,3 +183,47 @@ class TestSuccessFalseOnLandingFailure:
         audit = generate_audit_log(_make_config(tmp_path), _make_task(), result)
         assert audit["outcome"]["success"] is False
         assert audit["landing_event"]["landing_status"] == "failed"
+
+
+# ── Resume path: run_from_review landing failure ──────────────────────────────
+
+
+class TestResumeLandingFailure:
+    """Tests that _run_resume_coordinator sets result.success=False on landing failure."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_run_from_review_landing_failure_sets_success_false(
+        self, mock_shell, mock_pool, tmp_path: Path
+    ) -> None:
+        """run_from_review with auto_merge=True: landing failure → result.success=False.
+
+        Previously, the resume path had a merge-pr-only guard so direct-merge
+        failures left success=True. This test documents the fixed contract:
+        any landing failure → success=False, regardless of landing mode.
+        """
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Test\n\nImplement the thing.", encoding="utf-8")
+        config = _make_config(tmp_path)
+        task = TaskStory(name="Test Task", story_path=spec, slug="test-task")
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "git status --porcelain" in cmd:
+                return (True, "")  # clean worktree
+            if "git branch --list" in cmd:
+                return (True, "")  # base branch not found → landing fails
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_from_review(config, task, workspace, auto_merge=True)
+
+        assert result.success is False
+        assert result.landing_status == "failed"
+        assert result.merge is not None
+        assert result.merge["merged"] is False

--- a/tests/test_coord_workspace_merge.py
+++ b/tests/test_coord_workspace_merge.py
@@ -237,7 +237,7 @@ class TestCoordinatorAutoMerge:
 
         result = run_task(config, task, auto_merge=True)
 
-        assert result.success is True  # run still succeeds
+        assert result.success is False  # landing failure → success=False
         assert result.merge is not None
         assert result.merge["merged"] is False
         assert result.merge["error"] is not None
@@ -281,7 +281,7 @@ class TestCoordinatorAutoMerge:
 
         result = run_task(config, task, auto_merge=True)
 
-        assert result.success is True  # run still succeeds
+        assert result.success is False  # landing failure → success=False
         assert result.merge is not None
         assert result.merge["merged"] is False
         assert result.merge["error"] is not None
@@ -321,7 +321,7 @@ class TestCoordinatorAutoMerge:
 
         result = run_task(config, task, auto_merge=True)
 
-        assert result.success is True
+        assert result.success is False  # landing failure → success=False
         assert result.merge is not None
         assert result.merge["merged"] is False
         assert "no commits" in result.merge["error"]

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -466,7 +466,7 @@ class TestConflictResolution:
 
         result = run_task(config, task, auto_merge=True)
 
-        assert result.success is True  # overall run succeeds even if merge failed
+        assert result.success is False  # landing failure → success=False
         assert result.phase == Phase.DONE
         assert result.merge is not None
         assert result.merge["merged"] is False
@@ -496,8 +496,8 @@ class TestConflictResolution:
 
         result = run_task(config, task, auto_merge=True)
 
-        # Run succeeds overall but merge was not completed
-        assert result.success is True
+        # Landing failed — success=False
+        assert result.success is False
         assert result.phase == Phase.DONE
         assert result.merge is not None
         assert result.merge["merged"] is False
@@ -583,7 +583,7 @@ class TestConflictResolution:
 
         result = run_task(config, task, auto_merge=True)
 
-        assert result.success is True  # overall run succeeds
+        assert result.success is False  # landing failure → success=False
         assert result.phase == Phase.DONE
         assert result.merge is not None
         assert result.merge["merged"] is False

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -429,7 +429,7 @@ class TestParallelIndependentStories:
 
 class TestParallelDependencyGating:
     def test_dependency_blocks_until_predecessor_completes(self, tmp_path: Path) -> None:
-        """Story B is skipped when A cannot be landed for dependency satisfaction."""
+        """Story B is skipped when A's landing fails — landing failure is now fatal."""
         _make_spec_file(tmp_path, "Story A", "story-a")
         _make_spec_file(tmp_path, "Story B", "story-b", depends_on=["story-a"])
         manifest_path = _make_manifest_parallel(
@@ -440,19 +440,19 @@ class TestParallelDependencyGating:
         )
         config = _make_config(tmp_path)
 
-        # A succeeds but deferred merge fails → B should be skipped
+        # A succeeds but deferred merge fails → A=failed, B=skipped (dep unmet)
         result_a = _make_coordinator_result(success=True, cost=1.0, merged=False)
 
         with patch("theforge.sprint.runner.run_task", side_effect=[result_a]) as mock_run:
             sprint = run_sprint(config, manifest_path)
 
         assert mock_run.call_count == 1  # only A ran
-        assert sprint.specs_succeeded == 1
-        assert sprint.specs_failed == 0
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
         assert sprint.specs_skipped == 1
 
     def test_dependency_satisfied_by_merge_unlocks_dependent(self, tmp_path: Path) -> None:
-        """Story B runs after A merges (in max_parallel=1 mode with eager merge)."""
+        """Story B runs after A lands (in max_parallel=1 mode with eager merge)."""
         _make_spec_file(tmp_path, "Story A", "story-a")
         _make_spec_file(tmp_path, "Story B", "story-b", depends_on=["story-a"])
         manifest_path = _make_manifest_parallel(
@@ -463,7 +463,7 @@ class TestParallelDependencyGating:
         )
         config = _make_config(tmp_path)
 
-        result_a = _make_coordinator_result(success=True, cost=1.0, merged=True)
+        result_a = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
         result_b = _make_coordinator_result(success=True, cost=1.0)
 
         with patch(
@@ -574,13 +574,13 @@ class TestClassifyAndRecord:
         assert dag.ready() == []
 
     def test_success_with_merge_completes_for_dag(self) -> None:
-        """Success with merge → specs_succeeded, dag.mark_complete (unlocks deps)."""
+        """landing_status=landed → specs_succeeded, dag.mark_complete (unlocks deps)."""
         a = _make_task("a")
         b = _make_task("b", depends_on=["a"])
         dag = StoryDAG([a, b])
         merged_slugs: set[str] = set()
 
-        result = _make_coordinator_result(success=True, cost=1.0, merged=True)
+        result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
         ds, df, dsk = _classify_and_record(a, result, dag, merged_slugs)
 
         assert ds == 1
@@ -723,9 +723,9 @@ class TestMergeOrdering:
         )
         config = _make_config(tmp_path)
 
-        # A merges, then B has satisfied dep, can be merged
-        result_a = _make_coordinator_result(success=True, cost=1.0, merged=True)
-        result_b = _make_coordinator_result(success=True, cost=1.0, merged=True)
+        # A lands, then B has satisfied dep, can be merged
+        result_a = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+        result_b = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
 
         with patch(
             "theforge.sprint.runner.run_task", side_effect=[result_a, result_b]
@@ -1067,7 +1067,7 @@ class TestParallelMergeOrderingParallelMode:
         assert audit["error"] is None
 
     def test_merge_pr_failure_rewrites_story_audit(self, tmp_path: Path) -> None:
-        """Landing failures record failed integration without rewriting review success."""
+        """Landing failures set success=False and record failed integration in audit."""
         _make_spec_file(tmp_path, "Story A", "story-a")
         (tmp_path / "story-a").mkdir()
         manifest_path = _make_manifest_parallel(
@@ -1140,9 +1140,9 @@ class TestParallelMergeOrderingParallelMode:
 
         audit_path = tmp_path / "story-a" / ".forge" / "audit.yaml"
         audit = yaml.safe_load(audit_path.read_text(encoding="utf-8")) or {}
-        assert sprint.specs_succeeded == 1
-        assert sprint.specs_failed == 0
-        assert audit["outcome"]["success"] is True
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
+        assert audit["outcome"]["success"] is False
         assert audit["outcome"]["final_phase"] == "DONE"
         assert audit["landing_status"] == "failed"
         assert audit["merge"]["action"] == "merge-pr"
@@ -1231,7 +1231,7 @@ class TestParallelMergeOrderingParallelMode:
         assert audit["merge"]["merged"] is True
 
     def test_deferred_local_merge_failure_rewrites_story_audit(self, tmp_path: Path) -> None:
-        """Local landing failures record failed integration without rewriting review success."""
+        """Local landing failures set success=False and record failed integration in audit."""
         _make_spec_file(tmp_path, "Story A", "story-a")
         (tmp_path / "story-a").mkdir()
         manifest_path = _make_manifest_parallel(
@@ -1272,9 +1272,9 @@ class TestParallelMergeOrderingParallelMode:
 
         audit_path = tmp_path / "story-a" / ".forge" / "audit.yaml"
         audit = yaml.safe_load(audit_path.read_text(encoding="utf-8")) or {}
-        assert sprint.specs_succeeded == 1
-        assert sprint.specs_failed == 0
-        assert audit["outcome"]["success"] is True
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
+        assert audit["outcome"]["success"] is False
         assert audit["outcome"]["final_phase"] == "DONE"
         assert audit["landing_status"] == "failed"
         assert audit["merge"]["action"] == "merge"
@@ -2091,7 +2091,7 @@ class TestImmediateIntegrationLanding:
         assert result_b.landing_status == "landed"
         assert merge_calls == ["story-a", "story-b"]
 
-    def test_landing_failure_does_not_rewrite_success(self, tmp_path: Path) -> None:
+    def test_landing_failure_sets_success_false(self, tmp_path: Path) -> None:
         _make_spec_file(tmp_path, "Story A", "story-a")
         manifest_path = _make_manifest_parallel(
             tmp_path,
@@ -2146,9 +2146,9 @@ class TestImmediateIntegrationLanding:
         ):
             sprint = run_sprint(config, manifest_path)
 
-        assert sprint.specs_succeeded == 1
-        assert sprint.specs_failed == 0
-        assert result.success is True
+        assert sprint.specs_succeeded == 0
+        assert sprint.specs_failed == 1
+        assert result.success is False
         assert result.phase is Phase.DONE
         assert result.landing_status == "failed"
 

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1609,6 +1609,7 @@ class TestQueuedMergePolling:
             60,
         )
         assert result.landing_status == "failed"
+        assert result.success is False
         assert result.state.error == "Queued PR timed out after 60s: https://github.com/x/y/pull/7"
         assert sprint.specs_succeeded == 0
         assert sprint.specs_failed == 1
@@ -1802,6 +1803,7 @@ class TestQueuedMergePolling:
             sprint = run_sprint(config, manifest_path)
 
         assert result.landing_status == "failed"
+        assert result.success is False
         assert "closed" in (result.state.error or "")
         assert "timed out" not in (result.state.error or "")
         assert sprint.specs_succeeded == 0
@@ -1896,6 +1898,7 @@ class TestQueuedMergePolling:
         # Dependent story-b must never be dispatched when story-a times out
         assert "story-b" not in dispatched
         assert queued_result.landing_status == "failed"
+        assert queued_result.success is False
         assert "timed out" in (queued_result.state.error or "")
         assert sprint.specs_failed >= 1
 

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -85,6 +85,7 @@ def _make_coordinator_result(
     preflight_verdict: str = "PROCEED",
     phase: Phase = Phase.DONE,
     merged: bool = False,
+    landing_status: str | None = None,
 ) -> CoordinatorResult:
     state = CoordinatorState()
     state.preflight_verdict = preflight_verdict
@@ -98,6 +99,7 @@ def _make_coordinator_result(
         state=state,
         message="Done." if success else "Failed.",
         merge={"merged": True} if merged else None,
+        landing_status=landing_status,
     )
 
 
@@ -706,7 +708,7 @@ class TestSprintDependencies:
         manifest_path = _make_manifest(tmp_path, ["spec-a.md", "spec-b.md"], budget=10.0)
         config = _make_config(tmp_path)
 
-        result_a = _make_coordinator_result(success=True, cost=1.0, merged=True)
+        result_a = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
         result_b = _make_coordinator_result(success=True, cost=1.0, merged=False)
 
         with patch(


### PR DESCRIPTION
## Summary

Verified the prior landing-success bugs are fixed, the touched paths satisfy the acceptance criteria, and I found no new correctness regressions in the latest commits.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $10.95
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: separate landing status from review approval in CoordinatorResult (GitHub Issue #600)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #600