### PR TITLE
bug(self-host): dev prompt must prevent tests from depending on optional provider SDKs

### DIFF
--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -210,6 +210,15 @@ def build_dev_prompt(
             "  implementation is wrong — fix your code, not the tests."
         )
 
+    provider_sdk_test_rule = (
+        "- Tests must not rely on optional provider SDKs (e.g. `openai`, `anthropic`,\n"
+        "  `google-generativeai`) being installed. If code under test performs a\n"
+        "  provider SDK import check, mock or stub that boundary so the test passes\n"
+        "  whether the environment has `.[dev]` or `.[all,dev]` installed. Only\n"
+        "  stories explicitly about real provider integration may skip this isolation\n"
+        "  requirement."
+    )
+
     return dedent(f"""\
         You are implementing **{task.name}**.
 
@@ -284,6 +293,7 @@ def build_dev_prompt(
         - Do not create files outside `src/`, `tests/`, or `docs/`. If you need a
           scratch file for exploration, delete it before committing.
         {test_rule}
+        {provider_sdk_test_rule}
         - If you cannot finish, commit what you have and list blockers in
           `deferred_items`.
     """)

--- a/tests/test_dev_prompts.py
+++ b/tests/test_dev_prompts.py
@@ -192,3 +192,28 @@ class TestContractChangeTestRule:
     def test_contract_change_still_restricts_unrelated_tests(self, tmp_path: Path) -> None:
         prompt = self._make_prompt(tmp_path, contract_change=True)
         assert "Do NOT modify tests unrelated to the contract change" in prompt
+
+
+class TestProviderSdkIsolationRule:
+    """Verify that the provider SDK isolation rule is always present in dev prompts."""
+
+    def _make_prompt(self, tmp_path: Path, *, contract_change: bool) -> str:
+        task = _make_task(tmp_path)
+        return build_dev_prompt(
+            task,
+            workspace_path=tmp_path,
+            branch_name="feat/test",
+            story_content="# Test\n\nDo something.",
+            gate_command="make test",
+            contract_change=contract_change,
+        )
+
+    def test_rule_present_without_contract_change(self, tmp_path: Path) -> None:
+        prompt = self._make_prompt(tmp_path, contract_change=False)
+        assert "optional provider SDKs" in prompt
+        assert "mock or stub that boundary" in prompt
+
+    def test_rule_present_with_contract_change(self, tmp_path: Path) -> None:
+        prompt = self._make_prompt(tmp_path, contract_change=True)
+        assert "optional provider SDKs" in prompt
+        assert "mock or stub that boundary" in prompt


### PR DESCRIPTION
## Summary

[openai-reviewer] Dev prompt now explicitly requires provider SDK isolation in tests, and prompt tests cover the new guidance. | [gemini-reviewer] The implementation correctly adds the provider SDK isolation rule to the dev prompt and includes tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.05
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

bug(self-host): dev prompt must prevent tests from depending on optional provider SDKs (GitHub Issue #683)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #683