### PR TITLE
[P2] plan-review-corroboration: Pre-existing edge case: If a ModelProfil

### DIFF
--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -234,6 +234,12 @@ def _parse_profile(
     anything else uses DEFAULT_REVIEW_PROFILE. This prevents pool entries
     named "dev" from accidentally inheriting dev-level tools/timeouts.
     """
+    if "]" in name:
+        raise ValueError(
+            f"Profile name {name!r} contains ']', which is not allowed. "
+            "Profile names are used as '[name] description' attribution prefixes; "
+            "a ']' in the name would break reviewer attribution parsing."
+        )
     default = DEFAULT_DEV_PROFILE if role == "dev" else DEFAULT_REVIEW_PROFILE
     cli = data.get("cli")
     provider = data.get("provider")

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1015,6 +1015,15 @@ class TestAllowedToolsConfig:
 
         assert profile.thinking_budget == 2048
 
+    def test_parse_profile_name_with_bracket_raises(self):
+        """Profile names containing ']' are rejected at parse time."""
+        with pytest.raises(ValueError, match=r"contains '\]'"):
+            _parse_profile(
+                "bad]name",
+                {"cli": "claude", "model": "sonnet"},
+                role="review",
+            )
+
     def test_apply_profile_overrides_preserves_explicit_zero_thinking_budget(self):
         base = ModelProfile(
             name="gemini-reviewer",


### PR DESCRIPTION
## Summary

[openai-reviewer] Profile names containing ] are now rejected during config parsing, and the new validation is exercised by a focused test. | [gemini-reviewer] The implementation correctly forbids ']' in ModelProfile.name and includes appropriate tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.49
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] plan-review-corroboration: Pre-existing edge case: If a ModelProfil (GitHub Issue #260)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #260