### PR TITLE
bug: sprint-start warning about Codex/Gemini cost tracking fires unconditionally

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -57,6 +57,8 @@ from .query import normalize_dependency_plan
 from .sources import StorySource
 from .state_writer import SprintStateWriter
 
+_UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"codex", "gemini"})
+
 
 def _log(msg: str) -> None:
     slug = get_worker_slug()
@@ -82,6 +84,64 @@ def _read_prior_sprint_cost(project_root: Path) -> float:
         return float(data.get("sprint", {}).get("total_cost_usd", 0.0))
     except (OSError, ValueError, TypeError):
         return 0.0
+
+
+def _agent_cost_tracking_warnings(config: ForgeConfig) -> list[str]:
+    """Return sprint-start warnings for configured CLI agents with unknown cost."""
+
+    agents: list[tuple[str, str | None, str | None, str]] = [
+        (
+            config.preflight_profile.name,
+            config.preflight_profile.cli,
+            config.preflight_profile.provider,
+            config.preflight_profile.model,
+        ),
+        (
+            config.dev_profile.name,
+            config.dev_profile.cli,
+            config.dev_profile.provider,
+            config.dev_profile.model,
+        ),
+    ]
+
+    if config.plan.enabled:
+        agents.append(("planner", config.plan.cli, config.plan.provider, config.plan.model))
+
+    if config.plan_agent_review.enabled:
+        agents.extend(
+            (profile.name, profile.cli, profile.provider, profile.model)
+            for profile in config.plan_agent_review.profiles
+        )
+
+    agents.extend(
+        (profile.name, profile.cli, profile.provider, profile.model)
+        for profile in config.review_pool
+    )
+
+    if config.synthesis_profile is not None:
+        agents.append(
+            (
+                config.synthesis_profile.name,
+                config.synthesis_profile.cli,
+                config.synthesis_profile.provider,
+                config.synthesis_profile.model,
+            )
+        )
+
+    warnings: list[str] = []
+    seen: set[tuple[str, str, str]] = set()
+    for name, cli, provider, model in agents:
+        if provider is not None or cli not in _UNTRACKED_COST_CLIS:
+            continue
+        key = (name, cli, model)
+        if key in seen:
+            continue
+        seen.add(key)
+        warnings.append(
+            f"⚠ Cost not tracked for {name} ({cli} CLI, {model}). "
+            "Audit totals will exclude this agent's usage."
+        )
+    return warnings
 
 
 def parse_manifest_slugs(config: "ForgeConfig", manifest_path: Path) -> list[str]:
@@ -613,7 +673,8 @@ def run_sprint(
         file=sys.stderr,
         flush=True,
     )
-    _log("⚠ Budget tracks Claude costs only (Codex/Gemini report $0.00)")
+    for warning in _agent_cost_tracking_warnings(config):
+        _log(warning)
 
     # Sprint-level structured logger
     _cli_run_id = run_id

--- a/tests/test_sprint_lifecycle.py
+++ b/tests/test_sprint_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +16,7 @@ from theforge.config import (
     DEFAULT_VALIDATION,
     BackendConfig,
     ForgeConfig,
+    ModelProfile,
     NotificationConfig,
     RetryPolicy,
     WorkspaceConfig,
@@ -193,6 +195,75 @@ class TestRunSprint:
             run_sprint(config, manifest_path)
 
         mock_scrub.assert_called_once_with(config)
+
+    def test_api_non_claude_agents_do_not_emit_cost_tracking_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Claude CLI plus OpenAI/Google API agents should not warn about cost tracking."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=10.0)
+        config = _make_config(tmp_path)
+        config = replace(
+            config,
+            review_pool=[
+                replace(
+                    DEFAULT_REVIEW_PROFILE,
+                    name="openai-reviewer",
+                    cli=None,
+                    provider="openai",
+                    model="gpt-5.4",
+                ),
+                ModelProfile(
+                    name="google-reviewer",
+                    cli=None,
+                    provider="google",
+                    model="gemini-3.1-pro-preview",
+                    budget_usd=1.0,
+                    timeout_seconds=300,
+                    allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+                ),
+            ],
+            synthesis_profile=None,
+        )
+        result_a = _make_coordinator_result(success=True, cost=1.0)
+
+        with patch("theforge.sprint.runner.run_task", return_value=result_a):
+            run_sprint(config, manifest_path)
+
+        captured = capsys.readouterr()
+        assert "Cost not tracked" not in captured.err
+        assert "Budget tracks Claude costs only" not in captured.err
+
+    def test_codex_cli_reviewer_emits_targeted_cost_tracking_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A CLI Codex reviewer should produce a targeted warning naming that reviewer."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=10.0)
+        config = _make_config(tmp_path)
+        config = replace(
+            config,
+            review_pool=[
+                replace(
+                    DEFAULT_REVIEW_PROFILE,
+                    name="plan_reviewer",
+                    cli="codex",
+                    provider=None,
+                    model="gpt-5.4",
+                )
+            ],
+        )
+        result_a = _make_coordinator_result(success=True, cost=1.0)
+
+        with patch("theforge.sprint.runner.run_task", return_value=result_a):
+            run_sprint(config, manifest_path)
+
+        captured = capsys.readouterr()
+        assert (
+            "⚠ Cost not tracked for plan_reviewer (codex CLI, gpt-5.4). "
+            "Audit totals will exclude this agent's usage."
+        ) in captured.err
+        assert "Budget tracks Claude costs only" not in captured.err
 
     def test_success_path(self, tmp_path: Path) -> None:
         """Two specs both succeed, costs accumulate, audit written."""


### PR DESCRIPTION
## Summary

Targeted cost-tracking warnings correctly replace the unconditional blanket message; tests cover both API-only and Codex CLI cases.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.17
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: sprint-start warning about Codex/Gemini cost tracking fires unconditionally (GitHub Issue #837)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #837