### PR TITLE
[P2] review-convergence: _matches_prior requires severity match, so a fi

### DIFF
--- a/src/theforge/finding_classifier.py
+++ b/src/theforge/finding_classifier.py
@@ -66,10 +66,26 @@ def _matches_prior(
     prior: FindingRecord,
     threshold: float = JACCARD_THRESHOLD,
 ) -> bool:
-    """Return True if finding matches prior record (same file + sufficient token overlap)."""
+    """Return True if finding matches prior record (same file + same severity + token overlap)."""
     if finding.file != prior.file:
         return False
     if finding.severity != prior.severity:
+        return False
+    tokens_new = _normalize_tokens(finding.description)
+    tokens_prior = _normalize_tokens(prior.description)
+    return _jaccard(tokens_new, tokens_prior) >= threshold
+
+
+def _matches_prior_agnostic(
+    finding: ReviewFinding,
+    prior: FindingRecord,
+    threshold: float = JACCARD_THRESHOLD,
+) -> bool:
+    """Return True if finding matches prior record ignoring severity (same file + token overlap).
+
+    Used to detect severity downgrades between cycles (e.g. P1 → P2).
+    """
+    if finding.file != prior.file:
         return False
     tokens_new = _normalize_tokens(finding.description)
     tokens_prior = _normalize_tokens(prior.description)
@@ -194,12 +210,23 @@ def update_finding_registry(
         # Use the first report as representative
         first_reviewer, first_finding = reports[0]
 
-        # Look for match in prior registry (snapshot taken before this cycle's inserts)
+        # Look for match in prior registry (snapshot taken before this cycle's inserts).
+        # First pass: exact match (same severity).
+        # Second pass: severity-agnostic match to detect P1 → P2 downgrades.
         prior_match: FindingRecord | None = None
+        is_severity_downgrade = False
         for record in prior_registry:
             if _matches_prior(first_finding, record):
                 prior_match = record
                 break
+        if prior_match is None:
+            for record in prior_registry:
+                if _matches_prior_agnostic(first_finding, record):
+                    # Only treat as downgrade when severity decreased (P1 → P2)
+                    if record.severity == "P1" and first_finding.severity == "P2":
+                        prior_match = record
+                        is_severity_downgrade = True
+                    break
 
         in_changed_files = first_finding.file in changed_files if first_finding.file else False
         num_reporters = len({r for r, _ in reports})  # unique reviewer count
@@ -207,7 +234,10 @@ def update_finding_registry(
         if prior_match is not None:
             # Finding existed in a prior cycle
             disposition: str
-            if prior_match.disposition in (
+            if is_severity_downgrade:
+                # P1 finding was reported as P2 this cycle — record the downgrade
+                disposition = "downgraded"
+            elif prior_match.disposition in (
                 "unresolved",
                 "net_new",
                 "corroborated_new",

--- a/tests/test_finding_classifier.py
+++ b/tests/test_finding_classifier.py
@@ -11,6 +11,7 @@ from theforge.finding_classifier import (
     _fingerprint,
     _jaccard,
     _matches_prior,
+    _matches_prior_agnostic,
     _normalize_tokens,
     has_blocking_p1,
     net_new_p1s,
@@ -153,6 +154,44 @@ class TestMatchesPrior:
         finding = _make_finding("Completely different description about something else")
         record = self._make_record("Missing null check in handler method call")
         assert not _matches_prior(finding, record)
+
+
+class TestMatchesPriorAgnostic:
+    def _make_record(
+        self, description: str, file: str = "src/foo.py", severity: str = "P1"
+    ) -> FindingRecord:
+        fp = _fingerprint(severity, file, description)
+        return FindingRecord(
+            finding_id=fp,
+            cycle_first_seen=1,
+            cycle_last_seen=1,
+            file=file,
+            line=10,
+            severity=severity,
+            description=description,
+            reporter="reviewer-a",
+            disposition="net_new",
+        )
+
+    def test_same_severity_matches(self):
+        finding = _make_finding("Missing null check in handler")
+        record = self._make_record("Missing null check in handler")
+        assert _matches_prior_agnostic(finding, record)
+
+    def test_different_severity_still_matches(self):
+        finding = _make_finding("Missing null check in handler", severity="P2")
+        record = self._make_record("Missing null check in handler", severity="P1")
+        assert _matches_prior_agnostic(finding, record)
+
+    def test_different_file_no_match(self):
+        finding = _make_finding("Missing null check in handler", file="src/bar.py")
+        record = self._make_record("Missing null check in handler", file="src/foo.py")
+        assert not _matches_prior_agnostic(finding, record)
+
+    def test_low_overlap_no_match(self):
+        finding = _make_finding("Completely different description about something else")
+        record = self._make_record("Missing null check in handler method call")
+        assert not _matches_prior_agnostic(finding, record)
 
 
 class TestUpdateFindingRegistryCycle1:
@@ -404,6 +443,86 @@ class TestUpdateFindingRegistryCycle2:
         p1s = [r for r in classified if r.severity == "P1"]
         assert len(p1s) == 1
         assert p1s[0].disposition == "corroborated_new"
+
+    def test_p1_downgraded_to_p2_gets_downgraded_disposition(self, tmp_path):
+        """A P1 in cycle 1 reported as P2 in cycle 2 should get 'downgraded', not 'fixed'."""
+        state = _make_state()
+        self._populate_cycle1(state, "Missing null check in handler")
+
+        # Same description, but P2 this time
+        finding = _make_finding("Missing null check in handler", severity="P2")
+        review = _make_review([finding], verdict="APPROVE")
+        cycle_results = [("reviewer-a", review)]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        # The existing P1 record should be updated to 'downgraded'
+        assert len(state.finding_registry) == 1
+        record = state.finding_registry[0]
+        assert record.disposition == "downgraded"
+        assert record.cycle_last_seen == 2
+        # Severity stays P1 (it's the same record — the downgrade is noted in disposition)
+        assert record.severity == "P1"
+
+    def test_p1_downgraded_to_p2_is_not_marked_fixed(self, tmp_path):
+        """A downgraded finding's cycle_last_seen is updated, so it must not be marked fixed."""
+        state = _make_state()
+        self._populate_cycle1(state, "Missing null check in handler")
+
+        finding = _make_finding("Missing null check in handler", severity="P2")
+        review = _make_review([finding], verdict="APPROVE")
+        cycle_results = [("reviewer-a", review)]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        record = state.finding_registry[0]
+        assert record.disposition != "fixed"
+
+    def test_downgraded_p1_does_not_block(self, tmp_path):
+        """A downgraded P1 should not block — it was intentionally softened by reviewers."""
+        state = _make_state()
+        self._populate_cycle1(state, "Missing null check in handler")
+
+        finding = _make_finding("Missing null check in handler", severity="P2")
+        review = _make_review([finding], verdict="APPROVE")
+        cycle_results = [("reviewer-a", review)]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        assert not has_blocking_p1(classified)
+
+    def test_p2_upgraded_to_p1_creates_new_record(self, tmp_path):
+        """P2 in cycle 1 reported as P1 in cycle 2 → new finding (regression or net_new)."""
+        state = _make_state()
+        fp = _fingerprint("P2", "src/foo.py", "Style issue in handler")
+        record = FindingRecord(
+            finding_id=fp,
+            cycle_first_seen=1,
+            cycle_last_seen=1,
+            file="src/foo.py",
+            line=10,
+            severity="P2",
+            description="Style issue in handler",
+            reporter="reviewer-a",
+            disposition="net_new",
+        )
+        state.finding_registry.append(record)
+
+        # Same description but P1 now — upgrade case
+        finding = _make_finding("Style issue in handler", severity="P1", file="src/foo.py")
+        review = _make_review([finding])
+        cycle_results = [("reviewer-a", review)]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        # P2→P1 is NOT treated as downgrade; new P1 record created
+        p1_records = [r for r in state.finding_registry if r.severity == "P1"]
+        assert len(p1_records) == 1
+        assert p1_records[0].disposition in ("net_new", "regression")
 
 
 class TestHasBlockingP1:


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation satisfies the downgrade matching acceptance criteria and is covered by targeted tests. | [gemini-reviewer] Solid implementation of severity-agnostic matching for downgraded findings.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.03
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] review-convergence: _matches_prior requires severity match, so a fi (GitHub Issue #30)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #30