### PR TITLE
feat(config): ModelRef, derive_roles, and bridge for v0.8 schema (#265)

### DIFF
--- a/src/theforge/config/bridge.py
+++ b/src/theforge/config/bridge.py
@@ -1,0 +1,104 @@
+"""Boundary conversion: RoleAssignment → ModelProfile-based structures.
+
+role_assignment_to_profiles() is the sole crossing point between the new
+config-domain types (RoleAssignment / ModelRef) and the runtime types
+(ModelProfile) consumed by the coordinator and ForgeConfig.
+
+The coordinator and loader are not modified by this story; this bridge is
+additive. Downstream loader stories (#265b, #266) will wire in this bridge
+to replace the direct ForgeConfig construction in load.py.
+"""
+
+from __future__ import annotations
+
+from .schema import (
+    DevRoleConfig,
+    PlanRoleConfig,
+    PreflightRoleConfig,
+    ReviewRoleConfig,
+    RoleAssignment,
+)
+from .types import ModelProfile
+
+
+def _role_config_to_profile(
+    name: str,
+    role_config: DevRoleConfig | PreflightRoleConfig | PlanRoleConfig | ReviewRoleConfig,
+    phase: str | None = None,
+) -> ModelProfile:
+    """Convert a single role config to a ModelProfile.
+
+    All shared fields are copied from the embedded ModelRef. Phase-specific
+    fields (allowed_tools, sandbox_mode, review_role) are lifted from the
+    wrapper. This is the only place the naming gap between ModelRef fields
+    and ModelProfile fields is bridged (e.g. timeout_seconds → timeout_seconds
+    is consistent; the gap in PlanConfig.timeout vs ModelProfile.timeout_seconds
+    does not appear here because ModelRef always uses timeout_seconds).
+    """
+    ref = role_config.ref
+    allowed_tools: tuple[str, ...] = getattr(role_config, "allowed_tools", ())
+    review_role: str | None = getattr(role_config, "review_role", None)
+    sandbox_mode: str = getattr(role_config, "sandbox_mode", "workspace-write")
+
+    return ModelProfile(
+        name=name,
+        cli=ref.cli,
+        provider=ref.provider,
+        model=ref.model,
+        fallback_models=ref.fallback_models,
+        budget_usd=ref.budget_usd,
+        timeout_seconds=ref.timeout_seconds,
+        timeout_medium_seconds=ref.timeout_medium_seconds,
+        timeout_large_seconds=ref.timeout_large_seconds,
+        allowed_tools=allowed_tools,
+        reasoning_effort=ref.reasoning_effort,
+        thinking_budget=ref.thinking_budget,
+        base_url=ref.base_url,
+        max_iterations=ref.max_iterations,
+        max_tool_output_bytes=ref.max_tool_output_bytes,
+        api_fallback=ref.api_fallback,
+        review_role=review_role,
+        phase=phase,
+        sandbox_mode=sandbox_mode,
+    )
+
+
+def role_assignment_to_profiles(ra: RoleAssignment) -> dict[str, object]:
+    """Convert a RoleAssignment to ModelProfile-keyed structures for ForgeConfig.
+
+    This is the sole boundary crossing point between config-domain types and
+    the runtime types consumed by the coordinator. Coordinator code is not
+    modified; callers construct ForgeConfig from the returned dict.
+
+    Returns:
+        A dict with keys:
+          "dev_profile":       ModelProfile
+          "preflight_profile": ModelProfile
+          "plan_profile":      ModelProfile
+          "review_pool":       list[ModelProfile]
+          "synthesis_profile": ModelProfile | None
+    """
+    dev_profile = _role_config_to_profile("dev", ra.dev, phase="dev")
+    preflight_profile = _role_config_to_profile("preflight", ra.preflight, phase="preflight")
+    plan_profile = _role_config_to_profile("plan", ra.plan, phase="plan")
+
+    review_pool: list[ModelProfile] = [
+        _role_config_to_profile(
+            rc.ref.model.replace("/", "-"),
+            rc,
+            phase="review",
+        )
+        for rc in ra.review_pool
+    ]
+
+    synthesis_profile: ModelProfile | None = None
+    if ra.synthesis is not None:
+        synthesis_profile = _role_config_to_profile("synthesis", ra.synthesis, phase="review")
+
+    return {
+        "dev_profile": dev_profile,
+        "preflight_profile": preflight_profile,
+        "plan_profile": plan_profile,
+        "review_pool": review_pool,
+        "synthesis_profile": synthesis_profile,
+    }

--- a/src/theforge/config/bridge.py
+++ b/src/theforge/config/bridge.py
@@ -72,11 +72,13 @@ def role_assignment_to_profiles(ra: RoleAssignment) -> dict[str, object]:
 
     Returns:
         A dict with keys:
-          "dev_profile":       ModelProfile
-          "preflight_profile": ModelProfile
-          "plan_profile":      ModelProfile
-          "review_pool":       list[ModelProfile]
-          "synthesis_profile": ModelProfile | None
+          "dev_profile":              ModelProfile
+          "preflight_profile":        ModelProfile
+          "plan_profile":             ModelProfile
+          "plan_validate_spec":       bool  (preserves PlanRoleConfig.validate_spec)
+          "review_pool":              list[ModelProfile]
+          "synthesis_profile":        ModelProfile | None
+          "plan_agent_review_profile": ModelProfile | None
     """
     dev_profile = _role_config_to_profile("dev", ra.dev, phase="dev")
     preflight_profile = _role_config_to_profile("preflight", ra.preflight, phase="preflight")
@@ -95,10 +97,18 @@ def role_assignment_to_profiles(ra: RoleAssignment) -> dict[str, object]:
     if ra.synthesis is not None:
         synthesis_profile = _role_config_to_profile("synthesis", ra.synthesis, phase="review")
 
+    plan_agent_review_profile: ModelProfile | None = None
+    if ra.plan_agent_review is not None:
+        plan_agent_review_profile = _role_config_to_profile(
+            "plan-agent-review", ra.plan_agent_review, phase="plan_review"
+        )
+
     return {
         "dev_profile": dev_profile,
         "preflight_profile": preflight_profile,
         "plan_profile": plan_profile,
+        "plan_validate_spec": ra.plan.validate_spec,
         "review_pool": review_pool,
         "synthesis_profile": synthesis_profile,
+        "plan_agent_review_profile": plan_agent_review_profile,
     }

--- a/src/theforge/config/bridge.py
+++ b/src/theforge/config/bridge.py
@@ -86,7 +86,7 @@ def role_assignment_to_profiles(ra: RoleAssignment) -> dict[str, object]:
 
     review_pool: list[ModelProfile] = [
         _role_config_to_profile(
-            rc.ref.model.replace("/", "-"),
+            rc.name if rc.name else rc.ref.model.replace("/", "-"),
             rc,
             phase="review",
         )

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -141,6 +141,8 @@ def load_config(config_path: Path) -> ForgeConfig:
     # ── Smart config: models key ──────────────────────────────────────
     smart_config_models: list[str] | None = None
     _review_pool_is_default = False
+    _derived_plan_profile: ModelProfile | None = None
+    _derived_plan_validate_spec: bool | None = None
 
     if "models" in raw:
         models_list = raw["models"]
@@ -169,6 +171,8 @@ def load_config(config_path: Path) -> ForgeConfig:
         preflight_profile = _bridge["preflight_profile"]
         review_pool = _bridge["review_pool"]
         synthesis_profile = _bridge["synthesis_profile"]
+        _derived_plan_profile = _bridge["plan_profile"]
+        _derived_plan_validate_spec = _bridge["plan_validate_spec"]
 
         # Apply explicit profile overrides (partial override supported)
         profiles = raw.get("profiles", {})
@@ -294,17 +298,48 @@ def load_config(config_path: Path) -> ForgeConfig:
 
     plan_timeout_medium_raw = plan_data.get("timeout_medium")
     plan_timeout_large_raw = plan_data.get("timeout_large")
+
+    # Smart-config: when the user supplies `models:` and has not overridden the
+    # plan section's transport/model, source PlanConfig from the derived plan
+    # role so adaptive routing actually reaches the PLAN phase. Otherwise fall
+    # back to the legacy defaults (cli=claude, model=sonnet).
+    if _derived_plan_profile is not None and _plan_model_is_default:
+        _plan_default_cli: str | None = _derived_plan_profile.cli
+        _plan_default_model: str = _derived_plan_profile.model
+        _plan_default_provider: str | None = _derived_plan_profile.provider
+        _plan_default_budget: float = _derived_plan_profile.budget_usd
+        _plan_default_timeout: int = _derived_plan_profile.timeout_seconds
+        _plan_default_timeout_medium: int | None = _derived_plan_profile.timeout_medium_seconds
+        _plan_default_timeout_large: int | None = _derived_plan_profile.timeout_large_seconds
+        _plan_default_validate_spec: bool = (
+            _derived_plan_validate_spec if _derived_plan_validate_spec is not None else True
+        )
+    else:
+        _plan_default_cli = "claude"
+        _plan_default_model = "sonnet"
+        _plan_default_provider = None
+        _plan_default_budget = 0.50
+        _plan_default_timeout = 600
+        _plan_default_timeout_medium = None
+        _plan_default_timeout_large = None
+        _plan_default_validate_spec = True
+
+    _plan_provider = plan_data.get("provider", _plan_default_provider)
+    _plan_cli = plan_data.get("cli", _plan_default_cli) if _plan_provider is None else None
     plan_cfg = PlanConfig(
         enabled=bool(plan_data.get("enabled", False)),
-        cli=plan_data.get("cli", "claude") if plan_data.get("provider") is None else None,
-        model=str(plan_data.get("model", "sonnet")),
-        provider=plan_data.get("provider"),
-        budget_usd=float(plan_data.get("budget_usd", 0.50)),
-        timeout=int(plan_data.get("timeout", 600)),
+        cli=_plan_cli,
+        model=str(plan_data.get("model", _plan_default_model)),
+        provider=_plan_provider,
+        budget_usd=float(plan_data.get("budget_usd", _plan_default_budget)),
+        timeout=int(plan_data.get("timeout", _plan_default_timeout)),
         timeout_medium=int(plan_timeout_medium_raw)
         if plan_timeout_medium_raw is not None
-        else None,
-        timeout_large=int(plan_timeout_large_raw) if plan_timeout_large_raw is not None else None,
+        else _plan_default_timeout_medium,
+        timeout_large=int(plan_timeout_large_raw)
+        if plan_timeout_large_raw is not None
+        else _plan_default_timeout_large,
+        validate_spec=bool(plan_data.get("validate_spec", _plan_default_validate_spec)),
     )
 
     # ── Load-time validation for plan section ────────────────────────────

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -13,6 +13,7 @@ from dotenv import dotenv_values
 
 from ._loaders import _parse_plan_agent_review, _parse_workspace
 from .auth import check_agent_auth
+from .bridge import role_assignment_to_profiles
 from .defaults import (
     DEFAULT_DEV_PROFILE,
     DEFAULT_PREFLIGHT_PROFILE,
@@ -26,10 +27,10 @@ from .profiles import (
     CLI_PROVIDER_MAP,
     _apply_profile_overrides,
     _apply_provider_fallback,
-    _auto_assign_models,
     _parse_profile,
     _parse_provider_fallbacks,
 )
+from .role_derivation import derive_roles
 from .secrets import _parse_notifications
 from .types import (
     SUPPORTED_PROVIDERS,
@@ -162,9 +163,12 @@ def load_config(config_path: Path) -> ForgeConfig:
         if budget_usd_val <= 0:
             raise ValueError("budget_usd must be positive")
 
-        dev_profile, preflight_profile, review_pool, synthesis_profile = _auto_assign_models(
-            [str(m) for m in models_list], budget_usd_val
-        )
+        _ra = derive_roles([str(m) for m in models_list], budget_usd=budget_usd_val)
+        _bridge = role_assignment_to_profiles(_ra)
+        dev_profile = _bridge["dev_profile"]
+        preflight_profile = _bridge["preflight_profile"]
+        review_pool = _bridge["review_pool"]
+        synthesis_profile = _bridge["synthesis_profile"]
 
         # Apply explicit profile overrides (partial override supported)
         profiles = raw.get("profiles", {})

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -46,11 +46,31 @@ def _make_model_ref(
 
 
 def _apply_ref_overrides(ref: ModelRef, overrides: dict[str, Any]) -> ModelRef:
-    """Return a new ModelRef with fields replaced by values in overrides."""
+    """Return a new ModelRef with fields replaced by values in overrides.
+
+    Transport mutual exclusion: switching transports via overrides is supported.
+    If 'provider' is in overrides but 'cli' is not, cli is cleared to None so the
+    new ModelRef satisfies the mutual-exclusion constraint. The inverse applies when
+    'cli' is in overrides but 'provider' is not. If both are supplied, ModelRef's
+    __post_init__ will raise as expected (both supplied → invalid).
+    """
+    if "provider" in overrides and "cli" not in overrides:
+        # Switching to API transport — clear the derived cli value
+        new_cli: str | None = None
+        new_provider: str | None = overrides["provider"]
+    elif "cli" in overrides and "provider" not in overrides:
+        # Switching to CLI transport — clear the derived provider value
+        new_cli = overrides["cli"]
+        new_provider = None
+    else:
+        # Both present (error caught by ModelRef) or neither (keep derived values)
+        new_cli = overrides.get("cli", ref.cli)
+        new_provider = overrides.get("provider", ref.provider)
+
     return ModelRef(
         model=overrides.get("model", ref.model),
-        cli=overrides.get("cli", ref.cli),
-        provider=overrides.get("provider", ref.provider),
+        cli=new_cli,
+        provider=new_provider,
         budget_usd=overrides.get("budget_usd", ref.budget_usd),
         timeout_seconds=overrides.get("timeout_seconds", ref.timeout_seconds),
         fallback_models=overrides.get("fallback_models", ref.fallback_models),

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -220,13 +220,16 @@ def derive_roles(
             ReviewRoleConfig(
                 ref=review_ref,
                 allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+                # Preserve registry key format ("claude-opus") so name-based profile
+                # overrides in the loader continue to match auto-assigned pool entries.
+                name=k.replace("/", "-"),
             )
         )
 
     # --- Build synthesis role ---
     synthesis_role: ReviewRoleConfig | None = None
     if has_synthesis:
-        _, synth_info = max(review_pairs, key=lambda x: x[1].capability)
+        synth_key, synth_info = max(review_pairs, key=lambda x: x[1].capability)
         synth_ref = _make_model_ref(
             model=synth_info.model,
             cli=synth_info.cli,
@@ -241,10 +244,28 @@ def derive_roles(
             allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
         )
 
+    # --- Build plan_agent_review role (None unless overrides enable it) ---
+    plan_agent_review_role: ReviewRoleConfig | None = None
+    par_overrides = effective_overrides.get("plan_agent_review", {})
+    if par_overrides:
+        # Default base: dev model at plan-phase budget; overrides can change any field
+        par_ref = _make_model_ref(
+            model=dev_info.model,
+            cli=dev_info.cli,
+            budget_usd=_DEFAULT_PLAN_BUDGET_USD,
+            timeout_seconds=DEFAULT_REVIEW_PROFILE.timeout_seconds,
+        )
+        par_ref = _apply_ref_overrides(par_ref, par_overrides)
+        plan_agent_review_role = ReviewRoleConfig(
+            ref=par_ref,
+            allowed_tools=par_overrides.get("allowed_tools", DEFAULT_REVIEW_PROFILE.allowed_tools),
+        )
+
     return RoleAssignment(
         dev=dev_role,
         preflight=preflight_role,
         plan=plan_role,
         review_pool=tuple(review_pool),
         synthesis=synthesis_role,
+        plan_agent_review=plan_agent_review_role,
     )

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -1,0 +1,230 @@
+"""Role derivation logic: map a simple model list to a RoleAssignment.
+
+derive_roles() is the insertion point for future adaptive routing (v0.9).
+A router can replace this function and return a RoleAssignment without
+restructuring the type hierarchy. The function signature is stable: it
+accepts a list of model keys and optional per-role overrides and returns
+a RoleAssignment that the bridge module converts to ModelProfile instances.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .defaults import DEFAULT_DEV_PROFILE, DEFAULT_PREFLIGHT_PROFILE, DEFAULT_REVIEW_PROFILE
+from .models import _resolve_model_info
+from .schema import (
+    DevRoleConfig,
+    ModelRef,
+    PlanRoleConfig,
+    PreflightRoleConfig,
+    ReviewRoleConfig,
+    RoleAssignment,
+)
+
+# Default plan budget and timeout, matching PlanConfig defaults in types.py
+_DEFAULT_PLAN_BUDGET_USD: float = 0.50
+_DEFAULT_PLAN_TIMEOUT_SECONDS: int = 600
+
+
+def _make_model_ref(
+    *,
+    model: str,
+    cli: str | None,
+    provider: str | None = None,
+    budget_usd: float,
+    timeout_seconds: int,
+) -> ModelRef:
+    """Construct a ModelRef from resolved model info."""
+    return ModelRef(
+        model=model,
+        cli=cli,
+        provider=provider,
+        budget_usd=budget_usd,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _apply_ref_overrides(ref: ModelRef, overrides: dict[str, Any]) -> ModelRef:
+    """Return a new ModelRef with fields replaced by values in overrides."""
+    return ModelRef(
+        model=overrides.get("model", ref.model),
+        cli=overrides.get("cli", ref.cli),
+        provider=overrides.get("provider", ref.provider),
+        budget_usd=overrides.get("budget_usd", ref.budget_usd),
+        timeout_seconds=overrides.get("timeout_seconds", ref.timeout_seconds),
+        fallback_models=overrides.get("fallback_models", ref.fallback_models),
+        timeout_medium_seconds=overrides.get("timeout_medium_seconds", ref.timeout_medium_seconds),
+        timeout_large_seconds=overrides.get("timeout_large_seconds", ref.timeout_large_seconds),
+        reasoning_effort=overrides.get("reasoning_effort", ref.reasoning_effort),
+        thinking_budget=overrides.get("thinking_budget", ref.thinking_budget),
+        base_url=overrides.get("base_url", ref.base_url),
+        max_iterations=overrides.get("max_iterations", ref.max_iterations),
+        max_tool_output_bytes=overrides.get("max_tool_output_bytes", ref.max_tool_output_bytes),
+        api_fallback=overrides.get("api_fallback", ref.api_fallback),
+    )
+
+
+def derive_roles(
+    models: list[str],
+    overrides: dict[str, Any] | None = None,
+    *,
+    budget_usd: float = 10.0,
+) -> RoleAssignment:
+    """Map a simple model list to a RoleAssignment.
+
+    Assignment algorithm (mirrors _auto_assign_models in profiles.py):
+    1. Sort by cost_rank asc, capability desc
+    2. dev = cheapest dev-capable model (fallback: first in sorted list)
+    3. preflight = cheapest "fast" tier, else same as dev
+    4. review_pool = all models except dev (if only 1, pool = [dev])
+    5. synthesis = highest-capability model from review_pool (skip if pool <= 1)
+
+    Budget distribution:
+    - dev: 60% of total budget_usd
+    - preflight: max(2%, $1)
+    - synthesis: max(2%, $1) when pool > 1
+    - each reviewer: remaining / pool_size
+
+    Args:
+        models: Non-empty list of model keys (e.g. "claude/sonnet", "openai/gpt-5.4").
+            Keys are looked up in MODEL_REGISTRY; unknown keys get sensible defaults.
+        overrides: Optional dict keyed by role name ("dev", "preflight", "plan",
+            "synthesis"). Each value is a dict of field names → replacement values
+            for the ModelRef of that role. Phase-specific fields (allowed_tools,
+            sandbox_mode, etc.) can also be included. For "review_pool", the value
+            is a list of per-reviewer override dicts (indexed by pool position).
+        budget_usd: Total budget to distribute across all roles. Defaults to $10.
+
+    Returns:
+        A RoleAssignment holding the four derived role configs plus optional synthesis.
+        This is the stable insertion point for future adaptive routing: a router
+        replaces this function and returns a RoleAssignment without restructuring
+        the type hierarchy.
+    """
+    if not models:
+        raise ValueError("models list must be non-empty")
+
+    effective_overrides: dict[str, Any] = overrides or {}
+
+    # Build (model_key, ModelInfo) pairs and sort: cheapest first, then by capability desc
+    infos = [(m, _resolve_model_info(m)) for m in models]
+    sorted_models = sorted(infos, key=lambda x: (x[1].cost_rank, -x[1].capability))
+
+    # dev: cheapest dev-capable model; fall back to first if none are dev-capable
+    dev_candidates = [(k, i) for k, i in sorted_models if i.dev_capable]
+    dev_key, dev_info = dev_candidates[0] if dev_candidates else sorted_models[0]
+
+    # preflight: cheapest "fast" tier, else same as dev
+    fast_models = [(k, i) for k, i in sorted_models if i.tier == "fast"]
+    preflight_key, preflight_info = fast_models[0] if fast_models else (dev_key, dev_info)
+
+    # review_pool: all models except dev; if only one model total, pool = [dev]
+    review_pairs = [(k, i) for k, i in sorted_models if k != dev_key]
+    if not review_pairs:
+        review_pairs = [(dev_key, dev_info)]
+
+    has_synthesis = len(review_pairs) > 1
+
+    # Budget distribution
+    preflight_budget = max(budget_usd * 0.02, 1.0)
+    dev_budget = budget_usd * 0.60
+    synthesis_budget = max(budget_usd * 0.02, 1.0) if has_synthesis else 0.0
+    remaining = max(budget_usd - dev_budget - preflight_budget - synthesis_budget, 0.0)
+    reviewer_budget = remaining / len(review_pairs)
+
+    # --- Build dev role ---
+    dev_ref = _make_model_ref(
+        model=dev_info.model,
+        cli=dev_info.cli,
+        budget_usd=dev_budget,
+        timeout_seconds=DEFAULT_DEV_PROFILE.timeout_seconds,
+    )
+    dev_role_overrides = effective_overrides.get("dev", {})
+    if dev_role_overrides:
+        dev_ref = _apply_ref_overrides(dev_ref, dev_role_overrides)
+    dev_role = DevRoleConfig(
+        ref=dev_ref,
+        allowed_tools=dev_role_overrides.get("allowed_tools", DEFAULT_DEV_PROFILE.allowed_tools),
+        sandbox_mode=dev_role_overrides.get("sandbox_mode", "workspace-write"),
+    )
+
+    # --- Build preflight role ---
+    preflight_ref = _make_model_ref(
+        model=preflight_info.model,
+        cli=preflight_info.cli,
+        budget_usd=preflight_budget,
+        timeout_seconds=DEFAULT_PREFLIGHT_PROFILE.timeout_seconds,
+    )
+    preflight_role_overrides = effective_overrides.get("preflight", {})
+    if preflight_role_overrides:
+        preflight_ref = _apply_ref_overrides(preflight_ref, preflight_role_overrides)
+    preflight_role = PreflightRoleConfig(
+        ref=preflight_ref,
+        allowed_tools=preflight_role_overrides.get(
+            "allowed_tools", DEFAULT_PREFLIGHT_PROFILE.allowed_tools
+        ),
+    )
+
+    # --- Build plan role (defaults to same model as dev) ---
+    plan_ref = _make_model_ref(
+        model=dev_info.model,
+        cli=dev_info.cli,
+        budget_usd=_DEFAULT_PLAN_BUDGET_USD,
+        timeout_seconds=_DEFAULT_PLAN_TIMEOUT_SECONDS,
+    )
+    plan_role_overrides = effective_overrides.get("plan", {})
+    if plan_role_overrides:
+        plan_ref = _apply_ref_overrides(plan_ref, plan_role_overrides)
+    plan_role = PlanRoleConfig(
+        ref=plan_ref,
+        allowed_tools=plan_role_overrides.get(
+            "allowed_tools", DEFAULT_PREFLIGHT_PROFILE.allowed_tools
+        ),
+        validate_spec=plan_role_overrides.get("validate_spec", True),
+    )
+
+    # --- Build review pool ---
+    pool_overrides_list: list[dict[str, Any]] = effective_overrides.get("review_pool", [])
+    review_pool: list[ReviewRoleConfig] = []
+    for idx, (k, info) in enumerate(review_pairs):
+        review_ref = _make_model_ref(
+            model=info.model,
+            cli=info.cli,
+            budget_usd=reviewer_budget,
+            timeout_seconds=DEFAULT_REVIEW_PROFILE.timeout_seconds,
+        )
+        if isinstance(pool_overrides_list, list) and idx < len(pool_overrides_list):
+            review_ref = _apply_ref_overrides(review_ref, pool_overrides_list[idx])
+        review_pool.append(
+            ReviewRoleConfig(
+                ref=review_ref,
+                allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+            )
+        )
+
+    # --- Build synthesis role ---
+    synthesis_role: ReviewRoleConfig | None = None
+    if has_synthesis:
+        _, synth_info = max(review_pairs, key=lambda x: x[1].capability)
+        synth_ref = _make_model_ref(
+            model=synth_info.model,
+            cli=synth_info.cli,
+            budget_usd=synthesis_budget,
+            timeout_seconds=DEFAULT_REVIEW_PROFILE.timeout_seconds,
+        )
+        synth_overrides = effective_overrides.get("synthesis", {})
+        if synth_overrides:
+            synth_ref = _apply_ref_overrides(synth_ref, synth_overrides)
+        synthesis_role = ReviewRoleConfig(
+            ref=synth_ref,
+            allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+        )
+
+    return RoleAssignment(
+        dev=dev_role,
+        preflight=preflight_role,
+        plan=plan_role,
+        review_pool=tuple(review_pool),
+        synthesis=synthesis_role,
+    )

--- a/src/theforge/config/schema.py
+++ b/src/theforge/config/schema.py
@@ -1,0 +1,124 @@
+"""Config-domain types for the v0.8 simplified configuration schema.
+
+These types define the config-side representation — what you write in forge.yaml
+when using the new simplified model list. They are separate from the runtime types
+(ModelProfile, ForgeConfig) in types.py, which remain the coordinator's currency.
+
+New phases requiring model-backed agents compose ModelRef instead of duplicating
+transport fields (cli, provider, model, budget_usd, timeout_seconds, etc.).
+Use bridge.py (role_assignment_to_profiles) to convert to ModelProfile instances.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .types import ApiFallbackConfig
+
+
+@dataclass(frozen=True)
+class ModelRef:
+    """Transport/model atom — reusable core of every phase config.
+
+    Exactly one of cli/provider should be set, matching the same mutual-exclusion
+    convention as ModelProfile. All transport, timeout, and runtime-limit fields
+    live here so phase wrappers never need to duplicate them.
+
+    Adding a new model-backed phase requires only a new wrapper dataclass that
+    embeds a ModelRef — no transport fields are copy-pasted.
+    """
+
+    model: str
+    budget_usd: float
+    timeout_seconds: int
+    # Transport — exactly one of cli/provider should be set
+    cli: str | None = None
+    provider: str | None = None
+    # Optional: preference fallbacks
+    fallback_models: tuple[str, ...] = ()
+    # Optional: complexity-dependent timeout overrides
+    timeout_medium_seconds: int | None = None
+    timeout_large_seconds: int | None = None
+    # Optional: provider-specific runtime controls
+    reasoning_effort: str | None = None  # "low" | "medium" | "high"; Codex only
+    thinking_budget: int | None = None  # Gemini ThinkingConfig token budget
+    base_url: str | None = None  # override provider endpoint (Ollama, etc.)
+    max_iterations: int | None = None  # override default agent loop iterations
+    max_tool_output_bytes: int = 51200  # cap for tool output (50 KB default)
+    api_fallback: ApiFallbackConfig | None = None  # CLI-only same-provider API fallback
+
+    def __post_init__(self) -> None:
+        if self.cli and self.provider:
+            raise ValueError(
+                f"ModelRef for model {self.model!r} cannot have both 'cli' and 'provider' set. "
+                "Use one transport only."
+            )
+
+
+@dataclass(frozen=True)
+class DevRoleConfig:
+    """Configuration for the DEV phase agent.
+
+    Composes ModelRef for transport/limits; adds dev-specific controls.
+    No transport fields are duplicated here.
+    """
+
+    ref: ModelRef
+    allowed_tools: tuple[str, ...] = ("Read", "Edit", "Write", "Bash", "Glob", "Grep")
+    sandbox_mode: str = "workspace-write"
+
+
+@dataclass(frozen=True)
+class PreflightRoleConfig:
+    """Configuration for the PREFLIGHT phase agent.
+
+    Composes ModelRef for transport/limits; adds preflight-specific controls.
+    No transport fields are duplicated here.
+    """
+
+    ref: ModelRef
+    allowed_tools: tuple[str, ...] = ("Read", "Bash", "Glob", "Grep")
+
+
+@dataclass(frozen=True)
+class PlanRoleConfig:
+    """Configuration for the PLAN phase agent.
+
+    Composes ModelRef for transport/limits; adds plan-specific controls.
+    No transport fields are duplicated here.
+    """
+
+    ref: ModelRef
+    allowed_tools: tuple[str, ...] = ("Read", "Bash", "Glob", "Grep")
+    validate_spec: bool = True
+
+
+@dataclass(frozen=True)
+class ReviewRoleConfig:
+    """Configuration for a single REVIEW phase agent.
+
+    Composes ModelRef for transport/limits; adds review-specific controls.
+    No transport fields are duplicated here.
+    """
+
+    ref: ModelRef
+    review_role: str | None = None  # "correctness" | "patterns" | "edge-cases"
+    allowed_tools: tuple[str, ...] = ("Read", "Bash", "Glob", "Grep")
+
+
+@dataclass(frozen=True)
+class RoleAssignment:
+    """Container for all role configs derived from a simple model list.
+
+    Produced by derive_roles() in role_derivation.py. This dataclass is the
+    clean insertion point for future adaptive routing (v0.9): a router replaces
+    derive_roles() and returns a RoleAssignment without restructuring the type
+    hierarchy. The bridge module (bridge.py) converts this to ModelProfile
+    instances for the coordinator.
+    """
+
+    dev: DevRoleConfig
+    preflight: PreflightRoleConfig
+    plan: PlanRoleConfig
+    review_pool: tuple[ReviewRoleConfig, ...]
+    synthesis: ReviewRoleConfig | None = None

--- a/src/theforge/config/schema.py
+++ b/src/theforge/config/schema.py
@@ -104,6 +104,7 @@ class ReviewRoleConfig:
     ref: ModelRef
     review_role: str | None = None  # "correctness" | "patterns" | "edge-cases"
     allowed_tools: tuple[str, ...] = ("Read", "Bash", "Glob", "Grep")
+    name: str | None = None  # optional profile identifier; used by bridge for ModelProfile.name
 
 
 @dataclass(frozen=True)

--- a/src/theforge/config/schema.py
+++ b/src/theforge/config/schema.py
@@ -115,6 +115,11 @@ class RoleAssignment:
     derive_roles() and returns a RoleAssignment without restructuring the type
     hierarchy. The bridge module (bridge.py) converts this to ModelProfile
     instances for the coordinator.
+
+    plan_agent_review replaces PlanAgentReviewConfig's transport fields: it
+    composes ReviewRoleConfig (which embeds ModelRef) instead of duplicating
+    cli/provider/model/budget_usd/timeout fields. None = plan agent review
+    disabled, matching PlanAgentReviewConfig's enabled=False default.
     """
 
     dev: DevRoleConfig
@@ -122,3 +127,4 @@ class RoleAssignment:
     plan: PlanRoleConfig
     review_pool: tuple[ReviewRoleConfig, ...]
     synthesis: ReviewRoleConfig | None = None
+    plan_agent_review: ReviewRoleConfig | None = None  # None = disabled

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -581,6 +581,61 @@ class TestModelsKeyConfig:
         assert config.synthesis_profile is not None
         assert config.synthesis_profile.model == "opus"
 
+    def test_models_key_plan_uses_derived_role(self, tmp_path):
+        """Smart-config plan phase uses the derived plan role, not legacy sonnet.
+
+        Regression guard for #265: derive_roles() + bridge correctly produce a
+        plan_profile, but load_config used to drop it and build PlanConfig from
+        the hard-coded cli=claude/model=sonnet legacy defaults. The result was
+        that adaptive routing never reached the PLAN phase when the user opted
+        into smart config.
+        """
+        config_path = _write_config(
+            {
+                "models": ["openai/gpt-5.4", "claude/opus"],
+                "budget_usd": 50.0,
+                "plan": {"enabled": True},
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        # derive_roles picks the cheapest dev-capable model for dev AND plan.
+        # With [opus (rank 3), gpt-5.4 (rank 2)], dev = gpt-5.4.
+        assert config.dev_profile.cli == "codex"
+        assert config.dev_profile.model == "gpt-5.4"
+        # Plan must track the derived dev role, not the legacy sonnet default.
+        assert config.plan.enabled is True
+        assert config.plan.cli == "codex"
+        assert config.plan.model == "gpt-5.4"
+        assert config.plan.provider is None
+        # validate_spec flows through from the derived PlanRoleConfig default.
+        assert config.plan.validate_spec is True
+
+    def test_models_key_plan_explicit_override_wins(self, tmp_path):
+        """Explicit plan.model in forge.yaml overrides the derived plan role."""
+        config_path = _write_config(
+            {
+                "models": ["openai/gpt-5.4", "claude/opus"],
+                "budget_usd": 50.0,
+                "plan": {"enabled": True, "cli": "claude", "model": "opus"},
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.plan.cli == "claude"
+        assert config.plan.model == "opus"
+
+    def test_classic_config_plan_defaults_unchanged(self, tmp_path):
+        """Classic config (no models: key) still gets the legacy plan defaults."""
+        config_path = _write_config(
+            {"project": "classic", "plan": {"enabled": True}},
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.plan.cli == "claude"
+        assert config.plan.model == "sonnet"
+        assert config.plan.provider is None
+
 
 class TestAutoAssignBudgetClamping:
     """Tests for budget clamping (P1 fix: reviewer budget must not exceed total)."""

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -275,6 +275,30 @@ class TestDeriveRolesOverrides:
         )
         assert ra.plan.validate_spec is False
 
+    def test_switch_to_provider_transport_clears_cli(self):
+        """Overriding to 'provider' without explicit 'cli: None' must not raise ValueError.
+
+        derive_roles() produces refs with cli set (from ModelInfo). If _apply_ref_overrides
+        naively merged {'provider': 'anthropic'} without clearing cli, ModelRef.__post_init__
+        would raise 'cannot have both cli and provider set'.
+        """
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"dev": {"provider": "anthropic"}},
+        )
+        assert ra.dev.ref.provider == "anthropic"
+        assert ra.dev.ref.cli is None  # cli must be cleared when provider is overridden
+
+    def test_switch_to_cli_transport_clears_provider(self):
+        """Overriding to 'cli' without explicit 'provider: None' must clear provider."""
+        # Build an assignment starting from a known model, then override dev to CLI
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"dev": {"cli": "codex", "model": "gpt-5.4"}},
+        )
+        assert ra.dev.ref.cli == "codex"
+        assert ra.dev.ref.provider is None
+
     def test_synthesis_budget_override(self):
         # Need 3+ models so pool > 1 and synthesis is generated
         ra = derive_roles(
@@ -337,8 +361,10 @@ class TestRoleAssignmentToProfiles:
             "dev_profile",
             "preflight_profile",
             "plan_profile",
+            "plan_validate_spec",
             "review_pool",
             "synthesis_profile",
+            "plan_agent_review_profile",
         }
 
     def test_dev_profile_is_model_profile(self):
@@ -393,6 +419,42 @@ class TestRoleAssignmentToProfiles:
         ra = derive_roles(["claude/sonnet"])
         result = role_assignment_to_profiles(ra)
         assert result["synthesis_profile"] is None
+
+    def test_plan_validate_spec_preserved(self):
+        """validate_spec on PlanRoleConfig must not be silently dropped at the bridge boundary."""
+        ra = derive_roles(["claude/sonnet"], overrides={"plan": {"validate_spec": False}})
+        result = role_assignment_to_profiles(ra)
+        assert result["plan_validate_spec"] is False
+
+    def test_plan_validate_spec_default_preserved(self):
+        ra = derive_roles(["claude/sonnet"])
+        result = role_assignment_to_profiles(ra)
+        assert result["plan_validate_spec"] is True
+
+    def test_plan_agent_review_profile_none_by_default(self):
+        """plan_agent_review_profile is None when plan_agent_review is not configured."""
+        ra = derive_roles(["claude/sonnet"])
+        result = role_assignment_to_profiles(ra)
+        assert result["plan_agent_review_profile"] is None
+
+    def test_plan_agent_review_profile_when_set(self):
+        """plan_agent_review_profile is a ModelProfile when plan_agent_review is configured."""
+        ref = ModelRef(model="opus", cli="claude", budget_usd=0.5, timeout_seconds=300)
+        review_ref = ModelRef(model="sonnet", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        plan_ref = ModelRef(model="sonnet", cli="claude", budget_usd=0.5, timeout_seconds=600)
+        ra = RoleAssignment(
+            dev=DevRoleConfig(ref=ref),
+            preflight=PreflightRoleConfig(ref=review_ref),
+            plan=PlanRoleConfig(ref=plan_ref),
+            review_pool=(ReviewRoleConfig(ref=review_ref),),
+            plan_agent_review=ReviewRoleConfig(ref=ref),
+        )
+        result = role_assignment_to_profiles(ra)
+        par: ModelProfile = result["plan_agent_review_profile"]  # type: ignore[assignment]
+        assert isinstance(par, ModelProfile)
+        assert par.name == "plan-agent-review"
+        assert par.model == "opus"
+        assert par.phase == "plan_review"
 
     def test_all_optional_ref_fields_propagate(self):
         """Optional ModelRef fields (reasoning_effort, base_url, etc.) flow to ModelProfile."""

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -222,6 +222,41 @@ class TestDeriveRolesHappyPath:
         assert "Read" in ra.preflight.allowed_tools
         assert "Edit" not in ra.preflight.allowed_tools
 
+    def test_reviewer_names_match_registry_key_format(self):
+        """Reviewer pool entries are named using the registry key format (e.g. 'claude-opus').
+
+        This ensures name-based profile overrides in load.py continue to match
+        auto-assigned pool entries when derive_roles is wired into the loader.
+        """
+        ra = derive_roles(["claude/sonnet", "claude/opus"])
+        # dev=sonnet, pool=[opus]; opus reviewer should be named "claude-opus"
+        assert ra.review_pool[0].name == "claude-opus"
+
+    def test_plan_agent_review_none_by_default(self):
+        """plan_agent_review is None when no overrides are provided."""
+        ra = derive_roles(["claude/sonnet"])
+        assert ra.plan_agent_review is None
+
+    def test_plan_agent_review_enabled_via_overrides(self):
+        """plan_agent_review is constructed when plan_agent_review overrides are provided."""
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"plan_agent_review": {"budget_usd": 0.75}},
+        )
+        assert ra.plan_agent_review is not None
+        assert ra.plan_agent_review.ref.model == "sonnet"  # defaults to dev model
+        assert ra.plan_agent_review.ref.cli == "claude"
+        assert abs(ra.plan_agent_review.ref.budget_usd - 0.75) < 0.001
+
+    def test_plan_agent_review_model_override(self):
+        """plan_agent_review can override the model independently of dev."""
+        ra = derive_roles(
+            ["claude/sonnet", "claude/opus"],
+            overrides={"plan_agent_review": {"model": "opus", "budget_usd": 0.5}},
+        )
+        assert ra.plan_agent_review is not None
+        assert ra.plan_agent_review.ref.model == "opus"
+
     def test_empty_models_raises(self):
         with pytest.raises(ValueError, match="non-empty"):
             derive_roles([])

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,483 @@
+"""Unit tests for config schema types, derive_roles(), and bridge conversion.
+
+Tests cover:
+- ModelRef construction and cli/provider mutual exclusion validation
+- Phase wrapper composition (no transport field duplication)
+- derive_roles() happy path: correct role → model mapping
+- derive_roles() with overrides: override merges correctly
+- Bridge conversion round-trip: RoleAssignment → ModelProfile fields match
+- Clean insertion-point property: derive_roles can be replaced by a stub
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from theforge.config.bridge import role_assignment_to_profiles
+from theforge.config.role_derivation import derive_roles
+from theforge.config.schema import (
+    DevRoleConfig,
+    ModelRef,
+    PlanRoleConfig,
+    PreflightRoleConfig,
+    ReviewRoleConfig,
+    RoleAssignment,
+)
+from theforge.config.types import ApiFallbackConfig, ModelProfile
+
+# ---------------------------------------------------------------------------
+# ModelRef construction and validation
+# ---------------------------------------------------------------------------
+
+
+class TestModelRef:
+    def test_cli_only(self):
+        ref = ModelRef(model="sonnet", cli="claude", budget_usd=2.0, timeout_seconds=900)
+        assert ref.cli == "claude"
+        assert ref.provider is None
+        assert ref.model == "sonnet"
+
+    def test_provider_only(self):
+        ref = ModelRef(
+            model="claude-3-7-sonnet", provider="anthropic", budget_usd=1.0, timeout_seconds=300
+        )
+        assert ref.provider == "anthropic"
+        assert ref.cli is None
+
+    def test_neither_cli_nor_provider_is_allowed(self):
+        # ModelRef does not require one to be set — that's validated at profile parse time.
+        ref = ModelRef(model="sonnet", budget_usd=1.0, timeout_seconds=300)
+        assert ref.cli is None
+        assert ref.provider is None
+
+    def test_both_cli_and_provider_raises(self):
+        with pytest.raises(ValueError, match="cannot have both"):
+            ModelRef(
+                model="sonnet",
+                cli="claude",
+                provider="anthropic",
+                budget_usd=1.0,
+                timeout_seconds=300,
+            )
+
+    def test_optional_fields_default(self):
+        ref = ModelRef(model="sonnet", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        assert ref.fallback_models == ()
+        assert ref.timeout_medium_seconds is None
+        assert ref.timeout_large_seconds is None
+        assert ref.reasoning_effort is None
+        assert ref.thinking_budget is None
+        assert ref.base_url is None
+        assert ref.max_iterations is None
+        assert ref.max_tool_output_bytes == 51200
+        assert ref.api_fallback is None
+
+    def test_all_optional_fields(self):
+        fallback = ApiFallbackConfig(provider="anthropic", model="claude-3-5-haiku")
+        ref = ModelRef(
+            model="sonnet",
+            cli="claude",
+            budget_usd=2.0,
+            timeout_seconds=900,
+            fallback_models=("haiku",),
+            timeout_medium_seconds=600,
+            timeout_large_seconds=1200,
+            reasoning_effort="high",
+            thinking_budget=8000,
+            base_url="http://localhost:11434",
+            max_iterations=5,
+            max_tool_output_bytes=102400,
+            api_fallback=fallback,
+        )
+        assert ref.fallback_models == ("haiku",)
+        assert ref.timeout_medium_seconds == 600
+        assert ref.timeout_large_seconds == 1200
+        assert ref.reasoning_effort == "high"
+        assert ref.thinking_budget == 8000
+        assert ref.base_url == "http://localhost:11434"
+        assert ref.max_iterations == 5
+        assert ref.max_tool_output_bytes == 102400
+        assert ref.api_fallback is fallback
+
+    def test_is_frozen(self):
+        ref = ModelRef(model="sonnet", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        with pytest.raises((AttributeError, TypeError)):
+            ref.model = "opus"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Phase wrapper composition — no transport field duplication
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseWrappers:
+    """Phase wrappers embed ModelRef; they have no transport fields of their own."""
+
+    def test_dev_role_config_fields(self):
+        ref = ModelRef(model="sonnet", cli="claude", budget_usd=2.0, timeout_seconds=900)
+        dev = DevRoleConfig(ref=ref)
+        # Transport lives in ref, not duplicated on DevRoleConfig
+        assert not hasattr(dev, "cli")
+        assert not hasattr(dev, "provider")
+        assert not hasattr(dev, "model")
+        assert not hasattr(dev, "budget_usd")
+        assert not hasattr(dev, "timeout_seconds")
+        # Phase-specific fields
+        assert dev.allowed_tools == ("Read", "Edit", "Write", "Bash", "Glob", "Grep")
+        assert dev.sandbox_mode == "workspace-write"
+
+    def test_preflight_role_config_fields(self):
+        ref = ModelRef(model="sonnet", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        pf = PreflightRoleConfig(ref=ref)
+        assert not hasattr(pf, "cli")
+        assert not hasattr(pf, "budget_usd")
+        assert pf.allowed_tools == ("Read", "Bash", "Glob", "Grep")
+
+    def test_plan_role_config_fields(self):
+        ref = ModelRef(model="sonnet", cli="claude", budget_usd=0.5, timeout_seconds=600)
+        plan = PlanRoleConfig(ref=ref)
+        assert not hasattr(plan, "cli")
+        assert plan.validate_spec is True
+
+    def test_review_role_config_fields(self):
+        ref = ModelRef(model="opus", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        rev = ReviewRoleConfig(ref=ref, review_role="correctness")
+        assert not hasattr(rev, "cli")
+        assert rev.review_role == "correctness"
+        assert rev.allowed_tools == ("Read", "Bash", "Glob", "Grep")
+
+    def test_wrapper_is_frozen(self):
+        ref = ModelRef(model="sonnet", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        dev = DevRoleConfig(ref=ref)
+        with pytest.raises((AttributeError, TypeError)):
+            dev.sandbox_mode = "none"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# derive_roles() happy path
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveRolesHappyPath:
+    def test_single_model(self):
+        """Single model: dev uses it, preflight uses it, pool = [dev]."""
+        ra = derive_roles(["claude/sonnet"])
+        assert ra.dev.ref.model == "sonnet"
+        assert ra.dev.ref.cli == "claude"
+        assert ra.preflight.ref.model == "sonnet"
+        assert len(ra.review_pool) == 1
+        assert ra.review_pool[0].ref.model == "sonnet"
+        assert ra.synthesis is None  # pool <= 1, no synthesis
+
+    def test_two_models_assigns_cheapest_to_dev(self):
+        """Dev gets cheapest dev-capable model."""
+        ra = derive_roles(["claude/sonnet", "claude/opus"])
+        # sonnet is cost_rank=1, opus is cost_rank=3
+        assert ra.dev.ref.model == "sonnet"
+
+    def test_strongest_model_becomes_synthesis(self):
+        """Synthesis is the highest-capability reviewer when pool > 1."""
+        ra = derive_roles(["claude/sonnet", "claude/opus", "openai/gpt-5.4"])
+        assert ra.synthesis is not None
+        # claude/opus and openai/gpt-5.4 both have capability=10, gpt-5.4-pro is higher
+        # synthesis picks max capability among reviewers
+        assert ra.synthesis.ref.model in {"opus", "gpt-5.4"}
+
+    def test_preflight_gets_fast_tier(self):
+        """Preflight gets cheapest 'fast' tier model when available."""
+        # claude/sonnet is tier="fast", claude/opus is tier="strong"
+        ra = derive_roles(["claude/sonnet", "claude/opus"])
+        assert ra.preflight.ref.model == "sonnet"  # fast tier
+
+    def test_review_pool_excludes_dev(self):
+        """Review pool excludes the dev model when multiple models are available."""
+        ra = derive_roles(["claude/sonnet", "claude/opus"])
+        pool_models = [rc.ref.model for rc in ra.review_pool]
+        assert "sonnet" not in pool_models  # dev model excluded
+        assert "opus" in pool_models
+
+    def test_budget_distribution(self):
+        """Budget is distributed per the documented percentages."""
+        ra = derive_roles(["claude/sonnet", "claude/opus"], budget_usd=10.0)
+        # dev: 60% = $6.00
+        assert abs(ra.dev.ref.budget_usd - 6.0) < 0.001
+        # preflight: max(2%, $1) = max($0.20, $1.00) = $1.00
+        assert abs(ra.preflight.ref.budget_usd - 1.0) < 0.001
+
+    def test_plan_defaults(self):
+        """Plan role gets dev model and plan-specific budget/timeout."""
+        ra = derive_roles(["claude/sonnet"])
+        assert ra.plan.ref.model == ra.dev.ref.model
+        assert ra.plan.ref.budget_usd == 0.50
+        assert ra.plan.ref.timeout_seconds == 600
+        assert ra.plan.validate_spec is True
+
+    def test_dev_allowed_tools_default(self):
+        ra = derive_roles(["claude/sonnet"])
+        assert "Edit" in ra.dev.allowed_tools
+        assert "Write" in ra.dev.allowed_tools
+
+    def test_preflight_allowed_tools_default(self):
+        ra = derive_roles(["claude/sonnet"])
+        assert "Read" in ra.preflight.allowed_tools
+        assert "Edit" not in ra.preflight.allowed_tools
+
+    def test_empty_models_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            derive_roles([])
+
+    def test_unknown_model_handled_gracefully(self):
+        """Unknown models get sensible defaults from _resolve_model_info."""
+        ra = derive_roles(["custom/my-local-model"])
+        assert ra.dev.ref.model == "my-local-model"
+        assert ra.synthesis is None  # only one model
+
+
+# ---------------------------------------------------------------------------
+# derive_roles() with overrides
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveRolesOverrides:
+    def test_dev_budget_override(self):
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"dev": {"budget_usd": 5.0}},
+        )
+        assert ra.dev.ref.budget_usd == 5.0
+
+    def test_dev_timeout_override(self):
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"dev": {"timeout_seconds": 1800}},
+        )
+        assert ra.dev.ref.timeout_seconds == 1800
+
+    def test_dev_sandbox_mode_override(self):
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"dev": {"sandbox_mode": "read-only"}},
+        )
+        assert ra.dev.sandbox_mode == "read-only"
+
+    def test_preflight_model_override(self):
+        """Override preflight to use a specific model."""
+        ra = derive_roles(
+            ["claude/sonnet", "claude/opus"],
+            overrides={"preflight": {"model": "opus"}},
+        )
+        assert ra.preflight.ref.model == "opus"
+
+    def test_plan_validate_spec_override(self):
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"plan": {"validate_spec": False}},
+        )
+        assert ra.plan.validate_spec is False
+
+    def test_synthesis_budget_override(self):
+        # Need 3+ models so pool > 1 and synthesis is generated
+        ra = derive_roles(
+            ["claude/sonnet", "claude/opus", "openai/gpt-5.4"],
+            overrides={"synthesis": {"budget_usd": 3.0}},
+        )
+        assert ra.synthesis is not None
+        assert ra.synthesis.ref.budget_usd == 3.0
+
+    def test_review_pool_per_reviewer_override(self):
+        """Pool overrides are applied by index."""
+        ra = derive_roles(
+            ["claude/sonnet", "claude/opus"],
+            overrides={"review_pool": [{"budget_usd": 2.5}]},
+        )
+        assert ra.review_pool[0].ref.budget_usd == 2.5
+
+    def test_unrecognized_role_override_ignored(self):
+        """Overrides for unknown role keys are silently ignored."""
+        # Should not raise even if unknown key is present
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"nonexistent_role": {"budget_usd": 99.0}},
+        )
+        assert ra.dev.ref.model == "sonnet"
+
+    def test_override_does_not_mutate_base(self):
+        """Applying an override returns a new RoleAssignment without mutating shared state."""
+        ra1 = derive_roles(["claude/sonnet"])
+        ra2 = derive_roles(["claude/sonnet"], overrides={"dev": {"budget_usd": 99.0}})
+        # ra1 is unchanged
+        assert ra1.dev.ref.budget_usd != 99.0
+        assert ra2.dev.ref.budget_usd == 99.0
+
+    def test_ref_fields_not_overridden_keep_derived_values(self):
+        """Only specified override fields change; others retain derived values."""
+        ra = derive_roles(
+            ["claude/sonnet"],
+            overrides={"dev": {"budget_usd": 5.0}},
+            budget_usd=10.0,
+        )
+        # timeout_seconds was NOT overridden → keeps derived default
+        assert ra.dev.ref.timeout_seconds > 0
+        assert ra.dev.ref.model == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# Bridge conversion round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoleAssignmentToProfiles:
+    def _make_simple_assignment(self) -> RoleAssignment:
+        return derive_roles(["claude/sonnet", "claude/opus"], budget_usd=10.0)
+
+    def test_returns_expected_keys(self):
+        ra = self._make_simple_assignment()
+        result = role_assignment_to_profiles(ra)
+        assert set(result.keys()) == {
+            "dev_profile",
+            "preflight_profile",
+            "plan_profile",
+            "review_pool",
+            "synthesis_profile",
+        }
+
+    def test_dev_profile_is_model_profile(self):
+        ra = self._make_simple_assignment()
+        result = role_assignment_to_profiles(ra)
+        assert isinstance(result["dev_profile"], ModelProfile)
+
+    def test_dev_profile_fields_match_ref(self):
+        ra = self._make_simple_assignment()
+        result = role_assignment_to_profiles(ra)
+        dev: ModelProfile = result["dev_profile"]  # type: ignore[assignment]
+        assert dev.name == "dev"
+        assert dev.model == ra.dev.ref.model
+        assert dev.cli == ra.dev.ref.cli
+        assert dev.budget_usd == ra.dev.ref.budget_usd
+        assert dev.timeout_seconds == ra.dev.ref.timeout_seconds
+        assert dev.phase == "dev"
+        assert dev.allowed_tools == ra.dev.allowed_tools
+        assert dev.sandbox_mode == ra.dev.sandbox_mode
+
+    def test_preflight_profile_phase(self):
+        ra = self._make_simple_assignment()
+        result = role_assignment_to_profiles(ra)
+        pf: ModelProfile = result["preflight_profile"]  # type: ignore[assignment]
+        assert pf.phase == "preflight"
+
+    def test_plan_profile_phase(self):
+        ra = self._make_simple_assignment()
+        result = role_assignment_to_profiles(ra)
+        plan: ModelProfile = result["plan_profile"]  # type: ignore[assignment]
+        assert plan.phase == "plan"
+
+    def test_review_pool_is_list_of_model_profiles(self):
+        ra = self._make_simple_assignment()
+        result = role_assignment_to_profiles(ra)
+        pool = result["review_pool"]
+        assert isinstance(pool, list)
+        assert len(pool) == len(ra.review_pool)
+        for p in pool:
+            assert isinstance(p, ModelProfile)
+            assert p.phase == "review"
+
+    def test_synthesis_profile_present_when_pool_gt_1(self):
+        # Need 3+ models so review_pool > 1 and synthesis is generated
+        ra = derive_roles(["claude/sonnet", "claude/opus", "openai/gpt-5.4"], budget_usd=10.0)
+        result = role_assignment_to_profiles(ra)
+        assert result["synthesis_profile"] is not None
+        synth: ModelProfile = result["synthesis_profile"]  # type: ignore[assignment]
+        assert isinstance(synth, ModelProfile)
+
+    def test_synthesis_profile_none_when_single_model(self):
+        ra = derive_roles(["claude/sonnet"])
+        result = role_assignment_to_profiles(ra)
+        assert result["synthesis_profile"] is None
+
+    def test_all_optional_ref_fields_propagate(self):
+        """Optional ModelRef fields (reasoning_effort, base_url, etc.) flow to ModelProfile."""
+        ref = ModelRef(
+            model="sonnet",
+            cli="claude",
+            budget_usd=2.0,
+            timeout_seconds=900,
+            timeout_medium_seconds=600,
+            timeout_large_seconds=1200,
+            reasoning_effort="high",
+            thinking_budget=8000,
+            base_url="http://localhost:11434",
+            max_iterations=5,
+            max_tool_output_bytes=102400,
+        )
+        dev = DevRoleConfig(ref=ref)
+        pf_ref = ModelRef(model="sonnet", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        pf = PreflightRoleConfig(ref=pf_ref)
+        plan_ref = ModelRef(model="sonnet", cli="claude", budget_usd=0.5, timeout_seconds=600)
+        plan = PlanRoleConfig(ref=plan_ref)
+        rev_ref = ModelRef(model="opus", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        rev = ReviewRoleConfig(ref=rev_ref)
+        ra = RoleAssignment(
+            dev=dev,
+            preflight=pf,
+            plan=plan,
+            review_pool=(rev,),
+            synthesis=None,
+        )
+        result = role_assignment_to_profiles(ra)
+        dev_profile: ModelProfile = result["dev_profile"]  # type: ignore[assignment]
+        assert dev_profile.timeout_medium_seconds == 600
+        assert dev_profile.timeout_large_seconds == 1200
+        assert dev_profile.reasoning_effort == "high"
+        assert dev_profile.thinking_budget == 8000
+        assert dev_profile.base_url == "http://localhost:11434"
+        assert dev_profile.max_iterations == 5
+        assert dev_profile.max_tool_output_bytes == 102400
+
+
+# ---------------------------------------------------------------------------
+# Clean insertion-point property
+# ---------------------------------------------------------------------------
+
+
+class TestInsertionPoint:
+    """derive_roles() can be replaced by any function that returns a RoleAssignment.
+
+    This verifies the type contract: as long as the stub returns a valid
+    RoleAssignment, the bridge works without knowing how the roles were derived.
+    """
+
+    def test_stub_derive_roles_works_with_bridge(self):
+        """A stub that bypasses the real assignment logic still works with bridge."""
+        ref = ModelRef(model="custom-model", cli="codex", budget_usd=1.0, timeout_seconds=300)
+        stub_ra = RoleAssignment(
+            dev=DevRoleConfig(ref=ref),
+            preflight=PreflightRoleConfig(ref=ref),
+            plan=PlanRoleConfig(ref=ref),
+            review_pool=(ReviewRoleConfig(ref=ref),),
+            synthesis=None,
+        )
+        # Bridge must accept any valid RoleAssignment, regardless of how it was built
+        result = role_assignment_to_profiles(stub_ra)
+        dev: ModelProfile = result["dev_profile"]  # type: ignore[assignment]
+        assert dev.model == "custom-model"
+        assert dev.cli == "codex"
+
+    def test_role_assignment_accepts_any_valid_review_pool(self):
+        """review_pool can have any number of ReviewRoleConfigs."""
+        ref1 = ModelRef(model="sonnet", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        ref2 = ModelRef(model="opus", cli="claude", budget_usd=1.0, timeout_seconds=300)
+        ref3 = ModelRef(model="gpt-5.4", cli="codex", budget_usd=1.0, timeout_seconds=300)
+        dev_ref = ModelRef(model="sonnet", cli="claude", budget_usd=6.0, timeout_seconds=900)
+        plan_ref = ModelRef(model="sonnet", cli="claude", budget_usd=0.5, timeout_seconds=600)
+        ra = RoleAssignment(
+            dev=DevRoleConfig(ref=dev_ref),
+            preflight=PreflightRoleConfig(ref=ref1),
+            plan=PlanRoleConfig(ref=plan_ref),
+            review_pool=(
+                ReviewRoleConfig(ref=ref1),
+                ReviewRoleConfig(ref=ref2),
+                ReviewRoleConfig(ref=ref3),
+            ),
+        )
+        result = role_assignment_to_profiles(ra)
+        assert len(result["review_pool"]) == 3  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Adds `ModelRef`, `RoleAssignment`, config-domain schema types, and `derive_roles()` for deterministic model→role mapping from a simple `models:` list in forge.yaml.
- Adds `role_assignment_to_profiles()` bridge converting `RoleAssignment` → runtime `ModelProfile` structures consumed by the coordinator.
- **Wires the derived plan role into `PlanConfig`** so smart-config mode actually routes the PLAN phase through the derived model instead of falling back to the hard-coded `cli=claude`/`model=sonnet` legacy defaults. This was the final P1 from the sprint review escalation.
- Explicit `plan:` overrides in forge.yaml still win field-by-field; classic config (no `models:` key) is unchanged.

## Test plan

- [x] 3 new loader integration tests: derived plan role wins, explicit override wins, classic defaults unchanged
- [x] 580-line `test_config_schema.py` covering schema types, derive_roles, bridge boundary, validate_spec preservation
- [x] `make gate` PASS — 3004 passed, 1 skipped

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)