### PR TITLE
[P2] coordinator-http-timeout: Warning is logged via _cu._log with a 'WA

### DIFF
--- a/src/theforge/coordinator/ntfy_client.py
+++ b/src/theforge/coordinator/ntfy_client.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 import unicodedata
 import urllib.request
 
-from . import util as _cu
+_logger = logging.getLogger(__name__)
 
 _BLOCKING_POLL_CHUNK = 300  # seconds per poll iteration in blocking mode
 
@@ -53,7 +54,7 @@ def _ntfy_publish(
         with urllib.request.urlopen(req, timeout=15):
             pass
     except Exception as exc:
-        _cu._log(f"WARNING: ntfy publish failed (continuing): {exc}")
+        _logger.warning("ntfy publish failed (continuing): %s", exc)
 
 
 def _ntfy_poll_reply(

--- a/tests/test_http_timeout.py
+++ b/tests/test_http_timeout.py
@@ -60,17 +60,23 @@ class TestNtfyPublishTimeout:
         ):
             _ntfy_publish("https://ntfy.sh/topic", "Title", "Body")
 
-    def test_failure_logs_warning(self, capsys):
-        """A publish failure logs a WARNING message to stderr so ops can diagnose it."""
-        with patch(
-            "theforge.coordinator.ntfy_client.urllib.request.urlopen",
-            side_effect=OSError("network unreachable"),
-        ):
-            _ntfy_publish("https://ntfy.sh/topic", "Title", "Body")
+    def test_failure_logs_warning(self, caplog):
+        """A publish failure logs a WARNING message via Python logging."""
+        import logging
 
-        captured = capsys.readouterr()
-        assert "WARNING" in captured.err, "failure must be logged as WARNING to stderr"
-        assert "ntfy" in captured.err.lower(), "log message should mention ntfy"
+        with caplog.at_level(logging.WARNING, logger="theforge.coordinator.ntfy_client"):
+            with patch(
+                "theforge.coordinator.ntfy_client.urllib.request.urlopen",
+                side_effect=OSError("network unreachable"),
+            ):
+                _ntfy_publish("https://ntfy.sh/topic", "Title", "Body")
+
+        assert any(r.levelno == logging.WARNING for r in caplog.records), (
+            "failure must be logged at WARNING level"
+        )
+        assert any("ntfy" in r.message.lower() for r in caplog.records), (
+            "log message should mention ntfy"
+        )
 
 
 class TestNtfyPollTimeouts:


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation satisfies the acceptance criterion by logging ntfy publish failures at Python WARNING level and updating coverage accordingly. | [gemini-reviewer] The implementation correctly replaces _cu._log with a proper Python logger at WARNING level.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.58
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] coordinator-http-timeout: Warning is logged via _cu._log with a 'WA (GitHub Issue #92)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #92