### PR TITLE
Preflight parser: malformed/empty output should not become BLOCKED

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -17,12 +17,12 @@ if TYPE_CHECKING:
 _VALID_PREFLIGHT_VERDICTS = frozenset({"PROCEED", "ALREADY_DONE", "BLOCKED"})
 
 
-def _parse_preflight_verdict(output: str) -> tuple[str, str]:
+def _parse_preflight_verdict(output: str) -> tuple[str, str, bool]:
     """Extract verdict and reason from preflight agent output.
 
-    Returns (verdict, reason). Parse failures and invalid verdicts are treated
-    as BLOCKED because downstream classifications from a confused preflight are
-    unreliable.
+    Returns (verdict, reason, degraded). Parse failures and invalid verdicts
+    return PROCEED with degraded=True — a confused classifier should not become
+    process truth (same principle as the success=False path in preflight_flow).
     """
     # Extract YAML block from markdown fences
     yaml_text = output
@@ -38,22 +38,26 @@ def _parse_preflight_verdict(output: str) -> tuple[str, str]:
     try:
         parsed = yaml.safe_load(yaml_text)
     except yaml.YAMLError:
-        return "BLOCKED", f"Failed to parse preflight YAML; blocking. Raw: {output[:200]}"
+        return (
+            "PROCEED",
+            f"Failed to parse preflight YAML; falling back to PROCEED. Raw: {output[:200]}",
+            True,
+        )
 
     if not isinstance(parsed, dict):
-        return "BLOCKED", "Preflight output is not a dict; blocking."
+        return "PROCEED", "Preflight output is not a dict; falling back to PROCEED.", True
 
     verdict = str(parsed.get("verdict", "PROCEED")).upper()
     reason = str(parsed.get("reason", "(no reason provided)"))
 
     if verdict not in _VALID_PREFLIGHT_VERDICTS:
         return (
-            "BLOCKED",
-            "Unknown preflight verdict "
-            f"{verdict!r}; escalating because preflight output is invalid. {reason}",
+            "PROCEED",
+            f"Unknown preflight verdict {verdict!r}; falling back to PROCEED. {reason}",
+            True,
         )
 
-    return verdict, reason
+    return verdict, reason, False
 
 
 _VALID_COMPLEXITIES = frozenset({"small", "medium", "large"})

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -215,7 +215,11 @@ def _run_preflight_phase(
     log_agent_result(preflight_result, "PREFLIGHT")
 
     if preflight_result.success:
-        verdict, reason = _parse_preflight_verdict(preflight_result.output)
+        verdict, reason, _parse_degraded = _parse_preflight_verdict(preflight_result.output)
+        if _parse_degraded:
+            state.preflight_degraded = True
+            state.preflight_degraded_reason = "parse_error"
+            _log("  ⚠ PREFLIGHT output malformed — fallback PROCEED (degraded)")
     else:
         verdict, reason = (
             "PROCEED",

--- a/src/theforge/eval/preflight_harness.py
+++ b/src/theforge/eval/preflight_harness.py
@@ -166,7 +166,7 @@ def run_preflight_for_model(
     if submitted:
         valid_yaml = _output_has_valid_yaml(result.output)
         if valid_yaml:
-            verdict, _ = _parse_preflight_verdict(result.output)
+            verdict, _, _degraded = _parse_preflight_verdict(result.output)
             complexity = _parse_preflight_complexity(result.output)
         else:
             # Output is garbage — don't report the fallback-BLOCKED as a real verdict.

--- a/tests/test_coord_preflight_parse_error.py
+++ b/tests/test_coord_preflight_parse_error.py
@@ -1,0 +1,204 @@
+"""Tests for preflight parser degradation (#709).
+
+Covers the three success=True cases where _parse_preflight_verdict previously
+returned BLOCKED but should now return PROCEED with degraded=True:
+  1. YAML parse failure
+  2. Output is not a dict
+  3. Unknown verdict string
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.preflight import _parse_preflight_verdict
+from theforge.coordinator.state import Phase
+
+# ── Unit tests for _parse_preflight_verdict ───────────────────────────────────
+
+
+class TestParsePreflightVerdictUnit:
+    def test_yaml_parse_failure_returns_proceed_degraded(self):
+        """YAML parse error → PROCEED + degraded=True, not BLOCKED."""
+        output = "```yaml\n: invalid: yaml: [\n```"
+        verdict, reason, degraded = _parse_preflight_verdict(output)
+        assert verdict == "PROCEED"
+        assert degraded is True
+        assert "parse" in reason.lower() or "yaml" in reason.lower()
+
+    def test_non_dict_output_returns_proceed_degraded(self):
+        """Non-dict parsed YAML → PROCEED + degraded=True, not BLOCKED."""
+        output = "```yaml\n- item1\n- item2\n```"
+        verdict, reason, degraded = _parse_preflight_verdict(output)
+        assert verdict == "PROCEED"
+        assert degraded is True
+        assert "not a dict" in reason.lower() or "dict" in reason.lower()
+
+    def test_unknown_verdict_returns_proceed_degraded(self):
+        """Unknown verdict string → PROCEED + degraded=True, not BLOCKED."""
+        output = "```yaml\nverdict: SKIP\nreason: 'not a valid verdict'\n```"
+        verdict, reason, degraded = _parse_preflight_verdict(output)
+        assert verdict == "PROCEED"
+        assert degraded is True
+        assert "skip" in reason.lower() or "unknown" in reason.lower()
+
+    def test_valid_proceed_not_degraded(self):
+        """Valid PROCEED output → not degraded."""
+        output = "```yaml\nverdict: PROCEED\nreason: 'Go ahead'\n```"
+        verdict, reason, degraded = _parse_preflight_verdict(output)
+        assert verdict == "PROCEED"
+        assert degraded is False
+
+    def test_valid_blocked_not_degraded(self):
+        """Valid BLOCKED output → not degraded (classifier made a real decision)."""
+        output = "```yaml\nverdict: BLOCKED\nreason: 'Dependency missing'\n```"
+        verdict, reason, degraded = _parse_preflight_verdict(output)
+        assert verdict == "BLOCKED"
+        assert degraded is False
+
+    def test_valid_already_done_not_degraded(self):
+        """Valid ALREADY_DONE output → not degraded."""
+        output = "```yaml\nverdict: ALREADY_DONE\nreason: 'All criteria met'\n```"
+        verdict, reason, degraded = _parse_preflight_verdict(output)
+        assert verdict == "ALREADY_DONE"
+        assert degraded is False
+
+    def test_empty_output_returns_proceed_degraded(self):
+        """Empty output fails YAML parse → PROCEED + degraded=True."""
+        verdict, reason, degraded = _parse_preflight_verdict("")
+        # yaml.safe_load("") returns None, which is not a dict
+        assert verdict == "PROCEED"
+        assert degraded is True
+
+    def test_plain_text_no_fence_non_dict(self):
+        """Plain text that parses as a scalar → PROCEED + degraded=True."""
+        output = "just some text that is not yaml at all!!! @@@"
+        verdict, reason, degraded = _parse_preflight_verdict(output)
+        # yaml.safe_load returns a string (scalar), not a dict
+        assert verdict == "PROCEED"
+        assert degraded is True
+
+
+# ── Integration tests via run_task ────────────────────────────────────────────
+
+
+PREFLIGHT_MALFORMED_YAML = "```yaml\n: bad: yaml: [\n```"
+
+PREFLIGHT_NON_DICT = "```yaml\n- item1\n- item2\n```"
+
+PREFLIGHT_UNKNOWN_VERDICT = """\
+```yaml
+verdict: SKIP
+reason: "Not a valid verdict string"
+complexity: medium
+sufficiency: needs_planning
+work_type: feature
+```
+"""
+
+
+class TestPreflightParseErrorIntegration:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_yaml_parse_failure_falls_back_to_proceed(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """YAML parse error: success=True + malformed → degraded PROCEED, not BLOCKED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_MALFORMED_YAML, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "parse_error"
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_non_dict_output_falls_back_to_proceed(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Non-dict YAML: success=True + list output → degraded PROCEED, not BLOCKED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_NON_DICT, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "parse_error"
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_unknown_verdict_falls_back_to_proceed(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Unknown verdict: success=True + garbage verdict → degraded PROCEED, not BLOCKED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_UNKNOWN_VERDICT, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "parse_error"
+        assert result.phase == Phase.DONE
+        assert result.success is True

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -258,10 +258,10 @@ class TestCoordinatorPreflight:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_preflight_unparseable_blocks(
+    def test_preflight_unparseable_falls_back_to_proceed(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """If preflight output is not valid YAML, execution is blocked."""
+        """Unparseable preflight output falls back to degraded PROCEED, not BLOCKED."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -281,26 +281,28 @@ class TestCoordinatorPreflight:
 
         result = run_task(config, task)
 
-        assert result.success is False
-        assert result.phase == Phase.ESCALATE
-        assert result.state.preflight_verdict == "BLOCKED"
-        assert len(result.state.dev_results) == 0
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "parse_error"
+        assert len(result.state.dev_results) >= 1
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_preflight_unknown_verdict_escalates(
+    def test_preflight_unknown_verdict_falls_back_to_proceed(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """Unknown preflight verdicts are treated as hard failures."""
+        """Unknown preflight verdicts fall back to degraded PROCEED, not hard failure."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
 
-        mock_shell.return_value = (True, "OK")
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
         mock_preflight.return_value = _make_agent_result(
             success=True,
             output="""```yaml
@@ -314,18 +316,26 @@ likely_files:
             cost_usd=0.05,
             profile_name="review",
         )
+        dev_ok = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_agent
+        mock_agent.return_value = dev_ok
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
 
         result = run_task(config, task)
 
-        assert result.success is False
-        assert result.phase == Phase.ESCALATE
-        assert result.state.preflight_verdict == "BLOCKED"
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "parse_error"
         assert "unknown preflight verdict" in result.state.preflight_reason.lower()
+        # likely_files still parsed from the valid YAML even when verdict is unknown
         assert result.state.preflight_likely_files == [
             "src/theforge/coordinator/preflight_flow.py"
         ]
-        assert len(result.state.dev_results) == 0
-        mock_pool.assert_not_called()
+        assert len(result.state.dev_results) >= 1
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the spec: malformed successful preflight output now falls back to PROCEED with degraded state recorded, and runtime callers consume the new signal correctly. | [gemini-reviewer] The implementation correctly updates _parse_preflight_verdict to return a degraded flag and fall back to PROCEED on parse errors.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.00
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight parser: malformed/empty output should not become BLOCKED (GitHub Issue #709)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #709