### PR TITLE
fix: dev agent must not create scratch files outside standard project directories

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -26,6 +26,7 @@ conventions:
     max_test_file_lines: 1000
     no_circular_imports: true
     test_mirrors_source: true
+    no_scratch_files: true
   soft:
     - "Coordinator is pure Python — no LLM calls for routing or process decisions"
     - "Schema validation is the integrity boundary — do not relax cross-validation rules"
@@ -33,6 +34,7 @@ conventions:
     - "Keep pure-data types in low-dependency modules with stdlib-only imports"
     - "Separate prompt construction, output parsing, and coordinator control flow"
     - "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail — diagnosing sprint failures requires tracing real data, not reconstructing it"
+    - "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing."
 
 retry:
   max_dev_iterations: 3

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -436,6 +436,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         _max_test = conventions_hard_raw.get("max_test_file_lines", 1000)
         _no_circular = conventions_hard_raw.get("no_circular_imports", True)
         _test_mirrors = conventions_hard_raw.get("test_mirrors_source", True)
+        _no_scratch = conventions_hard_raw.get("no_scratch_files", True)
         if not isinstance(_max_module, int):
             raise ValueError(
                 "forge.yaml 'conventions.hard.max_module_lines' must be an int,"
@@ -456,11 +457,17 @@ def load_config(config_path: Path) -> ForgeConfig:
                 "forge.yaml 'conventions.hard.test_mirrors_source' must be a bool,"
                 f" got {_test_mirrors!r}"
             )
+        if not isinstance(_no_scratch, bool):
+            raise ValueError(
+                "forge.yaml 'conventions.hard.no_scratch_files' must be a bool,"
+                f" got {_no_scratch!r}"
+            )
         conventions_hard_cfg = HardConventionsConfig(
             max_module_lines=_max_module,
             max_test_file_lines=_max_test,
             no_circular_imports=_no_circular,
             test_mirrors_source=_test_mirrors,
+            no_scratch_files=_no_scratch,
         )
 
     _fc_raw = raw.get("finding_classifier", {})

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -322,6 +322,7 @@ class HardConventionsConfig:
     max_test_file_lines: int = 1000
     no_circular_imports: bool = True
     test_mirrors_source: bool = True
+    no_scratch_files: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -29,6 +29,8 @@ def check_hard_conventions(
         violations.extend(_check_circular_imports(project_root))
     if config.test_mirrors_source:
         violations.extend(_check_test_mirrors(project_root))
+    if config.no_scratch_files:
+        violations.extend(_check_no_scratch_files(project_root))
     return violations
 
 
@@ -267,6 +269,32 @@ def _best_match(name: str, adjacency: dict[str, list[str]]) -> str | None:
         if candidate in adjacency:
             return candidate
     return None
+
+
+# ── Scratch file check ────────────────────────────────────────────────
+
+
+def _check_no_scratch_files(project_root: Path) -> list[ConventionViolation]:
+    """Check that no Python files exist directly in the project root.
+
+    All source code must live under src/, tests/, docs/, or scripts/.
+    Python files in the project root are almost always scratch/exploration
+    files that were never deleted before committing.
+    """
+    violations: list[ConventionViolation] = []
+    for f in sorted(project_root.glob("*.py")):
+        rel = str(f.relative_to(project_root))
+        violations.append(
+            ConventionViolation(
+                rule="no_scratch_files",
+                file=rel,
+                detail=(
+                    f"{rel} is a Python file in the project root — "
+                    "source files must live under src/, tests/, docs/, or scripts/"
+                ),
+            )
+        )
+    return violations
 
 
 # ── Test mirror check ─────────────────────────────────────────────────

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -273,23 +273,79 @@ def _best_match(name: str, adjacency: dict[str, list[str]]) -> str | None:
 
 # ── Scratch file check ────────────────────────────────────────────────
 
+# Files that legitimately live in the project root (non-hidden only).
+# Hidden files (dotfiles) are always skipped — they're almost always tooling config.
+_ALLOWED_ROOT_FILES: frozenset[str] = frozenset(
+    {
+        # Build / packaging
+        "pyproject.toml",
+        "setup.py",
+        "setup.cfg",
+        "Makefile",
+        "makefile",
+        # Lock files
+        "uv.lock",
+        "poetry.lock",
+        "package-lock.json",
+        "yarn.lock",
+        # Requirements
+        "requirements.txt",
+        "requirements-dev.txt",
+        "requirements-test.txt",
+        # Documentation / metadata
+        "README.md",
+        "README.rst",
+        "README.txt",
+        "CHANGELOG.md",
+        "CHANGELOG.rst",
+        "CHANGELOG.txt",
+        "LICENSE",
+        "LICENSE.md",
+        "LICENSE.txt",
+        "LICENSE.rst",
+        "RELEASING.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        "CLAUDE.md",
+        "AGENTS.md",
+        # Orchestrator config
+        "forge.yaml",
+        # Python test config
+        "conftest.py",
+        # Tooling config
+        "tox.ini",
+        "Dockerfile",
+        "dockerignore",
+    }
+)
+
 
 def _check_no_scratch_files(project_root: Path) -> list[ConventionViolation]:
-    """Check that no Python files exist directly in the project root.
+    """Check that no unrecognised files exist directly in the project root.
 
     All source code must live under src/, tests/, docs/, or scripts/.
-    Python files in the project root are almost always scratch/exploration
-    files that were never deleted before committing.
+    Files that don't match the known-good whitelist of root files are almost
+    always scratch/exploration files that were never deleted before committing
+    (e.g. bin_script, fake_forge, test_exec.py from issue #646).
+
+    Hidden files (dotfiles) are skipped — they are conventionally tooling
+    configuration and pose no risk of accidental source-code pollution.
     """
     violations: list[ConventionViolation] = []
-    for f in sorted(project_root.glob("*.py")):
+    for f in sorted(project_root.iterdir()):
+        if not f.is_file():
+            continue
+        if f.name.startswith("."):
+            continue  # dotfiles are tooling config — always allowed
+        if f.name in _ALLOWED_ROOT_FILES:
+            continue
         rel = str(f.relative_to(project_root))
         violations.append(
             ConventionViolation(
                 rule="no_scratch_files",
                 file=rel,
                 detail=(
-                    f"{rel} is a Python file in the project root — "
+                    f"{rel} is not an allowed root-level file — "
                     "source files must live under src/, tests/, docs/, or scripts/"
                 ),
             )

--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -266,6 +266,8 @@ def build_dev_prompt(
 
         - Do NOT merge to main.
         - Do NOT leave uncommitted changes.
+        - Do not create files outside `src/`, `tests/`, or `docs/`. If you need a
+          scratch file for exploration, delete it before committing.
         {test_rule}
         - If you cannot finish, commit what you have and list blockers in
           `deferred_items`.

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -11,6 +11,7 @@ from theforge.conventions import (
     _check_circular_imports,
     _check_hard_conventions_at_git_ref,
     _check_line_counts,
+    _check_no_scratch_files,
     _check_test_mirrors,
     check_hard_conventions,
     new_hard_convention_violations_since_ref,
@@ -23,6 +24,7 @@ def _make_config(**kwargs) -> HardConventionsConfig:
         max_test_file_lines=1000,
         no_circular_imports=True,
         test_mirrors_source=True,
+        no_scratch_files=True,
     )
     defaults.update(kwargs)
     return HardConventionsConfig(**defaults)
@@ -337,6 +339,67 @@ class TestConventionBaseline:
 
         assert any("legacy.py" in v.file for v in current)
         assert not any("legacy.py" in v.file for v in net_new)
+
+
+# ── Scratch file check tests ──────────────────────────────────────────
+
+
+class TestNoScratchFilesCheck:
+    def test_py_file_in_root_is_violation(self, tmp_path):
+        """A .py file directly in the project root is a violation."""
+        _write(tmp_path / "scratch.py", "# oops\n")
+        violations = _check_no_scratch_files(tmp_path)
+        assert any(v.rule == "no_scratch_files" and "scratch.py" in v.file for v in violations)
+
+    def test_multiple_root_py_files_all_reported(self, tmp_path):
+        """Multiple .py files in root are all reported."""
+        _write(tmp_path / "test_exec.py", "# scratch\n")
+        _write(tmp_path / "fake_forge.py", "# scratch\n")
+        violations = _check_no_scratch_files(tmp_path)
+        files = {v.file for v in violations if v.rule == "no_scratch_files"}
+        assert "test_exec.py" in files
+        assert "fake_forge.py" in files
+
+    def test_py_in_src_is_ok(self, tmp_path):
+        """Python files under src/ are not flagged."""
+        _write(tmp_path / "src" / "theforge" / "module.py", "# fine\n")
+        violations = _check_no_scratch_files(tmp_path)
+        assert violations == []
+
+    def test_py_in_tests_is_ok(self, tmp_path):
+        """Python files under tests/ are not flagged."""
+        _write(tmp_path / "tests" / "test_module.py", "# fine\n")
+        violations = _check_no_scratch_files(tmp_path)
+        assert violations == []
+
+    def test_no_py_files_ok(self, tmp_path):
+        """Empty root directory produces no violations."""
+        violations = _check_no_scratch_files(tmp_path)
+        assert violations == []
+
+    def test_violation_is_blocking(self, tmp_path):
+        """no_scratch_files violations are blocking by default."""
+        _write(tmp_path / "oops.py", "# scratch\n")
+        violations = _check_no_scratch_files(tmp_path)
+        assert all(v.blocking for v in violations if v.rule == "no_scratch_files")
+
+    def test_check_hard_conventions_respects_no_scratch_files_flag(self, tmp_path):
+        """no_scratch_files=False disables the check."""
+        _write(tmp_path / "scratch.py", "# scratch\n")
+        cfg = _make_config(
+            no_scratch_files=False, no_circular_imports=False, test_mirrors_source=False
+        )
+        violations = check_hard_conventions(cfg, tmp_path)
+        assert not any(v.rule == "no_scratch_files" for v in violations)
+
+    def test_check_hard_conventions_includes_scratch_check_when_enabled(self, tmp_path):
+        """no_scratch_files=True (default) surfaces root .py files via check_hard_conventions."""
+        _write(tmp_path / "scratch.py", "# scratch\n")
+        (tmp_path / "src" / "theforge").mkdir(parents=True)
+        (tmp_path / "tests").mkdir(parents=True)
+        cfg = _make_config(no_circular_imports=False, test_mirrors_source=False)
+        violations = check_hard_conventions(cfg, tmp_path)
+        assert any(v.rule == "no_scratch_files" for v in violations)
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -351,14 +351,45 @@ class TestNoScratchFilesCheck:
         violations = _check_no_scratch_files(tmp_path)
         assert any(v.rule == "no_scratch_files" and "scratch.py" in v.file for v in violations)
 
-    def test_multiple_root_py_files_all_reported(self, tmp_path):
-        """Multiple .py files in root are all reported."""
+    def test_extensionless_script_in_root_is_violation(self, tmp_path):
+        """Scripts without extension (e.g. bin_script, fake_forge) are flagged."""
+        (tmp_path / "bin_script").write_text("#!/bin/bash\necho hi\n", encoding="utf-8")
+        (tmp_path / "fake_forge").write_text("#!/usr/bin/env python\n", encoding="utf-8")
+        violations = _check_no_scratch_files(tmp_path)
+        files = {v.file for v in violations if v.rule == "no_scratch_files"}
+        assert "bin_script" in files
+        assert "fake_forge" in files
+
+    def test_multiple_root_files_all_reported(self, tmp_path):
+        """Multiple unlisted files in root are all reported."""
         _write(tmp_path / "test_exec.py", "# scratch\n")
-        _write(tmp_path / "fake_forge.py", "# scratch\n")
+        (tmp_path / "bin_script2").write_text("#!/bin/bash\n", encoding="utf-8")
         violations = _check_no_scratch_files(tmp_path)
         files = {v.file for v in violations if v.rule == "no_scratch_files"}
         assert "test_exec.py" in files
-        assert "fake_forge.py" in files
+        assert "bin_script2" in files
+
+    def test_allowed_root_files_not_flagged(self, tmp_path):
+        """Known-good root files (forge.yaml, Makefile, etc.) are not flagged."""
+        (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+        (tmp_path / "Makefile").write_text("all:\n\techo hi\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+        (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+        violations = _check_no_scratch_files(tmp_path)
+        assert violations == []
+
+    def test_dotfiles_not_flagged(self, tmp_path):
+        """Hidden files (dotfiles) are always allowed."""
+        (tmp_path / ".gitignore").write_text("*.pyc\n", encoding="utf-8")
+        (tmp_path / ".env").write_text("KEY=val\n", encoding="utf-8")
+        violations = _check_no_scratch_files(tmp_path)
+        assert violations == []
+
+    def test_conftest_py_allowed(self, tmp_path):
+        """conftest.py at root is a legitimate pytest file — not flagged."""
+        _write(tmp_path / "conftest.py", "# root conftest\n")
+        violations = _check_no_scratch_files(tmp_path)
+        assert not any(v.rule == "no_scratch_files" for v in violations)
 
     def test_py_in_src_is_ok(self, tmp_path):
         """Python files under src/ are not flagged."""
@@ -372,20 +403,26 @@ class TestNoScratchFilesCheck:
         violations = _check_no_scratch_files(tmp_path)
         assert violations == []
 
-    def test_no_py_files_ok(self, tmp_path):
+    def test_directories_not_flagged(self, tmp_path):
+        """Directories in the root are never flagged (only files are checked)."""
+        (tmp_path / "scratch_dir").mkdir()
+        violations = _check_no_scratch_files(tmp_path)
+        assert violations == []
+
+    def test_empty_root_ok(self, tmp_path):
         """Empty root directory produces no violations."""
         violations = _check_no_scratch_files(tmp_path)
         assert violations == []
 
     def test_violation_is_blocking(self, tmp_path):
         """no_scratch_files violations are blocking by default."""
-        _write(tmp_path / "oops.py", "# scratch\n")
+        (tmp_path / "oops").write_text("scratch\n", encoding="utf-8")
         violations = _check_no_scratch_files(tmp_path)
         assert all(v.blocking for v in violations if v.rule == "no_scratch_files")
 
     def test_check_hard_conventions_respects_no_scratch_files_flag(self, tmp_path):
         """no_scratch_files=False disables the check."""
-        _write(tmp_path / "scratch.py", "# scratch\n")
+        (tmp_path / "bin_script").write_text("#!/bin/bash\n", encoding="utf-8")
         cfg = _make_config(
             no_scratch_files=False, no_circular_imports=False, test_mirrors_source=False
         )
@@ -393,8 +430,8 @@ class TestNoScratchFilesCheck:
         assert not any(v.rule == "no_scratch_files" for v in violations)
 
     def test_check_hard_conventions_includes_scratch_check_when_enabled(self, tmp_path):
-        """no_scratch_files=True (default) surfaces root .py files via check_hard_conventions."""
-        _write(tmp_path / "scratch.py", "# scratch\n")
+        """no_scratch_files=True surfaces unlisted root files via check_hard_conventions."""
+        (tmp_path / "bin_script").write_text("#!/bin/bash\n", encoding="utf-8")
         (tmp_path / "src" / "theforge").mkdir(parents=True)
         (tmp_path / "tests").mkdir(parents=True)
         cfg = _make_config(no_circular_imports=False, test_mirrors_source=False)


### PR DESCRIPTION
## Summary

[openai-reviewer] Prior root-file coverage gap is fixed, the new convention is wired into runtime enforcement, and I found no blocking regressions in the touched files. | [gemini-reviewer] The fix correctly broadens the scratch file check to all unlisted root files, resolving the previous P1.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.81
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

fix: dev agent must not create scratch files outside standard project directories (GitHub Issue #650)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #650