### PR TITLE
[P2] issue-289: The check for untracked files includes `line[:2] in {"??

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -823,9 +823,7 @@ def land_story(
         if status_ok:
             tracked_dirty = _parse_dirty_files(status_out)
             untracked_files = [
-                line[3:].strip()
-                for line in status_out.splitlines()
-                if len(line) >= 4 and line[:2] in {"??", " ?"}
+                line[3:].strip() for line in status_out.splitlines() if line.startswith("?? ")
             ]
             if tracked_dirty:
                 quoted = " ".join(shlex.quote(path) for path in tracked_dirty)


### PR DESCRIPTION
## Summary

[openai-reviewer] Change matches the spec by restricting untracked file detection to the documented porcelain prefix only. | [gemini-reviewer] The implementation correctly simplifies the untracked file check to use the standard `??` prefix.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.49
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/gate.py:30`** The `gate.py` file also contains a check for the non-standard ` ?` and ` !` prefixes in `_parse_dirty_files`. While outside the scope of this specific issue, it should probably be cleaned up similarly in a future PR.

## Story

[P2] issue-289: The check for untracked files includes `line[:2] in {"?? (GitHub Issue #501)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #501