### PR TITLE
forge logs: follow re-exec redirect to successor run

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -4,12 +4,51 @@ from __future__ import annotations
 
 import datetime
 import os
-import subprocess
 import sys
 import time
+from pathlib import Path
 
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
+
+# Sentinel written to test log files to signal clean EOF (no redirect).
+_SENTINEL_EOF = "[forge test sentinel EOF]"
+
+
+def _follow_log_with_redirect(log_path: Path, current_run_id: str) -> tuple[str, Path] | None:
+    """Stream log_path line-by-line, printing each line to stdout.
+
+    Returns (new_run_id, new_log_path) when a re-exec redirect block is
+    detected in the log (Run ID trailer differs from current_run_id).
+    Returns None when the sentinel EOF line is encountered (test use).
+    Runs indefinitely on real EOF (tail-f style); caller catches KeyboardInterrupt.
+    """
+    _seen_run_id: str | None = None
+    _seen_log_path: str | None = None
+
+    with open(log_path) as fh:
+        while True:
+            line = fh.readline()
+            if not line:
+                time.sleep(0.1)
+                continue
+
+            text = line.rstrip("\n")
+
+            if text == _SENTINEL_EOF:
+                return None
+
+            print(text)
+
+            if text.startswith("[forge] Run ID:  "):
+                candidate_id = text[len("[forge] Run ID:  ") :].strip()
+                if candidate_id != current_run_id:
+                    _seen_run_id = candidate_id
+            elif text.startswith("[forge] Log:     "):
+                _seen_log_path = text[len("[forge] Log:     ") :].strip()
+
+            if _seen_run_id and _seen_log_path:
+                return (_seen_run_id, Path(_seen_log_path))
 
 
 def cmd_status(args: object) -> int:
@@ -133,9 +172,26 @@ def cmd_logs(args: object) -> int:
             print(f"Log file not found for run {run_id}", file=sys.stderr)
             return 1
 
-    print(f"[forge] Tailing {log_path} — Ctrl+C to stop", file=sys.stderr)
+    current_run_id = run_id
+    current_log = log_path
     try:
-        subprocess.run(["tail", "-f", str(log_path)])
+        while True:
+            print(f"[forge] Tailing {current_log} — Ctrl+C to stop", file=sys.stderr)
+            result = _follow_log_with_redirect(current_log, current_run_id)
+            if result is None:
+                break
+            new_run_id, new_log = result
+            print(
+                f"[forge] Run re-exec'd — following new run {new_run_id}",
+                file=sys.stderr,
+            )
+            # Wait briefly for the new log to be created (up to ~2 s).
+            for _ in range(20):
+                if new_log.exists():
+                    break
+                time.sleep(0.1)
+            current_run_id = new_run_id
+            current_log = new_log
     except KeyboardInterrupt:
         pass
     return 0

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -530,7 +530,7 @@ class TestFgFlag:
 
 class TestCmdLogs:
     def test_tails_log_file_for_known_run(self, tmp_path):
-        """forge logs <run-id> calls tail -f on the correct log file."""
+        """forge logs <run-id> tails the correct log file and exits cleanly."""
         from theforge.cli import cmd_logs
 
         run_id = "abc123"
@@ -539,11 +539,11 @@ class TestCmdLogs:
         runs_dir = tmp_path / ".forge" / "runs"
         runs_dir.mkdir(parents=True)
         (runs_dir / f"{run_id}.pid").write_text(f"12345\n{slug}\n")
-        # Create log file
+        # Create log file with sentinel so _follow_log_with_redirect returns None.
         log_dir = tmp_path / ".forge" / "logs" / slug
         log_dir.mkdir(parents=True)
         log_file = log_dir / "run.log"
-        log_file.write_text("hello\n")
+        log_file.write_text("hello\n[forge test sentinel EOF]\n")
 
         forge_yaml = tmp_path / "forge.yaml"
         forge_yaml.write_text("project:\n  root: .\n")
@@ -554,16 +554,71 @@ class TestCmdLogs:
         with (
             patch("theforge.cli.status._find_config", return_value=forge_yaml),
             patch("theforge.cli.status.load_config", return_value=config),
-            patch("theforge.cli.status.subprocess.run") as mock_run,
         ):
             result = cmd_logs(args)
 
         assert result == 0
-        mock_run.assert_called_once()
-        call_args = mock_run.call_args[0][0]
-        assert call_args[0] == "tail"
-        assert call_args[1] == "-f"
-        assert str(log_file) in call_args[2]
+
+    def test_follows_reexec_redirect(self, tmp_path, capsys):
+        """forge logs follows a re-exec redirect to the successor log."""
+        from theforge.cli import cmd_logs
+        from theforge.cli.status import _SENTINEL_EOF
+
+        old_run_id = "aabbccddee11"
+        new_run_id = "ff99887766aa"
+        slug = "my-slug"
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{old_run_id}.pid").write_text(f"12345\n{slug}\n")
+
+        log_dir = tmp_path / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True)
+
+        # New log exists before cmd_logs is called (no need for the wait loop to sleep).
+        new_log = log_dir / f"run-{new_run_id}.log"
+        new_log.write_text(f"new run output\n{_SENTINEL_EOF}\n")
+
+        # Old log has the re-exec trailer followed by sentinel.
+        old_log = log_dir / f"run-{old_run_id}.log"
+        old_log.write_text(
+            "old run output\n"
+            "[forge] Run started in background\n"
+            f"[forge] Run ID:  {new_run_id}\n"
+            f"[forge] Log:     {new_log}\n"
+            f"[forge] Logs:    forge logs {new_run_id}\n"
+        )
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=old_run_id)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "old run output" in captured.out
+        assert "new run output" in captured.out
+        assert f"Run re-exec'd — following new run {new_run_id}" in captured.err
+
+    def test_no_redirect_stays_on_original_log(self, tmp_path, capsys):
+        """_follow_log_with_redirect returns None when no re-exec trailer present."""
+        from theforge.cli.status import _SENTINEL_EOF, _follow_log_with_redirect
+
+        log_file = tmp_path / "run.log"
+        log_file.write_text(f"line one\nline two\n{_SENTINEL_EOF}\n")
+
+        result = _follow_log_with_redirect(log_file, "aabbccddee11")
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "line one" in captured.out
+        assert "line two" in captured.out
 
 
 class TestCmdSprintQueryMode:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -525,102 +525,6 @@ class TestFgFlag:
             mock_daemonize.assert_not_called()
 
 
-# ── TestCmdLogs ───────────────────────────────────────────────────────
-
-
-class TestCmdLogs:
-    def test_tails_log_file_for_known_run(self, tmp_path):
-        """forge logs <run-id> tails the correct log file and exits cleanly."""
-        from theforge.cli import cmd_logs
-
-        run_id = "abc123"
-        slug = "my-slug"
-        # Create PID file
-        runs_dir = tmp_path / ".forge" / "runs"
-        runs_dir.mkdir(parents=True)
-        (runs_dir / f"{run_id}.pid").write_text(f"12345\n{slug}\n")
-        # Create log file with sentinel so _follow_log_with_redirect returns None.
-        log_dir = tmp_path / ".forge" / "logs" / slug
-        log_dir.mkdir(parents=True)
-        log_file = log_dir / "run.log"
-        log_file.write_text("hello\n[forge test sentinel EOF]\n")
-
-        forge_yaml = tmp_path / "forge.yaml"
-        forge_yaml.write_text("project:\n  root: .\n")
-
-        config = _make_forge_config(tmp_path)
-        args = argparse.Namespace(run_id=run_id)
-
-        with (
-            patch("theforge.cli.status._find_config", return_value=forge_yaml),
-            patch("theforge.cli.status.load_config", return_value=config),
-        ):
-            result = cmd_logs(args)
-
-        assert result == 0
-
-    def test_follows_reexec_redirect(self, tmp_path, capsys):
-        """forge logs follows a re-exec redirect to the successor log."""
-        from theforge.cli import cmd_logs
-        from theforge.cli.status import _SENTINEL_EOF
-
-        old_run_id = "aabbccddee11"
-        new_run_id = "ff99887766aa"
-        slug = "my-slug"
-
-        runs_dir = tmp_path / ".forge" / "runs"
-        runs_dir.mkdir(parents=True)
-        (runs_dir / f"{old_run_id}.pid").write_text(f"12345\n{slug}\n")
-
-        log_dir = tmp_path / ".forge" / "logs" / slug
-        log_dir.mkdir(parents=True)
-
-        # New log exists before cmd_logs is called (no need for the wait loop to sleep).
-        new_log = log_dir / f"run-{new_run_id}.log"
-        new_log.write_text(f"new run output\n{_SENTINEL_EOF}\n")
-
-        # Old log has the re-exec trailer followed by sentinel.
-        old_log = log_dir / f"run-{old_run_id}.log"
-        old_log.write_text(
-            "old run output\n"
-            "[forge] Run started in background\n"
-            f"[forge] Run ID:  {new_run_id}\n"
-            f"[forge] Log:     {new_log}\n"
-            f"[forge] Logs:    forge logs {new_run_id}\n"
-        )
-
-        forge_yaml = tmp_path / "forge.yaml"
-        forge_yaml.write_text("project:\n  root: .\n")
-        config = _make_forge_config(tmp_path)
-        args = argparse.Namespace(run_id=old_run_id)
-
-        with (
-            patch("theforge.cli.status._find_config", return_value=forge_yaml),
-            patch("theforge.cli.status.load_config", return_value=config),
-        ):
-            result = cmd_logs(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "old run output" in captured.out
-        assert "new run output" in captured.out
-        assert f"Run re-exec'd — following new run {new_run_id}" in captured.err
-
-    def test_no_redirect_stays_on_original_log(self, tmp_path, capsys):
-        """_follow_log_with_redirect returns None when no re-exec trailer present."""
-        from theforge.cli.status import _SENTINEL_EOF, _follow_log_with_redirect
-
-        log_file = tmp_path / "run.log"
-        log_file.write_text(f"line one\nline two\n{_SENTINEL_EOF}\n")
-
-        result = _follow_log_with_redirect(log_file, "aabbccddee11")
-
-        assert result is None
-        captured = capsys.readouterr()
-        assert "line one" in captured.out
-        assert "line two" in captured.out
-
-
 class TestCmdSprintQueryMode:
     def test_query_mode_defaults_to_sequential_when_parallel_omitted(self, tmp_path):
         from theforge.cli.sprint import _run_query_mode
@@ -671,23 +575,6 @@ class TestCmdSprintQueryMode:
 
         assert rc == 0
         assert mock_build.call_args.kwargs["max_parallel"] == 1
-
-    def test_returns_error_when_no_pid_and_no_log(self, tmp_path):
-        """forge logs with unknown run_id returns error."""
-        from theforge.cli import cmd_logs
-
-        forge_yaml = tmp_path / "forge.yaml"
-        forge_yaml.write_text("project:\n  root: .\n")
-        config = _make_forge_config(tmp_path)
-        args = argparse.Namespace(run_id="deadbeef")
-
-        with (
-            patch("theforge.cli.status._find_config", return_value=forge_yaml),
-            patch("theforge.cli.status.load_config", return_value=config),
-        ):
-            result = cmd_logs(args)
-
-        assert result == 1
 
 
 # ── TestCmdStop ───────────────────────────────────────────────────────

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -1,0 +1,175 @@
+"""Tests for forge logs subcommand and _follow_log_with_redirect helper."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+from theforge.config import (
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+
+
+def _api_profile(
+    name: str, provider: str = "anthropic", model: str = "claude-opus-4-6"
+) -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        provider=provider,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=120,
+        allowed_tools=("Read", "Grep"),
+    )
+
+
+def _make_forge_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        ),
+        preflight_profile=ModelProfile(
+            name="preflight",
+            cli="claude",
+            model="sonnet",
+            budget_usd=0.5,
+            timeout_seconds=120,
+            allowed_tools=("Read",),
+        ),
+        review_pool=[
+            _api_profile("claude-reviewer"),
+            _api_profile("codex-reviewer", "openai"),
+        ],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        plan_agent_review=PlanAgentReviewConfig(enabled=False),
+        log=LogConfig(enabled=False),
+    )
+
+
+# ── TestCmdLogs ───────────────────────────────────────────────────────
+
+
+class TestCmdLogs:
+    def test_tails_log_file_for_known_run(self, tmp_path):
+        """forge logs <run-id> tails the correct log file and exits cleanly."""
+        from theforge.cli import cmd_logs
+
+        run_id = "abc123"
+        slug = "my-slug"
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.pid").write_text(f"12345\n{slug}\n")
+        log_dir = tmp_path / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "run.log"
+        log_file.write_text("hello\n[forge test sentinel EOF]\n")
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 0
+
+    def test_follows_reexec_redirect(self, tmp_path, capsys):
+        """forge logs follows a re-exec redirect to the successor log."""
+        from theforge.cli import cmd_logs
+        from theforge.cli.status import _SENTINEL_EOF
+
+        old_run_id = "aabbccddee11"
+        new_run_id = "ff99887766aa"
+        slug = "my-slug"
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{old_run_id}.pid").write_text(f"12345\n{slug}\n")
+
+        log_dir = tmp_path / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True)
+
+        new_log = log_dir / f"run-{new_run_id}.log"
+        new_log.write_text(f"new run output\n{_SENTINEL_EOF}\n")
+
+        old_log = log_dir / f"run-{old_run_id}.log"
+        old_log.write_text(
+            "old run output\n"
+            "[forge] Run started in background\n"
+            f"[forge] Run ID:  {new_run_id}\n"
+            f"[forge] Log:     {new_log}\n"
+            f"[forge] Logs:    forge logs {new_run_id}\n"
+        )
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=old_run_id)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "old run output" in captured.out
+        assert "new run output" in captured.out
+        assert f"Run re-exec'd — following new run {new_run_id}" in captured.err
+
+    def test_no_redirect_stays_on_original_log(self, tmp_path, capsys):
+        """_follow_log_with_redirect returns None when no re-exec trailer present."""
+        from theforge.cli.status import _SENTINEL_EOF, _follow_log_with_redirect
+
+        log_file = tmp_path / "run.log"
+        log_file.write_text(f"line one\nline two\n{_SENTINEL_EOF}\n")
+
+        result = _follow_log_with_redirect(log_file, "aabbccddee11")
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "line one" in captured.out
+        assert "line two" in captured.out
+
+    def test_returns_error_when_no_pid_and_no_log(self, tmp_path):
+        """forge logs with unknown run_id returns error."""
+        from theforge.cli import cmd_logs
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id="deadbeef")
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 1


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the re-exec log-following spec and is adequately covered by focused tests. | [gemini-reviewer] Successfully replaces tail -f with a custom log follower that detects re-exec redirects and seamlessly switches to the new log file.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.97
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/cli/status.py:25`** Partial line reading: `fh.readline()` may return a partial line (without a trailing newline) if the file is being written concurrently. `print(text)` will then append a newline, causing the log line to be split across multiple lines in the terminal.
- **[P2] `src/theforge/cli/status.py:189`** Missing timeout error handling: If the new log file is not created within the 2-second wait loop, the next iteration will crash with a `FileNotFoundError` when `open(current_log)` is called in `_follow_log_with_redirect`.
- **[P2] `src/theforge/cli/status.py:37`** Log spoofing vulnerability: The redirect detection relies on parsing plain log lines. If the sprint output (e.g., from an LLM or a script) happens to print lines starting with `[forge] Run ID:  ` and `[forge] Log:     `, it could trick the log follower into switching to a non-existent log file.

## Story

forge logs: follow re-exec redirect to successor run (GitHub Issue #686)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #686