### PR TITLE
[P2] issue-684: The check for 'localhost' is case-sensitive. If a test a

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ _GUARD_MSG = (
 
 def _is_loopback(host: str) -> bool:
     """Return True if *host* is a loopback or localhost address."""
-    if host in ("", "localhost"):
+    if host.lower() in ("", "localhost"):
         return True
     try:
         return ipaddress.ip_address(host).is_loopback


### PR DESCRIPTION
## Summary

[openai-reviewer] Case-insensitive localhost handling is implemented in the active loopback guard and satisfies the acceptance criterion. | [gemini-reviewer] The change correctly handles case variations for 'localhost' in the network guard.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.22
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/conftest.py:30`** The change correctly implements case-insensitive checking for 'localhost', but there is no regression test added for 'LOCALHOST' or other case variations in `tests/test_network_guard.py`.

## Story

[P2] issue-684: The check for 'localhost' is case-sensitive. If a test a (GitHub Issue #687)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #687