### PR TITLE
[P2] issue-244: Default file value ('unknown') is treated as any other f

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -368,7 +368,13 @@ def _persistent_p1_descriptions(
 
 def _p1_findings_match(current: ReviewFinding, previous: ReviewFinding) -> bool:
     """Return True when two P1 findings should be treated as the same persistent issue."""
-    if current.file and previous.file and current.file == previous.file:
+    if (
+        current.file
+        and previous.file
+        and current.file != "unknown"
+        and previous.file != "unknown"
+        and current.file == previous.file
+    ):
         return True
 
     if current.description in previous.description or previous.description in current.description:

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -150,6 +150,18 @@ class TestHasPersistentP1:
         assert _has_persistent_p1([], [finding]) is False
         assert _has_persistent_p1([finding], []) is False
 
+    def test_unknown_file_not_matched_as_same_file(self):
+        """Two P1s with file='unknown' (the default) must not match via file equality."""
+        curr = [_make_review_finding(file="unknown", description="unrelated issue alpha")]
+        prev = [_make_review_finding(file="unknown", description="completely different beta")]
+        assert _has_persistent_p1(curr, prev) is False
+
+    def test_unknown_file_still_matches_by_description(self):
+        """'unknown' file P1s with similar descriptions are still caught by text similarity."""
+        curr = [_make_review_finding(file="unknown", description="gate_override never wired")]
+        prev = [_make_review_finding(file="unknown", description="gate_override never wired in")]
+        assert _has_persistent_p1(curr, prev) is True
+
 
 class TestEscalateDevModel:
     def test_escalation_swaps_to_higher_model(self):


### PR DESCRIPTION
## Summary

[openai-reviewer] Change correctly prevents default unknown file values from causing false-positive persistent P1 matches, with targeted tests covering the new behavior. | [gemini-reviewer] The implementation correctly excludes 'unknown' files from same-file P1 persistence matching.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.35
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-244: Default file value ('unknown') is treated as any other f (GitHub Issue #400)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #400