### PR TITLE
bug: closed issues dropped from manifest leave downstream deps permanently blocked

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -341,6 +341,7 @@ def _run_query_mode(
             project_root=config.project_root,
             base_branch=config.workspace.base_branch,
             branch_pattern=config.workspace.branch_pattern,
+            pre_satisfied=resolved.closed_dependency_slugs,
         )
         batch_plan = assign_dependency_batches_with_satisfied(
             tasks,

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -29,6 +29,7 @@ class ResolvedSprint:
     stories: list[tuple[TaskStory, StorySource, str]]  # (task, source, canonical_ref)
     max_parallel: int | None = None
     worker_timeout_seconds: int | None = None
+    closed_dependency_slugs: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -216,29 +217,36 @@ def resolve_from_manifest(manifest_path: Path, project_root: Path) -> ResolvedSp
     """
     manifest = load_sprint_manifest(manifest_path)
     _validate_story_paths(manifest, project_root)
-    task_entries = build_tasks_from_manifest(manifest, project_root)
+    _closed: set[str] = set()
+    task_entries = build_tasks_from_manifest(manifest, project_root, closed_slugs=_closed)
     return ResolvedSprint(
         name=manifest.name,
         budget_usd=manifest.budget_usd,
         stories=task_entries,
         max_parallel=manifest.max_parallel,
         worker_timeout_seconds=manifest.worker_timeout_seconds,
+        closed_dependency_slugs=_closed,
     )
 
 
 def build_tasks_from_manifest(
     manifest: SprintManifest,
     project_root: Path,
+    *,
+    closed_slugs: set[str] | None = None,
 ) -> list[tuple]:
     """Build (task, source, canonical_ref) tuples from a manifest.
 
     For file entries, resolves the path and builds the task from frontmatter.
     For issue entries, fetches the issue via gh CLI and applies overrides
     (depends_on, slug) from the manifest dict.
+
+    If ``closed_slugs`` is provided, issue slugs for any closed issues that are
+    dropped will be added to it so callers can mark them as satisfied.
     """
     import sys  # noqa: PLC0415
 
-    from .sources import IssueClosedError, resolve  # noqa: PLC0415
+    from .sources import GitHubIssueSource, IssueClosedError, resolve  # noqa: PLC0415
 
     results: list[tuple[TaskStory, StorySource, str]] = []
     for entry in manifest.stories:
@@ -247,6 +255,12 @@ def build_tasks_from_manifest(
             task = source.fetch(ref, project_root)
         except IssueClosedError as exc:
             print(f"[sprint] WARNING: skipping {canonical_ref} — {exc}", file=sys.stderr)
+            if (
+                closed_slugs is not None
+                and isinstance(source, GitHubIssueSource)
+                and ref.isdigit()
+            ):
+                closed_slugs.add(f"issue-{ref}")
             continue
 
         # Apply overrides from dict entries

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -318,12 +318,14 @@ def build_resolved_sprint(
 
     source = GitHubIssueSource()
     stories: list[tuple[TaskStory, StorySource, str]] = []
+    closed_dependency_slugs: set[str] = set()
     for issue in issues:
         number = issue["number"]
         try:
             task = source.fetch(str(number), project_root)
         except IssueClosedError as exc:
             _log(f"WARNING: skipping issue #{number} — {exc}")
+            closed_dependency_slugs.add(f"issue-{number}")
             continue
         canonical_ref = f"issue:{number}"
         stories.append((task, source, canonical_ref))
@@ -333,4 +335,5 @@ def build_resolved_sprint(
         budget_usd=budget_usd,
         stories=stories,
         max_parallel=max_parallel,
+        closed_dependency_slugs=closed_dependency_slugs,
     )

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -679,13 +679,17 @@ def run_sprint(
         # so that individual steps remain patchable by tests.
         _manifest = load_sprint_manifest(sprint)
         _validate_story_paths(_manifest, config.project_root)
-        _task_entries = build_tasks_from_manifest(_manifest, config.project_root)
+        _closed: set[str] = set()
+        _task_entries = build_tasks_from_manifest(
+            _manifest, config.project_root, closed_slugs=_closed
+        )
         resolved = ResolvedSprint(
             name=_manifest.name,
             budget_usd=_manifest.budget_usd,
             stories=_task_entries,
             max_parallel=_manifest.max_parallel,
             worker_timeout_seconds=_manifest.worker_timeout_seconds,
+            closed_dependency_slugs=_closed,
         )
 
     # Defensive scrub for the root checkout used by sprint commands.
@@ -787,9 +791,10 @@ def run_sprint(
             action_label = triage.action.upper().replace("_", " ")
             _log(f"  {triage.slug:<20} {action_label} ({triage.reason})")
 
-    # Build satisfied set: resume-mode skip states plus any cross-sprint
-    # depends_on slugs whose branch is already merged to the base branch.
-    pre_satisfied: set[str] = set()
+    # Build satisfied set: closed dep slugs detected at manifest build time,
+    # resume-mode skip states, plus any cross-sprint depends_on slugs whose
+    # branch is already merged to the base branch.
+    pre_satisfied: set[str] = set(resolved.closed_dependency_slugs)
     if resume:
         for triage in triages.values():
             if triage.action in ("skip_merged", "skip"):

--- a/tests/test_sprint_github_query.py
+++ b/tests/test_sprint_github_query.py
@@ -539,3 +539,124 @@ class TestIssueClosedErrorDistinction:
                 GitHubIssueSource().fetch("42", tmp_path)
             # Must NOT be IssueClosedError
             assert type(exc_info.value) is not IssueClosedError
+
+
+# ── closed_dependency_slugs — blocked deps are satisfied, not dropped ─────────
+
+
+class TestClosedDependencySlugs:
+    """Closed issues dropped from the manifest must be tracked as satisfied deps."""
+
+    def _open_issue_json(self, number: int, title: str) -> str:
+        return json.dumps({"title": title, "body": "", "state": "OPEN"})
+
+    def test_closed_issue_in_sprint_populates_closed_dependency_slugs(
+        self, tmp_path: Path
+    ) -> None:
+        """When a sprint issue is already closed, its slug lands in closed_dependency_slugs."""
+        issues = [{"number": 265, "title": "Closed"}, {"number": 750, "title": "Open"}]
+        side_effects = [
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps({"title": "Closed", "body": "", "state": "CLOSED"}),
+                stderr="",
+            ),
+            MagicMock(
+                returncode=0,
+                stdout=self._open_issue_json(750, "Open"),
+                stderr="",
+            ),
+            MagicMock(returncode=0, stdout="[]", stderr=""),
+        ]
+        with patch("subprocess.run", side_effect=side_effects):
+            resolved = build_resolved_sprint(
+                issues=issues,
+                name="Sprint",
+                budget_usd=5.0,
+                max_parallel=None,
+                project_root=tmp_path,
+            )
+
+        assert "issue-265" in resolved.closed_dependency_slugs
+        assert len(resolved.stories) == 1
+
+    def test_no_closed_issues_leaves_closed_dependency_slugs_empty(self, tmp_path: Path) -> None:
+        issues = [{"number": 1, "title": "Open"}]
+        side_effects = [
+            MagicMock(returncode=0, stdout=self._open_issue_json(1, "Open"), stderr=""),
+            MagicMock(returncode=0, stdout="[]", stderr=""),
+        ]
+        with patch("subprocess.run", side_effect=side_effects):
+            resolved = build_resolved_sprint(
+                issues=issues,
+                name="Sprint",
+                budget_usd=5.0,
+                max_parallel=None,
+                project_root=tmp_path,
+            )
+
+        assert resolved.closed_dependency_slugs == set()
+
+    def test_downstream_dep_not_blocked_when_dep_issue_closed(self, tmp_path: Path) -> None:
+        """Downstream story depending on a closed sprint issue must not be blocked.
+
+        Regression: before the fix, build_resolved_sprint dropped the closed
+        issue without recording it as satisfied, so normalize_dependency_plan
+        left it as an unresolved issue-backed dep and the downstream story
+        was permanently skipped.
+        """
+        from theforge.sprint.dag import resolve_satisfied_dependencies
+        from theforge.sprint.query import normalize_dependency_plan
+
+        # Issue 265 is closed and dropped; issue 750 depends on it.
+        issues = [{"number": 265, "title": "Done"}, {"number": 750, "title": "Blocked?"}]
+        dep_body = "depends_on: issue-265\n\nSome story text."
+        side_effects = [
+            # fetch #265 → closed
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps({"title": "Done", "body": "", "state": "CLOSED"}),
+                stderr="",
+            ),
+            # fetch #750 → open
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps({"title": "Blocked?", "body": dep_body, "state": "OPEN"}),
+                stderr="",
+            ),
+            # blockers query for #750
+            MagicMock(returncode=0, stdout="[]", stderr=""),
+        ]
+        with patch("subprocess.run", side_effect=side_effects):
+            resolved = build_resolved_sprint(
+                issues=issues,
+                name="Sprint",
+                budget_usd=5.0,
+                max_parallel=None,
+                project_root=tmp_path,
+            )
+
+        assert "issue-265" in resolved.closed_dependency_slugs
+
+        tasks = [task for task, _src, _ref in resolved.stories]
+        # resolve_satisfied_dependencies must not need a live gh call because
+        # issue-265 is already in pre_satisfied from closed_dependency_slugs.
+        satisfied = resolve_satisfied_dependencies(
+            tasks,
+            project_root=tmp_path,
+            base_branch="main",
+            branch_pattern="feat/{slug}",
+            pre_satisfied=resolved.closed_dependency_slugs,
+        )
+        assert "issue-265" in satisfied
+
+        from theforge.sprint.dag import build_dag
+
+        normalized = normalize_dependency_plan(tasks, satisfied=satisfied)
+        assert normalized.blocked == {}
+
+        # issue-265 stays in depends_on (satisfied external dep tracked for ordering),
+        # but the DAG treats it as completed so issue-750 is immediately ready.
+        dag = build_dag(normalized.tasks, satisfied=satisfied)
+        ready_slugs = [t.slug for t in dag.ready()]
+        assert "issue-750" in ready_slugs


### PR DESCRIPTION
## Summary

The change satisfies the closed issue dependency unblock behavior, and make gate passes.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $1.88
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:797`** Project Convention 6 says new data flowing between coordinator phases should be visible in the audit trail. closed_dependency_slugs now affects scheduling by seeding pre_satisfied, but the structured sprint run payload and sprint audit do not record those slugs, leaving only transient warnings to explain why a dependency was satisfied.

## Story

bug: closed issues dropped from manifest leave downstream deps permanently blocked (GitHub Issue #817)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #817