### PR TITLE
bug: simple models route Google models through Gemini CLI instead of API

### DIFF
--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -191,33 +191,30 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         capability=7,
         cost_rank=1,
     ),
-    # ── Google (CLI via Gemini) ───────────────────────────────────────
+    # ── Google (API) ─────────────────────────────────────────────────
     "google/gemini-3-flash-preview": AgentSpec(
         provider="google",
         model="gemini-3-flash-preview",
-        transport=_TRANSPORT_GEMINI_CLI,
+        transport=_TRANSPORT_GOOGLE_API,
         tier="cheap",
         capability=7,
         cost_rank=1,
-        dev_capable=False,
     ),
     "google/gemini-3.1-pro-preview": AgentSpec(
         provider="google",
         model="gemini-3.1-pro-preview",
-        transport=_TRANSPORT_GEMINI_CLI,
+        transport=_TRANSPORT_GOOGLE_API,
         tier="strong",
         capability=9,
         cost_rank=2,
-        dev_capable=False,
     ),
     "google/gemini-2.5-pro": AgentSpec(
         provider="google",
         model="gemini-2.5-pro",
-        transport=_TRANSPORT_GEMINI_CLI,
+        transport=_TRANSPORT_GOOGLE_API,
         tier="strong",
         capability=8,
         cost_rank=2,
-        dev_capable=False,
     ),
     # ── Local OpenAI-compatible models (route via Codex CLI with base_url) ──
     "openai/codestral": AgentSpec(
@@ -280,31 +277,33 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         # Reasoning-heavy — intentionally excluded from the preflight role.
         phase_eligibility=frozenset({"dev", "plan", "review"}),
     ),
-    # ── Google (API — disambiguated with 'google-api/' prefix so operators can
-    # select the Google API path separately from the Gemini CLI path) ─────
-    "google-api/gemini-2.5-pro": AgentSpec(
+    # ── Gemini CLI (explicit opt-in) ─────────────────────────────────
+    "gemini-cli/gemini-2.5-pro": AgentSpec(
         provider="google",
         model="gemini-2.5-pro",
-        transport=_TRANSPORT_GOOGLE_API,
+        transport=_TRANSPORT_GEMINI_CLI,
         tier="strong",
         capability=8,
         cost_rank=2,
+        dev_capable=False,
     ),
-    "google-api/gemini-3-flash-preview": AgentSpec(
+    "gemini-cli/gemini-3-flash-preview": AgentSpec(
         provider="google",
         model="gemini-3-flash-preview",
-        transport=_TRANSPORT_GOOGLE_API,
+        transport=_TRANSPORT_GEMINI_CLI,
         tier="cheap",
         capability=7,
         cost_rank=1,
+        dev_capable=False,
     ),
-    "google-api/gemini-3.1-pro-preview": AgentSpec(
+    "gemini-cli/gemini-3.1-pro-preview": AgentSpec(
         provider="google",
         model="gemini-3.1-pro-preview",
-        transport=_TRANSPORT_GOOGLE_API,
+        transport=_TRANSPORT_GEMINI_CLI,
         tier="strong",
         capability=9,
         cost_rank=2,
+        dev_capable=False,
     ),
 }
 

--- a/tests/test_agent_spec.py
+++ b/tests/test_agent_spec.py
@@ -50,7 +50,7 @@ class TestAgentRegistry:
             assert isinstance(spec.transport, TransportSpec), key
 
     def test_cli_backed_models_resolve_to_cli_transport(self):
-        for key in ("claude/sonnet", "claude/opus", "openai/gpt-5.4", "google/gemini-2.5-pro"):
+        for key in ("claude/sonnet", "claude/opus", "openai/gpt-5.4"):
             assert AGENT_REGISTRY[key].transport.kind == "cli"
 
     def test_api_backed_models_resolve_to_api_transport(self):
@@ -65,16 +65,28 @@ class TestAgentRegistry:
             assert spec.transport.runner == "openai"
             assert spec.provider == "openai"
 
-    def test_google_api_transport_entries_exist(self):
-        """Operators can explicitly select the Google API transport (not Gemini CLI)."""
+    def test_google_entries_default_to_api_transport(self):
+        """Plain google/ entries select the Google API transport."""
         for key in (
-            "google-api/gemini-2.5-pro",
-            "google-api/gemini-3-flash-preview",
-            "google-api/gemini-3.1-pro-preview",
+            "google/gemini-2.5-pro",
+            "google/gemini-3-flash-preview",
+            "google/gemini-3.1-pro-preview",
         ):
             spec = AGENT_REGISTRY[key]
             assert spec.transport.kind == "api"
             assert spec.transport.runner == "google"
+            assert spec.provider == "google"
+
+    def test_gemini_cli_transport_entries_exist(self):
+        """Operators can explicitly opt into Gemini CLI transport."""
+        for key in (
+            "gemini-cli/gemini-2.5-pro",
+            "gemini-cli/gemini-3-flash-preview",
+            "gemini-cli/gemini-3.1-pro-preview",
+        ):
+            spec = AGENT_REGISTRY[key]
+            assert spec.transport.kind == "cli"
+            assert spec.transport.executable == "gemini"
             assert spec.provider == "google"
 
     def test_deepseek_openai_google_and_all_cli_models_expressible(self):
@@ -236,6 +248,7 @@ class TestCheckConfigSeparateColumns:
 
         assert _split_provider_transport(None, "deepseek") == ("deepseek", "api")
         assert _split_provider_transport(None, "openai") == ("openai", "api")
+        assert _split_provider_transport(None, "google") == ("google", "api")
 
 
 class TestNoProviderPrefixGuessingInConfigLoad:

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -15,6 +15,7 @@ from theforge.config import (
     load_config,
 )
 from theforge.config.profiles import (
+    _agents_from_models,
     _auto_assign_models,
     _resolve_model_info,
 )
@@ -259,6 +260,38 @@ class TestModelsKeyConfig:
         assert deepseek_profiles
         assert all(p.cli is None for p in deepseek_profiles)
         assert all(p.provider == "deepseek" for p in deepseek_profiles)
+
+    def test_simple_models_google_defaults_to_api(self):
+        """Regression: simple models: google/... derives API-backed agent/profile data."""
+        agents = _agents_from_models(["google/gemini-3.1-pro-preview"], 50.0)
+        assert len(agents) == 1
+        assert agents[0].provider == "google"
+        assert agents[0].cli is None
+
+        dev, preflight, pool, synthesis = _auto_assign_models(
+            ["google/gemini-3.1-pro-preview"], 50.0
+        )
+        profiles = [dev, preflight, *pool]
+        if synthesis is not None:
+            profiles.append(synthesis)
+        assert all(p.provider == "google" for p in profiles)
+        assert all(p.cli is None for p in profiles)
+
+    def test_explicit_gemini_cli_override_routes_via_cli(self):
+        """Regression: gemini-cli/... remains an honest explicit CLI opt-in."""
+        from theforge.cli.check_config import _split_provider_transport
+
+        agents = _agents_from_models(["gemini-cli/gemini-3.1-pro-preview"], 50.0)
+        assert len(agents) == 1
+        assert agents[0].provider is None
+        assert agents[0].cli == "gemini"
+
+        dev, _preflight, _pool, _synthesis = _auto_assign_models(
+            ["gemini-cli/gemini-3.1-pro-preview"], 50.0
+        )
+        assert dev.cli == "gemini"
+        assert dev.provider is None
+        assert _split_provider_transport(dev.cli, dev.provider) == ("google", "cli:gemini")
 
     def test_models_with_profile_override(self, tmp_path):
         """Explicit overrides overlay auto-assigned values (v0.8: overrides: key)."""
@@ -729,16 +762,26 @@ class TestCurrentGenModelRegistry:
         [
             (
                 "google/gemini-3-flash-preview",
-                "gemini",
                 None,
+                "google",
                 "gemini-3-flash-preview",
                 "cheap",
                 7,
                 1,
-                False,
+                True,
             ),
             (
                 "google/gemini-3.1-pro-preview",
+                None,
+                "google",
+                "gemini-3.1-pro-preview",
+                "strong",
+                9,
+                2,
+                True,
+            ),
+            (
+                "gemini-cli/gemini-3.1-pro-preview",
                 "gemini",
                 None,
                 "gemini-3.1-pro-preview",

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -185,8 +185,11 @@ class TestEscalateDevModel:
         assert result == "claude/opus"
 
     def test_escalation_skips_non_dev_capable(self):
-        """google/gemini-2.5-pro has higher capability but dev_capable=False → skipped."""
-        result = _escalate_dev_model("claude/sonnet", ["claude/sonnet", "google/gemini-2.5-pro"])
+        """gemini-cli/gemini-2.5-pro has higher capability but dev_capable=False → skipped."""
+        result = _escalate_dev_model(
+            "claude/sonnet",
+            ["claude/sonnet", "gemini-cli/gemini-2.5-pro"],
+        )
         assert result is None
 
     def test_escalation_no_higher_model(self):
@@ -196,8 +199,8 @@ class TestEscalateDevModel:
 
     def test_escalation_selects_next_step_up(self):
         """Selects the lowest-capability model that still beats current."""
-        # sonnet(7) < gemini(8, not dev) < gpt-5.4(9) < opus(10)
-        # Should select gpt-5.4 as next step up from sonnet (gemini skipped)
+        # sonnet(7) < gpt-5.4(9) < opus(10)
+        # Should select gpt-5.4 as next step up from sonnet.
         result = _escalate_dev_model(
             "claude/sonnet",
             ["claude/sonnet", "openai/gpt-5.4", "claude/opus"],


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The implementation correctly addresses the bug by routing Google simple models via API by default and moving Gemini CLI to an explicit 'gemini-cli/' prefix. All acceptance criteria are satisfied with proper test coverage. | [claude-opus] Google simple model keys now default to API transport; Gemini CLI moved behind explicit gemini-cli/ prefix with regression tests covering both paths.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $1.31
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: simple models route Google models through Gemini CLI instead of API (GitHub Issue #855)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #855