### PR TITLE
bug: sprint log lines have no timestamps

### DIFF
--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from theforge.coordinator.log_tee import get_worker_slug
 from theforge.log_level import LogLevel
+from theforge.log_util import _log_line
 
 # Stable reference captured at import time so test patches that replace the
 # subprocess module attribute (e.g. patch("validate_phase.subprocess.run"))
@@ -54,7 +55,7 @@ def _log(msg: str) -> None:
     """Print coordinator status to stderr (always shown)."""
     slug = get_worker_slug()
     prefix = f"[{slug}] " if slug else ""
-    print(f"[forge] {prefix}{msg}", file=sys.stderr, flush=True)
+    _log_line("[forge]", f"{prefix}{msg}")
 
 
 def _log_verbose(msg: str) -> None:
@@ -62,7 +63,7 @@ def _log_verbose(msg: str) -> None:
     if _LOG_LEVEL >= LogLevel.VERBOSE:
         slug = get_worker_slug()
         prefix = f"[{slug}] " if slug else ""
-        print(f"[forge] {prefix}{msg}", file=sys.stderr, flush=True)
+        _log_line("[forge]", f"{prefix}{msg}")
 
 
 def _fmt_cost(cost: float | None) -> str:

--- a/src/theforge/log_util.py
+++ b/src/theforge/log_util.py
@@ -1,0 +1,20 @@
+"""Shared log-line emitter with HH:MM:SS.mmm timestamps.
+
+All modules with a local ``_log`` or ``_log_verbose`` wrapper delegate here
+so every line written to stderr carries a consistent timestamp prefix.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+
+
+def _log_line(tag: str, msg: str) -> None:
+    """Emit a single tagged log line to stderr with a millisecond timestamp.
+
+    Format: ``<tag> HH:MM:SS.mmm <msg>``
+    """
+    now = datetime.now()
+    ts = now.strftime("%H:%M:%S.") + f"{now.microsecond // 1000:03d}"
+    print(f"{tag} {ts} {msg}", file=sys.stderr, flush=True)

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -10,7 +10,6 @@ Provider-specific runners live in dedicated modules:
 from __future__ import annotations
 
 import subprocess
-import sys
 import threading
 import time
 from collections.abc import Callable
@@ -21,6 +20,7 @@ from typing import cast
 
 from theforge.agent_types import AgentResult
 from theforge.log_level import LogLevel
+from theforge.log_util import _log_line
 
 from ..config import ModelProfile
 
@@ -28,14 +28,14 @@ from ..config import ModelProfile
 
 
 def _log(msg: str) -> None:
-    print(f"[forge] {msg}", file=sys.stderr, flush=True)
+    _log_line("[forge]", msg)
 
 
 def _log_verbose(msg: str) -> None:
     from theforge.log_level import _LOG_LEVEL as _LL
 
     if _LL >= LogLevel.VERBOSE:
-        print(f"[forge] {msg}", file=sys.stderr, flush=True)
+        _log_line("[forge]", msg)
 
 
 # ── Heartbeat helper ─────────────────────────────────────────────────

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import threading
 import time
 from pathlib import Path
 from typing import Any
 
 from theforge.agent_types import AgentResult, ModelUsage
+from theforge.log_util import _log_line
 
 from ..config import ModelProfile
 
@@ -23,14 +23,14 @@ from ..config import ModelProfile
 
 
 def _log(msg: str) -> None:
-    print(f"[forge] {msg}", file=sys.stderr, flush=True)
+    _log_line("[forge]", msg)
 
 
 def _log_verbose(msg: str) -> None:
     from theforge.log_level import _LOG_LEVEL, LogLevel  # noqa: PLC0415
 
     if _LOG_LEVEL >= LogLevel.VERBOSE:
-        print(f"[forge] {msg}", file=sys.stderr, flush=True)
+        _log_line("[forge]", msg)
 
 
 # ── Claude-specific helpers ───────────────────────────────────────────

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import tempfile
 import time
 from datetime import datetime
@@ -17,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from theforge.agent_types import AgentResult
+from theforge.log_util import _log_line
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
@@ -25,14 +25,14 @@ from .cli import _handle_exception, _run_with_heartbeat
 
 
 def _log(msg: str) -> None:
-    print(f"[forge] {msg}", file=sys.stderr, flush=True)
+    _log_line("[forge]", msg)
 
 
 def _log_verbose(msg: str) -> None:
     from theforge.log_level import _LOG_LEVEL, LogLevel  # noqa: PLC0415
 
     if _LOG_LEVEL >= LogLevel.VERBOSE:
-        print(f"[forge] {msg}", file=sys.stderr, flush=True)
+        _log_line("[forge]", msg)
 
 
 # ── Codex-specific helpers ────────────────────────────────────────────

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 from typing import Any
 
 from theforge.agent_types import AgentResult
+from theforge.log_util import _log_line
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
@@ -22,14 +22,14 @@ from .cli import _handle_exception, _run_with_heartbeat
 
 
 def _log(msg: str) -> None:
-    print(f"[forge] {msg}", file=sys.stderr, flush=True)
+    _log_line("[forge]", msg)
 
 
 def _log_verbose(msg: str) -> None:
     from theforge.log_level import _LOG_LEVEL, LogLevel  # noqa: PLC0415
 
     if _LOG_LEVEL >= LogLevel.VERBOSE:
-        print(f"[forge] {msg}", file=sys.stderr, flush=True)
+        _log_line("[forge]", msg)
 
 
 # ── Gemini runner ─────────────────────────────────────────────────────

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import datetime
 import json
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
 
+from ..log_util import _log_line
 from .manifest import ResolvedSprint, SprintManifest, SprintResult
 
 if TYPE_CHECKING:
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 def _log(msg: str) -> None:
-    print(f"[sprint] {msg}", file=sys.stderr, flush=True)
+    _log_line("[sprint]", msg)
 
 
 def _write_sprint_audit(

--- a/src/theforge/sprint/collision.py
+++ b/src/theforge/sprint/collision.py
@@ -7,11 +7,12 @@ from dataclasses import dataclass, replace
 from ..config import ForgeConfig
 from ..coordinator.engine import run_task
 from ..coordinator.state import CoordinatorState, Phase
+from ..log_util import _log_line
 from ..task import TaskStory
 
 
 def _log(msg: str) -> None:
-    print(f"[sprint] {msg}", file=sys.stderr, flush=True)
+    _log_line("[sprint]", msg)
 
 
 @dataclass(frozen=True)

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import ForgeConfig
 from ..coordinator.audit import has_review_approve
 from ..coordinator.gate import _run_gate
+from ..log_util import _log_line
 from ..task import TaskStory
 from .manifest import _build_task_from_story
 
 
 def _log(msg: str) -> None:
-    print(f"[sprint] {msg}", file=sys.stderr, flush=True)
+    _log_line("[sprint]", msg)
 
 
 @dataclass

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-import sys
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,6 +17,8 @@ from urllib.parse import quote
 if TYPE_CHECKING:
     from ..task import TaskStory
     from .manifest import ResolvedSprint
+
+from ..log_util import _log_line
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class NormalizedDependencyPlan:
 
 
 def _log(msg: str) -> None:
-    print(f"[sprint] {msg}", file=sys.stderr, flush=True)
+    _log_line("[sprint]", msg)
 
 
 def _gh_api_paginate_issues(

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -22,6 +22,7 @@ from ..coordinator.ntfy_client import _ntfy_publish
 from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from ..coordinator.util import _fmt_duration, _generate_run_id
 from ..coordinator.workspace import pull_base_branch
+from ..log_util import _log_line
 from ..task import TaskStory
 from .audit import _write_sprint_audit, _write_sprint_summary, _write_story_audit
 from .ci_checks import poll_required_checks
@@ -56,7 +57,7 @@ from .state_writer import SprintStateWriter
 def _log(msg: str) -> None:
     slug = get_worker_slug()
     prefix = f"[{slug}] " if slug else ""
-    print(f"[sprint] {prefix}{msg}", file=sys.stderr, flush=True)
+    _log_line("[sprint]", f"{prefix}{msg}")
 
 
 def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:

--- a/tests/test_coord_logging.py
+++ b/tests/test_coord_logging.py
@@ -743,20 +743,26 @@ class TestWorkerSlugContext:
         assert results == {"a": "issue-99", "b": ""}
 
     def test_runner_log_includes_slug(self, monkeypatch, capsys) -> None:
+        import re
+
         from theforge.sprint import runner
 
         monkeypatch.setattr(runner, "get_worker_slug", lambda: "my-story")
         runner._log("hello")
 
-        assert "[sprint] [my-story] hello" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert re.search(r"\[sprint\] \d{2}:\d{2}:\d{2}\.\d{3} \[my-story\] hello", err)
 
     def test_util_log_includes_slug(self, monkeypatch, capsys) -> None:
+        import re
+
         from theforge.coordinator import util
 
         monkeypatch.setattr(util, "get_worker_slug", lambda: "my-story")
         util._log("hello")
 
-        assert "[forge] [my-story] hello" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert re.search(r"\[forge\] \d{2}:\d{2}:\d{2}\.\d{3} \[my-story\] hello", err)
 
 
 def test_preflight_yaml_includes_branch_merged(tmp_path):

--- a/tests/test_log_util.py
+++ b/tests/test_log_util.py
@@ -1,0 +1,51 @@
+"""Tests for the shared log-line emitter in theforge.log_util."""
+
+from __future__ import annotations
+
+import re
+
+from theforge.log_util import _log_line
+
+_TS_RE = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{3}")
+
+
+def test_forge_tag_present(capsys: object) -> None:
+    _log_line("[forge]", "hello")
+    captured = capsys.readouterr()  # type: ignore[union-attr]
+    line = captured.err.rstrip("\n")
+    assert line.startswith("[forge]"), f"Expected [forge] prefix, got: {line!r}"
+
+
+def test_timestamp_format(capsys: object) -> None:
+    _log_line("[forge]", "hello")
+    captured = capsys.readouterr()  # type: ignore[union-attr]
+    line = captured.err.rstrip("\n")
+    parts = line.split(" ", 2)
+    # parts[0] = "[forge]", parts[1] = "HH:MM:SS.mmm", parts[2] = "hello"
+    assert len(parts) == 3, f"Expected 3 space-separated parts, got: {line!r}"
+    assert _TS_RE.fullmatch(parts[1]), f"Timestamp {parts[1]!r} does not match HH:MM:SS.mmm"
+
+
+def test_message_at_end(capsys: object) -> None:
+    _log_line("[forge]", "hello")
+    captured = capsys.readouterr()  # type: ignore[union-attr]
+    line = captured.err.rstrip("\n")
+    assert line.endswith("hello"), f"Expected line to end with 'hello', got: {line!r}"
+
+
+def test_sprint_tag(capsys: object) -> None:
+    _log_line("[sprint]", "world")
+    captured = capsys.readouterr()  # type: ignore[union-attr]
+    line = captured.err.rstrip("\n")
+    assert line.startswith("[sprint]"), f"Expected [sprint] prefix, got: {line!r}"
+    parts = line.split(" ", 2)
+    assert len(parts) == 3
+    assert _TS_RE.fullmatch(parts[1]), f"Timestamp {parts[1]!r} does not match HH:MM:SS.mmm"
+    assert line.endswith("world"), f"Expected line to end with 'world', got: {line!r}"
+
+
+def test_message_with_spaces(capsys: object) -> None:
+    _log_line("[forge]", "a message with spaces")
+    captured = capsys.readouterr()  # type: ignore[union-attr]
+    line = captured.err.rstrip("\n")
+    assert line.endswith("a message with spaces"), f"Full message not preserved: {line!r}"


### PR DESCRIPTION
## Summary

Shared log utility correctly adds HH:MM:SS.mmm timestamps to the modified forge and sprint log wrappers while preserving slug prefixes.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.76
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: sprint log lines have no timestamps (GitHub Issue #573)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #573