### PR TITLE
Forge findings enter explicit needs-triage state at creation time

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,6 +49,8 @@ run() {
 
 # --- 1. Verify milestone is complete ---
 echo "==> Checking milestone v$VERSION..."
+UNTRIAGED_FINDINGS=$(gh issue list --repo fuzzypete/theforge --milestone "v$VERSION" --state open --label "forge-finding" --label "needs-triage" --json number --jq 'length')
+echo "    Open needs-triage forge-findings: $UNTRIAGED_FINDINGS"
 OPEN_ISSUES=$(gh issue list --repo fuzzypete/theforge --milestone "v$VERSION" --state open --json number --jq 'length')
 if [[ "$OPEN_ISSUES" != "0" ]]; then
     echo "Error: $OPEN_ISSUES open issue(s) remain in milestone v$VERSION. Close them before releasing." >&2

--- a/src/theforge/cli/hooks.py
+++ b/src/theforge/cli/hooks.py
@@ -34,6 +34,13 @@ branch=$(echo "$payload" | jq -r '.branch')
 summary=$(echo "$payload" | jq -r '.summary')
 findings_count=$(echo "$payload" | jq '.findings | length')
 
+# Ensure the intake label exists before filing findings. --force keeps the
+# description aligned without failing when the label already exists.
+gh label create "needs-triage" \\
+  --description "Forge finding awaiting explicit triage decision" \\
+  --color "D4C5F9" \\
+  --force >/dev/null 2>&1 || true
+
 # Only act on ESCALATE or APPROVE outcomes (REQUEST_CHANGES = still in review)
 if [ "$verdict" != "ESCALATE" ] && [ "$verdict" != "APPROVE" ]; then
   exit 0
@@ -75,6 +82,7 @@ if [ "$findings_count" -gt 0 ]; then
       --title "$title" \\
       --body "$body" \\
       --label "forge-finding" \\
+      --label "needs-triage" \\
       --label "$(echo "$sev" | tr 'A-Z' 'a-z')" || true
   done
 fi

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -602,6 +602,26 @@ class TestCmdInitHooks:
         content = sh_path.read_text(encoding="utf-8")
         assert "forge-finding" in content
 
+    def test_script_applies_needs_triage_label_at_creation(self, tmp_path, monkeypatch):
+        """Reference script adds needs-triage to newly filed finding issues."""
+        monkeypatch.chdir(tmp_path)
+        args = self._make_args()
+        cmd_init_hooks(args)
+        sh_path = tmp_path / ".forge" / "hooks" / "post_run.sh"
+        content = sh_path.read_text(encoding="utf-8")
+        assert '--label "forge-finding"' in content
+        assert '--label "needs-triage"' in content
+
+    def test_script_ensures_needs_triage_label_description(self, tmp_path, monkeypatch):
+        """Reference script creates or refreshes the needs-triage label."""
+        monkeypatch.chdir(tmp_path)
+        args = self._make_args()
+        cmd_init_hooks(args)
+        sh_path = tmp_path / ".forge" / "hooks" / "post_run.sh"
+        content = sh_path.read_text(encoding="utf-8")
+        assert 'gh label create "needs-triage"' in content
+        assert "Forge finding awaiting explicit triage decision" in content
+
 
 # ── TestApplyDevModelOverride ─────────────────────────────────────────
 

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -1,0 +1,68 @@
+"""Tests for release readiness reporting in scripts/release.sh."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_release_dry_run_reports_untriaged_finding_count(tmp_path: Path) -> None:
+    script_src = Path("scripts/release.sh")
+    script_dst = tmp_path / "release.sh"
+    shutil.copy(script_src, script_dst)
+
+    (tmp_path / "pyproject.toml").write_text('version = "1.2.3.dev0"\n', encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [Unreleased]\n\n## [1.2.3]\n\n- Existing release note.\n",
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh_log = tmp_path / "gh.log"
+
+    _write_executable(fake_bin / "make", "#!/usr/bin/env bash\nexit 0\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["BASH_FUNC_gh%%"] = f"""() {{
+  printf '%s\\n' "$*" >> {gh_log}
+  if [[ "$1 $2" == "issue list" ]]; then
+    if [[ "$*" == *'--label forge-finding'* && "$*" == *'--label needs-triage'* ]]; then
+      echo 2
+    else
+      echo 0
+    fi
+  fi
+}}"""
+    env["BASH_FUNC_git%%"] = """() {
+  if [[ "$1 $2" == "status --porcelain" ]]; then
+    return 0
+  fi
+  echo "+ git $*"
+}"""
+    result = subprocess.run(
+        ["bash", str(script_dst), "--dry-run", "1.2.3"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Open needs-triage forge-findings: 2" in result.stdout
+
+    gh_calls = gh_log.read_text(encoding="utf-8")
+    assert "--label forge-finding" in gh_calls
+    assert "--label needs-triage" in gh_calls
+    assert "issue edit" not in gh_calls


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Implementation satisfies all acceptance criteria: needs-triage label added at creation, release reporting counts untriaged findings, no blocking, tests cover all aspects. | [claude-opus] needs-triage intake label correctly added at finding creation with release readiness reporting; all ACs met.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $0.48
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Forge findings enter explicit needs-triage state at creation time (GitHub Issue #810)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #810