### PR TITLE
feat(audit): capture story text, plan content, and run identity in audit record (#798)

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -120,6 +120,10 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
             "cost_usd": round(state.total_plan_cost, 6),
             "duration_s": round(sum(state.plan_durations), 2) if state.plan_durations else None,
             "outcome": "success",
+            "plan_structured": state.plan_structured,
+            "attempt_plans": [
+                {"attempt": i, "plan": p} for i, p in enumerate(state.plan_attempt_plans)
+            ],
         }
 
     # ── plan_review ───────────────────────────────────────────────────────────
@@ -344,10 +348,14 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
 
     return {
         "forge_version": "0.1.0",
+        "schema_version": 2,
+        "run_id": state.run_id,
         "task": {
             "name": task.name,
             "slug": task.slug,
-            "story_path": str(task.story_path),
+            "story_path": str(task.story_path) if task.story_path is not None else None,
+            "story_text": state.story_content,
+            "github_issue": task.github_issue,
         },
         "outcome": {
             "success": result.success,

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -532,6 +532,7 @@ def run_task(
     state.started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
     _task_start = time.monotonic()
     story_content = task.story_text if task.story_text is not None else load_story(task.story_path)
+    state.story_content = story_content
     _sprint_name = sprint_name  # passed to _make_story_log_dir for sprint nesting
 
     # ── Structured logger ──────────────────────────────────────────
@@ -1151,6 +1152,7 @@ def run_review_only(
     _ro_task_start = time.monotonic()
 
     _run_id = _generate_run_id()
+    state.run_id = _run_id
     logger = StructuredLogger(
         run_id=_run_id,
         project=config.project,
@@ -1185,6 +1187,7 @@ def run_review_only(
     state.branch_name = branch_name
 
     story_content = task.story_text if task.story_text is not None else load_story(task.story_path)
+    state.story_content = story_content
 
     return _run_review_only_phase(
         state,

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -921,6 +921,7 @@ def _run_plan_agent_review(
         ensure_parent_dir(worktree_plan_path)
         worktree_plan_path.write_text(plan_text, encoding="utf-8")
         state.plan_output = plan_text
+        state.plan_attempt_plans.append(state.plan_structured)
         state.plan_structured = parse_plan_output(plan_text)
         _log(
             "  ✓ PLAN (regenerated)  "
@@ -1103,6 +1104,7 @@ def _run_human_plan_review(
             ensure_parent_dir(worktree_plan_path)
             worktree_plan_path.write_text(plan_text, encoding="utf-8")
             state.plan_output = plan_text
+            state.plan_attempt_plans.append(state.plan_structured)
             state.plan_structured = parse_plan_output(plan_text)
             _log(
                 "  ✓ PLAN (regenerated)  "

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -275,5 +275,6 @@ def _setup_resume_entry(
     state.branch_name = branch_name
 
     story_content = task.story_text if task.story_text is not None else load_story(task.story_path)
+    state.story_content = story_content
 
     return state, logger, branch_name, story_content, _task_start

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -221,7 +221,8 @@ class CoordinatorState:
 
     phase: Phase = Phase.INIT
     started_at: str | None = None  # ISO timestamp set at INIT
-    run_id: str | None = None  # unique id for this run; set by run_task / _setup_resume_entry
+    run_id: str | None = None  # stable 12-char hex run identity; set at engine entry
+    story_content: str | None = None  # story text as loaded before any runtime mutation
     workspace_path: Path | None = None
     branch_name: str | None = None
     dev_session_id: str | None = None
@@ -293,6 +294,9 @@ class CoordinatorState:
         None  # contents of the worktree plan file, passed to dev (raw string for audit)
     )
     plan_structured: PlanData | None = None  # parsed structured plan; None if fallback to markdown
+    plan_attempt_plans: list[PlanData | None] = field(
+        default_factory=list
+    )  # per-attempt plan snapshots; appended before each regen overwrite of plan_structured
     plan_review_decision: str | None = None  # "approve" | "regenerate" | "abandon"
     plan_regen_count: int = 0  # number of plan regen attempts so far
     plan_review_waited_seconds: float | None = None

--- a/tests/test_generate_audit_log.py
+++ b/tests/test_generate_audit_log.py
@@ -639,3 +639,187 @@ def test_generate_audit_log_includes_context_manifests(tmp_path: Path) -> None:
     assert manifest["git_sha"] == "abc123"
     assert manifest["items_included"][0]["type"] == "invariant"
     assert manifest["items_dropped"][0]["reason"] == "out of scope"
+
+
+# ── Layer 1 knowledge capture tests ──────────────────────────────────────────
+
+
+class TestKnowledgeCaptureLayer1:
+    """Tests for Layer 1 audit enrichment: run_id, story_text, github_issue,
+    story_path null fix, schema_version, plan_structured, attempt_plans."""
+
+    def test_schema_version_present(self, tmp_path: Path) -> None:
+        """schema_version is always emitted in the audit record."""
+        state = CoordinatorState()
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["schema_version"] == 2
+
+    def test_run_id_from_state(self, tmp_path: Path) -> None:
+        """run_id in audit record comes from state.run_id."""
+        state = CoordinatorState()
+        state.run_id = "abc123def456"
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["run_id"] == "abc123def456"
+
+    def test_run_id_none_when_not_set(self, tmp_path: Path) -> None:
+        """run_id is None when state.run_id was never set (backwards compat)."""
+        state = CoordinatorState()
+        assert state.run_id is None
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["run_id"] is None
+
+    def test_story_text_from_state(self, tmp_path: Path) -> None:
+        """task.story_text in audit comes from state.story_content."""
+        state = CoordinatorState()
+        state.story_content = "## Story\n\nDo the thing."
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["task"]["story_text"] == "## Story\n\nDo the thing."
+
+    def test_story_text_none_when_not_set(self, tmp_path: Path) -> None:
+        """task.story_text is None when state.story_content is not set."""
+        state = CoordinatorState()
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["task"]["story_text"] is None
+
+    def test_github_issue_propagated(self, tmp_path: Path) -> None:
+        """task.github_issue from TaskStory appears in audit task block."""
+        state = CoordinatorState()
+        task = TaskStory(name="Test", slug="test", github_issue=42)
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), task, result)
+
+        assert log["task"]["github_issue"] == 42
+
+    def test_github_issue_none(self, tmp_path: Path) -> None:
+        """task.github_issue is None when no issue is linked."""
+        state = CoordinatorState()
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["task"]["github_issue"] is None
+
+    def test_story_path_null_for_issue_sourced(self, tmp_path: Path) -> None:
+        """story_path serializes as None (not the string 'None') for issue-sourced tasks."""
+        state = CoordinatorState()
+        task = TaskStory(name="Test", slug="test", story_path=None)
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), task, result)
+
+        assert log["task"]["story_path"] is None
+        assert log["task"]["story_path"] != "None"
+
+    def test_story_path_string_when_present(self, tmp_path: Path) -> None:
+        """story_path serializes as a string when a path is set."""
+        state = CoordinatorState()
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert isinstance(log["task"]["story_path"], str)
+        assert log["task"]["story_path"] != "None"
+
+    def test_plan_structured_in_plan_block(self, tmp_path: Path) -> None:
+        """phases.plan.plan_structured contains the final parsed plan."""
+        state = CoordinatorState()
+        state.plan_results.append(_make_agent_result(cost_usd=0.10))
+        state.plan_durations.append(30.0)
+        state.plan_structured = {
+            "approach": "Refactor incrementally",
+            "steps": [
+                {
+                    "id": 1,
+                    "description": "Update types",
+                    "files": ["src/types.py"],
+                    "action": "modify",
+                    "details": "Add new fields",
+                }
+            ],
+        }
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        plan = log["phases"]["plan"]
+        assert plan is not None
+        assert plan["plan_structured"] is not None
+        assert plan["plan_structured"]["approach"] == "Refactor incrementally"
+        assert len(plan["plan_structured"]["steps"]) == 1
+
+    def test_plan_structured_none_when_fallback(self, tmp_path: Path) -> None:
+        """phases.plan.plan_structured is None when plan fell back to markdown."""
+        state = CoordinatorState()
+        state.plan_results.append(_make_agent_result(cost_usd=0.10))
+        state.plan_durations.append(30.0)
+        state.plan_structured = None
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["phases"]["plan"]["plan_structured"] is None
+
+    def test_attempt_plans_empty_when_no_regen(self, tmp_path: Path) -> None:
+        """phases.plan.attempt_plans is empty when no plan regeneration occurred."""
+        state = CoordinatorState()
+        state.plan_results.append(_make_agent_result(cost_usd=0.10))
+        state.plan_durations.append(30.0)
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["phases"]["plan"]["attempt_plans"] == []
+
+    def test_attempt_plans_lineage_preserved(self, tmp_path: Path) -> None:
+        """phases.plan.attempt_plans records prior plans with attempt numbers on regen."""
+        initial_plan = {
+            "approach": "Initial approach",
+            "steps": [],
+        }
+        state = CoordinatorState()
+        state.plan_results.append(_make_agent_result(cost_usd=0.10))
+        state.plan_durations.append(30.0)
+        state.plan_attempt_plans.append(initial_plan)  # simulates snapshot before regen
+        state.plan_structured = {
+            "approach": "Revised approach",
+            "steps": [],
+        }
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        attempts = log["phases"]["plan"]["attempt_plans"]
+        assert len(attempts) == 1
+        assert attempts[0]["attempt"] == 0
+        assert attempts[0]["plan"]["approach"] == "Initial approach"
+        # Final plan is in plan_structured, not attempt_plans
+        assert log["phases"]["plan"]["plan_structured"]["approach"] == "Revised approach"
+
+    def test_attempt_plans_multiple_regens(self, tmp_path: Path) -> None:
+        """Multiple regen cycles produce correctly indexed attempt entries."""
+        state = CoordinatorState()
+        state.plan_results.append(_make_agent_result(cost_usd=0.30))
+        state.plan_durations.append(90.0)
+        state.plan_attempt_plans.append({"approach": "Attempt 0", "steps": []})
+        state.plan_attempt_plans.append({"approach": "Attempt 1", "steps": []})
+        state.plan_structured = {"approach": "Final (attempt 2)", "steps": []}
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        attempts = log["phases"]["plan"]["attempt_plans"]
+        assert len(attempts) == 2
+        assert attempts[0]["attempt"] == 0
+        assert attempts[0]["plan"]["approach"] == "Attempt 0"
+        assert attempts[1]["attempt"] == 1
+        assert attempts[1]["plan"]["approach"] == "Attempt 1"
+
+    def test_attempt_plans_none_when_plan_not_run(self, tmp_path: Path) -> None:
+        """phases.plan is None when plan phase never ran (no attempt_plans key)."""
+        state = CoordinatorState()
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        assert log["phases"]["plan"] is None


### PR DESCRIPTION
## Summary
- Implements Knowledge Layer 1: enriches per-run audit records with the reasoning inputs that drove the run
- Adds `story_text`, `github_issue`, `run_id`, `schema_version` (2), `plan_structured`, and plan attempt lineage
- Fixes `story_path` null serialization bug (was emitting the string "None")

Closes #798

## Test plan
- [x] `tests/test_generate_audit_log.py` — 46 tests pass, including new `TestKnowledgeCaptureLayer1` suite
- [x] Full gate: 2946 passed, 1 skipped, ruff + format clean

## Notes
Rebased onto current main after #802 landed. Trivial conflict resolved in `state.py` (both sides added `run_id` field; kept #798's comment since the assignment lives in `engine.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)