### PR TITLE
fix(coordinator): use three-dot diff in review to prevent phantom regressions

### DIFF
--- a/src/theforge/coordinator/review_context.py
+++ b/src/theforge/coordinator/review_context.py
@@ -54,7 +54,7 @@ def _get_commit_log(workspace_path: Path, base_branch: str = "main") -> str:
 
 def _get_diff_stat(workspace_path: Path, base_branch: str = "main") -> str:
     """Get verified diff stat vs the base branch."""
-    ok, stat = _cu._run_shell(f"git diff {base_branch} --stat", workspace_path)
+    ok, stat = _cu._run_shell(f"git diff {base_branch}...HEAD --stat", workspace_path)
     if ok and stat.strip():
         return stat
     return "(no files changed vs base branch)"
@@ -67,7 +67,7 @@ def _get_diff_content(
     max_chars: int = 300_000,
 ) -> str:
     """Get verified diff content vs the base branch, truncating when too large."""
-    ok, diff = _cu._run_shell(f"git diff {base_branch}", workspace_path)
+    ok, diff = _cu._run_shell(f"git diff {base_branch}...HEAD", workspace_path)
     if not ok and not diff.strip():
         return "(failed to load git diff vs base branch)"
     if not diff.strip():

--- a/tests/test_coord_dev_phase_budget.py
+++ b/tests/test_coord_dev_phase_budget.py
@@ -304,9 +304,9 @@ class TestCoordinatorDevNotes:
                 return (True, "")
             if "git log" in cmd and "--oneline --reverse" in cmd:
                 return (True, "abc1234 feat: implement\ndef5678 test: add coverage")
-            if "git diff main --stat" in cmd:
+            if "git diff main...HEAD --stat" in cmd:
                 return (True, " src/foo.py | 2 ++\n tests/test_foo.py | 4 ++++")
-            if cmd.strip() == "git diff main":
+            if cmd.strip() == "git diff main...HEAD":
                 return (True, "diff --git a/src/foo.py b/src/foo.py\n+print('ok')")
             if "git show abc1234" in cmd:
                 return (True, "commit abc1234\n...diff one...")
@@ -382,9 +382,9 @@ class TestCoordinatorDevNotes:
                 return (True, "")
             if "git log" in cmd and "--oneline --reverse" in cmd:
                 return (True, "abc1234 feat: real commit")
-            if "git diff main --stat" in cmd:
+            if "git diff main...HEAD --stat" in cmd:
                 return (True, " src/foo.py | 1 +")
-            if cmd.strip() == "git diff main":
+            if cmd.strip() == "git diff main...HEAD":
                 return (True, "diff --git a/src/foo.py b/src/foo.py")
             if "git show abc1234" in cmd:
                 return (True, "commit abc1234\n...diff...")


### PR DESCRIPTION
## Summary

- Review context computed `git diff main` (two-dot, full tree diff) instead of `git diff main...HEAD` (three-dot, merge-base diff)
- In parallel sprints, sibling stories merge to main while a story is in DEV — the review diff then shows those additions as phantom deletions on the branch
- Reviewer flags them as P1 regressions, dev agent tries to "restore" code it never had, introduces real regressions, cycles exhaust → escalate
- Observed in sprint `d99a1025e626`: issues #100 and #363 both escalated with identical phantom regressions from 6 sibling-story merges

Fixes #770.

## Test plan

- [x] `make gate` passes (2874 passed)
- [ ] CI passes on all Python matrix versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)