### PR TITLE
bug(workspace): sprint must fail closed when base branch has diverged from origin

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -444,6 +444,10 @@ def pull_base_branch(config: ForgeConfig) -> bool:
 
     If the pull updates src/theforge source files, re-execs the process so the
     sprint runs with fresh imports rather than stale bytecode.
+
+    Raises RuntimeError if the base branch has diverged from origin (both ahead
+    and behind), or if origin is unreachable. A diverged base branch is an
+    invalid state for spawning a worktree — fail closed rather than continue.
     """
     base_branch = config.workspace.base_branch
 
@@ -464,7 +468,35 @@ def pull_base_branch(config: ForgeConfig) -> bool:
         _cu._log(f"✓ WORKSPACE  pulled latest {base_branch}")
     else:
         _cu._log(f"⚠ WORKSPACE  pull failed (non-ff / offline): {pull_out.strip()}")
-        return False
+        # Measure divergence to distinguish "unreachable" from "diverged".
+        # git pull --ff-only fetches before attempting the merge, so origin/<base>
+        # is current even on failure. If origin is truly unreachable, the fetch
+        # itself will have failed and the rev-list calls will also fail.
+        try:
+            ok_ahead, ahead_out = _cu._run_shell(
+                f"git rev-list --count origin/{base_branch}..{base_branch}",
+                config.project_root,
+            )
+            ok_behind, behind_out = _cu._run_shell(
+                f"git rev-list --count {base_branch}..origin/{base_branch}",
+                config.project_root,
+            )
+            if ok_ahead and ok_behind:
+                local_ahead = int(ahead_out.strip())
+                local_behind = int(behind_out.strip())
+                raise RuntimeError(
+                    f"WORKSPACE abort: base branch '{base_branch}' has diverged from origin "
+                    f"(local is {local_ahead} ahead, {local_behind} behind). "
+                    f"Run: git rebase origin/{base_branch}"
+                )
+        except RuntimeError:
+            raise
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"WORKSPACE abort: could not reach origin to verify base branch '{base_branch}' "
+            f"— aborting to avoid spawning a worktree from potentially stale state."
+        )
 
     ok_after, tree_after = _cu._run_shell("git rev-parse HEAD:src/theforge", config.project_root)
     if not ok_after:
@@ -517,7 +549,10 @@ def _create_workspace(
             return workspace_path, branch_name, None
 
     if not no_pull:
-        pull_base_branch(config)
+        try:
+            pull_base_branch(config)
+        except RuntimeError as exc:
+            return None, None, str(exc)
 
     _cu._log(f"Creating workspace: {cmd}")
     ok, output = _cu._run_shell(cmd, config.project_root)

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -64,17 +64,15 @@ def _write_last_setup_command(workspace_path: Path, cmd: str) -> None:
 
 
 def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, str]:
-    """Run workspace setup, always running pip install even if .venv exists.
+    """Run workspace setup, splitting venv creation from install.
 
-    Matches the {forge_python} template BEFORE substitution to avoid parsing
-    shlex.quote() output; falls back to the legacy bare-token form; then runs
-    setup_command verbatim if neither pattern matches.
+    Matches {forge_python} template before substitution to avoid parsing
+    shlex.quote() output; falls back to legacy form; then runs verbatim.
     """
     last_setup_command = _read_last_setup_command(workspace_path)
     if last_setup_command is not None and last_setup_command != setup_command:
         _cu._log("⚠ WORKSPACE  setup_command changed — re-running install")
 
-    # --- template form: match before substitution ---
     m = _VENV_GUARD_TEMPLATE_RE.search(setup_command)
     if m:
         install_cmd = m.group(1).strip()
@@ -87,7 +85,6 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
             _write_last_setup_command(workspace_path, setup_command)
         return ok, out
 
-    # --- legacy form: resolve then match ---
     cmd = _resolve_setup_command(setup_command)
     m = _VENV_GUARD_RE.search(cmd)
     if not m:
@@ -113,10 +110,8 @@ def _resolve_merge_conflicts(
     config: ForgeConfig,
     workspace_path: Path,
 ) -> bool:
-    """Attempt to auto-resolve merge conflicts using the dev agent.
-
-    Returns True if conflicts were resolved and the gate passed, False otherwise.
-    On failure, aborts the in-progress merge.
+    """Auto-resolve merge conflicts via dev agent. Returns True if gate passed.
+    On failure, aborts the in-progress merge and returns False.
     """
     ok, conflict_out = _cu._run_shell("git diff --name-only --diff-filter=U", project_root)
     if not ok or not conflict_out.strip():
@@ -216,9 +211,8 @@ def _merge_branch(
     task_name: str = "",
 ) -> dict:
     """Merge branch_name into base_branch in project_root.
-
-    Returns a merge info dict with keys: attempted, merged, base_branch, error.
-    When config is provided, auto-resolve merge conflicts using the dev agent.
+    Returns dict with keys: attempted, merged, base_branch, error.
+    When config is provided, auto-resolves merge conflicts via dev agent.
     """
     info: dict = {
         "attempted": True,
@@ -382,9 +376,7 @@ def _find_worktree_for_branch(branch: str, project_root: Path) -> Path | None:
 
 def _check_behind_origin(config: ForgeConfig) -> None:
     """Log an informational note if base_branch is behind origin.
-
-    Silently skips if the rev-list command fails (no remote, fetch needed, etc.).
-    This check is purely informational — it never blocks execution.
+    Silently skips if rev-list fails. Purely informational — never blocks.
     """
     base_branch = config.workspace.base_branch
     ok, out = _cu._run_shell(
@@ -405,19 +397,9 @@ _FORGE_ARTIFACTS = (".forge/handoff.yaml", ".forge/trajectory.yaml", ".forge/las
 
 
 def _deindex_forge_artifacts(workspace_path: Path, *, purge: bool = False) -> None:
-    """Remove transient .forge artifacts from the git index.
-
-    Uses -f so index removal succeeds even when the index entry has staged content
-    that differs from both HEAD and the working tree (the agent-misbehavior state
-    described in the story). Uses --ignore-unmatch so the call is a no-op when files
-    are not tracked.
-
-    When ``purge=True``, also deletes the artifact files from disk so reused
-    worktrees cannot carry stale handoff or trajectory state forward.  Pass
-    ``purge=True`` only at workspace setup time — validate-phase callers must
-    leave the handoff on disk so the engine can read it after the gate.
-
-    This helper is intentionally safe to run repeatedly.
+    """Remove transient .forge artifacts from the git index (git rm -f --cached --ignore-unmatch).
+    With purge=True, also deletes the files from disk to prevent stale state in reused worktrees.
+    Omit purge on validate-phase callers that need the handoff on disk. Safe to run repeatedly.
     """
     files_arg = " ".join(_FORGE_ARTIFACTS)
     ok, out = _cu._run_shell(f"git rm -f --cached --ignore-unmatch {files_arg}", workspace_path)
@@ -434,20 +416,10 @@ def _deindex_forge_artifacts(workspace_path: Path, *, purge: bool = False) -> No
 
 
 def pull_base_branch(config: ForgeConfig) -> bool:
-    """Pull the base branch in the project root. Returns True on success.
-
-    Safe to call once before parallel workspace creation to avoid the race
-    condition where concurrent workers each try to update the same git ref.
-
-    - If base_branch is checked out: git pull --ff-only (updates working tree)
-    - If base_branch is not checked out: git fetch origin base:base (updates ref)
-
-    If the pull updates src/theforge source files, re-execs the process so the
-    sprint runs with fresh imports rather than stale bytecode.
-
-    Raises RuntimeError if the base branch has diverged from origin (both ahead
-    and behind), or if origin is unreachable. A diverged base branch is an
-    invalid state for spawning a worktree — fail closed rather than continue.
+    """Pull the base branch once before parallel workspace creation.
+    Uses --ff-only (checked out) or fetch origin base:base (not checked out).
+    Re-execs if src/theforge source changes. Raises RuntimeError if base
+    branch diverged from origin or origin is unreachable.
     """
     base_branch = config.workspace.base_branch
 
@@ -468,34 +440,27 @@ def pull_base_branch(config: ForgeConfig) -> bool:
         _cu._log(f"✓ WORKSPACE  pulled latest {base_branch}")
     else:
         _cu._log(f"⚠ WORKSPACE  pull failed (non-ff / offline): {pull_out.strip()}")
-        # Measure divergence to distinguish "unreachable" from "diverged".
-        # git pull --ff-only fetches before attempting the merge, so origin/<base>
-        # is current even on failure. If origin is truly unreachable, the fetch
-        # itself will have failed and the rev-list calls will also fail.
         try:
-            ok_ahead, ahead_out = _cu._run_shell(
-                f"git rev-list --count origin/{base_branch}..{base_branch}",
-                config.project_root,
+            ok_a, a = _cu._run_shell(
+                f"git rev-list --count origin/{base_branch}..{base_branch}", config.project_root
             )
-            ok_behind, behind_out = _cu._run_shell(
-                f"git rev-list --count {base_branch}..origin/{base_branch}",
-                config.project_root,
+            ok_b, b = _cu._run_shell(
+                f"git rev-list --count {base_branch}..origin/{base_branch}", config.project_root
             )
-            if ok_ahead and ok_behind:
-                local_ahead = int(ahead_out.strip())
-                local_behind = int(behind_out.strip())
+            if ok_a and ok_b:
+                ahead, behind = int(a.strip()), int(b.strip())
                 raise RuntimeError(
-                    f"WORKSPACE abort: base branch '{base_branch}' has diverged from origin "
-                    f"(local is {local_ahead} ahead, {local_behind} behind). "
-                    f"Run: git rebase origin/{base_branch}"
+                    f"WORKSPACE abort: base branch '{base_branch}' has diverged from origin"
+                    f" (local is {ahead} ahead, {behind} behind)."
+                    f" Run: git rebase origin/{base_branch}"
                 )
         except RuntimeError:
             raise
         except Exception:
             pass
         raise RuntimeError(
-            f"WORKSPACE abort: could not reach origin to verify base branch '{base_branch}' "
-            f"— aborting to avoid spawning a worktree from potentially stale state."
+            f"WORKSPACE abort: could not reach origin to verify base branch '{base_branch}'"
+            f" — aborting to avoid spawning a worktree from potentially stale state."
         )
 
     ok_after, tree_after = _cu._run_shell("git rev-parse HEAD:src/theforge", config.project_root)

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -449,18 +449,18 @@ def pull_base_branch(config: ForgeConfig) -> bool:
             )
             if ok_a and ok_b:
                 ahead, behind = int(a.strip()), int(b.strip())
-                raise RuntimeError(
-                    f"WORKSPACE abort: base branch '{base_branch}' has diverged from origin"
-                    f" (local is {ahead} ahead, {behind} behind)."
-                    f" Run: git rebase origin/{base_branch}"
-                )
+                if ahead > 0 and behind > 0:
+                    raise RuntimeError(
+                        f"WORKSPACE abort: base branch '{base_branch}' has diverged from origin"
+                        f" (local is {ahead} ahead, {behind} behind)."
+                        f" Run: git rebase origin/{base_branch}"
+                    )
         except RuntimeError:
             raise
         except Exception:
             pass
         raise RuntimeError(
-            f"WORKSPACE abort: could not reach origin to verify base branch '{base_branch}'"
-            f" — aborting to avoid spawning a worktree from potentially stale state."
+            f"WORKSPACE abort: pull failed for base branch '{base_branch}' — {pull_out.strip()}"
         )
 
     ok_after, tree_after = _cu._run_shell("git rev-parse HEAD:src/theforge", config.project_root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,19 @@ def _block_real_notifications():
 
 
 @pytest.fixture(autouse=True)
+def _mock_pull_base_branch():
+    """Stub pull_base_branch to return True for all tests by default.
+
+    Tests that explicitly test pull behavior (e.g. workspace tests, pre-pull
+    tests) override this with their own patch. The autouse stub prevents the
+    new fail-closed behavior from breaking sprint tests that exercise parallel
+    scheduling, DAG logic, etc. but don't care about git pull semantics.
+    """
+    with patch("theforge.sprint.runner.pull_base_branch", return_value=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def _block_real_coordinator_runners():
     """Require tests to stub coordinator runner entry points explicitly.
 

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -132,17 +132,25 @@ class TestFreshWorkspacePull:
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
     def test_pull_offline_aborts(self, mock_log, mock_shell, tmp_path):
-        """When origin is unreachable (rev-list fails), workspace creation aborts."""
+        """When pull fails and the branch hasn't diverged, workspace creation aborts.
+
+        This covers the offline/network-error case: git rev-list is a local operation
+        that succeeds even when offline (as long as the origin tracking ref exists from
+        a previous fetch). The 0-ahead/0-behind result correctly distinguishes this from
+        a diverged branch and produces an error with the original pull failure message.
+        """
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
+        pull_err = "fatal: unable to access 'https://...': Could not resolve host"
 
         def shell_side_effect(cmd, cwd, **kwargs):
             if "rev-parse --abbrev-ref HEAD" in cmd:
                 return (True, config.workspace.base_branch)
             if "pull --ff-only" in cmd:
-                return (False, "fatal: unable to access 'https://...': Could not resolve host")
+                return (False, pull_err)
             if "rev-list" in cmd:
-                return (False, "fatal: ambiguous argument 'origin/main'")
+                # Local operation: succeeds even offline; 0 ahead, 0 behind
+                return (True, "0\n")
             if "mkdir" in cmd:
                 (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
                 return (True, "")
@@ -155,6 +163,9 @@ class TestFreshWorkspacePull:
         assert workspace_path is None
         assert err is not None
         assert "abort" in err.lower()
+        # The error should include the original pull failure message, not claim divergence
+        assert "diverged" not in err
+        assert "Could not resolve host" in err
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -2,7 +2,8 @@
 
 Covers:
 - Fresh workspace: pull succeeds before worktree creation
-- Fresh workspace: pull fails (non-ff / offline) -> warning logged, workspace still created
+- Fresh workspace: pull fails (diverged) -> hard abort, workspace NOT created, error returned
+- Fresh workspace: pull fails (offline/unreachable) -> hard abort, workspace NOT created
 - Resume path (existing worktree): behind-origin check logs informational note
 - Resume path: rev-list fails -> silently skipped
 - no_pull=True: no pull attempted on fresh path
@@ -96,8 +97,8 @@ class TestFreshWorkspacePull:
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_pull_fails_workspace_still_created(self, mock_log, mock_shell, tmp_path):
-        """When pull/fetch fails, a warning is logged but the workspace is still created."""
+    def test_pull_diverged_aborts(self, mock_log, mock_shell, tmp_path):
+        """When pull fails because local and origin have diverged, workspace creation aborts."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
 
@@ -106,6 +107,12 @@ class TestFreshWorkspacePull:
                 return (True, config.workspace.base_branch)
             if "pull --ff-only" in cmd:
                 return (False, "fatal: Not possible to fast-forward, aborting.")
+            if "rev-list --count origin/" in cmd and ".." + config.workspace.base_branch in cmd:
+                # local ahead count
+                return (True, "2\n")
+            if "rev-list --count " + config.workspace.base_branch + "..origin/" in cmd:
+                # local behind count
+                return (True, "2\n")
             if "mkdir" in cmd:
                 (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
                 return (True, "")
@@ -115,11 +122,39 @@ class TestFreshWorkspacePull:
 
         workspace_path, branch_name, err = _create_workspace(config, task, no_pull=False)
 
-        assert err is None
-        assert workspace_path is not None
+        assert workspace_path is None
+        assert err is not None
+        assert "diverged" in err
+        assert "2 ahead" in err
+        assert "2 behind" in err
+        assert "git rebase" in err
 
-        log_calls = [str(c) for c in mock_log.call_args_list]
-        assert any("pull failed" in c or "non-ff" in c for c in log_calls)
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_pull_offline_aborts(self, mock_log, mock_shell, tmp_path):
+        """When origin is unreachable (rev-list fails), workspace creation aborts."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, config.workspace.base_branch)
+            if "pull --ff-only" in cmd:
+                return (False, "fatal: unable to access 'https://...': Could not resolve host")
+            if "rev-list" in cmd:
+                return (False, "fatal: ambiguous argument 'origin/main'")
+            if "mkdir" in cmd:
+                (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        workspace_path, branch_name, err = _create_workspace(config, task, no_pull=False)
+
+        assert workspace_path is None
+        assert err is not None
+        assert "abort" in err.lower()
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1321,30 +1321,26 @@ class TestSprintPrePull:
             f"got {worker_no_pull_values}"
         )
 
-    def test_failed_prepull_preserves_worker_pulls(self, tmp_path: Path) -> None:
-        """When pull_base_branch fails, workers keep no_pull=False so stale-base warnings fire."""
+    def test_failed_prepull_aborts_sprint(self, tmp_path: Path) -> None:
+        """When pull_base_branch raises, run_sprint propagates the exception and aborts."""
         config = _make_config(tmp_path)
         manifest_path = self._make_manifest(tmp_path)
-        worker_no_pull_values: list[bool] = []
-
-        def capture_no_pull(*args, **kwargs):
-            worker_no_pull_values.append(kwargs.get("no_pull", args[8] if len(args) > 8 else None))
-            state = CoordinatorState()
-            state.preflight_verdict = "PROCEED"
-            state.preflight_result = MagicMock(cost_usd=0.0)
-            return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="Done.")
 
         with (
-            patch("theforge.sprint.runner.pull_base_branch", return_value=False) as mock_pull,
-            patch("theforge.sprint.runner.run_task", side_effect=capture_no_pull),
+            patch(
+                "theforge.sprint.runner.pull_base_branch",
+                side_effect=RuntimeError(
+                    "WORKSPACE abort: base branch 'main' has diverged from origin "
+                    "(local is 2 ahead, 2 behind). Run: git rebase origin/main"
+                ),
+            ) as mock_pull,
+            patch("theforge.sprint.runner.run_task") as mock_run_task,
         ):
-            run_sprint(config, manifest_path)
+            with pytest.raises(RuntimeError, match="diverged"):
+                run_sprint(config, manifest_path)
 
         mock_pull.assert_called_once_with(config)
-        assert all(v is False for v in worker_no_pull_values), (
-            "Expected all workers no_pull=False after failed pre-pull, "
-            f"got {worker_no_pull_values}"
-        )
+        mock_run_task.assert_not_called()
 
     def test_caller_no_pull_true_skips_prepull(self, tmp_path: Path) -> None:
         """When run_sprint is called with no_pull=True, pull_base_branch is never called."""


### PR DESCRIPTION
## Summary

[openai-reviewer] Verified the divergence fix is in place and found no blocking regressions in the touched files. | [gemini-reviewer] The fix correctly checks for both ahead and behind counts to determine divergence, resolving the Cycle 1 finding.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $5.26
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug(workspace): sprint must fail closed when base branch has diverged from origin (GitHub Issue #661)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #661