### PR TITLE
GitHub issue dependency parser should recognize depends-on language

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -104,6 +104,27 @@ stories:
 | `{issue: 123, depends_on: [other-slug]}` | Declare a dependency on another story in the sprint |
 | `{issue: 123, pytest_target: tests/test_foo.py}` | Override the pytest target for this story |
 
+### Declaring dependencies in GitHub issue bodies
+
+Forge extracts dependencies from prose in GitHub issue bodies. Use **`Depends on: #N`**
+as the preferred spelling when authoring or generating issues. `Blocked by #N` is
+supported as a compatibility alias.
+
+All of the following forms are recognized and normalized to `issue-N` slugs:
+
+- `Depends on #265` — simple hash form
+- `Depends on: #265` — colon form (preferred)
+- `depends on #265` — lowercase
+- `depends_on: #265` — underscore colon
+- `depends_on: issue-265` — slug form
+- `depends_on: [issue-265, issue-807]` — YAML list form (multiple dependencies)
+- Full GitHub issue URLs in any of the above positions
+- `Blocked by #265` — compatibility alias (still supported)
+
+Multiple dependencies in a single body are all extracted. Native GitHub
+`blocked_by` timeline relationships take precedence over body-text parsing
+when available.
+
 ### Behavior
 
 - Stories run in order. Each goes through the full pipeline.

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -21,6 +21,14 @@ _BLOCKED_BY_BODY_RE = re.compile(
     r"blocked by\s+(?:https?://github\.com/[^/\s]+/[^/\s]+/issues/)?#?(?P<number>\d+)",
     re.IGNORECASE,
 )
+# Matches "Depends on #N", "depends on: #N", "depends_on: #N", "depends_on: issue-N",
+# "depends_on: [issue-N, issue-M]", full GitHub issue URLs, etc.
+_DEPENDS_ON_BODY_RE = re.compile(
+    r"depends[_ ]on:?\s*"
+    r"(?:\[([^\]]*)\]|"  # bracketed list form: depends_on: [issue-1, issue-2]
+    r"(?:https?://github\.com/[^/\s]+/[^/\s]+/issues/|issue-)?#?(\d+))",  # single ref
+    re.IGNORECASE,
+)
 
 
 class IssueClosedError(RuntimeError):
@@ -143,6 +151,16 @@ class GitHubIssueSource:
     def _parse_issue_blockers_from_body(self, body: str) -> list[int]:
         """Return blocker issue numbers referenced in body text."""
         blockers = {int(match.group("number")) for match in _BLOCKED_BY_BODY_RE.finditer(body)}
+        # Also parse "depends on" / "depends_on" forms.
+        _NUMBER_RE = re.compile(r"(?:issue-)?#?(\d+)", re.IGNORECASE)
+        for match in _DEPENDS_ON_BODY_RE.finditer(body):
+            bracket_content, single_number = match.group(1), match.group(2)
+            if bracket_content is not None:
+                # Bracketed list: extract all issue numbers from within the brackets.
+                for num_match in _NUMBER_RE.finditer(bracket_content):
+                    blockers.add(int(num_match.group(1)))
+            elif single_number is not None:
+                blockers.add(int(single_number))
         return sorted(blockers)
 
     def fetch(self, ref: str, project_root: Path) -> TaskStory:

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -112,6 +112,34 @@ class TestGitHubIssueSource:
         assert task.depends_on == ["issue-7", "issue-12"]
         assert task.inferred_dependencies == ["issue-7", "issue-12"]
 
+    @pytest.mark.parametrize(
+        "body, expected",
+        [
+            ("Depends on #265", [265]),
+            ("Depends on: #265", [265]),
+            ("depends on #265", [265]),
+            ("depends_on: #265", [265]),
+            ("depends_on: issue-265", [265]),
+            ("depends_on: [issue-265, issue-807]", [265, 807]),
+            (
+                "depends_on: https://github.com/acme/repo/issues/265",
+                [265],
+            ),
+            (
+                "This is blocked by #12 and depends on #265",
+                [12, 265],
+            ),
+            (
+                "depends_on: [issue-265, issue-807]\nblocked by #12",
+                [12, 265, 807],
+            ),
+        ],
+    )
+    def test_parse_issue_blockers_from_body(self, body: str, expected: list) -> None:
+        source = GitHubIssueSource()
+        result = source._parse_issue_blockers_from_body(body)
+        assert result == expected
+
     def test_fetch_raises_on_failure(self, tmp_path: Path) -> None:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")


### PR DESCRIPTION
## Summary

[openai-reviewer] Implementation matches the dependency parsing spec and is exercised at runtime through GitHub issue fetch fallback. | [gemini-reviewer] The implementation correctly parses all specified 'depends on' forms from GitHub issue bodies.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $2.08
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

GitHub issue dependency parser should recognize depends-on language (GitHub Issue #808)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #808