### PR TITLE
bug: mid-sprint re-exec aborts with escalated worktree, silently drops remaining stories

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -131,16 +131,20 @@ def cmd_sprint(args: object) -> int:
         return 1
 
     slugs = parse_manifest_slugs(config, manifest_path)
-    locked_fds, launch_error = _acquire_launch_locks(slugs=slugs, config=config, resume=resume)
+    reexec = _is_reexec()
+    locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
+        slugs=slugs, config=config, resume=resume, allow_drop=reexec
+    )
     if launch_error is not None:
         return launch_error
 
+    live_slugs = [s for s in slugs if s not in dropped_slugs]
     if not getattr(args, "fg", False) and not getattr(args, "detach", False):
         run_id = _generate_run_id()
         slug = manifest_path.stem
         _detach.daemonize_run(run_id, slug, config.project_root)
         locked_fds = reacquire_story_locks_in_daemon(
-            slugs,
+            live_slugs,
             config.project_root,
             locked_fds,
         )
@@ -182,6 +186,7 @@ def cmd_sprint(args: object) -> int:
             resume=resume,
             no_pull=no_pull,
             run_id=run_id,
+            dropped_slugs=dropped_slugs,
         )
     except Exception as exc:
         import traceback
@@ -199,13 +204,31 @@ def cmd_sprint(args: object) -> int:
 
 
 def _acquire_launch_locks(
-    slugs: list[str], config: object, resume: bool
-) -> tuple[list, int | None]:
+    slugs: list[str],
+    config: object,
+    resume: bool,
+    *,
+    allow_drop: bool = False,
+) -> tuple[list, int | None, dict[str, str]]:
     return acquire_launch_story_locks(
         slugs=slugs,
         config=config,
         resume=resume,
+        allow_drop=allow_drop,
     )
+
+
+def _is_reexec() -> bool:
+    """Return True when the current process was started by a forge re-exec.
+
+    ``FORGE_PREV_RUN_ID`` is set by coordinator workspace.py just before
+    ``os.execv``; it is only popped inside ``daemonize_run``.  Seeing it here
+    (before daemonization) is the authoritative signal that we are running a
+    re-exec of a mid-sprint forge.
+    """
+    import os
+
+    return bool(os.environ.get("FORGE_PREV_RUN_ID"))
 
 
 def _run_query_mode(
@@ -336,9 +359,14 @@ def _run_query_mode(
 
     # ── Lock acquisition using resolved slugs (no manifest path needed) ──
     slugs = [task.slug for task, _src, _ref in resolved.stories]
-    locked_fds, launch_error = _acquire_launch_locks(slugs=slugs, config=config, resume=resume)
+    reexec = _is_reexec()
+    locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
+        slugs=slugs, config=config, resume=resume, allow_drop=reexec
+    )
     if launch_error is not None:
         return launch_error
+
+    live_slugs = [s for s in slugs if s not in dropped_slugs]
 
     # ── Daemonization: slug from sprint name, not manifest filename ───────
     run_id = _generate_run_id()
@@ -347,7 +375,7 @@ def _run_query_mode(
     if not getattr(args, "fg", False) and not getattr(args, "detach", False):
         _detach.daemonize_run(run_id, sprint_slug, config.project_root)
         locked_fds = reacquire_story_locks_in_daemon(
-            slugs,
+            live_slugs,
             config.project_root,
             locked_fds,
         )
@@ -374,6 +402,7 @@ def _run_query_mode(
             resume=resume,
             no_pull=no_pull,
             run_id=run_id,
+            dropped_slugs=dropped_slugs,
         )
     except Exception as exc:
         import traceback

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -107,12 +107,14 @@ def _write_sprint_audit(
     tasks_by_slug: "dict[str, TaskStory] | None" = None,
     ci_break_slug: str | None = None,
     sprint_id: str | None = None,
+    dropped_slugs: "dict[str, str] | None" = None,
 ) -> None:
     """Write sprint-audit.yaml to the project root."""
     story_times = story_times or {}
     batch_assignments = batch_assignments or {}
     slug_map = slug_map or {}
     tasks_by_slug = tasks_by_slug or {}
+    dropped_slugs = dropped_slugs or {}
 
     # Build per-spec entries
     spec_entries = []
@@ -226,14 +228,23 @@ def _write_sprint_audit(
                 entry["finished_at"] = None
             entry["batch"] = batch_assignments.get(slug, 0)
         else:
-            # Skipped due to budget or pre-skip (resume)
+            # Dropped by launch guard (active-worktree collision, lock held,
+            # or preserved-escalated) takes precedence over the generic
+            # SKIPPED path — operators need to see drop reasons explicitly.
+            drop_reason = dropped_slugs.get(slug)
+            if drop_reason == "preserved-escalated":
+                drop_outcome = "PRESERVED"
+            elif drop_reason is not None:
+                drop_outcome = "DROPPED"
+            else:
+                drop_outcome = "SKIPPED"
             entry = {
                 "path": display_key,
-                "outcome": "SKIPPED",
+                "outcome": drop_outcome,
                 "cost_usd": 0.0,
                 "preflight": None,
-                "error": None,
-                "error_type": None,
+                "error": drop_reason,
+                "error_type": "dropped" if drop_reason else None,
                 "merge": False,
                 "reviews": [],
                 "depends_on": task.depends_on if task else [],
@@ -249,6 +260,8 @@ def _write_sprint_audit(
                 "finished_at": None,
                 "batch": batch_assignments.get(slug, 0),
             }
+            if drop_reason:
+                entry["drop_reason"] = drop_reason
         spec_entries.append(entry)
 
     usage_distribution = []
@@ -330,6 +343,7 @@ def _write_sprint_summary(
     ci_break_slug: str | None = None,
     sprint_id: str | None = None,
     project_root: Path | None = None,
+    dropped_slugs: "dict[str, str] | None" = None,
 ) -> None:
     """Write sprint-summary.yaml to <project_root>/.forge/logs/<sprint-name>/.
 
@@ -343,6 +357,7 @@ def _write_sprint_summary(
     batch_assignments = batch_assignments or {}
     slug_map = slug_map or {}
     tasks_by_slug = tasks_by_slug or {}
+    dropped_slugs = dropped_slugs or {}
 
     # Load prior accumulated story entries from the sprint-level state file.
     # Keyed by canonical_ref so we can substitute them for stories not in
@@ -449,19 +464,28 @@ def _write_sprint_summary(
             spec_entries.append(entry)
             accumulated_for_state.append(prior)
         else:
+            drop_reason = dropped_slugs.get(slug)
+            if drop_reason == "preserved-escalated":
+                drop_outcome = "PRESERVED"
+            elif drop_reason is not None:
+                drop_outcome = "DROPPED"
+            else:
+                drop_outcome = "SKIPPED"
             entry = {
                 "path": display_key,
                 "slug": slug,
-                "outcome": "SKIPPED",
+                "outcome": drop_outcome,
                 "verdict": None,
                 "cost_usd": 0.0,
                 "preflight": None,
-                "error": None,
-                "error_type": None,
+                "error": drop_reason,
+                "error_type": "dropped" if drop_reason else None,
                 "merge": False,
                 "batch": batch_assignments.get(slug, 0),
                 "depends_on": list(getattr(tasks_by_slug.get(slug), "depends_on", None) or []),
             }
+            if drop_reason:
+                entry["drop_reason"] = drop_reason
             spec_entries.append(entry)
 
     # Persist accumulated state so future runs can find stories from this invocation.
@@ -505,9 +529,11 @@ def _write_sprint_summary(
     effective_failed = sum(
         1
         for e in spec_entries
-        if e.get("outcome") not in ("DONE", "ALREADY_DONE", "SKIPPED", None)
+        if e.get("outcome") not in ("DONE", "ALREADY_DONE", "SKIPPED", "PRESERVED", None)
     )
-    effective_skipped = sum(1 for e in spec_entries if e.get("outcome") in ("SKIPPED", None))
+    effective_skipped = sum(
+        1 for e in spec_entries if e.get("outcome") in ("SKIPPED", "PRESERVED", None)
+    )
 
     summary = {
         "sprint": {

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 
-from theforge.sprint.lock import acquire_story_locks
+from theforge.sprint.lock import acquire_story_locks, check_active_worktrees
 from theforge.sprint.preflight import (
+    abort_for_active_worktrees,
     abort_for_running_stories,
     check_active_worktrees_or_continue,
 )
@@ -16,16 +18,69 @@ def acquire_launch_story_locks(
     slugs: list[str],
     config: Any,
     resume: bool,
-) -> tuple[list, int | None]:
-    """Acquire launch-time story locks after checking for active worktrees."""
-    active_worktree_error = check_active_worktrees_or_continue(
-        slugs=slugs,
-        config=config,
-        resume=resume,
-    )
-    if active_worktree_error is not None:
-        return [], active_worktree_error
-    locked_fds, conflicted = acquire_story_locks(slugs, config.project_root)
+    allow_drop: bool = False,
+) -> tuple[list, int | None, dict[str, str]]:
+    """Acquire launch-time story locks after checking for active worktrees.
+
+    Returns ``(locked_fds, exit_code, dropped_slugs)``.
+
+    When ``allow_drop`` is False (default, initial launch), any active worktree
+    or locked-by-another-process conflict aborts the whole sprint — the caller
+    returns ``exit_code`` to the shell.
+
+    When ``allow_drop`` is True (re-exec path), conflicting stories are returned
+    individually in ``dropped_slugs`` (slug -> reason) and the remaining,
+    unconflicted stories have their locks acquired normally.  The caller is
+    expected to propagate the dropped set into ``run_sprint`` so those stories
+    are recorded in sprint-audit and appear in ``forge sprint-status``.
+    """
+    if not allow_drop:
+        active_worktree_error = check_active_worktrees_or_continue(
+            slugs=slugs,
+            config=config,
+            resume=resume,
+        )
+        if active_worktree_error is not None:
+            return [], active_worktree_error, {}
+        locked_fds, conflicted = acquire_story_locks(slugs, config.project_root)
+        if conflicted:
+            return [], abort_for_running_stories(conflicted), {}
+        return locked_fds, None, {}
+
+    dropped: dict[str, str] = {}
+    if resume:
+        active_worktrees: list[str] = []
+    else:
+        active_worktrees = check_active_worktrees(
+            slugs,
+            config.workspace.path_pattern,
+            config.workspace.base_branch,
+            config.project_root,
+        )
+    for slug in active_worktrees:
+        dropped[slug] = "active-worktree-collision"
+
+    remaining = [s for s in slugs if s not in dropped]
+    if active_worktrees:
+        # Visible, operator-facing marker: separate from the routine log stream.
+        print(
+            f"[forge] DROPPED {', '.join(active_worktrees)}: active worktree "
+            f"collision after re-exec; continuing with remaining stories.",
+            file=sys.stderr,
+            flush=True,
+        )
+        abort_for_active_worktrees(active_worktrees)
+
+    locked_fds, conflicted = acquire_story_locks(remaining, config.project_root)
+    for slug in conflicted:
+        dropped[slug] = "story-lock-held-by-other-process"
     if conflicted:
-        return [], abort_for_running_stories(conflicted)
-    return locked_fds, None
+        print(
+            f"[forge] DROPPED {', '.join(conflicted)}: story lock held by "
+            "another process after re-exec; continuing with remaining stories.",
+            file=sys.stderr,
+            flush=True,
+        )
+        abort_for_running_stories(conflicted)
+
+    return locked_fds, None, dropped

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -5,12 +5,22 @@ from __future__ import annotations
 import sys
 from typing import Any
 
-from theforge.sprint.lock import acquire_story_locks, check_active_worktrees
+from theforge.sprint.lock import (
+    acquire_story_locks,
+    check_active_worktrees,
+    check_escalated_worktrees,
+)
 from theforge.sprint.preflight import (
     abort_for_active_worktrees,
     abort_for_running_stories,
     check_active_worktrees_or_continue,
 )
+
+# Reason codes used as the value in the ``dropped_slugs`` mapping.  These are
+# consumed by the sprint runner for audit visibility and by tests.
+REASON_PRESERVED_ESCALATED = "preserved-escalated"
+REASON_ACTIVE_WORKTREE = "active-worktree-collision"
+REASON_LOCK_HELD = "story-lock-held-by-other-process"
 
 
 def acquire_launch_story_locks(
@@ -24,57 +34,100 @@ def acquire_launch_story_locks(
 
     Returns ``(locked_fds, exit_code, dropped_slugs)``.
 
+    ``dropped_slugs`` maps slug -> reason for every story that will NOT be
+    scheduled this launch.  The caller passes this mapping into ``run_sprint``
+    so the dropped stories still appear in sprint-audit and live status with
+    a distinct outcome (``dropped`` / ``preserved``) rather than silently
+    vanishing or falling back to a generic SKIPPED entry.
+
     When ``allow_drop`` is False (default, initial launch), any active worktree
     or locked-by-another-process conflict aborts the whole sprint — the caller
-    returns ``exit_code`` to the shell.
+    returns ``exit_code`` to the shell.  Escalated worktrees are still treated
+    as preserved (never collisions) and are removed from scheduling even on
+    the initial-launch path; otherwise a sprint resumed over an already-
+    escalated worktree would re-run it.
 
-    When ``allow_drop`` is True (re-exec path), conflicting stories are returned
-    individually in ``dropped_slugs`` (slug -> reason) and the remaining,
-    unconflicted stories have their locks acquired normally.  The caller is
-    expected to propagate the dropped set into ``run_sprint`` so those stories
-    are recorded in sprint-audit and appear in ``forge sprint-status``.
+    When ``allow_drop`` is True (re-exec path), conflicting stories are
+    individually recorded in ``dropped_slugs`` and the remaining, unconflicted
+    stories have their locks acquired normally.
+
+    Invariants the callers rely on:
+
+    - Every slug in the returned ``dropped_slugs`` is *not* counted in
+      ``locked_fds`` — we never hold a lock for a dropped story.
+    - Every slug *not* in ``dropped_slugs`` and present in the input ``slugs``
+      list is either present in ``locked_fds`` or the function returns with a
+      non-None exit code.  In particular, the non-re-exec path never returns a
+      partial lock set: if any story conflicts, no locks are returned.
     """
+    # ── Escalated worktrees: always preserved, on every launch path ─────
+    if resume:
+        escalated_slugs: list[str] = []
+    else:
+        escalated_slugs = check_escalated_worktrees(
+            slugs,
+            config.workspace.path_pattern,
+            config.project_root,
+        )
+    dropped: dict[str, str] = {s: REASON_PRESERVED_ESCALATED for s in escalated_slugs}
+    schedulable = [s for s in slugs if s not in dropped]
+
+    if escalated_slugs:
+        print(
+            f"[forge] PRESERVED {', '.join(escalated_slugs)}: escalated worktree "
+            "preserved for human review; not rescheduled.",
+            file=sys.stderr,
+            flush=True,
+        )
+
     if not allow_drop:
+        # Initial-launch path: escalated stories are silently excluded from
+        # scheduling, but any other collision still aborts the whole sprint.
         active_worktree_error = check_active_worktrees_or_continue(
-            slugs=slugs,
+            slugs=schedulable,
             config=config,
             resume=resume,
         )
         if active_worktree_error is not None:
-            return [], active_worktree_error, {}
-        locked_fds, conflicted = acquire_story_locks(slugs, config.project_root)
+            return [], active_worktree_error, dropped
+        locked_fds, conflicted = acquire_story_locks(schedulable, config.project_root)
         if conflicted:
-            return [], abort_for_running_stories(conflicted), {}
-        return locked_fds, None, {}
+            return [], abort_for_running_stories(conflicted), dropped
+        return locked_fds, None, dropped
 
-    dropped: dict[str, str] = {}
-    if resume:
-        active_worktrees: list[str] = []
-    else:
-        active_worktrees = check_active_worktrees(
-            slugs,
-            config.workspace.path_pattern,
-            config.workspace.base_branch,
-            config.project_root,
-        )
+    # ── Re-exec path: convert every collision into a per-story drop ─────
+    active_worktrees = check_active_worktrees(
+        schedulable,
+        config.workspace.path_pattern,
+        config.workspace.base_branch,
+        config.project_root,
+    )
     for slug in active_worktrees:
-        dropped[slug] = "active-worktree-collision"
-
-    remaining = [s for s in slugs if s not in dropped]
+        dropped[slug] = REASON_ACTIVE_WORKTREE
+    remaining = [s for s in schedulable if s not in dropped]
     if active_worktrees:
-        # Visible, operator-facing marker: separate from the routine log stream.
         print(
             f"[forge] DROPPED {', '.join(active_worktrees)}: active worktree "
-            f"collision after re-exec; continuing with remaining stories.",
+            "collision after re-exec; continuing with remaining stories.",
             file=sys.stderr,
             flush=True,
         )
         abort_for_active_worktrees(active_worktrees)
 
-    locked_fds, conflicted = acquire_story_locks(remaining, config.project_root)
-    for slug in conflicted:
-        dropped[slug] = "story-lock-held-by-other-process"
-    if conflicted:
+    # Acquire locks for everything that survived worktree checks.  On a lock
+    # conflict, acquire_story_locks releases the partial set it was holding —
+    # so we *must* retry for the non-conflicted remainder, otherwise the live
+    # stories would run without launch locks and a concurrent forge invocation
+    # could race them.
+    live_slugs: list[str] = list(remaining)
+    locked_fds: list = []
+    while live_slugs:
+        attempt_fds, conflicted = acquire_story_locks(live_slugs, config.project_root)
+        if not conflicted:
+            locked_fds = attempt_fds
+            break
+        for slug in conflicted:
+            dropped[slug] = REASON_LOCK_HELD
         print(
             f"[forge] DROPPED {', '.join(conflicted)}: story lock held by "
             "another process after re-exec; continuing with remaining stories.",
@@ -82,5 +135,8 @@ def acquire_launch_story_locks(
             flush=True,
         )
         abort_for_running_stories(conflicted)
+        live_slugs = [s for s in live_slugs if s not in dropped]
+        # attempt_fds is already empty/released by acquire_story_locks on
+        # conflict — loop around and reacquire for the surviving subset.
 
     return locked_fds, None, dropped

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -9,7 +9,31 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
+import yaml
+
 from theforge.pid import _is_pid_alive
+
+
+def _is_escalated_worktree(worktree_path: Path) -> bool:
+    """Return True when the worktree's audit marks it as an escalated, preserved run.
+
+    Escalated worktrees are intentionally kept for human triage after the
+    coordinator terminates in the ESCALATE phase.  They are not collisions.
+    """
+    audit_path = worktree_path / ".forge" / "audit.yaml"
+    if not audit_path.exists():
+        return False
+    try:
+        with open(audit_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    outcome = data.get("outcome")
+    if not isinstance(outcome, dict):
+        return False
+    return outcome.get("final_phase") == "ESCALATE"
 
 
 class SprintConflictError(Exception):
@@ -43,6 +67,8 @@ def check_active_worktrees(
     for slug in slugs:
         worktree_path = project_root / path_pattern.format(slug=slug)
         if not worktree_path.exists():
+            continue
+        if _is_escalated_worktree(worktree_path):
             continue
         result = subprocess.run(
             [

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -56,6 +56,28 @@ def _read_lock_pid(fd) -> int | None:
         return None
 
 
+def check_escalated_worktrees(
+    slugs: list[str],
+    path_pattern: str,
+    project_root: Path,
+) -> list[str]:
+    """Return slugs whose on-disk worktree is marked escalated (preserved).
+
+    Companion to :func:`check_active_worktrees` — the two cases are disjoint:
+    an escalated worktree is intentionally held for human triage and must not
+    be rescheduled, whereas an *active* worktree is a genuine collision that
+    must be handled as a conflict.
+    """
+    escalated: list[str] = []
+    for slug in slugs:
+        worktree_path = project_root / path_pattern.format(slug=slug)
+        if not worktree_path.exists():
+            continue
+        if _is_escalated_worktree(worktree_path):
+            escalated.append(slug)
+    return escalated
+
+
 def check_active_worktrees(
     slugs: list[str],
     path_pattern: str,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -760,16 +760,24 @@ def run_sprint(
         specs_skipped += 1
 
     # Stories dropped pre-launch (e.g. re-exec collision) never enter the DAG.
-    # They surface as FAILED in the sprint audit and live status so operators
-    # can see exactly which stories did not run and why — a silent WARNING is
-    # not enough visibility.
+    # They surface with a distinct DROPPED/PRESERVED outcome in sprint-audit and
+    # the live state file so operators can see exactly which stories did not
+    # run and why — a silent WARNING is not enough visibility.
+    #
+    # ``preserved-escalated`` is a disjoint case: the worktree is intentionally
+    # kept for human review, and counts as skipped (not failed) in aggregates.
     _dropped_slugs: dict[str, str] = dict(dropped_slugs or {})
     for slug, reason in _dropped_slugs.items():
         if slug not in slug_to_context:
             continue
-        _log(f"DROPPED {slug} (reason: {reason})")
-        dag.mark_skipped(slug)
-        specs_failed += 1
+        if reason == "preserved-escalated":
+            _log(f"PRESERVED {slug} (escalated worktree held for review)")
+            dag.mark_skipped(slug)
+            specs_skipped += 1
+        else:
+            _log(f"DROPPED {slug} (reason: {reason})")
+            dag.mark_skipped(slug)
+            specs_failed += 1
 
     # Initialise live state file for forge sprint-status (only when a CLI run_id
     # is present — headless/test invocations without a run_id skip this).
@@ -785,7 +793,10 @@ def run_sprint(
             )
             _blocked_by = list(blocked_slugs.get(_slug, []))
             _drop_reason = _dropped_slugs.get(_slug)
-            if _drop_reason:
+            if _drop_reason == "preserved-escalated":
+                _status = "preserved"
+                _blocked_by = [f"preserved: {_drop_reason}"]
+            elif _drop_reason:
                 _status = "failed"
                 _blocked_by = [f"dropped: {_drop_reason}"]
             elif _blocked_by:
@@ -1412,6 +1423,7 @@ def run_sprint(
         tasks_by_slug={slug: ctx[0] for slug, ctx in slug_to_context.items()},
         ci_break_slug=ci_halt_slug,
         sprint_id=_sprint_id,
+        dropped_slugs=_dropped_slugs,
     )
 
     # Write sprint-summary.yaml to .forge/logs/<sprint-name>/
@@ -1432,6 +1444,7 @@ def run_sprint(
             ci_break_slug=ci_halt_slug,
             sprint_id=_sprint_id,
             project_root=config.project_root,
+            dropped_slugs=_dropped_slugs,
         )
 
     # Remove live state file now that sprint-summary.yaml is the permanent record.

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -543,6 +543,7 @@ def run_sprint(
     state_update_fn: "Callable[[dict], None] | None" = None,
     no_pull: bool = False,
     run_id: str | None = None,
+    dropped_slugs: "dict[str, str] | None" = None,
 ) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -758,6 +759,18 @@ def run_sprint(
         dag.mark_skipped(slug)
         specs_skipped += 1
 
+    # Stories dropped pre-launch (e.g. re-exec collision) never enter the DAG.
+    # They surface as FAILED in the sprint audit and live status so operators
+    # can see exactly which stories did not run and why — a silent WARNING is
+    # not enough visibility.
+    _dropped_slugs: dict[str, str] = dict(dropped_slugs or {})
+    for slug, reason in _dropped_slugs.items():
+        if slug not in slug_to_context:
+            continue
+        _log(f"DROPPED {slug} (reason: {reason})")
+        dag.mark_skipped(slug)
+        specs_failed += 1
+
     # Initialise live state file for forge sprint-status (only when a CLI run_id
     # is present — headless/test invocations without a run_id skip this).
     _state_writer: SprintStateWriter | None = None
@@ -771,11 +784,19 @@ def run_sprint(
                 else _canonical_ref
             )
             _blocked_by = list(blocked_slugs.get(_slug, []))
+            _drop_reason = _dropped_slugs.get(_slug)
+            if _drop_reason:
+                _status = "failed"
+                _blocked_by = [f"dropped: {_drop_reason}"]
+            elif _blocked_by:
+                _status = "blocked"
+            else:
+                _status = "waiting"
             _initial_stories.append(
                 {
                     "slug": _slug,
                     "path": _display_key,
-                    "status": "blocked" if _blocked_by else "waiting",
+                    "status": _status,
                     "phase": None,
                     "cost_usd": 0.0,
                     "bundle_candidate": _slug in _bundle_candidate_slugs,

--- a/tests/test_cli_pid_cleanup.py
+++ b/tests/test_cli_pid_cleanup.py
@@ -205,7 +205,7 @@ class TestPidFileCleanupOnException:
             patch("theforge.cli.sprint.release_story_locks"),
             patch(
                 "theforge.cli.sprint._acquire_launch_locks",
-                return_value=([], None),
+                return_value=([], None, {}),
             ),
             patch("theforge.detach.remove_pid", side_effect=_fake_remove_pid),
         ):
@@ -243,7 +243,7 @@ class TestPidFileCleanupOnException:
             patch("theforge.cli.sprint.release_story_locks"),
             patch(
                 "theforge.cli.sprint._acquire_launch_locks",
-                return_value=([], None),
+                return_value=([], None, {}),
             ),
             patch("theforge.detach.remove_pid", side_effect=_fake_remove_pid),
         ):
@@ -284,7 +284,7 @@ class TestPidFileCleanupOnException:
             patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
             patch(
                 "theforge.cli.sprint._acquire_launch_locks",
-                return_value=([], None),
+                return_value=([], None, {}),
             ),
             patch("theforge.cli.sprint.release_story_locks"),
             patch(
@@ -357,7 +357,7 @@ class TestPidFileCleanupOnException:
             patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
             patch(
                 "theforge.cli.sprint._acquire_launch_locks",
-                return_value=([], None),
+                return_value=([], None, {}),
             ),
             patch("theforge.cli.sprint.release_story_locks"),
             patch("theforge.cli.sprint.run_sprint", return_value=stub_result),

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -219,6 +219,45 @@ class TestCheckActiveWorktrees:
 
         assert active == []
 
+    def test_escalated_worktree_is_not_active(self, tmp_path: Path) -> None:
+        """Worktrees with final_phase == ESCALATE are preserved, not collisions."""
+        import yaml as _yaml
+
+        worktree = tmp_path / ".forge" / "worktrees" / "story-a"
+        (worktree / ".forge").mkdir(parents=True)
+        (worktree / ".forge" / "audit.yaml").write_text(
+            _yaml.dump({"outcome": {"final_phase": "ESCALATE"}}),
+            encoding="utf-8",
+        )
+        # Worktree has commits ahead — git check would report "active" if reached.
+        completed = MagicMock(returncode=0, stdout="5\n")
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed) as mock_run:
+            active = check_active_worktrees(
+                ["story-a"], ".forge/worktrees/{slug}", "main", tmp_path
+            )
+
+        assert active == []
+        # Short-circuit: git rev-list must not have been invoked for escalated wt.
+        mock_run.assert_not_called()
+
+    def test_non_escalated_audit_is_still_active(self, tmp_path: Path) -> None:
+        """Worktrees whose audit shows DONE (or any non-ESCALATE phase) still count."""
+        import yaml as _yaml
+
+        worktree = tmp_path / ".forge" / "worktrees" / "story-a"
+        (worktree / ".forge").mkdir(parents=True)
+        (worktree / ".forge" / "audit.yaml").write_text(
+            _yaml.dump({"outcome": {"final_phase": "DEV"}}),
+            encoding="utf-8",
+        )
+        completed = MagicMock(returncode=0, stdout="3\n")
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+            active = check_active_worktrees(
+                ["story-a"], ".forge/worktrees/{slug}", "main", tmp_path
+            )
+
+        assert active == ["story-a"]
+
     def test_git_failure_is_not_active(self, tmp_path: Path) -> None:
         worktree = tmp_path / ".forge" / "worktrees" / "story-a"
         worktree.mkdir(parents=True)

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
 
 from theforge.sprint.launch_guard import acquire_launch_story_locks
@@ -40,12 +41,11 @@ def _make_worktree_with_audit(tmp_path: Path, slug: str, final_phase: str | None
 
 
 class TestEscalatedWorktreeNotTreatedAsCollision:
-    def test_escalated_worktree_passes_launch_guard(self, tmp_path: Path) -> None:
-        """An escalated worktree with committed work does NOT block launch."""
+    def test_escalated_worktree_is_preserved_not_scheduled(self, tmp_path: Path) -> None:
+        """An escalated worktree is excluded from scheduling — no lock, no rerun."""
         _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
         config = _mock_config(tmp_path)
 
-        # Even if git rev-list would report commits ahead, escalated marker wins.
         completed = MagicMock(returncode=0, stdout="7\n")
         with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
             locked_fds, launch_error, dropped = acquire_launch_story_locks(
@@ -56,24 +56,21 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
             )
 
         assert launch_error is None
-        assert dropped == {}
-        # Locks were acquired because the worktree was treated as preserved.
-        assert len(locked_fds) == 1
-        from theforge.sprint.lock import release_story_locks
-
-        release_story_locks(locked_fds)
+        assert dropped == {"issue-829": "preserved-escalated"}
+        # No lock is held for the preserved escalated worktree.
+        assert locked_fds == []
 
     def test_reexec_with_escalated_and_pending_story(self, tmp_path: Path) -> None:
         """Scenario from the bug: three stories, middle escalated, third must run.
 
         Simulates the post-re-exec launch guard path: ``slugs`` is the full
-        sprint slug list; one of them has an escalated worktree; no drop should
-        occur and all locks should be acquired.
+        sprint slug list; the escalated slug is returned as preserved, the
+        remaining slugs acquire locks and proceed.
         """
         _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
         config = _mock_config(tmp_path)
 
-        # issue-267 and issue-268 have no worktree, issue-829 has escalated one.
+        # issue-267 and issue-268 have no worktree; issue-829 is escalated.
         completed = MagicMock(returncode=0, stdout="0\n")
         with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
             locked_fds, launch_error, dropped = acquire_launch_story_locks(
@@ -85,8 +82,9 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
 
         try:
             assert launch_error is None, "re-exec must not abort when only collision is escalated"
-            assert dropped == {}
-            assert len(locked_fds) == 3
+            assert dropped == {"issue-829": "preserved-escalated"}
+            # Two live stories got locks; the preserved one did not.
+            assert len(locked_fds) == 2
         finally:
             from theforge.sprint.lock import release_story_locks
 
@@ -128,6 +126,71 @@ class TestGenuineCollisionDuringReexec:
 
             release_story_locks(locked_fds)
 
+    def test_reexec_live_lock_holder_drops_only_conflicted_and_keeps_locks(
+        self, tmp_path: Path
+    ) -> None:
+        """A real process holding a story lock results in only that slug dropped.
+
+        The remaining stories must still hold real locks after the launch guard
+        returns — otherwise a concurrent forge invocation could race them.
+        """
+        import fcntl
+        import multiprocessing as _mp_mod
+        import os
+
+        from theforge.sprint.lock import acquire_story_locks, release_story_locks
+
+        ctx = _mp_mod.get_context("fork")
+        config = _mock_config(tmp_path)
+
+        ready = ctx.Event()
+        release = ctx.Event()
+
+        def _hold_lock(root: str, slug: str, r: object, rel: object) -> None:
+            fds, _ = acquire_story_locks([slug], Path(root))
+            r.set()
+            rel.wait(timeout=10)
+            release_story_locks(fds)
+
+        proc = ctx.Process(
+            target=_hold_lock,
+            args=(str(tmp_path), "issue-829", ready, release),
+        )
+        proc.start()
+        try:
+            assert ready.wait(timeout=5)
+
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829", "issue-267", "issue-268"],
+                config=config,
+                resume=False,
+                allow_drop=True,
+            )
+
+            try:
+                assert launch_error is None
+                assert dropped == {"issue-829": "story-lock-held-by-other-process"}
+                # Two non-conflicted stories actually hold their flocks.
+                assert len(locked_fds) == 2
+
+                # Try to re-acquire one of the live locks from this process —
+                # it must fail because acquire_launch_story_locks still holds it.
+                live_lock = tmp_path / ".forge" / "locks" / "issue-267.lock"
+                fd = open(live_lock, "a+")
+                try:
+                    with pytest.raises(BlockingIOError):
+                        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                finally:
+                    fd.close()
+            finally:
+                release_story_locks(locked_fds)
+        finally:
+            release.set()
+            proc.join(timeout=5)
+            if proc.is_alive():
+                os.kill(proc.pid, 9)
+                proc.join(timeout=2)
+
     def test_initial_launch_still_aborts_on_active_worktree(self, tmp_path: Path) -> None:
         """Without re-exec (allow_drop=False) the legacy abort behavior is preserved."""
         _make_worktree_with_audit(tmp_path, "issue-829", final_phase=None)
@@ -145,6 +208,63 @@ class TestGenuineCollisionDuringReexec:
         assert launch_error == 1
         assert locked_fds == []
         assert dropped == {}
+
+
+class TestAuditVisibilityForDroppedStories:
+    def test_sprint_audit_records_dropped_and_preserved(self, tmp_path: Path) -> None:
+        """_write_sprint_audit emits distinct DROPPED / PRESERVED outcomes with reasons."""
+        import datetime
+
+        from theforge.sprint.audit import _write_sprint_audit
+        from theforge.sprint.manifest import SprintResult
+
+        manifest = MagicMock()
+        manifest.name = "test-sprint"
+        manifest.budget_usd = 1.0
+        manifest.max_parallel = 1
+
+        sprint_result = SprintResult(
+            name="test-sprint",
+            specs_total=3,
+            specs_succeeded=0,
+            specs_failed=1,
+            specs_skipped=2,
+            total_cost_usd=0.0,
+            budget_usd=1.0,
+            results=[],
+        )
+
+        now = datetime.datetime(2026, 4, 18, tzinfo=datetime.timezone.utc)
+        _write_sprint_audit(
+            manifest=manifest,
+            result=sprint_result,
+            canonical_refs=["issue:829", "issue:267", "issue:268"],
+            started_at=now,
+            finished_at=now,
+            duration=1.0,
+            project_root=tmp_path,
+            slug_map={
+                "issue:829": "issue-829",
+                "issue:267": "issue-267",
+                "issue:268": "issue-268",
+            },
+            dropped_slugs={
+                "issue-829": "preserved-escalated",
+                "issue-267": "active-worktree-collision",
+            },
+        )
+
+        audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+        data = yaml.safe_load(audit_path.read_text())
+        specs_by_path = {e["path"]: e for e in data["specs"]}
+
+        assert specs_by_path["Issue #829"]["outcome"] == "PRESERVED"
+        assert specs_by_path["Issue #829"]["drop_reason"] == "preserved-escalated"
+        assert specs_by_path["Issue #267"]["outcome"] == "DROPPED"
+        assert specs_by_path["Issue #267"]["drop_reason"] == "active-worktree-collision"
+        # Unmentioned story is still a plain SKIPPED (no drop_reason field).
+        assert specs_by_path["Issue #268"]["outcome"] == "SKIPPED"
+        assert "drop_reason" not in specs_by_path["Issue #268"]
 
 
 class TestCliReexecDetection:

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -1,0 +1,161 @@
+"""Regression tests for issue #835: re-exec must not silently drop stories.
+
+Covers two behaviors:
+
+1. Escalated worktrees are recognized by their state metadata and are not
+   treated as active-worktree collisions during re-exec.
+2. A genuine active-worktree collision after re-exec does not abort the whole
+   sprint — the conflicted story is marked failed, visibly, and the remaining
+   stories continue.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from theforge.sprint.launch_guard import acquire_launch_story_locks
+
+
+def _mock_config(tmp_path: Path) -> MagicMock:
+    config = MagicMock()
+    config.project_root = tmp_path
+    config.workspace.path_pattern = ".forge/worktrees/{slug}"
+    config.workspace.base_branch = "main"
+    return config
+
+
+def _make_worktree_with_audit(tmp_path: Path, slug: str, final_phase: str | None = None) -> Path:
+    worktree = tmp_path / ".forge" / "worktrees" / slug
+    worktree.mkdir(parents=True)
+    if final_phase is not None:
+        (worktree / ".forge").mkdir(parents=True, exist_ok=True)
+        (worktree / ".forge" / "audit.yaml").write_text(
+            yaml.dump({"outcome": {"final_phase": final_phase}}),
+            encoding="utf-8",
+        )
+    return worktree
+
+
+class TestEscalatedWorktreeNotTreatedAsCollision:
+    def test_escalated_worktree_passes_launch_guard(self, tmp_path: Path) -> None:
+        """An escalated worktree with committed work does NOT block launch."""
+        _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
+        config = _mock_config(tmp_path)
+
+        # Even if git rev-list would report commits ahead, escalated marker wins.
+        completed = MagicMock(returncode=0, stdout="7\n")
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829"],
+                config=config,
+                resume=False,
+                allow_drop=False,
+            )
+
+        assert launch_error is None
+        assert dropped == {}
+        # Locks were acquired because the worktree was treated as preserved.
+        assert len(locked_fds) == 1
+        from theforge.sprint.lock import release_story_locks
+
+        release_story_locks(locked_fds)
+
+    def test_reexec_with_escalated_and_pending_story(self, tmp_path: Path) -> None:
+        """Scenario from the bug: three stories, middle escalated, third must run.
+
+        Simulates the post-re-exec launch guard path: ``slugs`` is the full
+        sprint slug list; one of them has an escalated worktree; no drop should
+        occur and all locks should be acquired.
+        """
+        _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
+        config = _mock_config(tmp_path)
+
+        # issue-267 and issue-268 have no worktree, issue-829 has escalated one.
+        completed = MagicMock(returncode=0, stdout="0\n")
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829", "issue-267", "issue-268"],
+                config=config,
+                resume=False,
+                allow_drop=True,
+            )
+
+        try:
+            assert launch_error is None, "re-exec must not abort when only collision is escalated"
+            assert dropped == {}
+            assert len(locked_fds) == 3
+        finally:
+            from theforge.sprint.lock import release_story_locks
+
+            release_story_locks(locked_fds)
+
+
+class TestGenuineCollisionDuringReexec:
+    def test_reexec_active_worktree_drops_only_conflicted_story(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """A truly active (non-escalated) worktree is dropped, not an abort."""
+        # issue-829 has no audit.yaml -> treated as active (ahead commits).
+        _make_worktree_with_audit(tmp_path, "issue-829", final_phase=None)
+        config = _mock_config(tmp_path)
+
+        completed = MagicMock(returncode=0, stdout="3\n")
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829", "issue-267", "issue-268"],
+                config=config,
+                resume=False,
+                allow_drop=True,
+            )
+
+        try:
+            assert launch_error is None, "re-exec must not abort entire sprint"
+            assert "issue-829" in dropped
+            assert "issue-267" not in dropped
+            assert "issue-268" not in dropped
+            # Remaining stories acquired locks.
+            assert len(locked_fds) == 2
+
+            # Visibility: the drop is loud, not silent.
+            captured = capsys.readouterr()
+            assert "DROPPED" in captured.err
+            assert "issue-829" in captured.err
+        finally:
+            from theforge.sprint.lock import release_story_locks
+
+            release_story_locks(locked_fds)
+
+    def test_initial_launch_still_aborts_on_active_worktree(self, tmp_path: Path) -> None:
+        """Without re-exec (allow_drop=False) the legacy abort behavior is preserved."""
+        _make_worktree_with_audit(tmp_path, "issue-829", final_phase=None)
+        config = _mock_config(tmp_path)
+
+        completed = MagicMock(returncode=0, stdout="3\n")
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829", "issue-267"],
+                config=config,
+                resume=False,
+                allow_drop=False,
+            )
+
+        assert launch_error == 1
+        assert locked_fds == []
+        assert dropped == {}
+
+
+class TestCliReexecDetection:
+    def test_reexec_detected_when_prev_run_id_env_set(self, monkeypatch) -> None:
+        from theforge.cli.sprint import _is_reexec
+
+        monkeypatch.setenv("FORGE_PREV_RUN_ID", "run-prev-123")
+        assert _is_reexec() is True
+
+    def test_reexec_not_detected_without_env(self, monkeypatch) -> None:
+        from theforge.cli.sprint import _is_reexec
+
+        monkeypatch.delenv("FORGE_PREV_RUN_ID", raising=False)
+        assert _is_reexec() is False


### PR DESCRIPTION
## Summary

Prior P1 findings are resolved; no fix-introduced regressions found. Focused regressions passed, while full make gate failed in two unrelated environment-sensitive tests outside this diff.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $7.17
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_network_guard.py:99`** Project gate did not exit 0 because test_localhost_uppercase_is_allowed failed resolving uppercase LOCALHOST in this environment. This file was not modified by the reviewed commits, so this is not a blocking regression from the fix.
- **[P2] `tests/test_runner_sandbox.py:196`** Project gate also failed because sandbox-exec returned Operation not permitted in the macOS sandbox integration test. This file was not modified by the reviewed commits, so this is not a blocking regression from the fix.

## Story

bug: mid-sprint re-exec aborts with escalated worktree, silently drops remaining stories (GitHub Issue #835)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #835