### PR TITLE
bug: agent subprocesses can poison global Python when running bare pip/python

### DIFF
--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from theforge.coordinator.log_tee import get_worker_slug
 from theforge.log_level import LogLevel
 from theforge.log_util import _log_line
+from theforge.workspace_env import build_workspace_env
 
 # Stable reference captured at import time so test patches that replace the
 # subprocess module attribute (e.g. patch("validate_phase.subprocess.run"))
@@ -134,7 +135,7 @@ def _run_shell_detailed(
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(cwd),
-            env=env if env is not None else os.environ.copy(),
+            env=env if env is not None else build_workspace_env(cwd),
             start_new_session=True,
         )
     except Exception as e:

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -7,7 +7,6 @@ streams JSONL events, and returns an AgentResult.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import threading
 import time
@@ -17,6 +16,7 @@ from typing import Any
 from theforge.agent_types import AgentResult, ModelUsage
 from theforge.log_util import _log_line
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
+from theforge.workspace_env import build_workspace_env
 
 from ..config import ModelProfile
 
@@ -199,7 +199,7 @@ def _run_claude(
         cmd.extend(["--permission-mode", "default"])
 
     # Unset CLAUDECODE so the subprocess isn't blocked by the nested-session check
-    env = {**os.environ, **(secrets or {})}
+    env = build_workspace_env(working_dir, extra=secrets)
     env.pop("CLAUDECODE", None)
 
     label = profile.name or f"{profile.cli or profile.provider}/{profile.model}"

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -18,6 +18,7 @@ from typing import Any
 from theforge.agent_types import AgentResult
 from theforge.log_util import _log_line
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
+from theforge.workspace_env import build_workspace_env
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
@@ -147,7 +148,7 @@ def _run_codex(
 
     start_wall = time.time()
     label = profile.name or f"{profile.cli or profile.provider}/{profile.model}"
-    _codex_env = {**os.environ, **(secrets or {})}
+    _codex_env = build_workspace_env(working_dir, extra=secrets)
     outcome, elapsed = _run_with_heartbeat(
         run_fn=lambda: subprocess.run(
             cmd,

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -7,7 +7,6 @@ as a subprocess and returns an AgentResult.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -15,6 +14,7 @@ from typing import Any
 from theforge.agent_types import AgentResult
 from theforge.log_util import _log_line
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
+from theforge.workspace_env import build_workspace_env
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
@@ -117,7 +117,7 @@ def _run_gemini(
         cmd = sandboxed_cmd
 
     label = profile.name or f"{profile.cli or profile.provider}/{profile.model}"
-    _gemini_env = {**os.environ, **(secrets or {})}
+    _gemini_env = build_workspace_env(working_dir, extra=secrets)
     outcome, elapsed = _run_with_heartbeat(
         run_fn=lambda: subprocess.run(
             cmd,

--- a/src/theforge/runners/tool_runtime.py
+++ b/src/theforge/runners/tool_runtime.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from theforge.workspace_env import build_workspace_env
+
 from .sandbox import sandbox_command
 
 MAX_TOOL_OUTPUT_BYTES = 51200  # 50KB default
@@ -162,6 +164,7 @@ def _handle_bash(
             capture_output=True,
             text=True,
             timeout=_BASH_TIMEOUT,
+            env=build_workspace_env(Path(working_dir)),
         )
         combined = result.stdout + result.stderr
         output = f"Exit code: {result.returncode}\n{combined}"

--- a/src/theforge/workspace_env.py
+++ b/src/theforge/workspace_env.py
@@ -1,0 +1,36 @@
+"""Workspace subprocess environment helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping
+
+
+def build_workspace_env(
+    workspace_path: Path,
+    base_env: Mapping[str, str] | None = None,
+    *,
+    extra: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build an environment that prefers the workspace virtualenv when present."""
+    env = dict(base_env or os.environ)
+    venv_path = workspace_path / ".venv"
+    venv_bin = venv_path / "bin"
+
+    if venv_bin.exists():
+        path_entries = env.get("PATH", "").split(os.pathsep) if env.get("PATH") else []
+        filtered_entries = [
+            entry
+            for entry in path_entries
+            if "/.pyenv/shims" not in entry and "/.pyenv/versions/" not in entry
+        ]
+        env["PATH"] = os.pathsep.join([str(venv_bin), *filtered_entries])
+        env["VIRTUAL_ENV"] = str(venv_path)
+        env.pop("PYTHONHOME", None)
+        env.pop("PYTHONPATH", None)
+        env.pop("__PYVENV_LAUNCHER__", None)
+
+    if extra:
+        env.update(extra)
+    return env

--- a/tests/test_run_shell_timeout.py
+++ b/tests/test_run_shell_timeout.py
@@ -3,9 +3,12 @@ and non-blocking drain after process kill."""
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+from theforge.coordinator import util as coord_util
 from theforge.coordinator.util import _run_shell
 
 
@@ -64,3 +67,22 @@ class TestRunShellTimeout:
 
         assert ok is False
         assert "STDERR_MARKER" in output
+
+
+def test_run_shell_defaults_to_workspace_venv_env(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    proc = MagicMock()
+    proc.communicate.return_value = ("ok\n", "")
+    proc.returncode = 0
+    proc.stdout = MagicMock()
+    proc.stderr = MagicMock()
+
+    with patch("theforge.coordinator.util.subprocess.Popen", return_value=proc) as mock_popen:
+        ok, output = coord_util._run_shell("python -V", tmp_path)
+
+    env_passed = mock_popen.call_args[1]["env"]
+    assert ok is True
+    assert output == "ok"
+    assert env_passed["PATH"].split(os.pathsep)[0] == str(venv_bin)
+    assert env_passed["VIRTUAL_ENV"] == str(tmp_path / ".venv")

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -208,6 +208,27 @@ class TestRunAgentClaude:
         env_passed = mock_popen.call_args[1]["env"]
         assert "CLAUDECODE" not in env_passed
 
+    def test_uses_workspace_venv_env(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
+        """Claude subprocess env prefers the worktree virtualenv."""
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        mock_proc = _make_stream_mock([_result_line(result="done")])
+
+        with patch(
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(
+                prompt="test",
+                profile=dev_profile,
+                working_dir=tmp_path,
+                secrets={"API_KEY": "secret"},
+            )
+
+        env_passed = mock_popen.call_args[1]["env"]
+        assert env_passed["PATH"].split(os.pathsep)[0] == str(venv_bin)
+        assert env_passed["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+        assert env_passed["API_KEY"] == "secret"
+
     def test_with_session_resume(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = _make_stream_mock(
             [_result_line(result="continued.", session_id="sess-abc123")]

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -129,3 +130,26 @@ class TestCodexSandboxFlag:
         cmd = _extract_codex_cmd(mock_run)
         assert "--sandbox" not in cmd
         assert "resume" in cmd
+
+    def test_uses_workspace_venv_env(self, tmp_path: Path) -> None:
+        """Codex subprocess env prefers the worktree virtualenv."""
+        profile = _make_profile(sandbox_mode="none")
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        mock_proc = _make_subprocess_mock()
+
+        with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
+            with patch(
+                "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
+            ) as mock_run:
+                _run_codex(
+                    prompt="debug run",
+                    profile=profile,
+                    working_dir=tmp_path,
+                    secrets={"OPENAI_API_KEY": "secret"},
+                )
+
+        env_passed = mock_run.call_args[1]["env"]
+        assert env_passed["PATH"].split(os.pathsep)[0] == str(venv_bin)
+        assert env_passed["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+        assert env_passed["OPENAI_API_KEY"] == "secret"

--- a/tests/test_runner_gemini.py
+++ b/tests/test_runner_gemini.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -130,3 +131,25 @@ class TestGeminiSandboxWrapper:
         mock_sandbox.assert_not_called()
         mock_run.assert_called_once()
         assert result.success is True
+
+    def test_uses_workspace_venv_env(self, tmp_path: Path) -> None:
+        """Gemini subprocess env prefers the worktree virtualenv."""
+        profile = _make_profile(sandbox_mode="none")
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        mock_proc = _make_subprocess_mock()
+
+        with patch(
+            "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
+        ) as mock_run:
+            _run_gemini(
+                prompt="debug run",
+                profile=profile,
+                working_dir=tmp_path,
+                secrets={"GOOGLE_API_KEY": "secret"},
+            )
+
+        env_passed = mock_run.call_args[1]["env"]
+        assert env_passed["PATH"].split(os.pathsep)[0] == str(venv_bin)
+        assert env_passed["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+        assert env_passed["GOOGLE_API_KEY"] == "secret"

--- a/tests/test_tool_runtime.py
+++ b/tests/test_tool_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 from theforge.runners.tool_runtime import (
@@ -149,6 +150,25 @@ class TestBash:
         result = _handle_bash(command="sleep 999", working_dir=tmp_path)
         assert "timed out" in result
         assert isinstance(result, str)
+
+    def test_bash_uses_workspace_venv_env(self, tmp_path, monkeypatch):
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        captured_env = {}
+
+        def fake_run(*args, **kwargs):
+            captured_env.update(kwargs["env"])
+            return subprocess.CompletedProcess(
+                args=args[0], returncode=0, stdout="ok\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = _handle_bash(command="python -V", working_dir=tmp_path)
+
+        assert "Exit code: 0" in result
+        assert captured_env["PATH"].split(os.pathsep)[0] == str(venv_bin)
+        assert captured_env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
 
     def test_truncates_large_output(self, tmp_path):
         result = _handle_bash(

--- a/tests/test_workspace_env.py
+++ b/tests/test_workspace_env.py
@@ -1,0 +1,73 @@
+"""Tests for workspace subprocess environment construction."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from theforge.workspace_env import build_workspace_env
+
+
+def test_build_workspace_env_prepends_venv_and_sets_virtual_env(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    base_env = {"PATH": "/usr/bin:/bin", "PYTHONHOME": "/opt/python"}
+
+    env = build_workspace_env(tmp_path, base_env)
+
+    assert env["PATH"].split(os.pathsep)[0] == str(venv_bin)
+    assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+    assert "PYTHONHOME" not in env
+
+
+def test_build_workspace_env_without_venv_preserves_base_env(tmp_path: Path) -> None:
+    base_env = {"PATH": "/usr/bin", "PYTHONHOME": "/opt/python"}
+
+    env = build_workspace_env(tmp_path, base_env, extra={"EXTRA": "1"})
+
+    assert env == {"PATH": "/usr/bin", "PYTHONHOME": "/opt/python", "EXTRA": "1"}
+
+
+def test_build_workspace_env_strips_pyenv_path_entries(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    base_env = {
+        "PATH": os.pathsep.join(
+            [
+                "/Users/example/.pyenv/shims",
+                "/usr/local/bin",
+                "/Users/example/.pyenv/versions/3.12.12/bin",
+                "/usr/bin",
+            ]
+        )
+    }
+
+    env = build_workspace_env(tmp_path, base_env)
+
+    assert env["PATH"].split(os.pathsep) == [str(venv_bin), "/usr/local/bin", "/usr/bin"]
+
+
+def test_build_workspace_env_drops_python_leak_variables(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    base_env = {
+        "PATH": "/usr/bin",
+        "PYTHONHOME": "/opt/python",
+        "PYTHONPATH": "/tmp/imports",
+        "__PYVENV_LAUNCHER__": "/usr/bin/python",
+    }
+
+    env = build_workspace_env(tmp_path, base_env)
+
+    assert "PYTHONHOME" not in env
+    assert "PYTHONPATH" not in env
+    assert "__PYVENV_LAUNCHER__" not in env
+
+
+def test_build_workspace_env_merges_extra_last(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+
+    env = build_workspace_env(tmp_path, {"PATH": "/usr/bin"}, extra={"VIRTUAL_ENV": "override"})
+
+    assert env["VIRTUAL_ENV"] == "override"


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Change successfully implements workspace virtualenv isolation for agent-facing subprocesses. The new `build_workspace_env` helper prepends .venv/bin to PATH, strips pyenv entries, removes Python leak variables, and sets VIRTUAL_ENV. It is correctly integrated into CLI runners (Claude, Codex, Gemini), bash tool execution, and coordinator shell calls. All acceptance criteria are satisfied, tests are comprehensive, and the full gate passes. | [claude-opus] Workspace venv isolation is correctly wired through all agent subprocess entry points with solid test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $1.32
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/workspace_env.py:23`** The PATH filtering only removes entries containing '/.pyenv/shims' and '/.pyenv/versions/'. Pyenv installations at non-standard locations (e.g., ~/.local/pyenv) will not be stripped, potentially leaving a poisoning vector.

## Story

bug: agent subprocesses can poison global Python when running bare pip/python (GitHub Issue #862)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #862