### PR TITLE
Config loader bridge — parse v0.8 schema into existing ForgeConfig/ModelProfile

### DIFF
--- a/src/theforge/config/_loaders.py
+++ b/src/theforge/config/_loaders.py
@@ -20,6 +20,53 @@ from .types import (
 
 log = logging.getLogger("theforge.config")
 
+# Keys that existed in the legacy (pre-v0.8) schema and are rejected when
+# the v0.8 `models:` key is also present. `agents:` is intentionally excluded
+# because it remains valid alongside `models:` for adaptive assignment.
+_V0_8_LEGACY_KEYS: frozenset[str] = frozenset({"profiles", "smart_config_models"})
+
+# Fields that were scalars on the top-level `plan_agent_review:` section before
+# v0.8. In v0.8 these move into an `overrides.plan_agent_review` ref dict or
+# into a pool entry. Presence of these scalars at the top level alongside
+# `models:` indicates a mixed-mode config.
+_LEGACY_PAR_SCALAR_FIELDS: frozenset[str] = frozenset({"model", "cli", "provider", "budget_usd"})
+
+
+def _validate_v0_8_schema(raw: dict[str, Any]) -> None:
+    """Reject configs that mix v0.8 `models:` with legacy keys.
+
+    Only called (and only raises) when `models:` is present; classic-only
+    configs (no `models:`) pass through so the existing classic branch in
+    load_config() continues to work.
+    """
+    if "models" not in raw:
+        return
+
+    found_legacy = _V0_8_LEGACY_KEYS & raw.keys()
+    if found_legacy:
+        replacements = {
+            "profiles": "models + overrides",
+            "smart_config_models": "models",
+        }
+        details = "; ".join(
+            f"'{k}' → use '{replacements.get(k, 'models')}' instead" for k in sorted(found_legacy)
+        )
+        raise ValueError(
+            f"forge.yaml mixes v0.8 'models:' with legacy key(s): {details}. "
+            "Remove the legacy keys or switch to the classic profiles: schema."
+        )
+
+    par_raw = raw.get("plan_agent_review")
+    if isinstance(par_raw, dict):
+        found_par_legacy = _LEGACY_PAR_SCALAR_FIELDS & par_raw.keys()
+        if found_par_legacy:
+            details = ", ".join(f"'{f}'" for f in sorted(found_par_legacy))
+            raise ValueError(
+                f"forge.yaml: plan_agent_review has legacy scalar field(s) {details} "
+                "alongside 'models:'. Move plan_agent_review configuration into "
+                "'overrides.plan_agent_review' as a ModelRef, or use a pool: list."
+            )
+
 
 def _parse_workspace(ws_data: dict[str, Any]) -> WorkspaceConfig:
     """Parse workspace section from raw YAML dict."""

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -11,7 +11,7 @@ from typing import Any
 import yaml
 from dotenv import dotenv_values
 
-from ._loaders import _parse_plan_agent_review, _parse_workspace
+from ._loaders import _parse_plan_agent_review, _parse_workspace, _validate_v0_8_schema
 from .auth import check_agent_auth
 from .bridge import role_assignment_to_profiles
 from .defaults import (
@@ -42,6 +42,7 @@ from .types import (
     HooksConfig,
     LogConfig,
     ModelProfile,
+    PlanAgentReviewConfig,
     PlanConfig,
     PlanReviewConfig,
     RetryPolicy,
@@ -116,6 +117,8 @@ def load_config(config_path: Path) -> ForgeConfig:
     with open(config_path, encoding="utf-8") as f:
         raw: dict[str, Any] = yaml.safe_load(f) or {}
 
+    _validate_v0_8_schema(raw)
+
     provider_fallbacks = _parse_provider_fallbacks(
         raw.get("provider_fallbacks", {}),
         secrets=secrets,
@@ -143,6 +146,7 @@ def load_config(config_path: Path) -> ForgeConfig:
     _review_pool_is_default = False
     _derived_plan_profile: ModelProfile | None = None
     _derived_plan_validate_spec: bool | None = None
+    _derived_par_profile: ModelProfile | None = None
 
     if "models" in raw:
         models_list = raw["models"]
@@ -165,7 +169,20 @@ def load_config(config_path: Path) -> ForgeConfig:
         if budget_usd_val <= 0:
             raise ValueError("budget_usd must be positive")
 
-        _ra = derive_roles([str(m) for m in models_list], budget_usd=budget_usd_val)
+        # v0.8: overrides: key replaces the classic profiles: key for partial overrides.
+        # plan_agent_review overrides are passed into derive_roles() so the bridge
+        # can lower them to a ModelProfile (fixes silent loss of that config).
+        overrides = raw.get("overrides", {})
+        _par_derive_overrides: dict[str, Any] | None = (
+            {"plan_agent_review": overrides["plan_agent_review"]}
+            if "plan_agent_review" in overrides
+            else None
+        )
+        _ra = derive_roles(
+            [str(m) for m in models_list],
+            overrides=_par_derive_overrides,
+            budget_usd=budget_usd_val,
+        )
         _bridge = role_assignment_to_profiles(_ra)
         dev_profile = _bridge["dev_profile"]
         preflight_profile = _bridge["preflight_profile"]
@@ -173,18 +190,18 @@ def load_config(config_path: Path) -> ForgeConfig:
         synthesis_profile = _bridge["synthesis_profile"]
         _derived_plan_profile = _bridge["plan_profile"]
         _derived_plan_validate_spec = _bridge["plan_validate_spec"]
+        _derived_par_profile = _bridge.get("plan_agent_review_profile")
 
         # Apply explicit profile overrides (partial override supported)
-        profiles = raw.get("profiles", {})
-        if "dev" in profiles:
-            dev_profile = _apply_profile_overrides(dev_profile, profiles["dev"])
-        if "preflight" in profiles:
-            preflight_profile = _apply_profile_overrides(preflight_profile, profiles["preflight"])
-        if synthesis_profile is not None and "synthesis" in profiles:
-            synthesis_profile = _apply_profile_overrides(synthesis_profile, profiles["synthesis"])
+        if "dev" in overrides:
+            dev_profile = _apply_profile_overrides(dev_profile, overrides["dev"])
+        if "preflight" in overrides:
+            preflight_profile = _apply_profile_overrides(preflight_profile, overrides["preflight"])
+        if synthesis_profile is not None and "synthesis" in overrides:
+            synthesis_profile = _apply_profile_overrides(synthesis_profile, overrides["synthesis"])
         # Apply per-reviewer overrides matched by name
-        if "review_pool" in profiles:
-            pool_overrides = profiles["review_pool"]
+        if "review_pool" in overrides:
+            pool_overrides = overrides["review_pool"]
             if isinstance(pool_overrides, list):
                 override_by_name: dict[str, dict[str, Any]] = {
                     e["name"]: e for e in pool_overrides if isinstance(e, dict) and "name" in e
@@ -371,14 +388,20 @@ def load_config(config_path: Path) -> ForgeConfig:
     ]
     assignment_cfg = _parse_assignment(raw.get("assignment", {}))
 
-    plan_agent_review_cfg = _parse_plan_agent_review(
-        raw.get("plan_agent_review", {}),
-        secrets,
-        plan_cfg,
-        agents_list,
-        assignment_cfg.enabled,
-        _plan_model_is_default,
-    )
+    _raw_par = raw.get("plan_agent_review", {})
+    if not _raw_par and _derived_par_profile is not None:
+        # v0.8: plan_agent_review was configured via overrides.plan_agent_review;
+        # the bridge lowered it to a ModelProfile. Wrap it in PlanAgentReviewConfig.
+        plan_agent_review_cfg = PlanAgentReviewConfig(enabled=True, pool=[_derived_par_profile])
+    else:
+        plan_agent_review_cfg = _parse_plan_agent_review(
+            _raw_par,
+            secrets,
+            plan_cfg,
+            agents_list,
+            assignment_cfg.enabled,
+            _plan_model_is_default,
+        )
     if plan_agent_review_cfg.pool:
         plan_agent_review_cfg = dataclasses.replace(
             plan_agent_review_cfg,

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -172,7 +172,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         # v0.8: overrides: key replaces the classic profiles: key for partial overrides.
         # plan_agent_review overrides are passed into derive_roles() so the bridge
         # can lower them to a ModelProfile (fixes silent loss of that config).
-        overrides = raw.get("overrides", {})
+        overrides = raw.get("overrides") or {}
         _par_derive_overrides: dict[str, Any] | None = (
             {"plan_agent_review": overrides["plan_agent_review"]}
             if "plan_agent_review" in overrides
@@ -402,6 +402,13 @@ def load_config(config_path: Path) -> ForgeConfig:
             assignment_cfg.enabled,
             _plan_model_is_default,
         )
+        # v0.8: if overrides.plan_agent_review provided a derived profile but the
+        # explicit plan_agent_review: section didn't specify a pool, inject the
+        # derived profile so overrides are never silently dropped.
+        if _derived_par_profile is not None and not plan_agent_review_cfg.pool:
+            plan_agent_review_cfg = dataclasses.replace(
+                plan_agent_review_cfg, pool=[_derived_par_profile]
+            )
     if plan_agent_review_cfg.pool:
         plan_agent_review_cfg = dataclasses.replace(
             plan_agent_review_cfg,

--- a/tests/test_complexity_timeouts.py
+++ b/tests/test_complexity_timeouts.py
@@ -618,12 +618,12 @@ class TestLoadConfigTimeoutFields:
         assert config.plan.timeout_large is None
 
     def test_smart_config_applies_dev_timeout_overrides(self, tmp_path):
-        """Smart config (models:) path respects timeout_medium_seconds / timeout_large_seconds."""
+        """Smart config (models:) path respects timeout overrides via overrides: key."""
         config_path = _write_config(
             {
                 "models": ["claude/sonnet"],
                 "budget_usd": 10.0,
-                "profiles": {
+                "overrides": {
                     "dev": {
                         "timeout_seconds": 600,
                         "timeout_medium_seconds": 900,

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -500,12 +500,12 @@ class TestModelsKeyConfig:
         assert config.synthesis_profile is None
 
     def test_models_with_profile_override(self, tmp_path):
-        """Explicit profiles overlay auto-assigned values."""
+        """Explicit overrides overlay auto-assigned values (v0.8: overrides: key)."""
         config_path = _write_config(
             {
                 "models": ["claude/sonnet", "claude/opus"],
                 "budget_usd": 50.0,
-                "profiles": {
+                "overrides": {
                     "dev": {"budget_usd": 100.0},
                 },
             },
@@ -681,12 +681,12 @@ class TestModelsKeyReviewPoolOverride:
     """Tests for review_pool override in smart-config mode (P1 fix)."""
 
     def test_review_pool_override_by_name(self, tmp_path):
-        """profiles.review_pool entries are matched by name and override auto-assigned values."""
+        """overrides.review_pool entries are matched by name and override auto-assigned values."""
         config_path = _write_config(
             {
                 "models": ["claude/sonnet", "claude/opus"],
                 "budget_usd": 50.0,
-                "profiles": {
+                "overrides": {
                     "review_pool": [
                         {"name": "claude-opus", "budget_usd": 99.0},
                     ],
@@ -700,12 +700,12 @@ class TestModelsKeyReviewPoolOverride:
         assert abs(config.review_pool[0].budget_usd - 99.0) < 0.01
 
     def test_review_pool_override_partial(self, tmp_path):
-        """Overriding only budget_usd preserves auto-assigned cli/model."""
+        """Overriding only timeout_seconds preserves auto-assigned cli/model."""
         config_path = _write_config(
             {
                 "models": ["claude/sonnet", "claude/opus"],
                 "budget_usd": 50.0,
-                "profiles": {
+                "overrides": {
                     "review_pool": [
                         {"name": "claude-opus", "timeout_seconds": 600},
                     ],
@@ -724,7 +724,7 @@ class TestModelsKeyReviewPoolOverride:
             {
                 "models": ["claude/sonnet", "claude/opus"],
                 "budget_usd": 50.0,
-                "profiles": {
+                "overrides": {
                     "review_pool": [
                         {"name": "nonexistent", "budget_usd": 1.0},
                     ],

--- a/tests/test_config_v08_loader.py
+++ b/tests/test_config_v08_loader.py
@@ -246,6 +246,50 @@ profiles:
     assert "overrides" in str(exc_info.value)
 
 
+# ── Edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_v08_empty_overrides_key_does_not_crash(tmp_path):
+    """overrides: with null/empty value must not raise TypeError."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+overrides:
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+    # Overrides were empty — dev profile should use bridge defaults unchanged.
+    assert cfg.dev_profile.model == "sonnet"
+
+
+def test_v08_overrides_par_with_explicit_par_section_no_pool(tmp_path):
+    """overrides.plan_agent_review + explicit plan_agent_review: (no pool) → derived injected.
+
+    enabled: false avoids the planner-model independence check so we can test
+    pool injection in isolation without needing a second distinct model.
+    """
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+overrides:
+  plan_agent_review:
+    timeout_seconds: 999
+plan_agent_review:
+  enabled: false
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+    # The derived profile from overrides must be injected — not silently dropped.
+    assert len(cfg.plan_agent_review.pool) == 1
+    assert cfg.plan_agent_review.pool[0].timeout_seconds == 999
+
+
 # ── Classic config still works ────────────────────────────────────────────────
 
 

--- a/tests/test_config_v08_loader.py
+++ b/tests/test_config_v08_loader.py
@@ -1,0 +1,269 @@
+"""Tests for the v0.8 loader path (models: + overrides:)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from theforge.config import load_config
+
+# Patch check_agent_auth to always succeed so tests don't need real credentials.
+_auth_ok = patch(
+    "theforge.config._loaders.check_agent_auth",
+    return_value=(True, ""),
+)
+
+
+def _write(tmp_path, text: str):
+    p = tmp_path / "forge.yaml"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+# ── Simple mode ───────────────────────────────────────────────────────────────
+
+
+def test_v08_simple_mode_produces_forgeconfig(tmp_path):
+    """Single model list → ForgeConfig with dev_profile populated."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile.model == "sonnet"
+    assert cfg.dev_profile.cli == "claude"
+    assert cfg.smart_config_models == ["claude/sonnet"]
+
+
+def test_v08_simple_mode_two_models(tmp_path):
+    """Two models → review pool has one entry (not dev), dev gets cheapest."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+  - claude/opus
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile.model == "sonnet"
+    assert len(cfg.review_pool) == 1
+    assert cfg.review_pool[0].model == "opus"
+
+
+# ── Simple mode + overrides ───────────────────────────────────────────────────
+
+
+def test_v08_overrides_dev_timeout(tmp_path):
+    """overrides.dev.timeout_seconds is applied to the derived dev profile."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+overrides:
+  dev:
+    timeout_seconds: 1200
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile.timeout_seconds == 1200
+
+
+def test_v08_overrides_preflight_timeout(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+overrides:
+  preflight:
+    timeout_seconds: 999
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.preflight_profile.timeout_seconds == 999
+
+
+# ── Round-trip / no phantom models ───────────────────────────────────────────
+
+
+def test_v08_round_trip_no_extra_models(tmp_path):
+    """Bridge must not inject extra models beyond what was in the input list."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    all_models = {cfg.dev_profile.model, cfg.preflight_profile.model} | {
+        p.model for p in cfg.review_pool
+    }
+    # Only "sonnet" (from claude/sonnet) should appear; no phantom models injected.
+    assert all_models == {"sonnet"}
+
+
+def test_v08_round_trip_two_models_review_pool_matches_input(tmp_path):
+    """Two-model config: review_pool models are a subset of the declared models."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+  - claude/opus
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    declared = {"sonnet", "opus"}
+    pool_models = {p.model for p in cfg.review_pool}
+    assert pool_models <= declared
+
+
+# ── Legacy key rejection ──────────────────────────────────────────────────────
+
+
+def test_v08_rejects_profiles_alongside_models(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+profiles:
+  dev:
+    cli: claude
+    model: sonnet
+    budget_usd: 1
+    timeout_seconds: 30
+""",
+    )
+    with _auth_ok, pytest.raises(ValueError, match="profiles"):
+        load_config(cfg_path)
+
+
+def test_v08_rejects_smart_config_models_alongside_models(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+smart_config_models:
+  - claude/opus
+""",
+    )
+    with _auth_ok, pytest.raises(ValueError, match="smart_config_models"):
+        load_config(cfg_path)
+
+
+def test_v08_rejects_legacy_par_scalar_model_field(tmp_path):
+    """plan_agent_review.model is a legacy scalar — rejected alongside models:."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+plan_agent_review:
+  enabled: true
+  model: opus
+""",
+    )
+    with _auth_ok, pytest.raises(ValueError, match="plan_agent_review"):
+        load_config(cfg_path)
+
+
+def test_v08_rejects_legacy_par_scalar_budget_field(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+plan_agent_review:
+  enabled: true
+  budget_usd: 0.5
+""",
+    )
+    with _auth_ok, pytest.raises(ValueError, match="budget_usd"):
+        load_config(cfg_path)
+
+
+# ── Mixed-mode rejection ──────────────────────────────────────────────────────
+
+
+def test_v08_mixed_mode_models_and_profiles_rejected(tmp_path):
+    """models: + profiles: in the same file is invalid."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+profiles:
+  dev:
+    cli: claude
+    model: sonnet
+    budget_usd: 1
+    timeout_seconds: 30
+""",
+    )
+    with _auth_ok, pytest.raises(ValueError, match="models.*legacy|legacy.*models"):
+        load_config(cfg_path)
+
+
+def test_v08_mixed_mode_error_message_names_replacement(tmp_path):
+    """Error message should tell the user what to use instead of the legacy key."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+profiles:
+  dev:
+    cli: claude
+    model: sonnet
+    budget_usd: 1
+    timeout_seconds: 30
+""",
+    )
+    with _auth_ok:
+        with pytest.raises(ValueError) as exc_info:
+            load_config(cfg_path)
+    assert "overrides" in str(exc_info.value)
+
+
+# ── Classic config still works ────────────────────────────────────────────────
+
+
+def test_classic_profiles_config_still_works(tmp_path):
+    """A profiles:-only config (no models:) continues to use the classic branch."""
+    cfg_path = _write(
+        tmp_path,
+        """
+project: classic-test
+profiles:
+  dev:
+    cli: claude
+    model: sonnet
+    budget_usd: 5
+    timeout_seconds: 60
+""",
+    )
+    # Classic path validates cli auth which succeeds by default for cli=claude.
+    cfg = load_config(cfg_path)
+    assert cfg.dev_profile.model == "sonnet"
+    assert cfg.dev_profile.cli == "claude"


### PR DESCRIPTION
## Summary

[openai-reviewer] Prior P1s are fixed, no regressions were introduced in the touched files, and the v0.8 loader bridge satisfies the reviewed acceptance criteria. | [gemini-reviewer] The fixes for the null overrides key and the silent drop of the derived plan_agent_review profile are correct and resolve the previous P1 findings.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $4.99
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Config loader bridge — parse v0.8 schema into existing ForgeConfig/ModelProfile (GitHub Issue #750)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #750