### PR TITLE
bug: _extract_failed_tests parser records xdist worker IDs as test names

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -89,11 +89,17 @@ log_agent_result = None
 
 def _extract_failed_tests(gate_output_tail: str) -> list[str]:
     """Best-effort extraction of failing test identifiers from gate output."""
+    import re
+
+    _xdist_prefix = re.compile(r"^\[gw\d+\]\s+")
+
     failed: list[str] = []
     for raw_line in gate_output_tail.splitlines():
         line = raw_line.strip()
         if not line:
             continue
+        # Strip pytest-xdist worker prefix, e.g. "[gw7] FAILED tests/..."
+        line = _xdist_prefix.sub("", line)
         if line.startswith(("FAILED ", "ERROR ")):
             candidate = line.split()[1].rstrip(":")
             if candidate not in failed:

--- a/tests/test_coord_dev_phase_extract_failed_tests.py
+++ b/tests/test_coord_dev_phase_extract_failed_tests.py
@@ -1,0 +1,60 @@
+"""Tests for _extract_failed_tests xdist worker prefix handling."""
+
+from theforge.coordinator.dev_phase import _extract_failed_tests
+
+
+def test_plain_failed_line():
+    output = "FAILED tests/test_foo.py::test_bar"
+    assert _extract_failed_tests(output) == ["tests/test_foo.py::test_bar"]
+
+
+def test_plain_error_line():
+    output = "ERROR tests/test_foo.py::test_bar"
+    assert _extract_failed_tests(output) == ["tests/test_foo.py::test_bar"]
+
+
+def test_xdist_failed_line():
+    output = "[gw7] FAILED tests/test_foo.py::test_bar"
+    assert _extract_failed_tests(output) == ["tests/test_foo.py::test_bar"]
+
+
+def test_xdist_error_line():
+    output = "[gw0] ERROR tests/test_foo.py::TestClass::test_method"
+    assert _extract_failed_tests(output) == ["tests/test_foo.py::TestClass::test_method"]
+
+
+def test_xdist_multi_worker_deduplication():
+    output = "[gw3] FAILED tests/test_a.py::test_one\n[gw8] FAILED tests/test_a.py::test_one"
+    assert _extract_failed_tests(output) == ["tests/test_a.py::test_one"]
+
+
+def test_xdist_mixed_with_plain():
+    output = (
+        "FAILED tests/test_a.py::test_one\n"
+        "[gw7] FAILED tests/test_b.py::test_two\n"
+        "[gw8] FAILED tests/test_a.py::test_one\n"
+    )
+    result = _extract_failed_tests(output)
+    assert result == ["tests/test_a.py::test_one", "tests/test_b.py::test_two"]
+
+
+def test_no_worker_prefix_recorded():
+    """Worker IDs like [gw7] must never appear as test names."""
+    pool_test = (
+        "tests/test_coord_review_phase_pool.py"
+        "::TestReviewParseRetry::test_schema_error_also_retried"
+    )
+    output = f"[gw7] FAILED {pool_test}\n[gw8] FAILED tests/test_other.py::test_something\n"
+    result = _extract_failed_tests(output)
+    assert not any(name.startswith("[gw") for name in result), f"Worker IDs found: {result}"
+    assert pool_test in result
+    assert "tests/test_other.py::test_something" in result
+
+
+def test_empty_output():
+    assert _extract_failed_tests("") == []
+
+
+def test_pass_output_no_failures():
+    output = "1 passed in 0.12s"
+    assert _extract_failed_tests(output) == []


### PR DESCRIPTION
## Summary

[openai-reviewer] The xdist worker prefix fix satisfies the acceptance criterion and is exercised by targeted tests. | [gemini-reviewer] The implementation correctly strips xdist worker prefixes from failure lines and includes comprehensive tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.32
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: _extract_failed_tests parser records xdist worker IDs as test names (GitHub Issue #681)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #681