### PR TITLE
macOS bash-tool sandbox profile makes pytest/gate commands unusably slow

### DIFF
--- a/src/theforge/runners/tool_runtime.py
+++ b/src/theforge/runners/tool_runtime.py
@@ -15,8 +15,6 @@ from typing import Callable
 
 from theforge.workspace_env import build_workspace_env
 
-from .sandbox import sandbox_command
-
 MAX_TOOL_OUTPUT_BYTES = 51200  # 50KB default
 
 # Maps forge.yaml user-facing capitalized names → canonical internal names.
@@ -157,9 +155,8 @@ def _handle_bash(
 ) -> str:
     """Run a shell command in working_dir with a timeout."""
     try:
-        sandboxed = sandbox_command(["bash", "-c", command], Path(working_dir))
         result = subprocess.run(
-            sandboxed,
+            ["bash", "-c", command],
             cwd=working_dir,
             capture_output=True,
             text=True,

--- a/tests/test_runner_sandbox.py
+++ b/tests/test_runner_sandbox.py
@@ -48,31 +48,24 @@ def test_sandbox_command_fallback_logs_warning(
     assert wrapped == cmd
 
 
-def test_handle_bash_uses_sandbox_command(tmp_path: Path) -> None:
-    with (
-        patch(
-            "theforge.runners.tool_runtime.sandbox_command", return_value=["bash", "-c", "pwd"]
-        ) as mock_sandbox,
-        patch("theforge.runners.tool_runtime.subprocess.run") as mock_run,
-    ):
+def test_handle_bash_runs_raw_bash_command_without_sandbox_wrapping(tmp_path: Path) -> None:
+    with patch("theforge.runners.tool_runtime.subprocess.run") as mock_run:
         mock_run.return_value.stdout = "ok\n"
         mock_run.return_value.stderr = ""
         mock_run.return_value.returncode = 0
         _handle_bash(command="pwd", working_dir=tmp_path)
-    mock_sandbox.assert_called_once()
-    assert mock_run.call_args[0][0] == ["bash", "-c", "pwd"]
+
+    argv = mock_run.call_args[0][0]
+    assert argv == ["bash", "-c", "pwd"]
+    assert argv[0] != "sandbox-exec"
+    assert "sandbox-exec" not in argv
+    assert not any("(version 1)" in arg for arg in argv)
 
 
-def test_bash_outside_allowed_root_rejected_when_sandbox_denies() -> None:
-    with (
-        patch(
-            "theforge.runners.tool_runtime.sandbox_command",
-            return_value=["bash", "-c", "cat ../other/file"],
-        ),
-        patch(
-            "theforge.runners.tool_runtime.subprocess.run",
-            side_effect=PermissionError("Operation not permitted"),
-        ),
+def test_bash_permission_error_returns_workspace_sandbox_violation() -> None:
+    with patch(
+        "theforge.runners.tool_runtime.subprocess.run",
+        side_effect=PermissionError("Operation not permitted"),
     ):
         output = _handle_bash(command="cat ../other/file", working_dir=Path("/tmp/worktree"))
     assert "workspace sandbox violation" in output


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Removes sandbox wrapping from bash tool to restore pytest/make gate performance, matching spec's acceptable trade-off. | [google-gemini-3.1-pro-preview] Removed sandbox wrapping from bash tool to fix performance issues. | [claude-opus] Removes sandbox wrapping from bash tool; direct approach matches spec's first suggested direction and tests updated accordingly.

## Review

- **Verdict:** APPROVE (0 P1, 5 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.03
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/runners/tool_runtime.py:None`** PermissionError handler still returns 'workspace sandbox violation' message despite sandbox being removed, which could be confusing.
- **[P2] `src/theforge/runners/sandbox.py:272`** sandbox_command function is now unused except in tests; could be removed or marked as test-only.
- **[P2] `src/theforge/runners/tool_runtime.py:172`** PermissionError handler still returns 'workspace sandbox violation' message, but there is no longer a sandbox wrapping bash commands. The wording is now slightly misleading — any genuine filesystem PermissionError from a command will be reported as a sandbox violation. Non-blocking since the branch is a rare fallback.
- **[P2] `src/theforge/runners/sandbox.py:272`** sandbox_command remains exported and is still used by runner_gemini and the auth probe, so it is not dead code. No action needed, just noting that the macOS allow-list profile performance issue described in the spec still exists for any future caller; consider a follow-up to slim the profile before re-enabling it anywhere hot.
- **[P2] `.:None`** Commit message 'wip: uncommitted changes from dev iteration 1' is not descriptive of the change. Does not block merge but should be rewritten before the PR lands.

## Story

macOS bash-tool sandbox profile makes pytest/gate commands unusably slow (GitHub Issue #929)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #929