### PR TITLE
[P2] review-convergence: Corroboration detection uses exact fingerprint 

### DIFF
--- a/src/theforge/finding_classifier.py
+++ b/src/theforge/finding_classifier.py
@@ -159,6 +159,11 @@ def update_finding_registry(
         reports_a: list[tuple[str, ReviewFinding]],
         reports_b: list[tuple[str, ReviewFinding]],
     ) -> bool:
+        # Path 1: line-proximity merge.
+        # Requires ALL comparable pairs across the two buckets to satisfy same-file,
+        # same-severity, and within-3-line constraints.  The all-pairs requirement is
+        # intentional — it prevents transitive merging when a bucket grows after
+        # absorbing a finding whose line is far from a third bucket.
         comparable_a = [
             finding
             for _, finding in reports_a
@@ -169,17 +174,51 @@ def update_finding_registry(
             for _, finding in reports_b
             if finding.file is not None and finding.line is not None
         ]
-        if not comparable_a or not comparable_b:
-            return False
-        for finding_a in comparable_a:
-            for finding_b in comparable_b:
-                if finding_a.severity != finding_b.severity:
-                    return False
-                if finding_a.file != finding_b.file:
-                    return False
-                if abs(finding_a.line - finding_b.line) > 3:
-                    return False
-        return True
+        if comparable_a and comparable_b:
+            all_close = True
+            for finding_a in comparable_a:
+                for finding_b in comparable_b:
+                    if finding_a.severity != finding_b.severity:
+                        all_close = False
+                        break
+                    if finding_a.file != finding_b.file:
+                        all_close = False
+                        break
+                    if abs(finding_a.line - finding_b.line) > 3:
+                        all_close = False
+                        break
+                if not all_close:
+                    break
+            if all_close:
+                return True
+
+        # Path 2: Jaccard-similarity merge (different-reviewer pairs only).
+        # Catches paraphrased corroborations: same file + same severity + similar
+        # description tokens, regardless of line numbers.  Two reviewers describing the
+        # same issue with slightly different wording produce different fingerprints and
+        # end up in different buckets; Jaccard reunites them.
+        #
+        # Restricted to disjoint reviewer sets: a single reviewer can legitimately
+        # report the same class of issue at many locations (Jaccard 1.0 between those
+        # reports).  Merging intra-reviewer buckets early would suppress the
+        # corroboration signal from a second reviewer who describes the issue differently.
+        reviewers_a = {reviewer for reviewer, _ in reports_a}
+        reviewers_b = {reviewer for reviewer, _ in reports_b}
+        if reviewers_a.isdisjoint(reviewers_b):
+            all_a = [finding for _, finding in reports_a]
+            all_b = [finding for _, finding in reports_b]
+            for finding_a in all_a:
+                for finding_b in all_b:
+                    if finding_a.severity != finding_b.severity:
+                        continue
+                    if finding_a.file != finding_b.file:
+                        continue
+                    tokens_a = _normalize_tokens(finding_a.description)
+                    tokens_b = _normalize_tokens(finding_b.description)
+                    if _jaccard(tokens_a, tokens_b) >= JACCARD_THRESHOLD:
+                        return True
+
+        return False
 
     merged_reports: dict[str, list[tuple[str, ReviewFinding]]] = {
         fp: list(reports) for fp, reports in fingerprint_to_reports.items()

--- a/tests/test_finding_classifier.py
+++ b/tests/test_finding_classifier.py
@@ -322,6 +322,76 @@ class TestUpdateFindingRegistryCycle1:
             f"{[r.disposition for r in p1s]}"
         )
 
+    def test_paraphrased_descriptions_corroborated_via_jaccard(self, tmp_path):
+        """Two reviewers describing the same issue with similar but different wording
+        should be corroborated even when there is no line proximity to merge them.
+
+        'Missing null check when processing user requests' and
+        'User requests could fail if null check is missing' share enough tokens
+        (Jaccard ≥ 0.5) that the classifier should group them as corroborated_new.
+        """
+        state = _make_state()
+        # line=None so fingerprints only differ on token content, not line
+        finding_a = _make_finding(
+            "Missing null check when processing user requests",
+            line=None,
+        )
+        finding_b = _make_finding(
+            "User requests could fail if null check is missing",
+            line=None,
+        )
+        cycle_results = [
+            ("reviewer-a", _make_review([finding_a])),
+            ("reviewer-b", _make_review([finding_b])),
+        ]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=1)
+
+        p1s = [r for r in classified if r.severity == "P1"]
+        assert len(p1s) == 1, f"Expected 1 merged P1 bucket; got {len(p1s)}"
+        assert p1s[0].disposition == "corroborated_new"
+
+    def test_same_description_different_lines_corroborated_via_jaccard(self, tmp_path):
+        """Two reviewers reporting an identical description at distant line numbers
+        (fingerprints differ due to line inclusion) should be corroborated.
+
+        Jaccard of identical descriptions is 1.0 so they should always merge.
+        """
+        state = _make_state()
+        finding_a = _make_finding("Missing null check in handler", line=10)
+        finding_b = _make_finding("Missing null check in handler", line=50)
+        cycle_results = [
+            ("reviewer-a", _make_review([finding_a])),
+            ("reviewer-b", _make_review([finding_b])),
+        ]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=1)
+
+        p1s = [r for r in classified if r.severity == "P1"]
+        assert len(p1s) == 1, f"Expected 1 merged P1 bucket; got {len(p1s)}"
+        assert p1s[0].disposition == "corroborated_new"
+
+    def test_dissimilar_descriptions_different_lines_not_corroborated(self, tmp_path):
+        """Two reviewers with genuinely different descriptions and distant lines
+        should remain as separate net_new findings (Jaccard below threshold).
+        """
+        state = _make_state()
+        finding_a = _make_finding("Missing null check before dereferencing request.user", line=10)
+        finding_b = _make_finding("Handler can crash when account lookup returns None", line=50)
+        cycle_results = [
+            ("reviewer-a", _make_review([finding_a])),
+            ("reviewer-b", _make_review([finding_b])),
+        ]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=1)
+
+        p1s = [r for r in classified if r.severity == "P1"]
+        assert len(p1s) == 2
+        assert all(r.disposition == "net_new" for r in p1s)
+
     def test_nearby_line_corroboration_does_not_chain_transitively(self, tmp_path):
         state = _make_state()
         cycle_results = [


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation satisfies the within-cycle Jaccard corroboration requirement and the prior unrelated regressions are no longer present. | [gemini-reviewer] The implementation correctly addresses the review convergence spec and resolves all prior P1 findings.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.54
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] review-convergence: Corroboration detection uses exact fingerprint  (GitHub Issue #31)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #31