### PR TITLE
[P2] issue-420: The `ContextAssembler.from_config` method passes `config

### DIFF
--- a/src/theforge/task/context_assembler.py
+++ b/src/theforge/task/context_assembler.py
@@ -84,7 +84,16 @@ class ContextAssembler:
 
     @classmethod
     def from_config(cls, config: "ForgeConfig") -> "ContextAssembler":
-        return cls(config.project_root, budgets=config.context)
+        ctx = config.context
+        return cls(
+            config.project_root,
+            budgets=ContextBudgetConfig(
+                preflight_budget=ctx.preflight_budget,
+                plan_budget=ctx.plan_budget,
+                dev_budget=ctx.dev_budget,
+                review_budget=ctx.review_budget,
+            ),
+        )
 
     def assemble(
         self,


### PR DESCRIPTION
## Summary

[openai-reviewer] The change correctly converts ContextConfig into ContextBudgetConfig in from_config, satisfying the static typing fix without altering runtime behavior. | [gemini-reviewer] Phase-aware ContextAssembler utility implemented correctly with all prior findings resolved.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.49
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-420: The `ContextAssembler.from_config` method passes `config (GitHub Issue #539)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #539