### PR TITLE
fix: preflight config — use cli: claude, not provider: anthropic

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -51,11 +51,7 @@ profiles:
     timeout_medium_seconds: 900
     timeout_large_seconds: 1800
   preflight:
-<<<<<<< feat/preflight-model-swap
     cli: claude
-=======
-    provider: anthropic
->>>>>>> main
     model: claude-opus-4-5
     budget_usd: 5.00
     timeout_seconds: 300

--- a/forge.yaml
+++ b/forge.yaml
@@ -51,7 +51,7 @@ profiles:
     timeout_medium_seconds: 900
     timeout_large_seconds: 1800
   preflight:
-    provider: anthropic
+    cli: claude
     model: claude-opus-4-5
     budget_usd: 5.00
     timeout_seconds: 300

--- a/forge.yaml
+++ b/forge.yaml
@@ -51,9 +51,9 @@ profiles:
     timeout_medium_seconds: 900
     timeout_large_seconds: 1800
   preflight:
-    provider: deepseek
-    model: deepseek-reasoner
-    budget_usd: 1.00
+    provider: anthropic
+    model: claude-opus-4-5
+    budget_usd: 5.00
     timeout_seconds: 300
   review_pool:
     - name: openai-reviewer


### PR DESCRIPTION
## Summary

- PR #712 set `provider: anthropic` but there is no `ANTHROPIC_API_KEY` — Opus must run through Claude Code CLI
- Changes `provider: anthropic` → `cli: claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)