### PR TITLE
Point forge.yaml gate_command at make gate

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -28,7 +28,7 @@ workspace:
 validation:
   # Gate pass/fail is exit-code only. v0.8 removed handoff_file and
   # gate_decision_key; do not add them back under validation:.
-  gate_command: ".venv/bin/ruff check src/ tests/ && .venv/bin/ruff format --check src/ tests/ && .venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
+  gate_command: "make gate"
   # Canonical intermediate test command dev agents should use while working.
   test_command: ".venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
   gate_timeout: 45


### PR DESCRIPTION
## Summary

Collapse the two divergent gate definitions (Makefile `gate` target vs `forge.yaml` `validation.gate_command`) into a single source of truth by pointing the yaml at `make gate`. This closes the scrubbed-env leak that escalated #857: sprint validation was running a raw command that inherited the user's shell env, while `make gate` runs scrubbed under `env -i`.

Stop-gap only. #910 tracks the architectural fix (project-owned scrub policy + coordinator-enforced wrapping of `gate_command`).

## Test plan

- [x] `make gate` → 3250 passed, 1 skipped, 0 failures

Closes #911