### PR TITLE
fix(tests): gemini_profile fixture missing sandbox_mode=none breaks Linux CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,7 @@ def gemini_profile() -> ModelProfile:
         budget_usd=1.0,
         timeout_seconds=300,
         allowed_tools=(),
+        sandbox_mode="none",  # sandbox behaviour is tested in test_runner_gemini.py
     )
 
 


### PR DESCRIPTION
## Summary

- Adds `sandbox_mode="none"` to the `gemini_profile` fixture in `tests/conftest.py`
- Fixes all `TestRunGemini` tests failing on Linux CI (GitHub Actions, no `bwrap`) with `SANDBOX_UNAVAILABLE`
- Sandbox-specific behaviour is already tested in `test_runner_gemini.py` which correctly mocks `workspace_effect_sandbox_command`

Closes #702. Targets `feat/issue-654` (PR #698).

## Root cause

`gemini_profile` fixture defaulted `sandbox_mode` to `"workspace-write"`. The Gemini runner calls `workspace_effect_sandbox_command()` **before** `subprocess.run`. On Linux without `bwrap`, this returns the original cmd unchanged — triggering fail-closed behaviour that returns `SANDBOX_UNAVAILABLE` before the mocked subprocess is ever reached.

## Test plan

- [x] `TestRunGemini` (11 tests) pass locally after fix
- [x] Full gate: 2733 passed, 1 skipped — PASS
- [x] Sandbox-specific tests in `test_runner_gemini.py` unaffected (they mock `workspace_effect_sandbox_command` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)