### PR TITLE
[P2] forge-daemon: state_update_fn is called at WORKSPACE/PREFLIGHT/PLAN

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -309,6 +309,7 @@ def _coordinator_loop(
                 workspace_path,
                 notify=notify,
                 logger=logger,
+                state_update_fn=state_update_fn,
             )
             if _val_outcome == _ValidateOutcome.ESCALATE:
                 return _val_result  # type: ignore[return-value]
@@ -476,6 +477,7 @@ def _coordinator_loop(
             notify=notify,
             logger=logger,
             run_id=logger._run_id if logger else "",
+            state_update_fn=state_update_fn,
         )
         if _rev_outcome in (_ReviewOutcome.DONE, _ReviewOutcome.ESCALATE):
             return _rev_result  # type: ignore[return-value]

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import replace as _dc_replace
 from enum import Enum, auto
 from pathlib import Path
@@ -491,6 +492,7 @@ def _run_review_phase(
     notify: bool,
     logger: StructuredLogger | None,
     run_id: str = "",
+    state_update_fn: Callable[[dict], None] | None = None,
 ) -> tuple[_ReviewOutcome, CoordinatorResult | None, ForgeConfig]:
     """Run the full REVIEW phase: pool+synthesis, parse retries, verdict handling.
 
@@ -500,6 +502,14 @@ def _run_review_phase(
     config is returned because persistent-P1 model escalation may replace it.
     """
     state.phase = Phase.REVIEW
+    if state_update_fn is not None:
+        state_update_fn(
+            {
+                "phase": "REVIEW",
+                "iteration": state.review_cycle + 1,
+                "cost_usd": state.total_cost,
+            }
+        )
     if logger:
         logger._safe_emit("phase_start", phase="REVIEW", iteration=state.review_cycle + 1)
     # Reset per-cycle parse failure counts so transient failures from one cycle

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -7,6 +7,7 @@ import dataclasses
 import subprocess
 import time
 import types
+from collections.abc import Callable
 from enum import Enum, auto
 from pathlib import Path
 
@@ -128,6 +129,7 @@ def _run_validate_phase(
     *,
     notify: bool,
     logger: StructuredLogger | None,
+    state_update_fn: Callable[[dict], None] | None = None,
 ) -> tuple[_ValidateOutcome, CoordinatorResult | None]:
     """Run one VALIDATE iteration. Returns (outcome, result).
 
@@ -135,6 +137,14 @@ def _run_validate_phase(
     Does NOT emit 'phase_end VALIDATE pass' — caller emits that (it fires on skip too).
     """
     state.phase = Phase.VALIDATE
+    if state_update_fn is not None:
+        state_update_fn(
+            {
+                "phase": "VALIDATE",
+                "iteration": state.dev_iteration,
+                "cost_usd": state.total_cost,
+            }
+        )
     if logger:
         logger._safe_emit("phase_start", phase="VALIDATE", iteration=state.dev_iteration)
 


### PR DESCRIPTION
## Summary

[openai-reviewer] state_update_fn is now invoked on entry to both VALIDATE and REVIEW, and the coordinator passes the callback through at runtime. | [gemini-reviewer] Extended state_update_fn coverage to VALIDATE and REVIEW phases correctly.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.93
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] forge-daemon: state_update_fn is called at WORKSPACE/PREFLIGHT/PLAN (GitHub Issue #104)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #104