### PR TITLE
Structured metadata is the only source of dependency edges; prose becomes an authoring warning

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -213,6 +213,7 @@ def _write_sprint_audit(
                 },
                 "reviews": reviews_summary,
                 "depends_on": task.depends_on if task else [],
+                "dependency_warnings": task.dependency_warnings if task else [],
                 "inferred_dependencies": {
                     "manifest": [
                         dep
@@ -250,6 +251,7 @@ def _write_sprint_audit(
                 "merge": False,
                 "reviews": [],
                 "depends_on": task.depends_on if task else [],
+                "dependency_warnings": task.dependency_warnings if task else [],
                 "inferred_dependencies": {
                     "manifest": [
                         dep

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -722,6 +722,13 @@ def run_sprint(
     )
     for warning in _agent_cost_tracking_warnings(config):
         _log(warning)
+    for task, _src, _ref in task_entries:
+        for phrase in task.dependency_warnings:
+            _log(
+                "WARN: dependency-shaped prose ignored for "
+                f"{task.slug} ({task.name}): {phrase!r}; "
+                "declare dependencies in YAML frontmatter"
+            )
 
     # Sprint-level structured logger
     _cli_run_id = run_id

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -9,6 +9,8 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+import yaml
+
 from ..task import TaskStory
 from .manifest import _build_task_from_story
 
@@ -28,6 +30,10 @@ _DEPENDS_ON_BODY_RE = re.compile(
     r"(?:\[([^\]]*)\]|"  # bracketed list form: depends_on: [issue-1, issue-2]
     r"(?:https?://github\.com/[^/\s]+/[^/\s]+/issues/|issue-)?#?(\d+))",  # single ref
     re.IGNORECASE,
+)
+_ISSUE_REF_RE = re.compile(r"(?:https?://github\.com/[^/\s]+/[^/\s]+/issues/|issue-)?#?(\d+)")
+_ISSUE_FRONTMATTER_RE = re.compile(
+    r"\A---[ \t]*\r?\n(?P<yaml>.*?)\r?\n---[ \t]*(?:\r?\n|\Z)", re.DOTALL
 )
 
 
@@ -148,20 +154,82 @@ class GitHubIssueSource:
                         blockers.add(blocker_number)
         return blockers
 
-    def _parse_issue_blockers_from_body(self, body: str) -> list[int]:
-        """Return blocker issue numbers referenced in body text."""
-        blockers = {int(match.group("number")) for match in _BLOCKED_BY_BODY_RE.finditer(body)}
-        # Also parse "depends on" / "depends_on" forms.
-        _NUMBER_RE = re.compile(r"(?:issue-)?#?(\d+)", re.IGNORECASE)
-        for match in _DEPENDS_ON_BODY_RE.finditer(body):
+    def _parse_issue_blockers_from_body_metadata(self, body: str) -> list[int]:
+        """Return blocker issue numbers from explicit issue-body YAML metadata.
+
+        GitHub issues may declare scheduler dependencies in leading YAML
+        frontmatter:
+
+            ---
+            depends_on:
+              - issue-123
+            ---
+
+        Free-form prose is intentionally excluded from this parser.
+        """
+        metadata_match = _ISSUE_FRONTMATTER_RE.match(body)
+        if metadata_match is None:
+            return []
+        try:
+            metadata = yaml.safe_load(metadata_match.group("yaml")) or {}
+        except yaml.YAMLError:
+            return []
+        if not isinstance(metadata, dict):
+            return []
+
+        raw_deps = metadata.get("depends_on", [])
+        if raw_deps is None:
+            return []
+        if isinstance(raw_deps, (str, int)):
+            dep_values = [raw_deps]
+        elif isinstance(raw_deps, list):
+            dep_values = raw_deps
+        else:
+            return []
+
+        blockers: set[int] = set()
+        for raw_dep in dep_values:
+            match = _ISSUE_REF_RE.fullmatch(str(raw_dep).strip())
+            if match is not None:
+                blockers.add(int(match.group(1)))
+        return sorted(blockers)
+
+    def _body_without_issue_metadata(self, body: str) -> str:
+        """Return issue body with the structured metadata block removed."""
+        return _ISSUE_FRONTMATTER_RE.sub("", body, count=1)
+
+    def _find_prose_dependency_phrases(self, body: str) -> list[tuple[str, list[int]]]:
+        """Return non-authoritative dependency-shaped prose phrases and refs."""
+        scan_body = self._body_without_issue_metadata(body)
+        matches: list[tuple[str, list[int]]] = []
+        for match in _BLOCKED_BY_BODY_RE.finditer(scan_body):
+            matches.append((match.group(0), [int(match.group("number"))]))
+        for match in _DEPENDS_ON_BODY_RE.finditer(scan_body):
             bracket_content, single_number = match.group(1), match.group(2)
             if bracket_content is not None:
-                # Bracketed list: extract all issue numbers from within the brackets.
-                for num_match in _NUMBER_RE.finditer(bracket_content):
-                    blockers.add(int(num_match.group(1)))
+                refs = [
+                    int(num_match.group(1))
+                    for num_match in _ISSUE_REF_RE.finditer(bracket_content)
+                ]
             elif single_number is not None:
-                blockers.add(int(single_number))
-        return sorted(blockers)
+                refs = [int(single_number)]
+            else:
+                refs = []
+            if refs:
+                matches.append((match.group(0), sorted(set(refs))))
+        return matches
+
+    def _dependency_authoring_warnings(
+        self, body: str, structured_blockers: list[int]
+    ) -> list[str]:
+        """Warn when prose looks like a dependency but is not structured metadata."""
+        declared = set(structured_blockers)
+        warnings: list[str] = []
+        for phrase, refs in self._find_prose_dependency_phrases(body):
+            if refs and set(refs).issubset(declared):
+                continue
+            warnings.append(phrase)
+        return warnings
 
     def fetch(self, ref: str, project_root: Path) -> TaskStory:
         """Fetch issue body via `gh issue view` and build a TaskStory.
@@ -197,8 +265,9 @@ class GitHubIssueSource:
         body = data.get("body", "")
         blockers = self._fetch_issue_blockers(number, project_root)
         if not blockers:
-            blockers = self._parse_issue_blockers_from_body(body)
+            blockers = self._parse_issue_blockers_from_body_metadata(body)
         blocker_slugs = [f"issue-{blocker}" for blocker in blockers]
+        dependency_warnings = self._dependency_authoring_warnings(body, blockers)
 
         slug = f"issue-{number}"
         return TaskStory(
@@ -208,6 +277,7 @@ class GitHubIssueSource:
             story_text=body,
             depends_on=blocker_slugs,
             inferred_dependencies=blocker_slugs,
+            dependency_warnings=dependency_warnings,
             github_issue=number,
         )
 

--- a/src/theforge/task/story.py
+++ b/src/theforge/task/story.py
@@ -18,6 +18,7 @@ class TaskStory:
     gate_override: str | None = None  # from frontmatter "gate" key; "none" skips gate
     depends_on: list[str] = field(default_factory=list)  # slugs that must have merged first
     inferred_dependencies: list[str] = field(default_factory=list)  # inferred from GH blockers
+    dependency_warnings: list[str] = field(default_factory=list)  # non-authoritative prose matches
     github_issue: int | None = None  # GH issue number; PR will include "Closes #N"
 
 

--- a/tests/test_sprint_github_query.py
+++ b/tests/test_sprint_github_query.py
@@ -608,7 +608,7 @@ class TestClosedDependencySlugs:
         from theforge.sprint.dag import resolve_satisfied_dependencies
         from theforge.sprint.query import normalize_dependency_plan
 
-        # Issue 265 is closed and dropped; issue 750 depends on it.
+        # Issue 265 is closed and dropped; issue 750 only has a legacy prose signal.
         issues = [{"number": 265, "title": "Done"}, {"number": 750, "title": "Blocked?"}]
         dep_body = "depends_on: issue-265\n\nSome story text."
         side_effects = [
@@ -639,6 +639,8 @@ class TestClosedDependencySlugs:
         assert "issue-265" in resolved.closed_dependency_slugs
 
         tasks = [task for task, _src, _ref in resolved.stories]
+        assert tasks[0].depends_on == []
+        assert tasks[0].dependency_warnings == ["depends_on: issue-265"]
         # resolve_satisfied_dependencies must not need a live gh call because
         # issue-265 is already in pre_satisfied from closed_dependency_slugs.
         satisfied = resolve_satisfied_dependencies(
@@ -655,8 +657,7 @@ class TestClosedDependencySlugs:
         normalized = normalize_dependency_plan(tasks, satisfied=satisfied)
         assert normalized.blocked == {}
 
-        # issue-265 stays in depends_on (satisfied external dep tracked for ordering),
-        # but the DAG treats it as completed so issue-750 is immediately ready.
+        # Prose-only references no longer create a DAG edge, so issue-750 is immediately ready.
         dag = build_dag(normalized.tasks, satisfied=satisfied)
         ready_slugs = [t.slug for t in dag.ready()]
         assert "issue-750" in ready_slugs

--- a/tests/test_sprint_lifecycle.py
+++ b/tests/test_sprint_lifecycle.py
@@ -523,6 +523,42 @@ class TestRunSprint:
             "github_blockers": ["issue-9"],
         }
 
+    def test_authoring_warning_for_dependency_shaped_prose_is_visible(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Sprint start logs issue-body prose that looks dependency-shaped."""
+        from theforge.sprint.manifest import ResolvedSprint
+        from theforge.sprint.sources import GitHubIssueSource
+        from theforge.task import TaskStory
+
+        config = _make_config(tmp_path)
+        result_a = _make_coordinator_result(success=True, cost=1.0, merged=True)
+        resolved = ResolvedSprint(
+            name="Test Sprint",
+            budget_usd=10.0,
+            stories=[
+                (
+                    TaskStory(
+                        name="Issue B",
+                        slug="issue-2",
+                        github_issue=2,
+                        dependency_warnings=["Depends on #265"],
+                    ),
+                    GitHubIssueSource(),
+                    "issue:2",
+                )
+            ],
+            max_parallel=1,
+        )
+
+        with patch("theforge.sprint.runner.run_task", return_value=result_a):
+            run_sprint(config, resolved)
+
+        captured = capsys.readouterr()
+        assert "dependency-shaped prose ignored" in captured.err
+        assert "issue-2 (Issue B)" in captured.err
+        assert "Depends on #265" in captured.err
+
 
 # ── Notification tests ────────────────────────────────────────────────
 

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -94,7 +94,7 @@ class TestGitHubIssueSource:
         assert task.depends_on == ["issue-12"]
         assert task.inferred_dependencies == ["issue-12"]
 
-    def test_fetch_falls_back_to_blocked_by_body_pattern(self, tmp_path: Path) -> None:
+    def test_fetch_ignores_body_prose_dependency_as_edge(self, tmp_path: Path) -> None:
         issue_data = json.dumps(
             {
                 "title": "Fix the bug",
@@ -109,8 +109,31 @@ class TestGitHubIssueSource:
             ]
             task = GitHubIssueSource().fetch("42", tmp_path)
 
+        assert task.depends_on == []
+        assert task.inferred_dependencies == []
+        assert task.dependency_warnings == [
+            "blocked by #12",
+            "blocked by https://github.com/acme/repo/issues/7",
+        ]
+
+    def test_fetch_populates_depends_on_from_issue_frontmatter(self, tmp_path: Path) -> None:
+        issue_data = json.dumps(
+            {
+                "title": "Fix the bug",
+                "body": "---\ndepends_on:\n  - issue-12\n  - 7\n---\n\n## Details\nFix it.",
+                "state": "OPEN",
+            }
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=issue_data, stderr=""),
+                MagicMock(returncode=1, stdout="", stderr="preview unavailable"),
+            ]
+            task = GitHubIssueSource().fetch("42", tmp_path)
+
         assert task.depends_on == ["issue-7", "issue-12"]
         assert task.inferred_dependencies == ["issue-7", "issue-12"]
+        assert task.dependency_warnings == []
 
     @pytest.mark.parametrize(
         "body, expected",
@@ -135,10 +158,29 @@ class TestGitHubIssueSource:
             ),
         ],
     )
-    def test_parse_issue_blockers_from_body(self, body: str, expected: list) -> None:
+    def test_prose_dependency_phrases_are_diagnostics_only(
+        self, body: str, expected: list
+    ) -> None:
         source = GitHubIssueSource()
-        result = source._parse_issue_blockers_from_body(body)
+        result = sorted(
+            {ref for _phrase, refs in source._find_prose_dependency_phrases(body) for ref in refs}
+        )
         assert result == expected
+
+    def test_parse_issue_blockers_from_body_metadata_requires_frontmatter(self) -> None:
+        source = GitHubIssueSource()
+
+        assert source._parse_issue_blockers_from_body_metadata("depends_on: issue-265") == []
+        assert source._parse_issue_blockers_from_body_metadata(
+            "---\ndepends_on: issue-265\n---\n\nBody"
+        ) == [265]
+
+    def test_matching_structured_dependency_suppresses_prose_warning(self) -> None:
+        body = "---\ndepends_on: issue-265\n---\n\nDepends on #265 for context."
+
+        warnings = GitHubIssueSource()._dependency_authoring_warnings(body, [265])
+
+        assert warnings == []
 
     def test_fetch_raises_on_failure(self, tmp_path: Path) -> None:
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Implementation correctly separates structured dependency declarations from prose diagnostics, satisfying all acceptance criteria. | [claude-opus] Structured YAML frontmatter is the sole source of DAG edges; prose produces only diagnostic warnings surfaced at sprint start and in audit.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $0.70
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/sources.py:193`** Malformed YAML frontmatter causes dependency declarations to be silently ignored without warning. If YAML parsing fails, the frontmatter block is still removed from prose scanning, so 'depends_on' lines inside it produce neither edge nor warning.

## Story

Structured metadata is the only source of dependency edges; prose becomes an authoring warning (GitHub Issue #821)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #821