### PR TITLE
Post-release doc review for v0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,26 @@
 TheForge is a deterministic multi-LLM development orchestrator. This file provides
 conventions for any Codex agent working in this codebase.
 
+Directory-level `CLAUDE.md` files under `src/theforge/` provide subsystem-local
+context. When working inside `coordinator/`, `runners/`, `sprint/`, `task/`,
+`config/`, or `cli/`, read the nearest local guide in addition to this root guide.
+
+---
+
+## Current State — Start Here
+
+To understand what's in progress and what's next, run:
+```bash
+gh milestone list                              # see milestones
+gh issue list --milestone "v0.9.0"             # current priority after v0.8.0
+gh project item-list 1 --owner fuzzypete       # full project board
+```
+
+Project board: https://github.com/users/fuzzypete/projects/1
+
+Stories are GitHub issues — there are no local story files. GH milestones + issues
+are the single source of truth for priorities, status, and story content.
+
 ---
 
 ## Interactive Development Workflow
@@ -49,10 +69,10 @@ State machine: `INIT → WORKSPACE → PREFLIGHT → PLAN → PLAN_REVIEW → DE
 
 Key modules:
 - `src/theforge/coordinator/engine.py` — state machine, the heart of the system
-- `src/theforge/coordinator/` — all coordinator phases (dev_phase, review_phase, validate_phase, plan_flow, preflight, workspace, etc.)
+- `src/theforge/coordinator/` — all coordinator phases (dev_phase, review_phase, validate_phase, plan_flow, preflight_flow, workspace, etc.)
 - `src/theforge/runners/` — API and CLI agent runners; adapters per provider
 - `src/theforge/config/` — forge.yaml parsing and model profiles
-- `src/theforge/task/` — prompt builders (dev, review, plan)
+- `src/theforge/task/` — prompt builders (dev, review, plan, preflight)
 - `src/theforge/review.py` — review output parsing
 - `src/theforge/schemas.py` — review schema validation
 - `src/theforge/cli/main.py` — `forge` CLI entry point
@@ -118,10 +138,24 @@ test_coverage:
   gaps: []
 ```
 
-### Stories
-Stories are GitHub issues — there are no local story files. The primary term is
-"story" throughout the codebase. `TaskSpec` is a backward-compat alias for
-`TaskStory`; prefer `TaskStory` in new code.
+### Writing stories
+Stories describe WHAT and WHY — never HOW. The plan phase produces the HOW.
+
+- **No function names, class names, or file paths** unless the story is about a
+  specific file.
+- **Acceptance criteria describe observable behavior**, not implementation steps.
+- **`## Notes` is for soft hints, not requirements.** Notes may mention files,
+  patterns, or gotchas, but agents must verify them against the codebase.
+- The primary term is "story" throughout the codebase. `TaskSpec` is a
+  backward-compat alias for `TaskStory`; prefer `TaskStory` in new code.
+
+### Writing bug reports
+Bug reports contain exactly two things:
+
+1. **What happened** — observed behavior with evidence.
+2. **What was expected** — the correct behavior.
+
+No acceptance criteria, implementation hints, file paths, or suggested fix path.
 
 ### Dogfooding config
 `forge.yaml` at the project root configures theforge to develop itself. Worktrees
@@ -139,11 +173,17 @@ land in `.forge/worktrees/<slug>/` on branch `feat/<slug>`.
 
 ## Cutting a Release
 
-The full release process is documented in [`RELEASING.md`](RELEASING.md). Do not
-cut a release without reading it. Key points:
+The full release process is documented in [`RELEASING.md`](RELEASING.md). Use the
+script — do not run steps manually:
 
-- Update `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z] — date`)
-- Bump `pyproject.toml` version to match the tag
+```bash
+scripts/release.sh X.Y.Z
+scripts/release.sh --dry-run X.Y.Z
+```
+
+Key points:
+- Verify the CHANGELOG release section against the milestone and commit range
+  before tagging; GitHub release notes are generated from that section.
 - Tag and push **before** bumping back to `X.Y.Z+1.dev0`
 - Hotfixes branch from `release/vX.Y`, not `main`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0] — 2026-04-20
 
+### Added
+
+- **Simple `models:` config path:** `forge.yaml` can now declare a model list and
+  `budget_usd`; TheForge derives preflight, plan, dev, review, and synthesis roles
+  automatically instead of requiring hand-written `profiles:` blocks. (#807, #816, #820, #822)
+- **Explicit AgentSpec transport model:** provider/model identity and CLI/API transport are
+  now represented separately, so `check-config` reports API-backed models accurately and
+  Google models route through the intended API transport. (#861, #865, #866)
+- **Structured audit expansion:** per-run audit files now capture story text, plan content,
+  run identity, and redacted contract data for post-run diagnosis. (#798, #802, #804)
+- **Forge-owned handoff artifact:** the coordinator owns the handoff contract instead of
+  trusting a dev-written file for validation decisions. (#827)
+- **Story shape checks:** issue drafting and sprint entry now enforce story shape, with a
+  `forge sprint --force` escape hatch that prints skipped reason codes. (#867, #871, #879)
+- **Dependency metadata parsing:** issue dependencies are read from structured metadata, with
+  prose treated as an authoring warning instead of the source of scheduling truth. (#819, #881)
+
+### Changed
+
+- **Dogfooding config moved to v0.8 schema:** this repository's `forge.yaml` now uses the
+  simple model-list configuration path. (#833, #855)
+- **Legacy config removed from the v0.8 path:** `profiles:`, `smart_config_models:`, and
+  legacy `agents:` are rejected when mixed with `models:`; use `models:` plus `overrides:`
+  for derived-role configs. (#854)
+- **Preflight/model assignment guardrails:** role derivation now prevents bad
+  tier/complexity combinations and keeps model assignment visible through `check-config`.
+  (#815, #822)
+
+### Fixed
+
+- **Gate and timeout diagnosis:** multi-stage gate commands no longer produce false
+  CONTRADICTION results, and timed-out gates run `gate_debug_command` before escalation.
+  (#826, #838)
+- **Sprint scheduling and resumption:** stale no-pull behavior, synthetic dependency cycles,
+  dropped completed stories, mid-sprint re-exec aborts, closed dependency issues, and closed
+  manifest dependencies were fixed. (#805, #814, #832, #841, #853, #878)
+- **Run status accuracy:** stopped processes and orphaned runs no longer remain permanently
+  RUNNING in `forge status`. (#844, #845, #846)
+- **Squash-merge detection:** sprint triage no longer relies only on audit-trail APPROVE to
+  detect externally merged branches. (#876)
+- **Subprocess environment isolation:** agent subprocesses avoid poisoning global Python when
+  a bare `pip` or `python` appears in commands. (#864)
+- **Self-hosting gate/runtime regressions:** localhost network and sandbox-related gate
+  failures from this release cycle were corrected. (#849, #850)
+
 ### Removed
 
 - **File-based handoff contract removed (breaking):** `handoff_file` and `gate_decision_key` are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ sections as navigational guidance.
 To understand what's in progress and what's next, run:
 ```bash
 gh milestone list                              # see milestones
-gh issue list --milestone "v0.8.0"             # current priority
+gh issue list --milestone "v0.9.0"             # current priority after v0.8.0
 gh project item-list 1 --owner fuzzypete       # full project board
 ```
 
@@ -226,6 +226,8 @@ scripts/release.sh --dry-run X.Y.Z # preview
 ```
 
 Key points:
+- Verify the CHANGELOG release section against the milestone and commit range
+  before tagging; GitHub release notes are generated from that section.
 - Tag and push **before** bumping back to `X.Y.Z+1.dev0`
 - Hotfixes branch from `release/vX.Y`, not `main`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml/badge.svg)](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.7.0-orange)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.8.0-orange)](CHANGELOG.md)
 
 **Deterministic multi-LLM development orchestrator.**
 
@@ -168,32 +168,31 @@ recommended patterns.
 
 ## Minimal config
 
-This is the smallest useful mental model for `forge.yaml`:
+This is the smallest useful mental model for `forge.yaml` in v0.8:
 
 ```yaml
-profiles:
-  dev:
-    cli: claude
-    model: sonnet
-  review_pool:
-    - name: claude-reviewer
-      cli: claude
-      model: opus
+models:
+  - claude/sonnet
+  - claude/opus
+
+budget_usd: 30.0
 
 validation:
   gate_command: "pytest tests/"
 ```
 
-Add more reviewers for cross-model coverage, or switch to API-mode profiles
-when you want hosted providers and tool-runtime control. The full schema lives
-in [Inputs Reference](docs/guides/inputs-reference.md).
+TheForge derives preflight, plan, dev, review, and synthesis roles from the model
+list using the story's complexity. Use `overrides:` for targeted changes to
+derived roles, or classic `profiles:` when you need fully manual control. The
+full schema lives in [Inputs Reference](docs/guides/inputs-reference.md).
 
 ## Operating Runs
 
 Runs may detach by default so they can continue in the background. Use
 `forge run --fg` or `forge sprint --fg` when you want foreground execution, and
 use `forge status`, `forge logs <run-id>`, and `forge stop <run-id>` to monitor
-or control active runs.
+or control active runs. Active sprint detail is folded into `forge status`; the
+old standalone `forge sprint-status` parser entry is no longer exposed.
 
 ## What things cost
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,6 +59,17 @@ Rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`.
 
 Add a new `## [Unreleased]` section at the top for future work.
 
+Before continuing, verify the release section against both the milestone and the
+tag range:
+
+```bash
+gh issue list --milestone vX.Y.Z --state closed --limit 200
+git log --oneline <previous-release-tag>..HEAD
+```
+
+The GitHub release body is generated from this CHANGELOG section, so missing
+items here become missing release notes.
+
 ### 4. Bump version
 
 In `pyproject.toml`, change `version = "X.Y.Z.dev0"` to `version = "X.Y.Z"`.
@@ -110,6 +121,18 @@ gh release create vX.Y.Z \
 
 Or create manually via GitHub UI using the CHANGELOG section as release notes.
 
+After creation, verify the published body before starting the next sprint:
+
+```bash
+gh release view vX.Y.Z
+```
+
+If the body is incomplete, fix `CHANGELOG.md` first, then update the release:
+
+```bash
+gh release edit vX.Y.Z --notes-file <(awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+```
+
 ---
 
 ## Post-release doc review
@@ -127,8 +150,9 @@ starts. The release tag is what users see — docs should match what shipped.
 - [ ] **CLI help text** — `forge --help` and subcommand help reflect current flags and options
 - [ ] **GitHub release notes** — body covers what users need to know
 
-If anything is materially wrong, file a story for the next milestone. One-liner
-fixes can go directly on main.
+If anything is materially wrong, file a story for the next milestone. For small
+documentation fixes, create a small issue/worktree pair and still keep the audit
+trail intact.
 
 ---
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -112,6 +112,7 @@ Run multiple stories from a sprint manifest or directly from a GitHub milestone 
 forge sprint [manifest.yaml] [flags]
 forge sprint --milestone "v0.4.0" --budget 50 [flags]
 forge sprint --label "sprint-1" --budget 20 [flags]
+forge sprint --issues 123,124 --budget 20 [flags]
 ```
 
 **Use this when:** You want batch execution with shared budget and story ordering. The
@@ -137,6 +138,10 @@ manifest argument is optional when using `--milestone` or `--label`.
 | `--detach` | Queue the sprint on a running daemon and return immediately |
 | `--fg` | Run in the foreground instead of detaching |
 | `--no-pull` | Skip `git pull --ff-only` before fresh worktree creation |
+| `--force` | Bypass the sprint-entry shape gate and run every selected issue |
+
+`--detach` is manifest-only. Query mode (`--milestone`, `--label`, or `--issues`)
+must run in the current process, usually with `--fg` when you want foreground logs.
 
 **Sprint manifest format:**
 
@@ -212,6 +217,29 @@ forge check-config [forge.yaml]
 ```
 
 **Use this when:** After editing config, before a release, or when debugging model wiring.
+In v0.8, this is the quickest way to inspect the role table derived from `models:`.
+
+---
+
+## `forge eval-preflight`
+
+Evaluate candidate preflight models against a golden story set.
+
+```bash
+forge eval-preflight [flags]
+```
+
+**Use this when:** Comparing preflight models without running a full sprint.
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--golden-set <path>` | Path to `golden_stories.yaml` |
+| `--models <A,B,...>` | Comma-separated model identifiers to evaluate |
+| `--working-dir <path>` | Working directory for agent invocations |
+| `--output-format <text|json>` | Report format |
+| `--config <path>` | Path to `forge.yaml` |
 
 ---
 
@@ -241,6 +269,10 @@ Show active detached runs and pending decisions.
 forge status
 ```
 
+For an active sprint run, `forge status` includes the per-story sprint status
+view. The old standalone `forge sprint-status` command is no longer exposed by
+the top-level parser.
+
 ---
 
 ## `forge logs`
@@ -258,8 +290,10 @@ forge logs <run-id>
 Send `SIGTERM` to a running detached run.
 
 ```bash
-forge stop <run-id>
+forge stop <run-id> [--no-wait] [--timeout N]
 ```
+
+By default, `forge stop` waits up to 60 seconds for process exit.
 
 ---
 
@@ -269,6 +303,18 @@ Record a decision for a pending HITL checkpoint.
 
 ```bash
 forge decide <run-id> <action>
+```
+
+Common actions are `approve`, `reject`, `continue`, `retry`, `skip`, and `abort`.
+
+---
+
+## `forge runs-clean`
+
+Mark orphaned runs with no terminal marker so `forge status` shows accurate state.
+
+```bash
+forge runs-clean
 ```
 
 ---

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -143,6 +143,12 @@ Controls everything: which models to use, budgets, timeouts, retry policies.
 ```yaml
 project: my-project
 
+models:
+  - claude/sonnet
+  - claude/opus
+
+budget_usd: 30.0
+
 workspace:
   create_command: "git worktree add .forge/worktrees/{slug} -b forge/{slug} main"
   path_pattern: ".forge/worktrees/{slug}"
@@ -151,30 +157,36 @@ workspace:
 validation:
   gate_command: "python -m pytest tests/ -q"
 
-profiles:
-  dev:
-    cli: claude
-    model: sonnet
-    budget_usd: 5.00
-    timeout_seconds: 600
-    allowed_tools: [Read, Edit, Write, Bash, Glob, Grep]
-  review_pool:
-    - name: claude-reviewer
-      cli: claude
-      model: opus
-      budget_usd: 2.00
-      timeout_seconds: 300
-      allowed_tools: [Read, Bash, Glob, Grep]
-
 retry:
   max_dev_iterations: 3
   max_review_cycles: 2
 ```
 
+In v0.8, `models:` is the primary config path. TheForge derives preflight,
+plan, dev, review, and synthesis roles from the model list and the story's
+complexity. Use `forge check-config` to inspect the derived role table.
+
 ### Full config reference
 
 ```yaml
 project: my-project                # project name for logging/audit
+
+# ── Model list and derived roles ──────────────────────────
+models:
+  - claude/sonnet
+  - claude/opus
+  - openai/gpt-5.4
+
+budget_usd: 50.0                   # budget used to derive per-role ceilings
+
+# Optional targeted changes to derived roles. Do not mix top-level profiles:,
+# smart_config_models:, or agents: with models:.
+overrides:
+  dev:
+    timeout_seconds: 1200
+  review_pool:
+    - name: review-strong
+      timeout_seconds: 600
 
 # ── Workspace ──────────────────────────────────────────────
 workspace:
@@ -187,6 +199,7 @@ workspace:
   merge_strategy: "squash"            # "squash" | "merge" | "rebase" (used by merge-pr)
   pr_labels: []                       # labels applied when on_approve is "pr" or "merge-pr"
   pr_draft: false                     # create PR as draft when on_approve is "pr"
+  merge_wait_timeout_seconds: 3600    # max wait for queued merge-pr landing
 
 # ── Validation gate ────────────────────────────────────────
 validation:
@@ -194,6 +207,7 @@ validation:
   gate_timeout: 600                    # seconds; default varies
   gate_debug_command: ~                # optional: runs after gate_timeout for diagnostics
   gate_debug_timeout: ~                # seconds; default: same resolved value as gate_timeout
+  test_command: ~                      # optional command agents may run during dev
   pre_validate_command: ~              # optional: run before dirty check
 
 # ── Retry policy ───────────────────────────────────────────
@@ -203,7 +217,9 @@ retry:
   max_review_parse_retries: 2  # reviewer output parse/schema error retries
   max_plan_regen_attempts: 3 # plan review reject → regeneration cycles
 
-# ── Agent profiles ─────────────────────────────────────────
+# ── Classic manual profiles (advanced alternative) ─────────
+# Omit models: when using classic profiles. This path remains supported for
+# fully manual role control, but it is not the v0.8 default.
 profiles:
   # Dev agent (implements the story)
   dev:
@@ -291,11 +307,6 @@ notifications:
   ntfy:
     priority: high
     # url resolved from NTFY_URL in .forge/.env
-
-# ── Smart config (optional) ────────────────────────────────
-smart_config_models:
-  - claude/sonnet
-  - openai/gpt-5.4
 
 # ── Secrets (optional) ────────────────────────────────────
 # API keys are read from .forge/.env (run `forge secrets-init` to create)
@@ -385,7 +396,7 @@ findings:
     line: 42
     description: "What is wrong"
     suggestion: "How to fix it"
-spec_compliance:
+story_compliance:
   matches_spec: true | false
   mismatches: []
 test_coverage:
@@ -397,6 +408,8 @@ test_coverage:
 - `APPROVE` with any P1 → overridden to `REQUEST_CHANGES`
 - `REQUEST_CHANGES` with no P1 → schema error
 - Invalid YAML → treated as `REQUEST_CHANGES`
+- `spec_compliance` is accepted as a backward-compatible alias, but new
+  reviewers should emit `story_compliance`.
 
 ---
 

--- a/forge.yaml
+++ b/forge.yaml
@@ -1,8 +1,9 @@
 # forge.yaml — TheForge developing itself
 project: theforge
 
-# v0.8 simple model list — complexity-aware roles derived automatically at runtime
-# See: docs/guides/getting-started.md for the full schema reference
+# v0.8 simple model list. TheForge derives preflight, plan, dev, review,
+# and synthesis roles automatically from this list and the story complexity.
+# See docs/guides/inputs-reference.md for the full schema reference.
 models:
   - claude/sonnet
   - claude/opus
@@ -24,7 +25,10 @@ workspace:
   merge_wait_timeout_seconds: 3600
 
 validation:
+  # Gate pass/fail is exit-code only. v0.8 removed handoff_file and
+  # gate_decision_key; do not add them back under validation:.
   gate_command: ".venv/bin/ruff check src/ tests/ && .venv/bin/ruff format --check src/ tests/ && .venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
+  # Canonical intermediate test command dev agents should use while working.
   test_command: ".venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
   gate_timeout: 45
 


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Documentation updates accurately reflect v0.8.0 release; all local checks pass | [claude-opus] Docs-only refresh for v0.8.0 is accurate and consistent with shipped behavior; remote release-notes update is correctly deferred.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, claude-opus
- **Cost:** $1.21
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `docs/guides/cli-reference.md:293`** forge stop docs state a 60-second default wait, which should be verified against the actual CLI default in src/theforge/cli to avoid doc drift.
- **[P2] `RELEASING.md:133`** The gh release edit awk one-liner uses $VERSION inside a double-quoted awk program, relying on shell expansion; readers copy-pasting without exporting VERSION will get an empty pattern.
- **[P2] `CHANGELOG.md:13`** The 0.8.0 Added/Changed/Fixed entries should be spot-checked against the closed v0.8.0 milestone issue list; dev flagged GitHub release body could not be verified from sandbox.

## Story

Post-release doc review for v0.8.0 (GitHub Issue #884)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #884