### PR TITLE
Plan review JSON schema enforcement — extend API mode fix to plan review path

### DIFF
--- a/src/theforge/runners/finalizers.py
+++ b/src/theforge/runners/finalizers.py
@@ -31,29 +31,36 @@ def _make_openai_chat_finalizer(
         _openai_client,
         _translate_messages_openai_chat,
     )
-    from theforge.schemas import review_json_schema
+    from theforge.schemas import plan_review_json_schema, review_json_schema
 
     if client is None:
         client = _openai_client(profile, secrets)
-    schema = review_json_schema()
+
+    is_plan_review = profile.phase == "plan_review"
+    if is_plan_review:
+        schema = plan_review_json_schema()
+        schema_name = "plan_review_output"
+        time_up_content = (
+            "Time is up. Deliver your plan review verdict now as structured JSON. "
+            "Include verdict, summary, and findings."
+        )
+    else:
+        schema = review_json_schema()
+        schema_name = "review_output"
+        time_up_content = (
+            "Time is up. Deliver your code review verdict now as structured JSON. "
+            "Include verdict, summary, findings, story_compliance, and test_coverage."
+        )
 
     def finalizer(messages: list[dict]) -> LoopTurn:
         oai_messages = _translate_messages_openai_chat(messages)
-        oai_messages.append(
-            {
-                "role": "user",
-                "content": (
-                    "Time is up. Deliver your code review verdict now as structured JSON. "
-                    "Include verdict, summary, findings, story_compliance, and test_coverage."
-                ),
-            }
-        )
+        oai_messages.append({"role": "user", "content": time_up_content})
         kwargs: dict[str, Any] = {
             "model": profile.model,
             "messages": oai_messages,
             "response_format": {
                 "type": "json_schema",
-                "json_schema": {"name": "review_output", "schema": schema, "strict": True},
+                "json_schema": {"name": schema_name, "schema": schema, "strict": True},
             },
         }
         if not _is_reasoning_model(profile.model):
@@ -99,18 +106,23 @@ def _make_deepseek_finalizer(
     if client is None:
         client = _deepseek_client(profile, secrets)
 
+    is_plan_review = profile.phase == "plan_review"
+
     def finalizer(messages: list[dict]) -> LoopTurn:
         oai_messages = _translate_messages_openai_chat(messages)
-        oai_messages.append(
-            {
-                "role": "user",
-                "content": (
-                    "Time is up. Deliver your code review verdict now as JSON. "
-                    "Include verdict, summary, findings, story_compliance, and test_coverage. "
-                    "Output only valid JSON with no markdown fences."
-                ),
-            }
-        )
+        if is_plan_review:
+            time_up_content = (
+                "Time is up. Deliver your plan review verdict now as JSON. "
+                "Include verdict, summary, and findings. "
+                "Output only valid JSON with no markdown fences."
+            )
+        else:
+            time_up_content = (
+                "Time is up. Deliver your code review verdict now as JSON. "
+                "Include verdict, summary, findings, story_compliance, and test_coverage. "
+                "Output only valid JSON with no markdown fences."
+            )
+        oai_messages.append({"role": "user", "content": time_up_content})
         kwargs: dict[str, Any] = {
             "model": profile.model,
             "messages": oai_messages,

--- a/src/theforge/runners/finalizers.py
+++ b/src/theforge/runners/finalizers.py
@@ -42,7 +42,7 @@ def _make_openai_chat_finalizer(
         schema_name = "plan_review_output"
         time_up_content = (
             "Time is up. Deliver your plan review verdict now as structured JSON. "
-            "Include verdict, summary, and findings."
+            "Include verdict, summary, findings, and criteria_coverage."
         )
     else:
         schema = review_json_schema()
@@ -113,7 +113,7 @@ def _make_deepseek_finalizer(
         if is_plan_review:
             time_up_content = (
                 "Time is up. Deliver your plan review verdict now as JSON. "
-                "Include verdict, summary, and findings. "
+                "Include verdict, summary, findings, and criteria_coverage. "
                 "Output only valid JSON with no markdown fences."
             )
         else:

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -241,11 +241,11 @@ def _submit_plan_review_schema() -> dict:
         "parameters": {
             "type": "object",
             "additionalProperties": False,
-            "required": ["verdict", "summary", "findings"],
+            "required": ["verdict", "summary", "findings", "criteria_coverage"],
             "properties": {
                 "verdict": {
                     "type": "string",
-                    "enum": ["APPROVE", "REQUEST_CHANGES"],
+                    "enum": ["APPROVE", "REJECT"],
                     "description": "Overall verdict on the plan.",
                 },
                 "summary": {
@@ -259,8 +259,24 @@ def _submit_plan_review_schema() -> dict:
                         "additionalProperties": False,
                         "required": ["severity", "description"],
                         "properties": {
-                            "severity": {"type": "string", "enum": ["P1", "P1-impl", "P2"]},
+                            "severity": {
+                                "type": "string",
+                                "enum": ["P0", "P1", "P1-impl", "P2"],
+                            },
                             "description": {"type": "string"},
+                        },
+                    },
+                },
+                "criteria_coverage": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["criterion", "covered", "plan_section"],
+                        "properties": {
+                            "criterion": {"type": "string"},
+                            "covered": {"type": "boolean"},
+                            "plan_section": {"type": "string"},
                         },
                     },
                 },

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -358,11 +358,11 @@ def plan_review_json_schema() -> dict:
     return {
         "type": "object",
         "additionalProperties": False,
-        "required": ["verdict", "summary", "findings"],
+        "required": ["verdict", "summary", "findings", "criteria_coverage"],
         "properties": {
             "verdict": {
                 "type": "string",
-                "enum": ["APPROVE", "REQUEST_CHANGES"],
+                "enum": ["APPROVE", "REJECT"],
                 "description": "Overall verdict on the plan.",
             },
             "summary": {
@@ -378,9 +378,22 @@ def plan_review_json_schema() -> dict:
                     "properties": {
                         "severity": {
                             "type": "string",
-                            "enum": ["P1", "P1-impl", "P2"],
+                            "enum": ["P0", "P1", "P1-impl", "P2"],
                         },
                         "description": {"type": "string"},
+                    },
+                },
+            },
+            "criteria_coverage": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["criterion", "covered", "plan_section"],
+                    "properties": {
+                        "criterion": {"type": "string"},
+                        "covered": {"type": "boolean"},
+                        "plan_section": {"type": "string"},
                     },
                 },
             },

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -345,3 +345,44 @@ def review_json_schema() -> dict:
             },
         },
     }
+
+
+def plan_review_json_schema() -> dict:
+    """Export the plan review schema as a JSON Schema dict.
+
+    Mirrors the submit_plan_review tool parameters in schema_utils.py.
+    Conforms to OpenAI strict JSON Schema requirements:
+    - additionalProperties: false on every object
+    - all object properties listed in required
+    """
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["verdict", "summary", "findings"],
+        "properties": {
+            "verdict": {
+                "type": "string",
+                "enum": ["APPROVE", "REQUEST_CHANGES"],
+                "description": "Overall verdict on the plan.",
+            },
+            "summary": {
+                "type": "string",
+                "description": "One-line summary of the review.",
+            },
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["severity", "description"],
+                    "properties": {
+                        "severity": {
+                            "type": "string",
+                            "enum": ["P1", "P1-impl", "P2"],
+                        },
+                        "description": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -324,6 +324,76 @@ def test_api_schema_includes_p1_impl():
     assert "P2" in severity_enum
 
 
+def test_plan_review_json_schema_mirrors_submit_tool(tmp_path):
+    """plan_review_json_schema() must mirror the submit_plan_review tool parameters."""
+    from theforge.runners.schema_utils import _submit_plan_review_schema
+    from theforge.schemas import plan_review_json_schema
+
+    tool_params = _submit_plan_review_schema()["parameters"]
+    json_schema = plan_review_json_schema()
+
+    # Same top-level required fields
+    assert set(json_schema["required"]) == set(tool_params["required"])
+    # Severity enum must match
+    tool_severity = tool_params["properties"]["findings"]["items"]["properties"]["severity"][
+        "enum"
+    ]
+    schema_severity = json_schema["properties"]["findings"]["items"]["properties"]["severity"][
+        "enum"
+    ]
+    assert set(schema_severity) == set(tool_severity)
+    # additionalProperties: false at top level (required for OpenAI strict mode)
+    assert json_schema.get("additionalProperties") is False
+
+
+def test_plan_review_prompt_api_mode_uses_submit_tool(tmp_path):
+    """build_plan_review_prompt with mode='api' uses submit_plan_review tool and omits YAML."""
+    from theforge.task.plan_prompts import build_plan_review_prompt
+    from theforge.task.story import TaskStory
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n", encoding="utf-8")
+    task = TaskStory(
+        name="Test Task",
+        story_path=spec,
+        slug="test-task",
+        pytest_target="tests/",
+    )
+    prompt = build_plan_review_prompt(
+        task,
+        story_content="## Spec\n- AC: something",
+        plan_content="## Plan\n- step 1",
+        mode="api",
+    )
+    assert "submit_plan_review" in prompt
+    # YAML output block must not appear in API mode
+    assert "```yaml" not in prompt
+
+
+def test_plan_review_prompt_cli_mode_uses_yaml_block(tmp_path):
+    """build_plan_review_prompt with mode='cli' includes YAML block, omits submit_plan_review."""
+    from theforge.task.plan_prompts import build_plan_review_prompt
+    from theforge.task.story import TaskStory
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n", encoding="utf-8")
+    task = TaskStory(
+        name="Test Task",
+        story_path=spec,
+        slug="test-task",
+        pytest_target="tests/",
+    )
+    prompt = build_plan_review_prompt(
+        task,
+        story_content="## Spec\n- AC: something",
+        plan_content="## Plan\n- step 1",
+        mode="cli",
+    )
+    assert "```yaml" in prompt
+    # CLI mode must NOT instruct agent to use the tool
+    assert "submit_plan_review" not in prompt
+
+
 # ── Corroboration logic ──────────────────────────────────────────────────────
 
 

--- a/tests/test_runner_submit_tool_gating.py
+++ b/tests/test_runner_submit_tool_gating.py
@@ -290,6 +290,7 @@ class TestDeepSeekPlanReviewFinalizer:
         kwargs = mock_client.chat.completions.create.call_args[1]
         last_msg = kwargs["messages"][-1]["content"]
         assert "findings" in last_msg
+        assert "criteria_coverage" in last_msg
         assert "story_compliance" not in last_msg
         assert "test_coverage" not in last_msg
 
@@ -344,6 +345,7 @@ class TestOpenAIPlanReviewFinalizer:
         fn([{"role": "user", "content": "Review this plan."}])
         kwargs = mock_client.chat.completions.create.call_args[1]
         last_msg = kwargs["messages"][-1]["content"]
+        assert "criteria_coverage" in last_msg
         assert "story_compliance" not in last_msg
         assert "test_coverage" not in last_msg
 

--- a/tests/test_runner_submit_tool_gating.py
+++ b/tests/test_runner_submit_tool_gating.py
@@ -252,6 +252,121 @@ class TestDeepSeekSubmitGating:
         assert finalizer is not noop_finalizer
 
 
+class TestDeepSeekPlanReviewFinalizer:
+    """DeepSeek plan_review finalizer uses json_object and plan-review message fields."""
+
+    def _make_finalizer(self, phase: str):
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_openai = MagicMock()
+        mock_openai.BadRequestError = Exception
+        mock_openai.OpenAI = MagicMock()
+        mock_httpx = MagicMock()
+
+        with patch.dict(sys.modules, {"openai": mock_openai, "httpx": mock_httpx}):
+            from theforge.runners.finalizers import _make_deepseek_finalizer
+
+            profile = _make_profile("deepseek-plan-reviewer", provider="deepseek", phase=phase)
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.choices[
+                0
+            ].message.content = '{"verdict": "APPROVE", "summary": "ok", "findings": []}'
+            mock_response.usage = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            fn = _make_deepseek_finalizer(profile, {}, client=mock_client)
+            return fn, mock_client
+
+    def test_plan_review_uses_json_object(self):
+        fn, mock_client = self._make_finalizer("plan_review")
+        fn([{"role": "user", "content": "Review this plan."}])
+        kwargs = mock_client.chat.completions.create.call_args[1]
+        assert kwargs["response_format"] == {"type": "json_object"}
+
+    def test_plan_review_message_references_plan_fields(self):
+        fn, mock_client = self._make_finalizer("plan_review")
+        fn([{"role": "user", "content": "Review this plan."}])
+        kwargs = mock_client.chat.completions.create.call_args[1]
+        last_msg = kwargs["messages"][-1]["content"]
+        assert "findings" in last_msg
+        assert "story_compliance" not in last_msg
+        assert "test_coverage" not in last_msg
+
+    def test_code_review_message_references_code_review_fields(self):
+        fn, mock_client = self._make_finalizer("review")
+        fn([{"role": "user", "content": "Review this code."}])
+        kwargs = mock_client.chat.completions.create.call_args[1]
+        last_msg = kwargs["messages"][-1]["content"]
+        assert "story_compliance" in last_msg
+        assert "test_coverage" in last_msg
+
+
+class TestOpenAIPlanReviewFinalizer:
+    """OpenAI chat plan_review finalizer uses plan_review_json_schema and correct message."""
+
+    def _make_finalizer(self, phase: str):
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_openai = MagicMock()
+        mock_openai.BadRequestError = Exception
+        mock_openai.OpenAI = MagicMock()
+        mock_httpx = MagicMock()
+
+        with patch.dict(sys.modules, {"openai": mock_openai, "httpx": mock_httpx}):
+            from theforge.runners.finalizers import _make_openai_chat_finalizer
+
+            profile = _make_profile("openai-plan-reviewer", provider="openai", phase=phase)
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.choices[
+                0
+            ].message.content = '{"verdict": "APPROVE", "summary": "ok", "findings": []}'
+            mock_response.usage = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            fn = _make_openai_chat_finalizer(profile, {}, client=mock_client)
+            return fn, mock_client
+
+    def test_plan_review_uses_plan_review_json_schema(self):
+        from theforge.schemas import plan_review_json_schema
+
+        fn, mock_client = self._make_finalizer("plan_review")
+        fn([{"role": "user", "content": "Review this plan."}])
+        kwargs = mock_client.chat.completions.create.call_args[1]
+        rf = kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "plan_review_output"
+        assert rf["json_schema"]["schema"] == plan_review_json_schema()
+
+    def test_plan_review_message_omits_code_review_fields(self):
+        fn, mock_client = self._make_finalizer("plan_review")
+        fn([{"role": "user", "content": "Review this plan."}])
+        kwargs = mock_client.chat.completions.create.call_args[1]
+        last_msg = kwargs["messages"][-1]["content"]
+        assert "story_compliance" not in last_msg
+        assert "test_coverage" not in last_msg
+
+    def test_code_review_uses_review_json_schema(self):
+        from theforge.schemas import review_json_schema
+
+        fn, mock_client = self._make_finalizer("review")
+        fn([{"role": "user", "content": "Review this code."}])
+        kwargs = mock_client.chat.completions.create.call_args[1]
+        rf = kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "review_output"
+        assert rf["json_schema"]["schema"] == review_json_schema()
+
+    def test_code_review_message_references_code_review_fields(self):
+        fn, mock_client = self._make_finalizer("review")
+        fn([{"role": "user", "content": "Review this code."}])
+        kwargs = mock_client.chat.completions.create.call_args[1]
+        last_msg = kwargs["messages"][-1]["content"]
+        assert "story_compliance" in last_msg
+        assert "test_coverage" in last_msg
+
+
 class TestProviderFallbackPreservesPhase:
     """_apply_provider_fallback must carry phase through to the rebuilt ModelProfile."""
 


### PR DESCRIPTION
## Summary

[openai-reviewer] Plan review JSON schema enforcement is correctly extended to the API-mode plan review path with prior blockers resolved and no regressions found. | [gemini-reviewer] All prior P1 findings have been resolved and no new regressions were found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $4.65
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Plan review JSON schema enforcement — extend API mode fix to plan review path (GitHub Issue #332)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #332