### PR TITLE
bug: forge check-config reports transport (CLI) as provider, misrepresenting API-backed models

### DIFF
--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -7,7 +7,13 @@ import sys
 from pathlib import Path
 
 from theforge.cli.shared import _find_config
-from theforge.config import AGENT_REGISTRY, ForgeConfig, ModelProfile, TransportSpec, load_config
+from theforge.config import (
+    ForgeConfig,
+    ModelProfile,
+    TransportSpec,
+    load_config,
+    resolve_agent_spec,
+)
 from theforge.config.auth import check_agent_auth
 from theforge.config.profiles import _apply_provider_fallback
 from theforge.config.role_derivation import derive_roles
@@ -105,12 +111,15 @@ def _thinking_budget_label(profile: ModelProfile) -> str:
     return f"  thinking_budget={profile.thinking_budget}"
 
 
-def _provider_label(model_key: str) -> str:
+def _provider_label(model_key: str, warnings_list: list[str] | None = None) -> str:
     """Return a short human-readable label for a model key like 'claude/sonnet'."""
-    spec = AGENT_REGISTRY.get(model_key)
-    if spec is None:
-        provider = model_key.split("/", 1)[0] if "/" in model_key else model_key
-        return f"{provider} ?"
+    try:
+        spec = resolve_agent_spec(model_key)
+    except ValueError as exc:
+        if warnings_list is not None:
+            warnings_list.append(str(exc))
+        return "provider=? transport=?"
+
     provider_label, transport_label = _split_provider_transport(
         spec.transport.executable if spec.transport.kind == "cli" else None,
         spec.provider,
@@ -233,7 +242,7 @@ def _format_config(
             seen: set[str] = set()
             provider_labels: list[str] = []
             for mk in config.models:
-                lbl = _provider_label(mk)
+                lbl = _provider_label(mk, warnings_list)
                 if lbl not in seen:
                     seen.add(lbl)
                     provider_labels.append(lbl)

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from theforge.cli.shared import _find_config
-from theforge.config import ForgeConfig, ModelProfile, load_config
+from theforge.config import AGENT_REGISTRY, ForgeConfig, ModelProfile, TransportSpec, load_config
 from theforge.config.auth import check_agent_auth
 from theforge.config.profiles import _apply_provider_fallback
 from theforge.config.role_derivation import derive_roles
@@ -55,14 +55,26 @@ _CLI_PROVIDER_MAP: dict[str, str] = {
 }
 
 
-def _split_provider_transport(cli: str | None, provider: str | None) -> tuple[str, str]:
-    """Return (provider_label, transport_label) derived from cli/provider fields.
+def _split_provider_transport(
+    cli: str | None,
+    provider: str | None,
+    transport: TransportSpec | None = None,
+) -> tuple[str, str]:
+    """Return (provider_label, transport_label) for config display.
 
     CLI profiles carry an implicit provider (claude → anthropic, codex → openai,
     gemini → google); API profiles carry the provider explicitly. Transport is
     rendered as 'cli:<binary>' for CLI profiles and 'api' for API profiles, so
     the operator never conflates CLI-backed and API-backed models.
+
+    When an explicit TransportSpec is present, it is the same source of truth the
+    runner uses for dispatch and wins over legacy cli/provider inference.
     """
+    if transport is not None:
+        if transport.kind == "api":
+            return provider or transport.runner, "api"
+        runner = transport.executable or transport.runner
+        return provider or _CLI_PROVIDER_MAP.get(runner, runner), f"cli:{runner}"
     if cli is not None:
         return _CLI_PROVIDER_MAP.get(cli, cli), f"cli:{cli}"
     if provider is not None:
@@ -72,7 +84,11 @@ def _split_provider_transport(cli: str | None, provider: str | None) -> tuple[st
 
 def _transport_label(profile: ModelProfile) -> str:
     """Return 'provider  transport  / model' with provider and transport separate."""
-    provider_label, transport_label = _split_provider_transport(profile.cli, profile.provider)
+    provider_label, transport_label = _split_provider_transport(
+        profile.cli,
+        profile.provider,
+        profile.transport,
+    )
     return f"{provider_label:<10}{transport_label:<10}{profile.model}"
 
 
@@ -91,14 +107,25 @@ def _thinking_budget_label(profile: ModelProfile) -> str:
 
 def _provider_label(model_key: str) -> str:
     """Return a short human-readable label for a model key like 'claude/sonnet'."""
-    provider = model_key.split("/", 1)[0] if "/" in model_key else model_key
-    _CLI_PROVIDERS = {"claude"}
-    suffix = "cli" if provider in _CLI_PROVIDERS else "api"
-    return f"{provider} {suffix}"
+    spec = AGENT_REGISTRY.get(model_key)
+    if spec is None:
+        provider = model_key.split("/", 1)[0] if "/" in model_key else model_key
+        return f"{provider} ?"
+    provider_label, transport_label = _split_provider_transport(
+        spec.transport.executable if spec.transport.kind == "cli" else None,
+        spec.provider,
+        spec.transport,
+    )
+    return f"{provider_label} {transport_label}"
 
 
-def _ref_transport_label(cli: str | None, provider: str | None, model: str) -> str:
-    provider_label, transport_label = _split_provider_transport(cli, provider)
+def _ref_transport_label(
+    cli: str | None,
+    provider: str | None,
+    model: str,
+    transport: TransportSpec | None = None,
+) -> str:
+    provider_label, transport_label = _split_provider_transport(cli, provider, transport)
     return f"{provider_label:<10}{transport_label:<10}{model}"
 
 
@@ -124,13 +151,13 @@ def _format_complexity_aware_section(
 
     # Preflight: always static (runs before complexity is known)
     pre = ra_low.preflight.ref
-    pre_label = _ref_transport_label(pre.cli, pre.provider, pre.model)
+    pre_label = _ref_transport_label(pre.cli, pre.provider, pre.model, pre.transport)
     lines.append(f"  {'preflight:':<14}{pre_label:<28} (static — runs before complexity known)")
 
     # Plan: show per-complexity, collapsing equal adjacent levels
     def _plan_label(ra) -> str:  # type: ignore[no-untyped-def]
         r = ra.plan.ref
-        return _ref_transport_label(r.cli, r.provider, r.model)
+        return _ref_transport_label(r.cli, r.provider, r.model, r.transport)
 
     pl, pm, ph = _plan_label(ra_low), _plan_label(ra_mid), _plan_label(ra_high)
     plan_parts = _collapse_complexity_labels({"LOW": pl, "MEDIUM": pm, "HIGH": ph})
@@ -139,7 +166,7 @@ def _format_complexity_aware_section(
     # Dev: show per-complexity
     def _dev_label(ra) -> str:  # type: ignore[no-untyped-def]
         r = ra.dev.ref
-        return _ref_transport_label(r.cli, r.provider, r.model)
+        return _ref_transport_label(r.cli, r.provider, r.model, r.transport)
 
     dl, dm, dh = _dev_label(ra_low), _dev_label(ra_mid), _dev_label(ra_high)
     dev_parts = _collapse_complexity_labels({"LOW": dl, "MEDIUM": dm, "HIGH": dh})

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
-from theforge.cli.check_config import cmd_check_config, register_parser
+from theforge.cli.check_config import _provider_label, cmd_check_config, register_parser
 from theforge.config import (
     DEFAULT_VALIDATION,
     AssignmentConfig,
@@ -63,6 +63,9 @@ def _make_forge_config(
     plan_agent_review: PlanAgentReviewConfig | None = None,
     agents: list[AgentDef] | None = None,
     assignment: AssignmentConfig | None = None,
+    models: list[str] | None = None,
+    models_budget_usd: float | None = None,
+    models_overrides: dict | None = None,
 ) -> ForgeConfig:
     if review_pool is None:
         review_pool = [_api_profile("claude-reviewer")]
@@ -101,6 +104,9 @@ def _make_forge_config(
         agents=agents or [],
         assignment=assignment or AssignmentConfig(enabled=False),
         sprint=SprintConfig(max_parallel=1),
+        models=models,
+        models_budget_usd=models_budget_usd,
+        models_overrides=models_overrides,
     )
 
 
@@ -215,6 +221,79 @@ class TestCheckConfigHappyPath:
         assert "openai" in reviewer_line
         assert "api" in reviewer_line
         assert "cli:codex" not in reviewer_line
+
+    def test_simple_mode_providers_header_distinguishes_provider_and_transport(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Simple-mode provider summary keeps API and CLI transports distinct."""
+        config = _make_forge_config(
+            tmp_path,
+            models=[
+                "claude/sonnet",
+                "openai/gpt-5.4",
+                "deepseek/deepseek-reasoner",
+                "openai-api/gpt-5.4",
+            ],
+            models_budget_usd=10.0,
+        )
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch(
+                "theforge.cli.check_config.check_agent_auth",
+                return_value=(True, ""),
+            ),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        providers_line = next(line for line in out.splitlines() if line.startswith("Providers:"))
+        assert "anthropic cli:claude" in providers_line
+        assert "openai cli:codex" in providers_line
+        assert "deepseek api" in providers_line
+        assert "openai api" in providers_line
+
+    def test_simple_mode_rows_render_api_backed_deepseek_profile(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Derived PHASES/REVIEW POOL rows use TransportSpec for API-backed models."""
+        config = _make_forge_config(
+            tmp_path,
+            models=[
+                "claude/sonnet",
+                "openai/gpt-5.4",
+                "deepseek/deepseek-reasoner",
+                "openai-api/gpt-5.4",
+            ],
+            models_budget_usd=10.0,
+            review_pool=[
+                _api_profile("deepseek-reviewer", provider="deepseek", model="deepseek-reasoner")
+            ],
+        )
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch(
+                "theforge.cli.check_config.check_agent_auth",
+                return_value=(True, ""),
+            ),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        assert "DERIVED ROLES (complexity-aware)" in out
+        assert "deepseek  api       deepseek-reasoner" in out
+        deepseek_review_line = next(
+            line for line in out.splitlines() if "deepseek-reviewer" in line
+        )
+        assert "deepseek" in deepseek_review_line
+        assert "api" in deepseek_review_line
+        assert "cli:deepseek" not in deepseek_review_line
+
+    def test_provider_label_unknown_model_warns_without_prefix_fallback(self) -> None:
+        warnings: list[str] = []
+
+        assert _provider_label("openai/future-model", warnings) == "provider=? transport=?"
+        assert len(warnings) == 1
+        assert "not in AGENT_REGISTRY" in warnings[0]
 
     def test_explicit_thinking_budget_is_rendered(self, tmp_path: Path, capsys) -> None:
         review_pool = [

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from theforge.config import (
     PlanConfig,
     RetryPolicy,
     SprintConfig,
+    TransportSpec,
     WorkspaceConfig,
 )
 from theforge.config.models import AgentDef
@@ -183,6 +185,36 @@ class TestCheckConfigHappyPath:
         # API transport is rendered as a separate 'api' column, not as 'openai / gpt-4'
         assert "api" in out
         assert "gpt-4" in out
+
+    def test_transport_label_uses_explicit_transport(self, tmp_path: Path, capsys) -> None:
+        """Display follows TransportSpec.kind when legacy fields disagree."""
+        review_pool = [
+            ModelProfile(
+                name="api-reviewer",
+                cli="codex",
+                provider=None,
+                model="gpt-5.4",
+                budget_usd=1.0,
+                timeout_seconds=120,
+                allowed_tools=("Read",),
+                transport=TransportSpec(kind="api", runner="openai"),
+            )
+        ]
+        config = _make_forge_config(tmp_path, review_pool=review_pool)
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch(
+                "theforge.cli.check_config.check_agent_auth",
+                return_value=(True, ""),
+            ),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        reviewer_line = next(line for line in out.splitlines() if "api-reviewer" in line)
+        assert "openai" in reviewer_line
+        assert "api" in reviewer_line
+        assert "cli:codex" not in reviewer_line
 
     def test_explicit_thinking_budget_is_rendered(self, tmp_path: Path, capsys) -> None:
         review_pool = [
@@ -771,7 +803,22 @@ class TestComplexityAwareDisplay:
             cmd_check_config(_make_args())
         out = capsys.readouterr().out
         assert "Providers:" in out
-        assert "claude cli" in out
+        assert "anthropic cli:claude" in out
+
+    def test_providers_header_reports_api_transport(self, tmp_path: Path, capsys) -> None:
+        config = self._make_v08_forge_config(tmp_path)
+        config = replace(config, models=["openai-api/gpt-5.4", "deepseek/deepseek-reasoner"])
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        providers_line = next(line for line in out.splitlines() if line.startswith("Providers:"))
+        assert "openai api" in providers_line
+        assert "deepseek api" in providers_line
+        assert "openai-api" not in providers_line
 
     def test_derived_roles_not_shown_for_classic_config(self, tmp_path: Path, capsys) -> None:
         config = _make_forge_config(tmp_path)


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Implementation correctly reports provider and transport separately, fixing the misrepresentation issue with comprehensive test coverage. | [claude-opus] Prior P1s addressed; _provider_label now uses resolve_agent_spec and warnings propagate.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $1.34
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: forge check-config reports transport (CLI) as provider, misrepresenting API-backed models (GitHub Issue #858)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #858