### PR TITLE
[P2] forge-daemon: Dedup check uses linear scan (slug in self._queued_sp

### DIFF
--- a/src/theforge/daemon.py
+++ b/src/theforge/daemon.py
@@ -54,6 +54,7 @@ class DaemonServer:
         self._queue: asyncio.Queue[tuple[str, dict]] = asyncio.Queue()
         self._running_spec: str | None = None
         self._queued_specs: list[str] = []  # ordered list for FIFO display
+        self._queued_slugs: set[str] = set()  # parallel set for O(1) dedup
         self._completed: list[dict] = []
         self._shutdown_event: asyncio.Event = asyncio.Event()
         self._current_sprint_task: asyncio.Task | None = None
@@ -129,10 +130,11 @@ class DaemonServer:
 
         if slug == self._running_spec:
             return {"ok": False, "error": f"spec '{slug}' is already running"}
-        if slug in self._queued_specs:
+        if slug in self._queued_slugs:
             return {"ok": False, "error": f"spec '{slug}' is already queued"}
 
         self._queued_specs.append(slug)
+        self._queued_slugs.add(slug)
         await self._queue.put((manifest, args))
 
         # Update queue in state
@@ -168,6 +170,7 @@ class DaemonServer:
                     self._queued_specs.remove(slug)
                 except ValueError:
                     pass
+                self._queued_slugs.discard(slug)
 
                 started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
                 sprint_state: dict = {


### PR DESCRIPTION
## Summary

[openai-reviewer] Parallel queued slug set is wired correctly for O(1) dedup without breaking FIFO queue behavior. | [gemini-reviewer] Parallel set added for O(1) dedup check, preserving FIFO ordering and state serialization.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.31
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] forge-daemon: Dedup check uses linear scan (slug in self._queued_sp (GitHub Issue #102)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #102