### PR TITLE
[P2] issue-108: The comment on line 1113 still references the hardcoded 

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1110,7 +1110,7 @@ def run_sprint(
             batch_number += 1
 
             if not done_futs:
-                # Timeout: all active workers hung for >3600s — cancel and fail them
+                # Timeout: all active workers hung for >worker_timeout_seconds — cancel and fail
                 for g_slug, _gate in plan_gates.items():
                     _log(f"TIMEOUT releasing plan gate for {g_slug}")
                     _gate.set()


### PR DESCRIPTION
## Summary

[openai-reviewer] Comment update matches the spec and introduces no correctness issues. | [gemini-reviewer] The stale comment was successfully updated to reference worker_timeout_seconds.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.15
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-108: The comment on line 1113 still references the hardcoded  (GitHub Issue #729)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #729