### PR TITLE
fix(tests): remove racy exit-order assertion from test_integration_lock_serializes

### DIFF
--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2154,7 +2154,6 @@ class TestImmediateIntegrationLanding:
 
 def test_integration_lock_serializes(tmp_path: Path) -> None:
     entered: list[str] = []
-    exited: list[str] = []
     overlap = [False]
     inside = threading.Event()
     release = threading.Event()
@@ -2167,11 +2166,7 @@ def test_integration_lock_serializes(tmp_path: Path) -> None:
             entered.append(name)
             if name == "first":
                 release.wait(timeout=2)
-            else:
-                exited.append(name)
             inside.clear()
-        if name == "first":
-            exited.append(name)
 
     first = threading.Thread(target=worker, args=("first",))
     second = threading.Thread(target=worker, args=("second",))
@@ -2186,7 +2181,6 @@ def test_integration_lock_serializes(tmp_path: Path) -> None:
 
     assert overlap[0] is False
     assert entered == ["first", "second"]
-    assert exited == ["first", "second"]
 
 
 def test_write_sprint_summary_marks_cached_preflight(tmp_path):


### PR DESCRIPTION
## Summary

- `test_integration_lock_serializes` appended "first" to `exited` *after* releasing the lock, then asserted `exited == ["first", "second"]`
- On Linux CI, "second" acquires the lock immediately on release and appends before "first" gets CPU time — fails deterministically
- Exit ordering is not a property `integration_lock` guarantees; the meaningful invariants (no overlap, FIFO entry) are preserved in the `overlap` and `entered` assertions

Fixes #752. Unblocks PR #724 (sprint stalled waiting for it to merge).

## Test plan

- [x] `make gate` passes (2841 passed)
- [ ] CI passes on all three Python matrix versions