### PR TITLE
fix(devhandoff): join multi-line AC bullets in story extraction (#666)

### DIFF
--- a/src/theforge/devhandoff.py
+++ b/src/theforge/devhandoff.py
@@ -141,7 +141,12 @@ def _normalize_story_text(text: str) -> str:
 
 
 def _extract_story_acceptance_criteria(story_content: str) -> list[str]:
-    """Extract acceptance-criteria bullet text from a story document."""
+    """Extract acceptance-criteria bullet text from a story document.
+
+    Handles multi-line markdown bullets where continuation lines are indented
+    under the ``- `` prefix.  Continuation text is joined with a single space
+    so that normalised comparison works regardless of line-wrapping.
+    """
     lines = story_content.splitlines()
     in_acceptance_section = False
     criteria: list[str] = []
@@ -165,6 +170,9 @@ def _extract_story_acceptance_criteria(story_content: str) -> list[str]:
 
         if stripped.startswith(("- ", "* ")):
             criteria.append(stripped[2:].strip())
+        elif criteria:
+            # Continuation line for the current bullet — append to last criterion
+            criteria[-1] = criteria[-1] + " " + stripped
 
     return criteria
 

--- a/tests/test_devhandoff.py
+++ b/tests/test_devhandoff.py
@@ -430,6 +430,67 @@ gate_result: PASS
 
         assert errors == []
 
+    def test_multiline_ac_bullets_joined(self):
+        """Multi-line markdown bullets must be joined so full-text comparison works (#666)."""
+        handoff = DevHandoff(
+            summary="done",
+            commits=[{"sha": "abc1234", "message": "fix: done"}],
+            acceptance_criteria=[
+                {
+                    "criterion": (
+                        "All `urllib.request.urlopen` calls in `coord_notify.py` "
+                        "have an explicit `timeout=` parameter (connect + read, 15-30s)"
+                    ),
+                    "status": "MET",
+                    "notes": "done",
+                },
+                {
+                    "criterion": "No new dependencies introduced",
+                    "status": "MET",
+                    "notes": "done",
+                },
+            ],
+            story_deviations=[],
+            deferred_items=[],
+            gate_result="PASS",
+            parse_errors=[],
+            raw={},
+        )
+
+        story = (
+            "## Acceptance criteria\n\n"
+            "- All `urllib.request.urlopen` calls in `coord_notify.py` have an explicit\n"
+            "  `timeout=` parameter (connect + read, 15-30s)\n"
+            "- No new dependencies introduced\n"
+        )
+
+        errors = check_handoff_story_consistency(handoff, story)
+        assert errors == [], f"Expected no errors, got: {errors}"
+
+    def test_multiline_ac_three_line_continuation(self):
+        """Continuation lines spanning 3+ lines are joined correctly (#666)."""
+        handoff = DevHandoff(
+            summary="done",
+            commits=[{"sha": "abc1234", "message": "fix: done"}],
+            acceptance_criteria=[
+                {
+                    "criterion": "First line second line third line",
+                    "status": "MET",
+                    "notes": "done",
+                },
+            ],
+            story_deviations=[],
+            deferred_items=[],
+            gate_result="PASS",
+            parse_errors=[],
+            raw={},
+        )
+
+        story = "## Acceptance criteria\n\n- First line\n  second line\n  third line\n"
+
+        errors = check_handoff_story_consistency(handoff, story)
+        assert errors == [], f"Expected no errors, got: {errors}"
+
     def test_returns_empty_when_acceptance_criteria_is_empty(self):
         handoff = DevHandoff(
             summary="done",


### PR DESCRIPTION
## Summary
- `_extract_story_acceptance_criteria` truncated multi-line markdown bullets at the first newline, extracting only the first line of each `- ` item
- Dev agents writing the full criterion text in their handoff were rejected by the validator, causing valid implementations to escalate (observed: #292 escalated during v0.6.0 sprint, $2.24 wasted)
- Continuation lines within the AC section are now joined to the current bullet before normalization

## Test plan
- [x] `test_multiline_ac_bullets_joined` — real-world multi-line AC from #292
- [x] `test_multiline_ac_three_line_continuation` — 3-line bullet continuation
- [x] All 65 devhandoff tests pass
- [x] Full gate: 2589 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)