### PR TITLE
Flag unsubstantiated fix claims in handoff to reviewers

### DIFF
--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -18,6 +18,7 @@ import yaml
 
 from theforge.config import ForgeConfig
 from theforge.coordinator.context_scope import plan_file_list
+from theforge.handoff_claim_checker import check_handoff_fix_claims
 from theforge.review import (
     ReviewResult,
     _try_parse_review,
@@ -39,6 +40,7 @@ from .review_context import (
     _get_diff_stat,
     _get_handoff_commit_warning,
     _get_handoff_content,
+    _parse_dev_handoff,
 )
 from .state import CoordinatorState, Phase, ReviewCycleMetadata
 
@@ -87,6 +89,22 @@ def _emit_review_git_context(
         commit_log=commit_log,
         diff_stat=diff_stat,
         handoff_commit_warning=handoff_commit_warning,
+    )
+
+
+def _emit_fix_claim_check(
+    logger: Any | None,
+    *,
+    flagged: list[dict],
+    accepted: list[dict],
+) -> None:
+    """Emit handoff fix-claim check results to the audit trail."""
+    if logger is None:
+        return
+    logger._safe_emit(
+        "handoff_fix_claim_check",
+        flagged=flagged,
+        accepted=accepted,
     )
 
 
@@ -176,6 +194,35 @@ def _run_review_pool(
             handoff_commit_warning=handoff_commit_warning,
         )
 
+        # Heuristic fix-claim check: flag confident fix assertions in the
+        # handoff summary that reference a prior P1 but cite no test or invariant.
+        _prior_p1_descs: list[str] = [
+            desc
+            for ch in (state.cycle_history or [])
+            if ch.verdict == "REQUEST_CHANGES"
+            for desc in ch.p1_findings
+        ]
+        _parsed_handoff = _parse_dev_handoff(config, workspace_path)
+        _claim_summary = (
+            _parsed_handoff.summary
+            if _parsed_handoff is not None and not _parsed_handoff.parse_errors
+            else ""
+        )
+        _claim_check = check_handoff_fix_claims(_claim_summary, _prior_p1_descs)
+        _emit_fix_claim_check(
+            logger,
+            flagged=[
+                {"claim": r.claim_text, "finding": r.related_finding} for r in _claim_check.flagged
+            ],
+            accepted=[
+                {"claim": r.claim_text, "finding": r.related_finding}
+                for r in _claim_check.accepted
+            ],
+        )
+        fix_claim_flags: list[str] | None = [
+            r.flag_message for r in _claim_check.flagged if r.flag_message
+        ] or None
+
         review_context = ContextAssembler.from_config(config).assemble(
             phase="review",
             story_text=story_content,
@@ -203,6 +250,7 @@ def _run_review_pool(
                     conventions=config.conventions_soft,
                     assembled_context=review_context,
                     sandboxed=state.sandboxed,
+                    fix_claim_flags=fix_claim_flags,
                 )
                 for p in pool
             ]
@@ -224,6 +272,7 @@ def _run_review_pool(
                 conventions=config.conventions_soft,
                 assembled_context=review_context,
                 sandboxed=state.sandboxed,
+                fix_claim_flags=fix_claim_flags,
             )
         )
     _log_verbose(f"Running {pool_size} reviewer(s): {[p.name for p in pool]}")

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -196,12 +196,14 @@ def _run_review_pool(
 
         # Heuristic fix-claim check: flag confident fix assertions in the
         # handoff summary that reference a prior P1 but cite no test or invariant.
-        _prior_p1_descs: list[str] = [
-            desc
-            for ch in (state.cycle_history or [])
-            if ch.verdict == "REQUEST_CHANGES"
-            for desc in ch.p1_findings
-        ]
+        # Use only the most recent REQUEST_CHANGES cycle — its p1_findings are the
+        # currently unresolved findings. Earlier cycles may contain findings that
+        # were already fixed, and including them would cause false-positive flags.
+        _last_rc = next(
+            (ch for ch in reversed(state.cycle_history or []) if ch.verdict == "REQUEST_CHANGES"),
+            None,
+        )
+        _prior_p1_descs: list[str] = list(_last_rc.p1_findings) if _last_rc else []
         _parsed_handoff = _parse_dev_handoff(config, workspace_path)
         _claim_summary = (
             _parsed_handoff.summary

--- a/src/theforge/handoff_claim_checker.py
+++ b/src/theforge/handoff_claim_checker.py
@@ -1,0 +1,269 @@
+"""Heuristic check for unsubstantiated fix claims in dev handoff summaries.
+
+Detects sentences in the dev handoff summary that assert a prior finding has
+been fixed but cite no test name or invariant backing the claim.  Returns a
+structured result with flagged and accepted claims for injection into the
+reviewer prompt and the audit trail.
+
+Detection is entirely string-based — no LLM in the loop.
+
+Scoping rules
+-------------
+- Only claims that appear to be *about* a prior P1 finding are evaluated.
+  Generic fix-claim language with no keyword overlap to any known finding is
+  silently ignored (not flagged, not accepted).
+- Within a matched claim, the presence of a test-name reference (``test_*``,
+  ``*Test``, ``*Tests``) or an invariant phrase (e.g. "by construction",
+  "invariant") counts as backing evidence → accepted, not flagged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Fix-claim phrases
+# ---------------------------------------------------------------------------
+# Patterns that signal a confident fix assertion in prose.
+_FIX_CLAIM_PATTERNS: list[re.Pattern[str]] = [
+    # "ensures X never/always/no longer/cannot ..."
+    re.compile(r"\bensures?\b.{0,60}\b(never|always|no longer|can(?:not|'t))\b", re.I | re.S),
+    # "guarantees X"
+    re.compile(r"\bguarantees?\b", re.I),
+    # "fixes / fixed / resolves / resolved / addresses / addressed"
+    re.compile(r"\b(?:fix(?:es|ed)?|resolv(?:es|ed)|address(?:es|ed))\b", re.I),
+    # "no longer <verb>"
+    re.compile(r"\bno longer\b", re.I),
+    # "can never / cannot / can't ... happen / occur / be skipped / be missed"
+    re.compile(
+        r"\b(?:can(?:not|'t)|will never|won't)\b.{0,40}\b"
+        r"(?:happen|occur|be skipped|be missed|recur|fail)\b",
+        re.I | re.S,
+    ),
+    # "prevents X from Y"
+    re.compile(r"\bprevents?\b", re.I),
+    # "is now always / never / safe / correct / properly handled"
+    re.compile(
+        r"\bis now\b.{0,30}\b(?:always|never|safe|correct|properly|correctly|handled)\b",
+        re.I | re.S,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Backing-evidence patterns
+# ---------------------------------------------------------------------------
+# A claim is *backed* when it cites a concrete test or invariant argument.
+
+# Test-name references: test_*, *Test, *Tests, tests/test_*
+_TEST_REF_PATTERN = re.compile(
+    r"\btest_\w+|\w+Tests?\b|tests[\\/]test_\w+",
+    re.I,
+)
+
+# Explicit invariant / proof phrases
+_INVARIANT_PHRASES: tuple[str, ...] = (
+    "invariant",
+    "by construction",
+    "by design",
+    "guaranteed by",
+    "proven by",
+    "always holds",
+    "structurally impossible",
+    "structurally enforced",
+    "by invariant",
+    "type system",
+    "enforced by",
+)
+
+# ---------------------------------------------------------------------------
+# Stop-words for token-overlap scoping
+# ---------------------------------------------------------------------------
+_STOP: frozenset[str] = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "it",
+        "in",
+        "of",
+        "to",
+        "and",
+        "or",
+        "not",
+        "for",
+        "with",
+        "was",
+        "has",
+        "are",
+        "be",
+        "by",
+        "this",
+        "that",
+        "which",
+        "when",
+        "now",
+        "so",
+        "if",
+        "on",
+        "at",
+        "as",
+        "from",
+        "but",
+        "its",
+        "no",
+        "via",
+        "was",
+        "were",
+    }
+)
+
+_MIN_OVERLAP_TOKENS = 2
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FixClaimResult:
+    """Result for a single fix-claim sentence."""
+
+    claim_text: str
+    """The sentence that contains the fix claim."""
+
+    related_finding: str
+    """Prior P1 description that this claim appears to address (200-char cap)."""
+
+    has_backing: bool
+    """True when the claim cites a test name or invariant statement."""
+
+    flag_message: str | None
+    """Reviewer-facing warning string, or None when the claim is accepted."""
+
+
+@dataclass(frozen=True)
+class HandoffClaimCheckResult:
+    """Aggregated result of scanning all fix claims in a handoff summary."""
+
+    flagged: list[FixClaimResult] = field(default_factory=list)
+    """Claims that lack backing evidence (reviewer should verify)."""
+
+    accepted: list[FixClaimResult] = field(default_factory=list)
+    """Claims that cite a test name or invariant (accepted without warning)."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _tokens(text: str) -> set[str]:
+    """Return lowercase word tokens, minus stop-words."""
+    raw = set(re.findall(r"\b[a-z_]\w*\b", text.casefold()))
+    return raw - _STOP
+
+
+def _overlaps_with_finding(sentence: str, finding_desc: str) -> bool:
+    """Return True when *sentence* shares ≥ MIN_OVERLAP meaningful tokens with *finding_desc*."""
+    return len(_tokens(sentence) & _tokens(finding_desc)) >= _MIN_OVERLAP_TOKENS
+
+
+def _is_fix_claim(sentence: str) -> bool:
+    """Return True when *sentence* contains at least one fix-claim phrase."""
+    return any(p.search(sentence) for p in _FIX_CLAIM_PATTERNS)
+
+
+def _has_backing_evidence(sentence: str) -> bool:
+    """Return True when *sentence* cites a test name or invariant phrase."""
+    if _TEST_REF_PATTERN.search(sentence):
+        return True
+    lower = sentence.casefold()
+    return any(phrase in lower for phrase in _INVARIANT_PHRASES)
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split text into sentences on common end-of-sentence punctuation or newlines."""
+    # Split on sentence-ending punctuation followed by whitespace, or on newlines.
+    raw = re.split(r"(?<=[.!?])\s+|\n+", text)
+    return [s.strip() for s in raw if s.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_handoff_fix_claims(
+    summary: str,
+    prior_p1_descriptions: list[str],
+) -> HandoffClaimCheckResult:
+    """Scan *summary* for fix claims about prior P1 findings.
+
+    Only claims whose text overlaps meaningfully with a known prior P1 finding
+    description are evaluated.  Claims that reference no known finding are
+    silently skipped — the check is scoped, not global.
+
+    A claim is *accepted* when it cites a test name (``test_*``, ``*Test``) or
+    an explicit invariant phrase.  Otherwise it is *flagged*.
+
+    Args:
+        summary: Raw text of the dev handoff summary field.
+        prior_p1_descriptions: P1 finding description strings from prior
+            review cycles (already truncated to ≤200 chars by CycleHistory).
+
+    Returns:
+        HandoffClaimCheckResult with separate ``flagged`` and ``accepted`` lists.
+    """
+    if not summary or not prior_p1_descriptions:
+        return HandoffClaimCheckResult()
+
+    sentences = _split_sentences(summary)
+    flagged: list[FixClaimResult] = []
+    accepted: list[FixClaimResult] = []
+
+    for sentence in sentences:
+        if not _is_fix_claim(sentence):
+            continue
+
+        # Find the first prior P1 finding this sentence appears to address.
+        related: str | None = None
+        for desc in prior_p1_descriptions:
+            if _overlaps_with_finding(sentence, desc):
+                related = desc
+                break
+
+        if related is None:
+            # Claim doesn't map to any known prior finding — skip.
+            continue
+
+        has_backing = _has_backing_evidence(sentence)
+
+        if has_backing:
+            accepted.append(
+                FixClaimResult(
+                    claim_text=sentence,
+                    related_finding=related,
+                    has_backing=True,
+                    flag_message=None,
+                )
+            )
+        else:
+            flag_msg = (
+                "Dev claimed this finding fixed but cited no test or invariant"
+                " — verify independently.\n"
+                f'  Claim: "{sentence}"\n'
+                f'  Related finding: "{related}"'
+            )
+            flagged.append(
+                FixClaimResult(
+                    claim_text=sentence,
+                    related_finding=related,
+                    has_backing=False,
+                    flag_message=flag_msg,
+                )
+            )
+
+    return HandoffClaimCheckResult(flagged=flagged, accepted=accepted)

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -208,16 +208,7 @@ def build_review_prompt(
 
         """)
 
-    fix_claim_warnings = ""
-    if fix_claim_flags:
-        warnings_block = "\n".join(f"- {flag}" for flag in fix_claim_flags)
-        fix_claim_warnings = dedent(f"""\
-
-            ⚠ Unsubstantiated fix claims detected (heuristic — verify independently):
-            {warnings_block}
-        """)
-
-    dev_notes_section = (
+    _dev_notes_base = (
         dedent(f"""\
 
             ## Developer Notes
@@ -229,10 +220,20 @@ def build_review_prompt(
             evidence — verify technical claims against the actual code before
             accepting them. Flag deviations that are unjustified, incorrect, or
             whose justification does not hold up on inspection.
-            {fix_claim_warnings}""")
+        """)
         if dev_notes
         else ""
     )
+
+    # Append fix-claim warnings after dedent so dynamic multi-line content does
+    # not interfere with dedent's common-indent calculation.
+    if _dev_notes_base and fix_claim_flags:
+        _warn_lines = ["⚠ Unsubstantiated fix claims detected (heuristic — verify independently):"]
+        for _flag in fix_claim_flags:
+            _warn_lines.append(f"- {_flag}")
+        dev_notes_section = _dev_notes_base + "\n".join(_warn_lines) + "\n"
+    else:
+        dev_notes_section = _dev_notes_base
 
     context_section = ""
     if assembled_context and assembled_context.content:

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -147,6 +147,7 @@ def build_review_prompt(
     conventions: list[str] | None = None,
     assembled_context: ContextPack | None = None,
     sandboxed: bool = True,
+    fix_claim_flags: list[str] | None = None,
 ) -> str:
     """Build the review agent prompt.
 
@@ -207,6 +208,15 @@ def build_review_prompt(
 
         """)
 
+    fix_claim_warnings = ""
+    if fix_claim_flags:
+        warnings_block = "\n".join(f"- {flag}" for flag in fix_claim_flags)
+        fix_claim_warnings = dedent(f"""\
+
+            ⚠ Unsubstantiated fix claims detected (heuristic — verify independently):
+            {warnings_block}
+        """)
+
     dev_notes_section = (
         dedent(f"""\
 
@@ -219,7 +229,7 @@ def build_review_prompt(
             evidence — verify technical claims against the actual code before
             accepting them. Flag deviations that are unjustified, incorrect, or
             whose justification does not hold up on inspection.
-        """)
+            {fix_claim_warnings}""")
         if dev_notes
         else ""
     )

--- a/tests/test_handoff_claim_checker.py
+++ b/tests/test_handoff_claim_checker.py
@@ -1,0 +1,212 @@
+"""Tests for the heuristic handoff fix-claim checker."""
+
+from theforge.handoff_claim_checker import (
+    HandoffClaimCheckResult,
+    check_handoff_fix_claims,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+_P1_GAP = "gap in lagging component is silently skipped when delta is zero"
+_P1_RETRY = "retry loop does not reset the counter between attempts"
+
+
+# ---------------------------------------------------------------------------
+# Basic detection
+# ---------------------------------------------------------------------------
+
+
+class TestFixClaimDetection:
+    def test_no_prior_findings_returns_empty(self):
+        result = check_handoff_fix_claims(
+            "Fixed the lagging component gap issue.", prior_p1_descriptions=[]
+        )
+        assert result == HandoffClaimCheckResult()
+
+    def test_empty_summary_returns_empty(self):
+        result = check_handoff_fix_claims("", prior_p1_descriptions=[_P1_GAP])
+        assert result == HandoffClaimCheckResult()
+
+    def test_claim_unrelated_to_any_finding_is_skipped(self):
+        # "fixed the config loader" has no token overlap with _P1_GAP
+        result = check_handoff_fix_claims(
+            "Fixed the config loader path resolution.",
+            prior_p1_descriptions=[_P1_GAP],
+        )
+        assert result.flagged == []
+        assert result.accepted == []
+
+    def test_claim_about_prior_p1_without_backing_is_flagged(self):
+        summary = "Ensures the lagging component gap is never silently skipped when delta is zero."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert len(result.flagged) == 1
+        assert result.accepted == []
+        flag = result.flagged[0]
+        assert flag.related_finding == _P1_GAP
+        assert flag.has_backing is False
+        assert flag.flag_message is not None
+        assert "no test or invariant" in flag.flag_message
+
+    def test_claim_with_test_name_is_accepted(self):
+        summary = "Fixes the lagging component gap — covered by test_gap_skipped_delta_zero."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.flagged == []
+        assert len(result.accepted) == 1
+        assert result.accepted[0].has_backing is True
+
+    def test_claim_with_Test_suffix_is_accepted(self):
+        summary = "Resolves the gap in lagging component — verified in GapSkipTest."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.flagged == []
+        assert len(result.accepted) == 1
+
+    def test_claim_with_invariant_phrase_is_accepted(self):
+        summary = (
+            "Ensures the lagging component gap is never silently skipped — "
+            "by construction the delta guard runs before the skip path."
+        )
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.flagged == []
+        assert len(result.accepted) == 1
+
+    def test_claim_with_by_design_is_accepted(self):
+        summary = "Fixes gap in lagging component by design of the new delta guard."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.flagged == []
+        assert len(result.accepted) == 1
+
+
+# ---------------------------------------------------------------------------
+# Multi-finding / multi-sentence
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleFindings:
+    def test_multiple_prior_p1s_each_can_be_flagged(self):
+        summary = (
+            "Ensures the lagging component gap is no longer silently skipped. "
+            "Fixes the retry loop counter so it no longer persists between attempts."
+        )
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP, _P1_RETRY])
+        assert len(result.flagged) == 2
+        assert result.accepted == []
+
+    def test_mixed_backed_and_unbacked_claims(self):
+        summary = (
+            "Fixes the lagging component gap — covered by test_gap_delta_zero. "
+            "Resolves the retry counter issue so it no longer persists between attempts."
+        )
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP, _P1_RETRY])
+        assert len(result.accepted) == 1
+        assert len(result.flagged) == 1
+        assert result.accepted[0].related_finding == _P1_GAP
+        assert result.flagged[0].related_finding == _P1_RETRY
+
+    def test_claim_matched_to_first_overlapping_finding(self):
+        # If a sentence overlaps with both, it should be matched to the first.
+        summary = "Ensures gap in lagging component retry loop is fixed."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP, _P1_RETRY])
+        assert len(result.flagged) == 1
+        assert result.flagged[0].related_finding == _P1_GAP
+
+
+# ---------------------------------------------------------------------------
+# Phrase / pattern coverage
+# ---------------------------------------------------------------------------
+
+
+class TestFixClaimPhrases:
+    """Ensure all major fix-claim phrases are detected."""
+
+    def _flagged_for(self, sentence: str) -> bool:
+        result = check_handoff_fix_claims(sentence, prior_p1_descriptions=[_P1_GAP])
+        return len(result.flagged) > 0 or len(result.accepted) > 0
+
+    def test_no_longer_phrase(self):
+        assert self._flagged_for("The lagging component gap is no longer silently skipped.")
+
+    def test_ensures_never_phrase(self):
+        assert self._flagged_for(
+            "This ensures the lagging component gap can never be silently skipped."
+        )
+
+    def test_guarantees_phrase(self):
+        assert self._flagged_for("The new guard guarantees the lagging component gap is handled.")
+
+    def test_fixes_phrase(self):
+        assert self._flagged_for("This commit fixes the lagging component gap delta issue.")
+
+    def test_resolves_phrase(self):
+        assert self._flagged_for("Resolves the gap in lagging component skipped by delta check.")
+
+    def test_prevents_phrase(self):
+        assert self._flagged_for(
+            "The new guard prevents the lagging component gap from being skipped."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Backing evidence patterns
+# ---------------------------------------------------------------------------
+
+
+class TestBackingEvidence:
+    def test_test_underscore_prefix_accepted(self):
+        summary = "Fixes lagging component gap — see test_gap_skipped."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.accepted and result.accepted[0].has_backing is True
+
+    def test_Tests_suffix_accepted(self):
+        summary = "Fixes lagging component gap — see GapSkipTests."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.accepted and result.accepted[0].has_backing is True
+
+    def test_invariant_keyword_accepted(self):
+        summary = "Fixes lagging component gap; this is an invariant of the scheduler."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.accepted and result.accepted[0].has_backing is True
+
+    def test_by_construction_accepted(self):
+        summary = "Fixes lagging component gap by construction."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.accepted and result.accepted[0].has_backing is True
+
+    def test_no_backing_is_flagged(self):
+        summary = "Fixes lagging component gap."
+        result = check_handoff_fix_claims(summary, prior_p1_descriptions=[_P1_GAP])
+        assert result.flagged and result.flagged[0].has_backing is False
+
+
+# ---------------------------------------------------------------------------
+# Flag message format
+# ---------------------------------------------------------------------------
+
+
+class TestFlagMessage:
+    def test_flag_message_contains_claim_and_finding(self):
+        claim = "Ensures gap in lagging component is never silently skipped."
+        result = check_handoff_fix_claims(claim, prior_p1_descriptions=[_P1_GAP])
+        assert result.flagged
+        msg = result.flagged[0].flag_message
+        assert msg is not None
+        assert "no test or invariant" in msg
+        assert "verify independently" in msg
+        # Related finding should be included
+        assert "lagging component" in msg or _P1_GAP[:30] in msg
+
+    def test_accepted_claim_has_no_flag_message(self):
+        claim = "Fixes lagging gap — test_gap_delta_zero covers this."
+        result = check_handoff_fix_calls(claim, prior_p1_descriptions=[_P1_GAP])
+        assert result.accepted
+        assert result.accepted[0].flag_message is None
+
+
+# ---------------------------------------------------------------------------
+# Typo fix helper for the test above
+# ---------------------------------------------------------------------------
+
+# (rename the mistyped function call in the last test above)
+check_handoff_fix_calls = check_handoff_fix_claims

--- a/tests/test_task_review.py
+++ b/tests/test_task_review.py
@@ -276,6 +276,75 @@ class TestBuildReviewPromptCycleHistory:
         assert "## Commits" in prompt
 
 
+class TestBuildReviewPromptFixClaimFlags:
+    """Tests for build_review_prompt() fix_claim_flags parameter."""
+
+    def test_no_flags_no_warning_section(self, review_task: TaskStory) -> None:
+        """When fix_claim_flags is None, no warning section appears."""
+        prompt = build_review_prompt(
+            review_task,
+            **_REVIEW_COMMON_KWARGS,
+            dev_notes="Summary: implemented the feature.",
+            fix_claim_flags=None,
+        )
+        assert "Unsubstantiated fix claims" not in prompt
+
+    def test_single_flag_appears_in_dev_notes_section(self, review_task: TaskStory) -> None:
+        """A fix-claim flag is injected after the Developer Notes section."""
+        _flag = (
+            "Dev claimed this finding fixed but cited no test or invariant"
+            " — verify independently.\n"
+            '  Claim: "fixes gap"\n'
+            '  Related finding: "gap in component"'
+        )
+        prompt = build_review_prompt(
+            review_task,
+            **_REVIEW_COMMON_KWARGS,
+            dev_notes="Summary: fixed the gap.",
+            fix_claim_flags=[_flag],
+        )
+        assert "## Developer Notes" in prompt
+        assert "Unsubstantiated fix claims detected" in prompt
+        assert "verify independently" in prompt
+
+    def test_flags_without_dev_notes_are_suppressed(self, review_task: TaskStory) -> None:
+        """fix_claim_flags with no dev_notes produces no warning (nothing to attach to)."""
+        prompt = build_review_prompt(
+            review_task,
+            **_REVIEW_COMMON_KWARGS,
+            dev_notes=None,
+            fix_claim_flags=["some warning"],
+        )
+        assert "Unsubstantiated fix claims" not in prompt
+
+    def test_multiline_flag_message_does_not_corrupt_prompt(self, review_task: TaskStory) -> None:
+        """Multi-line flag_message (with Claim / Related finding lines) renders correctly.
+
+        Verifies the P2 fix: flag content with mixed indentation must not corrupt
+        the surrounding prompt sections via dedent interaction.
+        """
+        multiline_flag = (
+            "Dev claimed this finding fixed but cited no test or invariant"
+            " — verify independently.\n"
+            '  Claim: "ensures gap is never skipped"\n'
+            '  Related finding: "gap in lagging component"'
+        )
+        prompt = build_review_prompt(
+            review_task,
+            **_REVIEW_COMMON_KWARGS,
+            dev_notes="Summary: fixes applied.",
+            fix_claim_flags=[multiline_flag],
+        )
+        # All major prompt sections must still be present (not eaten by bad dedent)
+        assert "## Developer Notes" in prompt
+        assert "## Spec" in prompt
+        assert "## Verified Git Metadata" in prompt
+        assert "## Severity Definitions" in prompt
+        # Flag content itself must appear
+        assert "ensures gap is never skipped" in prompt
+        assert "gap in lagging component" in prompt
+
+
 class TestTaskStoryDependsOn:
     def test_depends_on_default_empty(self, tmp_path: Path) -> None:
         """TaskStory without depends_on argument defaults to []."""


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the spec: scoped heuristic detection, reviewer warning injection, and audit logging are all present and covered by tests. | [gemini-reviewer] The implementation correctly flags unsubstantiated fix claims, but has a minor formatting issue in the prompt.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.61
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/task/review_prompts.py:231`** The fix-claim warnings are appended to the developer notes section without a preceding blank line, causing them to be rendered as part of the same paragraph in Markdown.

## Story

Flag unsubstantiated fix claims in handoff to reviewers (GitHub Issue #257)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #257