### PR TITLE
[P2] workspace-branch-collision: When git log fails (ok_log is False), c

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -328,7 +328,10 @@ def _is_stale_worktree(path: Path, base_branch: str, config: ForgeConfig) -> tup
         f"git log {base_branch}..{branch_name} --oneline",
         config.project_root,
     )
-    commits_ahead = [ln for ln in log_out.strip().splitlines() if ln.strip()] if ok else []
+    if not ok:
+        return False, f"Cannot determine branch state — git log failed: {log_out.strip()}"
+
+    commits_ahead = [ln for ln in log_out.strip().splitlines() if ln.strip()]
 
     if not commits_ahead:
         return True, f"0 commits ahead of {base_branch} — removing (stale)"

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -330,17 +330,11 @@ def _is_stale_worktree(path: Path, base_branch: str, config: ForgeConfig) -> tup
     )
     if not ok:
         return False, f"Cannot determine branch state — git log failed: {log_out.strip()}"
-
     commits_ahead = [ln for ln in log_out.strip().splitlines() if ln.strip()]
-
     if not commits_ahead:
         return True, f"0 commits ahead of {base_branch} — removing (stale)"
-
-    n_commits = len(commits_ahead)
-    return (
-        False,
-        f"{n_commits} commit{'s' if n_commits != 1 else ''} ahead of {base_branch}",
-    )
+    n = len(commits_ahead)
+    return False, f"{n} commit{'s' if n != 1 else ''} ahead of {base_branch}"
 
 
 def _remove_worktree(path: Path, branch: str, project_root: Path, info_line: str = "") -> None:

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -156,6 +156,27 @@ class TestStaleWorktree:
         is_stale, info = _is_stale_worktree(workspace, "main", config)
         assert is_stale is True
 
+    @patch("theforge.coordinator.util._run_shell")
+    def test_git_log_failure_not_stale(self, mock_shell, tmp_path):
+        """git log failure -> not stale (cannot determine state, do not delete)."""
+        workspace = tmp_path / "my-spec"
+        workspace.mkdir()
+        config = _make_stale_config(tmp_path, stale_worktree_days=1)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "feat/my-spec")
+            if "--oneline" in cmd:
+                return (False, "fatal: ambiguous argument 'main'")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        is_stale, info = _is_stale_worktree(workspace, "main", config)
+        assert is_stale is False
+        assert "Cannot determine branch state" in info
+        assert "git log failed" in info
+
     # -- _remove_worktree unit tests --
 
     @patch("theforge.coordinator.util._run_shell")


### PR DESCRIPTION
## Summary

[openai-reviewer] Git log failures now correctly short-circuit as indeterminate, prior unrelated regressions are reverted, and no new blocking regressions were introduced by the fix. | [gemini-reviewer] The git log failure is now correctly handled and prior destructive changes were reverted.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.02
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/daemon.py:57`** Unrelated changes to daemon.py were included in this PR. The parallel set `_queued_slugs` was removed and replaced with O(N) lookups in `_queued_specs`. While this doesn't break functionality, it is an unrelated change that should ideally be in a separate PR or reverted.

## Story

[P2] workspace-branch-collision: When git log fails (ok_log is False), c (GitHub Issue #98)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #98