### PR TITLE
Per-run audit files with contract and redaction (Phase A dual-write)

### DIFF
--- a/docs/plans/forge-storage-layout.md
+++ b/docs/plans/forge-storage-layout.md
@@ -1,0 +1,597 @@
+# Design Note: `.forge/` Storage Layout & Git Policy
+
+Predecessor to knowledge-capture Layer 1. Settles what gets tracked, what
+format it takes, and how existing consumers migrate.
+
+---
+
+## The Decision
+
+**Shared project memory by default, merge-friendly by construction,
+local-only by init-time flag.**
+
+TheForge's audit and knowledge artifacts are part of the project's working
+memory — the same trust boundary as the source code. They should travel with
+the repo by default. Teams with stricter data boundaries opt in to local-only
+mode when they run `forge init`, not via a runtime config that changes
+behavior partway through a project's life.
+
+The default is not "memory is dangerous, uncomment if you dare." It is
+"project memory is designed to be shared. If your repo is public or you have
+stricter data boundaries, pass `--local-memory` to `forge init` and we'll
+write the template that keeps everything on your machine."
+
+**On the OSS concern:** Public-source projects are the one scenario where
+shared memory by default is genuinely the wrong call — audit records can
+contain exploratory prompts, partial plans, or cost data that maintainers
+don't want in the public diff noise. The answer is not a runtime mode but two
+concrete tools: (1) `forge init --local-memory` writes a template that
+gitignores `runs/` and `summaries/` from the start; (2) the `.gitattributes`
+generation below marks tracked per-run files as `linguist-generated=true`,
+which reduces PR diff noise for projects that do track them (mitigation,
+not a guarantee — see the `.gitattributes` section for specifics).
+Together these cover the OSS case without muddying the default.
+
+---
+
+## Design Principles
+
+Two principles govern every choice in this doc. They are stated here so later
+sections can be read against them.
+
+### 1. Shared memory, local override at init
+
+Project memory travels with the repo by default. Opt-out happens once, at
+`forge init`, not as a runtime mode that can be flipped mid-project. A
+runtime mode invites "it worked on my machine" class bugs where two
+contributors disagree about whether a record exists.
+
+### 2. PR-conflict minimization is load-bearing
+
+> Choices should keep PR conflicts minimal unless the alternative can be
+> considered significant complexity.
+
+Complexity is paid once by the implementer. Conflicts are paid forever by
+every user on every parallel run. When the two trade off, accept complexity
+up to a meaningful threshold before accepting conflict surface.
+
+This principle has direct consequences:
+
+- Append-only shared logs are banned. `history.jsonl` is merge-conflict bait
+  by construction and must become a derived view.
+- Single-file rewritten-on-every-run state is banned. `assignment_history.yaml`
+  in its current shape violates this and must become a derived view too (see
+  "Assignment History" below).
+- Per-run files are preferred because parallel runs on different branches
+  produce differently-named files, and git merges them trivially.
+- Binary indexes (SQLite) are acceptable on the read path because they are
+  local-only and gitignored — they have zero conflict surface by definition.
+
+---
+
+## The Category Model
+
+Four categories, enforced by both `.gitignore` and runtime checks:
+
+| Category | Examples | Tracked? | Committing would... |
+|----------|----------|----------|---------------------|
+| **Secrets** | `.env`, `secrets.yaml` | Never | Leak credentials |
+| **Machine-local runtime** | `worktrees/`, `locks/`, `merge.lock`, `daemon.json`, `pending/`, `runs/` (the execution state dir, not the audit dir), root `handoff.yaml` | Never | Break runs: stale PIDs, nested git repos, cross-machine lock false-positives |
+| **Noise / derived views** | `logs/`, `index/`, `audits/history.jsonl`, `audits/index.sqlite`, `knowledge/index.yaml`, `assignment_history.yaml` (derived) | Never (derived or ephemeral) | Create churn or merge conflicts; regenerable |
+| **Project memory + config** | `hooks/`, `.env.example`, `audits/runs/{run_id}.json`, `knowledge/summaries/{run_id}.yaml` | **Default on** (opt out via `forge init --local-memory`) | Nothing — this is the working memory of the project |
+
+The third category is important: **derived views are never tracked, even
+though they contain tracked data.** `history.jsonl`, `index.sqlite`,
+`knowledge/index.yaml`, and `assignment_history.yaml` are rebuildable from
+per-run files. Tracking them would create merge-conflict bait without adding
+information the per-run files don't already have.
+
+### Naming collision note
+
+There are two `runs/` directories with unfortunately similar names:
+
+- `.forge/runs/` — machine-local **execution state** (active run artifacts,
+  temp files, worktree bookkeeping). Never tracked.
+- `.forge/audits/runs/` — the canonical **per-run audit records**. Tracked by
+  default.
+
+Keep them straight. The migration story below is about the audit dir, not
+the execution dir.
+
+---
+
+## The Format Change
+
+The single most important decision: **audit records become per-run files,
+not append-only logs.** The canonical read path becomes a local SQLite index,
+rebuildable on demand from the per-run files.
+
+### Today
+
+```
+.forge/audits/forge_audit.yaml      # overwritten every run (useless as history)
+.forge/audits/history.jsonl         # append-only, single-writer, merge-conflict bait
+```
+
+### Target
+
+```
+.forge/audits/runs/{run_id}.json    # canonical per-run record — tracked, immutable
+.forge/audits/index.sqlite          # local read-path index — ignored, auto-rebuilt
+.forge/audits/history.jsonl         # migration compat only, dropped in Phase D — ignored
+.forge/audits/forge_audit.yaml      # latest-run convenience pointer — ignored
+```
+
+Per-run files merge the way source files do: parallel runs on different
+branches produce differently-named files, git takes both, done. The rollup
+becomes a locally-materialized binary index, rebuilt on demand from `runs/`.
+
+`run_id` is already generated in `run_setup.py` (line 218) and passed to
+`StructuredLogger`. Layer 1 of knowledge-capture surfaces it into the audit
+record. It becomes the stable filename.
+
+### Per-run file contract
+
+Every file in `.forge/audits/runs/` obeys the following invariants:
+
+- **`run_id` is globally unique.** Generated in `run_setup.py`; never reused.
+- **Immutable once written.** A run record is written exactly once, when the
+  run terminates. Mid-run updates go to execution state under `.forge/runs/`,
+  not here. This is what makes per-run files safe to track: they never change
+  after commit, so rebases and cherry-picks are trivial.
+- **`parent_run_id: string | null`** links resume-style runs back to their
+  predecessor. This preserves lineage for tasks that span multiple runs
+  (timeouts, human-interrupted retries, future story decomposition in
+  agent-intelligence Phase 11 — each sub-task is its own run with a pointer
+  back to the parent).
+- **`schema_version: int`** at the top level. Bumped on every breaking change
+  to the record shape. Readers check this before parsing and fall back to
+  migration helpers for old versions. This is how we avoid a flag day when
+  the audit schema evolves.
+- **Best-effort redaction pass before write.** A mandatory redaction pass
+  runs before serializing. It is best-effort, not a proof of absence —
+  arbitrary story text or plan content can still embed secrets the writer
+  can't recognize. What the pass does do, recursively over the audit object:
+  (1) load `.forge/.env` if present, parse `KEY=VALUE` lines (ignore
+  comments, skip empty values, skip values shorter than 8 chars to avoid
+  replacing common strings like `true` or `dev`), and scrub any occurrence
+  of a matched value anywhere in the record; (2) scrub values of any key
+  matching `(?i)(secret|token|password|api[_-]?key|authorization)`; (3)
+  replace `runtime.environment` with a key-only listing. Redaction is
+  applied in the writer, not the reader, so the file on disk is what ships
+  in the repo. Operators who need stronger guarantees layer their own
+  pre-commit hooks on top.
+
+### SQLite index as the read path
+
+`history.jsonl` was doing double duty: it was both the persistent log and the
+query index. Splitting those jobs:
+
+- **Persistent log → per-run JSON files.** Source of truth, tracked,
+  mergeable.
+- **Query index → `.forge/audits/index.sqlite`.** Local, binary, gitignored.
+  Zero merge-conflict surface (it's a binary file nobody commits). Contains
+  indexed columns for the common query shapes: `run_id`, `slug`, `phase`,
+  `outcome`, `model`, `started_at`, plus a full-record blob column.
+- **Staleness detection.** The correctness check is file-presence: on open,
+  the reader lists `runs/*.json` and cross-references against `run_id`s
+  recorded in the index. Any file missing from the index, or any indexed
+  `run_id` whose file is gone, triggers a rebuild. `mtime` is retained as
+  a fast-path optimization (compare max `mtime` against the index's
+  `built_at` to skip the presence check on the common no-change path), but
+  `mtime` alone is not load-bearing — checkout, merge, and clone operations
+  can rewrite timestamps in ways that would otherwise fool it. Rebuilds
+  stream the `runs/` directory in sorted order; the target is "fast
+  enough for interactive use" — measure on dogfood data before committing
+  to a harder number.
+- **`forge audits rebuild`** is the manual escape hatch: deletes the index
+  and rebuilds from scratch.
+
+`sqlite3` is Python stdlib, so this is not a new dependency. The index gives
+us fast structured queries (telemetry aggregation, sprint rollup,
+`_prior_approve_recorded`) without parsing JSONL from scratch on every call.
+
+### Why per-run JSON and not YAML
+
+The existing rollup is JSONL — line-delimited JSON. Per-run files should be
+JSON too for format consistency and faster loading. Human-readability is
+already served by `forge_audit.yaml` (the latest-run convenience copy,
+which stays YAML).
+
+---
+
+## Assignment History
+
+`.forge/assignment_history.yaml` today is a single YAML file rewritten on
+every run to record which models were assigned to which slugs. It violates
+PR-conflict minimization directly: every parallel run on a different branch
+rewrites the same file, and every merge hits the same conflict.
+
+The information it holds is already in the per-run audit records
+(`runtime.assignments`, plus phase-by-phase model selection). The fix is to
+stop treating `assignment_history.yaml` as tracked state and start treating
+it as a derived view over `audits/runs/`:
+
+- **Writer side:** delete the direct writes. The per-run audit record already
+  captures the assignment at run time.
+- **Reader side:** the callers that today load `assignment_history.yaml` to
+  make adaptive-assignment decisions query the SQLite index instead (or the
+  JSON files directly during Phase B).
+- **File status:** moved to the "noise / derived views" category. Gitignored.
+  A thin rebuild command (`forge audits rebuild` or a sibling) regenerates
+  a YAML snapshot locally for operators who want to eyeball it.
+
+This is a breaking change to the adaptive-assignment code path. It is
+staged into the migration sequence below alongside the other consumers.
+
+---
+
+## Consumers of `history.jsonl` — Migration Path
+
+A ripgrep inventory turned up five functional consumers plus tests, plus the
+assignment-history writer/reader pair:
+
+| Consumer | Purpose | Migration |
+|----------|---------|-----------|
+| `coordinator/audit.py` `_prior_approve_recorded()` | Skip-review eligibility when re-running | Query SQLite index by slug + filter for APPROVE |
+| `sprint/audit.py` (2 call sites) | Sprint-level append + rollup | Write per-run files; sprint rollup queries the index |
+| `cli/telemetry.py` — `forge telemetry` | Per-phase cost/duration aggregation | Query SQLite index directly |
+| `cli/shared.py` `_append_history` | The writer | Replace with per-run file writer; redaction pass; retain JSONL append under a feature flag for Phases A–C |
+| `assignment_history.yaml` writer/reader | Adaptive assignment state | Delete writer; readers query index |
+| Tests | Fixture creation | Update to write per-run files (mechanical) |
+
+### Migration sequence (no flag day)
+
+1. **Phase A — Dual-write.** `_write_audit` writes
+   `.forge/audits/runs/{run_id}.json` (with redaction pass, `schema_version`,
+   `parent_run_id`) *and* continues appending to `history.jsonl`. Both
+   consumers work unchanged. Tests verify both paths populate and that the
+   redaction pass strips secrets.
+
+2. **Phase B — Read from the index.** Stand up
+   `.forge/audits/index.sqlite` with staleness detection and cold-rebuild.
+   One consumer at a time, switch from scanning `history.jsonl` to querying
+   the index. Order: telemetry → sprint rollup → `_prior_approve_recorded`
+   → `assignment_history` readers. The last two are the highest-stakes —
+   they gate review skipping and model selection.
+
+   **Mixed-version fallback.** During Phase B, older clients in the same
+   repo still read `history.jsonl`. New-version readers must rebuild the
+   SQLite index from `runs/*.json` whenever they detect it missing or
+   stale — readers never trust a partial index; rebuild-on-miss is cheap.
+   While the dual-write is still active, the rebuild also imports any
+   legacy-only records from `history.jsonl` that have no corresponding
+   `runs/{run_id}.json` file, so readers get one unified view across the
+   migration. A `forge_version` field in each run record lets readers
+   detect and skip records written by newer clients they don't yet
+   understand.
+
+3. **Phase C — Stop writing `history.jsonl`.** Drop the dual-write.
+   **Prerequisite:** at least one release has shipped where all known
+   readers go through the audit repository / index abstraction, and the
+   legacy-import rebuild path has seen real use. Tracked template for new
+   projects already excludes `history.jsonl`. Existing projects keep their
+   file as a historical artifact; by this point nothing reads it.
+   `.forge/assignment_history.yaml` deletion lands in the same story, since
+   both are now derived-only.
+
+4. **Phase D — Clean up.** Delete the migration fallback code from readers.
+   `history.jsonl` is gone from new installs; old installs can delete it
+   manually or ignore it.
+
+Phases A and B can land in a single story. Phases C and D are follow-ups once
+the tracked-per-run path is proven on at least one real sprint.
+
+---
+
+## The Canonical `.gitignore` Block
+
+This is what `forge init` writes. A single commented block, one source of
+truth, embedded in TheForge so docs and runtime stay in sync.
+
+**Default-deny with explicit re-includes.** A blanket `.forge/` ignore
+followed by re-includes is the safer shape: when a future TheForge version
+introduces a new directory under `.forge/`, it defaults to ignored rather
+than accidentally-tracked. The prior draft used explicit-deny because
+re-include syntax is fiddly, but the failure mode (a new runtime dir leaks
+into repos on upgrade) is worse than the syntax cost (well-commented
+re-includes are fine).
+
+```gitignore
+# ── TheForge ──────────────────────────────────────────────────────────
+# TheForge writes everything under .forge/. We deny the whole directory
+# by default and explicitly re-include the paths that are project memory
+# (tracked, travel with the repo) and config (tracked, travel with the
+# repo). Everything else — secrets, runtime state, derived views — stays
+# local to your machine.
+#
+# To opt out of shared memory entirely (public repo, stricter data
+# boundary), run `forge init --local-memory` or delete the project-memory
+# re-includes below (the `audits/` and `knowledge/summaries/` lines —
+# keep the hooks and .env.example re-includes, those are config).
+#
+# See: docs/guides/forge-storage.md
+
+# Deny everything under .forge/ by default
+.forge/**
+
+# Re-include project memory (canonical per-run records)
+!.forge/audits/
+!.forge/audits/runs/
+!.forge/audits/runs/**
+!.forge/knowledge/
+!.forge/knowledge/summaries/
+!.forge/knowledge/summaries/**
+
+# Re-include config
+!.forge/hooks/
+!.forge/hooks/**
+!.forge/.env.example
+
+# Root-level runtime state — always ignored
+handoff.yaml
+# ──────────────────────────────────────────────────────────────────────
+```
+
+**Why this shape:**
+
+- **Default-deny fails closed for future directories.** If TheForge ships
+  a new `.forge/cache/` or `.forge/scratch/` in a future version, existing
+  users who pulled the template won't accidentally start tracking it.
+- **Re-includes are explicit and auditable.** Anyone reading the template
+  can see exactly what travels with the repo.
+- **Opt-out mode (`forge init --local-memory`) just deletes the
+  re-include lines.** The deny rule stays; the shared-memory exceptions
+  go away.
+- **`handoff.yaml` at the repo root is always ignored.** It's phase-routing
+  state that gets overwritten every run. Cross-machine staleness causes
+  wrong gate decisions.
+
+### `.gitattributes` for tracked per-run files
+
+`forge init` also writes (or appends to) `.gitattributes`:
+
+```gitattributes
+# ── TheForge ──────────────────────────────────────────────────────────
+# Audit runs and knowledge summaries are generated by TheForge. Collapse
+# them in PR diffs so reviewers focus on source changes.
+.forge/audits/runs/**  linguist-generated=true
+.forge/knowledge/summaries/**  linguist-generated=true
+# ──────────────────────────────────────────────────────────────────────
+```
+
+This reduces PR diff noise for projects that track memory: GitHub
+collapses the files in PR review by default and excludes them from
+language-statistics churn. It is a mitigation, not a guarantee — file
+lists, commit lists, and search results still surface them. Projects
+that want stronger isolation use `--local-memory` instead.
+
+### `forge init` flags
+
+```
+forge init [--shared-memory | --local-memory]
+```
+
+- `--shared-memory` (default): writes the template above as-is.
+- `--local-memory`: writes the template with the `!.forge/audits/runs/` and
+  `!.forge/knowledge/summaries/` re-includes omitted. Everything stays
+  local. `.gitattributes` is still written (harmless if nothing is tracked).
+
+The flag is resolved once at init time. Switching later means editing the
+`.gitignore` by hand — intentional, since flipping mid-project would strand
+already-committed records.
+
+---
+
+## Runtime Guards: `forge run` Preconditions
+
+`forge init` writes the template, but some users will have pre-existing
+repos or will have customized the template in ways that break. `forge run`
+should catch the catastrophic cases before they matter.
+
+**Blockers** (fail fast, don't start the run):
+
+- `.forge/worktrees/**` is tracked
+- `.forge/locks/**` is tracked
+- `.forge/merge.lock` is tracked
+- `.forge/daemon.json` is tracked
+- `.forge/pending/**` is tracked (execution state)
+- `.forge/runs/**` is tracked (execution state dir, not the audit dir)
+- `.forge/.env` or `.forge/secrets.yaml` is tracked
+- root `handoff.yaml` is tracked
+
+**Warnings** (proceed but surface):
+
+- `.forge/logs/**` is tracked (noise, not broken)
+- `.forge/audits/history.jsonl` is tracked after Phase C migration (should
+  be derived-local by then)
+- `.forge/audits/index.sqlite` is tracked (binary churn; unintended)
+- `.forge/assignment_history.yaml` is tracked after the derived-view
+  migration
+
+The existing `cli/run.py:59` already warns on tracked `secrets.yaml`. This
+story extends that check to the full blocker/warning list. Messages must be
+actionable: `".forge/worktrees/ is tracked in git — run 'git rm --cached -r
+.forge/worktrees/' and commit"`.
+
+---
+
+## Scope Boundaries
+
+**In scope for this design:**
+
+- Category model and naming
+- Per-run audit file format, naming, and contract (immutability,
+  `parent_run_id`, `schema_version`, redaction pass)
+- Canonical `.gitignore` template (default-deny shape)
+- `.gitattributes` generation for `linguist-generated`
+- `forge init --shared-memory | --local-memory`
+- SQLite index as the read path
+- Migration path for `history.jsonl` consumers with mixed-version fallback
+- `assignment_history.yaml` migration to derived view
+- Runtime precondition checks
+
+**Out of scope (explicit non-goals):**
+
+- Runtime config mode (`memory.mode: shared | local`). Rejected. Init-time
+  flag is simpler and avoids mid-project flips.
+- Moving learned state to a sibling directory (`.forge-history/`). Rejected
+  for now — touches every path in audit/router/knowledge code with no
+  proportional benefit once gitignore is crisp.
+- Retention policies, compaction, archival. Real future concerns but not
+  needed to ship the category model.
+- Audit record schema changes beyond adding `run_id`, `parent_run_id`,
+  `schema_version`, and the redaction pass (which Layer 1 leans on).
+- Cross-repo/remote-indexed query (`forge audits query --remote`). Future
+  work — the local index is the floor.
+
+---
+
+## Questions for Future Work
+
+These came up in review but don't block this design. Flagging them so they
+don't get forgotten.
+
+- **Feature branches vs main for audit commits.** Should per-run audit
+  records be committed on the feature branch as part of the work, or
+  squashed into the merge commit, or accumulated on a parallel
+  `audits/` branch? Each has tradeoffs (lineage clarity vs PR noise vs
+  tooling complexity). This doc assumes the first option (records commit
+  alongside source on the feature branch) because it's the simplest and
+  most git-native, but the question is open.
+
+- **Large-repo scaling.** At what point does `runs/*.json` stop being
+  cheap to list? 10k files is fine; 100k is a directory full of pain on
+  some filesystems. Possible future move: shard by date
+  (`runs/2026-04/{run_id}.json`). Not doing this yet because it changes
+  the `run_id → path` mapping and complicates every reader.
+
+- **Cross-repo query.** A future `forge audits query --repos 'foo,bar'`
+  would need a shared index format. Out of scope here but worth keeping
+  in mind when choosing SQLite column shapes — leave room for a `repo`
+  dimension even if we don't populate it yet.
+
+- **Audit record size.** Layer 1 of knowledge-capture adds story text,
+  plan content, and plan regeneration lineage. A large run record could
+  push into the tens of KB. Worth measuring on a real sprint before
+  deciding whether compression or reference-to-worktree-blob is needed.
+
+- **Public-repo review of tracked records.** Before dogfooding on this
+  repo, spot-check a handful of `runs/*.json` to confirm the redaction
+  pass catches what it needs to catch. If it doesn't, extend the pass
+  before flipping the default.
+
+---
+
+## Story Sequence
+
+This design decomposes into a story chain with three distinct classes of
+dependency. Mixing them up is how migrations get scary for no reason, so
+they're called out explicitly:
+
+- **Implementation dependency: Story 1 before knowledge-capture Layer 1.**
+  Layer 1 writes new fields into the per-run audit record. Those fields
+  need a file to land in. That's the whole hard dependency.
+- **Rollout dependency: Stories 1, 4, and 5 before telling users shared
+  memory is the default.** Story 1 gives us the canonical record format.
+  Story 4 gives users a gitignore/gitattributes template that fails closed
+  on new directories and collapses diffs in PR review. Story 5 blocks
+  `forge run` when catastrophic paths are tracked. Without all three,
+  users can generate good per-run files but still get bitten by a stray
+  `.forge/worktrees/` commit.
+- **Performance dependency: Story 2 before any consumer relies on
+  historical queries at scale.** The SQLite index turns O(N) file scans
+  into indexed lookups. Until it lands, `_prior_approve_recorded` and
+  telemetry aggregation stay on the direct-scan path, which is fine at
+  current repo sizes but won't scale.
+
+Stories 3 and 6 are independent of the above. Story 7 is a follow-up.
+Story 8 is a metadata update.
+
+The chain:
+
+1. **Per-run audit files (Phase A — dual-write) with contract and
+   redaction.** `_write_audit` writes `.forge/audits/runs/{run_id}.json`
+   including `schema_version`, `parent_run_id`, `forge_version`, and the
+   redaction pass, in addition to `history.jsonl` and `forge_audit.yaml`.
+   No consumer changes. Tests verify both paths populate, records are
+   immutable after write, and the redaction pass strips known secret shapes.
+
+2. **SQLite index + consumer migration (Phase B).** Stand up
+   `.forge/audits/index.sqlite` with staleness detection and cold-rebuild
+   (`forge audits rebuild`). Switch telemetry, sprint rollup,
+   `_prior_approve_recorded`, and the `assignment_history` readers from
+   scanning `history.jsonl` to querying the index, with a mixed-version
+   fallback to direct-scan `runs/*.json` on index miss. Each consumer is
+   independently testable.
+
+3. **`assignment_history.yaml` → derived view.** Delete the direct writer;
+   readers switch to the index. The tracked file is removed from the
+   template. Migration note for existing users: `forge audits rebuild`
+   regenerates a local YAML view for operators who want it.
+
+4. **Canonical gitignore template in `forge init`.** Write the full
+   default-deny commented block. Generate `.gitattributes` with
+   `linguist-generated=true` entries. Add `--shared-memory` /
+   `--local-memory` flags. Idempotent: don't duplicate if the block already
+   exists. Update `forge secrets-init` to use the same template path.
+
+5. **Runtime precondition checks in `forge run`.** Extend the existing
+   secrets-tracking check to the full blocker/warning list. Fail fast with
+   actionable messages.
+
+6. **Dogfood: align TheForge's own `.gitignore` and `.gitattributes`
+   against the template.** Replace the current ad-hoc block. The dogfood
+   config becomes the reference implementation users will look at. Spot-
+   check recent `runs/*.json` for leaked secrets before flipping.
+
+7. **Phase C cleanup — stop writing `history.jsonl`.** Drop the dual-write
+   once Phase B is proven on a real sprint. Follow-up story, not in the
+   initial chain.
+
+8. **Rescope #307.** The existing "document filesystem layout" issue
+   points at the canonical template and category model rather than
+   reinventing the documentation from scratch.
+
+Stories 1 and 2 are the substantive work. 3, 4, 5, 6 are mechanical once
+the format is settled.
+
+**Knowledge-capture Layer 1 can land as soon as Story 1 does**, writing
+`run_id`, story text, and plan content into the per-run audit records.
+No new storage decisions, just field additions. Stories 2–6 land in
+parallel or shortly after, on the rollout and performance timelines
+described above.
+
+---
+
+## Relationship to Knowledge Capture
+
+Knowledge-capture Layer 1 (`docs/plans/knowledge-capture.md`) adds fields to
+the audit record: story text, plan content, plan regeneration lineage,
+`run_id`. This design note adds the *file format, location, index, and
+policy* those fields land into.
+
+The two land together as a coherent story chain:
+
+```
+forge-storage-layout (this doc)
+  → Story 1: per-run audit files with contract + redaction (dual-write)
+  → Story 2: SQLite index + consumer migration (with mixed-version fallback)
+  → Story 3: assignment_history → derived view
+  → Story 4: canonical gitignore + gitattributes + init flags
+  → Story 5: runtime precondition checks
+  → Story 6: dogfood
+  → Story 7: Phase C cleanup (follow-up)
+  → Story 8: rescope #307
+
+knowledge-capture (sibling doc)
+  → Layer 1: richer audit capture (writes into per-run files)
+  → Layer 2: post-run summaries (.forge/knowledge/summaries/{run_id}.yaml)
+  → Layer 3: feedback loop
+```
+
+Knowledge-capture Layer 1 has a hard implementation dependency on Story 1
+and nothing else from this chain. Stories 2–6 are independent
+improvements that land on the rollout and performance timelines described
+in "Story Sequence" above, and they also unblock other downstream work
+(the self-adapting router flywheel queries the same index, for example).

--- a/docs/plans/knowledge-capture.md
+++ b/docs/plans/knowledge-capture.md
@@ -1,0 +1,492 @@
+# Proposal: Compounding Engineering Memory for TheForge
+
+From deterministic orchestration to a system that learns from its own work.
+
+---
+
+## The Observation
+
+TheForge runs stories through a deterministic pipeline — plan, dev, validate,
+review — and produces structured audit records for every run. But the audit
+trail captures **process metrics** (cost, duration, iterations, verdicts)
+while discarding the **reasoning inputs** that drove those metrics.
+
+The result: every run starts from scratch. The system doesn't know what plans
+worked for similar stories, what review findings recur, what failure modes
+have already been diagnosed and solved, or what conventions the codebase has
+evolved. Every agent rediscovers the same things.
+
+This proposal turns TheForge from a system that **runs work deterministically**
+into one that also **accumulates structured knowledge from every run** — and
+feeds that knowledge back into future runs.
+
+---
+
+## Why Now
+
+Three things are converging:
+
+**The adaptive router needs historical signal.** The self-adapting router
+vision (`docs/vision/self-adapting-router.md`) describes a flywheel:
+"Run stories → Collect telemetry → Update performance table → Better routing."
+That flywheel runs on process metrics alone today — model, phase, outcome,
+cost, duration. But the router's real power comes from correlating outcomes
+with *what was attempted*: story complexity, plan approach, domain, failure
+mode. That requires capturing the inputs, not just the outputs.
+
+**Story decomposition will produce ephemeral tasks.** Phase 11 in `vision.md`
+describes document-in decomposition: brief → stories → sub-tasks → sprint.
+Decomposed sub-tasks won't have stable file paths or GH issues — they're
+generated artifacts. If the audit doesn't snapshot what was requested, those
+runs leave no record of what was actually done.
+
+**Independent convergence.** A colleague working on spec-driven agent workflows
+arrived at the same architecture independently: bounded roles, deterministic
+gates, auditability, and a compounding documentation layer. When two people
+find the same shape without coordination, it's usually a constraint being
+surfaced, not a trend being followed.
+
+---
+
+## What's Missing Today
+
+### Inputs are discarded
+
+| Artifact | What's captured | What's lost |
+|----------|----------------|-------------|
+| Story | `story_path` as string (serializes as `"None"` for issue-sourced stories) | Story text the agent actually saw; `github_issue` number |
+| Plan | cost, duration, outcome (audit block at `audit.py:119`) | `plan_structured` content — approach, steps, files, risks |
+| Plan lineage | `plan_finding_registry`, `plan_match_provenance`, `plan_regen_filter_audit` (review-side trajectory) | Per-attempt parsed plan content (overwritten in `state.plan_structured` on each regen) |
+| Dev prompt | Nothing | What the agent was told |
+| Review narrative | Finding registry (severity, disposition, description) | Reviewer reasoning beyond individual findings |
+
+The audit tells you a run took 3 dev iterations and cost $18. It doesn't
+tell you what the plan said, what the story asked for, or what the reviewer
+was thinking.
+
+### Runs are isolated
+
+Each run is a closed system. The context assembler (`task/context_assembler.py`)
+builds context packs from the structural index, CLAUDE.md files, story text,
+plan output, and review findings — but only from the *current* run. It has
+no mechanism to include knowledge from prior runs: solved problems, validated
+approaches, recurring failure patterns, or codebase conventions learned through
+experience.
+
+### Knowledge lives in the wrong places
+
+Some knowledge does accumulate, but in places that are hard to query:
+
+- **Escalation history** (`assignment_history.yaml`) — records model failures,
+  feeds adaptive assignment. This is the closest thing to compounding memory
+  today, but it only covers model selection.
+- **Worktree artifacts** (plan.md, traces, logs) — rich but ephemeral. Gone
+  when the worktree is cleaned up.
+- **JSONL history** (`history.jsonl`) — append-only, complete, but stores
+  only process metrics per run.
+- **Git history** — the ultimate record of what changed, but has no link back
+  to why it was changed or what was learned.
+
+---
+
+## The Proposal: Three Layers
+
+### Layer 1 — Capture What We're Already Discarding
+
+Small, scoped changes to existing audit serialization. No new phases, no new
+config, no new artifacts. Pure data preservation.
+
+#### Data contract
+
+Layer 1 adds the following fields to the audit record produced by
+`generate_audit_log()`:
+
+```yaml
+# ── task block (existing, extended) ──────────────────────────
+task:
+  name: string
+  slug: string
+  story_path: string | null          # fixed: currently serializes as "None" for issue-sourced
+  story_text: string                 # the text the agent actually saw (snapshotted at load time)
+  github_issue: int | null           # link back to source issue
+
+# ── run identity (new) ───────────────────────────────────────
+run_id: string                       # already exists in StructuredLogger; surface in audit record
+
+# ── plan block (existing, extended) ──────────────────────────
+plan:
+  cost_usd: float
+  duration_s: float
+  outcome: string
+  plan_structured: PlanData | null   # the final parsed plan: approach, steps, files, risks
+  attempt_plans:                     # per-attempt plan snapshots (only populated on regen)
+    - attempt: int                   # 0-indexed
+      plan: PlanData | null          # parsed plan for this attempt
+```
+
+**What is explicitly out of scope for Layer 1:**
+
+- Raw dev prompts and full agent responses. These may contain secrets,
+  large pasted logs, or unbounded content. They remain in per-run log
+  files under `.forge/logs/{slug}/` where they already live.
+- Review narrative beyond the finding registry. The finding registry
+  already captures description, severity, disposition, cycle tracking,
+  and reporter identity — that's sufficient structured data for Layer 3
+  correlation without introducing freeform text.
+
+#### Implementation details
+
+**Story text plumbing.** `generate_audit_log(config, task, result)` does not
+currently receive `story_content`. The story is loaded in `engine.py` (line
+534: `story_content = task.story_text if task.story_text is not None else
+load_story(task.story_path)`) and in `run_setup.py` (line 276). Two options:
+
+- **(a) Store in state** — `CoordinatorState` gets a `story_content: str | None`
+  field, set at load time. `generate_audit_log` reads from `state`.
+- **(b) Re-read at audit time** — `audit.py` reads `task.story_path` if
+  `task.story_text` is None.
+
+Option (a) is better: it captures what the agent actually saw, not what the
+file contains at audit time (the story could be edited mid-run in an
+interactive session, or the worktree could be in a different state).
+
+**`story_path` serialization fix.** Currently `str(task.story_path)` produces
+the literal string `"None"` for issue-sourced stories. Fix to emit JSON null.
+
+**`run_id` in audit.** The run ID is generated in `run_setup.py` (line 218:
+`_run_id = run_id or _cu._generate_run_id()`) and passed to `StructuredLogger`,
+but is not included in the audit record. Add it as a top-level field. This
+becomes the stable identity key for Layer 2 summary storage.
+
+**Plan attempt snapshots.** The plan review trajectory fields
+(`plan_finding_registry`, `plan_match_provenance`, `plan_regen_filter_audit`,
+`plan_attempt_metadata`) already capture the *review-side* of each regen
+cycle. What's missing is the *plan-side*: the parsed plan content per attempt.
+Currently `state.plan_structured` is overwritten on each successful regen
+(`plan_flow.py` lines 922-924).
+
+Add `plan_attempt_plans: list[PlanData | None]` to `CoordinatorState`. Append
+`state.plan_structured` before overwriting on regen. This complements the
+existing trajectory fields without duplicating them — they track review
+decisions, this tracks what was reviewed.
+
+Serialize as `attempt_plans` in the plan audit block, alongside the existing
+`plan_attempt_metadata`.
+
+#### Layer 1 cost
+
+~40 lines across `audit.py`, `state.py`, `plan_flow.py`, `engine.py`.
+No new dependencies. Backward-compatible — existing audit consumers ignore
+unknown keys. Extends existing audit-generation tests to assert new fields.
+
+---
+
+### Layer 2 — Structured Run Summaries
+
+After REVIEW → DONE, the coordinator emits a structured knowledge artifact:
+a run summary that distills what happened into a form useful for future runs
+and human review.
+
+#### What the summary contains
+
+```yaml
+run_summary:
+  what_changed:
+    description: "Added retry logic to API client with exponential backoff"
+    files_modified: ["src/client.py", "tests/test_client.py"]
+    approach: "Wrapped existing call sites in retry decorator; added config..."
+
+  what_was_learned:
+    - claim: "API timeout handling requires both connection and read timeouts"
+      evidence:
+        - type: review_finding
+          finding_id: "f-003"
+          description: "P1: missing read timeout on retry path"
+        - type: plan_step
+          step_id: "s-2"
+          description: "Step 2: add configurable timeout pair"
+    - claim: "This codebase uses decorator pattern for cross-cutting concerns"
+      evidence:
+        - type: file
+          path: "src/decorators.py"
+          description: "Existing @rate_limit, @cache, @log_calls decorators"
+
+  review_insights:
+    recurring_findings:
+      - finding_id: "f-007"
+        description: "Missing type annotations on public API"
+        cycles_seen: 3
+    resolved_findings:
+      - finding_id: "f-003"
+        description: "Race condition in connection pool"
+        resolution: "Fixed via context manager in pool.acquire()"
+
+  complexity_signal:
+    actual_iterations: 2
+    plan_regenerations: 1
+    dominant_difficulty: "edge case coverage"
+```
+
+#### Provenance is mandatory
+
+Every claim in `what_was_learned` must include an `evidence` list linking it
+to concrete artifacts from the run: finding IDs, plan step IDs, file paths,
+diff hunks, or review cycle numbers. This is the guard against hallucinated
+institutional memory. A summary agent that can't cite evidence for a claim
+should omit the claim.
+
+The schema validator rejects `what_was_learned` entries with empty `evidence`
+lists.
+
+#### How it's generated
+
+This is a **bounded agent task** — summarize, don't decide. The coordinator
+provides the plan, story, diff, review findings, and iteration history. The
+agent returns structured YAML. The coordinator validates schema and persists.
+
+This fits the existing model: LLMs generate artifacts, the coordinator
+validates them mechanically. The summary is an artifact like any other —
+schema-enforced, auditable, stored in the run record.
+
+#### Where it lives
+
+- In the audit record, alongside the existing blocks (inline).
+- Written to `.forge/knowledge/summaries/{run_id}.yaml` for querying across
+  runs. Keyed by `run_id` (not slug) to avoid collisions across reruns of
+  the same story.
+
+#### When it runs
+
+**Optionally, after DONE.** Not on every run — configurable in `forge.yaml`:
+
+```yaml
+knowledge:
+  run_summaries: true    # default: false initially
+```
+
+Cost is minimal: one bounded agent call with constrained output. Estimated
+$0.10-0.30 per run using a mid-tier model. The summary phase is **not
+load-bearing** — if it fails, the run still succeeded. The DONE transition
+is already committed; summary generation is a post-DONE side effect, not a
+gate.
+
+---
+
+### Layer 3 — Knowledge Feedback Loop
+
+This is where it compounds. Prior run summaries feed into future runs
+through the existing context assembly machinery.
+
+#### 3a. Knowledge index
+
+Summaries accumulate in `.forge/knowledge/summaries/`. A lightweight index
+tracks them by domain, file, pattern, and recency:
+
+```yaml
+# .forge/knowledge/index.yaml (derived, rebuildable, disposable)
+entries:
+  - run_id: "20260410-143022-api-retry"
+    slug: "api-retry-logic"
+    domain: "backend-api"
+    files: ["src/client.py"]
+    patterns: ["retry", "timeout", "exponential-backoff"]
+    timestamp: "2026-04-10T14:30:00"
+    summary_path: ".forge/knowledge/summaries/20260410-143022-api-retry.yaml"
+```
+
+The index is **rebuilt deterministically from summaries** — no LLM in the
+loop. Simple keyword extraction from `what_changed.description`,
+file paths from `files_modified`, and domain from preflight classification
+(already captured in audit). The index is a materialized view, not a source
+of truth. It can be deleted and rebuilt at any time from the summary files.
+
+#### 3b. Context assembly integration
+
+The context assembler (`task/context_assembler.py`) already builds
+phase-specific context packs with budget-aware inclusion/exclusion and
+required/advisory separation. Knowledge items become a new advisory source
+alongside structural index, CLAUDE.md, and plan output:
+
+```python
+ContextItem(
+    source="knowledge:20260410-143022-api-retry",
+    kind="prior_run_summary",
+    required=False,        # advisory — droppable under budget pressure
+    lines=12,
+    content="...",
+    reason="Prior run modified src/client.py (file overlap with current plan)",
+    score=75,              # relevance: recency + file overlap + domain match
+)
+```
+
+The assembler scores knowledge items by relevance (file overlap with current
+story's plan, domain match, recency) and includes the top N within the
+phase's line budget. Low-relevance items get dropped — same as any other
+advisory context item. The manifest records what was included and what was
+dropped, maintaining full audit visibility into what knowledge the agents
+actually received.
+
+#### 3c. Phase-specific knowledge injection
+
+Different phases benefit from different knowledge:
+
+| Phase | Knowledge type | Example |
+|-------|---------------|---------|
+| Preflight | Complexity signals from similar stories | "Stories touching src/client.py averaged 2.5 iterations" |
+| Plan | Approaches that worked/failed for related changes | "Prior retry implementation used decorator pattern" |
+| Dev | Conventions and patterns from this codebase | "This codebase uses X pattern for cross-cutting concerns" |
+| Review | Recurring findings in this area | "Type annotations on public API flagged in 3 prior reviews" |
+
+#### 3d. The flywheel
+
+```
+Run story
+  → Capture inputs (Layer 1)
+  → Generate summary (Layer 2)
+  → Index summary (Layer 3a)
+  → Next run's context includes relevant summaries (Layer 3b)
+  → Agents start with knowledge, not from scratch
+  → Better plans, fewer iterations, fewer rediscovered findings
+  → Richer summaries from higher-quality runs
+  → Repeat
+```
+
+After 10-20 runs against a repo, the knowledge index contains a useful
+map of the codebase as experienced through actual work: which areas are
+tricky, what conventions matter, what patterns recur, what approaches
+work. This is not documentation — it's institutional memory earned through
+practice.
+
+#### 3e. Feeding the adaptive router
+
+The self-adapting router (`docs/vision/self-adapting-router.md`) consumes
+**deterministic metrics and structured inputs from the audit record**, not
+freeform summary claims. Layer 1 enriches the router's data model from:
+
+```
+{model, phase, outcome, cost, duration, p1_count, cycles}
+```
+
+to:
+
+```
+{model, phase, outcome, cost, duration, p1_count, cycles,
+ story_complexity, story_domain, plan_approach, plan_regen_count,
+ file_count, acceptance_criteria_count}
+```
+
+This enables correlations the current data can't support:
+
+- "Stories with >5 acceptance criteria in the backend-api domain average
+  3.2 iterations with sonnet, 1.8 with opus"
+- "Plan regeneration rate for this complexity class is 40% with mid-tier,
+  10% with strong-tier"
+- "Review cycle count correlates with plan quality score more than with
+  dev model tier"
+
+The router queries deterministic fields, not LLM-authored summaries. This
+is an important boundary: **the router trusts data the coordinator produced;
+it does not trust claims an LLM made about that data.** Summaries inform
+agents (which are already LLMs operating under bounded roles); the router
+operates on facts.
+
+---
+
+## What This Proposal Does NOT Include
+
+**Docs reorganization.** No new `docs/solutions/`, `docs/patterns/`,
+`docs/decisions/` directories. Human-facing documentation structure is a
+separate concern. The knowledge captured here is machine-readable run data,
+not prose documentation.
+
+**Target-repo documentation generation.** Generating docs *about* the repo
+TheForge is operating on (architecture docs, API references, etc.) is a
+different capability. This proposal captures knowledge *from runs*, not
+knowledge *about codebases*.
+
+**LLM-driven process decisions.** Summaries are artifacts, not routing
+inputs. The knowledge index is built deterministically. Context assembly
+scores items with simple heuristics. The coordinator remains pure Python
+throughout.
+
+**New pipeline states.** The summary generation in Layer 2 is a post-DONE
+step, not a new state machine state. If it fails, the run is still DONE.
+
+**Raw prompt or response capture.** Dev prompts, full agent responses, and
+review narratives may contain secrets, large pasted content, or unbounded
+text. These remain in per-run log files. Layer 1 captures structured,
+bounded inputs (story text, parsed plan data) — not raw I/O.
+
+---
+
+## Implementation Sequence
+
+| Layer | Scope | Effort | Depends on |
+|-------|-------|--------|------------|
+| 1a: Story text + issue in audit | `audit.py`, `state.py`, `engine.py` | ~15 lines | Nothing |
+| 1b: `story_path` null fix | `audit.py` | ~3 lines | Nothing |
+| 1c: `run_id` in audit | `audit.py` | ~3 lines | Nothing |
+| 1d: Plan content in audit | `audit.py` | ~5 lines | Nothing |
+| 1e: Plan attempt snapshots | `state.py`, `plan_flow.py`, `audit.py` | ~20 lines | Nothing |
+| 2: Run summaries | Schema, summary agent, config, storage | Medium story | Layer 1 |
+| 3a: Knowledge index | Index builder, storage | Small story | Layer 2 |
+| 3b: Context integration | `context_assembler.py`, scoring | Medium story | Layer 3a |
+| 3c: Phase-specific injection | Prompt builders in `task/` | Medium story | Layer 3b |
+| 3d: Router integration | Router queries against enriched audit data | Medium story | Layer 1 + router |
+
+Layer 1 is a single story — five small changes, ~45 lines total, no new
+dependencies. Ship it, start accumulating richer audit data immediately.
+
+Layer 2 is a story. Needs schema design for summaries (with provenance
+validation), a bounded agent call, `forge.yaml` config key, and storage
+under `.forge/knowledge/summaries/{run_id}.yaml`.
+
+Layer 3 is 2-3 stories: index builder, context assembly integration, and
+phase-specific prompt changes. Each builds on the previous but is
+independently useful.
+
+Router integration (3d) can happen in parallel with Layer 3 — it depends on
+Layer 1 data but not on summaries.
+
+---
+
+## Success Criteria
+
+The knowledge system compounds if:
+
+- **Rediscovery drops.** Agents stop re-learning the same conventions,
+  patterns, and failure modes. Measurable: compare iteration counts for
+  stories touching files that have prior run summaries vs. files that don't.
+
+- **Plan quality improves.** Plans that draw on prior approaches get fewer
+  REGEN cycles. Measurable: plan regeneration rate over time.
+
+- **Review findings converge.** Recurring findings get addressed proactively
+  in dev rather than caught in review. Measurable: restated-finding rate
+  across runs.
+
+- **Router accuracy improves.** Model selection based on story
+  characteristics outperforms static tier tables. Measurable: first-attempt
+  success rate.
+
+- **Sprint velocity increases.** The same budget buys more completed stories
+  over time because agents start smarter. Measurable: stories/dollar trend.
+
+If these metrics don't move after 20-30 runs, the knowledge layer isn't
+earning its keep and should be simplified or removed. The system should
+prove its value empirically, not be maintained on faith.
+
+---
+
+## Bottom Line
+
+TheForge already has the execution loop, the audit infrastructure, and the
+context assembly machinery. The gap is that runs don't learn from each other.
+
+Layer 1 closes the data gap — stop discarding inputs.
+Layer 2 distills runs into reusable knowledge — evidence-backed summaries.
+Layer 3 feeds knowledge back into future runs — the compounding effect.
+
+The end state: every story TheForge runs leaves the system better equipped
+for the next one. Not because someone wrote documentation, but because the
+system's own work is its training data.

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -16,6 +16,7 @@ from theforge.config import (
     _validate_plan_provider,
 )
 from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.redact import redact
 from theforge.coordinator.state import CoordinatorResult
 from theforge.task import TaskStory, build_dev_prompt, build_review_prompt, load_story
 
@@ -126,7 +127,59 @@ def _write_audit(result: CoordinatorResult, config: ForgeConfig, task: TaskStory
                 yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
         except Exception:
             pass  # best-effort
+    # Write per-run JSON record (Phase A dual-write).
+    _write_per_run_record(result, config, audit, audits_dir)
     return audit_path
+
+
+def _write_per_run_record(
+    result: CoordinatorResult,
+    config: ForgeConfig,
+    audit: dict,
+    audits_dir: Path,
+) -> None:
+    """Write a per-run JSON record to .forge/audits/runs/{run_id}.json.
+
+    The record is written exactly once at run termination, carries schema_version,
+    run_id, and parent_run_id (null for Phase A — resume lineage is not yet tracked),
+    and is scrubbed by a best-effort redaction pass before hitting disk.
+
+    Missing run_id (e.g. very old coordinator path) silently skips the write so
+    existing behaviour is unchanged.
+    """
+    run_id = result.state.run_id
+    if not run_id:
+        return
+
+    try:
+        runs_dir = audits_dir / "runs"
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        run_file = runs_dir / f"{run_id}.json"
+        # Don't overwrite an already-written record (immutability contract).
+        if run_file.exists():
+            return
+
+        record: dict = {
+            "schema_version": 1,
+            "run_id": run_id,
+            "parent_run_id": None,
+            "forge_version": audit.get("forge_version"),
+        }
+        record.update(audit)
+        # Ensure the envelope fields stay at the top (dict insertion order is preserved).
+        # Re-insert them so they shadow any same-named keys from audit.
+        record["schema_version"] = 1
+        record["run_id"] = run_id
+        record["parent_run_id"] = None
+        record["forge_version"] = audit.get("forge_version")
+
+        env_file = config.project_root / _SECRETS_FILE
+        redacted = redact(record, env_file if env_file.exists() else None)
+
+        with open(run_file, "w", encoding="utf-8") as f:
+            json.dump(redacted, f, default=str, indent=2)
+    except Exception:
+        pass  # best-effort — never block a run on audit write failure
 
 
 def _cmd_dry_run(config: ForgeConfig, task: TaskStory, story_path: Path) -> int:

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -536,6 +536,7 @@ def run_task(
 
     # ── Structured logger ──────────────────────────────────────────
     _run_id = run_id or _generate_run_id()
+    state.run_id = _run_id
     logger = StructuredLogger(
         run_id=_run_id,
         project=config.project,

--- a/src/theforge/coordinator/redact.py
+++ b/src/theforge/coordinator/redact.py
@@ -1,0 +1,108 @@
+"""Best-effort secret redaction for audit records.
+
+Applies three scrubbing passes before any audit record reaches disk:
+
+1. Key-pattern scrub: dict keys matching secret-shaped names (secret, token,
+   password, api_key, authorization, …) have their values replaced with
+   "[REDACTED]".
+2. Env-file value scrub: values loaded from a .env file are replaced wherever
+   they appear as substrings inside string values.  Values shorter than 8
+   characters are skipped to avoid replacing common innocuous strings like
+   "true" or "dev".
+3. Environment-dict replacement: any dict key named "environment" whose value
+   is a dict is replaced with a sorted list of its keys only.
+
+Redaction is best-effort.  Arbitrary story or plan text can still embed secrets
+the scrubber cannot recognise.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from pathlib import Path
+from typing import Any
+
+_SECRET_KEY_RE = re.compile(r"(?i)(secret|token|password|api[_-]?key|authorization)")
+_MIN_SECRET_LEN = 8
+
+
+def _load_env_secrets(env_file: Path) -> set[str]:
+    """Parse KEY=VALUE pairs from an env file; return the set of values to scrub.
+
+    Rules:
+    - Lines starting with # are comments and are skipped.
+    - Blank lines are skipped.
+    - Values shorter than _MIN_SECRET_LEN chars are skipped (avoids replacing
+      common non-secret strings like "true", "dev", "1").
+    - Surrounding quotes (" or ') are stripped from values.
+    """
+    secrets: set[str] = set()
+    try:
+        text = env_file.read_text(encoding="utf-8")
+    except OSError:
+        return secrets
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        _key, _, value = line.partition("=")
+        value = value.strip()
+        # Strip surrounding quotes
+        if len(value) >= 2 and value[0] in ('"', "'") and value[-1] == value[0]:
+            value = value[1:-1]
+        if len(value) >= _MIN_SECRET_LEN:
+            secrets.add(value)
+    return secrets
+
+
+def _redact_value(val: str, secrets: set[str]) -> str:
+    """Replace occurrences of any known secret inside a string value."""
+    for secret in secrets:
+        if secret in val:
+            val = "[REDACTED]"
+            break
+    return val
+
+
+def _redact_obj(obj: Any, secrets: set[str]) -> Any:
+    """Recursively walk and scrub a JSON-serialisable object."""
+    if isinstance(obj, dict):
+        result: dict[str, Any] = {}
+        for k, v in obj.items():
+            # Pass 3: environment dict → key-only list
+            if k == "environment" and isinstance(v, dict):
+                result[k] = sorted(v.keys())
+                continue
+            # Pass 1: secret-shaped key → redact value
+            if _SECRET_KEY_RE.search(str(k)):
+                result[k] = "[REDACTED]"
+                continue
+            result[k] = _redact_obj(v, secrets)
+        return result
+    if isinstance(obj, list):
+        return [_redact_obj(item, secrets) for item in obj]
+    if isinstance(obj, str):
+        return _redact_value(obj, secrets)
+    return obj
+
+
+def redact(obj: Any, env_file: Path | None) -> Any:
+    """Return a deep-copied, scrubbed version of *obj*.
+
+    Args:
+        obj: Any JSON-serialisable object (dict, list, scalar).
+        env_file: Optional path to a KEY=VALUE env file whose values should be
+            redacted from the output.  Missing files are silently ignored.
+
+    Returns:
+        A new object of the same type with secrets replaced by "[REDACTED]".
+    """
+    secrets: set[str] = set()
+    if env_file is not None:
+        secrets = _load_env_secrets(env_file)
+
+    return _redact_obj(copy.deepcopy(obj), secrets)

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -216,6 +216,7 @@ def _setup_resume_entry(
     _task_start = time.monotonic()
 
     _run_id = run_id or _cu._generate_run_id()
+    state.run_id = _run_id
     logger = StructuredLogger(
         run_id=_run_id,
         project=config.project,

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -221,6 +221,7 @@ class CoordinatorState:
 
     phase: Phase = Phase.INIT
     started_at: str | None = None  # ISO timestamp set at INIT
+    run_id: str | None = None  # unique id for this run; set by run_task / _setup_resume_entry
     workspace_path: Path | None = None
     branch_name: str | None = None
     dev_session_id: str | None = None

--- a/tests/test_cli_audit_per_run.py
+++ b/tests/test_cli_audit_per_run.py
@@ -1,0 +1,164 @@
+"""Tests for per-run audit file write in cli/shared.py (_write_per_run_record)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.cli.shared import _write_audit
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+
+
+def _make_result(tmp_path: Path, run_id: str | None = "run-test-001") -> CoordinatorResult:
+    state = CoordinatorState()
+    state.run_id = run_id
+    return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="done")
+
+
+class TestPerRunFileWrite:
+    def test_per_run_file_created(self, tmp_path: Path) -> None:
+        """_write_audit creates .forge/audits/runs/{run_id}.json."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-abc-001")
+
+        _write_audit(result, config, task)
+
+        run_file = tmp_path / ".forge" / "audits" / "runs" / "run-abc-001.json"
+        assert run_file.exists(), "per-run JSON file should have been written"
+
+    def test_per_run_file_is_valid_json(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-valid-json")
+
+        _write_audit(result, config, task)
+
+        run_file = tmp_path / ".forge" / "audits" / "runs" / "run-valid-json.json"
+        with open(run_file) as f:
+            data = json.load(f)
+        assert isinstance(data, dict)
+
+    def test_per_run_file_has_required_envelope_fields(self, tmp_path: Path) -> None:
+        """schema_version, run_id, and parent_run_id must be present."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-envelope-001")
+
+        _write_audit(result, config, task)
+
+        run_file = tmp_path / ".forge" / "audits" / "runs" / "run-envelope-001.json"
+        data = json.loads(run_file.read_text())
+
+        assert "schema_version" in data
+        assert data["schema_version"] == 1
+        assert "run_id" in data
+        assert data["run_id"] == "run-envelope-001"
+        assert "parent_run_id" in data
+        assert data["parent_run_id"] is None
+        assert "forge_version" in data
+
+    def test_per_run_file_not_written_when_run_id_is_none(self, tmp_path: Path) -> None:
+        """When run_id is None, the per-run file should not be written."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id=None)
+
+        _write_audit(result, config, task)
+
+        runs_dir = tmp_path / ".forge" / "audits" / "runs"
+        # Either the directory doesn't exist or contains no files
+        if runs_dir.exists():
+            assert list(runs_dir.iterdir()) == []
+
+    def test_history_jsonl_still_appended(self, tmp_path: Path) -> None:
+        """Dual-write: history.jsonl must also be appended."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-dual-write")
+
+        _write_audit(result, config, task)
+
+        history_path = tmp_path / ".forge" / "audits" / "history.jsonl"
+        assert history_path.exists(), "history.jsonl should still be appended"
+        lines = history_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert isinstance(record, dict)
+
+    def test_two_separate_run_ids_produce_distinct_files(self, tmp_path: Path) -> None:
+        """Two runs with different run_ids must produce two distinct files."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        result1 = _make_result(tmp_path, run_id="run-first-001")
+        result2 = _make_result(tmp_path, run_id="run-second-002")
+
+        _write_audit(result1, config, task)
+        _write_audit(result2, config, task)
+
+        runs_dir = tmp_path / ".forge" / "audits" / "runs"
+        files = sorted(f.name for f in runs_dir.iterdir())
+        assert "run-first-001.json" in files
+        assert "run-second-002.json" in files
+        assert len(files) == 2
+
+    def test_per_run_file_not_overwritten_on_second_call(self, tmp_path: Path) -> None:
+        """Immutability: a second write with the same run_id must not overwrite."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-immutable-001")
+
+        _write_audit(result, config, task)
+        run_file = tmp_path / ".forge" / "audits" / "runs" / "run-immutable-001.json"
+        mtime1 = run_file.stat().st_mtime
+
+        # Simulate a second call (e.g. accidental re-run with same id)
+        import time
+
+        time.sleep(0.01)
+        _write_audit(result, config, task)
+        mtime2 = run_file.stat().st_mtime
+
+        assert mtime1 == mtime2, "per-run file must not be modified after initial write"
+
+    def test_redaction_applied_to_secret_key(self, tmp_path: Path) -> None:
+        """Values under secret-shaped keys must be redacted in the per-run file."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-redact-001")
+
+        fake_audit = {
+            "forge_version": "0.0.0",
+            "credentials": {"token": "super-secret-value"},
+        }
+        with patch("theforge.cli.shared.generate_audit_log", return_value=fake_audit):
+            _write_audit(result, config, task)
+
+        run_file = tmp_path / ".forge" / "audits" / "runs" / "run-redact-001.json"
+        data = json.loads(run_file.read_text())
+        assert data["credentials"]["token"] == "[REDACTED]"
+
+    def test_redaction_applied_from_env_file(self, tmp_path: Path) -> None:
+        """Values present in .forge/.env must be redacted from the per-run file."""
+        env_dir = tmp_path / ".forge"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        (env_dir / ".env").write_text("MY_PRIVATE_KEY=private_key_value_here\n")
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-env-redact-001")
+
+        fake_audit = {
+            "forge_version": "0.0.0",
+            "output": "using key private_key_value_here in request",
+        }
+        with patch("theforge.cli.shared.generate_audit_log", return_value=fake_audit):
+            _write_audit(result, config, task)
+
+        run_file = tmp_path / ".forge" / "audits" / "runs" / "run-env-redact-001.json"
+        data = json.loads(run_file.read_text())
+        assert data["output"] == "[REDACTED]"

--- a/tests/test_coord_redact.py
+++ b/tests/test_coord_redact.py
@@ -1,0 +1,132 @@
+"""Tests for coordinator/redact.py (best-effort secret redaction)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.coordinator.redact import redact
+
+# ── redact() unit tests ─────────────────────────────────────────────────────
+
+
+class TestRedactEnvFile:
+    def test_replaces_env_value_in_string(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("MY_SECRET=supersecretvalue123\n")
+        result = redact({"output": "token is supersecretvalue123 done"}, env)
+        assert result["output"] == "[REDACTED]"
+
+    def test_skips_values_shorter_than_8_chars(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("SHORT=dev\n")  # 3 chars — should not be treated as a secret
+        result = redact({"output": "env is dev here"}, env)
+        assert result["output"] == "env is dev here"
+
+    def test_ignores_missing_env_file(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.env"
+        result = redact({"key": "value"}, missing)
+        assert result == {"key": "value"}
+
+    def test_none_env_file_no_crash(self) -> None:
+        result = redact({"x": "hello"}, None)
+        assert result == {"x": "hello"}
+
+    def test_strips_quoted_values_in_env(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text('API_KEY="mysecretkey9876"\n')
+        result = redact({"header": "Bearer mysecretkey9876"}, env)
+        assert result["header"] == "[REDACTED]"
+
+    def test_ignores_comment_lines(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("# This is a comment\nREAL_SECRET=actualsecretval\n")
+        result = redact({"v": "actualsecretval is here"}, env)
+        assert result["v"] == "[REDACTED]"
+
+    def test_recursive_replacement_in_nested_dict(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("DEEP_SECRET=deepsecretvalue\n")
+        obj = {"outer": {"inner": "contains deepsecretvalue here"}}
+        result = redact(obj, env)
+        assert result["outer"]["inner"] == "[REDACTED]"
+
+    def test_recursive_replacement_in_list(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("LIST_SECRET=listsecretvalue1\n")
+        obj = {"items": ["safe string", "contains listsecretvalue1 inside"]}
+        result = redact(obj, env)
+        assert result["items"][0] == "safe string"
+        assert result["items"][1] == "[REDACTED]"
+
+
+class TestRedactSecretKeys:
+    def test_scrubs_key_named_secret(self) -> None:
+        result = redact({"secret": "my-secret-value"}, None)
+        assert result["secret"] == "[REDACTED]"
+
+    def test_scrubs_key_named_token(self) -> None:
+        result = redact({"token": "tok_abc123"}, None)
+        assert result["token"] == "[REDACTED]"
+
+    def test_scrubs_key_named_password(self) -> None:
+        result = redact({"password": "hunter2"}, None)
+        assert result["password"] == "[REDACTED]"
+
+    def test_scrubs_key_named_api_key(self) -> None:
+        result = redact({"api_key": "ak_12345"}, None)
+        assert result["api_key"] == "[REDACTED]"
+
+    def test_scrubs_key_named_api_dash_key(self) -> None:
+        result = redact({"api-key": "ak_12345"}, None)
+        assert result["api-key"] == "[REDACTED]"
+
+    def test_scrubs_key_named_authorization(self) -> None:
+        result = redact({"authorization": "Bearer token123"}, None)
+        assert result["authorization"] == "[REDACTED]"
+
+    def test_case_insensitive_key_match(self) -> None:
+        result = redact({"API_KEY": "value", "Secret": "s", "TOKEN": "t"}, None)
+        assert result["API_KEY"] == "[REDACTED]"
+        assert result["Secret"] == "[REDACTED]"
+        assert result["TOKEN"] == "[REDACTED]"
+
+    def test_leaves_clean_key_intact(self) -> None:
+        result = redact({"status": "ok", "message": "all good"}, None)
+        assert result["status"] == "ok"
+        assert result["message"] == "all good"
+
+
+class TestRedactEnvironmentDict:
+    def test_replaces_environment_dict_with_sorted_keys(self) -> None:
+        result = redact(
+            {"environment": {"PATH": "/usr/bin", "SECRET_KEY": "abc", "HOME": "/root"}},
+            None,
+        )
+        assert result["environment"] == ["HOME", "PATH", "SECRET_KEY"]
+
+    def test_leaves_environment_non_dict_unchanged(self) -> None:
+        result = redact({"environment": ["already", "a", "list"]}, None)
+        assert result["environment"] == ["already", "a", "list"]
+
+    def test_environment_key_nested_inside_dict(self) -> None:
+        result = redact(
+            {"runtime": {"environment": {"A": "1", "B": "2"}}},
+            None,
+        )
+        assert result["runtime"]["environment"] == ["A", "B"]
+
+
+class TestRedactReturnsCopy:
+    def test_original_not_mutated(self) -> None:
+        original = {"password": "secret123", "name": "Alice"}
+        result = redact(original, None)
+        assert original["password"] == "secret123"
+        assert result["password"] == "[REDACTED]"
+
+    def test_non_string_scalars_pass_through(self) -> None:
+        result = redact({"count": 42, "flag": True, "ratio": 1.5}, None)
+        assert result == {"count": 42, "flag": True, "ratio": 1.5}
+
+    def test_none_values_pass_through(self) -> None:
+        result = redact({"val": None}, None)
+        assert result["val"] is None


### PR DESCRIPTION
## Summary

[openai-reviewer] Per-run audit dual-write and redaction implementation matches the Phase A acceptance criteria with no blocking correctness issues found. | [gemini-reviewer] Phase A dual-write for per-run audit files implemented successfully.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $4.47
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/redact.py:66`** The `_redact_value` function replaces the entire string with `[REDACTED]` if a secret is found, rather than replacing only the secret substring. If a large text block (like a story or plan) contains a secret, the entire block is lost, which destroys useful context.
- **[P2] `src/theforge/coordinator/redact.py:87`** The `_redact_obj` function does not recurse into tuples. If the audit object contains tuples (which `json.dump` can serialize as lists), any secrets inside them will not be redacted.
- **[P2] `src/theforge/coordinator/redact.py:108`** The `redact` function calls `copy.deepcopy(obj)` before passing it to `_redact_obj`. Since `_redact_obj` already builds new dicts and lists during its recursive walk, the deepcopy is redundant.

## Story

Per-run audit files with contract and redaction (Phase A dual-write) (GitHub Issue #791)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #791