### PR TITLE
Preflight: deterministic ALREADY_DONE verification

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -712,6 +712,9 @@ def run_task(
             state.preflight_cached = True
             state.preflight_cached_original_verdict = cached_preflight_state.preflight_verdict
             state.preflight_cached_from_run_id = getattr(cached_preflight_state, "run_id", None)
+            state.preflight_criteria_checked = list(
+                getattr(cached_preflight_state, "preflight_criteria_checked", None) or []
+            )
             config = _apply_preflight_config(config, state)
             from .preflight_flow import _handle_preflight_verdict  # noqa: PLC0415
 
@@ -943,6 +946,9 @@ def _run_resume_coordinator(
         state.preflight_cached = True
         state.preflight_cached_original_verdict = cached_preflight_state.preflight_verdict
         state.preflight_cached_from_run_id = getattr(cached_preflight_state, "run_id", None)
+        state.preflight_criteria_checked = list(
+            getattr(cached_preflight_state, "preflight_criteria_checked", None) or []
+        )
         config = _apply_preflight_config(config, state)
 
     with _run_log_context(config, logger, task, state, _task_start):

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -243,6 +243,49 @@ def _parse_preflight_sufficiency(output: str) -> str:
     return "needs_planning"
 
 
+def _parse_preflight_criteria_checked(output: str) -> list[dict]:
+    """Extract criteria_checked list from preflight agent output.
+
+    Each entry should have: criterion (str), files_checked (list[str]),
+    satisfied (bool), evidence (str).
+
+    Returns [] on parse failure, missing key, or non-list value so that
+    callers can treat an absent map as insufficient evidence (conservative).
+    """
+    yaml_text = output
+    if "```yaml" in output:
+        start = output.index("```yaml") + len("```yaml")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+    elif "```" in output:
+        start = output.index("```") + len("```")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+
+    try:
+        parsed = yaml.safe_load(yaml_text)
+        if not isinstance(parsed, dict):
+            return []
+        raw = parsed.get("criteria_checked")
+        if not isinstance(raw, list):
+            return []
+        result = []
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            result.append(
+                {
+                    "criterion": str(entry.get("criterion", "")),
+                    "files_checked": list(entry.get("files_checked") or []),
+                    "satisfied": bool(entry.get("satisfied", False)),
+                    "evidence": str(entry.get("evidence", "")),
+                }
+            )
+        return result
+    except yaml.YAMLError:
+        return []
+
+
 def _find_registry_info_for_profile(profile: ModelProfile) -> tuple[int, int]:
     """Return (cost_rank, capability) for a profile using the model registry.
 

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -41,6 +41,7 @@ from .preflight import (
     _parse_preflight_bundle_candidate,
     _parse_preflight_complexity,
     _parse_preflight_contract_change,
+    _parse_preflight_criteria_checked,
     _parse_preflight_likely_files,
     _parse_preflight_sufficiency,
     _parse_preflight_verdict,
@@ -244,6 +245,8 @@ def _run_preflight_phase(
         state.preflight_contract_change = contract_change
         bundle_candidate = _parse_preflight_bundle_candidate(preflight_result.output)
         state.preflight_bundle_candidate = bundle_candidate
+        criteria_checked = _parse_preflight_criteria_checked(preflight_result.output)
+        state.preflight_criteria_checked = criteria_checked
 
         # ── Deterministic contract-change policy ───────────────────────
         # A contract change touches a shared interface field, prompt template
@@ -276,6 +279,33 @@ def _run_preflight_phase(
             _log(f"  ⚠ PREFLIGHT warnings: {'; '.join(_warnings)}")
         if _likely_files is not None:
             _log(f"  Likely files: {', '.join(_likely_files)}")
+
+        # ── ALREADY_DONE evidence downgrade ───────────────────────────
+        # Require that every AC has concrete file evidence (files_checked is
+        # non-empty) and is marked satisfied=True.  An empty or absent
+        # criteria_checked map is itself treated as missing evidence —
+        # fail-safe toward PROCEED rather than silently honoring the verdict.
+        if verdict == "ALREADY_DONE":
+            downgrade_reasons: list[str] = []
+            if not criteria_checked:
+                downgrade_reasons.append(
+                    "criteria_checked absent or empty; cannot verify ALREADY_DONE"
+                )
+            else:
+                for entry in criteria_checked:
+                    criterion = entry.get("criterion", "(unnamed)")
+                    if not entry.get("satisfied"):
+                        downgrade_reasons.append(f"AC '{criterion}' marked satisfied=false")
+                    elif not entry.get("files_checked"):
+                        downgrade_reasons.append(
+                            f"AC '{criterion}' lacked concrete evidence (no files_checked)"
+                        )
+            if downgrade_reasons:
+                verdict = "PROCEED"
+                state.preflight_verdict = verdict
+                for dr in downgrade_reasons:
+                    _log(f"  ⚠ ALREADY_DONE downgraded → PROCEED: {dr}")
+                state.preflight_warnings = list(state.preflight_warnings or []) + downgrade_reasons
 
         # ── Ambiguity BLOCKED downgrade ───────────────────────────────
         # Must come *after* all signal parsing so that forced overrides are
@@ -336,6 +366,7 @@ def _run_preflight_phase(
         "bundle_candidate": state.preflight_bundle_candidate,
         "branch_merged": branch_merged,
         "evaluation_base_branch": config.workspace.base_branch,
+        "criteria_checked": state.preflight_criteria_checked,
     }
     _write_log_artifact(state.log_dir, "preflight-raw.log", preflight_result.output or "")
     _write_log_artifact(

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -283,6 +283,7 @@ class CoordinatorState:
     preflight_cached_original_verdict: str | None = None
     preflight_degraded: bool = False
     preflight_degraded_reason: str | None = None
+    preflight_criteria_checked: list[dict] = field(default_factory=list)
     plan_results: list[AgentResult] = field(default_factory=list)
     plan_output: str | None = (
         None  # contents of the worktree plan file, passed to dev (raw string for audit)

--- a/tests/coord_test_helpers.py
+++ b/tests/coord_test_helpers.py
@@ -248,6 +248,8 @@ reason: "All acceptance criteria are already satisfied."
 criteria_checked:
   - criterion: "Feature X"
     satisfied: true
+    files_checked:
+      - "coordinator.py"
     evidence: "Implemented in coordinator.py:42"
 ```
 """

--- a/tests/test_coord_preflight_already_done_verification.py
+++ b/tests/test_coord_preflight_already_done_verification.py
@@ -1,0 +1,297 @@
+"""Tests for preflight ALREADY_DONE AC-evidence downgrade logic (issue #705).
+
+Acceptance criteria:
+- All ACs evidenced (files_checked non-empty, satisfied=true) → ALREADY_DONE honored
+- Any AC lacking files_checked evidence → verdict downgraded to PROCEED
+- Missing/empty criteria_checked → verdict downgraded to PROCEED
+- criteria_checked evidence map persists in the preflight.yaml artifact
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import yaml as _yaml
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import Phase
+
+# ── Test fixtures ─────────────────────────────────────────────────────────────
+
+# All ACs satisfied with concrete file evidence — ALREADY_DONE should be honored.
+PREFLIGHT_ALREADY_DONE_ALL_EVIDENCED = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "All acceptance criteria are satisfied with file evidence."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    evidence: "Found implementation at engine.py:42"
+  - criterion: "Feature X has tests"
+    satisfied: true
+    files_checked:
+      - "tests/test_coord_engine.py"
+    evidence: "Test coverage confirmed at test_coord_engine.py:100"
+```
+"""
+
+# One AC has empty files_checked — should be downgraded to PROCEED.
+PREFLIGHT_ALREADY_DONE_PARTIAL_EVIDENCE = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Some criteria lack file evidence."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    evidence: "Confirmed at engine.py:42"
+  - criterion: "Feature Y is implemented"
+    satisfied: true
+    files_checked: []
+    evidence: "Believed to be done but no file checked"
+```
+"""
+
+# No criteria_checked field at all — should be downgraded to PROCEED.
+PREFLIGHT_ALREADY_DONE_NO_CRITERIA = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Looks done."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+```
+"""
+
+# AC marked satisfied=false — should be downgraded to PROCEED.
+PREFLIGHT_ALREADY_DONE_UNSATISFIED_AC = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "One AC not satisfied."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: false
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    evidence: "Found partial implementation"
+```
+"""
+
+
+class TestPreflightAlreadyDoneVerification:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow.has_review_approve", return_value=True)
+    def test_all_acs_evidenced_already_done_honored(
+        self,
+        mock_approve,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """All ACs have non-empty files_checked and satisfied=true → ALREADY_DONE honored."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_ALL_EVIDENCED, cost_usd=0.05
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.preflight_verdict == "ALREADY_DONE"
+        # No dev or review should have run
+        mock_dev.assert_not_called()
+        mock_pool.assert_not_called()
+        # Criteria evidence preserved on state
+        assert len(result.state.preflight_criteria_checked) == 2
+        assert (
+            result.state.preflight_criteria_checked[0]["criterion"] == "Feature X is implemented"
+        )
+        assert result.state.preflight_criteria_checked[0]["satisfied"] is True
+        assert (
+            "src/theforge/coordinator/engine.py"
+            in result.state.preflight_criteria_checked[0]["files_checked"]
+        )
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_partial_evidence_downgraded_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """One AC with files_checked=[] → ALREADY_DONE downgraded to PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_PARTIAL_EVIDENCE, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.preflight_verdict == "PROCEED"
+        # Warning about the missing evidence should appear
+        assert any("Feature Y" in w for w in (result.state.preflight_warnings or []))
+        # Run should have proceeded through dev
+        mock_dev.assert_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_no_criteria_checked_downgraded_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """Missing criteria_checked on ALREADY_DONE → downgraded to PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_NO_CRITERIA, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert any("criteria_checked absent" in w for w in (result.state.preflight_warnings or []))
+        mock_dev.assert_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_unsatisfied_ac_downgraded_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """AC with satisfied=false → ALREADY_DONE downgraded to PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_UNSATISFIED_AC, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert any("satisfied=false" in w for w in (result.state.preflight_warnings or []))
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow.has_review_approve", return_value=True)
+    def test_criteria_checked_preserved_in_artifact(
+        self,
+        mock_approve,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """criteria_checked evidence map is written to the preflight.yaml artifact."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_ALL_EVIDENCED, cost_usd=0.05
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        log_dir = result.state.log_dir
+        assert log_dir is not None
+        preflight_yaml = log_dir / "preflight.yaml"
+        assert preflight_yaml.exists(), f"preflight.yaml not found in {log_dir}"
+        artifact = _yaml.safe_load(preflight_yaml.read_text(encoding="utf-8"))
+        assert "criteria_checked" in artifact
+        criteria = artifact["criteria_checked"]
+        assert isinstance(criteria, list)
+        assert len(criteria) == 2
+        assert criteria[0]["criterion"] == "Feature X is implemented"
+        assert "src/theforge/coordinator/engine.py" in criteria[0]["files_checked"]


### PR DESCRIPTION
## Summary

Deterministic per-AC ALREADY_DONE verification is wired into runtime control flow, preserved in audit state, and covered by targeted tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.38
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight: deterministic ALREADY_DONE verification (GitHub Issue #705)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #705