### PR TITLE
bug: sprint runner `no_pull=True` optimization is stale — stories built from stale base after sibling merges

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -21,7 +21,6 @@ from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
 from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from ..coordinator.util import _fmt_duration, _generate_run_id
-from ..coordinator.workspace import pull_base_branch
 from ..log_util import _log_line
 from ..task import TaskStory
 from .audit import _write_sprint_audit, _write_sprint_summary, _write_story_audit
@@ -592,16 +591,6 @@ def run_sprint(
         if resolved.worker_timeout_seconds is not None
         else config.sprint.worker_timeout_seconds
     )
-
-    # Pull base branch once here, before any parallel workspace creation.
-    # Each worker would otherwise race to update the same git ref simultaneously,
-    # causing "incorrect old value provided" failures and leaving all worktrees
-    # on a stale base. Only suppress per-worker pulls when the shared sync
-    # succeeded — if it failed, workers retain their normal pull/behind-origin
-    # check so stale-base warnings still fire.
-    if not no_pull:
-        if pull_base_branch(config):
-            no_pull = True  # workers skip pull; base is already current
 
     # Build unified context mapping: (task, source, canonical_ref) per entry
     task_entries = resolved.stories

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,19 +190,6 @@ def _block_real_notifications():
 
 
 @pytest.fixture(autouse=True)
-def _mock_pull_base_branch():
-    """Stub pull_base_branch to return True for all tests by default.
-
-    Tests that explicitly test pull behavior (e.g. workspace tests, pre-pull
-    tests) override this with their own patch. The autouse stub prevents the
-    new fail-closed behavior from breaking sprint tests that exercise parallel
-    scheduling, DAG logic, etc. but don't care about git pull semantics.
-    """
-    with patch("theforge.sprint.runner.pull_base_branch", return_value=True):
-        yield
-
-
-@pytest.fixture(autouse=True)
 def _block_real_coordinator_runners():
     """Require tests to stub coordinator runner entry points explicitly.
 

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1286,7 +1286,7 @@ class TestParallelMergeOrderingParallelMode:
 
 
 class TestSprintPrePull:
-    """run_sprint() pulls base branch once before parallel workers start."""
+    """run_sprint() propagates no_pull to per-story workers without a shared pre-pull."""
 
     def _make_manifest(self, tmp_path: Path) -> Path:
         (tmp_path / "story-a.md").write_text("---\nname: Story A\nslug: story-a\n---\n# Story A\n")
@@ -1296,8 +1296,8 @@ class TestSprintPrePull:
         )
         return manifest_path
 
-    def test_successful_prepull_suppresses_worker_pulls(self, tmp_path: Path) -> None:
-        """When pull_base_branch succeeds, workers receive no_pull=True."""
+    def test_workers_receive_caller_no_pull_value(self, tmp_path: Path) -> None:
+        """Workers receive no_pull=False (the default) so each workspace pulls its own base."""
         config = _make_config(tmp_path)
         manifest_path = self._make_manifest(tmp_path)
         worker_no_pull_values: list[bool] = []
@@ -1309,58 +1309,34 @@ class TestSprintPrePull:
             state.preflight_result = MagicMock(cost_usd=0.0)
             return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="Done.")
 
-        with (
-            patch("theforge.sprint.runner.pull_base_branch", return_value=True) as mock_pull,
-            patch("theforge.sprint.runner.run_task", side_effect=capture_no_pull),
-        ):
+        with patch("theforge.sprint.runner.run_task", side_effect=capture_no_pull):
             run_sprint(config, manifest_path)
 
-        mock_pull.assert_called_once_with(config)
-        assert all(v is True for v in worker_no_pull_values), (
-            "Expected all workers no_pull=True after successful pre-pull, "
+        assert all(v is False for v in worker_no_pull_values), (
+            "Expected all workers no_pull=False so each workspace pulls a fresh base, "
             f"got {worker_no_pull_values}"
         )
 
-    def test_failed_prepull_aborts_sprint(self, tmp_path: Path) -> None:
-        """When pull_base_branch raises, run_sprint propagates the exception and aborts."""
+    def test_caller_no_pull_true_skips_worker_pulls(self, tmp_path: Path) -> None:
+        """When run_sprint is called with no_pull=True, workers receive no_pull=True."""
         config = _make_config(tmp_path)
         manifest_path = self._make_manifest(tmp_path)
+        worker_no_pull_values: list[bool] = []
 
-        with (
-            patch(
-                "theforge.sprint.runner.pull_base_branch",
-                side_effect=RuntimeError(
-                    "WORKSPACE abort: base branch 'main' has diverged from origin "
-                    "(local is 2 ahead, 2 behind). Run: git rebase origin/main"
-                ),
-            ) as mock_pull,
-            patch("theforge.sprint.runner.run_task") as mock_run_task,
-        ):
-            with pytest.raises(RuntimeError, match="diverged"):
-                run_sprint(config, manifest_path)
+        def capture_no_pull(*args, **kwargs):
+            worker_no_pull_values.append(kwargs.get("no_pull", args[8] if len(args) > 8 else None))
+            state = CoordinatorState()
+            state.preflight_verdict = "PROCEED"
+            state.preflight_result = MagicMock(cost_usd=0.0)
+            return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="Done.")
 
-        mock_pull.assert_called_once_with(config)
-        mock_run_task.assert_not_called()
-
-    def test_caller_no_pull_true_skips_prepull(self, tmp_path: Path) -> None:
-        """When run_sprint is called with no_pull=True, pull_base_branch is never called."""
-        config = _make_config(tmp_path)
-        manifest_path = self._make_manifest(tmp_path)
-
-        state = CoordinatorState()
-        state.preflight_verdict = "PROCEED"
-        state.preflight_result = MagicMock(cost_usd=0.0)
-        mock_result = CoordinatorResult(
-            success=True, phase=Phase.DONE, state=state, message="Done."
-        )
-
-        with (
-            patch("theforge.sprint.runner.pull_base_branch") as mock_pull,
-            patch("theforge.sprint.runner.run_task", return_value=mock_result),
-        ):
+        with patch("theforge.sprint.runner.run_task", side_effect=capture_no_pull):
             run_sprint(config, manifest_path, no_pull=True)
 
-        mock_pull.assert_not_called()
+        assert all(v is True for v in worker_no_pull_values), (
+            "Expected all workers no_pull=True when caller passes no_pull=True, "
+            f"got {worker_no_pull_values}"
+        )
 
 
 class TestParallelLogIsolation:

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -970,7 +970,7 @@ class TestSprintDependencies:
 
         with patch("theforge.sprint.runner._triage_spec", return_value=review_triage):
             with patch("theforge.sprint.runner.run_from_review", return_value=coord_result):
-                with patch("theforge.sprint.runner.pull_base_branch", return_value=True):
+                with patch("theforge.coordinator.workspace.pull_base_branch", return_value=True):
                     with patch("theforge.sprint.runner.run_batch_preflight", return_value={}):
                         result = run_sprint(config, manifest_path, resume=True)
 

--- a/tests/test_sprint_timeout_audit.py
+++ b/tests/test_sprint_timeout_audit.py
@@ -31,7 +31,7 @@ def test_run_sprint_timeout_writes_story_audit(tmp_path: Path) -> None:
             return _NeverDoneFuture()
 
     with (
-        patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
         patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
         patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
         patch("theforge.sprint.runner.wait", return_value=(set(), set())),

--- a/tests/test_sprint_worker_timeout.py
+++ b/tests/test_sprint_worker_timeout.py
@@ -136,7 +136,7 @@ class TestWorkerTimeoutPrecedence:
             return (set(), set())
 
         with (
-            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
             patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
             patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
         ):
@@ -162,7 +162,7 @@ class TestWorkerTimeoutPrecedence:
             return (set(), set())
 
         with (
-            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
             patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
             patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
         ):
@@ -197,7 +197,7 @@ class TestWorkerTimeoutPrecedence:
             return (set(), set())
 
         with (
-            patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+            patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
             patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
             patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
         ):
@@ -252,7 +252,7 @@ def test_timeout_error_message_uses_configured_value(tmp_path: Path) -> None:
             return _NeverDoneFuture()
 
     with (
-        patch("theforge.sprint.runner.pull_base_branch", return_value=True),
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
         patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
         patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
         patch("theforge.sprint.runner.wait", return_value=(set(), set())),


### PR DESCRIPTION
## Summary

[openai-reviewer] Removes the stale sprint-start pre-pull workaround so each workspace creation can refresh the base branch, matching the bug fix spec. | [gemini-reviewer] The stale no_pull=True workaround was successfully removed, allowing each workspace to pull a fresh base branch.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.37
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: sprint runner `no_pull=True` optimization is stale — stories built from stale base after sibling merges (GitHub Issue #803)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #803