### PR TITLE
[P2] issue-835: Project gate also failed because sandbox-exec returned O

### DIFF
--- a/tests/test_runner_sandbox.py
+++ b/tests/test_runner_sandbox.py
@@ -168,6 +168,16 @@ def test_macos_sandbox_profile_blocks_sibling_worktree_reads_in_practice(tmp_pat
     if shutil.which("sandbox-exec") is None:
         pytest.skip("sandbox-exec unavailable")
 
+    # Probe: some macOS environments deny sandbox-exec itself (SIP, CI entitlements).
+    probe = subprocess.run(
+        ["sandbox-exec", "-p", "(version 1)(allow default)", "true"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if probe.returncode != 0 and "Operation not permitted" in (probe.stderr + probe.stdout):
+        pytest.skip("sandbox-exec present but denied by host environment")
+
     worktree = tmp_path / ".forge" / "worktrees" / "issue-592"
     sibling = tmp_path / ".forge" / "worktrees" / "issue-777"
     worktree.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Acceptance criterion is met; sandbox-exec denial is probed and skipped before the integration assertions run.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.13
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_runner_sandbox.py:172`** Project testing convention says tests should avoid blocking subprocess calls without a timeout, but the added sandbox-exec probe uses subprocess.run without a timeout.

## Story

[P2] issue-835: Project gate also failed because sandbox-exec returned O (GitHub Issue #840)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #840