### PR TITLE
[P2] issue-835: Project gate did not exit 0 because test_localhost_upper

### DIFF
--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -96,8 +96,13 @@ def test_localhost_uppercase_is_allowed():
     """'LOCALHOST' (uppercase) must not trigger the guard — check is case-insensitive."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-        err = sock.connect_ex(("LOCALHOST", 19994))
-        assert isinstance(err, int)
+        try:
+            err = sock.connect_ex(("LOCALHOST", 19994))
+            assert isinstance(err, int)
+        except socket.gaierror:
+            # Some environments don't resolve uppercase 'LOCALHOST'; that's an OS
+            # resolution failure, not a guard block — the guard passed correctly.
+            pass
     finally:
         sock.close()
 


### PR DESCRIPTION
## Summary

The change satisfies the acceptance criterion by making the uppercase localhost guard test independent of OS hostname resolution behavior.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.17
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-835: Project gate did not exit 0 because test_localhost_upper (GitHub Issue #839)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #839