### PR TITLE
perf: optimize make gate runtime performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+norecursedirs = [".forge"]
 pythonpath = ["src", "tests"]
 addopts = "-n auto --dist worksteal"
 markers = [

--- a/src/theforge/indexer.py
+++ b/src/theforge/indexer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import os
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -103,10 +104,16 @@ def _extract_string_list(node: ast.AST) -> list[str] | None:
 def _iter_python_files(project_root: Path) -> list[Path]:
     excluded = {".git", ".venv", ".forge"}
     files: list[Path] = []
-    for path in project_root.rglob("*.py"):
-        if any(part in excluded for part in path.parts):
-            continue
-        files.append(path)
+
+    # Using os.walk for faster directory skipping compared to rglob
+    for root, dirs, filenames in os.walk(project_root):
+        # In-place modify dirs to skip excluded ones from traversal
+        dirs[:] = [d for d in dirs if d not in excluded]
+
+        for name in filenames:
+            if name.endswith(".py"):
+                files.append(Path(root) / name)
+
     return sorted(files)
 
 

--- a/tests/test_run_shell_timeout.py
+++ b/tests/test_run_shell_timeout.py
@@ -22,10 +22,10 @@ class TestRunShellTimeout:
             "sys.stdout.flush(); "
             'time.sleep(300)"'
         )
-        ok, output = _run_shell(cmd, tmp_path, timeout=2)
+        ok, output = _run_shell(cmd, tmp_path, timeout=0.2)
 
         assert ok is False
-        assert output.startswith("TIMEOUT after 2s:")
+        assert output.startswith("TIMEOUT after 0.2s:")
         assert "PARTIAL_MARKER" in output
 
     def test_timeout_handler_does_not_block(self, tmp_path: Path) -> None:
@@ -33,23 +33,23 @@ class TestRunShellTimeout:
         # Process that writes nothing and sleeps forever.
         cmd = 'python3 -c "import time; time.sleep(300)"'
         start = time.monotonic()
-        ok, output = _run_shell(cmd, tmp_path, timeout=1)
+        ok, output = _run_shell(cmd, tmp_path, timeout=0.1)
         elapsed = time.monotonic() - start
 
         assert ok is False
-        assert output.startswith("TIMEOUT after 1s:")
+        assert output.startswith("TIMEOUT after 0.1s:")
         # Should return within a few seconds of the timeout, not hang.
         # Allow generous slack (5s) for CI variance, but catch infinite blocks.
-        assert elapsed < 8, f"Timeout handler took {elapsed:.1f}s — possible pipe read block"
+        assert elapsed < 5, f"Timeout handler took {elapsed:.1f}s — possible pipe read block"
 
     def test_timeout_prefix_format(self, tmp_path: Path) -> None:
         """Output must start with 'TIMEOUT after <N>s:' for gate.py sentinel."""
         cmd = 'python3 -c "import time; time.sleep(300)"'
-        ok, output = _run_shell(cmd, tmp_path, timeout=1)
+        ok, output = _run_shell(cmd, tmp_path, timeout=0.1)
 
         assert ok is False
         # gate.py relies on output.startswith("TIMEOUT") to detect timeouts.
-        assert output.startswith("TIMEOUT after 1s:")
+        assert output.startswith("TIMEOUT after 0.1s:")
 
     def test_timeout_captures_stderr(self, tmp_path: Path) -> None:
         """Partial stderr should also be captured on timeout."""
@@ -60,7 +60,7 @@ class TestRunShellTimeout:
             "sys.stderr.flush(); "
             'time.sleep(300)"'
         )
-        ok, output = _run_shell(cmd, tmp_path, timeout=2)
+        ok, output = _run_shell(cmd, tmp_path, timeout=0.2)
 
         assert ok is False
         assert "STDERR_MARKER" in output

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -276,13 +276,13 @@ class TestRunAgentClaude:
         assert result.output == "some error"
 
     def test_timeout(self, tmp_path: Path) -> None:
-        # Use a 1-second timeout so the test completes quickly.
+        # Use a short timeout so the test completes very quickly.
         profile = ModelProfile(
             name="dev",
             cli="claude",
             model="sonnet",
             budget_usd=1.0,
-            timeout_seconds=1,
+            timeout_seconds=0.1,
             allowed_tools=(),
         )
 
@@ -290,7 +290,7 @@ class TestRunAgentClaude:
             """Simulates a stdout that blocks longer than the timeout."""
 
             def __iter__(self):
-                time.sleep(5)  # longer than timeout_seconds=1
+                time.sleep(0.5)  # longer than timeout_seconds=0.1
                 return iter([])
 
         mock_proc = MagicMock()
@@ -314,14 +314,14 @@ class TestRunAgentClaude:
             cli="claude",
             model="sonnet",
             budget_usd=1.0,
-            timeout_seconds=1,
+            timeout_seconds=0.1,
             allowed_tools=(),
         )
 
         class _PartialStdout:
             def __iter__(self):
                 yield json.dumps({"type": "assistant", "session_id": "sess-timeout"}) + "\n"
-                time.sleep(2)
+                time.sleep(0.5)
                 return
 
         mock_proc = MagicMock()


### PR DESCRIPTION
Optimized indexer disk walk, pytest collection, and slow test timeouts to reduce 'make gate' runtime. Closes GH-785