### PR TITLE
[P2] issue-686: Missing timeout error handling: If the new log file is n

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -434,6 +434,12 @@ def cmd_logs(args: object) -> int:
                 if new_log.exists():
                     break
                 time.sleep(0.1)
+            if not new_log.exists():
+                print(
+                    f"[forge] Timed out waiting for new log {new_log} — run may have exited",
+                    file=sys.stderr,
+                )
+                return 1
             current_run_id = new_run_id
             current_log = new_log
     except KeyboardInterrupt:

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
 
-# Sentinel written to test log files to signal clean EOF (no redirect).
 _SENTINEL_EOF = "[forge test sentinel EOF]"
 
 
@@ -34,8 +33,7 @@ def _follow_log_with_redirect(log_path: Path, current_run_id: str) -> tuple[str,
                 time.sleep(0.1)
                 continue
 
-            # Partial write in progress — rewind and wait for the complete line.
-            if not line.endswith("\n"):
+            if not line.endswith("\n"):  # partial write — rewind and wait
                 fh.seek(pos)
                 time.sleep(0.1)
                 continue
@@ -56,9 +54,6 @@ def _follow_log_with_redirect(log_path: Path, current_run_id: str) -> tuple[str,
 
             if _seen_run_id and _seen_log_path:
                 return (_seen_run_id, Path(_seen_log_path))
-
-
-# ── Run-discovery helpers ─────────────────────────────────────────────────────
 
 
 def _find_active_run_id(project_root: Path) -> str | None:
@@ -265,9 +260,6 @@ def _show_single_run_status(run_id: str, project_root: Path) -> None:
     print(f"{'RUN ID':<12}  {'STORY':<30}  {'PHASE':<12}  {'COST':>7}  {'ELAPSED':>8}")
     print("-" * 78)
     print(f"{run_id:<12}  {story_label:<30}  {phase:<12}  {cost_str:>7}  {elapsed_str:>8}")
-
-
-# ── Command handlers ─────────────────────────────────────────────────────────
 
 
 def cmd_status(args: object) -> int:

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -173,3 +173,49 @@ class TestCmdLogs:
             result = cmd_logs(args)
 
         assert result == 1
+
+    def test_reexec_redirect_new_log_never_appears(self, tmp_path, capsys):
+        """forge logs returns error gracefully when the new log never appears after re-exec."""
+        from unittest.mock import patch
+
+        from theforge.cli import cmd_logs
+
+        old_run_id = "aabbccddee11"
+        new_run_id = "ff99887766aa"
+        slug = "my-slug"
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{old_run_id}.pid").write_text(f"12345\n{slug}\n")
+
+        log_dir = tmp_path / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True)
+
+        # The new log path is referenced in the redirect block but never created.
+        new_log = log_dir / f"run-{new_run_id}.log"
+
+        old_log = log_dir / f"run-{old_run_id}.log"
+        old_log.write_text(
+            "old run output\n"
+            "[forge] Run started in background\n"
+            f"[forge] Run ID:  {new_run_id}\n"
+            f"[forge] Log:     {new_log}\n"
+            f"[forge] Logs:    forge logs {new_run_id}\n"
+        )
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=old_run_id)
+
+        # Patch time.sleep so the wait loop runs instantly.
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status.time.sleep"),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Timed out waiting for new log" in captured.err


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation satisfies the timeout-handling acceptance criterion and adds focused coverage for the graceful error path. | [gemini-reviewer] The implementation correctly handles the timeout when a new log file is not created after a re-exec redirect.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.81
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-686: Missing timeout error handling: If the new log file is n (GitHub Issue #691)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #691