### PR TITLE
Forge gate must run in scrubbed environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,9 @@ land in `.forge/worktrees/<slug>/` on branch `feat/<slug>`.
 - All tests must pass before committing
 - New coordinator behaviour → add a `tests/test_coord_*.py` file matching the phase
 - New runner behaviour → `tests/test_runner_*.py`
-- Mock subprocess; never invoke real agent CLIs in tests
+- `make gate` runs in a scrubbed environment: agent credentials, CLI auth state, and dotenv autoload inputs are stripped before tests execute.
+- Mock subprocess; never invoke real agent CLIs in tests. Any forgotten runner/provider mock in the default gate suite should fail fast under the gate scrub sentinel.
+- Tests that legitimately require real credentials must be marked `@pytest.mark.network_integration` and run via `make test-integration`; they are not part of `make gate`.
 - **Never use `fcntl.flock` in tests that also use `threading`.** pytest runs with
   `-n auto --dist worksteal` (xdist), which forks worker processes. A forked worker
   inherits open file descriptors with held locks, causing sibling threads to block

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SCRUBBED_ENV_VARS := OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY XAI_API_KEY GROQ_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_BASE_URL DOTENV_PATH DOTENV_FILE PYTHON_DOTENV_DISABLED
 GATE_PYTEST_CMD = PYTHONPATH=src python -m pytest tests/ -q -n auto --dist worksteal
-SCRUBBED_GATE_CMD = env -i PATH=".venv/bin:$$PATH" HOME="$$HOME" /bin/sh -c 'unset $(SCRUBBED_ENV_VARS); ruff check src/ tests/ && ruff format --check src/ tests/ && $(GATE_PYTEST_CMD)'
+SCRUBBED_GATE_CMD = env -i PATH=".venv/bin:$$PATH" HOME="$$HOME" PYTHON_DOTENV_DISABLED=1 /bin/sh -c 'unset $(SCRUBBED_ENV_VARS); export PYTHON_DOTENV_DISABLED=1; ruff check src/ tests/ && ruff format --check src/ tests/ && $(GATE_PYTEST_CMD)'
 
 # Format
 fmt:
@@ -37,7 +37,7 @@ gate-strict:
 
 # Serial gate: same checks without xdist, useful for debugging hangs.
 gate-serial:
-	@env -i PATH=".venv/bin:$$PATH" HOME="$$HOME" /bin/sh -c 'unset $(SCRUBBED_ENV_VARS); ruff check src/ tests/ && ruff format --check src/ tests/ && PYTHONPATH=src python -m pytest tests/ -q'
+	@env -i PATH=".venv/bin:$$PATH" HOME="$$HOME" PYTHON_DOTENV_DISABLED=1 /bin/sh -c 'unset $(SCRUBBED_ENV_VARS); export PYTHON_DOTENV_DISABLED=1; ruff check src/ tests/ && ruff format --check src/ tests/ && PYTHONPATH=src python -m pytest tests/ -q'
 
 test-integration:
 	@THEFORGE_RUN_INTEGRATION=1 THEFORGE_ALLOW_AGENT_CREDS=1 PYTHONPATH=src .venv/bin/python -m pytest tests/ -v -n auto --dist worksteal -m network_integration

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: fmt lint test test-parallel gate gate-serial clean
+.PHONY: fmt lint test test-parallel gate gate-strict gate-serial test-integration clean
+
+SCRUBBED_ENV_VARS := OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY XAI_API_KEY GROQ_API_KEY ANTHROPIC_AUTH_TOKEN OPENAI_BASE_URL DOTENV_PATH DOTENV_FILE PYTHON_DOTENV_DISABLED
+GATE_PYTEST_CMD = PYTHONPATH=src python -m pytest tests/ -q -n auto --dist worksteal
+SCRUBBED_GATE_CMD = env -i PATH=".venv/bin:$$PATH" HOME="$$HOME" /bin/sh -c 'unset $(SCRUBBED_ENV_VARS); ruff check src/ tests/ && ruff format --check src/ tests/ && $(GATE_PYTEST_CMD)'
 
 # Format
 fmt:
@@ -25,15 +29,18 @@ test-parallel:
 gate:
 	@mkdir -p .forge/index .forge && \
 	forge index && \
-	ruff check src/ tests/ && \
-	ruff format --check src/ tests/ && \
-	PYTHONPATH=src python -m pytest tests/ -q -n auto --dist worksteal
+	$(SCRUBBED_GATE_CMD)
+
+# Transitional alias retained for one release while the scrubbed gate rolls out.
+gate-strict:
+	@$(SCRUBBED_GATE_CMD)
 
 # Serial gate: same checks without xdist, useful for debugging hangs.
 gate-serial:
-	@ruff check src/ tests/ && \
-	ruff format --check src/ tests/ && \
-	PYTHONPATH=src python -m pytest tests/ -q
+	@env -i PATH=".venv/bin:$$PATH" HOME="$$HOME" /bin/sh -c 'unset $(SCRUBBED_ENV_VARS); ruff check src/ tests/ && ruff format --check src/ tests/ && PYTHONPATH=src python -m pytest tests/ -q'
+
+test-integration:
+	@THEFORGE_RUN_INTEGRATION=1 THEFORGE_ALLOW_AGENT_CREDS=1 PYTHONPATH=src .venv/bin/python -m pytest tests/ -v -n auto --dist worksteal -m network_integration
 
 clean:
 	rm -rf .forge/worktrees/ .forge/audit.yaml

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -146,6 +146,12 @@ forge check-providers
 `forge check-config` is the fastest way to catch config drift, missing auth,
 and deprecated settings before spending tokens on a real run.
 
+For this repo's own development workflow, `make gate` now scrubs agent credentials,
+CLI auth state, and dotenv-related inputs before running tests. That makes a green
+local gate match CI more closely: if a test forgot to mock a runner or only passes
+because your shell is authenticated, it should fail locally too. Real-credential
+checks belong in the opt-in `make test-integration` suite instead.
+
 ## 6. Write your first story
 
 Copy `stories/TEMPLATE.md` to `stories/my-feature.md` and fill it in:

--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -19,6 +19,7 @@ from .defaults import (
     SUPPORTED_CLIS,
     generate_default_config,
 )
+from .gate_scrub import SCRUBBED_ENV_VARS, SCRUBBED_HOME_PATHS
 from .load import _validate_plan_provider, load_config
 from .models import (
     AGENT_REGISTRY,
@@ -97,6 +98,8 @@ __all__ = [
     "PROVIDER_SDK_MAP",
     "SUPPORTED_CLIS",
     "generate_default_config",
+    "SCRUBBED_ENV_VARS",
+    "SCRUBBED_HOME_PATHS",
     # load
     "_validate_plan_provider",
     "load_config",

--- a/src/theforge/config/gate_scrub.py
+++ b/src/theforge/config/gate_scrub.py
@@ -1,0 +1,42 @@
+"""Credential and auth-state scrub definitions for gate/test isolation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .auth import PROVIDER_API_KEY_MAP
+from .models import AGENT_REGISTRY
+
+_PROVIDER_ENV_ALIASES: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_AUTH_TOKEN",),
+    "google": ("GEMINI_API_KEY",),
+    "openai": ("OPENAI_BASE_URL",),
+}
+
+_DOTENV_ENV_VARS: tuple[str, ...] = (
+    "DOTENV_PATH",
+    "DOTENV_FILE",
+    "PYTHON_DOTENV_DISABLED",
+)
+
+_PROVIDER_ENV_VARS = {env_var for env_var in PROVIDER_API_KEY_MAP.values()}
+for spec in AGENT_REGISTRY.values():
+    _PROVIDER_ENV_VARS.update(_PROVIDER_ENV_ALIASES.get(spec.provider, ()))
+
+SCRUBBED_ENV_VARS: tuple[str, ...] = tuple(
+    sorted(
+        {
+            *_PROVIDER_ENV_VARS,
+            *_DOTENV_ENV_VARS,
+        }
+    )
+)
+
+SCRUBBED_HOME_PATHS: tuple[Path, ...] = (
+    Path(".codex") / "auth.json",
+    Path(".claude"),
+    Path(".config") / "gcloud",
+    Path(".gemini"),
+)
+
+__all__ = ["SCRUBBED_ENV_VARS", "SCRUBBED_HOME_PATHS"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,7 +252,14 @@ def _block_real_coordinator_runners():
 
     Tests that genuinely need one of these boundaries should patch that symbol
     explicitly in the test body or decorator stack.
+
+    Lifted when ``THEFORGE_ALLOW_AGENT_CREDS=1`` so that
+    ``make test-integration`` and other opt-in suites can exercise real
+    coordinator/runner paths end-to-end.
     """
+    if not _gate_scrub_enabled():
+        yield
+        return
 
     def _unexpected_call(symbol: str) -> AssertionError:
         return AssertionError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import ipaddress
 import os
 import socket as _socket_module
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from theforge.config import ModelProfile
+from theforge.config import SCRUBBED_ENV_VARS, SCRUBBED_HOME_PATHS, ModelProfile
 
 # ---------------------------------------------------------------------------
 # Global network guard — installed at conftest load time
@@ -71,6 +73,57 @@ class _BlockedSocket(_REAL_SOCKET):
 
 # Install the guard before any test module is imported.
 _socket_module.socket = _BlockedSocket
+
+
+def _gate_scrub_enabled() -> bool:
+    return os.environ.get("THEFORGE_ALLOW_AGENT_CREDS") != "1"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _scrub_agent_credentials_for_gate():
+    """Strip agent credentials/auth state unless explicitly opted out.
+
+    This mirrors the Makefile gate scrub so direct pytest runs in a dirty shell
+    still enforce the same minimum isolation contract.
+    """
+    if not _gate_scrub_enabled():
+        yield
+        return
+
+    stripped = sorted(name for name in SCRUBBED_ENV_VARS if name in os.environ)
+    original_env = {name: os.environ.get(name) for name in SCRUBBED_ENV_VARS}
+    original_home = os.environ.get("HOME")
+
+    for name in SCRUBBED_ENV_VARS:
+        os.environ.pop(name, None)
+    os.environ["PYTHON_DOTENV_DISABLED"] = "1"
+
+    with tempfile.TemporaryDirectory(prefix="theforge-gate-home-") as tmp_home:
+        scrubbed_home = Path(tmp_home)
+        for rel_path in SCRUBBED_HOME_PATHS:
+            target = scrubbed_home / rel_path
+            if rel_path.suffix:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.touch()
+            else:
+                target.mkdir(parents=True, exist_ok=True)
+        os.environ["HOME"] = str(scrubbed_home)
+        print(
+            "[theforge-test-guard] scrubbed agent credentials: "
+            + (", ".join(stripped) if stripped else "none")
+        )
+        try:
+            yield
+        finally:
+            if original_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = original_home
+            for name, value in original_env.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
 
 
 @pytest.fixture(autouse=True)
@@ -202,7 +255,9 @@ def _block_real_coordinator_runners():
     """
 
     def _unexpected_call(symbol: str) -> AssertionError:
-        return AssertionError(f"Test hit real {symbol}; patch {symbol} explicitly.")
+        return AssertionError(
+            f"real agent call blocked by gate scrub: {symbol}; patch {symbol} explicitly."
+        )
 
     with (
         patch(
@@ -228,6 +283,34 @@ def _block_real_coordinator_runners():
         patch(
             "theforge.coordinator.dev_phase.run_agent",
             side_effect=_unexpected_call("theforge.coordinator.dev_phase.run_agent"),
+        ),
+        patch(
+            "theforge.coordinator.workspace.run_agent",
+            side_effect=_unexpected_call("theforge.coordinator.workspace.run_agent"),
+        ),
+        patch(
+            "theforge.ideate.run_agent",
+            side_effect=_unexpected_call("theforge.ideate.run_agent"),
+        ),
+        patch(
+            "theforge.ideate.run_agent_pool",
+            side_effect=_unexpected_call("theforge.ideate.run_agent_pool"),
+        ),
+        patch(
+            "theforge.cli.providers.run_api_agent",
+            side_effect=_unexpected_call("theforge.cli.providers.run_api_agent"),
+        ),
+        patch(
+            "theforge.runners.run_agent",
+            side_effect=_unexpected_call("theforge.runners.run_agent"),
+        ),
+        patch(
+            "theforge.runners.run_agent_pool",
+            side_effect=_unexpected_call("theforge.runners.run_agent_pool"),
+        ),
+        patch(
+            "theforge.runners.run_api_agent",
+            side_effect=_unexpected_call("theforge.runners.run_api_agent"),
         ),
     ):
         yield

--- a/tests/test_gate_scrub.py
+++ b/tests/test_gate_scrub.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from theforge.config import SCRUBBED_ENV_VARS, SCRUBBED_HOME_PATHS
+from theforge.config.gate_scrub import SCRUBBED_ENV_VARS as MODULE_ENV_VARS
+
+
+def test_scrubbed_env_vars_cover_expected_credentials():
+    expected = {
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "OPENAI_BASE_URL",
+        "DOTENV_PATH",
+        "DOTENV_FILE",
+        "PYTHON_DOTENV_DISABLED",
+    }
+    assert expected.issubset(set(SCRUBBED_ENV_VARS))
+    assert SCRUBBED_ENV_VARS == MODULE_ENV_VARS
+
+
+def test_scrubbed_home_paths_cover_cli_auth_locations():
+    scrubbed = {Path(p) for p in SCRUBBED_HOME_PATHS}
+    assert Path(".codex/auth.json") in scrubbed
+    assert Path(".claude") in scrubbed
+    assert Path(".config/gcloud") in scrubbed
+    assert Path(".gemini") in scrubbed
+
+
+def test_gate_scrub_fixture_sets_dotenv_disable_and_rehomes_home():
+    assert os.environ["PYTHON_DOTENV_DISABLED"] == "1"
+    scrubbed_home = Path(os.environ["HOME"])
+    for rel_path in SCRUBBED_HOME_PATHS:
+        assert (scrubbed_home / rel_path).exists()
+
+
+def test_real_runner_sentinel_message_is_gate_specific():
+    with pytest.raises(AssertionError, match="real agent call blocked by gate scrub"):
+        raise AssertionError(
+            "real agent call blocked by gate scrub: theforge.runners.run_agent; "
+            "patch theforge.runners.run_agent explicitly."
+        )

--- a/tests/test_makefile_gate.py
+++ b/tests/test_makefile_gate.py
@@ -8,8 +8,11 @@ def test_gate_runs_index_before_pytest() -> None:
     gate_block = makefile[gate_start:gate_end]
 
     index_cmd = "forge index"
+    scrubbed_invocation = "$(SCRUBBED_GATE_CMD)"
     pytest_cmd = "PYTHONPATH=src python -m pytest tests/ -q -n auto --dist worksteal"
 
     assert index_cmd in gate_block
-    assert pytest_cmd in gate_block
-    assert gate_block.index(index_cmd) < gate_block.index(pytest_cmd)
+    assert scrubbed_invocation in gate_block
+    assert gate_block.index(index_cmd) < gate_block.index(scrubbed_invocation)
+    # The scrubbed gate command itself carries the pytest invocation.
+    assert pytest_cmd in makefile


### PR DESCRIPTION
## Summary

The default `make gate` now runs lint/format/pytest inside a scrubbed `env -i` shell that strips provider API keys, CLI auth tokens, base-URL overrides, and dotenv inputs. The pytest conftest mirrors the same scrub for direct invocations and rehomes `HOME` to a tempdir seeded with empty placeholders for `~/.codex`, `~/.claude`, `~/.config/gcloud`, and `~/.gemini`. Runner entry points are sentinel-patched so tests that forget to stub dispatch fail fast with a gate-specific error. Real-credentialed tests opt in via `@pytest.mark.network_integration` and `make test-integration` (`THEFORGE_RUN_INTEGRATION=1` + `THEFORGE_ALLOW_AGENT_CREDS=1`).

## Review

- **Verdict:** APPROVE (0 P1, 2 P2 — both addressed in `5de6fe0`)
- **Reviewer:** Human (this chat)
- **Findings addressed:**
  - Makefile was unsetting `PYTHON_DOTENV_DISABLED`, which diverged from conftest setting it to `"1"`. Gate now exports it inside the scrubbed shell so `.env` autoload is actually suppressed in both paths.
  - `_block_real_coordinator_runners` patched runner entry points unconditionally, defeating the `make test-integration` escape hatch. Now gated on `_gate_scrub_enabled()`.

## Story

Forge gate must run in scrubbed environment with no agent credentials available (GitHub Issue #900)

## Test plan

- [x] `make gate` → 3246 passed, 1 skipped, 0 failures
- [x] New `tests/test_gate_scrub.py` covers env-var + HOME-path invariants
- [x] `tests/test_makefile_gate.py` updated to validate the scrubbed-gate contract

---
*Manually created — completes the escalated #900 worktree.*

Closes #900