### PR TITLE
bug: squash-merge detection relies solely on audit trail APPROVE, misses external merges

### DIFF
--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -27,6 +27,13 @@ def _issue_number_from_slug(slug: str) -> int | None:
     return int(match.group(1))
 
 
+def _issue_number_from_ref(ref: str) -> int | None:
+    match = re.search(r"(?:^|[/-])issue-(\d+)(?:$|[^0-9])", ref)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
 @dataclass
 class StoryTriage:
     """Result of triaging a story for sprint resume."""
@@ -61,6 +68,40 @@ def _has_prior_review_approve(
     )
 
 
+def _has_base_commit_referencing_issue(
+    project_root: Path,
+    base_branch: str,
+    issue_number: int,
+) -> bool:
+    """Return True when base has a commit message that references the issue.
+
+    GitHub squash commits commonly preserve PR or issue references in the final
+    base-branch commit even though the branch tip is not topologically merged.
+    This git-level check catches externally merged branches that never produced
+    a forge APPROVE audit record.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                "--format=%H",
+                "--max-count=1",
+                "--fixed-strings",
+                f"--grep=(#{issue_number})",
+                base_branch,
+            ],
+            cwd=str(project_root),
+            capture_output=True,
+            timeout=30,
+        )
+        return result.returncode == 0 and bool(
+            result.stdout.decode("utf-8", errors="replace").strip()
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
 def _is_branch_merged(
     branch: str,
     base_branch: str,
@@ -83,12 +124,10 @@ def _is_branch_merged(
     3. Squash merge (configured default):
        The feature branch tip remains an ancestor of base because it was based
        on base, but the squash commit on base is a new commit with no parent
-       relationship to the branch. Git topology alone therefore looks identical
-       to an empty/stale branch: branch..base_branch count == 0 and
-       base_branch..branch count == 0. When slug is provided, the audit trail
-       (has_review_approve) acts as the tiebreaker: a story that ran through
-       the pipeline has an APPROVE record; a freshly created branch with no work
-       does not.
+       relationship to the branch. Git topology alone therefore cannot prove
+       the merge. Issue-backed branches first look for a base commit that
+       references the issue, then fall back to the forge APPROVE audit trail
+       when slug is provided.
 
     A branch that was merely created at base HEAD (count == 0, no audit entry)
     correctly returns False.
@@ -128,6 +167,16 @@ def _is_branch_merged(
                     return True
     except (subprocess.TimeoutExpired, OSError, ValueError):
         pass
+
+    issue_number = _issue_number_from_slug(slug) if slug is not None else None
+    if issue_number is None:
+        issue_number = _issue_number_from_ref(branch)
+    if issue_number is not None and _has_base_commit_referencing_issue(
+        project_root,
+        base_branch,
+        issue_number,
+    ):
+        return True
 
     # Fast-forward merges at the same tip and squash merges both need the audit
     # trail fallback. In real squash merges, --is-ancestor returns non-zero, so

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -342,6 +342,51 @@ def test_is_branch_merged_not_ancestor_without_audit(tmp_path: Path) -> None:
     assert result is False
 
 
+def test_is_branch_merged_external_squash_merge_by_issue_commit(tmp_path: Path) -> None:
+    """A GitHub squash commit referencing the issue counts even without audit."""
+
+    def _mock_external_squash(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if "--is-ancestor" in cmd:
+            m.returncode = 1
+            m.stdout = b""
+        elif cmd[:2] == ["git", "log"] and "--grep=(#265)" in cmd:
+            m.returncode = 0
+            m.stdout = b"abc123\n"
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    with patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_squash):
+        result = _is_branch_merged("feat/issue-265", "main", tmp_path)
+    assert result is True
+
+
+def test_is_branch_merged_issue_branch_without_base_commit_or_audit(tmp_path: Path) -> None:
+    """Issue branch stays unmerged when base has no matching squash commit."""
+
+    def _mock_no_external_squash(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if "--is-ancestor" in cmd:
+            m.returncode = 1
+            m.stdout = b""
+        elif cmd[:2] == ["git", "log"] and "--grep=(#265)" in cmd:
+            m.returncode = 0
+            m.stdout = b""
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_no_external_squash),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+    ):
+        result = _is_branch_merged("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert result is False
+
+
 def test_run_sprint_summary_records_run_log(tmp_path: Path) -> None:
     from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Implementation successfully adds a git-level fallback for detecting external squash merges by searching for issue references in commit messages. All acceptance criteria are met with no blocking issues. | [claude-opus] Git-level squash-merge detection via issue-reference grep correctly supplements audit trail fallback; all ACs met with focused test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $0.78
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/dag.py:31`** Regex pattern r'(?:^|[/-])issue-(\d+)(?:$|[^0-9])' may not match all branch naming conventions, such as those using underscores or other delimiters.
- **[P2] `src/theforge/shape_check/action.py:36`** Field auto_close_superseded in ActionConfig is defined but never used in the run_action logic.
- **[P2] `src/theforge/sprint/dag.py:71`** _has_base_commit_referencing_issue can match any base commit whose message contains the literal '(#N)', including revert commits or cross-references, not only the squash-merge for that branch. In practice GitHub squash commits use this exact form and the false-positive surface is narrow, but a branch that is referenced in an unrelated commit could be marked merged.

## Story

bug: squash-merge detection relies solely on audit trail APPROVE, misses external merges (GitHub Issue #818)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #818