### PR TITLE
[P2] issue-370: TOCTOU window between the _is_pid_alive check and lock_p

### DIFF
--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -107,6 +107,13 @@ def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, lis
                 if owner_pid is None or _is_pid_alive(owner_pid):
                     conflicted.append(slug)
                     break
+                # TOCTOU: a live process could acquire this lock and write its
+                # PID between the _is_pid_alive check above and unlink() below.
+                # If that happens, we delete a valid lock file and two callers
+                # may briefly believe they hold the lock.  The risk is
+                # acceptable: the window is extremely narrow, and the 3-attempt
+                # retry loop means any caller that loses the race will re-detect
+                # the conflict on the next flock attempt and back off cleanly.
                 try:
                     lock_path.unlink()
                 except FileNotFoundError:


### PR DESCRIPTION
## Summary

[openai-reviewer] Comment-only change documents the accepted TOCTOU window at the stale-lock unlink site and satisfies the stated acceptance criterion. | [gemini-reviewer] Added comment documenting TOCTOU window as requested.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.23
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-370: TOCTOU window between the _is_pid_alive check and lock_p (GitHub Issue #386)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #386