### PR TITLE
[P2] issue-684: The guard only overrides `connect` and `connect_ex`, whi

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,19 +43,30 @@ class _BlockedSocket(_REAL_SOCKET):
     are always allowed; only TCP/UDP tuples are checked.
     """
 
-    def connect(self, address):  # type: ignore[override]
+    def _check_address(self, address: object) -> None:
         if isinstance(address, tuple):
             host = str(address[0])
             if not _is_loopback(host):
                 raise OSError(_GUARD_MSG.format(host=host))
+
+    def connect(self, address):  # type: ignore[override]
+        self._check_address(address)
         return super().connect(address)
 
     def connect_ex(self, address):  # type: ignore[override]
-        if isinstance(address, tuple):
-            host = str(address[0])
-            if not _is_loopback(host):
-                raise OSError(_GUARD_MSG.format(host=host))
+        self._check_address(address)
         return super().connect_ex(address)
+
+    def sendto(self, data, *args):  # type: ignore[override]
+        # sendto(data, address) or sendto(data, flags, address)
+        address = args[-1]
+        self._check_address(address)
+        return super().sendto(data, *args)
+
+    def sendmsg(self, buffers, ancdata=(), flags=0, address=None):  # type: ignore[override]
+        if address is not None:
+            self._check_address(address)
+        return super().sendmsg(buffers, ancdata, flags, address)
 
 
 # Install the guard before any test module is imported.

--- a/tests/test_conftest_network_guard.py
+++ b/tests/test_conftest_network_guard.py
@@ -1,0 +1,148 @@
+"""Regression tests for the global network guard in conftest.py.
+
+Verifies that TCP (connect/connect_ex) and UDP (sendto/sendmsg) calls to
+non-loopback addresses are blocked, while loopback addresses are not.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+# External address used in all guard-block assertions.
+_EXTERNAL = ("8.8.8.8", 53)
+# Loopback addresses that the guard must allow through.
+_LOOPBACKS = [
+    ("127.0.0.1", 9999),
+    ("::1", 9999),
+    ("localhost", 9999),
+]
+
+
+def _udp_sock() -> socket.socket:
+    return socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+
+def _tcp_sock() -> socket.socket:
+    return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+
+# ---------------------------------------------------------------------------
+# TCP — connect / connect_ex
+# ---------------------------------------------------------------------------
+
+
+def test_connect_external_blocked():
+    sock = _tcp_sock()
+    try:
+        with pytest.raises(OSError, match="Blocked external network"):
+            sock.connect(_EXTERNAL)
+    finally:
+        sock.close()
+
+
+def test_connect_ex_external_blocked():
+    sock = _tcp_sock()
+    try:
+        with pytest.raises(OSError, match="Blocked external network"):
+            sock.connect_ex(_EXTERNAL)
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize("addr", _LOOPBACKS)
+def test_connect_loopback_not_blocked(addr):
+    """Guard must not raise for loopback addresses (connection itself may fail)."""
+    sock = _tcp_sock()
+    try:
+        # connect() to a port with nothing listening raises ConnectionRefused,
+        # NOT our guard error.  Either way, our guard message must be absent.
+        try:
+            sock.connect(addr)
+        except OSError as exc:
+            assert "Blocked external network" not in str(exc)
+    finally:
+        sock.close()
+
+
+# ---------------------------------------------------------------------------
+# UDP — sendto
+# ---------------------------------------------------------------------------
+
+
+def test_sendto_external_blocked():
+    sock = _udp_sock()
+    try:
+        with pytest.raises(OSError, match="Blocked external network"):
+            sock.sendto(b"ping", _EXTERNAL)
+    finally:
+        sock.close()
+
+
+def test_sendto_with_flags_external_blocked():
+    """sendto(data, flags, address) form must also be blocked."""
+    sock = _udp_sock()
+    try:
+        with pytest.raises(OSError, match="Blocked external network"):
+            sock.sendto(b"ping", 0, _EXTERNAL)
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize("addr", [("127.0.0.1", 9999), ("localhost", 9999)])
+def test_sendto_loopback_not_blocked(addr):
+    """Guard must not raise for loopback UDP destinations."""
+    sock = _udp_sock()
+    try:
+        # sendto to a loopback address with nothing listening is fine at the
+        # socket layer — the guard must not raise its specific error.
+        try:
+            sock.sendto(b"ping", addr)
+        except OSError as exc:
+            assert "Blocked external network" not in str(exc)
+    finally:
+        sock.close()
+
+
+# ---------------------------------------------------------------------------
+# UDP — sendmsg (POSIX only; not available on Windows)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(socket.socket, "sendmsg"), reason="sendmsg not available")
+def test_sendmsg_external_blocked():
+    sock = _udp_sock()
+    try:
+        with pytest.raises(OSError, match="Blocked external network"):
+            sock.sendmsg([b"ping"], [], 0, _EXTERNAL)
+    finally:
+        sock.close()
+
+
+@pytest.mark.skipif(not hasattr(socket.socket, "sendmsg"), reason="sendmsg not available")
+def test_sendmsg_no_address_not_blocked():
+    """sendmsg without an address (connected socket) must not trigger guard."""
+    sock = _udp_sock()
+    try:
+        # Without address= the guard has nothing to check; the call may fail
+        # for other reasons (not connected), but not with our guard message.
+        try:
+            sock.sendmsg([b"ping"])
+        except OSError as exc:
+            assert "Blocked external network" not in str(exc)
+    finally:
+        sock.close()
+
+
+@pytest.mark.skipif(not hasattr(socket.socket, "sendmsg"), reason="sendmsg not available")
+def test_sendmsg_loopback_not_blocked():
+    """Guard must not raise for loopback sendmsg destinations."""
+    sock = _udp_sock()
+    try:
+        try:
+            sock.sendmsg([b"ping"], [], 0, ("127.0.0.1", 9999))
+        except OSError as exc:
+            assert "Blocked external network" not in str(exc)
+    finally:
+        sock.close()


### PR DESCRIPTION
## Summary

[openai-reviewer] UDP network guard extensions in tests/conftest.py match the acceptance criteria and are covered by passing regression tests. | [gemini-reviewer] Global network guard correctly extended to block UDP sendto and sendmsg.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.01
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/conftest.py:58`** If `sendto` is called with only 1 argument (e.g., `sock.sendto(b'data')`), `args` is empty and `args[-1]` raises an `IndexError` instead of the expected `TypeError`.

## Story

[P2] issue-684: The guard only overrides `connect` and `connect_ex`, whi (GitHub Issue #688)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #688