### PR TITLE
LOC violations produce follow-up stories, not blocking findings

### DIFF
--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -104,6 +104,7 @@ def _check_line_counts(
                     rule="max_module_lines",
                     file=rel,
                     detail=f"{rel} has {line_count} lines (limit {config.max_module_lines})",
+                    blocking=False,
                 )
             )
 
@@ -116,6 +117,7 @@ def _check_line_counts(
                     rule="max_test_file_lines",
                     file=rel,
                     detail=f"{rel} has {line_count} lines (limit {config.max_test_file_lines})",
+                    blocking=False,
                 )
             )
 

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -279,15 +279,24 @@ def _run_validate_phase(
                 success=False, phase=state.phase, state=state, message=state.error
             )
         if _cv_violations:
-            lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _cv_violations]
-            state.human_feedback += (
-                "\n\nAdditionally, hard convention violations were detected:\n" + "\n".join(lines)
-            )
+            _blocking_cv = [v for v in _cv_violations if v.blocking]
+            _followup_cv = [v for v in _cv_violations if not v.blocking]
             state.convention_violations = [
                 {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
                 for v in _cv_violations
             ]
-            _log(f"  ✗ VALIDATE   convention violations also found ({len(_cv_violations)})")
+            if _blocking_cv:
+                lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _blocking_cv]
+                state.human_feedback += (
+                    "\n\nAdditionally, hard convention violations were detected:\n"
+                    + "\n".join(lines)
+                )
+            for v in _followup_cv:
+                _log(f"  Convention follow-up [hygiene]: {v.rule} in {v.file} — {v.detail}")
+            _log(
+                f"  ✗ VALIDATE   convention violations also found"
+                f" ({len(_blocking_cv)} blocking, {len(_followup_cv)} follow-up)"
+            )
         _log(f"  ✗ VALIDATE   FAIL  (iter={state.dev_iteration} → retrying)")
         if logger:
             logger._safe_emit("phase_end", phase="VALIDATE", outcome="fail")
@@ -431,15 +440,24 @@ def _run_validate_phase(
                 success=False, phase=state.phase, state=state, message=state.error
             )
         if _cv_violations:
-            lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _cv_violations]
-            state.human_feedback += (
-                "\n\nAdditionally, hard convention violations were detected:\n" + "\n".join(lines)
-            )
+            _blocking_cv2 = [v for v in _cv_violations if v.blocking]
+            _followup_cv2 = [v for v in _cv_violations if not v.blocking]
             state.convention_violations = [
                 {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
                 for v in _cv_violations
             ]
-            _log(f"  ✗ VALIDATE   convention violations also found ({len(_cv_violations)})")
+            if _blocking_cv2:
+                lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _blocking_cv2]
+                state.human_feedback += (
+                    "\n\nAdditionally, hard convention violations were detected:\n"
+                    + "\n".join(lines)
+                )
+            for v in _followup_cv2:
+                _log(f"  Convention follow-up [hygiene]: {v.rule} in {v.file} — {v.detail}")
+            _log(
+                f"  ✗ VALIDATE   convention violations also found"
+                f" ({len(_blocking_cv2)} blocking, {len(_followup_cv2)} follow-up)"
+            )
         if logger:
             logger._safe_emit("phase_end", phase="VALIDATE", outcome="fail")
         return _ValidateOutcome.RETRY_DEV, None
@@ -466,6 +484,10 @@ def _run_validate_phase(
     # worktree's version of conventions.py, not the coordinator's own copy.
     if config.conventions_hard is not None:
         if _cv_violations:
+            blocking_violations = [v for v in _cv_violations if v.blocking]
+            followup_violations = [v for v in _cv_violations if not v.blocking]
+
+            # Record ALL violations on state — blocking flag preserved
             state.convention_violations = [
                 {
                     "rule": v.rule,
@@ -475,27 +497,48 @@ def _run_validate_phase(
                 }
                 for v in _cv_violations
             ]
-            lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _cv_violations]
-            human_feedback = "Hard convention violations detected:\n" + "\n".join(lines)
-            state.human_feedback = human_feedback
-            state.retry_reason = RetryReason.CONVENTION_VIOLATIONS
-            _log(f"  ✗ VALIDATE   convention violations ({len(_cv_violations)} found)")
-            for v in _cv_violations:
-                _log(f"    [{v.rule}] {v.file}: {v.detail}")
-            if state.budget.is_exhausted():
-                state.phase = Phase.ESCALATE
-                state.error = f"Hard convention violations after {state.dev_iteration} attempts"
-                _log(f"✗ ESCALATE   {state.error}")
+
+            # Log and emit follow-up (hygiene) violations — not blocking
+            for v in followup_violations:
+                _log(f"  Convention follow-up [hygiene]: {v.rule} in {v.file} — {v.detail}")
                 if logger:
-                    logger._safe_emit("phase_end", phase="VALIDATE", outcome="escalate")
-                    logger._safe_emit("escalate", reason=state.error, phase="VALIDATE")
-                _escalate_notify(task, state, notify, config)
-                return _ValidateOutcome.ESCALATE, CoordinatorResult(
-                    success=False, phase=state.phase, state=state, message=state.error
+                    logger._safe_emit(
+                        "convention_followup",
+                        severity="hygiene",
+                        rule=v.rule,
+                        file=v.file,
+                        detail=v.detail,
+                        suggested_story_title=f"Split {v.file} below LOC limit",
+                    )
+
+            if blocking_violations:
+                lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in blocking_violations]
+                human_feedback = "Hard convention violations detected:\n" + "\n".join(lines)
+                state.human_feedback = human_feedback
+                state.retry_reason = RetryReason.CONVENTION_VIOLATIONS
+                _log(
+                    f"  ✗ VALIDATE   convention violations"
+                    f" ({len(blocking_violations)} blocking found)"
                 )
-            if logger:
-                logger._safe_emit("phase_end", phase="VALIDATE", outcome="convention_fail")
-            return _ValidateOutcome.REVIEW_CONVENTION_BLOCK, None
+                for v in blocking_violations:
+                    _log(f"    [{v.rule}] {v.file}: {v.detail}")
+                if state.budget.is_exhausted():
+                    state.phase = Phase.ESCALATE
+                    state.error = (
+                        f"Hard convention violations after {state.dev_iteration} attempts"
+                    )
+                    _log(f"✗ ESCALATE   {state.error}")
+                    if logger:
+                        logger._safe_emit("phase_end", phase="VALIDATE", outcome="escalate")
+                        logger._safe_emit("escalate", reason=state.error, phase="VALIDATE")
+                    _escalate_notify(task, state, notify, config)
+                    return _ValidateOutcome.ESCALATE, CoordinatorResult(
+                        success=False, phase=state.phase, state=state, message=state.error
+                    )
+                if logger:
+                    logger._safe_emit("phase_end", phase="VALIDATE", outcome="convention_fail")
+                return _ValidateOutcome.REVIEW_CONVENTION_BLOCK, None
+            # Only follow-up violations — proceed to PASS
         else:
             state.convention_violations = [
                 {

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -40,12 +40,14 @@ def _write(path: Path, content: str) -> None:
 
 class TestLineCountCheck:
     def test_line_count_violation(self, tmp_path):
-        """File over max_module_lines is reported."""
+        """File over max_module_lines is reported with blocking=False."""
         py_file = tmp_path / "src" / "theforge" / "big.py"
         _write(py_file, "\n" * 501)  # 501 lines (empty lines count)
         cfg = _make_config(max_module_lines=500)
         violations = _check_line_counts(cfg, tmp_path)
         assert any(v.rule == "max_module_lines" and "big.py" in v.file for v in violations)
+        loc_violations = [v for v in violations if v.rule == "max_module_lines"]
+        assert all(v.blocking is False for v in loc_violations)
 
     def test_line_count_ok(self, tmp_path):
         """File at exactly the limit is not reported."""
@@ -56,12 +58,14 @@ class TestLineCountCheck:
         assert not any(v.rule == "max_module_lines" and "small.py" in v.file for v in violations)
 
     def test_test_file_line_count_violation(self, tmp_path):
-        """Test file over max_test_file_lines is reported with correct rule."""
+        """Test file over max_test_file_lines is reported with correct rule and blocking=False."""
         py_file = tmp_path / "tests" / "test_big.py"
         _write(py_file, "\n" * 1001)
         cfg = _make_config(max_test_file_lines=1000)
         violations = _check_line_counts(cfg, tmp_path)
         assert any(v.rule == "max_test_file_lines" and "test_big.py" in v.file for v in violations)
+        test_loc_violations = [v for v in violations if v.rule == "max_test_file_lines"]
+        assert all(v.blocking is False for v in test_loc_violations)
 
     def test_test_file_line_count_ok(self, tmp_path):
         """Test file at limit is not reported."""
@@ -85,13 +89,15 @@ class TestLineCountCheck:
 
 class TestCircularImportCheck:
     def test_circular_import_detected(self, tmp_path):
-        """Two files that import each other → no_circular_imports violation."""
+        """Two files that import each other → no_circular_imports violation (blocking=True)."""
         pkg = tmp_path / "src" / "theforge"
         pkg.mkdir(parents=True)
         _write(pkg / "a.py", "from theforge import b\n")
         _write(pkg / "b.py", "from theforge import a\n")
         violations = _check_circular_imports(tmp_path)
         assert any(v.rule == "no_circular_imports" for v in violations)
+        circular_violations = [v for v in violations if v.rule == "no_circular_imports"]
+        assert all(v.blocking is True for v in circular_violations)
 
     def test_no_circular_imports(self, tmp_path):
         """Linear imports → no violation."""
@@ -159,11 +165,13 @@ class TestCircularImportCheck:
 
 class TestTestMirrorCheck:
     def test_missing_test_mirror(self, tmp_path):
-        """src/theforge/bar.py with no tests/test_bar.py → violation."""
+        """src/theforge/bar.py with no tests/test_bar.py → violation (blocking=True)."""
         _write(tmp_path / "src" / "theforge" / "bar.py", "# module\n")
         (tmp_path / "tests").mkdir(parents=True)
         violations = _check_test_mirrors(tmp_path)
         assert any(v.rule == "test_mirrors_source" and "bar.py" in v.file for v in violations)
+        mirror_violations = [v for v in violations if v.rule == "test_mirrors_source"]
+        assert all(v.blocking is True for v in mirror_violations)
 
     def test_test_mirror_ok(self, tmp_path):
         """Mirror exists → no violation."""
@@ -258,7 +266,7 @@ class TestCheckHardConventions:
         assert violations == []
 
     def test_violation_dataclass_fields(self, tmp_path):
-        """ConventionViolation has correct fields."""
+        """ConventionViolation has correct fields; line-count violations are non-blocking."""
         _write(tmp_path / "src" / "theforge" / "over.py", "\n" * 6)
         (tmp_path / "tests").mkdir(parents=True)
         cfg = _make_config(
@@ -271,7 +279,8 @@ class TestCheckHardConventions:
         assert v.rule
         assert v.file
         assert v.detail
-        assert v.blocking is True
+        # max_module_lines is a hygiene/follow-up rule — non-blocking
+        assert v.blocking is False
 
 
 class TestConventionBaseline:

--- a/tests/test_coord_convention_parallel.py
+++ b/tests/test_coord_convention_parallel.py
@@ -95,7 +95,7 @@ class TestConventionParallelCheck:
         mock_telemetry,
         tmp_path,
     ):
-        """When gate PASSes but conventions have violations, outcome is REVIEW_CONVENTION_BLOCK."""
+        """Gate PASSes with blocking=True violations → outcome is REVIEW_CONVENTION_BLOCK."""
         config = dataclasses.replace(
             _make_config(tmp_path),
             conventions_hard=HardConventionsConfig(max_module_lines=500),
@@ -105,7 +105,7 @@ class TestConventionParallelCheck:
         workspace.mkdir()
         state = _make_state()
 
-        viol = _make_violation()
+        viol = _make_violation(blocking=True)
         state.budget.max_iterations = config.retry.max_dev_iterations
         mock_gate.return_value = ("PASS", None, "", "make gate")
         mock_cv.return_value = ([viol], [viol])
@@ -125,6 +125,111 @@ class TestConventionParallelCheck:
         assert state.retry_reason == RetryReason.CONVENTION_VIOLATIONS
         assert len(state.convention_violations) == 1
         assert "Hard convention violations" in state.human_feedback
+
+    @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
+    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
+    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase._cu._run_shell")
+    @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
+    def test_gate_pass_followup_only_violations_proceed_to_pass(
+        self,
+        mock_deindex,
+        mock_shell,
+        mock_gate,
+        mock_cv,
+        mock_telemetry,
+        tmp_path,
+    ):
+        """Gate PASSes with only follow-up (blocking=False) violations → outcome is PASS."""
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            conventions_hard=HardConventionsConfig(max_module_lines=500),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        state = _make_state()
+
+        # LOC violations are non-blocking follow-ups
+        viol = _make_violation(rule="max_module_lines", blocking=False)
+        state.budget.max_iterations = config.retry.max_dev_iterations
+        mock_gate.return_value = ("PASS", None, "", "make gate")
+        mock_cv.return_value = ([viol], [viol])
+        mock_shell.return_value = (True, "")  # clean worktree
+
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            workspace,
+            notify=False,
+            logger=None,
+        )
+
+        # Follow-up violations do not block — proceed to PASS
+        assert outcome is _ValidateOutcome.PASS
+        assert result is None
+        # Violations are recorded on state for audit visibility
+        assert len(state.convention_violations) == 1
+        assert state.convention_violations[0]["rule"] == "max_module_lines"
+        assert state.convention_violations[0]["blocking"] is False
+        # Follow-up violations are NOT injected into human_feedback
+        assert not state.human_feedback or "convention" not in state.human_feedback.lower()
+        # retry_reason is not set to CONVENTION_VIOLATIONS
+        assert state.retry_reason != RetryReason.CONVENTION_VIOLATIONS
+
+    @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
+    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
+    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase._cu._run_shell")
+    @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
+    def test_gate_pass_mixed_violations_blocks_on_blocking_only(
+        self,
+        mock_deindex,
+        mock_shell,
+        mock_gate,
+        mock_cv,
+        mock_telemetry,
+        tmp_path,
+    ):
+        """Mixed blocking + follow-up violations: REVIEW_CONVENTION_BLOCK fires; both recorded."""
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            conventions_hard=HardConventionsConfig(max_module_lines=500),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        state = _make_state()
+
+        blocking_viol = _make_violation(rule="no_circular_imports", file="src/a.py", blocking=True)
+        followup_viol = _make_violation(rule="max_module_lines", file="src/big.py", blocking=False)
+        state.budget.max_iterations = config.retry.max_dev_iterations
+        mock_gate.return_value = ("PASS", None, "", "make gate")
+        mock_cv.return_value = ([blocking_viol, followup_viol], [blocking_viol, followup_viol])
+        mock_shell.return_value = (True, "")  # clean worktree
+
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            workspace,
+            notify=False,
+            logger=None,
+        )
+
+        # Blocking violations trigger REVIEW_CONVENTION_BLOCK
+        assert outcome is _ValidateOutcome.REVIEW_CONVENTION_BLOCK
+        assert result is None
+        assert state.retry_reason == RetryReason.CONVENTION_VIOLATIONS
+        # Both violations recorded on state
+        assert len(state.convention_violations) == 2
+        rules = {v["rule"] for v in state.convention_violations}
+        assert "no_circular_imports" in rules
+        assert "max_module_lines" in rules
+        # Only blocking violation text in human_feedback
+        assert "no_circular_imports" in state.human_feedback
+        assert "max_module_lines" not in state.human_feedback
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._get_handoff_content")


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the non-blocking LOC follow-up spec and preserves blocking behavior for correctness conventions. | [gemini-reviewer] Implementation correctly makes LOC violations non-blocking and emits follow-up artifacts, with minor schema deviations in the audit event.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $3.78
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/validate_phase.py:505`** The `convention_followup` audit event omits the `observed` and `limit` fields specified in the example YAML, emitting `detail` instead.
- **[P2] `tests/test_coord_convention_routing.py:1`** The spec requested adding or adjusting tests in `tests/test_coord_convention_routing.py`, but this file was not modified.

## Story

LOC violations produce follow-up stories, not blocking findings (GitHub Issue #748)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #748