### PR TITLE
bug: gate timeout escalates without running gate_debug_command

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -192,6 +192,8 @@ workspace:
 validation:
   gate_command: "make gate"            # must exit 0 on success
   gate_timeout: 600                    # seconds; default varies
+  gate_debug_command: ~                # optional: runs after gate_timeout for diagnostics
+  gate_debug_timeout: ~                # seconds; default: same resolved value as gate_timeout
   pre_validate_command: ~              # optional: run before dirty check
 
 # ── Retry policy ───────────────────────────────────────────

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -143,6 +143,7 @@ def load_config(config_path: Path) -> ForgeConfig:
             val_data.get("gate_output_tail_chars", DEFAULT_VALIDATION.gate_output_tail_chars)
         ),
         gate_debug_command=val_data.get("gate_debug_command"),
+        gate_debug_timeout=val_data.get("gate_debug_timeout"),
         test_command=val_data.get("test_command"),
         pre_validate_command=val_data.get("pre_validate_command"),
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -171,6 +171,7 @@ class ValidationConfig:
     gate_debug_command: str | None = (
         None  # diagnostic command on timeout (e.g. "pytest -x -v -n 0")
     )
+    gate_debug_timeout: int | None = None  # seconds; None = same resolved value as gate_timeout
     test_command: str | None = None  # canonical command for intermediate test runs in dev loop
     pre_validate_command: str | None = None  # optional command run before dirty check
 

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -150,13 +150,16 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
 
     # ── validate ──────────────────────────────────────────────────────────────
     validate_block: dict | None = None
-    if state.gate_decisions:
+    if state.gate_decisions or state.gate_debug_telemetry or state.validate_durations:
         validate_block = {
             "cost_usd": 0.0,
             "duration_s": round(sum(state.validate_durations), 2)
             if state.validate_durations
             else None,
-            "outcome": state.gate_decisions[-1].lower() if state.gate_decisions else None,
+            "outcome": state.gate_decisions[-1].lower()
+            if state.gate_decisions
+            else ("error" if state.validate_durations else None),
+            "gate_debug": _serialize_gate_debug_metrics(state),
         }
 
     # ── review ────────────────────────────────────────────────────────────────
@@ -278,6 +281,21 @@ def _serialize_dev_iteration_metrics(state: CoordinatorState) -> list[dict]:
     ]
 
 
+def _serialize_gate_debug_metrics(state: CoordinatorState) -> list[dict]:
+    return [
+        {
+            "iteration": item.iteration,
+            "command": item.command,
+            "ran": item.ran,
+            "timeout_s": item.timeout_s,
+            "exit_code": item.exit_code,
+            "output_tail": item.output_tail,
+            "output_truncated": item.output_truncated,
+        }
+        for item in state.gate_debug_telemetry
+    ]
+
+
 def _serialize_review_iteration_metrics(state: CoordinatorState) -> list[dict]:
     return [
         {
@@ -382,6 +400,7 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             "dev_iterations": len(state.dev_results),
             "gate_decisions": state.gate_decisions,
             "dev_loop": _serialize_dev_iteration_metrics(state),
+            "gate_debug": _serialize_gate_debug_metrics(state),
             "review_loop": _serialize_review_iteration_metrics(state),
             "usage_summary": _build_iteration_usage_summary(state, config),
             "budget_consumption_log": [

--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -6,6 +6,7 @@ import shlex
 from pathlib import Path
 
 from theforge.config import ForgeConfig
+from theforge.coordinator.state import GateDebugTelemetry
 from theforge.task import TaskStory
 from theforge.traces import write_trace
 
@@ -119,6 +120,47 @@ def _run_gate_full(
     if decision == "FAIL":
         _cu._log(f"Gate command failed (exit non-zero): {output_tail}")
     return decision, None, output_tail, gate_cmd
+
+
+def _run_gate_debug_command(
+    config: ForgeConfig,
+    workspace_path: Path,
+    *,
+    iter_num: int,
+) -> GateDebugTelemetry | None:
+    """Run the configured gate debug command after a gate timeout."""
+    debug_cmd = config.validation.gate_debug_command
+    if not debug_cmd:
+        return None
+
+    gate_timeout = config.validation.gate_timeout or 600
+    debug_timeout = config.validation.gate_debug_timeout or gate_timeout
+    _cu._log(f"  Running gate debug command after timeout: {debug_cmd}")
+    ok, output, exit_code, _timed_out = _cu._run_shell_detailed(
+        debug_cmd,
+        workspace_path,
+        timeout=debug_timeout,
+    )
+    if output.startswith("TIMEOUT") and exit_code is None:
+        _cu._log(f"  Gate debug command timed out after {debug_timeout}s")
+    elif not ok:
+        _cu._log(f"  Gate debug command exited non-zero: {exit_code}")
+
+    tail_chars = config.validation.gate_output_tail_chars
+    output_tail = output[-tail_chars:]
+    write_trace(
+        workspace_path / ".forge/traces" / f"{iter_num}-gate-debug.txt",
+        output,
+    )
+    return GateDebugTelemetry(
+        iteration=iter_num,
+        command=debug_cmd,
+        ran=True,
+        timeout_s=debug_timeout,
+        exit_code=exit_code,
+        output_tail=output_tail,
+        output_truncated=len(output) > len(output_tail),
+    )
 
 
 def _run_gate(

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -178,6 +178,19 @@ class DevIterationTelemetry:
 
 
 @dataclass(frozen=True)
+class GateDebugTelemetry:
+    """Diagnostic command telemetry captured when the validation gate times out."""
+
+    iteration: int
+    command: str
+    ran: bool
+    timeout_s: int
+    exit_code: int | None
+    output_tail: str
+    output_truncated: bool
+
+
+@dataclass(frozen=True)
 class ReviewIterationTelemetry:
     """Per-review-cycle telemetry captured for audit output."""
 
@@ -325,6 +338,7 @@ class CoordinatorState:
     dev_prompt_injected_finding_ids: list[list[str]] = field(default_factory=list)
     dev_handoff_snapshots: list[dict[str, Any] | None] = field(default_factory=list)
     dev_iteration_telemetry: list[DevIterationTelemetry] = field(default_factory=list)
+    gate_debug_telemetry: list[GateDebugTelemetry] = field(default_factory=list)
     review_iteration_telemetry: list[ReviewIterationTelemetry] = field(default_factory=list)
     context_manifests: list[dict] = field(default_factory=list)
     # One entry per dev invocation (same index as dev_results).

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -118,10 +118,10 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
         pass
 
 
-def _run_shell(
+def _run_shell_detailed(
     cmd: str, cwd: Path, timeout: int = 120, env: dict[str, str] | None = None
-) -> tuple[bool, str]:
-    """Run a shell command. Returns (success, combined output).
+) -> tuple[bool, str, int | None, bool]:
+    """Run a shell command. Returns (success, combined output, exit_code, timed_out).
 
     On abnormal exit, kills the entire process group so child processes (e.g.
     pytest-xdist workers) don't outlive the shell and consume unbounded memory.
@@ -138,11 +138,11 @@ def _run_shell(
             start_new_session=True,
         )
     except Exception as e:
-        return False, f"ERROR: {e}"
+        return False, f"ERROR: {e}", None, False
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
         output = (stdout + stderr).strip()
-        return proc.returncode == 0, output
+        return proc.returncode == 0, output, proc.returncode, False
     except subprocess.TimeoutExpired as te:
         # Kill the whole process group before draining pipes so grandchildren
         # such as pytest-xdist workers cannot keep writing indefinitely after
@@ -164,8 +164,8 @@ def _run_shell(
             pass
         header = f"TIMEOUT after {timeout}s: {cmd}"
         if partial_out:
-            return False, f"{header}\n{partial_out}"
-        return False, header
+            return False, f"{header}\n{partial_out}", None, True
+        return False, header, None, True
     except BaseException:
         _kill_process_group(proc)
         proc.wait()
@@ -178,6 +178,19 @@ def _run_shell(
                     stream.close()
                 except Exception:
                     pass
+
+
+def _run_shell(
+    cmd: str, cwd: Path, timeout: int = 120, env: dict[str, str] | None = None
+) -> tuple[bool, str]:
+    """Run a shell command. Returns (success, combined output)."""
+    ok, output, _exit_code, _timed_out = _run_shell_detailed(
+        cmd,
+        cwd,
+        timeout=timeout,
+        env=env,
+    )
+    return ok, output
 
 
 # ── Worktree project-code evaluation ────────────────────────────────────

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -16,7 +16,7 @@ from theforge.task import TaskStory
 
 from . import util as _cu
 from .dev_phase import _extract_failed_tests, record_dev_iteration_telemetry
-from .gate import _is_gate_skip, _parse_dirty_files, _run_gate_full
+from .gate import _is_gate_skip, _parse_dirty_files, _run_gate_debug_command, _run_gate_full
 from .logging import StructuredLogger
 from .notify import _escalate_notify
 from .review_context import _get_handoff_content, _get_raw_dev_notes, _latest_forge_handoff_path
@@ -200,6 +200,20 @@ def _run_validate_phase(
 
     if gate_err:
         is_timeout = "timed out" in (gate_err or "").lower()
+        if is_timeout:
+            debug_telemetry = _run_gate_debug_command(
+                config,
+                workspace_path,
+                iter_num=state.dev_iteration,
+            )
+            if debug_telemetry is not None:
+                state.gate_debug_telemetry.append(debug_telemetry)
+                gate_err = (
+                    f"{gate_err}. Gate debug command ran; see audit "
+                    f"iterations.gate_debug[-1] and trace "
+                    f".forge/traces/{state.dev_iteration}-gate-debug.txt."
+                    f"\nGate debug output tail:\n{debug_telemetry.output_tail}"
+                )
         record_dev_iteration_telemetry(
             state,
             workspace_path,

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1427,6 +1427,21 @@ class TestValidationTestCommand:
         config = load_config(config_path)
         assert config.validation.test_command is None
 
+    def test_gate_debug_timeout_parsed_when_present(self, tmp_path):
+        config_path = _write_config(
+            {
+                "validation": {
+                    "gate_command": "make gate",
+                    "gate_debug_command": "pytest -x -v -n 0",
+                    "gate_debug_timeout": 90,
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.validation.gate_debug_command == "pytest -x -v -n 0"
+        assert config.validation.gate_debug_timeout == 90
+
     def test_handoff_file_raises_value_error(self, tmp_path):
         """handoff_file and gate_decision_key are removed in v0.8 and must raise ValueError."""
         config_path = _write_config(

--- a/tests/test_generate_audit_log.py
+++ b/tests/test_generate_audit_log.py
@@ -19,6 +19,7 @@ from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.state import (
     CoordinatorResult,
     CoordinatorState,
+    GateDebugTelemetry,
     Phase,
     ReviewCycleMetadata,
 )
@@ -504,6 +505,32 @@ class TestPhasesBlock:
         assert validate is not None
         assert validate["duration_s"] == pytest.approx(12.0)
         assert validate["outcome"] == "pass"
+
+    def test_validate_phase_records_gate_debug_timeout_audit(self, tmp_path: Path) -> None:
+        """Gate timeout diagnostics appear in validate phase and iteration audit."""
+        state = CoordinatorState()
+        state.validate_durations.append(45.0)
+        state.gate_debug_telemetry.append(
+            GateDebugTelemetry(
+                iteration=1,
+                command="pytest -x -v -n 0",
+                ran=True,
+                timeout_s=45,
+                exit_code=5,
+                output_tail="debug tail",
+                output_truncated=True,
+            )
+        )
+        result = _make_coordinator_result(state)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        validate = log["phases"]["validate"]
+        assert validate is not None
+        assert validate["outcome"] == "error"
+        assert validate["gate_debug"][0]["ran"] is True
+        assert validate["gate_debug"][0]["exit_code"] == 5
+        assert validate["gate_debug"][0]["output_tail"] == "debug tail"
+        assert log["iterations"]["gate_debug"][0]["command"] == "pytest -x -v -n 0"
 
     def test_review_phase_per_reviewer(self, tmp_path: Path) -> None:
         """phases.review.per_reviewer groups agents by profile, cross-refs verdict."""

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -178,6 +179,97 @@ def test_run_validate_phase_records_gate_error_escalation_once(tmp_path: Path) -
     assert telemetry.gate_result == "ERROR"
     assert telemetry.failed_tests == []
     assert telemetry.existing_test_failures is False
+
+
+def test_run_validate_phase_runs_gate_debug_command_on_timeout(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        validation=dataclasses.replace(
+            config.validation,
+            gate_debug_command="pytest -x -v -n 0",
+            gate_debug_timeout=7,
+            gate_output_tail_chars=40,
+        ),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.5)
+    state.last_dev_start_commit = "HEAD"
+
+    def shell_side_effect(cmd, cwd, **kwargs):
+        if cmd == "pytest -x -v -n 0":
+            assert kwargs["timeout"] == 7
+            return False, "debug stdout\n" + ("x" * 80) + "\ndebug stderr", 5, False
+        return True, "", 0, False
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=(
+                None,
+                "Gate timed out after 120s",
+                "TIMEOUT after 120s: pytest tests/",
+                "pytest tests/",
+            ),
+        ),
+        patch("theforge.coordinator.util._run_shell_detailed", side_effect=shell_side_effect),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert "Gate debug command ran" in result.message
+    assert "iterations.gate_debug[-1]" in result.message
+    assert "debug stderr" in result.message
+    assert len(state.gate_debug_telemetry) == 1
+    debug = state.gate_debug_telemetry[0]
+    assert debug.ran is True
+    assert debug.exit_code == 5
+    assert debug.timeout_s == 7
+    assert debug.output_truncated is True
+    trace = tmp_path / ".forge" / "traces" / "1-gate-debug.txt"
+    assert trace.read_text(encoding="utf-8").startswith("debug stdout")
+
+
+def test_run_validate_phase_timeout_without_gate_debug_command_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.5)
+    state.last_dev_start_commit = "HEAD"
+
+    with patch(
+        "theforge.coordinator.validate_phase._run_gate_full",
+        return_value=(None, "Gate timed out after 120s", "", "pytest tests/"),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.message == "Gate timed out after 120s"
+    assert state.gate_debug_telemetry == []
 
 
 def _git(repo: Path, *args: str) -> str:


### PR DESCRIPTION
## Summary

Gate timeout now runs configured debug command, captures bounded output to audit/trace, and surfaces it in escalate reason; well-tested.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.24
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: gate timeout escalates without running gate_debug_command (GitHub Issue #834)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #834