### PR TITLE
bug: gate CONTRADICTION false positive on multi-stage gate commands

### DIFF
--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -14,15 +14,6 @@ from theforge.traces import write_trace
 
 from . import util as _cu
 
-# Phrases that unambiguously indicate the test runner reported success.
-# Used to detect the contradiction where exit code is non-zero but output says success.
-_GATE_SUCCESS_PATTERNS: tuple[str, ...] = (
-    "all checks passed",
-    "passed, no failures",
-    "0 failed",
-    "no failures detected",
-)
-
 
 def _parse_dirty_files(raw_output: str) -> list[str]:
     """Parse filenames from ``git status --porcelain`` output.
@@ -176,11 +167,7 @@ def _run_gate_full(
 
     # Gate decision comes from exit code. Write it into handoff.yaml (merging, not
     # overwriting) so downstream validation sees gate_decision alongside dev notes.
-    if not ok and any(p in output.lower() for p in _GATE_SUCCESS_PATTERNS):
-        decision = "CONTRADICTION"
-        _cu._log(f"Gate contradiction: exit non-zero but output indicates success: {output_tail}")
-    else:
-        decision = "PASS" if ok else "FAIL"
+    decision = "PASS" if ok else "FAIL"
     if config.validation.handoff_file:
         _write_gate_decision(config, workspace_path, decision)
     if decision == "FAIL":

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -385,28 +385,6 @@ def _run_validate_phase(
                         message=state.error,
                     )
 
-    elif gate_decision == "CONTRADICTION":
-        state.phase = Phase.ESCALATE
-        state.error = (
-            "Gate exited non-zero but output indicated success — likely a test-runner quirk"
-            " (pytest-xdist, non-fatal warning exit). Human review required."
-        )
-        _log(f"✗ ESCALATE   {state.error}")
-        record_dev_iteration_telemetry(
-            state,
-            workspace_path,
-            max_iterations=config.retry.max_dev_iterations,
-            gate_result="CONTRADICTION",
-            gate_output_tail=gate_output_tail,
-        )
-        if logger:
-            logger._safe_emit("phase_end", phase="VALIDATE", outcome="escalate")
-            logger._safe_emit("escalate", reason=state.error, phase="VALIDATE")
-        _escalate_notify(task, state, notify, config)
-        return _ValidateOutcome.ESCALATE, CoordinatorResult(
-            success=False, phase=state.phase, state=state, message=state.error
-        )
-
     elif gate_decision in ("FAIL", "BLOCKED"):
         if state.budget.is_exhausted():
             state.phase = Phase.ESCALATE

--- a/tests/test_coord_gate_contradiction_exit.py
+++ b/tests/test_coord_gate_contradiction_exit.py
@@ -1,9 +1,9 @@
-"""Tests for gate CONTRADICTION detection and validate-phase escalation.
+"""Tests for gate exit-code decision and validate-phase retry behavior.
 
 Covers:
-- gate.py detects exit-nonzero + success-text → "CONTRADICTION" decision
-- gate.py plain fail (no success text) → "FAIL" unchanged
-- validate_phase.py escalates immediately on CONTRADICTION (no dev retry)
+- gate.py exit non-zero → FAIL regardless of stdout content
+- gate.py exit zero → PASS regardless of stdout content
+- validate_phase.py FAIL → RETRY_DEV
 """
 
 from __future__ import annotations
@@ -24,44 +24,11 @@ from theforge.coordinator.validate_phase import _run_validate_phase, _ValidateOu
 # ── gate.py unit tests ────────────────────────────────────────────────────────
 
 
-class TestGateContradictionDetection:
-    """_run_gate_full returns CONTRADICTION when exit!=0 but output says success."""
-
-    def test_gate_contradiction_detected_all_checks_passed(self, tmp_path: Path):
-        """Exit non-zero + 'All checks passed!' → CONTRADICTION."""
-        config = _make_config(tmp_path)
-        workspace = tmp_path / "ws"
-        workspace.mkdir()
-        _write_handoff(workspace)
-
-        with patch("theforge.coordinator.gate._cu._run_shell") as mock_shell:
-            mock_shell.return_value = (
-                False,
-                "Some warnings\nAll checks passed!\nExit 1 due to coverage threshold",
-            )
-            with patch("theforge.coordinator.gate._cu._log"):
-                decision, error, _tail, _cmd = _run_gate_full(config, workspace)
-
-        assert decision == "CONTRADICTION"
-        assert error is None
-
-    def test_gate_contradiction_detected_0_failed(self, tmp_path: Path):
-        """Exit non-zero + '0 failed' in output → CONTRADICTION."""
-        config = _make_config(tmp_path)
-        workspace = tmp_path / "ws"
-        workspace.mkdir()
-        _write_handoff(workspace)
-
-        with patch("theforge.coordinator.gate._cu._run_shell") as mock_shell:
-            mock_shell.return_value = (False, "0 failed, 5 passed")
-            with patch("theforge.coordinator.gate._cu._log"):
-                decision, error, _tail, _cmd = _run_gate_full(config, workspace)
-
-        assert decision == "CONTRADICTION"
-        assert error is None
+class TestGateDecision:
+    """_run_gate_full trusts exit code as sole gate signal."""
 
     def test_gate_plain_fail_unchanged(self, tmp_path: Path):
-        """Exit non-zero with genuine failure output → FAIL (not CONTRADICTION)."""
+        """Exit non-zero with genuine failure output → FAIL."""
         config = _make_config(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -90,19 +57,28 @@ class TestGateContradictionDetection:
         assert decision == "PASS"
         assert error is None
 
-    def test_gate_contradiction_case_insensitive(self, tmp_path: Path):
-        """Pattern matching is case-insensitive."""
+    def test_gate_nonzero_with_ruff_success_message_is_fail(self, tmp_path: Path):
+        """Exit non-zero + ruff 'All checks passed!' in stdout → FAIL (not CONTRADICTION).
+
+        Regression: ruff emits 'All checks passed!' when linting succeeds. A
+        multi-stage gate (ruff && pytest) exits non-zero when pytest fails even
+        though ruff passed. This must be classified as FAIL, not escalated.
+        """
         config = _make_config(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
         _write_handoff(workspace)
 
         with patch("theforge.coordinator.gate._cu._run_shell") as mock_shell:
-            mock_shell.return_value = (False, "ALL CHECKS PASSED!")
+            mock_shell.return_value = (
+                False,
+                "All checks passed!\n2 failed, 3 passed\nFAILED tests/test_foo.py::test_bar",
+            )
             with patch("theforge.coordinator.gate._cu._log"):
                 decision, error, _tail, _cmd = _run_gate_full(config, workspace)
 
-        assert decision == "CONTRADICTION"
+        assert decision == "FAIL"
+        assert error is None
 
 
 # ── validate_phase.py integration tests ───────────────────────────────────────
@@ -116,86 +92,8 @@ def _make_state(config) -> CoordinatorState:
     return state
 
 
-class TestValidatePhaseContradictionEscalates:
-    """Validate phase escalates immediately on CONTRADICTION instead of retrying dev."""
-
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
-    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._escalate_notify")
-    def test_contradiction_escalates(
-        self, mock_notify, mock_conventions, mock_gate, tmp_path: Path
-    ):
-        """CONTRADICTION gate decision → ESCALATE outcome, no dev retry."""
-        config = _make_config(tmp_path)
-        task = _make_task(tmp_path)
-        workspace = tmp_path / "test-task"
-        workspace.mkdir()
-        _write_handoff(workspace, "CONTRADICTION")
-
-        mock_gate.return_value = ("CONTRADICTION", None, "All checks passed!", "make gate")
-        mock_conventions.return_value = None  # no conventions configured
-
-        state = _make_state(config)
-
-        outcome, result = _run_validate_phase(
-            state,
-            config,
-            task,
-            workspace,
-            notify=False,
-            logger=None,
-        )
-
-        assert outcome == _ValidateOutcome.ESCALATE
-        assert result is not None
-        assert result.success is False
-        assert state.phase == Phase.ESCALATE
-        assert "non-zero" in state.error.lower() or "indicated success" in state.error.lower()
-        mock_notify.assert_called_once()
-
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
-    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._escalate_notify")
-    def test_contradiction_error_message_content(
-        self, mock_notify, mock_conventions, mock_gate, tmp_path: Path
-    ):
-        """CONTRADICTION escalation message mentions test-runner quirk for human context."""
-        config = _make_config(tmp_path)
-        task = _make_task(tmp_path)
-        workspace = tmp_path / "test-task"
-        workspace.mkdir()
-        _write_handoff(workspace, "CONTRADICTION")
-
-        mock_gate.return_value = ("CONTRADICTION", None, "All checks passed!", "make gate")
-        mock_conventions.return_value = None
-
-        state = _make_state(config)
-
-        _run_validate_phase(state, config, task, workspace, notify=False, logger=None)
-
-        assert "human review" in state.error.lower() or "test-runner" in state.error.lower()
-
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
-    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._escalate_notify")
-    def test_contradiction_appended_to_gate_decisions(
-        self, mock_notify, mock_conventions, mock_gate, tmp_path: Path
-    ):
-        """CONTRADICTION is recorded in state.gate_decisions for audit trail."""
-        config = _make_config(tmp_path)
-        task = _make_task(tmp_path)
-        workspace = tmp_path / "test-task"
-        workspace.mkdir()
-        _write_handoff(workspace, "CONTRADICTION")
-
-        mock_gate.return_value = ("CONTRADICTION", None, "All checks passed!", "make gate")
-        mock_conventions.return_value = None
-
-        state = _make_state(config)
-
-        _run_validate_phase(state, config, task, workspace, notify=False, logger=None)
-
-        assert "CONTRADICTION" in state.gate_decisions
+class TestValidatePhaseFailRetries:
+    """Validate phase retries dev on FAIL."""
 
     @patch("theforge.coordinator.validate_phase._run_gate_full")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
@@ -203,7 +101,7 @@ class TestValidatePhaseContradictionEscalates:
     def test_plain_fail_still_retries(
         self, mock_notify, mock_conventions, mock_gate, tmp_path: Path
     ):
-        """Plain FAIL still causes RETRY_DEV (not broken by CONTRADICTION branch)."""
+        """Plain FAIL → RETRY_DEV."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"


### PR DESCRIPTION
## Summary

[openai-reviewer] Gate classification now correctly trusts exit code only, and the obsolete CONTRADICTION escalation path has been removed with matching regression coverage. | [gemini-reviewer] The implementation correctly removes the CONTRADICTION branch and trusts the exit code.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $1.18
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: gate CONTRADICTION false positive on multi-stage gate commands (GitHub Issue #789)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #789