### PR TITLE
update_finding_registry crashes when Finding.line is mixed str/int

### DIFF
--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -15,6 +15,21 @@ import yaml
 from .schemas import repair_review_yaml, validate_review_yaml
 
 
+def _coerce_line(value: object) -> int | None:
+    """Coerce a reviewer-supplied line value to int or None.
+
+    Reviewers sometimes emit line numbers as strings (e.g. "42") or omit them
+    entirely.  Any value that cannot be interpreted as a non-negative integer is
+    treated as None so downstream arithmetic never crashes.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass(frozen=True)
 class ReviewFinding:
     """A single review finding with severity and location."""
@@ -77,7 +92,7 @@ def parse_review_json(data: dict) -> ReviewResult:
                 ReviewFinding(
                     severity=f.get("severity", "P2"),
                     file=f.get("file", "unknown"),
-                    line=f.get("line"),
+                    line=_coerce_line(f.get("line")),
                     description=f.get("description", ""),
                     suggestion=f.get("suggestion"),
                 )
@@ -165,7 +180,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
                 ReviewFinding(
                     severity=f.get("severity", "P2"),
                     file=f.get("file", "unknown"),
-                    line=f.get("line"),
+                    line=_coerce_line(f.get("line")),
                     description=f.get("description", ""),
                     suggestion=f.get("suggestion"),
                 )

--- a/tests/test_finding_classifier.py
+++ b/tests/test_finding_classifier.py
@@ -13,6 +13,7 @@ from theforge.finding_classifier import (
     _matches_prior,
     _matches_prior_agnostic,
     _normalize_tokens,
+    _should_merge_line_proximity,
     has_blocking_p1,
     net_new_p1s,
     update_finding_registry,
@@ -663,6 +664,39 @@ class TestNetNewP1s:
         assert len(result) == 1
         assert result[0].disposition == "net_new"
         assert result[0].severity == "P1"
+
+
+class TestShouldMergeLineProximity:
+    """Tests for _should_merge_line_proximity."""
+
+    def _make_reports(self, line: int | None) -> list[tuple[str, ReviewFinding]]:
+        return [
+            (
+                "reviewer-a",
+                ReviewFinding(
+                    severity="P1",
+                    file="src/foo.py",
+                    line=line,
+                    description="some bug",
+                    suggestion="fix it",
+                ),
+            )
+        ]
+
+    def test_int_lines_within_3_merge(self):
+        reports_a = self._make_reports(10)
+        reports_b = self._make_reports(12)
+        assert _should_merge_line_proximity(reports_a, reports_b) is True
+
+    def test_int_lines_beyond_3_no_merge(self):
+        reports_a = self._make_reports(10)
+        reports_b = self._make_reports(20)
+        assert _should_merge_line_proximity(reports_a, reports_b) is False
+
+    def test_none_lines_no_merge(self):
+        reports_a = self._make_reports(None)
+        reports_b = self._make_reports(None)
+        assert _should_merge_line_proximity(reports_a, reports_b) is False
 
 
 class TestGetChangedFiles:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -4,6 +4,7 @@ from theforge.review import (
     ReviewFinding,
     ReviewResult,
     _best_individual_result,
+    _coerce_line,
     _dedup_findings,
     _try_parse_review,
     findings_to_markdown,
@@ -507,3 +508,63 @@ class TestMergeReviewResultsDedup:
         merged = merge_review_results([valid, invalid], ["a", "b"])
         assert not merged.parse_errors
         assert len(merged.findings) == 1
+
+
+# ── Tests: _coerce_line ──────────────────────────────────────────────
+
+
+class TestCoerceLine:
+    def test_none_returns_none(self):
+        assert _coerce_line(None) is None
+
+    def test_int_passthrough(self):
+        assert _coerce_line(42) == 42
+
+    def test_string_int_coerced(self):
+        assert _coerce_line("42") == 42
+
+    def test_string_zero(self):
+        assert _coerce_line("0") == 0
+
+    def test_float_truncated(self):
+        assert _coerce_line(3.9) == 3
+
+    def test_non_numeric_string_returns_none(self):
+        assert _coerce_line("N/A") is None
+
+    def test_empty_string_returns_none(self):
+        assert _coerce_line("") is None
+
+    def test_object_returns_none(self):
+        assert _coerce_line([1, 2]) is None
+
+
+# ── Tests: parse_review_output with string line values ───────────────
+
+
+REVIEW_WITH_STRING_LINE = """\
+```yaml
+verdict: REQUEST_CHANGES
+summary: "String line number emitted by reviewer"
+findings:
+  - severity: P1
+    file: src/foo.py
+    line: "42"
+    description: "Bug with string line"
+    suggestion: "Fix it"
+story_compliance:
+  matches_spec: true
+  mismatches: []
+test_coverage:
+  adequate: true
+  gaps: []
+```
+"""
+
+
+class TestParseReviewOutputStringLine:
+    def test_string_line_coerced_to_int(self):
+        result = parse_review_output(REVIEW_WITH_STRING_LINE)
+        assert len(result.findings) == 1
+        assert result.findings[0].line == 42
+        assert isinstance(result.findings[0].line, int)


### PR DESCRIPTION
## Summary

Line coercion is applied on both review parsing paths, prevents the reported str/int crash, and is covered by focused tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.61
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

update_finding_registry crashes when Finding.line is mixed str/int (GitHub Issue #908)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #908