### PR TITLE
[P2] issue-686: Log spoofing vulnerability: The redirect detection relie

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -16,21 +16,12 @@ _SENTINEL_EOF = "[forge test sentinel EOF]"
 
 
 def _follow_log_with_redirect(
-    log_path: Path,
-    current_run_id: str,
-    *,
-    runs_dir: Path | None = None,
+    log_path: Path, current_run_id: str, *, runs_dir: Path | None = None
 ) -> tuple[str, Path] | None:
-    """Stream log_path line-by-line, printing each line to stdout.
+    """Stream log_path to stdout; poll ``runs_dir/<current_run_id>.redirect`` on EOF.
 
-    Returns (new_run_id, new_log_path) when a re-exec redirect sidecar file
-    is found at ``runs_dir/<current_run_id>.redirect`` (written by the new
-    daemon process after a source-update re-exec).
-    Returns None when the sentinel EOF line is encountered (test use).
+    Returns (new_run_id, new_log_path) on redirect, None on sentinel EOF.
     Runs indefinitely on real EOF (tail-f style); caller catches KeyboardInterrupt.
-
-    ``runs_dir`` should be ``.forge/runs/``. Without it, no redirect detection
-    is performed (useful in tests that only exercise log-tailing behaviour).
     """
     redirect_file = (runs_dir / f"{current_run_id}.redirect") if runs_dir else None
 
@@ -39,17 +30,12 @@ def _follow_log_with_redirect(
             pos = fh.tell()
             line = fh.readline()
             if not line:
-                # On EOF, check the sidecar redirect file written by the new
-                # daemon after a re-exec.  This file is written by forge itself
-                # (not derived from log content), so LLM output cannot spoof it.
                 if redirect_file is not None and redirect_file.exists():
                     try:
-                        data = json.loads(redirect_file.read_text(encoding="utf-8"))
-                        new_run_id = data["new_run_id"]
-                        new_log = Path(data["new_log"])
-                        return (new_run_id, new_log)
+                        d = json.loads(redirect_file.read_text(encoding="utf-8"))
+                        return d["new_run_id"], Path(d["new_log"])
                     except (OSError, KeyError, ValueError, json.JSONDecodeError):
-                        pass  # incomplete or malformed write — keep tailing
+                        pass
                 time.sleep(0.1)
                 continue
 

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import os
 import sys
 import time
@@ -14,22 +15,41 @@ from theforge.config import load_config
 _SENTINEL_EOF = "[forge test sentinel EOF]"
 
 
-def _follow_log_with_redirect(log_path: Path, current_run_id: str) -> tuple[str, Path] | None:
+def _follow_log_with_redirect(
+    log_path: Path,
+    current_run_id: str,
+    *,
+    runs_dir: Path | None = None,
+) -> tuple[str, Path] | None:
     """Stream log_path line-by-line, printing each line to stdout.
 
-    Returns (new_run_id, new_log_path) when a re-exec redirect block is
-    detected in the log (Run ID trailer differs from current_run_id).
+    Returns (new_run_id, new_log_path) when a re-exec redirect sidecar file
+    is found at ``runs_dir/<current_run_id>.redirect`` (written by the new
+    daemon process after a source-update re-exec).
     Returns None when the sentinel EOF line is encountered (test use).
     Runs indefinitely on real EOF (tail-f style); caller catches KeyboardInterrupt.
+
+    ``runs_dir`` should be ``.forge/runs/``. Without it, no redirect detection
+    is performed (useful in tests that only exercise log-tailing behaviour).
     """
-    _seen_run_id: str | None = None
-    _seen_log_path: str | None = None
+    redirect_file = (runs_dir / f"{current_run_id}.redirect") if runs_dir else None
 
     with open(log_path) as fh:
         while True:
             pos = fh.tell()
             line = fh.readline()
             if not line:
+                # On EOF, check the sidecar redirect file written by the new
+                # daemon after a re-exec.  This file is written by forge itself
+                # (not derived from log content), so LLM output cannot spoof it.
+                if redirect_file is not None and redirect_file.exists():
+                    try:
+                        data = json.loads(redirect_file.read_text(encoding="utf-8"))
+                        new_run_id = data["new_run_id"]
+                        new_log = Path(data["new_log"])
+                        return (new_run_id, new_log)
+                    except (OSError, KeyError, ValueError, json.JSONDecodeError):
+                        pass  # incomplete or malformed write — keep tailing
                 time.sleep(0.1)
                 continue
 
@@ -44,16 +64,6 @@ def _follow_log_with_redirect(log_path: Path, current_run_id: str) -> tuple[str,
                 return None
 
             print(text)
-
-            if text.startswith("[forge] Run ID:  "):
-                candidate_id = text[len("[forge] Run ID:  ") :].strip()
-                if candidate_id != current_run_id:
-                    _seen_run_id = candidate_id
-            elif text.startswith("[forge] Log:     "):
-                _seen_log_path = text[len("[forge] Log:     ") :].strip()
-
-            if _seen_run_id and _seen_log_path:
-                return (_seen_run_id, Path(_seen_log_path))
 
 
 def _find_active_run_id(project_root: Path) -> str | None:
@@ -410,10 +420,11 @@ def cmd_logs(args: object) -> int:
 
     current_run_id = run_id
     current_log = log_path
+    runs_dir = project_root / ".forge" / "runs"
     try:
         while True:
             print(f"[forge] Tailing {current_log} — Ctrl+C to stop", file=sys.stderr)
-            result = _follow_log_with_redirect(current_log, current_run_id)
+            result = _follow_log_with_redirect(current_log, current_run_id, runs_dir=runs_dir)
             if result is None:
                 break
             new_run_id, new_log = result

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -467,6 +467,22 @@ def pull_base_branch(config: ForgeConfig) -> bool:
     if tree_before and tree_after and tree_before.strip() != tree_after.strip():
         _cu._log("Source updated after pull — re-execing to load new code")
         os.chdir(str(config.project_root))
+        # Expose our run_id via the environment so the re-exec'd daemon can write
+        # a sidecar redirect file for the log follower (instead of relying on
+        # log-line parsing, which LLM output could spoof).
+        _my_pid = os.getpid()
+        _runs_dir = config.project_root / ".forge" / "runs"
+        try:
+            for _pf in _runs_dir.glob("*.pid"):
+                try:
+                    _lines = _pf.read_text(encoding="utf-8").splitlines()
+                    if _lines and int(_lines[0].strip()) == _my_pid:
+                        os.environ["FORGE_PREV_RUN_ID"] = _pf.stem
+                        break
+                except (OSError, ValueError):
+                    continue
+        except OSError:
+            pass
         try:
             os.execv(sys.executable, [sys.executable] + sys.argv)
         except OSError:

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 from theforge.config import ForgeConfig
+from theforge.detach import find_run_id_for_pid as _find_run_id_for_pid
 from theforge.task import TaskStory
 
 from . import util as _cu
@@ -467,22 +468,8 @@ def pull_base_branch(config: ForgeConfig) -> bool:
     if tree_before and tree_after and tree_before.strip() != tree_after.strip():
         _cu._log("Source updated after pull — re-execing to load new code")
         os.chdir(str(config.project_root))
-        # Expose our run_id via the environment so the re-exec'd daemon can write
-        # a sidecar redirect file for the log follower (instead of relying on
-        # log-line parsing, which LLM output could spoof).
-        _my_pid = os.getpid()
-        _runs_dir = config.project_root / ".forge" / "runs"
-        try:
-            for _pf in _runs_dir.glob("*.pid"):
-                try:
-                    _lines = _pf.read_text(encoding="utf-8").splitlines()
-                    if _lines and int(_lines[0].strip()) == _my_pid:
-                        os.environ["FORGE_PREV_RUN_ID"] = _pf.stem
-                        break
-                except (OSError, ValueError):
-                    continue
-        except OSError:
-            pass
+        if _prev := _find_run_id_for_pid(config.project_root, os.getpid()):
+            os.environ["FORGE_PREV_RUN_ID"] = _prev
         try:
             os.execv(sys.executable, [sys.executable] + sys.argv)
         except OSError:

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -6,6 +6,7 @@ PID file management, and run status queries.
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import sys
@@ -238,6 +239,28 @@ def suppress_app_nap() -> None:
         pass
 
 
+# ── Re-exec redirect sidecar ─────────────────────────────────────────
+
+
+def write_reexec_redirect(
+    prev_run_id: str, new_run_id: str, new_log: Path, project_root: Path
+) -> None:
+    """Write a sidecar redirect file so the log follower can switch to the new log.
+
+    Written by the grandchild daemon after a re-exec (source changed after git pull)
+    so that ``_follow_log_with_redirect`` in the CLI can detect the new run without
+    parsing log lines (which LLM output could spoof).
+    """
+    redirect_file = project_root / ".forge" / "runs" / f"{prev_run_id}.redirect"
+    try:
+        redirect_file.write_text(
+            json.dumps({"new_run_id": new_run_id, "new_log": str(new_log)}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass  # best-effort; log follower will time out gracefully if this fails
+
+
 # ── Daemonization ────────────────────────────────────────────────────
 
 
@@ -287,6 +310,13 @@ def daemonize_run(run_id: str, slug: str, project_root: Path) -> None:
 
     # Grandchild: write PID file, redirect stdio
     write_pid(run_id, slug, project_root)
+
+    # If this is a re-exec (source changed after git pull), write a sidecar
+    # redirect file so the log follower can switch to this new run without
+    # relying on log-line parsing (which LLM output could spoof).
+    prev_run_id = os.environ.pop("FORGE_PREV_RUN_ID", None)
+    if prev_run_id:
+        write_reexec_redirect(prev_run_id, run_id, log_file, project_root)
 
     # Redirect stdin to /dev/null — use raw fd ops to avoid issues with
     # Python file objects in forked processes

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -242,6 +242,22 @@ def suppress_app_nap() -> None:
 # ── Re-exec redirect sidecar ─────────────────────────────────────────
 
 
+def find_run_id_for_pid(project_root: Path, pid: int) -> str | None:
+    """Return the run_id whose PID file contains ``pid``, or None."""
+    runs_dir = project_root / ".forge" / "runs"
+    try:
+        for pf in runs_dir.glob("*.pid"):
+            try:
+                lines = pf.read_text(encoding="utf-8").splitlines()
+                if lines and int(lines[0].strip()) == pid:
+                    return pf.stem
+            except (OSError, ValueError):
+                continue
+    except OSError:
+        pass
+    return None
+
+
 def write_reexec_redirect(
     prev_run_id: str, new_run_id: str, new_log: Path, project_root: Path
 ) -> None:

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -99,7 +99,9 @@ class TestCmdLogs:
         assert result == 0
 
     def test_follows_reexec_redirect(self, tmp_path, capsys):
-        """forge logs follows a re-exec redirect to the successor log."""
+        """forge logs follows a re-exec redirect via sidecar file to the successor log."""
+        import json
+
         from theforge.cli import cmd_logs
         from theforge.cli.status import _SENTINEL_EOF
 
@@ -118,12 +120,13 @@ class TestCmdLogs:
         new_log.write_text(f"new run output\n{_SENTINEL_EOF}\n")
 
         old_log = log_dir / f"run-{old_run_id}.log"
-        old_log.write_text(
-            "old run output\n"
-            "[forge] Run started in background\n"
-            f"[forge] Run ID:  {new_run_id}\n"
-            f"[forge] Log:     {new_log}\n"
-            f"[forge] Logs:    forge logs {new_run_id}\n"
+        old_log.write_text("old run output\n")
+
+        # Write the sidecar redirect file (normally written by the new daemon's
+        # grandchild after re-exec; here we write it directly for the test).
+        (runs_dir / f"{old_run_id}.redirect").write_text(
+            json.dumps({"new_run_id": new_run_id, "new_log": str(new_log)}),
+            encoding="utf-8",
         )
 
         forge_yaml = tmp_path / "forge.yaml"
@@ -176,6 +179,7 @@ class TestCmdLogs:
 
     def test_reexec_redirect_new_log_never_appears(self, tmp_path, capsys):
         """forge logs returns error gracefully when the new log never appears after re-exec."""
+        import json
         from unittest.mock import patch
 
         from theforge.cli import cmd_logs
@@ -191,16 +195,16 @@ class TestCmdLogs:
         log_dir = tmp_path / ".forge" / "logs" / slug
         log_dir.mkdir(parents=True)
 
-        # The new log path is referenced in the redirect block but never created.
+        # The new log path is referenced in the sidecar redirect file but never created.
         new_log = log_dir / f"run-{new_run_id}.log"
 
         old_log = log_dir / f"run-{old_run_id}.log"
-        old_log.write_text(
-            "old run output\n"
-            "[forge] Run started in background\n"
-            f"[forge] Run ID:  {new_run_id}\n"
-            f"[forge] Log:     {new_log}\n"
-            f"[forge] Logs:    forge logs {new_run_id}\n"
+        old_log.write_text("old run output\n")
+
+        # Write sidecar redirect file pointing to a non-existent new log.
+        (runs_dir / f"{old_run_id}.redirect").write_text(
+            json.dumps({"new_run_id": new_run_id, "new_log": str(new_log)}),
+            encoding="utf-8",
         )
 
         forge_yaml = tmp_path / "forge.yaml"
@@ -219,3 +223,55 @@ class TestCmdLogs:
         assert result == 1
         captured = capsys.readouterr()
         assert "Timed out waiting for new log" in captured.err
+
+    def test_spoof_log_lines_do_not_trigger_redirect(self, tmp_path, capsys):
+        """Log lines that look like re-exec trailers must NOT trigger a redirect.
+
+        LLM output printed to the log could contain ``[forge] Run ID:`` and
+        ``[forge] Log:`` lines.  The new sidecar-file mechanism ensures these
+        are ignored — a redirect only happens when forge itself writes the
+        ``.redirect`` file.
+        """
+        from theforge.cli import cmd_logs
+        from theforge.cli.status import _SENTINEL_EOF
+
+        old_run_id = "aabbccddee11"
+        spoof_run_id = "deadbeefcafe"
+        slug = "my-slug"
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{old_run_id}.pid").write_text(f"12345\n{slug}\n")
+
+        log_dir = tmp_path / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True)
+
+        spoof_log = log_dir / f"run-{spoof_run_id}.log"
+        # Do NOT create the spoof log — if redirect happens it would fail anyway.
+
+        old_log = log_dir / f"run-{old_run_id}.log"
+        old_log.write_text(
+            "legitimate output\n"
+            f"[forge] Run ID:  {spoof_run_id}\n"
+            f"[forge] Log:     {spoof_log}\n"
+            f"{_SENTINEL_EOF}\n"
+        )
+
+        # No .redirect sidecar file is written — these are just spoofed log lines.
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=old_run_id)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        # The follower must stop at the sentinel EOF without switching logs.
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "legitimate output" in captured.out
+        assert "Run re-exec'd" not in captured.err


### PR DESCRIPTION
## Summary

[openai-reviewer] Sidecar-based redirect detection replaces spoofable log parsing, is wired into the re-exec path, and is covered by focused regression tests. | [gemini-reviewer] The implementation correctly replaces log-line parsing with a sidecar file mechanism to prevent log spoofing.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $3.30
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-686: Log spoofing vulnerability: The redirect detection relie (GitHub Issue #692)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #692