### PR TITLE
Revert #920: sandbox-exec wrapping breaks Claude CLI auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,9 @@ classification that controls $20-50 of downstream spend is correct.
 
 ## Conventions
 
+### Coordinator seam changes require integration tests
+Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow.
+
 ### No LLM in the loop for process decisions
 The coordinator is pure Python. If you find yourself writing code where an LLM
 decides whether to retry or escalate, stop — that decision belongs in the coordinator.

--- a/forge.yaml
+++ b/forge.yaml
@@ -48,6 +48,7 @@ conventions:
     - "Separate prompt construction, output parsing, and coordinator control flow"
     - "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail — diagnosing sprint failures requires tracing real data, not reconstructing it"
     - "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing."
+    - "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
 
 retry:
   max_dev_iterations: 3

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -19,7 +19,6 @@ from theforge.task.handoff_parser import ParseError, extract_dev_handoff
 from theforge.workspace_env import build_workspace_env
 
 from ..config import ModelProfile
-from .sandbox import read_only_sandbox_command, workspace_effect_sandbox_command
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -184,62 +183,20 @@ def _run_claude(
     if session_id:
         cmd.extend(["--resume", session_id])
 
-    # Keep Claude's native permission mode enabled when sandboxing is requested.
-    # The OS sandbox is the enforcement mechanism; Claude's own permission mode
-    # remains as a cooperative layer.
+    # Engage Claude's native permission mode when sandboxing is requested.
+    # "default" prompts before writes outside cwd; in automated runs where there is
+    # no human to approve, out-of-worktree writes are effectively blocked.
+    # NOTE: Claude CLI has no mechanically-enforced read-only mode. When
+    # sandbox_mode == "read-only" we apply the same --permission-mode default and
+    # log a warning so operators know the read-only constraint is not syscall-enforced.
+    if profile.sandbox_mode == "read-only":
+        _log(
+            "  WARNING: sandbox_mode=read-only is not mechanically enforced by Claude CLI; "
+            "applying --permission-mode default (writes require permission approval). "
+            "Use a provider/API profile for true read-only enforcement."
+        )
     if profile.sandbox_mode != "none":
         cmd.extend(["--permission-mode", "default"])
-        claude_state_dir = Path.home() / ".claude"
-        if not claude_state_dir.exists():
-            try:
-                claude_state_dir.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
-                return AgentResult(
-                    success=False,
-                    output=(
-                        "SANDBOX_UNAVAILABLE: unable to prepare Claude state directory "
-                        f"{claude_state_dir}: {exc}"
-                    ),
-                    session_id=None,
-                    cost_usd=None,
-                    exit_code=-1,
-                    raw={},
-                    profile_name=profile.name,
-                    startup_failure=True,
-                )
-        sandbox_builder = (
-            read_only_sandbox_command
-            if profile.sandbox_mode == "read-only"
-            else workspace_effect_sandbox_command
-        )
-        sandboxed_cmd = sandbox_builder(
-            cmd,
-            working_dir,
-            extra_write_roots=[claude_state_dir],
-        )
-        if sandboxed_cmd == cmd:
-            _log(
-                f"✗ claude: sandbox_mode={profile.sandbox_mode!r} requested but platform "
-                "sandbox (sandbox-exec/bwrap) is unavailable — refusing to run unsandboxed. "
-                "Set sandbox_mode: none to explicitly opt out of write containment."
-            )
-            return AgentResult(
-                success=False,
-                output=(
-                    f"SANDBOX_UNAVAILABLE: sandbox_mode={profile.sandbox_mode!r} is set but "
-                    "the platform sandbox (sandbox-exec on macOS, bwrap on Linux) is not "
-                    "available on this host. Claude CLI relies on OS sandboxing for "
-                    "mechanical write containment. Set sandbox_mode: none to run without "
-                    "write containment."
-                ),
-                session_id=None,
-                cost_usd=None,
-                exit_code=-1,
-                raw={},
-                profile_name=profile.name,
-                startup_failure=True,
-            )
-        cmd = sandboxed_cmd
 
     # Unset CLAUDECODE so the subprocess isn't blocked by the nested-session check
     env = build_workspace_env(working_dir, extra=secrets)

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -92,12 +92,8 @@ def _run_gemini(
     # detector has been removed, so running without containment would leave writes
     # undetected. Set sandbox_mode: none explicitly to opt out of containment.
     if profile.sandbox_mode != "none":
-        sandboxed_cmd = workspace_effect_sandbox_command(
-            cmd,
-            working_dir,
-            sandbox_mode=profile.sandbox_mode,
-        )
-        if sandboxed_cmd == cmd:
+        sandboxed_cmd = workspace_effect_sandbox_command(cmd, working_dir)
+        if sandboxed_cmd[0] == cmd[0]:
             _log(
                 f"✗ gemini: sandbox_mode={profile.sandbox_mode!r} requested but platform "
                 "sandbox (sandbox-exec/bwrap) is unavailable — refusing to run unsandboxed. "

--- a/src/theforge/runners/sandbox.py
+++ b/src/theforge/runners/sandbox.py
@@ -5,7 +5,7 @@ import os
 import platform
 import shutil
 import subprocess
-from functools import cache, lru_cache
+from functools import lru_cache
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -18,14 +18,14 @@ _SYSTEM = platform.system()
 # per-story worktree root, not the repository root.
 
 
-@cache
+@lru_cache(maxsize=None)
 def _sandbox_available(binary: str, probe_key: tuple[str, ...]) -> bool:
     probe = list(probe_key)
     if shutil.which(binary) is None:
         logger.warning("Sandbox binary '%s' not found; filesystem isolation disabled", binary)
         return False
     try:
-        result = subprocess.run(probe, capture_output=True, text=True, check=False, timeout=5)
+        result = subprocess.run(probe, capture_output=True, text=True, timeout=5, check=False)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "Sandbox binary '%s' probe failed (%s); filesystem isolation disabled",
@@ -145,19 +145,10 @@ def _workspace_read_roots(allowed_root: Path) -> tuple[Path, ...]:
     return _unique_existing_paths(roots)
 
 
-def _workspace_write_roots(allowed_root: Path, sandbox_mode: str) -> tuple[Path, ...]:
-    root = allowed_root.resolve()
-    if sandbox_mode == "read-only":
-        return ()
-    return (root,)
-
-
 def _macos_profile(
     allowed_root: Path,
     *,
-    sandbox_mode: str = "workspace-write",
     extra_read_roots: tuple[Path, ...] = (),
-    extra_write_roots: tuple[Path, ...] = (),
     denied_read_roots: tuple[Path, ...] = (),
 ) -> str:
     root = allowed_root.resolve()
@@ -180,24 +171,21 @@ def _macos_profile(
         f'    (subpath "{_escape_subpath(path)}")'
         for path in _unique_existing_paths(list(denied_read_roots))
     )
-    write_roots = _unique_existing_paths(
-        [*_workspace_write_roots(root, sandbox_mode), *extra_write_roots]
-    )
-    write_rules = "\n".join(f'    (subpath "{_escape_subpath(path)}")' for path in write_roots)
+    escaped_root = _escape_subpath(root)
     deny_block = ""
     if deny_rules:
         deny_block = f"""(deny file-read*
 {deny_rules}
 )
 """
-    return f"""(version 1)
+    return f'''(version 1)
 (deny default)
 (import "system.sb")
 (allow process-exec)
 (allow process-fork)
 (allow signal (target self))
 (allow file-write*
-{write_rules}
+    (subpath "{escaped_root}")
     (subpath "/private/tmp")
     (subpath "/tmp")
     (subpath "/dev")
@@ -205,16 +193,14 @@ def _macos_profile(
 (allow file-read*
 {read_rules}
 )
-{deny_block}"""
+{deny_block}'''
 
 
 def _linux_command(
     cmd: list[str],
     allowed_root: Path,
     *,
-    sandbox_mode: str = "workspace-write",
     extra_read_roots: tuple[Path, ...] = (),
-    extra_write_roots: tuple[Path, ...] = (),
     masked_read_roots: tuple[Path, ...] = (),
 ) -> list[str]:
     root = allowed_root.resolve()
@@ -245,21 +231,15 @@ def _linux_command(
         "/etc",
         "/etc",
     ]
-    write_roots = _unique_existing_paths(
-        [*_workspace_write_roots(root, sandbox_mode), *extra_write_roots]
-    )
     for read_root in read_roots:
-        if read_root == root or read_root in write_roots:
+        if read_root == root:
             continue
         wrapped.extend(["--ro-bind-try", str(read_root), str(read_root)])
-    for write_root in write_roots:
-        wrapped.extend(["--bind", str(write_root), str(write_root)])
     for masked_root in _unique_existing_paths(list(masked_read_roots)):
         wrapped.extend(["--tmpfs", str(masked_root)])
-    root_bind_flag = "--bind" if root in write_roots else "--ro-bind"
     wrapped.extend(
         [
-            root_bind_flag,
+            "--bind",
             str(root),
             str(root),
             "--tmpfs",
@@ -272,54 +252,21 @@ def _linux_command(
     return wrapped
 
 
-def workspace_effect_sandbox_command(
-    cmd: list[str],
-    allowed_root: Path,
-    *,
-    sandbox_mode: str = "workspace-write",
-    extra_write_roots: list[Path] | tuple[Path, ...] = (),
-) -> list[str]:
+def workspace_effect_sandbox_command(cmd: list[str], allowed_root: Path) -> list[str]:
     root = allowed_root.resolve()
     blocked_worktrees = _blocked_worktree_roots(root)
-    write_roots = _unique_existing_paths(list(extra_write_roots))
     if _SYSTEM == "Darwin":
-        profile = _macos_profile(
-            root,
-            sandbox_mode=sandbox_mode,
-            extra_write_roots=write_roots,
-            denied_read_roots=blocked_worktrees,
-        )
+        profile = _macos_profile(root, denied_read_roots=blocked_worktrees)
         if _sandbox_available(
-            "sandbox-exec",
-            ("sandbox-exec", "-p", "(version 1) (allow default)", "true"),
+            "sandbox-exec", ("sandbox-exec", "-p", "(version 1) (allow default)", "true")
         ):
             return ["sandbox-exec", "-p", profile, *cmd]
         return cmd
     if _SYSTEM == "Linux":
         if _sandbox_available("bwrap", ("bwrap", "--ro-bind", "/", "/", "true")):
-            return _linux_command(
-                cmd,
-                root,
-                sandbox_mode=sandbox_mode,
-                extra_write_roots=write_roots,
-                masked_read_roots=blocked_worktrees,
-            )
+            return _linux_command(cmd, root, masked_read_roots=blocked_worktrees)
         return cmd
     return cmd
-
-
-def read_only_sandbox_command(
-    cmd: list[str],
-    allowed_root: Path,
-    *,
-    extra_write_roots: list[Path] | tuple[Path, ...] = (),
-) -> list[str]:
-    return workspace_effect_sandbox_command(
-        cmd,
-        allowed_root,
-        sandbox_mode="read-only",
-        extra_write_roots=extra_write_roots,
-    )
 
 
 def sandbox_command(cmd: list[str], allowed_root: Path) -> list[str]:

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -15,16 +15,6 @@ from theforge.agent_types import AgentResult
 from theforge.config import ModelProfile
 from theforge.log_level import LogLevel, set_log_level
 from theforge.runners import run_agent, run_agent_pool
-from theforge.runners.runner_claude import _run_claude
-
-
-def _sandbox_wrap(
-    cmd: list[str],
-    wd: Path,
-    sandbox_mode: str = "workspace-write",
-    extra_write_roots: list[Path] | tuple[Path, ...] = (),
-) -> list[str]:
-    return ["sandbox-exec", "-p", f"profile-{sandbox_mode}", *cmd]
 
 
 def _make_stream_mock(lines: list[str], returncode: int = 0, stderr: str = "") -> MagicMock:
@@ -164,17 +154,13 @@ class TestRunAgentClaude:
             ]
         )
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                result = run_agent(
-                    prompt="implement the thing",
-                    profile=dev_profile,
-                    working_dir=tmp_path,
-                )
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            result = run_agent(
+                prompt="implement the thing",
+                profile=dev_profile,
+                working_dir=tmp_path,
+            )
 
         assert result.success is True
         assert result.output == "I implemented the feature."
@@ -214,14 +200,10 @@ class TestRunAgentClaude:
 
         mock_proc = _make_stream_mock([_result_line(result="done")])
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                with patch.dict(os.environ, {"CLAUDECODE": "1"}):
-                    run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            with patch.dict(os.environ, {"CLAUDECODE": "1"}):
+                run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         env_passed = mock_popen.call_args[1]["env"]
         assert "CLAUDECODE" not in env_passed
@@ -233,18 +215,14 @@ class TestRunAgentClaude:
         mock_proc = _make_stream_mock([_result_line(result="done")])
 
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                run_agent(
-                    prompt="test",
-                    profile=dev_profile,
-                    working_dir=tmp_path,
-                    secrets={"API_KEY": "secret"},
-                )
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(
+                prompt="test",
+                profile=dev_profile,
+                working_dir=tmp_path,
+                secrets={"API_KEY": "secret"},
+            )
 
         env_passed = mock_popen.call_args[1]["env"]
         assert env_passed["PATH"].split(os.pathsep)[0] == str(venv_bin)
@@ -256,18 +234,14 @@ class TestRunAgentClaude:
             [_result_line(result="continued.", session_id="sess-abc123")]
         )
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                run_agent(
-                    prompt="continue",
-                    profile=dev_profile,
-                    working_dir=tmp_path,
-                    session_id="sess-abc123",
-                )
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(
+                prompt="continue",
+                profile=dev_profile,
+                working_dir=tmp_path,
+                session_id="sess-abc123",
+            )
 
         cmd = mock_popen.call_args[0][0]
         assert "--resume" in cmd
@@ -284,13 +258,9 @@ class TestRunAgentClaude:
         )
         mock_proc = _make_stream_mock([_result_line(result="done")])
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
 
         cmd = mock_popen.call_args[0][0]
         assert "--allowedTools" not in cmd
@@ -300,12 +270,8 @@ class TestRunAgentClaude:
             [_result_line(result="partial work", total_cost_usd=0.15)],
             returncode=1,
         )
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.success is False
         assert result.exit_code == 1
@@ -314,12 +280,8 @@ class TestRunAgentClaude:
 
     def test_non_json_output(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = _make_stream_mock(["plain text output"])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.success is True
         assert result.output == "plain text output"
@@ -328,12 +290,8 @@ class TestRunAgentClaude:
 
     def test_empty_output(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = _make_stream_mock([], returncode=1, stderr="some error")
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.success is False
         assert result.output == "some error"
@@ -364,12 +322,8 @@ class TestRunAgentClaude:
         mock_proc.wait.return_value = -1
         mock_proc.poll.return_value = None
 
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=profile, working_dir=tmp_path)
 
         assert result.success is False
         assert "TIMEOUT" in result.output
@@ -399,12 +353,8 @@ class TestRunAgentClaude:
         mock_proc.wait.return_value = -1
         mock_proc.poll.return_value = None
 
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=profile, working_dir=tmp_path)
 
         assert result.success is False
         assert result.exit_code == -9
@@ -412,14 +362,10 @@ class TestRunAgentClaude:
 
     def test_cli_not_found(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
+            "theforge.runners.runner_claude.subprocess.Popen",
+            side_effect=FileNotFoundError(),
         ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen",
-                side_effect=FileNotFoundError(),
-            ):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.success is False
         assert "not found" in result.output
@@ -430,14 +376,8 @@ class TestRunAgentClaude:
     ) -> None:
         """AgentResult.profile_name must be set to profile.name."""
         mock_proc = _make_stream_mock([_result_line(result="reviewed.", total_cost_usd=0.10)])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(
-                    prompt="review this", profile=review_profile, working_dir=tmp_path
-                )
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="review this", profile=review_profile, working_dir=tmp_path)
 
         assert result.profile_name == "review"
 
@@ -459,14 +399,8 @@ class TestRunAgentClaude:
         )
         set_log_level(LogLevel.VERBOSE)
         try:
-            with patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=_sandbox_wrap,
-            ):
-                with patch(
-                    "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-                ):
-                    run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+                run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
         finally:
             set_log_level(LogLevel.PROGRESS)
 
@@ -492,14 +426,8 @@ class TestRunAgentClaude:
             mock_proc = _make_stream_mock(
                 [summary_line, _result_line(result="done", total_cost_usd=0.01)]
             )
-            with patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=_sandbox_wrap,
-            ):
-                with patch(
-                    "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-                ):
-                    run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+                run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
             captured = capsys.readouterr()
             assert "↳ Read file.py (10 lines)" in captured.err
             assert "[dev]" not in captured.err
@@ -508,14 +436,8 @@ class TestRunAgentClaude:
             mock_proc2 = _make_stream_mock(
                 [summary_line, _result_line(result="done", total_cost_usd=0.01)]
             )
-            with patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=_sandbox_wrap,
-            ):
-                with patch(
-                    "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc2
-                ):
-                    run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path, quiet=True)
+            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc2):
+                run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path, quiet=True)
             captured2 = capsys.readouterr()
             assert "↳ [dev] Read file.py (10 lines)" in captured2.err
         finally:
@@ -547,14 +469,8 @@ class TestRunAgentClaude:
         )
         set_log_level(LogLevel.VERBOSE)
         try:
-            with patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=_sandbox_wrap,
-            ):
-                with patch(
-                    "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-                ):
-                    run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+                run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
         finally:
             set_log_level(LogLevel.PROGRESS)
 
@@ -567,12 +483,8 @@ class TestRunAgentClaude:
         mock_proc = _make_stream_mock(
             [json.dumps({"type": "assistant", "session_id": "sess-fallback"}) + "\n"]
         )
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.success is True
         assert result.session_id == "sess-fallback"
@@ -599,20 +511,19 @@ class TestClaudePermissionMode:
         )
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
         cmd = self._popen_capture(mock_popen)
         assert "--permission-mode" in cmd
         idx = cmd.index("--permission-mode")
         assert cmd[idx + 1] == "default"
 
-    def test_read_only_adds_permission_mode(self, tmp_path: Path) -> None:
-        """sandbox_mode=read-only → --permission-mode default in cmd."""
+    def test_read_only_adds_permission_mode_with_warning(self, tmp_path: Path) -> None:
+        """sandbox_mode=read-only → --permission-mode default + WARNING that read-only is not
+        mechanically enforced by Claude CLI."""
+        import theforge.runners.runner_claude as _mod
+
         profile = ModelProfile(
             name="dev",
             cli="claude",
@@ -624,17 +535,17 @@ class TestClaudePermissionMode:
         )
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
         with patch(
-            "theforge.runners.runner_claude.read_only_sandbox_command",
-            side_effect=lambda cmd, wd, extra_write_roots=(): _sandbox_wrap(
-                cmd, wd, sandbox_mode="read-only", extra_write_roots=extra_write_roots
-            ),
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            with patch.object(_mod, "_log") as mock_log:
                 run_agent(prompt="test", profile=profile, working_dir=tmp_path)
         cmd = self._popen_capture(mock_popen)
         assert "--permission-mode" in cmd
+        # A warning must be logged explaining that read-only is not mechanically enforced
+        log_calls = [str(c) for c in mock_log.call_args_list]
+        assert any(
+            "read-only" in call and "not mechanically enforced" in call for call in log_calls
+        )
 
     def test_none_omits_permission_mode(self, tmp_path: Path) -> None:
         """sandbox_mode=none → no --permission-mode flag in cmd."""
@@ -649,173 +560,11 @@ class TestClaudePermissionMode:
         )
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
         with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen:
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
         cmd = self._popen_capture(mock_popen)
         assert "--permission-mode" not in cmd
-
-
-class TestClaudeSandboxWrapper:
-    def test_workspace_write_uses_sandbox_wrapper(self, tmp_path: Path) -> None:
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="workspace-write",
-        )
-        mock_proc = _make_stream_mock([_result_line(result="done")])
-        claude_dir = Path.home() / ".claude"
-        wrapped_cmd = _sandbox_wrap(
-            ["claude", "-p"],
-            tmp_path,
-            sandbox_mode="workspace-write",
-            extra_write_roots=[claude_dir],
-        )
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            return_value=wrapped_cmd,
-        ) as mock_sandbox:
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                with (
-                    patch("pathlib.Path.exists", return_value=True),
-                    patch("pathlib.Path.mkdir") as mock_mkdir,
-                ):
-                    _run_result = run_agent(prompt="test", profile=profile, working_dir=tmp_path)
-        assert _run_result.success is True
-        mock_mkdir.assert_not_called()
-        mock_sandbox.assert_called_once()
-        assert mock_sandbox.call_args.kwargs["extra_write_roots"] == [claude_dir]
-        assert mock_popen.call_args[0][0] == wrapped_cmd
-
-    def test_read_only_uses_sandbox_wrapper(self, tmp_path: Path) -> None:
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="read-only",
-        )
-        mock_proc = _make_stream_mock([_result_line(result="done")])
-        claude_dir = Path.home() / ".claude"
-        wrapped_cmd = _sandbox_wrap(
-            ["claude", "-p"],
-            tmp_path,
-            sandbox_mode="read-only",
-            extra_write_roots=[claude_dir],
-        )
-        with patch(
-            "theforge.runners.runner_claude.read_only_sandbox_command",
-            return_value=wrapped_cmd,
-        ) as mock_sandbox:
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                with patch("pathlib.Path.exists", return_value=True):
-                    run_agent(prompt="test", profile=profile, working_dir=tmp_path)
-        mock_sandbox.assert_called_once()
-        assert mock_sandbox.call_args.kwargs["extra_write_roots"] == [claude_dir]
-
-    def test_none_skips_sandbox_wrapper(self, tmp_path: Path) -> None:
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="none",
-        )
-        mock_proc = _make_stream_mock([_result_line(result="done")])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command"
-        ) as mock_sandbox:
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                run_agent(prompt="test", profile=profile, working_dir=tmp_path)
-        mock_sandbox.assert_not_called()
-        assert mock_popen.call_args[0][0][0] == "claude"
-
-    def test_sandbox_unavailable_fails_closed(self, tmp_path: Path) -> None:
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="workspace-write",
-        )
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=lambda cmd, wd, extra_write_roots=(): cmd,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen") as mock_popen:
-                with (
-                    patch("pathlib.Path.exists", return_value=True),
-                    patch("pathlib.Path.mkdir") as mock_mkdir,
-                ):
-                    result = run_agent(prompt="test", profile=profile, working_dir=tmp_path)
-        mock_mkdir.assert_not_called()
-        mock_popen.assert_not_called()
-        assert result.success is False
-        assert result.startup_failure is True
-        assert result.exit_code == -1
-        assert "SANDBOX_UNAVAILABLE" in result.output
-
-    def test_sandbox_unavailable_none_mode_still_runs(self, tmp_path: Path) -> None:
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="none",
-        )
-        mock_proc = _make_stream_mock([_result_line(result="done")])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command"
-        ) as mock_sandbox:
-            with patch(
-                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-            ) as mock_popen:
-                result = run_agent(prompt="test", profile=profile, working_dir=tmp_path)
-        mock_sandbox.assert_not_called()
-        mock_popen.assert_called_once()
-        assert result.success is True
-
-    def test_claude_state_dir_mkdir_failure_returns_startup_failure(self, tmp_path: Path) -> None:
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read",),
-            sandbox_mode="workspace-write",
-        )
-        with (
-            patch("pathlib.Path.exists", return_value=False),
-            patch("pathlib.Path.mkdir", side_effect=PermissionError("nope")),
-        ):
-            result = _run_claude(prompt="test", profile=profile, working_dir=tmp_path)
-
-        assert result.success is False
-        assert result.startup_failure is True
-        assert result.exit_code == -1
-        assert "SANDBOX_UNAVAILABLE" in result.output
-        assert ".claude" in result.output
 
 
 class TestClaudeSessionIdHelper:
@@ -870,35 +619,23 @@ class TestRunAgentCostCoercion:
 
     def test_string_cost_usd(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd="0.42")])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.cost_usd == 0.42
         assert isinstance(result.cost_usd, float)
 
     def test_null_cost_usd(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = _make_stream_mock([_result_line(result="done", cost_usd=None)])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.cost_usd is None
 
     def test_garbage_cost_usd(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd="not-a-number")])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.cost_usd is None
 
@@ -924,12 +661,8 @@ class TestRunAgentModelUsage:
                 )
             ]
         )
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="do it", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="do it", profile=dev_profile, working_dir=tmp_path)
 
         assert result.cost_usd == 0.123
         assert len(result.model_usage) == 1
@@ -945,12 +678,8 @@ class TestRunAgentModelUsage:
         self, dev_profile: ModelProfile, tmp_path: Path
     ) -> None:
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.05)])
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="do it", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="do it", profile=dev_profile, working_dir=tmp_path)
 
         assert result.model_usage == ()
 
@@ -980,12 +709,8 @@ class TestRunAgentModelUsage:
                 )
             ]
         )
-        with patch(
-            "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-            side_effect=_sandbox_wrap,
-        ):
-            with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
-                result = run_agent(prompt="do it", profile=dev_profile, working_dir=tmp_path)
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(prompt="do it", profile=dev_profile, working_dir=tmp_path)
 
         assert result.cost_usd == 0.20
         assert len(result.model_usage) == 2
@@ -1018,13 +743,8 @@ class TestRunAgentUnknownCli:
 def test_claude_launcher_invokes_cmd_directly(dev_profile: ModelProfile, tmp_path: Path) -> None:
     mock_proc = _make_stream_mock([_result_line(result="done")])
     with patch(
-        "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-        side_effect=_sandbox_wrap,
-    ):
-        with patch(
-            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-        ) as mock_popen:
-            run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+    ) as mock_popen:
+        run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
     cmd = mock_popen.call_args[0][0]
-    assert cmd[0] == "sandbox-exec"
-    assert "claude" in cmd
+    assert cmd[0] == "claude"

--- a/tests/test_runner_gemini.py
+++ b/tests/test_runner_gemini.py
@@ -51,7 +51,6 @@ class TestGeminiSandboxWrapper:
                     working_dir=tmp_path,
                 )
         mock_sandbox.assert_called_once()
-        assert mock_sandbox.call_args.kwargs["sandbox_mode"] == "workspace-write"
         # The cmd passed to subprocess.run should be the sandboxed version
         actual_cmd = mock_run.call_args[0][0]
         assert actual_cmd == wrapped_cmd
@@ -72,7 +71,6 @@ class TestGeminiSandboxWrapper:
                     working_dir=tmp_path,
                 )
         mock_sandbox.assert_called_once()
-        assert mock_sandbox.call_args.kwargs["sandbox_mode"] == "read-only"
 
     def test_none_skips_sandbox_wrapper(self, tmp_path: Path) -> None:
         """sandbox_mode=none → workspace_effect_sandbox_command is NOT called."""
@@ -100,7 +98,7 @@ class TestGeminiSandboxWrapper:
         # Return the original cmd unchanged → sandbox unavailable
         with patch(
             "theforge.runners.runner_gemini.workspace_effect_sandbox_command",
-            side_effect=lambda cmd, wd, sandbox_mode: cmd,
+            side_effect=lambda cmd, wd: list(cmd),
         ):
             with patch("theforge.runners.runner_gemini.subprocess.run") as mock_run:
                 result = _run_gemini(

--- a/tests/test_runner_pool.py
+++ b/tests/test_runner_pool.py
@@ -92,18 +92,7 @@ class TestRunAgentPool:
             allowed_tools=(),
         )
         mock_proc = _make_stream_mock([_result_line(result="solo review", total_cost_usd=0.20)])
-        with (
-            patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=lambda cmd, wd, extra_write_roots=(): [
-                    "sandbox-exec",
-                    "-p",
-                    "profile",
-                    *cmd,
-                ],
-            ),
-            patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc),
-        ):
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
             results = run_agent_pool(
                 prompt="review this",
                 profiles=[profile],

--- a/tests/test_runner_providers.py
+++ b/tests/test_runner_providers.py
@@ -634,18 +634,7 @@ class TestSecretsInjection:
             return mock
 
         secrets = {"MY_SECRET_KEY": "secret-value"}
-        with (
-            patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=lambda cmd, wd, extra_write_roots=(): [
-                    "sandbox-exec",
-                    "-p",
-                    "profile",
-                    *cmd,
-                ],
-            ),
-            patch("subprocess.Popen", side_effect=fake_popen),
-        ):
+        with patch("subprocess.Popen", side_effect=fake_popen):
             run_agent(
                 prompt="test",
                 profile=dev_profile,
@@ -668,18 +657,7 @@ class TestSecretsInjection:
                 [_result_line(result="done", session_id="s1", total_cost_usd=0.0)]
             )
 
-        with (
-            patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=lambda cmd, wd, extra_write_roots=(): [
-                    "sandbox-exec",
-                    "-p",
-                    "profile",
-                    *cmd,
-                ],
-            ),
-            patch("subprocess.Popen", side_effect=fake_popen),
-        ):
+        with patch("subprocess.Popen", side_effect=fake_popen):
             run_agent(
                 prompt="test",
                 profile=dev_profile,
@@ -700,18 +678,7 @@ class TestSecretsInjection:
                 [_result_line(result="done", session_id="s1", total_cost_usd=0.0)]
             )
 
-        with (
-            patch(
-                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
-                side_effect=lambda cmd, wd, extra_write_roots=(): [
-                    "sandbox-exec",
-                    "-p",
-                    "profile",
-                    *cmd,
-                ],
-            ),
-            patch("subprocess.Popen", side_effect=fake_popen),
-        ):
+        with patch("subprocess.Popen", side_effect=fake_popen):
             result = run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
 
         assert result.success

--- a/tests/test_runner_sandbox.py
+++ b/tests/test_runner_sandbox.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from theforge.runners.sandbox import read_only_sandbox_command, sandbox_command
+from theforge.runners.sandbox import sandbox_command
 from theforge.runners.tool_runtime import _handle_bash
 
 
@@ -87,19 +87,6 @@ def test_macos_profile_does_not_allow_global_reads(tmp_path: Path) -> None:
     assert f'(subpath "{tmp_path.resolve()}")' in profile
 
 
-def test_macos_profile_allows_extra_write_roots(tmp_path: Path) -> None:
-    from theforge.runners.sandbox import _macos_profile
-
-    extra_write_root = tmp_path / "home" / ".claude"
-    extra_write_root.mkdir(parents=True)
-
-    profile = _macos_profile(tmp_path, extra_write_roots=(extra_write_root,))
-
-    assert f'(subpath "{extra_write_root.resolve()}")' in profile
-    write_block = profile.split("(allow file-write*", 1)[1].split("(allow file-read*", 1)[0]
-    assert f'(subpath "{extra_write_root.resolve()}")' in write_block
-
-
 def test_sandbox_command_linux_probe_uses_hashable_cache_key(tmp_path: Path) -> None:
     cmd = ["bash", "-c", "pwd"]
 
@@ -114,54 +101,6 @@ def test_sandbox_command_linux_probe_uses_hashable_cache_key(tmp_path: Path) -> 
         wrapped = sandbox_command(cmd, tmp_path)
 
     assert wrapped[0] == "bwrap"
-
-
-def test_linux_command_uses_bind_for_extra_write_roots(tmp_path: Path) -> None:
-    from theforge.runners.sandbox import _linux_command
-
-    extra_write_root = tmp_path / "home" / ".claude"
-    extra_write_root.mkdir(parents=True)
-
-    wrapped = _linux_command(
-        ["bash", "-c", "pwd"], tmp_path, extra_write_roots=(extra_write_root,)
-    )
-
-    bind_triplets = [wrapped[i : i + 3] for i in range(len(wrapped) - 2)]
-    assert ["--bind", str(extra_write_root), str(extra_write_root)] in bind_triplets
-    assert ["--ro-bind-try", str(extra_write_root), str(extra_write_root)] not in bind_triplets
-
-
-def test_linux_command_read_only_binds_workspace_read_only(tmp_path: Path) -> None:
-    from theforge.runners.sandbox import _linux_command
-
-    wrapped = _linux_command(["bash", "-c", "pwd"], tmp_path, sandbox_mode="read-only")
-
-    triplets = [wrapped[i : i + 3] for i in range(len(wrapped) - 2)]
-    assert ["--ro-bind", str(tmp_path.resolve()), str(tmp_path.resolve())] in triplets
-    assert ["--bind", str(tmp_path.resolve()), str(tmp_path.resolve())] not in triplets
-
-
-def test_read_only_sandbox_command_sets_read_only_mode(tmp_path: Path) -> None:
-    with patch(
-        "theforge.runners.sandbox.workspace_effect_sandbox_command",
-        return_value=["sandbox-exec", "-p", "profile", "bash"],
-    ) as mock_workspace:
-        wrapped = read_only_sandbox_command(
-            ["bash"], tmp_path, extra_write_roots=(tmp_path / ".claude",)
-        )
-
-    assert wrapped == ["sandbox-exec", "-p", "profile", "bash"]
-    assert mock_workspace.call_args.kwargs["sandbox_mode"] == "read-only"
-    assert mock_workspace.call_args.kwargs["extra_write_roots"] == (tmp_path / ".claude",)
-
-
-def test_macos_profile_read_only_omits_workspace_write_access(tmp_path: Path) -> None:
-    from theforge.runners.sandbox import _macos_profile
-
-    profile = _macos_profile(tmp_path, sandbox_mode="read-only")
-
-    write_block = profile.split("(allow file-write*", 1)[1].split("(allow file-read*", 1)[0]
-    assert f'(subpath "{tmp_path.resolve()}")' not in write_block
 
 
 def test_workspace_sandbox_allows_project_root_but_blocks_sibling_worktrees(


### PR DESCRIPTION
## Summary

- Reverts #920 (commit 7375579) — the sandbox-exec wrapper around Claude CLI introduced in that PR broke auth bootstrap on macOS ("Not logged in" on every sprint run).
- Restores the design principle: don't double-sandbox CLIs that already have their own permission mechanism. Claude's `--permission-mode` is now the enforcement layer, as it was before #920.
- Does not re-address #137 (sibling-worktree damage) — that problem stands and should get its own story scoped to worktree-level isolation rather than process sandboxing.

Closes #924.

## Test plan

- [x] `make gate` passes (3279 passed, 1 skipped)
- [ ] Re-run a live sprint (e.g. issues-922) and confirm preflight + plan no longer fail with "Not logged in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)