### PR TITLE
bug: DAG scheduler treats closed dependency issues as still blocking

### DIFF
--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +18,13 @@ from .manifest import _build_task_from_story
 
 def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
+
+
+def _issue_number_from_slug(slug: str) -> int | None:
+    match = re.fullmatch(r"issue-(\d+)", slug)
+    if match is None:
+        return None
+    return int(match.group(1))
 
 
 @dataclass
@@ -131,6 +140,32 @@ def _is_branch_merged(
     return False
 
 
+def _is_issue_closed(issue_number: int, project_root: Path) -> bool:
+    """Return True when GitHub issue ``issue_number`` is not OPEN.
+
+    GitHub is the source of truth for issue-backed external dependencies. Any
+    CLI, parsing, or schema failure returns False so missing state does not
+    spuriously unblock dependent sprint work.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(issue_number), "--json", "state"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return False
+        data = json.loads(result.stdout)
+        state = data.get("state")
+        if not isinstance(state, str):
+            return False
+        return state.upper() != "OPEN"
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+        return False
+
+
 class StoryDAG:
     """Dependency-aware scheduler for concurrent story execution.
 
@@ -164,7 +199,8 @@ class StoryDAG:
     def mark_complete(self, slug: str) -> None:
         """Story satisfied deps (merged / ALREADY_DONE). Unlocks dependents."""
         self._completed.add(slug)
-        self._finished.add(slug)
+        if slug in self._tasks:
+            self._finished.add(slug)
 
     def mark_skipped(self, slug: str) -> None:
         """Story finished without satisfying deps (failed / budget / blocked)."""
@@ -201,7 +237,11 @@ def build_dag(tasks: list[TaskStory], satisfied: set[str] | None = None) -> Stor
     # Validate all depends_on slugs exist in the manifest or are pre-satisfied
     for task in tasks:
         missing = [
-            dep for dep in task.depends_on if dep not in known_slugs and dep not in _satisfied
+            dep
+            for dep in task.depends_on
+            if dep not in known_slugs
+            and dep not in _satisfied
+            and _issue_number_from_slug(dep) is None
         ]
         if missing:
             raise ValueError(
@@ -211,7 +251,10 @@ def build_dag(tasks: list[TaskStory], satisfied: set[str] | None = None) -> Stor
 
     # Detect circular dependencies via DFS (gray/white/black coloring).
     # Exclude satisfied slugs — they are external and not in the DFS graph.
-    deps = {t.slug: [d for d in t.depends_on if d not in _satisfied] for t in tasks}
+    deps = {
+        t.slug: [d for d in t.depends_on if d not in _satisfied and d in known_slugs]
+        for t in tasks
+    }
     visited: set[str] = set()
     in_stack: set[str] = set()
 
@@ -258,6 +301,10 @@ def resolve_satisfied_dependencies(
             continue
         branch = branch_pattern.format(slug=dep_slug)
         if _is_branch_merged(branch, base_branch, project_root, slug=dep_slug):
+            satisfied_slugs.add(dep_slug)
+            continue
+        issue_number = _issue_number_from_slug(dep_slug)
+        if issue_number is not None and _is_issue_closed(issue_number, project_root):
             satisfied_slugs.add(dep_slug)
 
     return satisfied_slugs

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -45,6 +46,10 @@ class NormalizedDependencyPlan:
 
 def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
+
+
+def _is_issue_slug(slug: str) -> bool:
+    return re.fullmatch(r"issue-\d+", slug) is not None
 
 
 def _gh_api_paginate_issues(
@@ -251,7 +256,9 @@ def normalize_dependency_plan(
     """Normalize external dependencies and classify stories blocked before scheduling.
 
     External dependencies already listed in ``satisfied`` are removed from the
-    DAG inputs. Unresolved external dependencies are preserved in ``blocked`` so
+    DAG inputs. Unresolved issue-backed dependencies remain in the DAG so a live
+    scheduler can re-check GitHub issue state and unblock them on a later tick.
+    Other unresolved external dependencies are preserved in ``blocked`` so
     callers can keep the affected stories out of the runnable graph while still
     reporting the blocker chain explicitly.
     """
@@ -260,7 +267,9 @@ def normalize_dependency_plan(
         task.slug: sorted(
             dep_slug
             for dep_slug in task.depends_on
-            if dep_slug not in known_slugs and dep_slug not in satisfied
+            if dep_slug not in known_slugs
+            and dep_slug not in satisfied
+            and not _is_issue_slug(dep_slug)
         )
         for task in tasks
     }
@@ -271,7 +280,9 @@ def normalize_dependency_plan(
             depends_on=[
                 dep_slug
                 for dep_slug in task.depends_on
-                if dep_slug in known_slugs or dep_slug in satisfied
+                if dep_slug in known_slugs
+                or dep_slug in satisfied
+                or (dep_slug not in known_slugs and _is_issue_slug(dep_slug))
             ],
         )
         for task in tasks

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -592,6 +592,48 @@ def _classify_and_record(
     return delta_succeeded, delta_failed, delta_skipped
 
 
+def _refresh_external_satisfied(
+    dag: StoryDAG,
+    all_tasks: list[TaskStory],
+    config: ForgeConfig,
+    merged_slugs: set[str] | None = None,
+) -> set[str]:
+    """Re-check unmet external dependencies and mark newly satisfied slugs.
+
+    External issue dependencies can close while a sprint is running. Keeping this
+    refresh in the scheduler loop lets dependents become ready without requiring
+    operators to stop and resume the sprint.
+    """
+    manifest_slugs = {task.slug for task in all_tasks}
+    external_deps = {
+        dep
+        for task in dag.remaining()
+        for dep in dag.unmet_deps(task.slug)
+        if dep not in manifest_slugs
+    }
+    if not external_deps:
+        return set()
+
+    dependent_tasks = [
+        task for task in all_tasks if any(dep in external_deps for dep in task.depends_on)
+    ]
+    satisfied = resolve_satisfied_dependencies(
+        dependent_tasks,
+        project_root=config.project_root,
+        base_branch=config.workspace.base_branch,
+        branch_pattern=config.workspace.branch_pattern,
+    )
+    newly_satisfied = {
+        slug for slug in satisfied if slug in external_deps and slug not in dag._completed
+    }
+    for slug in sorted(newly_satisfied):
+        dag.mark_complete(slug)
+        if merged_slugs is not None:
+            merged_slugs.add(slug)
+        _log(f"dep satisfied: {slug} (GitHub issue closed)")
+    return newly_satisfied
+
+
 def run_sprint(
     config: ForgeConfig,
     sprint: "Path | ResolvedSprint",
@@ -995,6 +1037,7 @@ def run_sprint(
     with ThreadPoolExecutor(max_workers=max_parallel) as pool:
         while not dag.is_done():
             _log(f"[debug] loop: active={list(active.keys())} fin={dag._finished}")
+            _refresh_external_satisfied(dag, all_tasks, config, merged_slugs)
             ready = [t for t in dag.ready() if t.slug not in active]
 
             for task in ready:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -11,7 +11,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from theforge.sprint.dag import StoryDAG, _is_branch_merged, build_dag
+from theforge.sprint.dag import (
+    StoryDAG,
+    _is_branch_merged,
+    build_dag,
+    resolve_satisfied_dependencies,
+)
+from theforge.sprint.runner import _refresh_external_satisfied
 from theforge.task import TaskStory
 
 
@@ -39,6 +45,15 @@ def test_build_dag_dep_not_in_manifest_but_satisfied_no_error() -> None:
     stories = [_make_story("story-b", depends_on=["story-a"])]
     dag = build_dag(stories, satisfied={"story-a"})
     assert dag is not None
+
+
+def test_build_dag_external_issue_dep_blocks_without_error() -> None:
+    """An external GitHub issue slug can block until a live state refresh satisfies it."""
+    stories = [_make_story("issue-831", depends_on=["issue-807"])]
+    dag = build_dag(stories)
+
+    assert dag.ready() == []
+    assert dag.unmet_deps("issue-831") == ["issue-807"]
 
 
 def test_build_dag_satisfied_returns_story_dag() -> None:
@@ -139,6 +154,60 @@ def test_story_dag_satisfied_not_in_tasks() -> None:
     dag = StoryDAG(stories, satisfied={"story-a"})
     assert "story-a" not in dag._tasks
     assert "story-b" in dag._tasks
+
+
+def test_resolve_satisfied_dependencies_closed_issue(tmp_path: Path) -> None:
+    """A CLOSED external issue dependency is treated as satisfied."""
+    stories = [_make_story("issue-831", depends_on=["issue-807"])]
+    with (
+        patch("theforge.sprint.dag._is_branch_merged", return_value=False),
+        patch("theforge.sprint.dag._is_issue_closed", return_value=True) as is_issue_closed,
+    ):
+        satisfied = resolve_satisfied_dependencies(
+            stories,
+            project_root=tmp_path,
+            base_branch="main",
+            branch_pattern="forge/{slug}",
+        )
+
+    assert "issue-807" in satisfied
+    is_issue_closed.assert_called_once_with(807, tmp_path)
+
+
+def test_scheduler_tick_unblocks_on_issue_close(tmp_path: Path) -> None:
+    """A live scheduler refresh marks a newly CLOSED external issue dep satisfied."""
+    from types import SimpleNamespace
+
+    ready = _make_story("issue-749")
+    blocked = _make_story("issue-751", depends_on=["issue-750"])
+    all_tasks = [ready, blocked]
+    dag = build_dag(all_tasks)
+    config = SimpleNamespace(
+        project_root=tmp_path,
+        workspace=SimpleNamespace(base_branch="main", branch_pattern="forge/{slug}"),
+    )
+    issue_closed = False
+    merged_slugs: set[str] = set()
+
+    def _mock_issue_closed(issue_number: int, project_root: Path) -> bool:
+        assert issue_number == 750
+        assert project_root == tmp_path
+        return issue_closed
+
+    with (
+        patch("theforge.sprint.dag._is_branch_merged", return_value=False),
+        patch("theforge.sprint.dag._is_issue_closed", side_effect=_mock_issue_closed),
+    ):
+        assert {task.slug for task in dag.ready()} == {"issue-749"}
+        assert _refresh_external_satisfied(dag, all_tasks, config, merged_slugs) == set()
+        assert {task.slug for task in dag.ready()} == {"issue-749"}
+
+        issue_closed = True
+        assert _refresh_external_satisfied(dag, all_tasks, config, merged_slugs) == {"issue-750"}
+
+    assert "issue-750" in merged_slugs
+    assert {task.slug for task in dag.ready()} == {"issue-749", "issue-751"}
+    assert not dag.is_done()
 
 
 # ── _is_branch_merged: fast-forward merge regression ─────────────────


### PR DESCRIPTION
## Summary

Issue-state-aware dependency resolution is correctly implemented; external issue slugs flow through DAG, scheduler tick refresh, and tests cover both sprint-start and live-close paths.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.82
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:1040`** _refresh_external_satisfied runs on every scheduler loop iteration and shells out to 'gh issue view' for each unmet external dep. With multiple external issue deps and a tight loop, this can generate frequent gh API calls. Not a correctness issue, but worth considering a small rate-limit or tick-interval gate in a follow-up.
- **[P2] `src/theforge/sprint/runner.py:625`** _refresh_external_satisfied reads dag._completed directly (private attribute). Same-package access is fine functionally, but a small accessor would keep the StoryDAG surface cleaner.

## Story

bug: DAG scheduler treats closed dependency issues as still blocking (GitHub Issue #831)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #831