### PR TITLE
Use native CLI sandbox flags for write containment; retire sibling detector

### DIFF
--- a/src/theforge/config/auth.py
+++ b/src/theforge/config/auth.py
@@ -21,14 +21,16 @@ _LOCAL_PREFIXES = (
 
 
 def _sandbox_readiness(profile: ModelProfile) -> tuple[bool, str]:
-    """Return whether workspace-effect sandboxing is available for this profile.
+    """Return whether workspace-effect sandboxing is active for this profile.
 
-    Launcher startup is intentionally unsandboxed for external CLI agents. This
-    check only reports whether runtime workspace effects that still flow through
-    the forge tool runtime (currently API-provider bash/tool execution) can be
-    confined to the assigned working directory on supported platforms.
+    For CLI profiles, reports whether native CLI sandboxing is engaged based on
+    the profile's sandbox_mode field. For API profiles, probes whether the
+    platform can confine bash/tool effects to the working directory.
     """
     if profile.mode != "api":
+        # CLI profiles: sandboxing is active when sandbox_mode is not "none"
+        if profile.sandbox_mode == "none":
+            return (False, "sandbox disabled by sandbox_mode: none")
         return (True, "")
     if "bash" not in profile.allowed_tools:
         return (True, "")
@@ -66,7 +68,7 @@ def sandbox_available_for_profile(profile: ModelProfile) -> bool:
 
 
 def _launcher_sandbox_readiness(profile: ModelProfile) -> tuple[bool, str]:
-    """CLI launchers are intentionally unsandboxed; always report ready."""
+    """CLI launchers are always auth-ready; binary presence checked separately."""
     return (True, "")
 
 

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -78,6 +78,9 @@ def _parse_model_spec(
     return primary, fallbacks
 
 
+_VALID_SANDBOX_MODES = {"workspace-write", "read-only", "none"}
+
+
 def _apply_profile_overrides(base: ModelProfile, data: dict[str, Any]) -> ModelProfile:
     """Apply partial forge.yaml profile overrides on top of an auto-assigned profile."""
     tools = data.get("allowed_tools")
@@ -88,6 +91,12 @@ def _apply_profile_overrides(base: ModelProfile, data: dict[str, Any]) -> ModelP
         raise ValueError(
             f"reasoning_effort must be one of {sorted(_VALID_REASONING_EFFORTS)}, "
             f"got {reasoning_effort!r} in profile {base.name!r}"
+        )
+    sandbox_mode = data.get("sandbox_mode", base.sandbox_mode)
+    if sandbox_mode not in _VALID_SANDBOX_MODES:
+        raise ValueError(
+            f"sandbox_mode must be one of {sorted(_VALID_SANDBOX_MODES)}, "
+            f"got {sandbox_mode!r} in profile {base.name!r}"
         )
     timeout_medium_raw = data.get("timeout_medium_seconds", base.timeout_medium_seconds)
     timeout_large_raw = data.get("timeout_large_seconds", base.timeout_large_seconds)
@@ -120,6 +129,7 @@ def _apply_profile_overrides(base: ModelProfile, data: dict[str, Any]) -> ModelP
         api_fallback=base.api_fallback,
         github_handle=data.get("github_handle", base.github_handle),
         phase=base.phase,
+        sandbox_mode=sandbox_mode,
     )
 
 
@@ -299,6 +309,12 @@ def _parse_profile(
     else:
         allowed_tools_tuple = default.allowed_tools
 
+    sandbox_mode = data.get("sandbox_mode", "workspace-write")
+    if sandbox_mode not in _VALID_SANDBOX_MODES:
+        raise ValueError(
+            f"sandbox_mode must be one of {sorted(_VALID_SANDBOX_MODES)}, "
+            f"got {sandbox_mode!r} in profile {name!r}"
+        )
     model_str, fallback_models = _parse_model_spec(data, default.model, (), name)
     return ModelProfile(
         name=name,
@@ -322,6 +338,7 @@ def _parse_profile(
         if (max_iter_raw := data.get("max_iterations")) is not None
         else None,
         github_handle=data.get("github_handle"),
+        sandbox_mode=sandbox_mode,
     )
 
 
@@ -400,4 +417,5 @@ def _apply_provider_fallback(
         api_fallback=fallback,
         github_handle=profile.github_handle,
         phase=profile.phase,
+        sandbox_mode=profile.sandbox_mode,
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -112,6 +112,7 @@ class ModelProfile:
     api_fallback: ApiFallbackConfig | None = None  # CLI-only fallback to same-provider API
     github_handle: str | None = None  # optional GitHub username for reviewer assignment
     fallback_models: tuple[str, ...] = ()  # additional models to try on quota/not-found failure
+    sandbox_mode: str = "workspace-write"  # CLI sandbox: "workspace-write" | "read-only" | "none"
 
     @property
     def models(self) -> tuple[str, ...]:

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -23,61 +23,6 @@ from .notify import _escalate_notify
 from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase, RetryReason
 from .util import _fmt_duration, _log, _log_phase, _log_verbose, resolve_timeout
 
-# ── Sibling-worktree write detector ──────────────────────────────────
-# CLI agents run unsandboxed and could write to sibling worktrees. These helpers
-# snapshot and diff sibling worktrees around each dev iteration so cross-worktree
-# contamination is detected and escalated before it can corrupt parallel work.
-
-
-def _iter_sibling_worktrees(active_worktree: Path, project_root: Path) -> list[Path]:
-    """Return paths of sibling worktrees — all dirs under .forge/worktrees/ except active."""
-    worktrees_dir = project_root / ".forge" / "worktrees"
-    if not worktrees_dir.is_dir():
-        return []
-    active_resolved = active_worktree.resolve()
-    siblings = []
-    for entry in worktrees_dir.iterdir():
-        if entry.is_dir() and entry.resolve() != active_resolved:
-            siblings.append(entry)
-    return siblings
-
-
-def _is_forge_artifact_status_line(line: str) -> bool:
-    """Return True if this porcelain status line refers to a forge-owned artifact.
-
-    Forge writes its own files under .forge/ (plan.md, sessions.json, handoff.yaml,
-    traces/, audit.yaml) during normal coordinator operation. These are not agent
-    writes and must not trigger the sibling-worktree contamination detector.
-
-    The porcelain format is ``XY PATH`` (two status chars, space, then path).
-    Ignored directories are reported as ``!! .forge/`` (with trailing slash).
-    """
-    # Strip the two-character status prefix and the separating space
-    path_part = line[3:] if len(line) > 3 else ""
-    return path_part == ".forge" or path_part.startswith(".forge/")
-
-
-def _git_status_porcelain_ignored(path: Path) -> frozenset[str]:
-    """Return the set of non-empty status lines from git status --porcelain --ignored.
-
-    Includes ignored files so that writes to build outputs or other ignored paths
-    in sibling worktrees are visible. Returns empty frozenset on any error.
-    """
-    try:
-        proc = subprocess.run(
-            ["git", "status", "--porcelain", "--ignored"],
-            cwd=str(path),
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if proc.returncode != 0:
-            return frozenset()
-        return frozenset(line for line in proc.stdout.splitlines() if line.strip())
-    except Exception:  # noqa: BLE001  # best-effort, any error treated as clean
-        return frozenset()
-
-
 # ── Lazy runner slot ──────────────────────────────────────────────────
 # None until first call; tests may replace before calling run_task.
 # Patch targets:
@@ -241,6 +186,11 @@ def _run_dev_phase(
     _ensure_runners()
     # Probe sandbox availability once per run (lru_cache-backed — cheap on repeat calls).
     state.sandboxed = sandbox_available_for_profile(config.dev_profile)
+    if config.dev_profile.mode == "cli" and config.dev_profile.sandbox_mode == "none":
+        _log(
+            "  WARNING: sandbox_mode: none — dev agent runs without write containment. "
+            "Use for debugging only."
+        )
     _log_phase(
         state.phase,
         f"{config.dev_profile.model}  iter={state.dev_iteration}",
@@ -380,14 +330,6 @@ def _run_dev_phase(
         _log(f"  Dev timeout: {_dev_timeout}s")
     _dev_profile = _dc_replace(config.dev_profile, timeout_seconds=_dev_timeout)
 
-    # Snapshot sibling worktrees before dev agent runs.
-    # CLI agents are opaque — we cannot intercept their writes, so we detect
-    # cross-worktree contamination by diffing state before and after.
-    _sibling_baselines: dict[Path, frozenset[str]] = {
-        _sib: _git_status_porcelain_ignored(_sib)
-        for _sib in _iter_sibling_worktrees(workspace_path, config.project_root)
-    }
-
     _dev_start = time.monotonic()
     dev_result = run_agent(
         prompt=prompt,
@@ -433,43 +375,6 @@ def _run_dev_phase(
             cost_usd=dev_result.cost_usd,
             duration_s=round(_dev_elapsed, 2),
         )
-
-    # ── Sibling-worktree write detector ──────────────────────────────
-    # Check each sibling for any on-disk changes (tracked, untracked, or ignored)
-    # that were not present before the dev agent ran. Any mismatch is escalated
-    # immediately — CLI agents must not write outside their own worktree.
-    for _sib_path, _baseline in _sibling_baselines.items():
-        _current = _git_status_porcelain_ignored(_sib_path)
-        # Strip forge-owned artifact lines from both snapshots before diffing.
-        # The coordinator writes .forge/ paths (plan.md, sessions.json, traces/,
-        # handoff.yaml, audit.yaml) during normal operation — these are not agent
-        # writes and must not trigger a false contamination escalation.
-        _baseline_filtered = frozenset(
-            ln for ln in _baseline if not _is_forge_artifact_status_line(ln)
-        )
-        _current_filtered = frozenset(
-            ln for ln in _current if not _is_forge_artifact_status_line(ln)
-        )
-        if _current_filtered != _baseline_filtered:
-            _changed = sorted(
-                (_current_filtered - _baseline_filtered) | (_baseline_filtered - _current_filtered)
-            )
-            _preview = ", ".join(_changed[:5])
-            state.phase = Phase.ESCALATE
-            state.error = (
-                f"Sibling worktree write detected in {_sib_path}: "
-                f"{len(_changed)} change(s) — {_preview}"
-            )
-            _log(f"✗ ESCALATE   {state.error}")
-            if logger:
-                logger._safe_emit("escalate", reason=state.error, phase="DEV")
-            _escalate_notify(task, state, notify, config)
-            return CoordinatorResult(
-                success=False,
-                phase=state.phase,
-                state=state,
-                message=state.error,
-            )
 
     if state.total_dev_cost > config.dev_profile.budget_usd:
         state.phase = Phase.ESCALATE

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -173,6 +173,13 @@ def _run_claude(
     if session_id:
         cmd.extend(["--resume", session_id])
 
+    # Engage Claude's native permission mode when sandboxing is requested.
+    # "default" confines writes to cwd by prompting before any write outside it;
+    # there is no "read-only" mode in Claude CLI — "default" is the most restrictive
+    # available option for both workspace-write and read-only sandbox modes.
+    if profile.sandbox_mode != "none":
+        cmd.extend(["--permission-mode", "default"])
+
     # Unset CLAUDECODE so the subprocess isn't blocked by the nested-session check
     env = {**os.environ, **(secrets or {})}
     env.pop("CLAUDECODE", None)

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -174,9 +174,17 @@ def _run_claude(
         cmd.extend(["--resume", session_id])
 
     # Engage Claude's native permission mode when sandboxing is requested.
-    # "default" confines writes to cwd by prompting before any write outside it;
-    # there is no "read-only" mode in Claude CLI — "default" is the most restrictive
-    # available option for both workspace-write and read-only sandbox modes.
+    # "default" prompts before writes outside cwd; in automated runs where there is
+    # no human to approve, out-of-worktree writes are effectively blocked.
+    # NOTE: Claude CLI has no mechanically-enforced read-only mode. When
+    # sandbox_mode == "read-only" we apply the same --permission-mode default and
+    # log a warning so operators know the read-only constraint is not syscall-enforced.
+    if profile.sandbox_mode == "read-only":
+        _log(
+            "  WARNING: sandbox_mode=read-only is not mechanically enforced by Claude CLI; "
+            "applying --permission-mode default (writes require permission approval). "
+            "Use a provider/API profile for true read-only enforcement."
+        )
     if profile.sandbox_mode != "none":
         cmd.extend(["--permission-mode", "default"])
 

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -115,6 +115,8 @@ def _run_codex(
         ]
         if profile.reasoning_effort:
             cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
+        if profile.sandbox_mode != "none":
+            cmd += ["--sandbox", profile.sandbox_mode]
         cmd += ["-C", str(working_dir), "-o", str(output_file), "-"]
         stdin_prompt: str | None = prompt
     else:
@@ -128,6 +130,8 @@ def _run_codex(
         ]
         if profile.reasoning_effort:
             cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
+        if profile.sandbox_mode != "none":
+            cmd += ["--sandbox", profile.sandbox_mode]
         cmd += ["-C", str(working_dir), "-o", str(output_file), prompt]
         stdin_prompt = None
 

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -17,6 +17,7 @@ from theforge.log_util import _log_line
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
+from .sandbox import workspace_effect_sandbox_command
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -70,6 +71,21 @@ def _run_gemini(
     # NOTE: Gemini CLI has no --config flag for thinking config.
     # reasoning_effort is silently ignored for gemini until a CLI mechanism exists.
     # The model uses its default thinking level.
+
+    # Gemini CLI has no native sandbox flag. When sandboxing is requested, wrap the
+    # command with the platform sandbox (macOS Seatbelt / Linux bwrap). This is the
+    # correct approach for Gemini — unlike #624 (which double-sandboxed claude-within-
+    # claude), wrapping the Gemini binary is safe because Gemini has no native sandbox
+    # of its own. If the sandbox infrastructure is unavailable, log a warning and
+    # continue unsandboxed; operators can set sandbox_mode: none to suppress this.
+    if profile.sandbox_mode != "none":
+        sandboxed_cmd = workspace_effect_sandbox_command(cmd, working_dir)
+        if sandboxed_cmd[0] == cmd[0]:
+            _log(
+                f"  WARNING: sandbox_mode={profile.sandbox_mode!r} requested for gemini but "
+                "platform sandbox (sandbox-exec/bwrap) is unavailable — running unsandboxed"
+            )
+        cmd = sandboxed_cmd
 
     label = profile.name or f"{profile.cli or profile.provider}/{profile.model}"
     _gemini_env = {**os.environ, **(secrets or {})}

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -76,14 +76,33 @@ def _run_gemini(
     # command with the platform sandbox (macOS Seatbelt / Linux bwrap). This is the
     # correct approach for Gemini — unlike #624 (which double-sandboxed claude-within-
     # claude), wrapping the Gemini binary is safe because Gemini has no native sandbox
-    # of its own. If the sandbox infrastructure is unavailable, log a warning and
-    # continue unsandboxed; operators can set sandbox_mode: none to suppress this.
+    # of its own.
+    # Fail closed: if the platform sandbox is unavailable and sandbox_mode is not
+    # "none", return a failure result rather than running unsandboxed. The sibling
+    # detector has been removed, so running without containment would leave writes
+    # undetected. Set sandbox_mode: none explicitly to opt out of containment.
     if profile.sandbox_mode != "none":
         sandboxed_cmd = workspace_effect_sandbox_command(cmd, working_dir)
         if sandboxed_cmd[0] == cmd[0]:
             _log(
-                f"  WARNING: sandbox_mode={profile.sandbox_mode!r} requested for gemini but "
-                "platform sandbox (sandbox-exec/bwrap) is unavailable — running unsandboxed"
+                f"✗ gemini: sandbox_mode={profile.sandbox_mode!r} requested but platform "
+                "sandbox (sandbox-exec/bwrap) is unavailable — refusing to run unsandboxed. "
+                "Set sandbox_mode: none to explicitly opt out of write containment."
+            )
+            return AgentResult(
+                success=False,
+                output=(
+                    f"SANDBOX_UNAVAILABLE: sandbox_mode={profile.sandbox_mode!r} is set but "
+                    "the platform sandbox (sandbox-exec on macOS, bwrap on Linux) is not "
+                    "available on this host. Gemini CLI has no native sandbox flag. "
+                    "Set sandbox_mode: none to run without write containment."
+                ),
+                session_id=None,
+                cost_usd=None,
+                exit_code=-1,
+                raw={},
+                profile_name=profile.name,
+                startup_failure=True,
             )
         cmd = sandboxed_cmd
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,7 @@ def gemini_profile() -> ModelProfile:
         budget_usd=1.0,
         timeout_seconds=300,
         allowed_tools=(),
+        sandbox_mode="none",  # sandbox behaviour is tested in test_runner_gemini.py
     )
 
 

--- a/tests/test_coord_dev_phase_sibling_detector.py
+++ b/tests/test_coord_dev_phase_sibling_detector.py
@@ -1,9 +1,11 @@
-"""Tests for the sibling-worktree write detector in dev_phase.
+"""Regression tests confirming the sibling-worktree write detector has been removed.
 
-Covers:
-  - _iter_sibling_worktrees: discovers siblings, excludes active worktree
-  - _git_status_porcelain_ignored: returns status lines, handles errors gracefully
-  - _run_dev_phase: escalates when a sibling worktree has new writes after the dev agent runs
+The detector (_iter_sibling_worktrees, _git_status_porcelain_ignored,
+_is_forge_artifact_status_line) was retired in favour of native CLI sandboxing.
+These tests verify:
+  - The helper functions no longer exist in dev_phase
+  - _run_dev_phase does NOT escalate on sibling-worktree writes
+  - Parallel sprints (max_parallel > 1) no longer trip on legitimate sibling activity
 """
 
 from __future__ import annotations
@@ -20,369 +22,101 @@ from coord_test_helpers import (
     _shell_with_gate,
 )
 
-from theforge.coordinator.dev_phase import (
-    _git_status_porcelain_ignored,
-    _is_forge_artifact_status_line,
-    _iter_sibling_worktrees,
-)
+import theforge.coordinator.dev_phase as dev_phase_mod
 from theforge.coordinator.engine import run_task
 from theforge.coordinator.state import Phase
-
-# ── _iter_sibling_worktrees ──────────────────────────────────────────
-
-
-class TestIterSiblingWorktrees:
-    def test_no_worktrees_dir(self, tmp_path: Path) -> None:
-        """Returns empty list when .forge/worktrees/ does not exist."""
-        active = tmp_path / ".forge" / "worktrees" / "issue-1"
-        result = _iter_sibling_worktrees(active, tmp_path)
-        assert result == []
-
-    def test_only_active_worktree(self, tmp_path: Path) -> None:
-        """Returns empty list when the only worktree is the active one."""
-        active = tmp_path / ".forge" / "worktrees" / "issue-1"
-        active.mkdir(parents=True)
-        result = _iter_sibling_worktrees(active, tmp_path)
-        assert result == []
-
-    def test_returns_siblings_excludes_active(self, tmp_path: Path) -> None:
-        """Returns sibling worktrees but not the active one."""
-        wt_dir = tmp_path / ".forge" / "worktrees"
-        active = wt_dir / "issue-1"
-        sibling_a = wt_dir / "issue-2"
-        sibling_b = wt_dir / "issue-3"
-        for d in (active, sibling_a, sibling_b):
-            d.mkdir(parents=True)
-        result = _iter_sibling_worktrees(active, tmp_path)
-        assert set(result) == {sibling_a, sibling_b}
-        assert active not in result
-
-    def test_non_directory_entries_excluded(self, tmp_path: Path) -> None:
-        """Non-directory entries under .forge/worktrees/ are ignored."""
-        wt_dir = tmp_path / ".forge" / "worktrees"
-        active = wt_dir / "issue-1"
-        sibling = wt_dir / "issue-2"
-        for d in (active, sibling):
-            d.mkdir(parents=True)
-        # Create a file (not a directory) in worktrees/
-        (wt_dir / "README.txt").write_text("notes", encoding="utf-8")
-        result = _iter_sibling_worktrees(active, tmp_path)
-        assert result == [sibling]
-
-    def test_resolves_symlinks(self, tmp_path: Path) -> None:
-        """Active worktree matched by resolved path (handles symlinks)."""
-        wt_dir = tmp_path / ".forge" / "worktrees"
-        real = wt_dir / "issue-1"
-        real.mkdir(parents=True)
-        link = tmp_path / "active-link"
-        link.symlink_to(real)
-        sibling = wt_dir / "issue-2"
-        sibling.mkdir()
-        # Pass the symlink as active_worktree — it resolves to real
-        result = _iter_sibling_worktrees(link, tmp_path)
-        assert result == [sibling]
-        assert real not in result
+from theforge.runners import AgentResult
 
 
-# ── _git_status_porcelain_ignored ───────────────────────────────────
+def _approve_pool_result() -> list[AgentResult]:
+    return [
+        AgentResult(
+            success=True,
+            output=APPROVE_REVIEW,
+            session_id=None,
+            cost_usd=0.10,
+            exit_code=0,
+            raw={},
+            profile_name="review",
+        )
+    ]
 
 
-class TestGitStatusPorcelainIgnored:
-    def test_returns_status_lines(self, tmp_path: Path) -> None:
-        """Returns frozenset of non-empty status lines on success."""
-        output = " M src/foo.py\n?? new_file.txt\n!! build/\n"
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = output
-        with patch("theforge.coordinator.dev_phase.subprocess.run", return_value=mock_proc):
-            result = _git_status_porcelain_ignored(tmp_path)
-        assert result == frozenset([" M src/foo.py", "?? new_file.txt", "!! build/"])
+class TestSiblingDetectorRemoved:
+    """The three detector helpers must not exist in dev_phase."""
 
-    def test_empty_on_clean_worktree(self, tmp_path: Path) -> None:
-        """Returns empty frozenset for a clean worktree."""
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = ""
-        with patch("theforge.coordinator.dev_phase.subprocess.run", return_value=mock_proc):
-            result = _git_status_porcelain_ignored(tmp_path)
-        assert result == frozenset()
+    def test_iter_sibling_worktrees_not_exported(self) -> None:
+        """_iter_sibling_worktrees must not exist in dev_phase."""
+        assert not hasattr(dev_phase_mod, "_iter_sibling_worktrees"), (
+            "_iter_sibling_worktrees was not removed from dev_phase"
+        )
 
-    def test_empty_on_git_error(self, tmp_path: Path) -> None:
-        """Returns empty frozenset when git returns non-zero exit."""
-        mock_proc = MagicMock()
-        mock_proc.returncode = 128
-        mock_proc.stdout = ""
-        with patch("theforge.coordinator.dev_phase.subprocess.run", return_value=mock_proc):
-            result = _git_status_porcelain_ignored(tmp_path)
-        assert result == frozenset()
+    def test_is_forge_artifact_status_line_not_exported(self) -> None:
+        """_is_forge_artifact_status_line must not exist in dev_phase."""
+        assert not hasattr(dev_phase_mod, "_is_forge_artifact_status_line"), (
+            "_is_forge_artifact_status_line was not removed from dev_phase"
+        )
 
-    def test_empty_on_exception(self, tmp_path: Path) -> None:
-        """Returns empty frozenset when subprocess raises (e.g. not a git repo)."""
-        with patch(
-            "theforge.coordinator.dev_phase.subprocess.run",
-            side_effect=FileNotFoundError("git not found"),
-        ):
-            result = _git_status_porcelain_ignored(tmp_path)
-        assert result == frozenset()
-
-    def test_uses_ignored_flag(self, tmp_path: Path) -> None:
-        """Passes --ignored to git so that writes to ignored dirs are detected."""
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = ""
-        with patch(
-            "theforge.coordinator.dev_phase.subprocess.run", return_value=mock_proc
-        ) as mock_run:
-            _git_status_porcelain_ignored(tmp_path)
-        args = mock_run.call_args[0][0]
-        assert "--ignored" in args
-        assert "--porcelain" in args
-
-    def test_skips_blank_lines(self, tmp_path: Path) -> None:
-        """Blank lines in git output are excluded from the result set."""
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = " M src/foo.py\n\n   \n?? bar.txt\n"
-        with patch("theforge.coordinator.dev_phase.subprocess.run", return_value=mock_proc):
-            result = _git_status_porcelain_ignored(tmp_path)
-        assert result == frozenset([" M src/foo.py", "?? bar.txt"])
-
-    def test_returns_forge_artifact_lines_unfiltered(self, tmp_path: Path) -> None:
-        """_git_status_porcelain_ignored returns raw lines; caller filters forge artifacts."""
-        output = " M src/foo.py\n!! .forge/plan.md\n!! build/leaked.o\n"
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = output
-        with patch("theforge.coordinator.dev_phase.subprocess.run", return_value=mock_proc):
-            result = _git_status_porcelain_ignored(tmp_path)
-        # All non-blank lines returned; forge artifact filtering is the caller's job
-        assert result == frozenset([" M src/foo.py", "!! .forge/plan.md", "!! build/leaked.o"])
+    def test_git_status_porcelain_ignored_not_exported(self) -> None:
+        """_git_status_porcelain_ignored must not exist in dev_phase."""
+        assert not hasattr(dev_phase_mod, "_git_status_porcelain_ignored"), (
+            "_git_status_porcelain_ignored was not removed from dev_phase"
+        )
 
 
-# ── _is_forge_artifact_status_line ──────────────────────────────────
-
-
-class TestIsForgeArtifactStatusLine:
-    def test_forge_plan_md(self) -> None:
-        assert _is_forge_artifact_status_line("!! .forge/plan.md") is True
-
-    def test_forge_handoff_yaml(self) -> None:
-        assert _is_forge_artifact_status_line("!! .forge/handoff.yaml") is True
-
-    def test_forge_sessions_json(self) -> None:
-        assert _is_forge_artifact_status_line("!! .forge/sessions.json") is True
-
-    def test_forge_traces_directory(self) -> None:
-        """Directories are reported with trailing slash."""
-        assert _is_forge_artifact_status_line("!! .forge/traces/") is True
-
-    def test_forge_audit_yaml(self) -> None:
-        assert _is_forge_artifact_status_line("!! .forge/audit.yaml") is True
-
-    def test_forge_root_directory(self) -> None:
-        """Bare .forge entry (no trailing slash) is also excluded."""
-        assert _is_forge_artifact_status_line("!! .forge") is True
-
-    def test_src_file_not_artifact(self) -> None:
-        assert _is_forge_artifact_status_line("?? src/leaked.py") is False
-
-    def test_build_dir_not_artifact(self) -> None:
-        assert _is_forge_artifact_status_line("!! build/") is False
-
-    def test_modified_non_forge(self) -> None:
-        assert _is_forge_artifact_status_line(" M README.md") is False
-
-    def test_short_line_no_crash(self) -> None:
-        """Lines shorter than 3 chars do not raise."""
-        assert _is_forge_artifact_status_line("!!") is False
-        assert _is_forge_artifact_status_line("") is False
-
-
-# ── Escalation integration via run_task ─────────────────────────────
-
-
-class TestSiblingWriteDetectorEscalation:
-    """Integration tests: sibling-worktree write detection escalates the run."""
-
-    def _make_subprocess_run_spy(
-        self, sibling_before: frozenset[str], sibling_after: frozenset[str]
-    ):
-        """Return a side_effect for subprocess.run that returns sibling status.
-
-        First call to git status --porcelain --ignored for the sibling → baseline.
-        Second call → changed state (simulating a write by the dev agent).
-        Other subprocess.run calls (e.g. git rev-parse HEAD) are handled normally
-        by a MagicMock with returncode=0.
-        """
-        call_counts: dict[str, int] = {"sibling_status": 0}
-
-        def side_effect(args, **kwargs):
-            cwd = kwargs.get("cwd", "")
-            if (
-                isinstance(args, list)
-                and "--porcelain" in args
-                and "--ignored" in args
-                and "sibling" in str(cwd)
-            ):
-                n = call_counts["sibling_status"]
-                call_counts["sibling_status"] += 1
-                proc = MagicMock()
-                proc.returncode = 0
-                if n == 0:
-                    proc.stdout = "\n".join(sorted(sibling_before)) + (
-                        "\n" if sibling_before else ""
-                    )
-                else:
-                    proc.stdout = "\n".join(sorted(sibling_after)) + (
-                        "\n" if sibling_after else ""
-                    )
-                return proc
-            # Default: success
-            proc = MagicMock()
-            proc.returncode = 0
-            proc.stdout = b"" if isinstance(b"", bytes) else ""
-            try:
-                proc.stdout = "abc1234\n"
-            except Exception:
-                pass
-            return proc
-
-        return side_effect
+class TestNoSiblingEscalation:
+    """_run_dev_phase must NOT escalate when a sibling worktree has new writes."""
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
-    @patch("theforge.coordinator.preflight_flow.run_agent")
-    @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_no_siblings_no_escalation(
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.log_agent_result")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    def test_sibling_write_does_not_escalate(
         self,
-        mock_shell,
         mock_dev_agent,
-        mock_preflight,
+        mock_log_result,
+        mock_preflight_agent,
+        mock_shell,
         mock_pool,
         tmp_path: Path,
     ) -> None:
-        """When there are no sibling worktrees, the run proceeds normally."""
+        """A write to a sibling worktree no longer causes ESCALATE."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
 
-        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
-        mock_preflight.return_value = _PREFLIGHT_RESULT
-        mock_dev_agent.return_value = _make_agent_result()
-        mock_pool.return_value = [
-            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
-        ]
+        # Set up a sibling worktree that will appear to have new files
+        sibling = tmp_path / ".forge" / "worktrees" / "issue-999"
+        sibling.mkdir(parents=True)
+        (sibling / "new_file.py").write_text("# written by sibling agent\n")
 
-        # No .forge/worktrees/ dir — zero siblings
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight_agent.return_value = _PREFLIGHT_RESULT
+        mock_dev_agent.return_value = _make_agent_result()
+        mock_pool.return_value = _approve_pool_result()
+
         result = run_task(config, task, notify=False)
-        assert result.state.phase == Phase.DONE
+
+        # Must NOT escalate — sibling writes are now contained by native sandbox
+        assert result.state.phase != Phase.ESCALATE, f"Unexpected ESCALATE: {result.message}"
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
-    @patch("theforge.coordinator.preflight_flow.run_agent")
-    @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_unchanged_sibling_no_escalation(
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.log_agent_result")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    def test_git_status_not_called_for_siblings(
         self,
-        mock_shell,
         mock_dev_agent,
-        mock_preflight,
+        mock_log_result,
+        mock_preflight_agent,
+        mock_shell,
         mock_pool,
         tmp_path: Path,
     ) -> None:
-        """Sibling worktree unchanged after dev run → no escalation."""
-        config = _make_config(tmp_path)
-        task = _make_task(tmp_path)
-        workspace = tmp_path / "test-task"
-        workspace.mkdir()
-
-        # Create a sibling worktree dir
-        sibling = tmp_path / ".forge" / "worktrees" / "issue-999"
-        sibling.mkdir(parents=True)
-
-        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
-        mock_preflight.return_value = _PREFLIGHT_RESULT
-        mock_dev_agent.return_value = _make_agent_result()
-        mock_pool.return_value = [
-            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
-        ]
-
-        # Both baseline and post-run status are identical (clean)
-        clean_status = frozenset()
-        with patch(
-            "theforge.coordinator.dev_phase._git_status_porcelain_ignored",
-            return_value=clean_status,
-        ):
-            result = run_task(config, task, notify=False)
-
-        assert result.state.phase == Phase.DONE
-
-    @patch("theforge.coordinator.review_pool.run_agent_pool")
-    @patch("theforge.coordinator.preflight_flow.run_agent")
-    @patch("theforge.coordinator.dev_phase.run_agent")
-    @patch("theforge.coordinator.util._run_shell")
-    def test_sibling_write_escalates(
-        self,
-        mock_shell,
-        mock_dev_agent,
-        mock_preflight,
-        mock_pool,
-        tmp_path: Path,
-    ) -> None:
-        """Sibling worktree has new files after dev run → ESCALATE."""
-        config = _make_config(tmp_path)
-        task = _make_task(tmp_path)
-        workspace = tmp_path / "test-task"
-        workspace.mkdir()
-
-        # Create a sibling worktree dir
-        sibling = tmp_path / ".forge" / "worktrees" / "issue-999"
-        sibling.mkdir(parents=True)
-
-        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
-        mock_preflight.return_value = _PREFLIGHT_RESULT
-        mock_dev_agent.return_value = _make_agent_result()
-
-        # First call (snapshot) → clean; second call (post-dev check) → new file
-        call_n = {"n": 0}
-
-        def status_side_effect(path: Path) -> frozenset[str]:
-            if path.resolve() == sibling.resolve():
-                n = call_n["n"]
-                call_n["n"] += 1
-                if n == 0:
-                    return frozenset()  # baseline: clean
-                return frozenset(["?? src/leaked_file.py"])  # post-dev: contaminated
-            return frozenset()
-
-        with patch(
-            "theforge.coordinator.dev_phase._git_status_porcelain_ignored",
-            side_effect=status_side_effect,
-        ):
-            result = run_task(config, task, notify=False)
-
-        assert result.state.phase == Phase.ESCALATE
-        assert "sibling worktree write detected" in result.message.lower()
-        assert str(sibling) in result.message
-
-    @patch("theforge.coordinator.review_pool.run_agent_pool")
-    @patch("theforge.coordinator.preflight_flow.run_agent")
-    @patch("theforge.coordinator.dev_phase.run_agent")
-    @patch("theforge.coordinator.util._run_shell")
-    def test_sibling_forge_artifact_write_does_not_escalate(
-        self,
-        mock_shell,
-        mock_dev_agent,
-        mock_preflight,
-        mock_pool,
-        tmp_path: Path,
-    ) -> None:
-        """Forge-owned .forge/ artifact changes in sibling do NOT escalate.
-
-        Normal coordinator operation writes plan.md, sessions.json, handoff.yaml,
-        traces/, and audit.yaml under .forge/ in worktrees. These must not trigger
-        the sibling-write detector.
-        """
+        """subprocess.run is NOT called with --porcelain --ignored for siblings."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -392,129 +126,19 @@ class TestSiblingWriteDetectorEscalation:
         sibling.mkdir(parents=True)
 
         mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
-        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_preflight_agent.return_value = _PREFLIGHT_RESULT
         mock_dev_agent.return_value = _make_agent_result()
-        mock_pool.return_value = [
-            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
-        ]
+        mock_pool.return_value = _approve_pool_result()
 
-        # All .forge/ artifact forms that the coordinator writes
-        forge_artifact_lines = frozenset(
-            [
-                "!! .forge/plan.md",
-                "!! .forge/handoff.yaml",
-                "!! .forge/sessions.json",
-                "!! .forge/traces/",
-                "!! .forge/audit.yaml",
-            ]
-        )
+        with patch("theforge.coordinator.dev_phase.subprocess.run") as mock_sub:
+            # Generic success response for any subprocess.run call in dev_phase
+            mock_sub.return_value = MagicMock(returncode=0, stdout=b"abc123\n", stderr=b"")
+            run_task(config, task, notify=False)
 
-        call_n = {"n": 0}
-
-        def status_side_effect(path: Path) -> frozenset[str]:
-            if path.resolve() == sibling.resolve():
-                n = call_n["n"]
-                call_n["n"] += 1
-                # After dev runs, sibling has forge artifact writes — not escalatable
-                return frozenset() if n == 0 else forge_artifact_lines
-            return frozenset()
-
-        with patch(
-            "theforge.coordinator.dev_phase._git_status_porcelain_ignored",
-            side_effect=status_side_effect,
-        ):
-            result = run_task(config, task, notify=False)
-
-        assert result.state.phase != Phase.ESCALATE, (
-            f"Should not escalate on forge artifact writes, got: {result.message}"
-        )
-
-    @patch("theforge.coordinator.review_pool.run_agent_pool")
-    @patch("theforge.coordinator.preflight_flow.run_agent")
-    @patch("theforge.coordinator.dev_phase.run_agent")
-    @patch("theforge.coordinator.util._run_shell")
-    def test_sibling_non_forge_ignored_write_escalates(
-        self,
-        mock_shell,
-        mock_dev_agent,
-        mock_preflight,
-        mock_pool,
-        tmp_path: Path,
-    ) -> None:
-        """Ignored-file write outside .forge/ in sibling (e.g. build/) → ESCALATE."""
-        config = _make_config(tmp_path)
-        task = _make_task(tmp_path)
-        workspace = tmp_path / "test-task"
-        workspace.mkdir()
-
-        sibling = tmp_path / ".forge" / "worktrees" / "issue-889"
-        sibling.mkdir(parents=True)
-
-        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
-        mock_preflight.return_value = _PREFLIGHT_RESULT
-        mock_dev_agent.return_value = _make_agent_result()
-
-        call_n = {"n": 0}
-
-        def status_side_effect(path: Path) -> frozenset[str]:
-            if path.resolve() == sibling.resolve():
-                n = call_n["n"]
-                call_n["n"] += 1
-                if n == 0:
-                    return frozenset()
-                # Agent leaked a build artifact into sibling — should escalate
-                return frozenset(["!! build/leaked_output.o"])
-            return frozenset()
-
-        with patch(
-            "theforge.coordinator.dev_phase._git_status_porcelain_ignored",
-            side_effect=status_side_effect,
-        ):
-            result = run_task(config, task, notify=False)
-
-        assert result.state.phase == Phase.ESCALATE
-        assert "sibling worktree write detected" in result.message.lower()
-
-    @patch("theforge.coordinator.review_pool.run_agent_pool")
-    @patch("theforge.coordinator.preflight_flow.run_agent")
-    @patch("theforge.coordinator.dev_phase.run_agent")
-    @patch("theforge.coordinator.util._run_shell")
-    def test_escalation_message_includes_changes(
-        self,
-        mock_shell,
-        mock_dev_agent,
-        mock_preflight,
-        mock_pool,
-        tmp_path: Path,
-    ) -> None:
-        """Escalation message includes the changed paths for diagnosis."""
-        config = _make_config(tmp_path)
-        task = _make_task(tmp_path)
-        workspace = tmp_path / "test-task"
-        workspace.mkdir()
-
-        sibling = tmp_path / ".forge" / "worktrees" / "issue-777"
-        sibling.mkdir(parents=True)
-
-        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
-        mock_preflight.return_value = _PREFLIGHT_RESULT
-        mock_dev_agent.return_value = _make_agent_result()
-
-        call_n = {"n": 0}
-        changed_line = "?? src/cross_contamination.py"
-
-        def status_side_effect(path: Path) -> frozenset[str]:
-            if path.resolve() == sibling.resolve():
-                n = call_n["n"]
-                call_n["n"] += 1
-                return frozenset() if n == 0 else frozenset([changed_line])
-            return frozenset()
-
-        with patch(
-            "theforge.coordinator.dev_phase._git_status_porcelain_ignored",
-            side_effect=status_side_effect,
-        ):
-            result = run_task(config, task, notify=False)
-
-        assert result.state.phase == Phase.ESCALATE
-        assert changed_line in result.message
+        # None of the subprocess.run calls should use --porcelain --ignored
+        for call in mock_sub.call_args_list:
+            args = call[0][0] if call[0] else call[1].get("args", [])
+            assert "--porcelain" not in args or "--ignored" not in args, (
+                "subprocess.run was called with --porcelain --ignored — "
+                "the sibling detector was not fully removed"
+            )

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -498,8 +498,11 @@ class TestClaudePermissionMode:
         idx = cmd.index("--permission-mode")
         assert cmd[idx + 1] == "default"
 
-    def test_read_only_adds_permission_mode(self, tmp_path: Path) -> None:
-        """sandbox_mode=read-only → --permission-mode default (most restrictive available)."""
+    def test_read_only_adds_permission_mode_with_warning(self, tmp_path: Path) -> None:
+        """sandbox_mode=read-only → --permission-mode default + WARNING that read-only is not
+        mechanically enforced by Claude CLI."""
+        import theforge.runners.runner_claude as _mod
+
         profile = ModelProfile(
             name="dev",
             cli="claude",
@@ -513,9 +516,15 @@ class TestClaudePermissionMode:
         with patch(
             "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
         ) as mock_popen:
-            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+            with patch.object(_mod, "_log") as mock_log:
+                run_agent(prompt="test", profile=profile, working_dir=tmp_path)
         cmd = self._popen_capture(mock_popen)
         assert "--permission-mode" in cmd
+        # A warning must be logged explaining that read-only is not mechanically enforced
+        log_calls = [str(c) for c in mock_log.call_args_list]
+        assert any(
+            "read-only" in call and "not mechanically enforced" in call for call in log_calls
+        )
 
     def test_none_omits_permission_mode(self, tmp_path: Path) -> None:
         """sandbox_mode=none → no --permission-mode flag in cmd."""

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -470,6 +470,73 @@ class TestRunAgentClaude:
         assert result.output == json.dumps({"type": "assistant", "session_id": "sess-fallback"})
 
 
+class TestClaudePermissionMode:
+    """Assert that --permission-mode is injected based on sandbox_mode."""
+
+    def _popen_capture(self, mock_popen: MagicMock) -> list[str]:
+        """Extract the cmd list from the Popen call."""
+        return mock_popen.call_args[0][0]
+
+    def test_workspace_write_adds_permission_mode(self, tmp_path: Path) -> None:
+        """sandbox_mode=workspace-write → --permission-mode default in cmd."""
+        profile = ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=900,
+            allowed_tools=("Read", "Edit", "Write", "Bash"),
+            sandbox_mode="workspace-write",
+        )
+        mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
+        with patch(
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        cmd = self._popen_capture(mock_popen)
+        assert "--permission-mode" in cmd
+        idx = cmd.index("--permission-mode")
+        assert cmd[idx + 1] == "default"
+
+    def test_read_only_adds_permission_mode(self, tmp_path: Path) -> None:
+        """sandbox_mode=read-only → --permission-mode default (most restrictive available)."""
+        profile = ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=900,
+            allowed_tools=("Read", "Edit", "Write", "Bash"),
+            sandbox_mode="read-only",
+        )
+        mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
+        with patch(
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        cmd = self._popen_capture(mock_popen)
+        assert "--permission-mode" in cmd
+
+    def test_none_omits_permission_mode(self, tmp_path: Path) -> None:
+        """sandbox_mode=none → no --permission-mode flag in cmd."""
+        profile = ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=900,
+            allowed_tools=("Read", "Edit", "Write", "Bash"),
+            sandbox_mode="none",
+        )
+        mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
+        with patch(
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        cmd = self._popen_capture(mock_popen)
+        assert "--permission-mode" not in cmd
+
+
 class TestClaudeSessionIdHelper:
     def test_get_claude_session_id_from_jsonl(self, tmp_path: Path) -> None:
         output = "\n".join(

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -1,0 +1,131 @@
+"""Tests for Codex CLI runner: sandbox flag injection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.config import ModelProfile
+from theforge.runners.runner_codex import _run_codex
+
+
+def _make_profile(
+    sandbox_mode: str = "workspace-write",
+    reasoning_effort: str | None = None,
+) -> ModelProfile:
+    return ModelProfile(
+        name="dev",
+        cli="codex",
+        model="o4-mini",
+        budget_usd=2.0,
+        timeout_seconds=900,
+        allowed_tools=("Read", "Edit", "Write", "Bash"),
+        sandbox_mode=sandbox_mode,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def _make_subprocess_mock(returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = ""
+    proc.stderr = ""
+    return proc
+
+
+def _extract_codex_cmd(mock_run: MagicMock) -> list[str]:
+    """Return the cmd list from the subprocess.run call."""
+    return mock_run.call_args[0][0]
+
+
+class TestCodexSandboxFlag:
+    """Assert that --sandbox flag is injected based on sandbox_mode."""
+
+    def test_workspace_write_adds_sandbox_flag(self, tmp_path: Path) -> None:
+        """sandbox_mode=workspace-write → --sandbox workspace-write in cmd."""
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+            with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
+                with patch(
+                    "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
+                ) as mock_run:
+                    _run_codex(
+                        prompt="implement the thing",
+                        profile=profile,
+                        working_dir=tmp_path,
+                    )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--sandbox" in cmd
+        sandbox_idx = cmd.index("--sandbox")
+        assert cmd[sandbox_idx + 1] == "workspace-write"
+
+    def test_read_only_adds_sandbox_flag(self, tmp_path: Path) -> None:
+        """sandbox_mode=read-only → --sandbox read-only in cmd."""
+        profile = _make_profile(sandbox_mode="read-only")
+        mock_proc = _make_subprocess_mock()
+        with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
+            with patch(
+                "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
+            ) as mock_run:
+                _run_codex(
+                    prompt="review only",
+                    profile=profile,
+                    working_dir=tmp_path,
+                )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--sandbox" in cmd
+        sandbox_idx = cmd.index("--sandbox")
+        assert cmd[sandbox_idx + 1] == "read-only"
+
+    def test_none_omits_sandbox_flag(self, tmp_path: Path) -> None:
+        """sandbox_mode=none → no --sandbox flag in cmd."""
+        profile = _make_profile(sandbox_mode="none")
+        mock_proc = _make_subprocess_mock()
+        with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
+            with patch(
+                "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
+            ) as mock_run:
+                _run_codex(
+                    prompt="debug run",
+                    profile=profile,
+                    working_dir=tmp_path,
+                )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--sandbox" not in cmd
+
+    def test_sandbox_flag_present_on_resume(self, tmp_path: Path) -> None:
+        """--sandbox flag is also injected on session resume (not just fresh start)."""
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        with patch(
+            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
+        ) as mock_run:
+            _run_codex(
+                prompt="continue",
+                profile=profile,
+                working_dir=tmp_path,
+                session_id="sess-abc123",
+            )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--sandbox" in cmd
+        assert "resume" in cmd
+        sandbox_idx = cmd.index("--sandbox")
+        assert cmd[sandbox_idx + 1] == "workspace-write"
+
+    def test_sandbox_flag_none_on_resume(self, tmp_path: Path) -> None:
+        """sandbox_mode=none omits --sandbox on resume too."""
+        profile = _make_profile(sandbox_mode="none")
+        mock_proc = _make_subprocess_mock()
+        with patch(
+            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
+        ) as mock_run:
+            _run_codex(
+                prompt="continue",
+                profile=profile,
+                working_dir=tmp_path,
+                session_id="sess-abc123",
+            )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--sandbox" not in cmd
+        assert "resume" in cmd

--- a/tests/test_runner_gemini.py
+++ b/tests/test_runner_gemini.py
@@ -1,0 +1,112 @@
+"""Tests for Gemini CLI runner: sandbox wrapper injection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.config import ModelProfile
+from theforge.runners.runner_gemini import _run_gemini
+
+
+def _make_profile(sandbox_mode: str = "workspace-write") -> ModelProfile:
+    return ModelProfile(
+        name="dev",
+        cli="gemini",
+        model="gemini-2.5-flash",
+        budget_usd=2.0,
+        timeout_seconds=900,
+        allowed_tools=("Read", "Edit", "Write", "Bash"),
+        sandbox_mode=sandbox_mode,
+    )
+
+
+def _make_subprocess_mock(returncode: int = 0, stdout: str = "{}") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = ""
+    return proc
+
+
+class TestGeminiSandboxWrapper:
+    """Assert that workspace_effect_sandbox_command is called when sandboxing is requested."""
+
+    def test_workspace_write_uses_sandbox_wrapper(self, tmp_path: Path) -> None:
+        """sandbox_mode=workspace-write → workspace_effect_sandbox_command is called."""
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        wrapped_cmd = ["sandbox-exec", "-f", "/tmp/profile.sb", "npx", "@google/gemini-cli"]
+        with patch(
+            "theforge.runners.runner_gemini.workspace_effect_sandbox_command",
+            return_value=wrapped_cmd,
+        ) as mock_sandbox:
+            with patch(
+                "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
+            ) as mock_run:
+                _run_gemini(
+                    prompt="implement the thing",
+                    profile=profile,
+                    working_dir=tmp_path,
+                )
+        mock_sandbox.assert_called_once()
+        # The cmd passed to subprocess.run should be the sandboxed version
+        actual_cmd = mock_run.call_args[0][0]
+        assert actual_cmd == wrapped_cmd
+
+    def test_read_only_uses_sandbox_wrapper(self, tmp_path: Path) -> None:
+        """sandbox_mode=read-only → workspace_effect_sandbox_command is called."""
+        profile = _make_profile(sandbox_mode="read-only")
+        mock_proc = _make_subprocess_mock()
+        wrapped_cmd = ["sandbox-exec", "-f", "/tmp/profile.sb", "npx", "@google/gemini-cli"]
+        with patch(
+            "theforge.runners.runner_gemini.workspace_effect_sandbox_command",
+            return_value=wrapped_cmd,
+        ) as mock_sandbox:
+            with patch("theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc):
+                _run_gemini(
+                    prompt="review only",
+                    profile=profile,
+                    working_dir=tmp_path,
+                )
+        mock_sandbox.assert_called_once()
+
+    def test_none_skips_sandbox_wrapper(self, tmp_path: Path) -> None:
+        """sandbox_mode=none → workspace_effect_sandbox_command is NOT called."""
+        profile = _make_profile(sandbox_mode="none")
+        mock_proc = _make_subprocess_mock()
+        with patch(
+            "theforge.runners.runner_gemini.workspace_effect_sandbox_command"
+        ) as mock_sandbox:
+            with patch(
+                "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
+            ) as mock_run:
+                _run_gemini(
+                    prompt="debug run",
+                    profile=profile,
+                    working_dir=tmp_path,
+                )
+        mock_sandbox.assert_not_called()
+        # The raw npx command is passed directly
+        actual_cmd = mock_run.call_args[0][0]
+        assert actual_cmd[0] == "npx"
+
+    def test_sandbox_unavailable_logs_warning(self, tmp_path: Path, capsys) -> None:
+        """When sandbox wrapper returns cmd unchanged, a WARNING is logged."""
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        # Return the original cmd unchanged → sandbox unavailable
+        with patch(
+            "theforge.runners.runner_gemini.workspace_effect_sandbox_command",
+            side_effect=lambda cmd, wd: list(cmd),
+        ):
+            with patch("theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc):
+                with patch("theforge.runners.runner_gemini._log") as mock_log:
+                    _run_gemini(
+                        prompt="test",
+                        profile=profile,
+                        working_dir=tmp_path,
+                    )
+        # Check that a WARNING was emitted
+        warning_calls = [str(c) for c in mock_log.call_args_list]
+        assert any("WARNING" in call for call in warning_calls)

--- a/tests/test_runner_gemini.py
+++ b/tests/test_runner_gemini.py
@@ -91,22 +91,42 @@ class TestGeminiSandboxWrapper:
         actual_cmd = mock_run.call_args[0][0]
         assert actual_cmd[0] == "npx"
 
-    def test_sandbox_unavailable_logs_warning(self, tmp_path: Path, capsys) -> None:
-        """When sandbox wrapper returns cmd unchanged, a WARNING is logged."""
+    def test_sandbox_unavailable_fails_closed(self, tmp_path: Path) -> None:
+        """When sandbox wrapper returns cmd unchanged, the runner fails closed."""
         profile = _make_profile(sandbox_mode="workspace-write")
-        mock_proc = _make_subprocess_mock()
         # Return the original cmd unchanged → sandbox unavailable
         with patch(
             "theforge.runners.runner_gemini.workspace_effect_sandbox_command",
             side_effect=lambda cmd, wd: list(cmd),
         ):
-            with patch("theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc):
-                with patch("theforge.runners.runner_gemini._log") as mock_log:
-                    _run_gemini(
-                        prompt="test",
-                        profile=profile,
-                        working_dir=tmp_path,
-                    )
-        # Check that a WARNING was emitted
-        warning_calls = [str(c) for c in mock_log.call_args_list]
-        assert any("WARNING" in call for call in warning_calls)
+            with patch("theforge.runners.runner_gemini.subprocess.run") as mock_run:
+                result = _run_gemini(
+                    prompt="test",
+                    profile=profile,
+                    working_dir=tmp_path,
+                )
+        # subprocess.run must NOT have been called — we fail before invoking the agent
+        mock_run.assert_not_called()
+        assert result.success is False
+        assert result.startup_failure is True
+        assert result.exit_code == -1
+        assert "SANDBOX_UNAVAILABLE" in result.output
+
+    def test_sandbox_unavailable_none_mode_still_runs(self, tmp_path: Path) -> None:
+        """sandbox_mode=none → sandbox wrapper not called, subprocess runs normally."""
+        profile = _make_profile(sandbox_mode="none")
+        mock_proc = _make_subprocess_mock()
+        with patch(
+            "theforge.runners.runner_gemini.workspace_effect_sandbox_command"
+        ) as mock_sandbox:
+            with patch(
+                "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
+            ) as mock_run:
+                result = _run_gemini(
+                    prompt="debug run",
+                    profile=profile,
+                    working_dir=tmp_path,
+                )
+        mock_sandbox.assert_not_called()
+        mock_run.assert_called_once()
+        assert result.success is True

--- a/tests/test_runner_providers.py
+++ b/tests/test_runner_providers.py
@@ -466,6 +466,8 @@ class TestRunGemini:
         assert result.exit_code == -1
 
     def test_gemini_command_structure(self, gemini_profile: ModelProfile, tmp_path: Path) -> None:
+        # The command may be wrapped by a platform sandbox (sandbox-exec / bwrap).
+        # Verify the Gemini CLI flags are present anywhere in the command, not at a fixed index.
         json_output = json.dumps({"result": "done"})
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=json_output, stderr=""
@@ -476,7 +478,7 @@ class TestRunGemini:
             run_agent(prompt="review", profile=gemini_profile, working_dir=tmp_path)
 
         cmd = mock_run.call_args[0][0]
-        assert cmd[0] == "npx"
+        assert "npx" in cmd
         assert "@google/gemini-cli" in cmd
         assert "-p" in cmd
         assert "--yolo" in cmd
@@ -488,7 +490,11 @@ class TestRunGemini:
     def test_gemini_prompt_passed_via_flag(
         self, gemini_profile: ModelProfile, tmp_path: Path
     ) -> None:
-        """Prompt is passed via -p flag, not via stdin input=."""
+        """Prompt is passed via -p flag, not via stdin input=.
+
+        The command may be wrapped by a platform sandbox (sandbox-exec / bwrap),
+        so we find -p by index rather than assuming a fixed position.
+        """
         json_output = json.dumps({"result": "done"})
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=json_output, stderr=""
@@ -501,8 +507,12 @@ class TestRunGemini:
         call_kwargs = mock_run.call_args[1]
         assert "input" not in call_kwargs
         cmd = mock_run.call_args[0][0]
-        p_idx = cmd.index("-p")
-        assert cmd[p_idx + 1] == "my prompt"
+        # The command may be sandbox-wrapped (sandbox-exec also uses -p for its policy arg).
+        # Find -p that appears after @google/gemini-cli to get the prompt flag.
+        gemini_start = cmd.index("@google/gemini-cli")
+        gemini_args = cmd[gemini_start:]
+        p_idx = gemini_args.index("-p")
+        assert gemini_args[p_idx + 1] == "my prompt"
 
     def test_gemini_non_json_output(self, gemini_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = subprocess.CompletedProcess(


### PR DESCRIPTION
## Summary

[openai-reviewer] Prior P1s are fixed, no new blocking regressions found in the sandboxing changes. | [gemini-reviewer] The implementation correctly addresses the previous review findings and implements the spec.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $8.06
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Use native CLI sandbox flags for write containment; retire sibling detector (GitHub Issue #654)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #654