### PR TITLE
[P2] parallel-sprint-execution: The wait() timeout of 3600 seconds is ha

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -406,7 +406,21 @@ def load_config(config_path: Path) -> ForgeConfig:
         raise ValueError(
             f"forge.yaml 'sprint.max_parallel' must be >= 1, got {sprint_max_parallel_raw}"
         )
-    sprint_cfg = SprintConfig(max_parallel=sprint_max_parallel_raw)
+    sprint_worker_timeout_raw = sprint_data.get("worker_timeout_seconds", 3600)
+    if not isinstance(sprint_worker_timeout_raw, int):
+        raise ValueError(
+            f"forge.yaml 'sprint.worker_timeout_seconds' must be an integer, "
+            f"got {sprint_worker_timeout_raw!r}"
+        )
+    if sprint_worker_timeout_raw < 1:
+        raise ValueError(
+            f"forge.yaml 'sprint.worker_timeout_seconds' must be >= 1, "
+            f"got {sprint_worker_timeout_raw}"
+        )
+    sprint_cfg = SprintConfig(
+        max_parallel=sprint_max_parallel_raw,
+        worker_timeout_seconds=sprint_worker_timeout_raw,
+    )
 
     context_data = raw.get("context", {})
     context_cfg = ContextConfig(

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -320,6 +320,7 @@ class SprintConfig:
     """Project-level sprint defaults from forge.yaml."""
 
     max_parallel: int = 1
+    worker_timeout_seconds: int = 3600
 
 
 @dataclass(frozen=True)

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -28,6 +28,7 @@ class ResolvedSprint:
     budget_usd: float
     stories: list[tuple[TaskStory, StorySource, str]]  # (task, source, canonical_ref)
     max_parallel: int | None = None
+    worker_timeout_seconds: int | None = None
 
 
 @dataclass
@@ -38,6 +39,7 @@ class SprintManifest:
     budget_usd: float
     stories: list[str | dict]  # relative paths to story files or {issue: N} dicts
     max_parallel: int | None = None
+    worker_timeout_seconds: int | None = None
 
 
 @dataclass
@@ -91,6 +93,18 @@ def load_sprint_manifest(manifest_path: Path) -> SprintManifest:
             raise ValueError(f"Sprint 'max_parallel' must be >= 1, got {max_parallel_raw}")
     max_parallel = max_parallel_raw
 
+    worker_timeout_raw = raw.get("worker_timeout_seconds")
+    if worker_timeout_raw is not None:
+        if not isinstance(worker_timeout_raw, int):
+            raise ValueError(
+                f"Sprint 'worker_timeout_seconds' must be an integer, got {worker_timeout_raw!r}"
+            )
+        if worker_timeout_raw < 1:
+            raise ValueError(
+                f"Sprint 'worker_timeout_seconds' must be >= 1, got {worker_timeout_raw}"
+            )
+    worker_timeout_seconds = worker_timeout_raw
+
     # Accept both 'stories' (new) and 'specs' (deprecated) keys
     stories = raw.get("stories")
     if stories is None:
@@ -121,7 +135,11 @@ def load_sprint_manifest(manifest_path: Path) -> SprintManifest:
         )
 
     return SprintManifest(
-        name=name, budget_usd=budget_usd, stories=stories, max_parallel=max_parallel
+        name=name,
+        budget_usd=budget_usd,
+        stories=stories,
+        max_parallel=max_parallel,
+        worker_timeout_seconds=worker_timeout_seconds,
     )
 
 
@@ -204,6 +222,7 @@ def resolve_from_manifest(manifest_path: Path, project_root: Path) -> ResolvedSp
         budget_usd=manifest.budget_usd,
         stories=task_entries,
         max_parallel=manifest.max_parallel,
+        worker_timeout_seconds=manifest.worker_timeout_seconds,
     )
 
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -578,6 +578,7 @@ def run_sprint(
             budget_usd=_manifest.budget_usd,
             stories=_task_entries,
             max_parallel=_manifest.max_parallel,
+            worker_timeout_seconds=_manifest.worker_timeout_seconds,
         )
 
     # Defensive scrub for the root checkout used by sprint commands.
@@ -585,6 +586,11 @@ def run_sprint(
 
     max_parallel = (
         resolved.max_parallel if resolved.max_parallel is not None else config.sprint.max_parallel
+    )
+    worker_timeout_seconds = (
+        resolved.worker_timeout_seconds
+        if resolved.worker_timeout_seconds is not None
+        else config.sprint.worker_timeout_seconds
     )
 
     # Pull base branch once here, before any parallel workspace creation.
@@ -1081,10 +1087,11 @@ def run_sprint(
             # this, gated workers block in _run_fresh waiting for their gate
             # while the scheduler blocks here waiting for a future to finish
             # — a deadlock.
-            _poll_interval = 2.0 if plan_gates else 3600.0
+            _wt_float = float(worker_timeout_seconds)
+            _poll_interval = 2.0 if plan_gates else _wt_float
             _total_waited = 0.0
             done_futs: set = set()
-            while not done_futs and _total_waited < 3600.0:
+            while not done_futs and _total_waited < _wt_float:
                 _current_interval = _poll_interval
                 done_futs, _ = wait(
                     list(active.values()),
@@ -1096,7 +1103,7 @@ def run_sprint(
                     _release_plan_gates(plan_done, file_footprints, plan_gates, active, phase_lock)
                     # All gates released — switch to long poll
                     if not plan_gates:
-                        _poll_interval = 3600.0
+                        _poll_interval = _wt_float
                 _total_waited += _current_interval
 
             _log(f"[debug] wait() returned: {len(done_futs)} done")
@@ -1110,7 +1117,10 @@ def run_sprint(
                 plan_gates.clear()
                 for slug, fut in list(active.items()):
                     fut.cancel()
-                    _log(f"TIMEOUT {slug} (worker unresponsive after 3600s — marking as failed)")
+                    _log(
+                        f"TIMEOUT {slug} (worker unresponsive after "
+                        f"{worker_timeout_seconds}s — marking as failed)"
+                    )
                     spec_str = slug_to_spec[slug]
                     timed_out_at = datetime.datetime.now(datetime.timezone.utc)
                     story_started_at = story_times.get(slug, (timed_out_at, timed_out_at))[0]
@@ -1121,14 +1131,14 @@ def run_sprint(
                             config.project_root / config.workspace.path_pattern.format(slug=slug)
                         ),
                         log_dir=_make_story_log_dir(config, slug, resolved.name),
-                        error="Worker timeout (>3600s)",
+                        error=f"Worker timeout (>{worker_timeout_seconds}s)",
                         error_type="TimeoutError",
                     )
                     _timeout_result = CoordinatorResult(
                         success=False,
                         phase=Phase.ESCALATE,
                         state=_timeout_state,
-                        message="Worker thread timed out after 3600s",
+                        message=f"Worker thread timed out after {worker_timeout_seconds}s",
                     )
                     story_times[slug] = (story_started_at, timed_out_at)
                     results.append((spec_str, _timeout_result))
@@ -1138,7 +1148,7 @@ def run_sprint(
                     dag.mark_skipped(slug)
                     specs_failed += 1
                 active.clear()
-                stopped_reason = stopped_reason or "Worker timeout (>3600s)"
+                stopped_reason = stopped_reason or f"Worker timeout (>{worker_timeout_seconds}s)"
                 continue
 
             for slug, fut in list(active.items()):

--- a/tests/test_sprint_worker_timeout.py
+++ b/tests/test_sprint_worker_timeout.py
@@ -1,0 +1,271 @@
+"""Tests for configurable worker_timeout_seconds in sprint manifest and forge.yaml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from tests.test_sprint_parallel import (
+    _make_config,
+    _make_config_with_sprint,
+    _make_spec_file,
+)
+from theforge.config import SprintConfig
+from theforge.sprint import run_sprint
+from theforge.sprint.manifest import ResolvedSprint, load_sprint_manifest
+
+# ── SprintConfig defaults ─────────────────────────────────────────────────────
+
+
+def test_sprint_config_default_timeout() -> None:
+    """SprintConfig.worker_timeout_seconds defaults to 3600."""
+    cfg = SprintConfig()
+    assert cfg.worker_timeout_seconds == 3600
+
+
+def test_sprint_config_custom_timeout() -> None:
+    """SprintConfig accepts an explicit worker_timeout_seconds."""
+    cfg = SprintConfig(worker_timeout_seconds=7200)
+    assert cfg.worker_timeout_seconds == 7200
+
+
+# ── SprintManifest parsing ────────────────────────────────────────────────────
+
+
+class TestWorkerTimeoutManifest:
+    def test_parses_worker_timeout_seconds(self, tmp_path: Path) -> None:
+        """load_sprint_manifest parses worker_timeout_seconds=7200 correctly."""
+        path = tmp_path / "sprint.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "name": "X",
+                    "budget_usd": 5.0,
+                    "stories": ["a.md"],
+                    "worker_timeout_seconds": 7200,
+                }
+            ),
+            encoding="utf-8",
+        )
+        manifest = load_sprint_manifest(path)
+        assert manifest.worker_timeout_seconds == 7200
+
+    def test_defaults_to_none_when_absent(self, tmp_path: Path) -> None:
+        """worker_timeout_seconds is None (sentinel) when not specified in manifest."""
+        path = tmp_path / "sprint.yaml"
+        path.write_text(
+            yaml.dump({"name": "X", "budget_usd": 5.0, "stories": ["a.md"]}),
+            encoding="utf-8",
+        )
+        manifest = load_sprint_manifest(path)
+        assert manifest.worker_timeout_seconds is None
+
+    def test_rejects_zero(self, tmp_path: Path) -> None:
+        """worker_timeout_seconds=0 is rejected with ValueError."""
+        path = tmp_path / "sprint.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "name": "X",
+                    "budget_usd": 5.0,
+                    "stories": ["a.md"],
+                    "worker_timeout_seconds": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="worker_timeout_seconds"):
+            load_sprint_manifest(path)
+
+    def test_rejects_negative(self, tmp_path: Path) -> None:
+        """worker_timeout_seconds=-1 is rejected with ValueError."""
+        path = tmp_path / "sprint.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "name": "X",
+                    "budget_usd": 5.0,
+                    "stories": ["a.md"],
+                    "worker_timeout_seconds": -100,
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="worker_timeout_seconds"):
+            load_sprint_manifest(path)
+
+    def test_rejects_non_integer(self, tmp_path: Path) -> None:
+        """worker_timeout_seconds as float string is rejected."""
+        path = tmp_path / "sprint.yaml"
+        path.write_text(
+            'name: X\nbudget_usd: 5.0\nstories: [a.md]\nworker_timeout_seconds: "3600"\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="worker_timeout_seconds"):
+            load_sprint_manifest(path)
+
+
+# ── Precedence: manifest vs forge.yaml ───────────────────────────────────────
+
+
+class TestWorkerTimeoutPrecedence:
+    """Manifest worker_timeout_seconds overrides forge.yaml default; absent means use config."""
+
+    def _make_manifest(self, tmp_path: Path, timeout: int | None = None) -> Path:
+        data: dict = {"name": "X", "budget_usd": 5.0, "stories": ["story-a.md"]}
+        if timeout is not None:
+            data["worker_timeout_seconds"] = timeout
+        path = tmp_path / "sprint.yaml"
+        path.write_text(yaml.dump(data), encoding="utf-8")
+        return path
+
+    def test_manifest_wins_over_config_default(self, tmp_path: Path) -> None:
+        """Manifest worker_timeout_seconds=120 overrides config default of 3600."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = self._make_manifest(tmp_path, timeout=120)
+        # Config uses the default 3600 but manifest says 120.
+        config = _make_config(tmp_path)
+
+        wait_calls: list[float] = []
+
+        def _fake_wait(futs, *, return_when, timeout):
+            wait_calls.append(timeout)
+            return (set(), set())
+
+        with (
+            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+        ):
+            run_sprint(config, manifest_path)
+
+        # The poll loop uses the configured timeout as its ceiling.
+        # At least one wait() call should use 120.0 (not 3600.0) as the timeout.
+        assert any(t == pytest.approx(120.0) for t in wait_calls), (
+            f"Expected a wait() call with timeout=120.0 but got: {wait_calls}"
+        )
+
+    def test_config_default_used_when_manifest_omits(self, tmp_path: Path) -> None:
+        """When manifest omits worker_timeout_seconds, config default is used."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = self._make_manifest(tmp_path, timeout=None)
+        config = _make_config_with_sprint(tmp_path, sprint_max_parallel=1)
+        # config.sprint.worker_timeout_seconds defaults to 3600
+
+        wait_calls: list[float] = []
+
+        def _fake_wait(futs, *, return_when, timeout):
+            wait_calls.append(timeout)
+            return (set(), set())
+
+        with (
+            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+        ):
+            run_sprint(config, manifest_path)
+
+        assert any(t == pytest.approx(3600.0) for t in wait_calls), (
+            f"Expected a wait() call with timeout=3600.0 but got: {wait_calls}"
+        )
+
+    def test_resolved_sprint_timeout_overrides_config(self, tmp_path: Path) -> None:
+        """ResolvedSprint with worker_timeout_seconds=60 overrides config default."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        spec_path = tmp_path / "story-a.md"
+        from theforge.sprint.manifest import _build_task_from_story
+        from theforge.sprint.sources import FileSource
+
+        task = _build_task_from_story(spec_path)
+        source = FileSource()
+        resolved = ResolvedSprint(
+            name="Direct",
+            budget_usd=5.0,
+            stories=[(task, source, "story-a.md")],
+            max_parallel=1,
+            worker_timeout_seconds=60,
+        )
+        config = _make_config(tmp_path)
+
+        wait_calls: list[float] = []
+
+        def _fake_wait(futs, *, return_when, timeout):
+            wait_calls.append(timeout)
+            return (set(), set())
+
+        with (
+            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+        ):
+            run_sprint(config, resolved)
+
+        assert any(t == pytest.approx(60.0) for t in wait_calls), (
+            f"Expected a wait() call with timeout=60.0 but got: {wait_calls}"
+        )
+
+    def test_manifest_none_is_sentinel_for_config_fallback(self, tmp_path: Path) -> None:
+        """After load_sprint_manifest without timeout, worker_timeout_seconds is None."""
+        manifest_path = self._make_manifest(tmp_path, timeout=None)
+        manifest = load_sprint_manifest(manifest_path)
+        assert manifest.worker_timeout_seconds is None
+
+
+# ── Timeout error message uses configured value ───────────────────────────────
+
+
+def test_timeout_error_message_uses_configured_value(tmp_path: Path) -> None:
+    """When timeout fires, error messages reference the configured timeout (not 3600)."""
+    from tests.test_sprint_resume import _make_manifest as _make_basic_manifest
+    from tests.test_sprint_resume import _make_spec_file
+
+    spec = _make_spec_file(tmp_path, "Feature A", "feature-a")
+    manifest = _make_basic_manifest(tmp_path, [spec.name])
+    # Write a custom timeout into the manifest
+    manifest_data = yaml.safe_load(manifest.read_text())
+    manifest_data["worker_timeout_seconds"] = 42
+    manifest.write_text(yaml.dump(manifest_data), encoding="utf-8")
+
+    config = _make_config(tmp_path)
+
+    class _NeverDoneFuture:
+        def cancel(self):
+            return True
+
+        def result(self):
+            raise AssertionError("should not be called")
+
+    class _FakeExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def submit(self, *args, **kwargs):
+            return _NeverDoneFuture()
+
+    with (
+        patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
+        patch("theforge.sprint.runner.wait", return_value=(set(), set())),
+    ):
+        result = run_sprint(config, manifest)
+
+    assert result.stopped_reason is not None
+    assert "42" in result.stopped_reason, (
+        f"Expected '42' in stopped_reason, got: {result.stopped_reason!r}"
+    )
+    # Verify story result also has timeout message with configured value
+    assert result.results
+    _, story_result = result.results[0]
+    assert "42" in story_result.message, (
+        f"Expected '42' in story result message, got: {story_result.message!r}"
+    )


### PR DESCRIPTION
## Summary

[openai-reviewer] Configurable sprint worker timeout is correctly wired through config, manifest resolution, runtime use, and tests. | [gemini-reviewer] The implementation correctly makes the worker timeout configurable and meets all acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.44
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:1113`** The comment on line 1113 still references the hardcoded 3600s timeout instead of the configured value.

## Story

[P2] parallel-sprint-execution: The wait() timeout of 3600 seconds is ha (GitHub Issue #108)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #108