### PR TITLE
bug: coordinator runs DEV on ALREADY_DONE stories in sprint/batch mode

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -713,8 +713,19 @@ def run_task(
             state.preflight_cached_original_verdict = cached_preflight_state.preflight_verdict
             state.preflight_cached_from_run_id = getattr(cached_preflight_state, "run_id", None)
             config = _apply_preflight_config(config, state)
-            _pf_result = None
-            _pf_already_done_loop = False
+            from .preflight_flow import _handle_preflight_verdict  # noqa: PLC0415
+
+            config, _pf_result, _pf_already_done_loop = _handle_preflight_verdict(
+                verdict=state.preflight_verdict,
+                reason=state.preflight_reason,
+                state=state,
+                config=config,
+                task=task,
+                branch_name=branch_name,
+                notify=notify,
+                logger=logger,
+                task_start=_task_start,
+            )
         else:
             from .preflight_flow import _run_preflight_phase  # noqa: PLC0415
 

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -296,6 +296,43 @@ def _run_preflight_phase(
             False,
         )
 
+    return _handle_preflight_verdict(
+        verdict=verdict,
+        reason=reason,
+        state=state,
+        config=config,
+        task=task,
+        branch_name=branch_name,
+        notify=notify,
+        logger=logger,
+        task_start=task_start,
+        branch_merged=branch_merged,
+    )
+
+
+def _handle_preflight_verdict(
+    verdict: str,
+    reason: str | None,
+    state: CoordinatorState,
+    config: ForgeConfig,
+    task: TaskStory,
+    branch_name: str,
+    *,
+    notify: bool,
+    logger: "StructuredLogger | None",
+    task_start: float,
+    branch_merged: bool | None = None,
+) -> tuple[ForgeConfig, CoordinatorResult | None, bool]:
+    """Dispatch on a preflight verdict and return the standard 3-tuple.
+
+    Returns ``(updated_config, result, already_done_loop)``:
+
+    - ``result is not None`` — stop; caller returns ``result`` immediately.
+    - ``result is None, already_done_loop is True`` — ALREADY_DONE override;
+      caller enters ``_coordinator_loop`` with ``skip_dev_first_iter=True``.
+    - ``result is None, already_done_loop is False`` — PROCEED; caller
+      continues to ``_run_plan_phase``.
+    """
     # ── ALREADY_DONE ──────────────────────────────────────────────────
     if verdict == "ALREADY_DONE":
         branch_merged = (

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -1,0 +1,88 @@
+"""Tests for cached-preflight verdict dispatch in batch/sprint mode.
+
+When run_task() receives a cached_preflight_state, the coordinator must honour
+ALREADY_DONE and BLOCKED verdicts and terminate the run before reaching
+PLAN/DEV — exactly as it does for freshly-run preflight in single-story mode.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import CoordinatorState, Phase
+
+
+class TestCachedPreflightVerdictDispatch:
+    def test_cached_already_done_skips_dev(self, tmp_path):
+        """Cached ALREADY_DONE verdict → DONE without invoking plan or dev agents."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        cached_state = replace(
+            CoordinatorState(),
+            preflight_verdict="ALREADY_DONE",
+            preflight_reason="All acceptance criteria already satisfied.",
+            preflight_complexity="medium",
+            preflight_sufficiency="implementation_ready",
+            preflight_work_type="feature",
+        )
+
+        with (
+            patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+            patch("theforge.coordinator.preflight_flow._is_branch_merged", return_value=True),
+            patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+            patch("theforge.coordinator.dev_phase.run_agent") as mock_dev,
+            patch("theforge.coordinator.plan_flow.run_agent") as mock_plan,
+            patch("theforge.coordinator.review_pool.run_agent_pool") as mock_pool,
+        ):
+            result = run_task(config, task, cached_preflight_state=cached_state)
+
+        assert result.phase == Phase.DONE
+        assert result.success is True
+        assert "already" in result.message.lower()
+        assert mock_preflight.call_count == 0
+        assert mock_dev.call_count == 0
+        assert mock_plan.call_count == 0
+        mock_pool.assert_not_called()
+        assert len(result.state.dev_results) == 0
+        assert len(result.state.review_results) == 0
+
+    def test_cached_blocked_escalates_without_dev(self, tmp_path):
+        """Cached BLOCKED verdict → ESCALATE without invoking plan or dev agents."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        cached_state = replace(
+            CoordinatorState(),
+            preflight_verdict="BLOCKED",
+            preflight_reason="Dependency removed_function() no longer exists.",
+            preflight_complexity="medium",
+            preflight_sufficiency="needs_planning",
+            preflight_work_type="feature",
+        )
+
+        with (
+            patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+            patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+            patch("theforge.coordinator.dev_phase.run_agent") as mock_dev,
+            patch("theforge.coordinator.plan_flow.run_agent") as mock_plan,
+            patch("theforge.coordinator.review_pool.run_agent_pool") as mock_pool,
+        ):
+            result = run_task(config, task, cached_preflight_state=cached_state)
+
+        assert result.phase == Phase.ESCALATE
+        assert result.success is False
+        assert "blocked" in result.message.lower()
+        assert mock_preflight.call_count == 0
+        assert mock_dev.call_count == 0
+        assert mock_plan.call_count == 0
+        mock_pool.assert_not_called()
+        assert len(result.state.dev_results) == 0


### PR DESCRIPTION
## Summary

[openai-reviewer] Fix correctly routes cached preflight verdicts through the same dispatch as live preflight, and tests cover the ALREADY_DONE and BLOCKED batch-mode regressions. | [gemini-reviewer] The fix correctly honors cached ALREADY_DONE and BLOCKED verdicts in batch mode by extracting and reusing the verdict dispatch logic.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.25
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/engine.py:746`** When returning early due to a preflight verdict (e.g., ALREADY_DONE or BLOCKED), the code returns `_pf_result` directly, bypassing `_fire_post_run_hook`. This is a pre-existing issue in the live preflight path as well, but it means post-run hooks won't fire for stories that terminate during preflight.

## Story

bug: coordinator runs DEV on ALREADY_DONE stories in sprint/batch mode (GitHub Issue #674)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #674