### PR TITLE
CLI-first with API fallback should be the ergonomic default for mixed-transport pools

### DIFF
--- a/docs/vision/cost-tiered-generation.md
+++ b/docs/vision/cost-tiered-generation.md
@@ -171,6 +171,23 @@ where reasoning quality determines outcomes. DEV pass 1, when constrained
 by a strong plan, is closer to transcription than reasoning — and that's
 where cheap/local models can deliver.
 
+## CLI-first with API fallback
+
+When an operator lists a CLI transport model in `models:` and the registry also
+contains the same provider/model on an API transport, TheForge now auto-wires
+that API variant as `api_fallback` for the CLI profile. This makes the ergonomic
+default "burn CLI quota first, then fall back to tracked API usage if quota or
+availability forces the crossing."
+
+Operators can disable this behavior with top-level `auto_api_fallback: false`,
+or override the auto choice for a provider with an explicit
+`provider_fallbacks:` entry.
+
+Sprint-start warnings for CLI transports now distinguish between fully
+untracked CLI-only usage and CLI profiles that have a tracked API fallback. In
+that paired case the warning explains that CLI cost is still untracked, but the
+API fallback cost will be tracked if it triggers.
+
 ## Relationship to Existing Architecture
 
 - **Smart config** already assigns by cost_rank — local models slot in

--- a/src/theforge/config/defaults.py
+++ b/src/theforge/config/defaults.py
@@ -101,6 +101,9 @@ context:
   review_budget: 80
 
 # Optional: same-provider API fallback when a CLI is rate-limited/unavailable.
+# For any CLI model in models: whose same-provider API variant is registered,
+# TheForge wires that API fallback automatically. Set auto_api_fallback: false
+# to disable auto-pairing, or specify provider_fallbacks to override it.
 # provider_fallbacks:
 #   openai:
 #     model: o4-mini

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -24,6 +24,7 @@ from .defaults import (
 )
 from .models import AGENT_REGISTRY, _parse_assignment, resolve_agent_spec
 from .profiles import (
+    CLI_PROVIDER_MAP,
     _agents_from_models,
     _apply_profile_overrides,
     _apply_provider_fallback,
@@ -55,24 +56,75 @@ log = logging.getLogger("theforge.config")
 
 
 def _derive_auto_provider_fallbacks(models: list[str]) -> dict[str, ApiFallbackConfig]:
-    """Auto-wire same-provider API fallbacks for CLI transport models."""
-    fallbacks: dict[str, ApiFallbackConfig] = {}
+    """Auto-wire same-provider API fallbacks for CLI transport models.
+
+    Returns only unambiguous per-provider fallbacks. If multiple CLI models from the
+    same provider appear in models:, auto-wiring is skipped for that provider so we
+    never attach the wrong API model to sibling CLI profiles.
+    """
+    cli_models_by_provider: dict[str, set[str]] = {}
+    api_models_by_provider: dict[str, set[str]] = {}
+
+    for spec in AGENT_REGISTRY.values():
+        if spec.transport.kind == "api":
+            api_models_by_provider.setdefault(spec.provider, set()).add(spec.model)
+
     for model_key in models:
         spec = resolve_agent_spec(model_key)
         if spec.transport.kind != "cli":
             continue
-        provider = spec.provider
-        if provider in fallbacks:
+        cli_models_by_provider.setdefault(spec.provider, set()).add(spec.model)
+
+    fallbacks: dict[str, ApiFallbackConfig] = {}
+    for provider, cli_models in cli_models_by_provider.items():
+        if len(cli_models) != 1:
             continue
-        for candidate in AGENT_REGISTRY.values():
-            if (
-                candidate.transport.kind == "api"
-                and candidate.provider == provider
-                and candidate.model == spec.model
-            ):
-                fallbacks[provider] = ApiFallbackConfig(provider=provider, model=spec.model)
-                break
+        model = next(iter(cli_models))
+        if model not in api_models_by_provider.get(provider, set()):
+            continue
+        fallbacks[provider] = ApiFallbackConfig(provider=provider, model=model)
     return fallbacks
+
+
+def _validate_auto_api_fallback_schema(raw: dict[str, Any]) -> None:
+    """Reject legacy plan_agent_review scalar config only when auto-pairing needs it.
+
+    v0.8 generally rejects legacy scalar plan_agent_review fields alongside models:.
+    For this story we still need to support the legacy scalar shape when it is a CLI
+    profile that can receive the same-provider auto API fallback. Keep the integrity
+    boundary strict for all other mixed-mode cases.
+    """
+    if "models" not in raw:
+        return
+
+    par_raw = raw.get("plan_agent_review")
+    if not isinstance(par_raw, dict):
+        return
+
+    legacy_fields = {"model", "cli", "provider", "budget_usd"} & par_raw.keys()
+    if not legacy_fields:
+        return
+
+    cli = par_raw.get("cli")
+    provider = par_raw.get("provider")
+    model = par_raw.get("model")
+    if provider is not None or not isinstance(cli, str) or not isinstance(model, str):
+        _validate_v0_8_schema(raw)
+        return
+
+    model_key = next(
+        (
+            key
+            for key in raw.get("models", [])
+            if key in AGENT_REGISTRY
+            and (spec := resolve_agent_spec(str(key))).transport.kind == "cli"
+            and spec.provider == CLI_PROVIDER_MAP.get(cli)
+            and spec.model == model
+        ),
+        None,
+    )
+    if model_key is None:
+        _validate_v0_8_schema(raw)
 
 
 def _validate_plan_provider(plan_cfg: "PlanConfig", secrets: dict[str, str]) -> None:
@@ -139,7 +191,12 @@ def load_config(config_path: Path) -> ForgeConfig:
     with open(config_path, encoding="utf-8") as f:
         raw: dict[str, Any] = yaml.safe_load(f) or {}
 
-    _validate_v0_8_schema(raw)
+    try:
+        _validate_v0_8_schema(raw)
+    except ValueError as exc:
+        if "plan_agent_review has legacy scalar field(s)" not in str(exc):
+            raise
+    _validate_auto_api_fallback_schema(raw)
 
     provider_fallbacks = _parse_provider_fallbacks(
         raw.get("provider_fallbacks", {}),
@@ -347,7 +404,25 @@ def load_config(config_path: Path) -> ForgeConfig:
         if plan_timeout_large_raw is not None
         else _plan_default_timeout_large,
         validate_spec=bool(plan_data.get("validate_spec", _plan_default_validate_spec)),
+        api_fallback=_derived_plan_profile.api_fallback
+        if _derived_plan_profile is not None
+        else None,
     )
+    if plan_cfg.cli is not None:
+        plan_profile = ModelProfile(
+            name="plan",
+            cli=plan_cfg.cli,
+            provider=plan_cfg.provider,
+            model=plan_cfg.model,
+            budget_usd=plan_cfg.budget_usd,
+            timeout_seconds=plan_cfg.timeout,
+            timeout_medium_seconds=plan_cfg.timeout_medium,
+            timeout_large_seconds=plan_cfg.timeout_large,
+            allowed_tools=(),
+            api_fallback=plan_cfg.api_fallback,
+        )
+        plan_profile = _apply_provider_fallback(plan_profile, provider_fallbacks)
+        plan_cfg = dataclasses.replace(plan_cfg, api_fallback=plan_profile.api_fallback)
 
     # ── Load-time validation for plan section ────────────────────────────
     if plan_cfg.enabled:
@@ -401,6 +476,23 @@ def load_config(config_path: Path) -> ForgeConfig:
                 _apply_provider_fallback(profile, provider_fallbacks)
                 for profile in plan_agent_review_cfg.pool
             ],
+        )
+    elif plan_agent_review_cfg.cli is not None:
+        legacy_plan_review_profile = ModelProfile(
+            name="plan-review",
+            cli=plan_agent_review_cfg.cli,
+            provider=plan_agent_review_cfg.provider,
+            model=plan_agent_review_cfg.model or "sonnet",
+            budget_usd=plan_agent_review_cfg.budget_usd,
+            timeout_seconds=plan_agent_review_cfg.timeout,
+            allowed_tools=(),
+        )
+        legacy_plan_review_profile = _apply_provider_fallback(
+            legacy_plan_review_profile, provider_fallbacks
+        )
+        plan_agent_review_cfg = dataclasses.replace(
+            plan_agent_review_cfg,
+            api_fallback=legacy_plan_review_profile.api_fallback,
         )
 
     # Logging

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -22,7 +22,7 @@ from .defaults import (
     PROVIDER_SDK_MAP,
     SUPPORTED_CLIS,
 )
-from .models import AGENT_REGISTRY, _parse_assignment
+from .models import AGENT_REGISTRY, _parse_assignment, resolve_agent_spec
 from .profiles import (
     _agents_from_models,
     _apply_profile_overrides,
@@ -33,6 +33,7 @@ from .role_derivation import derive_roles
 from .secrets import _parse_notifications
 from .types import (
     SUPPORTED_PROVIDERS,
+    ApiFallbackConfig,
     ContextConfig,
     FindingClassifierConfig,
     ForgeConfig,
@@ -51,6 +52,27 @@ from .types import (
 )
 
 log = logging.getLogger("theforge.config")
+
+
+def _derive_auto_provider_fallbacks(models: list[str]) -> dict[str, ApiFallbackConfig]:
+    """Auto-wire same-provider API fallbacks for CLI transport models."""
+    fallbacks: dict[str, ApiFallbackConfig] = {}
+    for model_key in models:
+        spec = resolve_agent_spec(model_key)
+        if spec.transport.kind != "cli":
+            continue
+        provider = spec.provider
+        if provider in fallbacks:
+            continue
+        for candidate in AGENT_REGISTRY.values():
+            if (
+                candidate.transport.kind == "api"
+                and candidate.provider == provider
+                and candidate.model == spec.model
+            ):
+                fallbacks[provider] = ApiFallbackConfig(provider=provider, model=spec.model)
+                break
+    return fallbacks
 
 
 def _validate_plan_provider(plan_cfg: "PlanConfig", secrets: dict[str, str]) -> None:
@@ -123,6 +145,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         raw.get("provider_fallbacks", {}),
         secrets=secrets,
     )
+    auto_api_fallback = bool(raw.get("auto_api_fallback", True))
 
     workspace = _parse_workspace(raw.get("workspace", {}))
 
@@ -225,6 +248,9 @@ def load_config(config_path: Path) -> ForgeConfig:
                 ]
 
         models = [str(m) for m in models_list]
+        if auto_api_fallback:
+            auto_provider_fallbacks = _derive_auto_provider_fallbacks(models)
+            provider_fallbacks = {**auto_provider_fallbacks, **provider_fallbacks}
         # Track which roles were auto-derived vs explicitly overridden. Complexity-aware
         # adaptation (preflight._apply_complexity_adaptation) only rewrites auto-derived
         # roles so explicit overrides bypass routing.
@@ -558,6 +584,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         agents=agents_list,
         assignment=assignment_cfg,
         provider_fallbacks=provider_fallbacks,
+        auto_api_fallback=auto_api_fallback,
         review_pool_is_default=_review_pool_is_default,
         plan_model_is_default=_plan_model_is_default,
         dev_profile_is_default=_dev_profile_is_default,

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -96,6 +96,8 @@ def _validate_auto_api_fallback_schema(raw: dict[str, Any]) -> None:
     """
     if "models" not in raw:
         return
+    if not isinstance(raw.get("models"), list):
+        return
 
     par_raw = raw.get("plan_agent_review")
     if not isinstance(par_raw, dict):
@@ -115,7 +117,7 @@ def _validate_auto_api_fallback_schema(raw: dict[str, Any]) -> None:
     model_key = next(
         (
             key
-            for key in raw.get("models", [])
+            for key in (raw.get("models") or [])
             if key in AGENT_REGISTRY
             and (spec := resolve_agent_spec(str(key))).transport.kind == "cli"
             and spec.provider == CLI_PROVIDER_MAP.get(cli)

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -453,8 +453,10 @@ def _apply_provider_fallback(
         base_url=profile.base_url,
         max_tool_output_bytes=profile.max_tool_output_bytes,
         max_iterations=profile.max_iterations,
+        fallback_models=profile.fallback_models,
         api_fallback=fallback,
         github_handle=profile.github_handle,
         phase=profile.phase,
         sandbox_mode=profile.sandbox_mode,
+        transport=profile.transport,
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -383,6 +383,7 @@ class ForgeConfig:
     agents: list[AgentDef] = field(default_factory=list)
     assignment: AssignmentConfig = field(default_factory=AssignmentConfig)
     provider_fallbacks: dict[str, ApiFallbackConfig] = field(default_factory=dict)
+    auto_api_fallback: bool = True
     review_pool_is_default: bool = False  # True when review_pool was not explicitly configured
     plan_model_is_default: bool = False  # True when plan.cli/model were not explicitly configured
     dev_profile_is_default: bool = (

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -226,6 +226,7 @@ class PlanConfig:
     timeout_medium: int | None = None  # override for medium complexity
     timeout_large: int | None = None  # override for large complexity
     validate_spec: bool = True  # whether to run story_validator before planning
+    api_fallback: ApiFallbackConfig | None = None  # CLI-only fallback to same-provider API
 
 
 @dataclass(frozen=True)
@@ -258,6 +259,7 @@ class PlanAgentReviewConfig:
     timeout: int = 300
     # Pool format — populated by load_forge_yaml when pool: key is present.
     pool: list[ModelProfile] = field(default_factory=list)
+    api_fallback: ApiFallbackConfig | None = None  # legacy scalar profile fallback
     min_reviewers: int = 1
 
     @property
@@ -282,6 +284,7 @@ class PlanAgentReviewConfig:
                 budget_usd=self.budget_usd,
                 timeout_seconds=self.timeout,
                 allowed_tools=allowed_tools,
+                api_fallback=self.api_fallback,
             )
         ]
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -107,7 +107,15 @@ def _agent_cost_tracking_warnings(config: ForgeConfig) -> list[str]:
     ]
 
     if config.plan.enabled:
-        agents.append(("planner", config.plan.cli, config.plan.provider, config.plan.model, None))
+        agents.append(
+            (
+                "planner",
+                config.plan.cli,
+                config.plan.provider,
+                config.plan.model,
+                config.plan.api_fallback,
+            )
+        )
 
     if config.plan_agent_review.enabled:
         agents.extend(

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -89,32 +89,34 @@ def _read_prior_sprint_cost(project_root: Path) -> float:
 def _agent_cost_tracking_warnings(config: ForgeConfig) -> list[str]:
     """Return sprint-start warnings for configured CLI agents with unknown cost."""
 
-    agents: list[tuple[str, str | None, str | None, str]] = [
+    agents: list[tuple[str, str | None, str | None, str, object | None]] = [
         (
             config.preflight_profile.name,
             config.preflight_profile.cli,
             config.preflight_profile.provider,
             config.preflight_profile.model,
+            config.preflight_profile.api_fallback,
         ),
         (
             config.dev_profile.name,
             config.dev_profile.cli,
             config.dev_profile.provider,
             config.dev_profile.model,
+            config.dev_profile.api_fallback,
         ),
     ]
 
     if config.plan.enabled:
-        agents.append(("planner", config.plan.cli, config.plan.provider, config.plan.model))
+        agents.append(("planner", config.plan.cli, config.plan.provider, config.plan.model, None))
 
     if config.plan_agent_review.enabled:
         agents.extend(
-            (profile.name, profile.cli, profile.provider, profile.model)
+            (profile.name, profile.cli, profile.provider, profile.model, profile.api_fallback)
             for profile in config.plan_agent_review.profiles
         )
 
     agents.extend(
-        (profile.name, profile.cli, profile.provider, profile.model)
+        (profile.name, profile.cli, profile.provider, profile.model, profile.api_fallback)
         for profile in config.review_pool
     )
 
@@ -125,18 +127,27 @@ def _agent_cost_tracking_warnings(config: ForgeConfig) -> list[str]:
                 config.synthesis_profile.cli,
                 config.synthesis_profile.provider,
                 config.synthesis_profile.model,
+                config.synthesis_profile.api_fallback,
             )
         )
 
     warnings: list[str] = []
-    seen: set[tuple[str, str, str]] = set()
-    for name, cli, provider, model in agents:
+    seen: set[tuple[str, str, str, str | None, str | None]] = set()
+    for name, cli, provider, model, api_fallback in agents:
         if provider is not None or cli not in _UNTRACKED_COST_CLIS:
             continue
-        key = (name, cli, model)
+        fallback_provider = getattr(api_fallback, "provider", None)
+        fallback_model = getattr(api_fallback, "model", None)
+        key = (name, cli, model, fallback_provider, fallback_model)
         if key in seen:
             continue
         seen.add(key)
+        if api_fallback is not None:
+            warnings.append(
+                f"⚠ CLI cost not tracked for {name} ({cli} CLI, {model}); API fallback to "
+                f"{fallback_provider}/{fallback_model} will be tracked if it triggers."
+            )
+            continue
         warnings.append(
             f"⚠ Cost not tracked for {name} ({cli} CLI, {model}). "
             "Audit totals will exclude this agent's usage."

--- a/tests/test_config_auto_api_fallback.py
+++ b/tests/test_config_auto_api_fallback.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from theforge.config import load_config
 from theforge.config.types import PlanConfig
 from theforge.sprint.runner import _agent_cost_tracking_warnings
@@ -170,3 +172,22 @@ plan:
         for warning in warnings
     )
     assert any("planner" in warning for warning in warnings)
+
+
+def test_models_null_still_raises_clean_schema_error_with_legacy_plan_agent_review(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+plan_agent_review:
+  enabled: true
+  cli: codex
+  model: gpt-5.4
+""",
+    )
+    with (
+        _auth_ok,
+        _import_ok,
+        pytest.raises(ValueError, match="'models' must be a non-empty list"),
+    ):
+        load_config(cfg_path)

--- a/tests/test_config_auto_api_fallback.py
+++ b/tests/test_config_auto_api_fallback.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from theforge.config import load_config
+from theforge.sprint.runner import _agent_cost_tracking_warnings
+
+
+def _write(tmp_path, text: str):
+    p = tmp_path / "forge.yaml"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+_auth_ok = patch("theforge.config.load.check_agent_auth", return_value=(True, ""))
+_import_ok = patch("importlib.import_module")
+
+
+def test_cli_model_auto_pairs_same_provider_api_fallback(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - openai/gpt-5.4
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile.cli == "codex"
+    assert cfg.dev_profile.api_fallback is not None
+    assert cfg.dev_profile.api_fallback.provider == "openai"
+    assert cfg.dev_profile.api_fallback.model == "gpt-5.4"
+
+
+def test_cli_model_without_matching_api_sibling_does_not_auto_pair(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile.cli == "claude"
+    assert cfg.dev_profile.api_fallback is None
+
+
+def test_auto_api_fallback_false_disables_auto_pairing(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+auto_api_fallback: false
+models:
+  - openai/gpt-5.4
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.auto_api_fallback is False
+    assert cfg.dev_profile.api_fallback is None
+
+
+def test_explicit_provider_fallback_wins_over_auto_pairing(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - openai/gpt-5.4
+provider_fallbacks:
+  openai:
+    model: o4-mini
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile.api_fallback is not None
+    assert cfg.dev_profile.api_fallback.provider == "openai"
+    assert cfg.dev_profile.api_fallback.model == "o4-mini"
+
+
+def test_sprint_warning_mentions_tracked_api_fallback(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - openai/gpt-5.4
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    warnings = _agent_cost_tracking_warnings(cfg)
+    assert any(
+        "API fallback to openai/gpt-5.4 will be tracked if it triggers" in warning
+        for warning in warnings
+    )

--- a/tests/test_config_auto_api_fallback.py
+++ b/tests/test_config_auto_api_fallback.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from theforge.config import load_config
+from theforge.config.types import PlanConfig
 from theforge.sprint.runner import _agent_cost_tracking_warnings
 
 
@@ -83,12 +84,81 @@ provider_fallbacks:
     assert cfg.dev_profile.api_fallback.model == "o4-mini"
 
 
+def test_multiple_cli_models_same_provider_do_not_cross_wire_auto_fallbacks(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - openai/gpt-5.4
+  - openai/gpt-5.4-mini
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile.cli == "codex"
+    assert cfg.dev_profile.model in {"gpt-5.4", "gpt-5.4-mini"}
+    assert cfg.dev_profile.api_fallback is None
+    assert all(profile.api_fallback is None for profile in cfg.review_pool)
+
+
+def test_plan_cli_model_receives_auto_api_fallback(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - openai/gpt-5.4
+plan:
+  enabled: true
+  cli: codex
+  model: gpt-5.4
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    assert isinstance(cfg.plan, PlanConfig)
+    assert cfg.plan.api_fallback is not None
+    assert cfg.plan.api_fallback.provider == "openai"
+    assert cfg.plan.api_fallback.model == "gpt-5.4"
+
+
+def test_legacy_plan_agent_review_cli_receives_auto_api_fallback(tmp_path):
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - openai/gpt-5.4
+plan:
+  enabled: true
+  cli: claude
+  model: sonnet
+plan_agent_review:
+  enabled: true
+  cli: codex
+  model: gpt-5.4
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    profiles = cfg.plan_agent_review.profiles
+    assert len(profiles) == 1
+    assert profiles[0].api_fallback is not None
+    assert profiles[0].api_fallback.provider == "openai"
+    assert profiles[0].api_fallback.model == "gpt-5.4"
+
+
 def test_sprint_warning_mentions_tracked_api_fallback(tmp_path):
     cfg_path = _write(
         tmp_path,
         """
 models:
   - openai/gpt-5.4
+plan:
+  enabled: true
+  cli: codex
+  model: gpt-5.4
 """,
     )
     with _auth_ok, _import_ok:
@@ -99,3 +169,4 @@ models:
         "API fallback to openai/gpt-5.4 will be tracked if it triggers" in warning
         for warning in warnings
     )
+    assert any("planner" in warning for warning in warnings)


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] All prior P1 issues resolved, implementation satisfies acceptance criteria, tests pass, no regressions detected | [claude-opus] All four prior P1 findings resolved; no regressions introduced.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $13.65
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

CLI-first with API fallback should be the ergonomic default for mixed-transport pools (GitHub Issue #891)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #891