### PR TITLE
Profile transport mutation produces malformed dispatch state

### DIFF
--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -27,6 +27,7 @@ from .models import (
     AgentSpec,
     ModelInfo,
     TransportSpec,
+    apply_model_info,
     resolve_agent_spec,
 )
 from .types import (
@@ -83,6 +84,7 @@ __all__ = [
     "AgentSpec",
     "MODEL_REGISTRY",
     "TransportSpec",
+    "apply_model_info",
     "resolve_agent_spec",
     # defaults
     "API_PROVIDER_DEFAULT_TOOLS",

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -9,10 +9,12 @@ callers continue to work while the codebase migrates.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, fields, replace
+from typing import Any, TypeVar, overload
 
-from .types import ApiFallbackConfig, AssignmentConfig, ModelProfile
+from .types import ApiFallbackConfig, AssignmentConfig, ModelProfile, PlanConfig
+
+_ProfileT = TypeVar("_ProfileT", ModelProfile, PlanConfig)
 
 
 @dataclass(frozen=True)
@@ -344,6 +346,32 @@ def _spec_to_model_info(spec: AgentSpec) -> ModelInfo:
 MODEL_REGISTRY: dict[str, ModelInfo] = {
     k: _spec_to_model_info(v) for k, v in AGENT_REGISTRY.items()
 }
+
+
+@overload
+def apply_model_info(profile: ModelProfile, info: ModelInfo) -> ModelProfile: ...
+
+
+@overload
+def apply_model_info(profile: PlanConfig, info: ModelInfo) -> PlanConfig: ...
+
+
+def apply_model_info(profile: _ProfileT, info: ModelInfo) -> _ProfileT:
+    """Return profile with model identity and dispatch transport from ``info``.
+
+    Mid-run model swaps must update all fields that define dispatch together.
+    ``PlanConfig`` predates explicit ``TransportSpec`` storage, so this helper
+    writes ``transport`` only for profiles that carry that field.
+    """
+    profile_fields = {field.name for field in fields(profile)}
+    updates: dict[str, object] = {
+        "cli": info.cli,
+        "model": info.model,
+        "provider": info.provider,
+    }
+    if "transport" in profile_fields:
+        updates["transport"] = info.transport
+    return replace(profile, **updates)
 
 
 def resolve_agent_spec(model_key: str) -> AgentSpec:

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 
 from theforge.artifacts import PLAN_PATH, ensure_parent_dir, plan_paths, resolve_plan_path
-from theforge.config import MODEL_REGISTRY, ForgeConfig, ModelProfile
+from theforge.config import MODEL_REGISTRY, ForgeConfig, ModelProfile, apply_model_info
 from theforge.config.profiles import _apply_provider_fallback
 from theforge.log_level import _LOG_LEVEL, LogLevel
 from theforge.plan_finding_classifier import (
@@ -149,11 +149,11 @@ def _run_plan_phase(
     if _should_validate_spec:
         from theforge.story_validator import validate_story  # noqa: PLC0415
 
-        _fast_profile = (
-            dataclasses.replace(config.dev_profile, model="sonnet")
-            if "opus" in config.dev_profile.model.lower()
-            else config.dev_profile
-        )
+        _fast_profile = config.dev_profile
+        if "opus" in config.dev_profile.model.lower():
+            _sonnet_info = MODEL_REGISTRY.get("claude/sonnet")
+            if _sonnet_info is not None:
+                _fast_profile = apply_model_info(config.dev_profile, _sonnet_info)
         _sv_result = validate_story(
             story_content=story_content,
             profile=_fast_profile,
@@ -716,11 +716,7 @@ def _run_plan_agent_review(
                     _next_info = MODEL_REGISTRY[_next_key]
                     _old_model = plan_profile.model
                     _new_model = _next_info.model
-                    plan_profile = dataclasses.replace(
-                        plan_profile,
-                        cli=_next_info.cli,
-                        model=_next_info.model,
-                    )
+                    plan_profile = apply_model_info(plan_profile, _next_info)
                     state.plan_escalated = True
                     state.plan_escalation_note = (
                         f"MODEL ESCALATION: The plan was rejected"

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from theforge.config import MODEL_REGISTRY, ForgeConfig, ModelInfo, ModelProfile
+from theforge.config import MODEL_REGISTRY, ForgeConfig, ModelInfo, ModelProfile, apply_model_info
 from theforge.review import ReviewFinding
 
 if TYPE_CHECKING:
@@ -366,7 +366,11 @@ def _find_registry_key_for_profile(profile: ModelProfile) -> str | None:
             if info.cli == profile.cli and info.model == profile.model:
                 return key
             continue
-        if profile.provider is not None and key == f"{profile.provider}/{profile.model}":
+        if (
+            profile.provider is not None
+            and info.provider == profile.provider
+            and info.model == profile.model
+        ):
             return key
     return None
 
@@ -505,11 +509,7 @@ def _apply_complexity_adaptation(config: ForgeConfig, complexity: str) -> ForgeC
         target_plan_rank = _TIER_TO_RANK[_PHASE_COMPLEXITY_TIER["plan"][norm]]
         target_plan_info = _pick_pool_entry_by_rank(pool_entries, target_plan_rank)
         if target_plan_info.model != config.plan.model:
-            new_plan = _dc_replace(
-                config.plan, model=target_plan_info.model, cli=target_plan_info.cli
-            )
-            if target_plan_info.cli is not None:
-                new_plan = _dc_replace(new_plan, provider=None)
+            new_plan = apply_model_info(config.plan, target_plan_info)
             new_config = _dc_replace(new_config, plan=new_plan)
 
     # ── dev ────────────────────────────────────────────────────────
@@ -518,11 +518,7 @@ def _apply_complexity_adaptation(config: ForgeConfig, complexity: str) -> ForgeC
         target_dev_rank = _TIER_TO_RANK[_PHASE_COMPLEXITY_TIER["dev"][norm]]
         target_dev_info = _pick_pool_entry_by_rank(dev_pool, target_dev_rank)
         if target_dev_info.model != config.dev_profile.model:
-            new_dev = _dc_replace(
-                config.dev_profile,
-                cli=target_dev_info.cli,
-                model=target_dev_info.model,
-            )
+            new_dev = apply_model_info(config.dev_profile, target_dev_info)
             new_config = _dc_replace(new_config, dev_profile=new_dev)
 
     # ── review_pool ────────────────────────────────────────────────

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -9,7 +9,7 @@ from dataclasses import replace as _dc_replace
 from enum import Enum, auto
 from pathlib import Path
 
-from theforge.config import MODEL_REGISTRY, ForgeConfig
+from theforge.config import MODEL_REGISTRY, ForgeConfig, apply_model_info
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.review import (
     ReviewFinding,
@@ -911,9 +911,7 @@ def _run_review_phase(
                     f" (persistent P1 in {_p1_file})"
                 )
                 _old_model = config.dev_profile.model
-                _new_dev = _dc_replace(
-                    config.dev_profile, cli=_next_info.cli, model=_next_info.model
-                )
+                _new_dev = apply_model_info(config.dev_profile, _next_info)
                 config = _dc_replace(config, dev_profile=_new_dev)
                 state.dev_escalated = True
                 _prev_result = state.review_results[-2]

--- a/tests/test_profile_transport_mutation.py
+++ b/tests/test_profile_transport_mutation.py
@@ -1,0 +1,298 @@
+"""Regression tests for model-swap transport consistency."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from coord_test_helpers import _make_agent_result, _make_task
+
+from theforge.config import (
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    MODEL_REGISTRY,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    PlanConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+    apply_model_info,
+)
+from theforge.coordinator import plan_flow, review_phase
+from theforge.coordinator.preflight import _apply_complexity_adaptation
+from theforge.coordinator.review_phase import _ReviewOutcome
+from theforge.coordinator.state import CoordinatorState
+from theforge.review import ReviewFinding, ReviewResult
+
+PLAN_AGENT_APPROVE = """\
+```yaml
+verdict: APPROVE
+findings: []
+```
+"""
+
+PLAN_AGENT_REJECT_P0 = """\
+```yaml
+verdict: REJECT
+findings:
+  - severity: P0
+    description: "Plan misses a required behavior"
+    suggestion: "Cover the missing behavior"
+```
+"""
+
+
+class _Logger:
+    def _safe_emit(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def _workspace(tmp_path: Path) -> WorkspaceConfig:
+    return WorkspaceConfig(
+        create_command="mkdir -p {slug}",
+        path_pattern="{slug}",
+        branch_pattern="forge/{slug}",
+    )
+
+
+def _profile_from(model_key: str, *, name: str = "dev") -> ModelProfile:
+    info = MODEL_REGISTRY[model_key]
+    return apply_model_info(
+        ModelProfile(
+            name=name,
+            cli="claude",
+            provider=None,
+            model="sonnet",
+            budget_usd=10.0,
+            timeout_seconds=300,
+            allowed_tools=(),
+        ),
+        info,
+    )
+
+
+def _config(
+    tmp_path: Path,
+    *,
+    dev_profile: ModelProfile,
+    models: list[str],
+    plan: PlanConfig | None = None,
+    retry: RetryPolicy | None = None,
+    plan_agent_review: PlanAgentReviewConfig | None = None,
+) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=_workspace(tmp_path),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev_profile,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=retry or RetryPolicy(max_dev_iterations=2, max_review_cycles=3),
+        log=LogConfig(enabled=False),
+        models=models,
+        plan=plan or PlanConfig(enabled=True),
+        plan_agent_review=plan_agent_review or PlanAgentReviewConfig(enabled=False),
+        review_pool_is_default=True,
+        plan_model_is_default=True,
+        dev_profile_is_default=True,
+    )
+
+
+def _assert_api_profile(profile: ModelProfile, *, provider: str, model: str) -> None:
+    assert profile.cli is None
+    assert profile.provider == provider
+    assert profile.model == model
+    assert profile.transport is not None
+    assert profile.transport.kind == "api"
+
+
+def _assert_cli_profile(profile: ModelProfile, *, cli: str, model: str) -> None:
+    assert profile.cli == cli
+    assert profile.provider is None
+    assert profile.model == model
+    assert profile.transport is not None
+    assert profile.transport.kind == "cli"
+
+
+def _p1_review() -> ReviewResult:
+    finding = ReviewFinding(
+        severity="P1",
+        file="src/example.py",
+        line=1,
+        description="Persistent bug",
+        suggestion="Fix it",
+    )
+    return ReviewResult(
+        verdict="REQUEST_CHANGES",
+        summary="needs changes",
+        findings=[finding],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def test_preflight_complexity_adaptation_cli_to_api_dev_profile(tmp_path: Path) -> None:
+    config = _config(
+        tmp_path,
+        dev_profile=_profile_from("claude/sonnet"),
+        models=["claude/sonnet", "deepseek/deepseek-reasoner"],
+    )
+
+    updated = _apply_complexity_adaptation(config, "medium")
+
+    _assert_api_profile(updated.dev_profile, provider="deepseek", model="deepseek-reasoner")
+
+
+def test_preflight_complexity_adaptation_api_to_cli_dev_profile(tmp_path: Path) -> None:
+    config = _config(
+        tmp_path,
+        dev_profile=_profile_from("deepseek/deepseek-chat"),
+        models=["deepseek/deepseek-chat", "claude/opus"],
+    )
+
+    updated = _apply_complexity_adaptation(config, "large")
+
+    _assert_cli_profile(updated.dev_profile, cli="claude", model="opus")
+
+
+def test_preflight_complexity_adaptation_plan_uses_target_transport_fields(
+    tmp_path: Path,
+) -> None:
+    config = _config(
+        tmp_path,
+        dev_profile=_profile_from("claude/sonnet"),
+        models=["claude/sonnet", "openai-api/gpt-5.4-pro"],
+        plan=PlanConfig(enabled=True, cli="claude", provider=None, model="sonnet"),
+    )
+
+    updated = _apply_complexity_adaptation(config, "medium")
+
+    assert updated.plan.cli is None
+    assert updated.plan.provider == "openai"
+    assert updated.plan.model == "gpt-5.4-pro"
+
+
+def test_review_phase_dev_escalation_cli_to_api_updates_transport(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(
+        tmp_path,
+        dev_profile=_profile_from("claude/sonnet"),
+        models=["claude/sonnet", "deepseek/deepseek-reasoner"],
+        retry=RetryPolicy(
+            max_dev_iterations=2,
+            max_review_cycles=3,
+            auto_model_escalation=True,
+        ),
+    )
+    state = CoordinatorState()
+    state.review_results.append(_p1_review())
+
+    def fake_review_pool(*_args, **_kwargs):
+        current = _p1_review()
+        return [], [], current, [current], [("review", current)]
+
+    monkeypatch.setattr(review_phase, "_run_review_pool", fake_review_pool)
+    monkeypatch.setattr(
+        review_phase,
+        "_run_worktree_eval",
+        lambda *_args, **_kwargs: {"finding_registry": [], "classified_indices": []},
+    )
+
+    outcome, result, updated = review_phase._run_review_phase(
+        state,
+        config,
+        _make_task(tmp_path),
+        "story",
+        tmp_path,
+        "forge/test",
+        time.monotonic(),
+        interactive=False,
+        auto_merge=False,
+        notify=False,
+        logger=None,
+    )
+
+    assert outcome is _ReviewOutcome.RETRY_DEV
+    assert result is None
+    _assert_api_profile(updated.dev_profile, provider="deepseek", model="deepseek-reasoner")
+
+
+def test_plan_review_escalation_cli_to_api_updates_regen_profile(
+    tmp_path: Path, monkeypatch
+) -> None:
+    captured_profiles: list[ModelProfile] = []
+    plan_reviewer_a = _profile_from("claude/sonnet", name="plan-review-a")
+    plan_reviewer_b = _profile_from("claude/sonnet", name="plan-review-b")
+    config = _config(
+        tmp_path,
+        dev_profile=_profile_from("claude/sonnet"),
+        models=["claude/sonnet", "deepseek/deepseek-reasoner"],
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=3, plan_escalation_threshold=1),
+        plan_agent_review=PlanAgentReviewConfig(
+            enabled=True,
+            pool=[plan_reviewer_a, plan_reviewer_b],
+            min_reviewers=2,
+        ),
+    )
+    state = CoordinatorState()
+    state.log_dir = tmp_path / ".forge" / "logs"
+    state.plan_output = "steps: []"
+    state._explicit_roles = set()
+
+    monkeypatch.setattr(
+        plan_flow,
+        "run_agent_pool",
+        lambda **_kwargs: (
+            [
+                _make_agent_result(
+                    success=True, output=PLAN_AGENT_REJECT_P0, profile_name="plan-review-a"
+                ),
+                _make_agent_result(
+                    success=True, output=PLAN_AGENT_REJECT_P0, profile_name="plan-review-b"
+                ),
+            ]
+            if not state.plan_escalated
+            else [
+                _make_agent_result(
+                    success=True, output=PLAN_AGENT_APPROVE, profile_name="plan-review-a"
+                ),
+                _make_agent_result(
+                    success=True, output=PLAN_AGENT_APPROVE, profile_name="plan-review-b"
+                ),
+            ]
+        ),
+    )
+
+    def fake_run_agent(**kwargs):
+        captured_profiles.append(kwargs["profile"])
+        return _make_agent_result(success=True, output="steps: []", profile_name="plan")
+
+    monkeypatch.setattr(plan_flow, "run_agent", fake_run_agent)
+    monkeypatch.setattr(plan_flow, "save_sessions", lambda *_args, **_kwargs: None)
+
+    result = plan_flow._run_plan_agent_review(
+        state=state,
+        config=config,
+        task=_make_task(tmp_path),
+        story_content="story",
+        workspace_path=tmp_path,
+        plan_profile=_profile_from("claude/sonnet", name="plan"),
+        plan_text="steps: []",
+        preflight_result=None,
+        notify=False,
+        logger=_Logger(),
+    )
+
+    assert result is None
+    assert captured_profiles
+    _assert_api_profile(captured_profiles[0], provider="deepseek", model="deepseek-reasoner")


### PR DESCRIPTION
## Summary

Centralizing profile mutation through apply_model_info() correctly preserves transport across CLI/API swaps; registry-key matching fix and tests cover both directions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, claude-opus
- **Cost:** $0.60
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Profile transport mutation produces malformed dispatch state (GitHub Issue #890)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #890