### PR TITLE
Coordinator: make preflight failure modes conservative and resumable

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -407,6 +407,8 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "cached": state.preflight_cached,
                 "original_verdict": state.preflight_cached_original_verdict,
                 "source_run_id": state.preflight_cached_from_run_id,
+                "degraded": state.preflight_degraded,
+                "degraded_reason": state.preflight_degraded_reason,
             }
             if state.preflight_verdict is not None
             else None

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -50,6 +50,43 @@ from .preflight import (
 from .state import CoordinatorResult, CoordinatorState, Phase
 from .util import _fmt_duration, _log_phase
 
+# Tokens that indicate a BLOCKED verdict is based on ambiguity/verifiability
+# concerns rather than a concrete hard blocker.  Two conditions must hold
+# simultaneously before the override fires: an ambiguity token matches AND
+# prior-execution evidence exists on the branch.  The conjunction prevents
+# false positives from BLOCKEDs that legitimately mention "verifiable" in a
+# non-ambiguity context.
+_AMBIGUITY_TOKENS = (
+    "ambiguous",
+    "verif",
+    "not objectively",
+    "cannot verify",
+    "unclear",
+    "measurable",
+)
+
+
+def _has_prior_execution_evidence(
+    project_root: "Path", branch_name: str, base_branch: str
+) -> bool:
+    """Return True if branch_name has commits ahead of base_branch.
+
+    Uses ``git log <base>..<branch> --oneline``; returns False on any error so
+    that the caller fails conservatively (keeps BLOCKED) rather than crashing.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", f"{base_branch}..{branch_name}", "--oneline"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+        return len(lines) > 0
+    except Exception:
+        return False
+
 
 def _prepare_preflight_working_dir(
     project_root: Path, base_branch: str
@@ -180,10 +217,13 @@ def _run_preflight_phase(
         verdict, reason = _parse_preflight_verdict(preflight_result.output)
     else:
         verdict, reason = (
-            "BLOCKED",
-            f"Preflight agent failed (exit={preflight_result.exit_code}); blocking execution.",
+            "PROCEED",
+            f"Preflight agent failed (exit={preflight_result.exit_code}); "
+            "falling back to conservative PROCEED.",
         )
-        _log("  ⚠ PREFLIGHT failed — blocking execution")
+        state.preflight_degraded = True
+        state.preflight_degraded_reason = "timeout_no_verdict"
+        _log("  ⚠ PREFLIGHT failed — fallback PROCEED (degraded)")
 
     state.preflight_verdict = verdict
     state.preflight_reason = reason
@@ -236,11 +276,32 @@ def _run_preflight_phase(
             _log(f"  ⚠ PREFLIGHT warnings: {'; '.join(_warnings)}")
         if _likely_files is not None:
             _log(f"  Likely files: {', '.join(_likely_files)}")
+
+        # ── Ambiguity BLOCKED downgrade ───────────────────────────────
+        # Must come *after* all signal parsing so that forced overrides are
+        # not later clobbered by the parsers.
+        if verdict == "BLOCKED" and any(t in (reason or "").lower() for t in _AMBIGUITY_TOKENS):
+            if _has_prior_execution_evidence(
+                config.project_root, branch_name, config.workspace.base_branch
+            ):
+                _log(
+                    "  ⚠ PREFLIGHT BLOCKED (ambiguity) overridden — prior execution evidence found"
+                )
+                verdict = "PROCEED"
+                state.preflight_verdict = verdict
+                state.preflight_degraded = True
+                state.preflight_degraded_reason = "blocked_downgraded_prior_evidence"
+                # Compensate for missing classification: force planning and
+                # upgrade complexity to at least medium.
+                if state.preflight_complexity == "small":
+                    state.preflight_complexity = "medium"
+                state.preflight_sufficiency = "needs_planning"
     else:
-        complexity = state.preflight_complexity or "medium"
-        state.preflight_complexity = complexity
-        state.preflight_sufficiency = state.preflight_sufficiency or "needs_planning"
-        state.preflight_work_type = state.preflight_work_type or "feature"
+        # Agent failed — skip all parsers; hard-set conservative values so
+        # downstream phases plan carefully despite missing classification.
+        state.preflight_complexity = "large"
+        state.preflight_sufficiency = "needs_planning"
+        state.preflight_work_type = "feature"
         state.preflight_bundle_candidate = False
 
     config = _apply_preflight_config(config, state, log=_log, log_verbose=_log_verbose)

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -281,6 +281,8 @@ class CoordinatorState:
     preflight_cached: bool = False
     preflight_cached_from_run_id: str | None = None
     preflight_cached_original_verdict: str | None = None
+    preflight_degraded: bool = False
+    preflight_degraded_reason: str | None = None
     plan_results: list[AgentResult] = field(default_factory=list)
     plan_output: str | None = (
         None  # contents of the worktree plan file, passed to dev (raw string for audit)

--- a/tests/test_coord_preflight_fallback.py
+++ b/tests/test_coord_preflight_fallback.py
@@ -1,0 +1,197 @@
+"""Tests for preflight conservative fallback scenarios.
+
+Covers #332-style timeout and #257-style false BLOCKED:
+  1. Agent non-success (timeout / exit=1) → degraded PROCEED with needs_planning / large.
+  2. Ambiguous BLOCKED with prior-execution evidence → downgraded to PROCEED.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import Phase
+
+# ── BLOCKED output with an ambiguous/verifiability reason ────────────────────
+
+PREFLIGHT_BLOCKED_AMBIGUOUS = """\
+```yaml
+verdict: BLOCKED
+reason: "Acceptance criteria are ambiguous and not objectively verifiable."
+complexity: small
+sufficiency: needs_planning
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X"
+    satisfied: false
+    evidence: "Cannot verify without external API"
+```
+"""
+
+PREFLIGHT_BLOCKED_CONCRETE = """\
+```yaml
+verdict: BLOCKED
+reason: "Required dependency removed_function() no longer exists in the codebase."
+complexity: medium
+sufficiency: needs_planning
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X"
+    satisfied: false
+    evidence: "removed_function() was deleted"
+```
+"""
+
+
+class TestPreflightConservativeFallback:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_timeout_fallback_proceeds_with_degraded_status(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """#332: agent failure (timeout/exit=1) → degraded PROCEED, not BLOCKED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(success=False, output="", cost_usd=0.0)
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "timeout_no_verdict"
+        assert result.state.preflight_sufficiency == "needs_planning"
+        assert result.state.preflight_complexity == "large"
+        # Run should proceed to completion, not ESCALATE
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow._has_prior_execution_evidence", return_value=True)
+    def test_ambiguous_blocked_with_prior_commits_is_downgraded(
+        self,
+        mock_evidence,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """#257: ambiguous BLOCKED + prior-execution evidence → downgraded to PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BLOCKED_AMBIGUOUS, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "blocked_downgraded_prior_evidence"
+        assert result.state.preflight_sufficiency == "needs_planning"
+        # small→medium upgrade should have fired
+        assert result.state.preflight_complexity in ("medium", "large")
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow._has_prior_execution_evidence", return_value=False)
+    def test_genuine_blocked_without_prior_commits_not_downgraded(
+        self,
+        mock_evidence,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """Ambiguous BLOCKED *without* prior-execution evidence stays BLOCKED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BLOCKED_AMBIGUOUS, cost_usd=0.05
+        )
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "BLOCKED"
+        assert result.state.preflight_degraded is False
+        assert result.phase == Phase.ESCALATE
+        assert result.success is False
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow._has_prior_execution_evidence", return_value=True)
+    def test_genuine_blocked_concrete_reason_not_downgraded(
+        self,
+        mock_evidence,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """Concrete BLOCKED (non-ambiguous) is NOT downgraded even with prior commits."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BLOCKED_CONCRETE, cost_usd=0.05
+        )
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "BLOCKED"
+        assert result.state.preflight_degraded is False
+        assert result.phase == Phase.ESCALATE
+        assert result.success is False

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -221,10 +221,10 @@ class TestCoordinatorPreflight:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_preflight_agent_failure_blocks(
+    def test_preflight_agent_failure_falls_back_to_degraded_proceed(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """If the preflight agent itself fails, execution is blocked."""
+        """If the preflight agent itself fails, coordinator falls back to degraded PROCEED."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -242,11 +242,16 @@ class TestCoordinatorPreflight:
 
         result = run_task(config, task)
 
-        assert result.success is False
-        assert result.phase == Phase.ESCALATE
-        assert result.state.preflight_verdict == "BLOCKED"
+        # Fallback PROCEED — not BLOCKED/ESCALATE
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "timeout_no_verdict"
         assert "failed" in result.state.preflight_reason.lower()
-        assert len(result.state.dev_results) == 0
+        # Conservative classification applied
+        assert result.state.preflight_sufficiency == "needs_planning"
+        assert result.state.preflight_complexity == "large"
+        # Run continues to dev
+        assert len(result.state.dev_results) >= 1
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")


### PR DESCRIPTION
## Summary

Implementation matches the conservative preflight fallback spec and is adequately covered by tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.70
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Coordinator: make preflight failure modes conservative and resumable (GitHub Issue #699)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #699