### PR TITLE
bug: forge stop kills the process but forge status still shows RUNNING forever

### DIFF
--- a/src/theforge/cli/main.py
+++ b/src/theforge/cli/main.py
@@ -91,6 +91,7 @@ def main() -> None:
         "logs": status.cmd_logs,
         "stop": status.cmd_stop,
         "decide": status.cmd_decide,
+        "runs-clean": status.cmd_runs_clean,
         "version": cmd_version,
     }
 

--- a/src/theforge/cli/run.py
+++ b/src/theforge/cli/run.py
@@ -286,7 +286,10 @@ def cmd_run(args: "argparse.Namespace") -> int:
 
         return 0 if result.success else 1
     finally:
-        # Remove PID file unconditionally — ensures cleanup even if run_task raises
+        # Write terminal marker then remove PID — ensures status is accurate even
+        # if run_task raises. SIGTERM handler may have already written "stopped";
+        # write_run_ended is a no-op when the file already exists.
+        _detach.write_run_ended(run_id, config.project_root, "completed")
         _detach.remove_pid(run_id, config.project_root)
 
 

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -197,7 +197,10 @@ def cmd_sprint(args: object) -> int:
         return 1
     finally:
         release_story_locks(locked_fds)
-        # Remove PID file unconditionally — ensures cleanup even if run_sprint raises
+        # Write terminal marker then remove PID — ensures status is accurate even
+        # if run_sprint raises. SIGTERM handler may have already written "stopped";
+        # write_run_ended is a no-op when the file already exists.
+        _detach.write_run_ended(run_id, config.project_root, "completed")
         _detach.remove_pid(run_id, config.project_root)
 
     return 0 if result.specs_failed == 0 else 1
@@ -413,7 +416,8 @@ def _run_query_mode(
         return 1
     finally:
         release_story_locks(locked_fds)
-        # Remove PID file unconditionally — ensures cleanup even if run_sprint raises
+        # Write terminal marker then remove PID — same pattern as manifest mode.
+        _detach.write_run_ended(run_id, config.project_root, "completed")
         _detach.remove_pid(run_id, config.project_root)
 
     return 0 if result.specs_failed == 0 else 1

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -208,7 +208,9 @@ def _show_recent_runs(project_root: Path) -> int:
                 mtime = log_file.stat().st_mtime
             except OSError:
                 continue
-            rows.append((mtime, run_id, "single", "completed", "—", "—"))
+            outcome = _detach.read_run_ended(run_id, project_root)
+            status_str = outcome if outcome is not None else "orphaned"
+            rows.append((mtime, run_id, "single", status_str, "—", "—"))
             seen_ids.add(run_id)
 
     if not rows:
@@ -467,6 +469,7 @@ def cmd_stop(args: object) -> int:
     except ProcessLookupError:
         print(f"Process {pid} not found — cleaning up stale PID file")
         _detach.remove_pid(run_id, project_root)
+        _detach.write_run_ended(run_id, project_root, "stopped", force=True)
         return 1
     except OSError as exc:
         print(f"Could not signal process {pid}: {exc}", file=sys.stderr)
@@ -483,6 +486,7 @@ def cmd_stop(args: object) -> int:
         time.sleep(0.1)
 
     if not _detach._is_pid_alive(pid):
+        _detach.write_run_ended(run_id, project_root, "stopped", force=True)
         print(f"[forge] Run {run_id} has stopped.")
         return 0
 
@@ -491,6 +495,48 @@ def cmd_stop(args: object) -> int:
         file=sys.stderr,
     )
     return 1
+
+
+def cmd_runs_clean(args: object) -> int:
+    """Mark orphaned runs (no PID, no .ended) by writing a .ended sentinel."""
+    from theforge import detach as _detach
+
+    config_path = _find_config()
+    if config_path is None or not config_path.exists():
+        print("forge.yaml not found.", file=sys.stderr)
+        return 1
+    config = load_config(config_path)
+    project_root = config.project_root
+
+    logs_dir = project_root / ".forge" / "logs"
+    runs_dir = project_root / ".forge" / "runs"
+    if not logs_dir.exists():
+        print("No runs found.")
+        return 0
+
+    # Collect run IDs that are currently alive (have a live PID).
+    active_pids: set[str] = set()
+    for run in _detach.list_active_runs(project_root):
+        active_pids.add(run["run_id"])
+
+    cleaned = 0
+    for log_file in logs_dir.rglob("run-*.log"):
+        run_id = log_file.stem[4:]
+        if run_id in active_pids:
+            continue
+        ended_file = runs_dir / f"{run_id}.ended"
+        if ended_file.exists():
+            continue
+        # Orphan: has a log, no live process, no terminal marker.
+        _detach.write_run_ended(run_id, project_root, "orphaned")
+        print(f"[forge] Marked {run_id} as orphaned")
+        cleaned += 1
+
+    if cleaned == 0:
+        print("No orphaned runs found.")
+    else:
+        print(f"Cleaned {cleaned} orphaned run(s).")
+    return 0
 
 
 def cmd_decide(args: object) -> int:
@@ -581,6 +627,12 @@ def register_parsers(subparsers: object) -> None:
         default=60,
         metavar="N",
         help="Seconds to wait for process exit (default 60)",
+    )
+
+    # forge runs-clean
+    subparsers.add_parser(
+        "runs-clean",
+        help="Mark orphaned runs (no terminal marker) so forge status shows correct state",
     )
 
     # forge decide

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -45,6 +45,35 @@ def remove_pid(run_id: str, project_root: Path) -> None:
         pass
 
 
+def write_run_ended(
+    run_id: str, project_root: Path, outcome: str = "stopped", *, force: bool = False
+) -> None:
+    """Write .forge/runs/<run_id>.ended with the terminal outcome.
+
+    outcome is a short string: "stopped", "completed", or "orphaned".
+    When force=False (default) the file is not overwritten if it already
+    exists — the first writer (usually the SIGTERM handler) wins.
+    """
+    runs_dir = project_root / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    ended_file = runs_dir / f"{run_id}.ended"
+    if not force and ended_file.exists():
+        return
+    try:
+        ended_file.write_text(outcome, encoding="utf-8")
+    except OSError:
+        pass
+
+
+def read_run_ended(run_id: str, project_root: Path) -> str | None:
+    """Return the terminal outcome recorded in .forge/runs/<run_id>.ended, or None."""
+    ended_file = project_root / ".forge" / "runs" / f"{run_id}.ended"
+    try:
+        return ended_file.read_text(encoding="utf-8").strip() or None
+    except FileNotFoundError:
+        return None
+
+
 def _read_pid_file(pid_file: Path) -> tuple[int, str] | None:
     """Parse a PID file. Returns (pid, slug) or None on error."""
     try:
@@ -110,47 +139,34 @@ def _is_pid_alive(pid: int) -> bool:
 
 
 def read_run_status(run_id: str, slug: str, project_root: Path) -> dict:
-    """Return best-effort status dict for a running process.
+    """Return best-effort status dict for a run (active, terminal, or orphaned).
 
-    Searches the run log for the most recent phase marker and
-    computes elapsed from the log file's creation time.
+    Checks in order:
+    1. .ended sentinel → returns terminal outcome as phase (STOPPED, COMPLETED, …).
+    2. Active PID file → reads phase from log (existing behaviour).
+    3. No PID and no .ended → run exited without writing a terminal marker → ORPHANED.
 
     Returns dict with keys: phase, cost_usd, elapsed_seconds, log_path.
     """
     log_path = _find_log_path(slug, run_id, project_root)
-
-    phase = "RUNNING"
-    cost_usd: float | None = None
     elapsed_seconds: float | None = None
+    cost_usd: float | None = None
 
+    # Compute elapsed and cost once; reused across all return paths.
     if log_path is not None and log_path.exists():
-        # Extract elapsed from file mtime vs creation time
         try:
             stat = log_path.stat()
-            # Use st_birthtime (macOS) or st_ctime as creation proxy
             created = getattr(stat, "st_birthtime", stat.st_ctime)
             elapsed_seconds = time.time() - created
         except OSError:
             pass
 
-        # Scan log for most recent phase marker and cost
         try:
-            content = log_path.read_text(encoding="utf-8", errors="replace")
-            lines = content.splitlines()
-            for line in reversed(lines):
-                if "[forge] ▸ " in line:
-                    # e.g. "[forge] ▸ DEV   $1.23 elapsed"
-                    parts = line.split("[forge] ▸ ", 1)
-                    if len(parts) == 2:
-                        phase_part = parts[1].split()[0] if parts[1].split() else phase
-                        phase = phase_part
-                    break
-            # Find most recent cost line
-            for line in reversed(lines):
-                if "Total cost:" in line or "total_cost" in line:
-                    # e.g. "  Total cost: $1.234"
-                    import re
+            import re
 
+            content = log_path.read_text(encoding="utf-8", errors="replace")
+            for line in reversed(content.splitlines()):
+                if "Total cost:" in line or "total_cost" in line:
                     m = re.search(r"\$([0-9]+\.[0-9]+)", line)
                     if m:
                         cost_usd = float(m.group(1))
@@ -158,12 +174,32 @@ def read_run_status(run_id: str, slug: str, project_root: Path) -> dict:
         except OSError:
             pass
 
-    return {
-        "phase": phase,
-        "cost_usd": cost_usd,
-        "elapsed_seconds": elapsed_seconds,
-        "log_path": log_path,
-    }
+    base = {"cost_usd": cost_usd, "elapsed_seconds": elapsed_seconds, "log_path": log_path}
+
+    # 1. Terminal marker — written by forge stop or normal exit.
+    outcome = read_run_ended(run_id, project_root)
+    if outcome is not None:
+        return {**base, "phase": outcome.upper()}
+
+    # 2. Active run — PID file exists; read phase from log.
+    pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
+    if pid_file.exists():
+        phase = "RUNNING"
+        if log_path is not None and log_path.exists():
+            try:
+                lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+                for line in reversed(lines):
+                    if "[forge] ▸ " in line:
+                        parts = line.split("[forge] ▸ ", 1)
+                        if len(parts) == 2:
+                            phase = parts[1].split()[0] if parts[1].split() else phase
+                        break
+            except OSError:
+                pass
+        return {**base, "phase": phase}
+
+    # 3. No PID, no .ended → process exited without writing a terminal marker.
+    return {**base, "phase": "ORPHANED"}
 
 
 def _find_log_path(slug: str, run_id: str, project_root: Path) -> Path | None:
@@ -356,10 +392,11 @@ def daemonize_run(run_id: str, slug: str, project_root: Path) -> None:
 
 
 def install_cleanup_handler(run_id: str, project_root: Path) -> None:
-    """Install SIGTERM handler that removes the PID file on clean shutdown."""
+    """Install SIGTERM handler that writes a terminal marker and removes the PID file."""
     original_handler = signal.getsignal(signal.SIGTERM)
 
     def _handler(signum: int, frame: object) -> None:
+        write_run_ended(run_id, project_root, "stopped")
         remove_pid(run_id, project_root)
         if callable(original_handler):
             original_handler(signum, frame)  # type: ignore[call-arg]

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -261,6 +261,49 @@ class TestCmdStatusRouting:
         mock_recent.assert_called_once_with(config.project_root)
 
 
+# ── Regression: forge stop writes .ended; forge status shows STOPPED ─────────
+
+
+class TestStopWritesTerminalMarker:
+    def test_stopped_run_shows_stopped_not_running(self, tmp_path: Path) -> None:
+        """Regression: after forge stop, forge status shows STOPPED not RUNNING.
+
+        Simulates SIGTERM stop: writes .ended 'stopped', removes PID file.
+        Then verifies read_run_status returns STOPPED, not RUNNING.
+        """
+        from theforge import detach
+
+        # Set up a log file so read_run_status has something to work with.
+        log_dir = tmp_path / ".forge" / "logs" / "issues-828"
+        log_dir.mkdir(parents=True)
+        (log_dir / "run-6f59d22b.log").write_text("✓ PREFLIGHT PROCEED\n")
+
+        # Simulate what forge stop does: write .ended, no PID file present.
+        detach.write_run_ended("6f59d22b", tmp_path, "stopped", force=True)
+
+        st = detach.read_run_status("6f59d22b", "issues-828", tmp_path)
+        assert st["phase"] == "STOPPED", f"Expected STOPPED, got {st['phase']!r}"
+
+    def test_orphaned_run_shows_orphaned_not_running(self, tmp_path: Path) -> None:
+        """Regression: a run that died silently shows ORPHANED, not RUNNING.
+
+        Simulates a silent crash: log file exists, no PID file, no .ended.
+        forge status should detect this as ORPHANED.
+        """
+        from theforge import detach
+
+        # Set up a log file — process wrote some output but no terminal marker.
+        log_dir = tmp_path / ".forge" / "logs" / "issues-828"
+        log_dir.mkdir(parents=True)
+        (log_dir / "run-deadbeef.log").write_text("✓ PREFLIGHT PROCEED\n")
+
+        # No PID file (stale PID cleaned up by list_active_runs).
+        # No .ended file (process crashed without writing one).
+
+        st = detach.read_run_status("deadbeef", "issues-828", tmp_path)
+        assert st["phase"] == "ORPHANED", f"Expected ORPHANED, got {st['phase']!r}"
+
+
 # ── Parser-level coverage ─────────────────────────────────────────────────────
 
 

--- a/tests/test_detach.py
+++ b/tests/test_detach.py
@@ -191,6 +191,98 @@ class TestDaemonizeRun:
                 detach.daemonize_run("run123", "slug", tmp_path)
 
 
+# ── Terminal marker (.ended) ──────────────────────────────────────────
+
+
+class TestWriteRunEnded:
+    def test_creates_ended_file(self, tmp_path):
+        detach.write_run_ended("abc123", tmp_path, "stopped")
+        ended = tmp_path / ".forge" / "runs" / "abc123.ended"
+        assert ended.exists()
+        assert ended.read_text() == "stopped"
+
+    def test_default_outcome_is_stopped(self, tmp_path):
+        detach.write_run_ended("abc123", tmp_path)
+        assert (tmp_path / ".forge" / "runs" / "abc123.ended").read_text() == "stopped"
+
+    def test_no_overwrite_by_default(self, tmp_path):
+        detach.write_run_ended("abc123", tmp_path, "stopped")
+        detach.write_run_ended("abc123", tmp_path, "completed")
+        assert (tmp_path / ".forge" / "runs" / "abc123.ended").read_text() == "stopped"
+
+    def test_force_overwrites(self, tmp_path):
+        detach.write_run_ended("abc123", tmp_path, "stopped")
+        detach.write_run_ended("abc123", tmp_path, "completed", force=True)
+        assert (tmp_path / ".forge" / "runs" / "abc123.ended").read_text() == "completed"
+
+
+class TestReadRunEnded:
+    def test_returns_outcome_when_file_exists(self, tmp_path):
+        detach.write_run_ended("abc123", tmp_path, "stopped")
+        assert detach.read_run_ended("abc123", tmp_path) == "stopped"
+
+    def test_returns_none_when_missing(self, tmp_path):
+        assert detach.read_run_ended("no-such-run", tmp_path) is None
+
+
+class TestReadRunStatus:
+    def test_returns_stopped_when_ended_file_exists(self, tmp_path):
+        detach.write_run_ended("abc123", tmp_path, "stopped")
+        st = detach.read_run_status("abc123", "my-slug", tmp_path)
+        assert st["phase"] == "STOPPED"
+
+    def test_returns_completed_when_ended_file_says_completed(self, tmp_path):
+        detach.write_run_ended("abc123", tmp_path, "completed")
+        st = detach.read_run_status("abc123", "my-slug", tmp_path)
+        assert st["phase"] == "COMPLETED"
+
+    def test_returns_orphaned_when_no_pid_no_ended(self, tmp_path):
+        # No PID file, no .ended — process exited without writing a terminal marker.
+        log_dir = tmp_path / ".forge" / "logs" / "my-slug"
+        log_dir.mkdir(parents=True)
+        (log_dir / "run-abc123.log").write_text("some log content\n")
+        st = detach.read_run_status("abc123", "my-slug", tmp_path)
+        assert st["phase"] == "ORPHANED"
+
+    def test_returns_running_when_pid_file_exists(self, tmp_path):
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "abc123.pid").write_text(f"{os.getpid()}\nmy-slug\n")
+        st = detach.read_run_status("abc123", "my-slug", tmp_path)
+        assert st["phase"] == "RUNNING"
+
+    def test_ended_takes_priority_over_pid_file(self, tmp_path):
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "abc123.pid").write_text(f"{os.getpid()}\nmy-slug\n")
+        detach.write_run_ended("abc123", tmp_path, "stopped")
+        st = detach.read_run_status("abc123", "my-slug", tmp_path)
+        assert st["phase"] == "STOPPED"
+
+
+class TestInstallCleanupHandlerWritesEnded:
+    def test_sigterm_writes_ended_and_removes_pid(self, tmp_path):
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        pid_file = runs_dir / "abc123.pid"
+        pid_file.write_text(f"{os.getpid()}\nmy-slug\n")
+
+        import signal
+
+        detach.install_cleanup_handler("abc123", tmp_path)
+        try:
+            # Simulate SIGTERM inline by calling the handler directly.
+            signal.raise_signal(signal.SIGTERM)
+        except SystemExit:
+            pass
+
+        assert not pid_file.exists()
+        assert detach.read_run_ended("abc123", tmp_path) == "stopped"
+
+        # Restore default SIGTERM handler to avoid interfering with other tests.
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+
 def test_find_log_path_prefers_per_run_log(tmp_path):
     log_path = tmp_path / ".forge" / "logs" / "my-slug" / "run-run123.log"
     log_path.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Terminal marker (.ended) + orphan detection cleanly resolve ghost RUNNING status; tests cover stopped/orphaned/priority cases.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.45
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/cli/status.py:211`** _show_recent_runs labels any run without an .ended file as 'orphaned', including currently-active runs whose PID is still alive. This branch is only reached when the run is not in the active-runs list, but a race (run starts between the two scans) could briefly mislabel it. Minor.
- **[P2] `src/theforge/detach.py:155`** import re moved inside read_run_status loop body; works but re is already a stdlib module — top-level import would be marginally cleaner and avoid repeated import lookups on each call.

## Story

bug: forge stop kills the process but forge status still shows RUNNING forever (GitHub Issue #829)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #829