### PR TITLE
[P2] plan-regen-backtrack-prompt: The new backtrack path is still gated 

### DIFF
--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -434,7 +434,7 @@ def _run_plan_agent_review(
         _log("  ⚠ Both plan_agent_review and plan_review enabled — agent review takes precedence")
 
     _max = config.retry.max_plan_regen_attempts
-    for _attempt in range(_max + 1):
+    for _attempt in range(_max + 2):
         _log_phase(
             state.phase,
             f"agent review ({_pool_label}, {len(par_profiles)} reviewer(s))",
@@ -748,23 +748,25 @@ def _run_plan_agent_review(
                     )
 
         if state.plan_regen_count > config.retry.max_plan_regen_attempts:
-            state.plan_review_decision = "reject"
-            state.phase = Phase.ESCALATE
-            _max_regen = config.retry.max_plan_regen_attempts
-            state.error = (
-                f"Plan rejected {state.plan_regen_count} time(s)"
-                f" by agent reviewer"
-                f" (max_plan_regen_attempts={_max_regen})."
-                f" Findings:\n{findings_text}"
-            )
-            _log(f"  ✗ PLAN_REVIEW   rejected {state.plan_regen_count}x — escalating")
-            _escalate_notify(task, state, notify, config)
-            return CoordinatorResult(
-                success=False,
-                phase=Phase.ESCALATE,
-                state=state,
-                message=state.error,
-            )
+            _disposition_now = state.plan_regen_disposition or "patch"
+            if _disposition_now != "backtrack" or state.plan_backtrack_used:
+                state.plan_review_decision = "reject"
+                state.phase = Phase.ESCALATE
+                _max_regen = config.retry.max_plan_regen_attempts
+                state.error = (
+                    f"Plan rejected {state.plan_regen_count} time(s)"
+                    f" by agent reviewer"
+                    f" (max_plan_regen_attempts={_max_regen})."
+                    f" Findings:\n{findings_text}"
+                )
+                _log(f"  ✗ PLAN_REVIEW   rejected {state.plan_regen_count}x — escalating")
+                _escalate_notify(task, state, notify, config)
+                return CoordinatorResult(
+                    success=False,
+                    phase=Phase.ESCALATE,
+                    state=state,
+                    message=state.error,
+                )
 
         # Early escalation: disposition tracker determined the backtrack attempt
         # itself diverged — no further regen will help; escalate immediately.
@@ -803,6 +805,7 @@ def _run_plan_agent_review(
             # text (opening, learned constraints, rejected strategy, instructions).
             # The patch ## Instructions block is intentionally omitted here — patch
             # guidance ("Do not discard working parts") contradicts backtrack intent.
+            state.plan_backtrack_used = True
             disposition_ctx = build_disposition_context(state)
             regen_prompt = dedent(f"""\
                 You are a planning agent for **{task.name}**.

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -747,7 +747,10 @@ def _run_plan_agent_review(
                         " — continuing with current model"
                     )
 
-        if state.plan_regen_count > config.retry.max_plan_regen_attempts:
+        # Backtrack regen is separate from the patch-loop budget: exclude it from
+        # the ceiling count so an early backtrack does not consume a patch slot.
+        _patch_regen_count = state.plan_regen_count - (1 if state.plan_backtrack_used else 0)
+        if _patch_regen_count > config.retry.max_plan_regen_attempts:
             _disposition_now = state.plan_regen_disposition or "patch"
             if _disposition_now != "backtrack" or state.plan_backtrack_used:
                 state.plan_review_decision = "reject"

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -307,6 +307,7 @@ class CoordinatorState:
         default_factory=list
     )  # per-attempt: {files_touched, p1_count, p2_count, finding_themes}
     plan_regen_disposition: str | None = None  # "patch" | "backtrack" | "escalate"
+    plan_backtrack_used: bool = False  # True once the backtrack regen has been dispatched
     log_dir: Path | None = None  # per-story log directory under <project_root>/.forge/logs/
     error: str | None = None
     error_type: str | None = None

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -1097,6 +1097,100 @@ findings:
         assert result.state.plan_output == "# Plan\n\nFixed plan."
         assert len(result.state.plan_results) == 2
 
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_plan_agent_review_backtrack_allowed_when_max_regen_is_one(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """With max_plan_regen_attempts=1 and recurring P0 theme, backtrack regen runs.
+
+        Three consecutive P0 rejections share the snake_case anchor 'parse_config',
+        so classify_disposition returns 'backtrack' after the second rejection.
+        The fix ensures the backtrack attempt is NOT gated by the
+        max_plan_regen_attempts ceiling, so the review pool is called a third time
+        (for the backtrack regen output) before the run finally escalates.
+
+        P0 severity is used (not P1) so the finding blocks on a single reviewer
+        without requiring corroboration.
+
+        Bug: without the fix, pool is only called twice — the ceiling check fires on
+        the second rejection and escalates before the backtrack regen is dispatched.
+        """
+        # P0 with a snake_case anchor so extract_finding_themes produces an
+        # overlapping non-file-path theme ('parse_config') across all three cycles.
+        reject_p0_with_theme = """\
+```yaml
+verdict: REJECT
+findings:
+  - severity: P0
+    description: "Plan calls parse_config() which does not exist"
+    suggestion: "Replace parse_config with load_config throughout the plan"
+```
+"""
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2, max_review_cycles=2, max_plan_regen_attempts=1
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        # Three plan outputs: initial plan, patch regen, backtrack regen
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nInitial plan.", cost_usd=0.10),
+            _make_agent_result(success=True, output="# Plan\n\nPatch attempt.", cost_usd=0.12),
+            _make_agent_result(success=True, output="# Plan\n\nBacktrack attempt.", cost_usd=0.12),
+        ]
+        # Three review rounds all REJECT P0 with the same snake_case theme.
+        # Repeated parse_config across attempts → _has_sufficient_overlap returns
+        # True across cycles, so classify_disposition returns "backtrack" after the
+        # second rejection (and "escalate" after the third).
+        mock_pool.side_effect = [
+            [
+                _make_agent_result(
+                    success=True,
+                    output=reject_p0_with_theme,
+                    cost_usd=0.08,
+                    profile_name="plan-review",
+                )
+            ],
+            [
+                _make_agent_result(
+                    success=True,
+                    output=reject_p0_with_theme,
+                    cost_usd=0.08,
+                    profile_name="plan-review",
+                )
+            ],
+            [
+                _make_agent_result(
+                    success=True,
+                    output=reject_p0_with_theme,
+                    cost_usd=0.08,
+                    profile_name="plan-review",
+                )
+            ],
+        ]
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        # Backtrack review ran — pool called 3 times; if bug present, only 2
+        assert mock_pool.call_count == 3
+        assert result.state.plan_backtrack_used is True
+        assert result.state.plan_regen_count >= 2
+
 
 # ── TestPlanReviewerFailureAudit ──────────────────────────────────────
 

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -1191,6 +1191,100 @@ findings:
         assert result.state.plan_backtrack_used is True
         assert result.state.plan_regen_count >= 2
 
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_early_backtrack_does_not_consume_patch_slot(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Backtrack regen dispatched before the ceiling is hit must not consume a patch slot.
+
+        Scenario: max_plan_regen_attempts=2.  The first two rejections share the
+        'parse_config' theme, triggering 'backtrack' at iteration 1 (before the
+        ceiling).  After the backtrack the reviewer switches to a different theme
+        ('validate_schema') so the disposition goes back to 'patch' — the early
+        escalation guard (disposition=='escalate') stays silent and only the ceiling
+        check governs exit.
+
+          iter 0: REJECT parse_config  → regen_count=1, dispose="patch"  → patch regen
+          iter 1: REJECT parse_config  → regen_count=2, dispose="backtrack" → backtrack regen
+          iter 2: REJECT validate_schema → regen_count=3, dispose="patch"
+                  effective=3-1=2 > 2? No (fix!) → patch regen
+                  BUG: without fix, 3 > 2 → ESCALATE (only 1 patch after backtrack)
+          iter 3: REJECT validate_schema → regen_count=4, backtrack used
+                  effective=4-1=3 > 2 → ESCALATE
+
+        Pool is therefore called 4 times with the fix (3 without).
+        """
+        reject_parse_config = """\
+```yaml
+verdict: REJECT
+findings:
+  - severity: P0
+    description: "Plan calls parse_config() which does not exist"
+    suggestion: "Replace parse_config with load_config throughout the plan"
+```
+"""
+        reject_validate_schema = """\
+```yaml
+verdict: REJECT
+findings:
+  - severity: P0
+    description: "Plan calls validate_schema() which is not defined"
+    suggestion: "Remove validate_schema or define it in the plan"
+```
+"""
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2, max_review_cycles=2, max_plan_regen_attempts=2
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        # 4 plan outputs: initial + patch-1 + backtrack + patch-2
+        # (escalation fires during iter-3 review before a 5th regen is needed)
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nInitial.", cost_usd=0.10),
+            _make_agent_result(success=True, output="# Plan\n\nPatch-1.", cost_usd=0.12),
+            _make_agent_result(success=True, output="# Plan\n\nBacktrack.", cost_usd=0.12),
+            _make_agent_result(success=True, output="# Plan\n\nPatch-2.", cost_usd=0.12),
+        ]
+
+        # iter 0-1: parse_config theme  →  'backtrack' at iter 1
+        # iter 2-3: validate_schema theme (no overlap with parse_config)  →  'patch' at iter 2,
+        #           'backtrack' at iter 3 (validate_schema now overlaps, but backtrack used)
+        def _r(output: str) -> list:
+            return [
+                _make_agent_result(
+                    success=True, output=output, cost_usd=0.08, profile_name="plan-review"
+                )
+            ]
+
+        mock_pool.side_effect = [
+            _r(reject_parse_config),
+            _r(reject_parse_config),
+            _r(reject_validate_schema),
+            _r(reject_validate_schema),
+        ]
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        # 4 pool calls with fix; without fix only 3 (escalates at iter 2 ceiling)
+        assert mock_pool.call_count == 4
+        assert result.state.plan_backtrack_used is True
+
 
 # ── TestPlanReviewerFailureAudit ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Prior regen-budget issue is fixed, the new backtrack path is no longer gated by the patch budget, and I found no P1 regressions in the touched code.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $3.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] plan-regen-backtrack-prompt: The new backtrack path is still gated  (GitHub Issue #225)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #225