### PR TITLE
bug: dev agent runs pytest without xdist parallelism, wasting wall-clock time

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -16,6 +16,7 @@ workspace:
 validation:
   gate_command: ".venv/bin/ruff check src/ tests/ && .venv/bin/ruff format --check src/ tests/ && .venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
   gate_debug_command: ".venv/bin/python -m pytest tests/ -x -v -n 0 --timeout=10"
+  test_command: ".venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
   handoff_file: ".forge/handoff.yaml"
   gate_decision_key: "gate_decision"
   gate_timeout: 45

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -133,6 +133,7 @@ def load_config(config_path: Path) -> ForgeConfig:
             val_data.get("gate_output_tail_chars", DEFAULT_VALIDATION.gate_output_tail_chars)
         ),
         gate_debug_command=val_data.get("gate_debug_command"),
+        test_command=val_data.get("test_command"),
         pre_validate_command=val_data.get("pre_validate_command"),
     )
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -175,6 +175,7 @@ class ValidationConfig:
     gate_debug_command: str | None = (
         None  # diagnostic command on timeout (e.g. "pytest -x -v -n 0")
     )
+    test_command: str | None = None  # canonical command for intermediate test runs in dev loop
     pre_validate_command: str | None = None  # optional command run before dirty check
 
 

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -267,6 +267,7 @@ def _run_dev_phase(
         if task.gate_override is not None and not _is_gate_skip(task.gate_override)
         else config.validation.gate_command
     )
+    _test_cmd = config.validation.test_command or _gate_cmd
     _dev_entry_reason = state.retry_reason  # snapshot before consumed by prompt routing
     match state.retry_reason:
         case RetryReason.TIMEOUT_RESUME:
@@ -286,6 +287,7 @@ def _run_dev_phase(
                 branch_name=branch_name,
                 review_findings=state.last_review_findings,
                 gate_command=_gate_cmd,
+                test_command=_test_cmd,
                 gate_skipped=_is_gate_skip(task.gate_override),
                 iteration=state.dev_iteration,
                 cycle_history=state.cycle_history or None,
@@ -328,6 +330,7 @@ def _run_dev_phase(
                 branch_name=branch_name,
                 story_content=story_content,
                 gate_command=_gate_cmd,
+                test_command=_test_cmd,
                 gate_skipped=_is_gate_skip(task.gate_override),
                 review_findings=state.last_review_findings,
                 human_feedback=state.human_feedback,

--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -16,6 +16,7 @@ def build_dev_prompt(
     branch_name: str,
     story_content: str,
     gate_command: str,
+    test_command: str | None = None,
     gate_skipped: bool = False,
     review_findings: str | None = None,
     human_feedback: str | None = None,
@@ -167,6 +168,20 @@ def build_dev_prompt(
             {assembled_context.content}
         """)
 
+    if test_command and test_command != gate_command:
+        test_section = dedent(f"""\
+
+            ## Testing During Development
+
+            When running tests during development, use exactly:
+            ```bash
+            {test_command}
+            ```
+            Do not hand-roll pytest invocations — always use this command.
+        """)
+    else:
+        test_section = ""
+
     if gate_skipped:
         gate_section = dedent("""\
             Gate is disabled for this spec. Skip the gate command.
@@ -220,7 +235,7 @@ def build_dev_prompt(
         > most reasonable interpretation and flag the ambiguity in `dev_notes`.
 
         {story_content}
-        {feedback_section}{preflight_section}{context_section}{
+        {feedback_section}{preflight_section}{context_section}{test_section}{
         render_conventions_block(conventions)
     }
         ## Workflow

--- a/src/theforge/task/fix_prompts.py
+++ b/src/theforge/task/fix_prompts.py
@@ -126,6 +126,7 @@ def build_fix_prompt(
     branch_name: str,
     review_findings: str,
     gate_command: str,
+    test_command: str | None = None,
     gate_skipped: bool = False,
     iteration: int = 2,
     cycle_history: list[CycleHistory] | None = None,
@@ -153,6 +154,16 @@ def build_fix_prompt(
             "The coordinator runs it automatically after you complete.\n        "
         )
     )
+
+    if test_command and test_command != gate_command:
+        test_bullet = (
+            f"- When running tests during development, use exactly: "
+            f"`{test_command}`. Do not hand-roll pytest invocations.\n        "
+        )
+    else:
+        test_bullet = ""
+
+    _pfx = f"{gate_bullet}{test_bullet}"
 
     context_sections = ""
     if escalation_note:
@@ -328,7 +339,7 @@ def build_fix_prompt(
 
         ## Important
 
-        {gate_bullet}- Focus on fixing the identified findings. Do not refactor unrelated code.
+        {_pfx}- Focus on fixing the identified findings. Do not refactor unrelated code.
         - When a finding describes a **pattern bug** (e.g., a flawed lookup key,
           an unsafe cast, a missing guard), search the entire file — and related
           files — for **all occurrences** of that pattern before committing your

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1388,3 +1388,36 @@ class TestConventionsConfig:
         )
         with pytest.raises(ValueError, match="max_module_lines"):
             load_config(config_path)
+
+
+class TestValidationTestCommand:
+    """Tests for validation.test_command config field."""
+
+    def test_test_command_parsed_when_present(self, tmp_path):
+        config_path = _write_config(
+            {
+                "validation": {
+                    "gate_command": "make gate",
+                    "handoff_file": "handoff.yaml",
+                    "gate_decision_key": "gate_decision",
+                    "test_command": "pytest tests/ -v -n auto",
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.validation.test_command == "pytest tests/ -v -n auto"
+
+    def test_test_command_defaults_to_none_when_absent(self, tmp_path):
+        config_path = _write_config(
+            {
+                "validation": {
+                    "gate_command": "make gate",
+                    "handoff_file": "handoff.yaml",
+                    "gate_decision_key": "gate_decision",
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.validation.test_command is None

--- a/tests/test_task_dev.py
+++ b/tests/test_task_dev.py
@@ -565,3 +565,68 @@ class TestNotesConventionInPrompts:
         )
         assert "Notes" in prompt
         assert "NOT requirements" in prompt
+
+
+class TestTestCommandInPrompts:
+    """Tests that test_command is injected into dev and fix prompts."""
+
+    def test_dev_prompt_includes_test_command_when_different_from_gate(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test-task",
+            story_content="# Spec\n\nDo the thing.",
+            gate_command="make gate",
+            test_command="pytest tests/ -v -n auto --dist worksteal",
+        )
+        assert "pytest tests/ -v -n auto --dist worksteal" in prompt
+
+    def test_dev_prompt_omits_test_section_when_test_command_equals_gate(self, tmp_path):
+        task = _make_task(tmp_path)
+        cmd = "make gate"
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test-task",
+            story_content="# Spec\n\nDo the thing.",
+            gate_command=cmd,
+            test_command=cmd,
+        )
+        assert "Testing During Development" not in prompt
+
+    def test_dev_prompt_omits_test_section_when_test_command_is_none(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test-task",
+            story_content="# Spec\n\nDo the thing.",
+            gate_command="make gate",
+        )
+        assert "Testing During Development" not in prompt
+
+    def test_fix_prompt_includes_test_command_when_different_from_gate(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_fix_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test-task",
+            review_findings="- P1: Bug in src/foo.py:10",
+            gate_command="make gate",
+            test_command="pytest tests/ -v -n auto --dist worksteal",
+        )
+        assert "pytest tests/ -v -n auto --dist worksteal" in prompt
+
+    def test_fix_prompt_omits_test_bullet_when_test_command_equals_gate(self, tmp_path):
+        task = _make_task(tmp_path)
+        cmd = "make gate"
+        prompt = build_fix_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test-task",
+            review_findings="- P1: Bug in src/foo.py:10",
+            gate_command=cmd,
+            test_command=cmd,
+        )
+        assert "hand-roll pytest" not in prompt


### PR DESCRIPTION
## Summary

Implementation satisfies the spec by introducing a canonical test_command and wiring it into the dev and fix prompts used at runtime.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.36
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: dev agent runs pytest without xdist parallelism, wasting wall-clock time (GitHub Issue #574)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #574