### PR TITLE
[P2] m1-remaining: The conversation JSON dump created on 'max iterations

### DIFF
--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -65,6 +65,25 @@ if TYPE_CHECKING:
 _MAX_RATE_LIMIT_RETRIES = 4
 _RATE_LIMIT_BACKOFF_BASE = 30  # seconds
 
+# Argument names that may carry large or sensitive content (file bodies, edit
+# payloads, stdin data).  These are redacted in any diagnostic log or trace
+# artifact that serialises ToolCallRequest objects — they are NOT removed from
+# the live conversation history sent to the provider, which needs them for
+# context.
+_SENSITIVE_ARG_NAMES: frozenset[str] = frozenset(
+    {"content", "new_content", "old_string", "new_string", "input"}
+)
+
+
+def _redact_tool_call_arguments(arguments: dict) -> dict:
+    """Return a copy of *arguments* with sensitive fields replaced by a placeholder.
+
+    Only keys in _SENSITIVE_ARG_NAMES are redacted.  All other arguments (paths,
+    patterns, commands) are preserved so the diagnostic output is still useful.
+    """
+    return {k: "<redacted>" if k in _SENSITIVE_ARG_NAMES else v for k, v in arguments.items()}
+
+
 # Patterns in result.output that indicate a model-preference fallback should fire.
 # Only usage-exhaustion and model-not-found errors trigger fallback; runtime errors
 # (bad code, schema violations) propagate immediately.
@@ -259,7 +278,7 @@ class AgentLoopManager:
                     content = f"Error: {type(exc).__name__} — {exc}"
                 duration_ms = int((time.monotonic() - t0) * 1000)
 
-            # Brief summary for logging
+            # Brief summary for logging — never include sensitive argument values.
             if call.name == "read_file":
                 summary = call.arguments.get("path", "")
                 sl = call.arguments.get("start_line")
@@ -271,8 +290,11 @@ class AgentLoopManager:
                 summary = cmd[:60] + ("..." if len(cmd) > 60 else "")
             elif call.name in ("grep", "glob"):
                 summary = call.arguments.get("pattern", "")
+            elif call.name in ("write_file", "edit_file"):
+                # content/old_string/new_string can be large — log only the path.
+                summary = call.arguments.get("path", "")
             else:
-                summary = str(call.arguments)[:60]
+                summary = str(_redact_tool_call_arguments(call.arguments))[:60]
 
             _log_verbose(f"  ↳ {call.name}: {summary} ({duration_ms}ms)")
             return {"id": call.id, "name": call.name, "content": content}
@@ -468,7 +490,17 @@ class AgentLoopManager:
     def _finalize_or_timeout(
         self, messages: list[dict], iterations: int, reason: str
     ) -> AgentResult:
-        """Attempt finalization via constrained output; fall back to timeout failure."""
+        """Attempt finalization via constrained output; fall back to timeout failure.
+
+        *messages* contains the full conversation history, including assistant turns
+        with ToolCallRequest objects whose arguments may hold sensitive data (file
+        contents, edit payloads, etc.).  The history is passed to the provider as-is
+        so the model has full context for producing its final output.
+
+        If this method ever needs to write *messages* to a diagnostic artifact (log
+        file, trace, etc.), use _redact_tool_call_arguments() on each call's
+        arguments before serialising to avoid leaking sensitive content.
+        """
         if self._finalizer is None:
             return self._timeout_result(iterations, reason=reason)
 

--- a/tests/test_runner_api_loop.py
+++ b/tests/test_runner_api_loop.py
@@ -9,7 +9,9 @@ from unittest.mock import MagicMock, patch
 from theforge.agent_types import ModelUsage
 from theforge.config import ModelProfile
 from theforge.runners.api import (
+    _SENSITIVE_ARG_NAMES,
     AgentLoopManager,
+    _redact_tool_call_arguments,
     run_api_agent,
 )
 from theforge.runners.schema_utils import (
@@ -799,3 +801,46 @@ class TestTimeNudge:
         assert len(time_nudges) >= 1
         # All nudge messages should be identical (sent once, seen in subsequent turns)
         assert len(set(time_nudges)) == 1
+
+
+class TestRedactToolCallArguments:
+    """Unit tests for _redact_tool_call_arguments and _SENSITIVE_ARG_NAMES."""
+
+    def test_sensitive_arg_names_contains_content(self):
+        assert "content" in _SENSITIVE_ARG_NAMES
+        assert "new_content" in _SENSITIVE_ARG_NAMES
+        assert "old_string" in _SENSITIVE_ARG_NAMES
+        assert "new_string" in _SENSITIVE_ARG_NAMES
+        assert "input" in _SENSITIVE_ARG_NAMES
+
+    def test_non_sensitive_args_preserved(self):
+        args = {"path": "src/foo.py", "start_line": 1, "end_line": 10}
+        result = _redact_tool_call_arguments(args)
+        assert result == args
+
+    def test_content_redacted(self):
+        args = {"path": "src/foo.py", "content": "SECRET_API_KEY=abc123\nimport os\n"}
+        result = _redact_tool_call_arguments(args)
+        assert result["path"] == "src/foo.py"
+        assert result["content"] == "<redacted>"
+        assert "SECRET_API_KEY" not in str(result)
+
+    def test_edit_args_redacted(self):
+        args = {
+            "path": "src/bar.py",
+            "old_string": "password = 'hunter2'",
+            "new_string": "password = env.get('PASSWORD')",
+        }
+        result = _redact_tool_call_arguments(args)
+        assert result["path"] == "src/bar.py"
+        assert result["old_string"] == "<redacted>"
+        assert result["new_string"] == "<redacted>"
+        assert "hunter2" not in str(result)
+
+    def test_original_dict_not_mutated(self):
+        args = {"path": "x.py", "content": "sensitive data"}
+        _redact_tool_call_arguments(args)
+        assert args["content"] == "sensitive data"
+
+    def test_empty_args(self):
+        assert _redact_tool_call_arguments({}) == {}


### PR DESCRIPTION
## Summary

[openai-reviewer] Redaction change is correctly scoped, prior regression concern is resolved, and no new blocking defects were introduced. | [gemini-reviewer] The implementation successfully redacts sensitive tool call arguments in diagnostic logs and provides a robust, extensible mechanism for identifying sensitive fields.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.99
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] m1-remaining: The conversation JSON dump created on 'max iterations (GitHub Issue #39)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #39