### PR TITLE
[P2] adaptive-model-assignment: _enforce_budget excludes planner and pla

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -258,7 +258,14 @@ def _enforce_budget(
     agents: list[AgentDef],
     budget_per_story_usd: float,
 ) -> AssignmentDecision:
-    """Downgrade highest-cost non-preflight model if over budget cap."""
+    """Downgrade highest-cost non-preflight model if over budget cap.
+
+    Candidates for downgrade: planner, plan_reviewers, dev, code_reviewers.
+    Preflight is excluded to preserve classification quality.
+    Plan-phase models are included because for MEDIUM+ complexity their costs
+    alone can exceed the cap, making it impossible to reach via dev/code_review
+    downgrades alone.
+    """
     from dataclasses import replace as _dc_replace
 
     def _total(d: AssignmentDecision) -> float:
@@ -303,10 +310,14 @@ def _enforce_budget(
         if _total(decision) <= budget_per_story_usd:
             break
 
-        # Find highest-cost non-preflight, non-planner profile that can be downgraded
-        # Candidates: dev, code_reviewers (exclude preflight to preserve quality).
-        # All profiles are candidates — _next_cheaper_profile handles pool lookup.
-        candidates = []
+        # Find highest-cost non-preflight profile that can be downgraded.
+        # Include plan-phase (planner, plan_reviewers) alongside dev and code_reviewers
+        # so that MEDIUM+ stories where plan-phase costs alone exceed the cap can still
+        # converge. Preflight is excluded to preserve classification quality.
+        candidates: list[tuple[str, ModelProfile]] = []
+        candidates.append(("planner", decision.planner))
+        for i, p in enumerate(decision.plan_reviewers):
+            candidates.append((f"plan_review_{i}", p))
         candidates.append(("dev", decision.dev))
         for i, p in enumerate(decision.code_reviewers):
             candidates.append((f"code_review_{i}", p))
@@ -322,6 +333,13 @@ def _enforce_budget(
             if cheaper is not None:
                 if role == "dev":
                     decision = _dc_replace(decision, dev=cheaper)
+                elif role == "planner":
+                    decision = _dc_replace(decision, planner=cheaper)
+                elif role.startswith("plan_review_"):
+                    i = int(role.split("_")[-1])
+                    new_reviewers = list(decision.plan_reviewers)
+                    new_reviewers[i] = cheaper
+                    decision = _dc_replace(decision, plan_reviewers=new_reviewers)
                 else:
                     i = int(role.split("_")[-1])
                     new_reviewers = list(decision.code_reviewers)
@@ -331,9 +349,11 @@ def _enforce_budget(
                 break
 
         if not downgraded:
-            # Can't downgrade any model; try removing a code reviewer (keep min 1)
+            # Can't downgrade any model; try removing a reviewer (keep min 1 each)
             if len(decision.code_reviewers) > 1:
                 decision = _dc_replace(decision, code_reviewers=decision.code_reviewers[:-1])
+            elif len(decision.plan_reviewers) > 1:
+                decision = _dc_replace(decision, plan_reviewers=decision.plan_reviewers[:-1])
             else:
                 break
 

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -358,8 +358,9 @@ def test_budget_cap_enforcement():
     """When sum of budgets exceeds cap, downgrade until within budget."""
     # Use a very tight budget that forces downgrades
     agents = _make_agents_one_per_tier()
-    # Each story: preflight(1) + planner(8) + plan_review(8) + dev(5) + code_review(8)
-    # Total ≈ 30 — much more than budget_per_story_usd=10
+    # Uncapped MEDIUM story: preflight(1) + planner(8) + plan_review(8) + dev(5) +
+    # code_review(8) ≈ $30. With budget=$10 and all phases as downgrade candidates,
+    # enforcement should converge: all-cheap = $1×5 = $5 ≤ $10.
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
@@ -367,18 +368,56 @@ def test_budget_cap_enforcement():
         prefer_cross_provider=False,
     )
 
-    import warnings
+    decision = assign_models(agents, cfg, "medium")
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        decision = assign_models(agents, cfg, "medium")
-
-    # Budget enforcement may still exceed cap if no cheaper option,
-    # but should have attempted to downgrade
-    # At minimum: decision must be a valid AssignmentDecision
+    total = (
+        decision.preflight.budget_usd
+        + decision.planner.budget_usd
+        + sum(p.budget_usd for p in decision.plan_reviewers)
+        + decision.dev.budget_usd
+        + sum(p.budget_usd for p in decision.code_reviewers)
+    )
+    assert total <= 10.0, f"Budget cap not met: total ${total:.2f} > $10.00"
     assert isinstance(decision, AssignmentDecision)
     assert decision.dev is not None
     assert len(decision.code_reviewers) >= 1
+
+
+def test_budget_cap_plan_phase_downgraded():
+    """Plan-phase models are downgraded when they alone exceed the cap.
+
+    This guards against the regression where _enforce_budget excluded planner and
+    plan_reviewers from candidates, making the cap unreachable for MEDIUM+ stories.
+    """
+    agents = _make_agents_one_per_tier()
+    # MEDIUM complexity: planner=strong($8) + plan_reviewer=strong($8) = $16 alone.
+    # With budget=$12, plan-phase models must be downgraded to reach the cap.
+    # All-cheap floor = $1×5 = $5 so $12 IS achievable.
+    cfg = _make_cfg(
+        min_reviewers=1,
+        max_reviewers=1,
+        budget_per_story_usd=12.0,
+        prefer_cross_provider=False,
+    )
+
+    decision = assign_models(agents, cfg, "medium")
+
+    total = (
+        decision.preflight.budget_usd
+        + decision.planner.budget_usd
+        + sum(p.budget_usd for p in decision.plan_reviewers)
+        + decision.dev.budget_usd
+        + sum(p.budget_usd for p in decision.code_reviewers)
+    )
+    assert total <= 12.0, f"Budget cap not met: total ${total:.2f} > $12.00"
+    # At least one plan-phase model must have been downgraded from strong ($8)
+    plan_phase_max = max(
+        decision.planner.budget_usd,
+        *(p.budget_usd for p in decision.plan_reviewers),
+    )
+    assert plan_phase_max < 8.0, (
+        f"Plan-phase models were not downgraded (max budget ${plan_phase_max:.2f})"
+    )
 
 
 def test_budget_cap_downgrade_dev():


### PR DESCRIPTION
## Summary

[openai-reviewer] Budget enforcement now downgrades plan-phase models as required, and the updated tests cover the regression path and cap convergence. | [gemini-reviewer] All acceptance criteria met. The budget enforcement logic correctly includes plan-phase models.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.48
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] adaptive-model-assignment: _enforce_budget excludes planner and pla (GitHub Issue #95)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #95