### PR TITLE
[P2] issue-523: `_kill_process_group` catches `ProcessLookupError`, but 

### DIFF
--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -110,11 +110,11 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
     try:
         os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         return
-    except (ProcessLookupError, PermissionError):
+    except OSError:
         pass
     try:
         proc.terminate()
-    except (ProcessLookupError, PermissionError):
+    except OSError:
         pass
 
 


### PR DESCRIPTION
## Summary

[openai-reviewer] Change matches the spec and broadens best-effort cleanup handling without introducing correctness issues. | [gemini-reviewer] LGTM. The change correctly simplifies the exception handling to catch all OSErrors during best-effort process group cleanup.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.16
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-523: `_kill_process_group` catches `ProcessLookupError`, but  (GitHub Issue #531)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #531