### PR TITLE
[P2] gemini-adapter-hardening: The finish_reason check uses multiple str

### DIFF
--- a/src/theforge/runners/adapters/google.py
+++ b/src/theforge/runners/adapters/google.py
@@ -24,12 +24,19 @@ if TYPE_CHECKING:
 def _is_stop_finish_reason(finish_reason: Any) -> bool:
     """Return True if finish_reason represents a normal STOP completion.
 
-    Normalises across string ("STOP"), dotted-enum ("FinishReason.STOP"),
-    and integer ("1") representations emitted by different SDK versions.
+    Prefers the canonical enum .name attribute when finish_reason is an enum
+    so we compare against a single well-known name ("STOP") rather than
+    juggling multiple string representations.  Falls back to string
+    normalisation for plain strings and legacy SDK integer representations.
     """
     if finish_reason is None:
         return True
-    # Split on "." so "FinishReason.STOP" → "STOP"; plain "STOP" → "STOP"
+    # Prefer enum .name (FinishReason.STOP → "STOP") — canonical, single check.
+    enum_name = getattr(finish_reason, "name", None)
+    if enum_name is not None:
+        return enum_name == "STOP"
+    # String fallback: split on "." so "FinishReason.STOP" → "STOP".
+    # Keep "1" for SDK versions that serialise the enum as its integer value.
     name = str(finish_reason).split(".")[-1]
     return name in ("", "STOP", "1")
 

--- a/tests/test_runner_google.py
+++ b/tests/test_runner_google.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import sys
+from enum import IntEnum
 from unittest.mock import MagicMock, patch
 
 from theforge.config import ModelProfile
-from theforge.runners.adapters.google import _make_google_adapter, _run_google
+from theforge.runners.adapters.google import (
+    _is_stop_finish_reason,
+    _make_google_adapter,
+    _run_google,
+)
 from theforge.runners.schema_utils import ToolCallRequest
 
 
@@ -75,6 +80,53 @@ def _make_response(
     response.candidates = [candidate]
     response.prompt_feedback = feedback
     return response
+
+
+class _FakeFinishReason(IntEnum):
+    """Minimal enum that mimics google.genai.types.FinishReason for unit tests."""
+
+    STOP = 1
+    SAFETY = 2
+    RECITATION = 3
+    MAX_TOKENS = 4
+    MALFORMED_FUNCTION_CALL = 5
+
+
+class TestIsStopFinishReason:
+    """Unit tests for _is_stop_finish_reason — the canonical finish-reason check."""
+
+    def test_none_is_stop(self):
+        assert _is_stop_finish_reason(None) is True
+
+    def test_enum_stop_is_stop(self):
+        """Enum path: FinishReason.STOP (name='STOP') → True."""
+        assert _is_stop_finish_reason(_FakeFinishReason.STOP) is True
+
+    def test_enum_safety_is_not_stop(self):
+        """Enum path: FinishReason.SAFETY (name='SAFETY') → False."""
+        assert _is_stop_finish_reason(_FakeFinishReason.SAFETY) is False
+
+    def test_enum_max_tokens_is_not_stop(self):
+        assert _is_stop_finish_reason(_FakeFinishReason.MAX_TOKENS) is False
+
+    def test_string_stop_is_stop(self):
+        """String 'STOP' → True via string-fallback path."""
+        assert _is_stop_finish_reason("STOP") is True
+
+    def test_dotted_string_stop_is_stop(self):
+        """'FinishReason.STOP' normalises to 'STOP' via split-on-dot fallback."""
+        assert _is_stop_finish_reason("FinishReason.STOP") is True
+
+    def test_string_safety_is_not_stop(self):
+        assert _is_stop_finish_reason("SAFETY") is False
+
+    def test_string_1_is_stop(self):
+        """Legacy SDK: integer-as-string '1' maps to STOP."""
+        assert _is_stop_finish_reason("1") is True
+
+    def test_empty_string_is_stop(self):
+        """Empty string (unset finish_reason) treated as STOP."""
+        assert _is_stop_finish_reason("") is True
 
 
 class TestRunGoogle:


### PR DESCRIPTION
## Summary

[openai-reviewer] Finish reason handling now uses the enum name canonically on the live runtime path and is covered by focused tests. | [gemini-reviewer] The finish_reason check has been successfully updated to use a more canonical approach.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.54
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] gemini-adapter-hardening: The finish_reason check uses multiple str (GitHub Issue #276)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #276