### PR TITLE
[P2] stage-aware-pipeline: The --until init stop check fires before WORK

### DIFF
--- a/src/theforge/cli/run.py
+++ b/src/theforge/cli/run.py
@@ -378,7 +378,7 @@ def register_parser(subparsers: object) -> None:
         default=None,
         help=(
             "Stop pipeline after specified phase. "
-            "Valid phases: init, workspace, preflight, plan, plan-review, "
+            "Valid phases: workspace, preflight, plan, plan-review, "
             "dev, validate, review. Worktree preserved on stop. Exit code 0."
         ),
     )

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -39,7 +39,6 @@ class Phase(Enum):
 
 
 _PHASE_NAME_MAP: dict[str, Phase] = {
-    "init": Phase.INIT,
     "workspace": Phase.WORKSPACE,
     "preflight": Phase.PREFLIGHT,
     "plan": Phase.PLAN,
@@ -54,8 +53,12 @@ _PHASE_NAME_MAP: dict[str, Phase] = {
 def parse_phase_name(name: str) -> Phase:
     """Parse a lowercase hyphenated phase name into a Phase enum value.
 
-    Accepted names: init, workspace, preflight, plan, plan-review, dev,
+    Accepted names: workspace, preflight, plan, plan-review, dev,
     validate, review, human-review.
+
+    ``init`` is intentionally excluded: INIT completes before any observable
+    work begins, so ``--until init`` would be a silent no-op.  Use
+    ``--until workspace`` to stop after workspace creation.
 
     Raises ValueError with valid names on unknown input.
     """

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -589,7 +589,6 @@ class TestParsePhaseNameUtility:
 
     def test_all_valid_names(self):
         expected = {
-            "init": Phase.INIT,
             "workspace": Phase.WORKSPACE,
             "preflight": Phase.PREFLIGHT,
             "plan": Phase.PLAN,
@@ -601,6 +600,11 @@ class TestParsePhaseNameUtility:
         }
         for name, phase in expected.items():
             assert parse_phase_name(name) == phase
+
+    def test_init_not_a_valid_stop_phase(self):
+        """'init' must not be accepted as a --until phase: it is a no-op."""
+        with pytest.raises(ValueError, match="Unknown phase name"):
+            parse_phase_name("init")
 
     def test_case_insensitive(self):
         assert parse_phase_name("DEV") == Phase.DEV


### PR DESCRIPTION
## Summary

[openai-reviewer] Removes init from --until parsing and user-facing help, with runtime wiring and tests aligned to the intended behavior. | [gemini-reviewer] The implementation correctly removes 'init' from the valid phase names for --until and --from, satisfying the spec.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $0.34
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] stage-aware-pipeline: The --until init stop check fires before WORK (GitHub Issue #100)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #100