### PR TITLE
config: switch preflight to claude-opus-4-5

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -51,9 +51,9 @@ profiles:
     timeout_medium_seconds: 900
     timeout_large_seconds: 1800
   preflight:
-    provider: deepseek
-    model: deepseek-reasoner
-    budget_usd: 1.00
+    provider: anthropic
+    model: claude-opus-4-5
+    budget_usd: 5.00
     timeout_seconds: 300
   review_pool:
     - name: openai-reviewer


### PR DESCRIPTION
## Summary

- Switch preflight model from `deepseek-reasoner` to `claude-opus-4-5`
- Raise preflight budget from $1.00 to $5.00 (Opus token pricing)

DeepSeek-reasoner and Gemini 3.1 Pro both consistently hit 50 iterations without submitting a verdict on coordinator-internal stories. Opus is better at following multi-constraint structured output instructions.

## Test plan

- [x] Config-only change, no code
- [ ] Observe preflight cost/latency on next sprint run

🤖 Generated with [Claude Code](https://claude.com/claude-code)