### PR TITLE
fix: avoid synthetic sprint dependency cycles

### DIFF
--- a/src/theforge/sprint/collision.py
+++ b/src/theforge/sprint/collision.py
@@ -205,6 +205,7 @@ def compute_synthetic_edges(
 ) -> dict[str, list[str]]:
     task_by_slug = {task.slug: task for task in tasks}
     file_to_slugs: dict[str, list[str]] = {}
+    deps: dict[str, set[str]] = {task.slug: set(task.depends_on) for task in tasks}
     synthetic: dict[str, set[str]] = {}
 
     for slug, state in preflight_states.items():
@@ -217,15 +218,39 @@ def compute_synthetic_edges(
         issue = task_by_slug[slug].github_issue
         return (issue if issue is not None else sys.maxsize, slug)
 
+    def _has_dependency_path(start: str, target: str) -> bool:
+        stack = list(deps.get(start, set()))
+        seen: set[str] = set()
+        while stack:
+            slug = stack.pop()
+            if slug == target:
+                return True
+            if slug in seen:
+                continue
+            seen.add(slug)
+            stack.extend(deps.get(slug, set()) - seen)
+        return False
+
     for path, slugs in sorted(file_to_slugs.items()):
         unique_slugs = sorted(set(slugs), key=_sort_key)
         if len(unique_slugs) <= 1:
             continue
         injected: list[str] = []
+        skipped: list[str] = []
         for prev, curr in zip(unique_slugs, unique_slugs[1:], strict=False):
+            if _has_dependency_path(curr, prev):
+                skipped.append(f"{curr} already depends_on {prev}")
+                continue
+            if _has_dependency_path(prev, curr):
+                skipped.append(f"{curr} depends_on {prev} would cycle")
+                continue
             synthetic.setdefault(curr, set()).add(prev)
+            deps.setdefault(curr, set()).add(prev)
             injected.append(f"{curr} depends_on {prev}")
-        _log(f"Collision detected for {path}: stories={unique_slugs}; injected={injected}")
+        detail = f"Collision detected for {path}: stories={unique_slugs}; injected={injected}"
+        if skipped:
+            detail += f"; skipped={skipped}"
+        _log(detail)
 
     return {slug: sorted(deps) for slug, deps in synthetic.items()}
 

--- a/tests/test_sprint_collision.py
+++ b/tests/test_sprint_collision.py
@@ -6,7 +6,7 @@ from theforge.sprint.collision import (
     compute_synthetic_edges,
     inject_synthetic_deps,
 )
-from theforge.sprint.dag import StoryTriage
+from theforge.sprint.dag import StoryTriage, build_dag
 from theforge.sprint.runner import _register_resumed_story_footprints
 from theforge.task import TaskStory
 
@@ -71,6 +71,38 @@ def test_compute_synthetic_edges_falls_back_to_slug_order_when_issue_missing() -
     }
 
     assert compute_synthetic_edges(states, tasks) == {"b-story": ["a-story"]}
+
+
+def test_compute_synthetic_edges_skips_edges_that_would_cycle() -> None:
+    tasks = [
+        _task("issue-267", 267, depends_on=["issue-750"]),
+        _task("issue-750", 750),
+    ]
+    states = {
+        "issue-267": CoordinatorState(preflight_likely_files=["tests/test_config_load.py"]),
+        "issue-750": CoordinatorState(preflight_likely_files=["tests/test_config_load.py"]),
+    }
+
+    synthetic = compute_synthetic_edges(states, tasks)
+
+    assert synthetic == {}
+    build_dag(inject_synthetic_deps(tasks, synthetic))
+
+
+def test_compute_synthetic_edges_skips_already_serialized_collisions() -> None:
+    tasks = [
+        _task("issue-267", 267),
+        _task("issue-750", 750, depends_on=["issue-267"]),
+    ]
+    states = {
+        "issue-267": CoordinatorState(preflight_likely_files=["tests/test_config_load.py"]),
+        "issue-750": CoordinatorState(preflight_likely_files=["tests/test_config_load.py"]),
+    }
+
+    synthetic = compute_synthetic_edges(states, tasks)
+
+    assert synthetic == {}
+    build_dag(inject_synthetic_deps(tasks, synthetic))
 
 
 def test_register_resumed_story_footprints_reads_plan_md(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Prevent synthetic sprint collision edges from introducing dependency cycles when the existing story graph already serializes the colliding stories.

## Why

The sprint runner can currently fail after preflight when collision detection sorts shared-file stories by issue number and injects an edge that contradicts a real `depends_on` path from issue bodies. The DAG rejection is correct, but the synthetic edge is unnecessary because the stories are already ordered.

## Root Cause

For the observed config-routing sprint, `issue-267` already depended on `issue-750`, while the file-collision chain attempted to inject `issue-750 depends_on issue-267` because `267` sorts before `750`. That produced an avoidable cycle during DAG construction.

## Changes

- Track the accumulated dependency graph while computing synthetic collision edges.
- Skip synthetic edges that are already implied by an existing dependency path.
- Skip synthetic edges that would create a cycle because the opposite path already exists.
- Add regression coverage for both already-serialized and cycle-forming collision pairs.

## Validation

- `pytest tests/test_sprint_collision.py -q` — 9 passed
- `pytest tests/test_sprint_collision.py tests/test_sprint_runner.py tests/test_sprint_github_query.py -q` — 64 passed
- `make gate` — 2947 passed, 1 skipped, 3 warnings; `[gate] PASS`

Follow-up: #813 tracks making collision ordering topology-aware and invariant under file iteration order.

Closes #809