### PR TITLE
[P2] issue-674: When returning early due to a preflight verdict (e.g., A

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -748,6 +748,8 @@ def run_task(
                 stop_phase=stop_phase,
             )
         if _pf_result is not None:
+            _total_elapsed = time.monotonic() - _task_start
+            _fire_post_run_hook(config, state, task, _pf_result, _run_id, _total_elapsed, logger)
             return _pf_result
         if _pf_already_done_loop:
             # ALREADY_DONE override: commits on branch without prior APPROVE → resume REVIEW

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -400,6 +400,76 @@ likely_files:
         assert "src/theforge/old_module.py" in result.state.preflight_warnings[0]
         assert len(result.state.dev_results) == 1
 
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow.has_review_approve", return_value=True)
+    @patch("theforge.coordinator.engine._fire_post_run_hook")
+    def test_post_run_hook_fires_on_already_done(
+        self,
+        mock_hook,
+        mock_approve,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """ALREADY_DONE verdict → post_run hook fires exactly once."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.return_value = (True, "OK")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE, cost_usd=0.08, profile_name="review"
+        )
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "ALREADY_DONE"
+        mock_hook.assert_called_once()
+        called_result = mock_hook.call_args[0][3]
+        assert called_result is result
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.engine._fire_post_run_hook")
+    def test_post_run_hook_fires_on_blocked(
+        self,
+        mock_hook,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """BLOCKED verdict → post_run hook fires exactly once."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.return_value = (True, "OK")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BLOCKED, cost_usd=0.08, profile_name="review"
+        )
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "BLOCKED"
+        mock_hook.assert_called_once()
+        called_result = mock_hook.call_args[0][3]
+        assert called_result is result
+
     def test_parse_preflight_likely_files_requires_explicit_field(self):
         """Missing likely_files stays unknown instead of defaulting to zero-footprint."""
         from coord_test_helpers import PREFLIGHT_PROCEED


### PR DESCRIPTION
## Summary

[openai-reviewer] Live preflight early exits now fire the post_run hook before returning, and regression tests cover both ALREADY_DONE and BLOCKED paths. | [gemini-reviewer] The fix correctly routes cached preflight verdicts through the same dispatch as live preflight, and tests cover the ALREADY_DONE and BLOCKED batch-mode regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.68
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-674: When returning early due to a preflight verdict (e.g., A (GitHub Issue #678)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #678