### PR TITLE
[P2] issue-829: import re moved inside read_run_status loop body; works 

### DIFF
--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import signal
 import sys
 import time
@@ -162,8 +163,6 @@ def read_run_status(run_id: str, slug: str, project_root: Path) -> dict:
             pass
 
         try:
-            import re
-
             content = log_path.read_text(encoding="utf-8", errors="replace")
             for line in reversed(content.splitlines()):
                 if "Total cost:" in line or "total_cost" in line:


### PR DESCRIPTION
## Summary

Moves the stdlib re import to module scope as requested with no behavioral change.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.11
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-829: import re moved inside read_run_status loop body; works  (GitHub Issue #843)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #843