### PR TITLE
bug: sprint reporting loses stories completed under earlier run_ids

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -495,9 +495,19 @@ def _write_sprint_summary(
             }
         )
 
-    # When prior stories were merged in, recompute specs_total so it reflects
-    # the full logical sprint rather than just the stories run this invocation.
+    # Recompute all aggregate metrics from spec_entries so prior-run stories
+    # contributed by the accumulated state are included in the totals.
     effective_specs_total = len(spec_entries)
+    effective_cost_usd = round(sum(e.get("cost_usd", 0.0) for e in spec_entries), 4)
+    effective_succeeded = sum(
+        1 for e in spec_entries if e.get("outcome") in ("DONE", "ALREADY_DONE")
+    )
+    effective_failed = sum(
+        1
+        for e in spec_entries
+        if e.get("outcome") not in ("DONE", "ALREADY_DONE", "SKIPPED", None)
+    )
+    effective_skipped = sum(1 for e in spec_entries if e.get("outcome") in ("SKIPPED", None))
 
     summary = {
         "sprint": {
@@ -507,14 +517,14 @@ def _write_sprint_summary(
             "run_id": run_id,
             "sprint_id": sprint_id,
             "run_log": f"run-{run_id}.log" if run_id else None,
-            "total_cost_usd": round(result.total_cost_usd, 4),
+            "total_cost_usd": effective_cost_usd,
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "duration_seconds": round(duration, 1),
             "specs_total": effective_specs_total,
-            "specs_succeeded": result.specs_succeeded,
-            "specs_failed": result.specs_failed,
-            "specs_skipped": result.specs_skipped,
+            "specs_succeeded": effective_succeeded,
+            "specs_failed": effective_failed,
+            "specs_skipped": effective_skipped,
             "stopped_reason": result.stopped_reason,
             "ci_break_slug": ci_break_slug,
         },

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -22,6 +22,77 @@ def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
 
 
+# ── Sprint-level stable identity ──────────────────────────────────────────────
+
+
+def _get_or_create_sprint_id(sprint_name: str, project_root: Path) -> str:
+    """Return stable sprint_id for this logical sprint, creating it on first call.
+
+    Stored at .forge/logs/<sprint-name>/.sprint_id so it persists across
+    worker restarts, detach/attach, and --resume invocations.
+    """
+    sprint_log_dir = project_root / ".forge" / "logs" / sprint_name
+    sprint_id_path = sprint_log_dir / ".sprint_id"
+    try:
+        sprint_log_dir.mkdir(parents=True, exist_ok=True)
+        if sprint_id_path.exists():
+            return sprint_id_path.read_text(encoding="utf-8").strip()
+        from ..coordinator.util import _generate_run_id  # noqa: PLC0415
+
+        new_id = _generate_run_id()
+        sprint_id_path.write_text(new_id, encoding="utf-8")
+        return new_id
+    except OSError:
+        from ..coordinator.util import _generate_run_id  # noqa: PLC0415
+
+        return _generate_run_id()
+
+
+def _load_accumulated_stories(sprint_id: str, project_root: Path) -> list[dict]:
+    """Load per-story data from .forge/sprints/<sprint_id>/state.yaml.
+
+    Returns the stories list, or [] if the file does not exist or cannot be read.
+    Each entry includes a ``canonical_ref`` key used for cross-run matching.
+    """
+    state_path = project_root / ".forge" / "sprints" / sprint_id / "state.yaml"
+    if not state_path.exists():
+        return []
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("stories", [])
+    except Exception:
+        return []
+
+
+def _save_accumulated_stories(
+    sprint_id: str,
+    sprint_name: str,
+    project_root: Path,
+    stories: list[dict],
+) -> None:
+    """Save story entries to .forge/sprints/<sprint_id>/state.yaml.
+
+    Each entry should have a ``canonical_ref`` field for cross-run matching.
+    Writes atomically via a temp file.
+    """
+    state_dir = project_root / ".forge" / "sprints" / sprint_id
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        state_path = state_dir / "state.yaml"
+        tmp_path = state_path.with_suffix(".tmp")
+        data: dict = {
+            "sprint_id": sprint_id,
+            "sprint_name": sprint_name,
+            "stories": stories,
+        }
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        tmp_path.replace(state_path)
+    except Exception:
+        pass
+
+
 def _write_sprint_audit(
     manifest: SprintManifest | ResolvedSprint,
     result: SprintResult,
@@ -35,6 +106,7 @@ def _write_sprint_audit(
     slug_map: "dict[str, str] | None" = None,
     tasks_by_slug: "dict[str, TaskStory] | None" = None,
     ci_break_slug: str | None = None,
+    sprint_id: str | None = None,
 ) -> None:
     """Write sprint-audit.yaml to the project root."""
     story_times = story_times or {}
@@ -211,6 +283,7 @@ def _write_sprint_audit(
             "name": manifest.name,
             "budget_usd": manifest.budget_usd,
             "max_parallel": manifest.max_parallel,
+            "sprint_id": sprint_id,
             "total_cost_usd": round(result.total_cost_usd, 4),
             "budget_note": "Costs reflect Claude invocations only; Codex/Gemini report $0.00",
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -255,14 +328,33 @@ def _write_sprint_summary(
     run_id: str | None = None,
     tasks_by_slug: "dict[str, TaskStory] | None" = None,
     ci_break_slug: str | None = None,
+    sprint_id: str | None = None,
+    project_root: Path | None = None,
 ) -> None:
-    """Write sprint-summary.yaml to <project_root>/.forge/logs/<sprint-name>/."""
+    """Write sprint-summary.yaml to <project_root>/.forge/logs/<sprint-name>/.
+
+    When sprint_id and project_root are provided, prior story entries from
+    .forge/sprints/<sprint_id>/state.yaml are merged in for stories that did
+    not run in this invocation (e.g., completed under an earlier run_id).
+    This ensures the summary reflects the full logical sprint across all
+    worker-process boundaries.
+    """
     story_times = story_times or {}
     batch_assignments = batch_assignments or {}
     slug_map = slug_map or {}
     tasks_by_slug = tasks_by_slug or {}
 
+    # Load prior accumulated story entries from the sprint-level state file.
+    # Keyed by canonical_ref so we can substitute them for stories not in
+    # this invocation's results (e.g., stories completed under an earlier run_id).
+    prior_by_ref: dict[str, dict] = {}
+    if sprint_id and project_root:
+        prior_stories = _load_accumulated_stories(sprint_id, project_root)
+        prior_by_ref = {s["canonical_ref"]: s for s in prior_stories if "canonical_ref" in s}
+
     spec_entries = []
+    # Tracks story entries with canonical_ref for saving to accumulated state.
+    accumulated_for_state: list[dict] = []
     results_by_spec = {spec_str: res for spec_str, res in result.results}
 
     for canonical_ref in canonical_refs:
@@ -347,6 +439,15 @@ def _write_sprint_summary(
                 entry["finished_at"] = story_times[slug][1].strftime("%Y-%m-%dT%H:%M:%SZ")
             entry["batch"] = batch_assignments.get(slug, 0)
             entry["depends_on"] = list(getattr(tasks_by_slug.get(slug), "depends_on", None) or [])
+            spec_entries.append(entry)
+            accumulated_for_state.append({"canonical_ref": canonical_ref, **entry})
+        elif canonical_ref in prior_by_ref:
+            # Story ran under an earlier run_id — use its accumulated data instead
+            # of emitting a SKIPPED entry (which would hide a completed story).
+            prior = prior_by_ref[canonical_ref]
+            entry = {k: v for k, v in prior.items() if k != "canonical_ref"}
+            spec_entries.append(entry)
+            accumulated_for_state.append(prior)
         else:
             entry = {
                 "path": display_key,
@@ -361,7 +462,11 @@ def _write_sprint_summary(
                 "batch": batch_assignments.get(slug, 0),
                 "depends_on": list(getattr(tasks_by_slug.get(slug), "depends_on", None) or []),
             }
-        spec_entries.append(entry)
+            spec_entries.append(entry)
+
+    # Persist accumulated state so future runs can find stories from this invocation.
+    if sprint_id and project_root:
+        _save_accumulated_stories(sprint_id, manifest.name, project_root, accumulated_for_state)
 
     usage_distribution = []
     for spec_str, res in result.results:
@@ -390,18 +495,23 @@ def _write_sprint_summary(
             }
         )
 
+    # When prior stories were merged in, recompute specs_total so it reflects
+    # the full logical sprint rather than just the stories run this invocation.
+    effective_specs_total = len(spec_entries)
+
     summary = {
         "sprint": {
             "name": manifest.name,
             "budget_usd": manifest.budget_usd,
             "max_parallel": manifest.max_parallel,
             "run_id": run_id,
+            "sprint_id": sprint_id,
             "run_log": f"run-{run_id}.log" if run_id else None,
             "total_cost_usd": round(result.total_cost_usd, 4),
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "duration_seconds": round(duration, 1),
-            "specs_total": result.specs_total,
+            "specs_total": effective_specs_total,
             "specs_succeeded": result.specs_succeeded,
             "specs_failed": result.specs_failed,
             "specs_skipped": result.specs_skipped,
@@ -426,6 +536,7 @@ def _write_story_audit(
     config: "ForgeConfig",
     task: "TaskStory",
     result: "CoordinatorResult",
+    sprint_id: str | None = None,
 ) -> None:
     """Write per-story audit.yaml to the worktree and the durable log directory.
 
@@ -439,6 +550,9 @@ def _write_story_audit(
     except Exception as exc:
         _log(f"Warning: failed to generate story audit log for {task.slug}: {exc}")
         return
+
+    if sprint_id is not None:
+        audit_data["sprint_id"] = sprint_id
 
     workspace_path = config.project_root / config.workspace.path_pattern.format(slug=task.slug)
     if workspace_path.exists() and not (

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -23,7 +23,12 @@ from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from ..coordinator.util import _fmt_duration, _generate_run_id
 from ..log_util import _log_line
 from ..task import TaskStory
-from .audit import _write_sprint_audit, _write_sprint_summary, _write_story_audit
+from .audit import (
+    _get_or_create_sprint_id,
+    _write_sprint_audit,
+    _write_sprint_summary,
+    _write_story_audit,
+)
 from .ci_checks import poll_required_checks
 from .collision import (
     compute_bundle_assignments,
@@ -635,6 +640,14 @@ def run_sprint(
     except Exception:
         _sprint_log_dir = None  # type: ignore[assignment]
 
+    # Stable sprint_id — does not change across run_id rollovers or --resume.
+    # Used to aggregate story outcomes across all worker-process boundaries.
+    _sprint_id: str | None = None
+    try:
+        _sprint_id = _get_or_create_sprint_id(resolved.name, config.project_root)
+    except Exception:
+        pass
+
     started_at = datetime.datetime.now(datetime.timezone.utc)
     accumulated_cost = 0.0
     prior_cost = 0.0
@@ -807,7 +820,7 @@ def run_sprint(
 
         if not all(dep in merged_slugs for dep in task.depends_on):
             result.landing_status = "pending_integration"
-            _write_story_audit(config, task, result)
+            _write_story_audit(config, task, result, sprint_id=_sprint_id)
             return False
 
         branch = config.workspace.branch_pattern.format(slug=slug)
@@ -852,7 +865,7 @@ def run_sprint(
         if merge_info.get("merged"):
             merged_slugs.add(slug)
             dag.mark_complete(slug)
-            _write_story_audit(config, task, result)
+            _write_story_audit(config, task, result, sprint_id=_sprint_id)
             if effective_on_approve == "merge-pr" and not merge_info.get(
                 "auto_merge_queued", False
             ):
@@ -877,13 +890,13 @@ def run_sprint(
 
         if merge_info.get("merge_queued"):
             queued_prs[slug] = (task, result, merge_info["pr_url"])
-            _write_story_audit(config, task, result)
+            _write_story_audit(config, task, result, sprint_id=_sprint_id)
             _log(f"INFO {slug}: PR auto-merge queued; waiting for GitHub to report MERGED")
             return True
 
         result.state.error = merge_info.get("error") or "integration failed"
         _log(f"WARN {slug}: integration failed: {merge_info.get('error')}")
-        _write_story_audit(config, task, result)
+        _write_story_audit(config, task, result, sprint_id=_sprint_id)
         return True
 
     with ThreadPoolExecutor(max_workers=max_parallel) as pool:
@@ -906,7 +919,7 @@ def run_sprint(
                             merged_slugs.add(dep)
                             dag.mark_complete(dep)
                             del queued_prs[dep]
-                            _write_story_audit(config, dep_task, dep_result)
+                            _write_story_audit(config, dep_task, dep_result, sprint_id=_sprint_id)
                         else:
                             dep_result.landing_status = "failed"
                             dep_result.success = False
@@ -920,7 +933,7 @@ def run_sprint(
                                     f"Queued PR {poll_result['status']}: {dep_pr_url}"
                                 )
                             del queued_prs[dep]
-                            _write_story_audit(config, dep_task, dep_result)
+                            _write_story_audit(config, dep_task, dep_result, sprint_id=_sprint_id)
                             _log(
                                 f"✗ {dep}: queued PR {poll_result['status']} "
                                 "before dependent dispatch"
@@ -1049,7 +1062,7 @@ def run_sprint(
                         dag.mark_complete(_qp_slug)
                         _qp_result.landing_status = "landed"
                         del queued_prs[_qp_slug]
-                        _write_story_audit(config, _qp_task, _qp_result)
+                        _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
                         _log(f"INFO {_qp_slug}: queued PR merged; unblocking dependents")
                     else:
                         specs_succeeded -= 1
@@ -1066,7 +1079,7 @@ def run_sprint(
                                 f"Queued PR {_qp_poll['status']}: {_qp_pr_url}"
                             )
                         del queued_prs[_qp_slug]
-                        _write_story_audit(config, _qp_task, _qp_result)
+                        _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
                         _log(f"✗ {_qp_slug}: queued PR {_qp_poll['status']} (no active workers)")
                 continue
 
@@ -1131,7 +1144,9 @@ def run_sprint(
                     )
                     story_times[slug] = (story_started_at, timed_out_at)
                     results.append((spec_str, _timeout_result))
-                    _write_story_audit(config, slug_to_context[slug][0], _timeout_result)
+                    _write_story_audit(
+                        config, slug_to_context[slug][0], _timeout_result, sprint_id=_sprint_id
+                    )
                     if _state_writer is not None:
                         _state_writer.update(slug, status="failed", phase="ESCALATE")
                     dag.mark_skipped(slug)
@@ -1169,7 +1184,9 @@ def run_sprint(
                     )
                     story_times[slug] = (story_started_at, failed_at)
                     results.append((spec_str, _exc_result))
-                    _write_story_audit(config, slug_to_context[slug][0], _exc_result)
+                    _write_story_audit(
+                        config, slug_to_context[slug][0], _exc_result, sprint_id=_sprint_id
+                    )
                     if _state_writer is not None:
                         _state_writer.update(slug, status="failed", phase="ESCALATE")
                     dag.mark_skipped(slug)
@@ -1243,7 +1260,7 @@ def run_sprint(
                                     specs_failed += 1
                                 changed = True
                 else:
-                    _write_story_audit(config, task, result)
+                    _write_story_audit(config, task, result, sprint_id=_sprint_id)
 
                 # Fire StorySource lifecycle callbacks
                 ctx = slug_to_context.get(slug)
@@ -1290,7 +1307,7 @@ def run_sprint(
                 else:
                     result.state.error = f"Queued PR {poll_result['status']}: {pr_url}"
                 _log(f"✗ {slug}: queued PR {poll_result['status']} during sprint wrap-up")
-            _write_story_audit(config, task, result)
+            _write_story_audit(config, task, result, sprint_id=_sprint_id)
             del queued_prs[slug]
 
     finished_at = datetime.datetime.now(datetime.timezone.utc)
@@ -1373,6 +1390,7 @@ def run_sprint(
         slug_map=slug_map,
         tasks_by_slug={slug: ctx[0] for slug, ctx in slug_to_context.items()},
         ci_break_slug=ci_halt_slug,
+        sprint_id=_sprint_id,
     )
 
     # Write sprint-summary.yaml to .forge/logs/<sprint-name>/
@@ -1391,6 +1409,8 @@ def run_sprint(
             run_id=run_id,
             tasks_by_slug={slug: ctx[0] for slug, ctx in slug_to_context.items()},
             ci_break_slug=ci_halt_slug,
+            sprint_id=_sprint_id,
+            project_root=config.project_root,
         )
 
     # Remove live state file now that sprint-summary.yaml is the permanent record.

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -23,11 +23,43 @@ class StoryStatusEntry:
     detail: str = ""
 
 
+def _follow_redirect_chain(run_id: str, project_root: Path, max_hops: int = 20) -> str:
+    """Follow .forge/runs/<run_id>.redirect files to find the terminal run_id.
+
+    Each redirect file contains JSON with a ``new_run_id`` key written when the
+    daemon hands off to a new worker process.  Returns the original run_id if no
+    redirect chain exists.
+    """
+    import json  # noqa: PLC0415
+
+    current = run_id
+    runs_dir = project_root / ".forge" / "runs"
+    for _ in range(max_hops):
+        redirect_file = runs_dir / f"{current}.redirect"
+        if not redirect_file.exists():
+            break
+        try:
+            data = json.loads(redirect_file.read_text(encoding="utf-8"))
+            new_id = data.get("new_run_id", "")
+            if not new_id or new_id == current:
+                break
+            current = new_id
+        except Exception:
+            break
+    return current
+
+
 def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
     """Scan .forge/logs/*/sprint-summary.yaml for the file containing run_id.
 
+    After a run_id rollover the summary is written under the terminal run_id.
+    Follows the redirect chain so earlier run_ids resolve to the same summary.
+
     Returns the Path to the matching sprint-summary.yaml, or None if not found.
     """
+    terminal_run_id = _follow_redirect_chain(run_id, project_root)
+    candidate_ids = {run_id, terminal_run_id}
+
     logs_dir = project_root / ".forge" / "logs"
     if not logs_dir.exists():
         return None
@@ -44,7 +76,7 @@ def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
                 data = yaml.safe_load(f)
             if isinstance(data, dict):
                 sprint_info = data.get("sprint", {})
-                if isinstance(sprint_info, dict) and sprint_info.get("run_id") == run_id:
+                if isinstance(sprint_info, dict) and sprint_info.get("run_id") in candidate_ids:
                     return summary_path
         except Exception:
             continue

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -30,7 +30,11 @@ from theforge.sprint.audit import (
     _save_accumulated_stories,
 )
 from theforge.sprint.dag import StoryTriage
-from theforge.sprint.status_reader import read_completed_status
+from theforge.sprint.status_reader import (
+    _follow_redirect_chain,
+    find_sprint_summary,
+    read_completed_status,
+)
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -252,6 +256,12 @@ class TestRunIdRolloverReporting:
         # sprint_id field is present
         assert summary["sprint"].get("sprint_id") == sprint_id
 
+        # Aggregate totals must include costs from both runs
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(1.18 + 9.26)
+        assert summary["sprint"]["specs_succeeded"] == 2
+        assert summary["sprint"]["specs_failed"] == 0
+        assert summary["sprint"]["specs_skipped"] == 0
+
     def test_read_completed_status_shows_all_stories(self, tmp_path: Path) -> None:
         """read_completed_status returns entries for all stories including prior-run ones."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")
@@ -357,3 +367,78 @@ class TestRunIdRolloverReporting:
         sprint_entries = [ln for ln in lines if "sprint" in ln and "specs" in ln]
         assert sprint_entries, "No sprint-level history entry found"
         assert sprint_entries[0]["sprint"].get("sprint_id") == sprint_id
+
+
+# ── redirect chain: earlier run_id finds terminal summary ────────────────────
+
+
+class TestRedirectChainResolution:
+    def test_follow_redirect_chain_no_redirect(self, tmp_path: Path) -> None:
+        result = _follow_redirect_chain("run-abc", tmp_path)
+        assert result == "run-abc"
+
+    def test_follow_redirect_chain_single_hop(self, tmp_path: Path) -> None:
+        import json
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-a.redirect").write_text(
+            json.dumps({"new_run_id": "run-b"}), encoding="utf-8"
+        )
+        result = _follow_redirect_chain("run-a", tmp_path)
+        assert result == "run-b"
+
+    def test_follow_redirect_chain_multi_hop(self, tmp_path: Path) -> None:
+        import json
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-a.redirect").write_text(
+            json.dumps({"new_run_id": "run-b"}), encoding="utf-8"
+        )
+        (runs_dir / "run-b.redirect").write_text(
+            json.dumps({"new_run_id": "run-c"}), encoding="utf-8"
+        )
+        result = _follow_redirect_chain("run-a", tmp_path)
+        assert result == "run-c"
+
+    def test_find_sprint_summary_with_earlier_run_id(self, tmp_path: Path) -> None:
+        """find_sprint_summary() called with an earlier run_id returns the terminal summary."""
+        import json
+
+        # Create redirect: run-a → run-b (terminal)
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-a.redirect").write_text(
+            json.dumps({"new_run_id": "run-b"}), encoding="utf-8"
+        )
+
+        # Write a summary file that records run_id = "run-b"
+        sprint_log_dir = tmp_path / ".forge" / "logs" / "My Sprint"
+        sprint_log_dir.mkdir(parents=True)
+        summary_path = sprint_log_dir / "sprint-summary.yaml"
+        import yaml
+
+        summary_path.write_text(
+            yaml.dump({"sprint": {"name": "My Sprint", "run_id": "run-b"}}),
+            encoding="utf-8",
+        )
+
+        # Querying with the earlier run_id should still find the summary
+        found = find_sprint_summary("run-a", tmp_path)
+        assert found == summary_path
+
+    def test_find_sprint_summary_direct_match_still_works(self, tmp_path: Path) -> None:
+        """Direct run_id match (no redirect) continues to work."""
+        import yaml
+
+        sprint_log_dir = tmp_path / ".forge" / "logs" / "My Sprint"
+        sprint_log_dir.mkdir(parents=True)
+        summary_path = sprint_log_dir / "sprint-summary.yaml"
+        summary_path.write_text(
+            yaml.dump({"sprint": {"name": "My Sprint", "run_id": "run-xyz"}}),
+            encoding="utf-8",
+        )
+
+        found = find_sprint_summary("run-xyz", tmp_path)
+        assert found == summary_path

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -1,0 +1,359 @@
+"""Tests for sprint reporting across run_id boundaries.
+
+Verifies that when a sprint spans multiple worker processes (run_id rollover),
+forge status and sprint-summary.yaml show all stories from the full logical
+sprint, not just those completed under the terminal run_id.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.sprint import run_sprint
+from theforge.sprint.audit import (
+    _get_or_create_sprint_id,
+    _load_accumulated_stories,
+    _save_accumulated_stories,
+)
+from theforge.sprint.dag import StoryTriage
+from theforge.sprint.status_reader import read_completed_status
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_spec_file(tmp_path: Path, name: str, slug: str) -> Path:
+    spec = tmp_path / f"{slug}.md"
+    spec.write_text(
+        f"---\nname: {name}\nslug: {slug}\n---\n# {name}\nDo the thing.",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _make_manifest(tmp_path: Path, specs: list[str], name: str = "Test Sprint") -> Path:
+    manifest_path = tmp_path / "sprint.yaml"
+    manifest_path.write_text(
+        yaml.dump({"name": name, "budget_usd": 50.0, "specs": specs}),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _make_coordinator_result(
+    success: bool = True, cost: float = 1.0, phase: Phase = Phase.DONE
+) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    mock_preflight = MagicMock()
+    mock_preflight.cost_usd = cost
+    state.preflight_result = mock_preflight
+    return CoordinatorResult(
+        success=success,
+        phase=phase,
+        state=state,
+        message="Done." if success else "Failed.",
+        merge={"merged": True} if success else None,
+        landing_status="landed" if success else None,
+    )
+
+
+# ── sprint_id persistence ─────────────────────────────────────────────────────
+
+
+class TestSprintIdPersistence:
+    def test_creates_sprint_id_on_first_call(self, tmp_path: Path) -> None:
+        sprint_id = _get_or_create_sprint_id("my-sprint", tmp_path)
+        assert sprint_id
+        assert len(sprint_id) == 12  # _generate_run_id returns 12-char hex
+
+    def test_returns_same_id_on_subsequent_calls(self, tmp_path: Path) -> None:
+        id1 = _get_or_create_sprint_id("my-sprint", tmp_path)
+        id2 = _get_or_create_sprint_id("my-sprint", tmp_path)
+        assert id1 == id2
+
+    def test_different_sprints_get_different_ids(self, tmp_path: Path) -> None:
+        id1 = _get_or_create_sprint_id("sprint-a", tmp_path)
+        id2 = _get_or_create_sprint_id("sprint-b", tmp_path)
+        assert id1 != id2
+
+    def test_sprint_id_file_location(self, tmp_path: Path) -> None:
+        sprint_id = _get_or_create_sprint_id("my-sprint", tmp_path)
+        id_file = tmp_path / ".forge" / "logs" / "my-sprint" / ".sprint_id"
+        assert id_file.exists()
+        assert id_file.read_text(encoding="utf-8").strip() == sprint_id
+
+
+# ── accumulated state round-trip ──────────────────────────────────────────────
+
+
+class TestAccumulatedState:
+    def test_load_returns_empty_when_missing(self, tmp_path: Path) -> None:
+        stories = _load_accumulated_stories("nonexistent-id", tmp_path)
+        assert stories == []
+
+    def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
+        sprint_id = "testabc123456"
+        stories = [
+            {
+                "canonical_ref": "feature-a.md",
+                "slug": "feature-a",
+                "path": "feature-a.md",
+                "outcome": "DONE",
+                "verdict": "APPROVE",
+                "cost_usd": 1.5,
+            }
+        ]
+        _save_accumulated_stories(sprint_id, "Test Sprint", tmp_path, stories)
+        loaded = _load_accumulated_stories(sprint_id, tmp_path)
+        assert len(loaded) == 1
+        assert loaded[0]["canonical_ref"] == "feature-a.md"
+        assert loaded[0]["outcome"] == "DONE"
+        assert loaded[0]["cost_usd"] == pytest.approx(1.5)
+
+    def test_state_yaml_location(self, tmp_path: Path) -> None:
+        sprint_id = "testabc123456"
+        _save_accumulated_stories(sprint_id, "Test Sprint", tmp_path, [])
+        state_path = tmp_path / ".forge" / "sprints" / sprint_id / "state.yaml"
+        assert state_path.exists()
+
+
+# ── run_id rollover: two runs, both stories visible ───────────────────────────
+
+
+class TestRunIdRolloverReporting:
+    def test_summary_includes_prior_run_stories(self, tmp_path: Path) -> None:
+        """A resume run shows stories from prior run_ids in sprint-summary.yaml.
+
+        Simulates: story-a ran under run_id A (already merged), story-b runs
+        under run_id B (resume).  The final summary must show both.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+        config = _make_config(tmp_path)
+        sprint_name = "Test Sprint"
+
+        # Pre-create stable sprint_id and accumulated state to simulate a prior run
+        # where feature-a completed under an earlier run_id.
+        sprint_id = _get_or_create_sprint_id(sprint_name, tmp_path)
+        prior_stories = [
+            {
+                "canonical_ref": "feature-a.md",
+                "slug": "feature-a",
+                "path": "feature-a.md",
+                "outcome": "DONE",
+                "verdict": "APPROVE",
+                "cost_usd": 1.18,
+                "preflight": "PROCEED",
+                "preflight_original_verdict": None,
+                "preflight_source_run_id": None,
+                "error": None,
+                "error_type": None,
+                "merge": True,
+                "started_at": "2026-04-17T10:00:00Z",
+                "finished_at": "2026-04-17T10:30:00Z",
+                "batch": 0,
+                "depends_on": [],
+                "iteration_usage": {
+                    "dev": {"used": 1, "max": 5, "hit_limit": False, "early_finish": True},
+                    "review": {"used": 1, "max": 3, "hit_limit": False, "early_finish": True},
+                },
+            }
+        ]
+        _save_accumulated_stories(sprint_id, sprint_name, tmp_path, prior_stories)
+
+        # Second invocation: feature-a is skip_merged, feature-b runs fresh.
+        skip_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="skip_merged",
+            reason="already merged to main",
+            worktree_path=None,
+            slug="feature-a",
+        )
+        full_triage = StoryTriage(
+            story_path="feature-b.md",
+            action="full",
+            reason="no prior run",
+            worktree_path=None,
+            slug="feature-b",
+        )
+
+        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+            slug = task.slug if task else Path(canonical_ref).stem
+            return skip_triage if slug == "feature-a" else full_triage
+
+        result_b = _make_coordinator_result(success=True, cost=9.26)
+
+        with (
+            patch("theforge.sprint.runner._triage_spec", side_effect=_mock_triage),
+            patch("theforge.sprint.runner.run_task", return_value=result_b),
+        ):
+            sprint_result = run_sprint(config, manifest_path, resume=True, run_id="run-b-test")
+
+        # Both stories should be counted
+        assert sprint_result.specs_total == 2
+
+        # sprint-summary.yaml must have both stories
+        summary_path = tmp_path / ".forge" / "logs" / sprint_name / "sprint-summary.yaml"
+        assert summary_path.exists()
+        with open(summary_path, encoding="utf-8") as f:
+            summary = yaml.safe_load(f)
+
+        stories = summary.get("stories", [])
+        assert len(stories) == 2, f"Expected 2 stories, got {len(stories)}: {stories}"
+
+        slugs = {s["slug"] for s in stories}
+        assert "feature-a" in slugs, "feature-a (prior run) missing from summary"
+        assert "feature-b" in slugs, "feature-b (current run) missing from summary"
+
+        # feature-a must show DONE (from prior run), not SKIPPED
+        fa = next(s for s in stories if s["slug"] == "feature-a")
+        assert fa["outcome"] == "DONE", f"feature-a outcome should be DONE, got {fa['outcome']}"
+        assert fa["cost_usd"] == pytest.approx(1.18)
+        assert fa.get("verdict") == "APPROVE"
+
+        # feature-b from current run
+        fb = next(s for s in stories if s["slug"] == "feature-b")
+        assert fb["outcome"] == "DONE"
+        assert fb["cost_usd"] == pytest.approx(9.26)
+
+        # sprint_id field is present
+        assert summary["sprint"].get("sprint_id") == sprint_id
+
+    def test_read_completed_status_shows_all_stories(self, tmp_path: Path) -> None:
+        """read_completed_status returns entries for all stories including prior-run ones."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+        config = _make_config(tmp_path)
+        sprint_name = "Test Sprint"
+
+        sprint_id = _get_or_create_sprint_id(sprint_name, tmp_path)
+        prior_stories = [
+            {
+                "canonical_ref": "feature-a.md",
+                "slug": "feature-a",
+                "path": "feature-a.md",
+                "outcome": "DONE",
+                "verdict": "APPROVE",
+                "cost_usd": 1.18,
+                "preflight": "PROCEED",
+                "preflight_original_verdict": None,
+                "preflight_source_run_id": None,
+                "error": None,
+                "error_type": None,
+                "merge": True,
+                "batch": 0,
+                "depends_on": [],
+            }
+        ]
+        _save_accumulated_stories(sprint_id, sprint_name, tmp_path, prior_stories)
+
+        skip_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="skip_merged",
+            reason="already merged",
+            worktree_path=None,
+            slug="feature-a",
+        )
+        full_triage = StoryTriage(
+            story_path="feature-b.md",
+            action="full",
+            reason="no prior run",
+            worktree_path=None,
+            slug="feature-b",
+        )
+
+        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+            slug = task.slug if task else Path(canonical_ref).stem
+            return skip_triage if slug == "feature-a" else full_triage
+
+        result_b = _make_coordinator_result(success=True, cost=9.26)
+
+        with (
+            patch("theforge.sprint.runner._triage_spec", side_effect=_mock_triage),
+            patch("theforge.sprint.runner.run_task", return_value=result_b),
+        ):
+            run_sprint(config, manifest_path, resume=True, run_id="run-b-test")
+
+        summary_path = tmp_path / ".forge" / "logs" / sprint_name / "sprint-summary.yaml"
+        entries = read_completed_status(summary_path)
+        assert len(entries) == 2
+
+        slugs = {e.slug for e in entries}
+        assert "feature-a" in slugs
+        assert "feature-b" in slugs
+
+        fa = next(e for e in entries if e.slug == "feature-a")
+        assert fa.status == "done"
+        assert fa.cost_usd == pytest.approx(1.18)
+
+    def test_sprint_id_stable_across_two_run_invocations(self, tmp_path: Path) -> None:
+        """sprint_id does not change between the first and second run_sprint() invocations."""
+        sprint_name = "Test Sprint"
+
+        # Pre-create sprint_id (first invocation would have created this)
+        sprint_id_first = _get_or_create_sprint_id(sprint_name, tmp_path)
+
+        # Simulate second invocation reading the same sprint_id
+        sprint_id_second = _get_or_create_sprint_id(sprint_name, tmp_path)
+
+        assert sprint_id_first == sprint_id_second
+
+    def test_history_jsonl_includes_sprint_id(self, tmp_path: Path) -> None:
+        """history.jsonl entries include sprint_id when it is set."""
+        import json
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
+        config = _make_config(tmp_path)
+        sprint_name = "Test Sprint"
+
+        sprint_id = _get_or_create_sprint_id(sprint_name, tmp_path)
+        result_a = _make_coordinator_result(success=True, cost=1.0)
+
+        with patch("theforge.sprint.runner.run_task", return_value=result_a):
+            run_sprint(config, manifest_path, run_id="run-a-test")
+
+        history_path = tmp_path / ".forge" / "audits" / "history.jsonl"
+        assert history_path.exists()
+        lines = [
+            json.loads(line) for line in history_path.read_text(encoding="utf-8").splitlines()
+        ]
+
+        # Sprint-level audit entry should have sprint_id
+        sprint_entries = [ln for ln in lines if "sprint" in ln and "specs" in ln]
+        assert sprint_entries, "No sprint-level history entry found"
+        assert sprint_entries[0]["sprint"].get("sprint_id") == sprint_id


### PR DESCRIPTION
## Summary

[openai-reviewer] Prior P1s are resolved, no regressions were introduced in the touched files, and the rollover reporting fix is adequately covered by tests. | [gemini-reviewer] Fixes for sprint reporting across run_id rollovers look good.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-reviewer, gemini-reviewer
- **Cost:** $5.76
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: sprint reporting loses stories completed under earlier run_ids (GitHub Issue #828)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #828