### PR TITLE
Story shape check Action — enforce shape on issues.opened and issues.edited

### DIFF
--- a/.github/workflows/shape-check.yml
+++ b/.github/workflows/shape-check.yml
@@ -1,0 +1,50 @@
+name: Story shape check
+
+# Runs the TheForge shape_check module (#806) against every issue when it is
+# opened or edited. On failures it labels the issue (needs-grooming / epic) and
+# posts a single bot-owned comment with the findings. The comment is updated in
+# place on subsequent edits — we never spam new comments.
+#
+# This Action NEVER rejects the create event. A malformed issue is always
+# created; the Action only labels and comments.
+
+on:
+  issues:
+    types: [opened, edited]
+
+# Least-privilege: the token can label and comment, nothing else.
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  shape-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out TheForge
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install shape_check package
+        # Install in place — shape_check is stdlib-only, so this does not pull
+        # in coordinator/provider runtime deps.
+        run: pip install -e .
+
+      - name: Run shape check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          SHAPE_CHECK_BOT_LOGIN: "github-actions[bot]"
+          # Per-repo configurable labels:
+          SHAPE_CHECK_NEEDS_GROOMING_LABEL: "needs-grooming"
+          SHAPE_CHECK_TRACKING_LABEL: "epic"
+          # Default: comment-only on superseded; do not auto-close (avoids
+          # racing with a human who may still be editing).
+          SHAPE_CHECK_AUTO_CLOSE_SUPERSEDED: "0"
+        run: python -m theforge.shape_check

--- a/src/theforge/shape_check/__main__.py
+++ b/src/theforge/shape_check/__main__.py
@@ -1,0 +1,10 @@
+"""Module entrypoint: ``python -m theforge.shape_check`` runs the GitHub Action."""
+
+from __future__ import annotations
+
+import sys
+
+from theforge.shape_check.action import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/theforge/shape_check/action.py
+++ b/src/theforge/shape_check/action.py
@@ -1,0 +1,247 @@
+"""GitHub Action entrypoint for enforcing shape on issues.opened/edited.
+
+Runs the shape_check module against an issue payload, applies/removes labels,
+and posts a single bot-owned comment per issue (updated in place on edits).
+
+Depends only on the shape_check subpackage and the stdlib. No imports from
+coordinator, config, or provider adapters — the module must run in a minimal
+GitHub Actions runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+from theforge.shape_check import Shape, ShapeResult, check
+
+COMMENT_MARKER = "<!-- shape-check-v1 -->"
+
+DEFAULT_NEEDS_GROOMING_LABEL = "needs-grooming"
+DEFAULT_TRACKING_LABEL = "epic"
+
+logger = logging.getLogger("shape_check.action")
+
+
+@dataclass(frozen=True)
+class ActionConfig:
+    needs_grooming_label: str = DEFAULT_NEEDS_GROOMING_LABEL
+    tracking_label: str = DEFAULT_TRACKING_LABEL
+    auto_close_superseded: bool = False
+
+
+# ----- GitHub API boundary --------------------------------------------------
+
+
+class GitHubAPI(Protocol):
+    """Minimal surface of the GitHub REST API required by the action."""
+
+    def add_label(self, issue_number: int, label: str) -> None: ...
+    def remove_label(self, issue_number: int, label: str) -> None: ...
+    def list_comments(self, issue_number: int) -> list[dict[str, Any]]: ...
+    def create_comment(self, issue_number: int, body: str) -> None: ...
+    def update_comment(self, comment_id: int, body: str) -> None: ...
+    def bot_login(self) -> str: ...
+
+
+class HttpGitHubAPI:
+    """HTTP-backed GitHubAPI using stdlib urllib — no extra dependencies."""
+
+    def __init__(self, repo: str, token: str, bot_login: str) -> None:
+        self._repo = repo
+        self._token = token
+        self._bot_login = bot_login
+        self._base = f"https://api.github.com/repos/{repo}"
+
+    def _request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        url = f"{self._base}{path}"
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        req = urlrequest.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self._token}")
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        req.add_header("User-Agent", "theforge-shape-check-action")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urlrequest.urlopen(req) as resp:  # noqa: S310 (trusted host)
+                raw = resp.read()
+                return json.loads(raw) if raw else None
+        except urlerror.HTTPError as exc:
+            if method == "DELETE" and exc.code == 404:
+                return None
+            raise
+
+    def add_label(self, issue_number: int, label: str) -> None:
+        self._request("POST", f"/issues/{issue_number}/labels", {"labels": [label]})
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        from urllib.parse import quote
+
+        self._request("DELETE", f"/issues/{issue_number}/labels/{quote(label, safe='')}")
+
+    def list_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        result = self._request("GET", f"/issues/{issue_number}/comments?per_page=100")
+        return list(result or [])
+
+    def create_comment(self, issue_number: int, body: str) -> None:
+        self._request("POST", f"/issues/{issue_number}/comments", {"body": body})
+
+    def update_comment(self, comment_id: int, body: str) -> None:
+        self._request("PATCH", f"/issues/comments/{comment_id}", {"body": body})
+
+    def bot_login(self) -> str:
+        return self._bot_login
+
+
+# ----- Pure logic -----------------------------------------------------------
+
+
+def render_comment(result: ShapeResult) -> str:
+    """Render a structured bot comment. First line is the hidden marker."""
+    lines: list[str] = [COMMENT_MARKER]
+    lines.append("")
+    lines.append("**Story shape check**")
+    lines.append("")
+    lines.append(f"- shape: `{result.shape.value}`")
+    lines.append(f"- suggested action: `{result.suggested_action.value}`")
+    lines.append("")
+    if not result.reasons:
+        lines.append("No findings — this issue looks runnable.")
+    else:
+        lines.append("| severity | code | detail |")
+        lines.append("|---|---|---|")
+        for r in result.reasons:
+            detail = r.detail.replace("|", "\\|").replace("\n", " ")
+            lines.append(f"| `{r.severity.value}` | `{r.code}` | {detail} |")
+    lines.append("")
+    lines.append(
+        "_This comment is maintained by the shape-check Action and will be "
+        "updated on edits. See #806, #811._"
+    )
+    return "\n".join(lines)
+
+
+def find_bot_comment(comments: list[dict[str, Any]], bot_login: str) -> dict[str, Any] | None:
+    """Find the existing shape-check comment by author + marker, not substring scan."""
+    for c in comments:
+        user = (c.get("user") or {}).get("login") or ""
+        body = c.get("body") or ""
+        if user == bot_login and COMMENT_MARKER in body:
+            return c
+    return None
+
+
+def _log_result(issue_number: int, result: ShapeResult, author: str) -> None:
+    """Greppable one-line log for drift analysis."""
+    codes = ",".join(r.code for r in result.reasons) or "-"
+    logger.info(
+        "shape_check issue=%d author=%s shape=%s action=%s reasons=%s",
+        issue_number,
+        author,
+        result.shape.value,
+        result.suggested_action.value,
+        codes,
+    )
+
+
+def run_action(
+    event: dict[str, Any],
+    api: GitHubAPI,
+    config: ActionConfig | None = None,
+) -> ShapeResult:
+    """Act on a GitHub issues.opened/edited event payload.
+
+    Labels, posts/updates a bot comment, and returns the ShapeResult.
+    Never raises on a well-formed payload unless the API itself fails.
+    """
+    config = config or ActionConfig()
+    issue = event["issue"]
+    issue_number = int(issue["number"])
+    title = issue.get("title") or ""
+    body = issue.get("body") or ""
+    labels = [lbl["name"] for lbl in issue.get("labels") or [] if lbl.get("name")]
+    author = (issue.get("user") or {}).get("login") or "unknown"
+
+    result = check(title, body, labels)
+    _log_result(issue_number, result, author)
+
+    existing = set(labels)
+    desired_needs_grooming = result.shape is Shape.NEEDS_GROOMING
+    desired_tracking = result.shape is Shape.TRACKING_ONLY
+
+    if desired_needs_grooming and config.needs_grooming_label not in existing:
+        api.add_label(issue_number, config.needs_grooming_label)
+    elif not desired_needs_grooming and config.needs_grooming_label in existing:
+        api.remove_label(issue_number, config.needs_grooming_label)
+
+    if desired_tracking and config.tracking_label not in existing:
+        api.add_label(issue_number, config.tracking_label)
+
+    # Comment: exactly one bot-owned comment, updated on edits.
+    body_text = render_comment(result)
+    comments = api.list_comments(issue_number)
+    existing_comment = find_bot_comment(comments, api.bot_login())
+    if existing_comment is None:
+        api.create_comment(issue_number, body_text)
+    elif (existing_comment.get("body") or "") != body_text:
+        api.update_comment(int(existing_comment["id"]), body_text)
+
+    return result
+
+
+# ----- CLI entrypoint -------------------------------------------------------
+
+
+def _load_event_from_env() -> dict[str, Any]:
+    path = os.environ.get("GITHUB_EVENT_PATH")
+    if not path:
+        raise SystemExit("GITHUB_EVENT_PATH not set — must run inside a GitHub Action")
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("SHAPE_CHECK_LOG_LEVEL", "INFO"),
+        format="%(levelname)s %(name)s %(message)s",
+    )
+    del argv  # unused; action reads env vars
+
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    if event_name != "issues":
+        logger.info("shape_check skipped: event=%s is not issues", event_name)
+        return 0
+
+    event = _load_event_from_env()
+    action_kind = event.get("action") or ""
+    if action_kind not in ("opened", "edited"):
+        logger.info("shape_check skipped: action=%s", action_kind)
+        return 0
+
+    repo = os.environ.get("GITHUB_REPOSITORY") or ""
+    token = os.environ.get("GITHUB_TOKEN") or ""
+    bot_login = os.environ.get("SHAPE_CHECK_BOT_LOGIN", "github-actions[bot]")
+    if not repo or not token:
+        raise SystemExit("GITHUB_REPOSITORY and GITHUB_TOKEN must be set")
+
+    config = ActionConfig(
+        needs_grooming_label=os.environ.get(
+            "SHAPE_CHECK_NEEDS_GROOMING_LABEL", DEFAULT_NEEDS_GROOMING_LABEL
+        ),
+        tracking_label=os.environ.get("SHAPE_CHECK_TRACKING_LABEL", DEFAULT_TRACKING_LABEL),
+        auto_close_superseded=os.environ.get("SHAPE_CHECK_AUTO_CLOSE_SUPERSEDED") == "1",
+    )
+    api = HttpGitHubAPI(repo=repo, token=token, bot_login=bot_login)
+    run_action(event, api, config)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_shape_check_action.py
+++ b/tests/test_shape_check_action.py
@@ -1,0 +1,359 @@
+"""Tests for the shape_check GitHub Action entrypoint.
+
+Covers the Action-level behavior: label apply/remove, single bot comment with
+update-in-place, tracking_only, superseded, and the idempotent edit flows
+required by #811's acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any
+
+from theforge.shape_check import Reason, Severity, Shape, ShapeResult, SuggestedAction
+from theforge.shape_check.action import (
+    COMMENT_MARKER,
+    ActionConfig,
+    find_bot_comment,
+    render_comment,
+    run_action,
+)
+
+BOT_LOGIN = "github-actions[bot]"
+
+
+WELL_FORMED_BODY = textwrap.dedent(
+    """\
+    ## What
+    Do a thing.
+
+    ## Acceptance Criteria
+    - The command returns 0 on success.
+    - On failure, writes a diagnostic to stderr.
+    """
+)
+
+
+class FakeGitHubAPI:
+    """In-memory GitHubAPI double. Records calls; models labels + comments."""
+
+    def __init__(self, *, issue_number: int, labels: list[str] | None = None) -> None:
+        self.issue_number = issue_number
+        self.labels: list[str] = list(labels or [])
+        self.comments: list[dict[str, Any]] = []
+        self._next_comment_id = 1000
+        self.calls: list[tuple[str, Any]] = []
+
+    def add_label(self, issue_number: int, label: str) -> None:
+        self.calls.append(("add_label", (issue_number, label)))
+        if label not in self.labels:
+            self.labels.append(label)
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        self.calls.append(("remove_label", (issue_number, label)))
+        if label in self.labels:
+            self.labels.remove(label)
+
+    def list_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        self.calls.append(("list_comments", issue_number))
+        return list(self.comments)
+
+    def create_comment(self, issue_number: int, body: str) -> None:
+        self.calls.append(("create_comment", (issue_number, body)))
+        self.comments.append(
+            {
+                "id": self._next_comment_id,
+                "user": {"login": BOT_LOGIN},
+                "body": body,
+            }
+        )
+        self._next_comment_id += 1
+
+    def update_comment(self, comment_id: int, body: str) -> None:
+        self.calls.append(("update_comment", (comment_id, body)))
+        for c in self.comments:
+            if c["id"] == comment_id:
+                c["body"] = body
+                return
+        raise AssertionError(f"no comment with id={comment_id}")
+
+    def bot_login(self) -> str:
+        return BOT_LOGIN
+
+
+def _event(
+    *,
+    action: str,
+    number: int,
+    title: str,
+    body: str,
+    labels: list[str] | None = None,
+    author: str = "some-user",
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "issue": {
+            "number": number,
+            "title": title,
+            "body": body,
+            "labels": [{"name": n} for n in (labels or [])],
+            "user": {"login": author},
+        },
+    }
+
+
+# ----- render_comment / find_bot_comment ----------------------------------
+
+
+class TestRenderComment:
+    def test_includes_marker_on_first_line(self):
+        result = ShapeResult(
+            shape=Shape.RUNNABLE,
+            reasons=(),
+            suggested_action=SuggestedAction.PROCEED,
+        )
+        out = render_comment(result)
+        assert out.splitlines()[0] == COMMENT_MARKER
+
+    def test_includes_reason_codes_and_severity(self):
+        result = ShapeResult(
+            shape=Shape.NEEDS_GROOMING,
+            reasons=(
+                Reason(
+                    code="missing_acceptance_criteria",
+                    severity=Severity.BLOCKING,
+                    detail="No AC section found.",
+                ),
+            ),
+            suggested_action=SuggestedAction.CLARIFY,
+        )
+        out = render_comment(result)
+        assert "missing_acceptance_criteria" in out
+        assert "blocking" in out
+        assert "No AC section found." in out
+
+
+class TestFindBotComment:
+    def test_matches_by_author_and_marker(self):
+        comments = [
+            {"id": 1, "user": {"login": "someone-else"}, "body": COMMENT_MARKER},
+            {"id": 2, "user": {"login": BOT_LOGIN}, "body": "no marker here"},
+            {"id": 3, "user": {"login": BOT_LOGIN}, "body": f"{COMMENT_MARKER}\nfoo"},
+        ]
+        match = find_bot_comment(comments, BOT_LOGIN)
+        assert match is not None and match["id"] == 3
+
+    def test_returns_none_when_missing(self):
+        assert find_bot_comment([], BOT_LOGIN) is None
+
+
+# ----- run_action scenarios -----------------------------------------------
+
+
+class TestRunActionOpened:
+    def test_blocking_reasons_applies_label_and_posts_comment(self):
+        api = FakeGitHubAPI(issue_number=42)
+        event = _event(
+            action="opened",
+            number=42,
+            title="Do a thing",
+            body="## What\nDo stuff.",  # missing AC -> blocking
+            labels=[],
+        )
+
+        result = run_action(event, api)
+
+        assert result.shape is Shape.NEEDS_GROOMING
+        assert "needs-grooming" in api.labels
+        assert len(api.comments) == 1
+        assert COMMENT_MARKER in api.comments[0]["body"]
+
+    def test_runnable_issue_no_label_no_comment_reasons(self):
+        api = FakeGitHubAPI(issue_number=7)
+        event = _event(
+            action="opened",
+            number=7,
+            title="Add a flag",
+            body=WELL_FORMED_BODY,
+            labels=[],
+        )
+
+        result = run_action(event, api)
+
+        assert result.shape is Shape.RUNNABLE
+        assert "needs-grooming" not in api.labels
+        # Still posts a single comment (no findings); AC says "exactly one".
+        assert len(api.comments) == 1
+
+
+class TestRunActionEdited:
+    def test_edit_clears_reasons_removes_label_and_updates_comment(self):
+        api = FakeGitHubAPI(issue_number=99, labels=["needs-grooming"])
+        # Seed prior bot comment simulating previous run.
+        api.comments.append(
+            {
+                "id": 500,
+                "user": {"login": BOT_LOGIN},
+                "body": f"{COMMENT_MARKER}\nold findings here",
+            }
+        )
+        event = _event(
+            action="edited",
+            number=99,
+            title="Add a flag",
+            body=WELL_FORMED_BODY,
+            labels=["needs-grooming"],
+        )
+
+        result = run_action(event, api)
+
+        assert result.shape is Shape.RUNNABLE
+        assert "needs-grooming" not in api.labels
+        # Same comment id — updated in place, no new comment created.
+        assert len(api.comments) == 1
+        assert api.comments[0]["id"] == 500
+        assert "old findings here" not in api.comments[0]["body"]
+        # No create_comment call should appear in the call log.
+        assert not any(name == "create_comment" for name, _ in api.calls)
+
+    def test_edit_adds_new_reasons_updates_comment_in_place(self):
+        api = FakeGitHubAPI(issue_number=12)
+        api.comments.append(
+            {
+                "id": 800,
+                "user": {"login": BOT_LOGIN},
+                "body": f"{COMMENT_MARKER}\nOld body",
+            }
+        )
+        event = _event(
+            action="edited",
+            number=12,
+            title="Do a thing",
+            body="## What\nDo stuff.",  # now missing AC
+            labels=[],
+        )
+
+        run_action(event, api)
+
+        assert len(api.comments) == 1
+        assert api.comments[0]["id"] == 800
+        # Updated content, not a new comment.
+        assert not any(name == "create_comment" for name, _ in api.calls)
+        assert any(name == "update_comment" for name, _ in api.calls)
+
+    def test_repeated_edit_with_same_findings_does_not_spam(self):
+        api = FakeGitHubAPI(issue_number=33)
+        event = _event(
+            action="opened",
+            number=33,
+            title="Do a thing",
+            body="## What\nDo stuff.",
+            labels=[],
+        )
+        run_action(event, api)
+        first_body = api.comments[0]["body"]
+
+        # Replay identical edited event.
+        event["action"] = "edited"
+        run_action(event, api)
+
+        assert len(api.comments) == 1
+        assert api.comments[0]["body"] == first_body
+        # No update_comment call on second run since body is identical.
+        update_calls = [c for c in api.calls if c[0] == "update_comment"]
+        assert update_calls == []
+
+
+class TestRunActionTrackingOnly:
+    def test_applies_tracking_label(self):
+        api = FakeGitHubAPI(issue_number=55)
+        event = _event(
+            action="opened",
+            number=55,
+            title="Epic: big initiative",
+            body=WELL_FORMED_BODY,
+            labels=[],
+        )
+
+        result = run_action(event, api)
+
+        assert result.shape is Shape.TRACKING_ONLY
+        assert "epic" in api.labels
+        # Not needs-grooming — tracking issues are a separate shape.
+        assert "needs-grooming" not in api.labels
+
+    def test_respects_custom_tracking_label(self):
+        api = FakeGitHubAPI(issue_number=56)
+        event = _event(
+            action="opened",
+            number=56,
+            title="Epic: big initiative",
+            body=WELL_FORMED_BODY,
+            labels=[],
+        )
+        config = ActionConfig(tracking_label="tracking")
+
+        run_action(event, api, config)
+
+        assert "tracking" in api.labels
+
+
+class TestRunActionSuperseded:
+    def test_comment_only_no_close(self):
+        api = FakeGitHubAPI(issue_number=77)
+        event = _event(
+            action="opened",
+            number=77,
+            title="Old ticket",
+            body="This is superseded by #999.",
+            labels=[],
+        )
+
+        result = run_action(event, api)
+
+        assert result.shape is Shape.SUPERSEDED
+        # Default config: we do NOT auto-close; we only comment + don't label.
+        assert len(api.comments) == 1
+        # The action never invokes any close/state API on the issue.
+        assert not any(name in ("close_issue", "update_state") for name, _ in api.calls)
+
+
+class TestRunActionNeverRejects:
+    """The AC says a malformed issue still gets created — the Action never rejects."""
+
+    def test_blocking_result_does_not_raise(self):
+        api = FakeGitHubAPI(issue_number=1)
+        event = _event(
+            action="opened",
+            number=1,
+            title="empty",
+            body="",
+            labels=[],
+        )
+        # Must not raise even with a maximally bad issue.
+        result = run_action(event, api)
+        assert result.shape is Shape.NEEDS_GROOMING
+
+
+class TestLogging:
+    def test_emits_greppable_log_line(self, caplog):
+        import logging
+
+        api = FakeGitHubAPI(issue_number=4242)
+        event = _event(
+            action="opened",
+            number=4242,
+            title="bad issue",
+            body="## What\nno AC here",
+            labels=[],
+            author="some-bot",
+        )
+        with caplog.at_level(logging.INFO, logger="shape_check.action"):
+            run_action(event, api)
+
+        assert any(
+            "shape_check issue=4242" in rec.message
+            and "author=some-bot" in rec.message
+            and "shape=needs_grooming" in rec.message
+            for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary

[openai-gpt-5.4] The action is wired correctly, applies and removes labels as specified, maintains one bot-owned comment, and has focused coverage for the required issue flows. | [deepseek-deepseek-reasoner] Implementation satisfies all acceptance criteria with clean design and comprehensive tests

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $1.72
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/shape_check/action.py:36`** ActionConfig.auto_close_superseded field is defined but never used in run_action

## Story

Story shape check Action — enforce shape on issues.opened and issues.edited (GitHub Issue #811)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #811