### PR TITLE
Worktree lifecycle hygiene: stop leaving debris in .forge/worktrees/

### DIFF
--- a/src/theforge/artifacts.py
+++ b/src/theforge/artifacts.py
@@ -8,6 +8,7 @@ PLAN_PATH = Path(".forge/plan.md")
 LEGACY_PLAN_PATH = Path("forge_plan.md")
 AUDIT_PATH = Path(".forge/audit.yaml")
 LEGACY_AUDIT_PATH = Path("forge_audit.yaml")
+ESCALATED_MARKER_PATH = Path(".forge/escalated")
 
 
 def ensure_parent_dir(path: Path) -> None:

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -111,7 +111,7 @@ def _write_audit(result: CoordinatorResult, config: ForgeConfig, task: TaskStory
         yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
     # Append to history log (JSONL, never overwritten).
     _append_history(audits_dir, audit)
-    final_phase = result.state.phase.name if result.state.phase is not None else result.phase.name
+    final_phase = result.phase.name
     if (
         final_phase == "ESCALATE"
         and result.state.workspace_path

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -9,6 +9,7 @@ import yaml
 
 from theforge.artifacts import (
     AUDIT_PATH,
+    ESCALATED_MARKER_PATH,
     ensure_parent_dir,
 )
 from theforge.config import (
@@ -101,7 +102,7 @@ def _append_history(audits_dir: Path, record: dict) -> None:
 
 
 def _write_audit(result: CoordinatorResult, config: ForgeConfig, task: TaskStory) -> Path:
-    """Write the audit log to .forge/audits/forge_audit.yaml and .forge/audit.yaml."""
+    """Write the canonical audit log and preserve minimal worktree state on ESCALATE."""
     audit = generate_audit_log(config, task, result)
     audits_dir = config.project_root / ".forge" / "audits"
     audits_dir.mkdir(parents=True, exist_ok=True)
@@ -110,14 +111,23 @@ def _write_audit(result: CoordinatorResult, config: ForgeConfig, task: TaskStory
         yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
     # Append to history log (JSONL, never overwritten).
     _append_history(audits_dir, audit)
-    # Also write to worktree for per-story persistence (not overwritten by next run).
-    # Skip for ALREADY_DONE — no real work was done, worktree is just a checkout.
-    already_done = result.state.preflight_verdict == "ALREADY_DONE"
-    if not already_done and result.state.workspace_path and result.state.workspace_path.exists():
+    final_phase = result.state.phase.name if result.state.phase is not None else result.phase.name
+    if (
+        final_phase == "ESCALATE"
+        and result.state.workspace_path
+        and result.state.workspace_path.exists()
+    ):
         worktree_audit_path = result.state.workspace_path / AUDIT_PATH
         ensure_parent_dir(worktree_audit_path)
         with open(worktree_audit_path, "w", encoding="utf-8") as f:
             yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
+        marker_path = result.state.workspace_path / ESCALATED_MARKER_PATH
+        ensure_parent_dir(marker_path)
+        timestamp = audit.get("ended_at") or audit.get("started_at") or ""
+        marker_path.write_text(
+            f"slug: {task.slug}\nfinal_phase: {final_phase}\ntimestamp: {timestamp}\n",
+            encoding="utf-8",
+        )
     # Copy to durable per-story log dir (survives worktree cleanup)
     if result.state.log_dir is not None:
         try:

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
 
+from theforge.artifacts import AUDIT_PATH, ESCALATED_MARKER_PATH
 from theforge.config import ForgeConfig
 from theforge.detach import find_run_id_for_pid as _find_run_id_for_pid
 from theforge.task import TaskStory
@@ -371,6 +373,71 @@ def _find_worktree_for_branch(branch: str, project_root: Path) -> Path | None:
             if line[len("branch ") :] == f"refs/heads/{branch}":
                 return current_path
     return None
+
+
+def sweep_orphan_worktrees(project_root: Path, config: ForgeConfig) -> None:
+    """Remove orphaned or safely-removable worktrees under .forge/worktrees/."""
+    worktrees_root = project_root / ".forge" / "worktrees"
+    if not worktrees_root.exists():
+        return
+
+    ok, output = _cu._run_shell("git worktree list --porcelain", project_root)
+    registered: dict[Path, str | None] = {}
+    if ok:
+        current_path: Path | None = None
+        for line in output.splitlines():
+            if line.startswith("worktree "):
+                current_path = Path(line[len("worktree ") :]).resolve()
+                registered[current_path] = None
+            elif line.startswith("branch ") and current_path is not None:
+                ref = line[len("branch ") :]
+                if ref.startswith("refs/heads/"):
+                    registered[current_path] = ref.removeprefix("refs/heads/")
+
+    lock_dir = project_root / ".forge" / "locks"
+    base_branch = config.workspace.base_branch
+    remote_base = f"origin/{base_branch}"
+
+    for candidate in worktrees_root.iterdir():
+        if not candidate.is_dir():
+            continue
+        slug = candidate.name
+        if (lock_dir / f"{slug}.lock").exists():
+            continue
+        if (candidate / ESCALATED_MARKER_PATH).exists():
+            continue
+
+        resolved_candidate = candidate.resolve()
+        branch_name = registered.get(resolved_candidate)
+        if branch_name is None and resolved_candidate not in registered:
+            files = [
+                p.relative_to(candidate).as_posix() for p in candidate.rglob("*") if p.is_file()
+            ]
+            if not files or set(files) <= {AUDIT_PATH.as_posix()}:
+                shutil.rmtree(candidate, ignore_errors=True)
+            continue
+
+        if branch_name is None:
+            continue
+        ok_status, status_out = _cu._run_shell("git status --porcelain", candidate)
+        if not ok_status or status_out.strip():
+            continue
+        ok_gone, gone_out = _cu._run_shell(
+            f"git rev-parse --verify --quiet refs/remotes/origin/{branch_name}", project_root
+        )
+        branch_gone = not ok_gone or not gone_out.strip()
+        ok_merged, merged_out = _cu._run_shell(f"git branch --merged {remote_base}", project_root)
+        merged = False
+        if ok_merged:
+            merged_branches = {
+                line.strip().lstrip("* ").strip()
+                for line in merged_out.splitlines()
+                if line.strip()
+            }
+            merged = branch_name in merged_branches
+        if not (merged or branch_gone):
+            continue
+        _remove_worktree(candidate, branch_name, project_root, "sweep: merged or branch gone")
 
 
 def _check_behind_origin(config: ForgeConfig) -> None:

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -597,13 +597,15 @@ def _write_story_audit(
 
     if sprint_id is not None:
         audit_data["sprint_id"] = sprint_id
-        if "sprint_name" not in audit_data:
-            audit_data["sprint_name"] = (
-                result.state.log_dir.parent.name if result.state.log_dir else None
-            )
+        sprint_name = result.state.log_dir.parent.name if result.state.log_dir else None
+        if not sprint_name:
+            sprint_name = audit_data.get("sprint_name")
+        if not sprint_name:
+            sprint_name = "Parallel Sprint"
+        audit_data["sprint_name"] = sprint_name
 
     workspace_path = config.project_root / config.workspace.path_pattern.format(slug=task.slug)
-    final_phase = result.state.phase.name if result.state.phase is not None else result.phase.name
+    final_phase = result.phase.name
     if workspace_path.exists() and final_phase == "ESCALATE":
         audit_path = workspace_path / AUDIT_PATH
         ensure_parent_dir(audit_path)
@@ -629,6 +631,8 @@ def _write_story_audit(
     log_dir = result.state.log_dir
     if log_dir is None:
         sprint_name = audit_data.get("sprint_name")
+        if not isinstance(sprint_name, str) or not sprint_name:
+            sprint_name = None
         if isinstance(sprint_name, str) and sprint_name:
             log_dir = config.project_root / ".forge" / "logs" / sprint_name / task.slug
     if log_dir is not None:

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -582,11 +582,11 @@ def _write_story_audit(
     result: "CoordinatorResult",
     sprint_id: str | None = None,
 ) -> None:
-    """Write per-story audit.yaml to the worktree and the durable log directory.
+    """Write per-story audit.yaml to the durable log directory and preserve ESCALATE worktrees.
 
     Best-effort: silently ignores missing workspace or log dir.
     """
-    from ..artifacts import AUDIT_PATH, ensure_parent_dir  # noqa: PLC0415
+    from ..artifacts import AUDIT_PATH, ESCALATED_MARKER_PATH, ensure_parent_dir  # noqa: PLC0415
     from ..coordinator import audit as coordinator_audit  # noqa: PLC0415
 
     try:
@@ -597,15 +597,25 @@ def _write_story_audit(
 
     if sprint_id is not None:
         audit_data["sprint_id"] = sprint_id
+        if "sprint_name" not in audit_data:
+            audit_data["sprint_name"] = (
+                result.state.log_dir.parent.name if result.state.log_dir else None
+            )
 
     workspace_path = config.project_root / config.workspace.path_pattern.format(slug=task.slug)
-    if workspace_path.exists() and not (
-        result.state.workspace_path is None and result.state.preflight_verdict == "ALREADY_DONE"
-    ):
+    final_phase = result.state.phase.name if result.state.phase is not None else result.phase.name
+    if workspace_path.exists() and final_phase == "ESCALATE":
         audit_path = workspace_path / AUDIT_PATH
         ensure_parent_dir(audit_path)
         with open(audit_path, "w", encoding="utf-8") as f:
             yaml.dump(audit_data, f, default_flow_style=False, sort_keys=False)
+        marker_path = workspace_path / ESCALATED_MARKER_PATH
+        ensure_parent_dir(marker_path)
+        timestamp = audit_data.get("ended_at") or audit_data.get("started_at") or ""
+        marker_path.write_text(
+            f"slug: {task.slug}\nfinal_phase: {final_phase}\ntimestamp: {timestamp}\n",
+            encoding="utf-8",
+        )
         _log(f"Per-story audit written: {audit_path}")
 
     audits_dir = config.project_root / ".forge" / "audits"
@@ -616,9 +626,14 @@ def _write_story_audit(
     except OSError:
         pass
 
-    if result.state.log_dir is not None:
+    log_dir = result.state.log_dir
+    if log_dir is None:
+        sprint_name = audit_data.get("sprint_name")
+        if isinstance(sprint_name, str) and sprint_name:
+            log_dir = config.project_root / ".forge" / "logs" / sprint_name / task.slug
+    if log_dir is not None:
         try:
-            _story_audit_path = result.state.log_dir / "audit.yaml"
+            _story_audit_path = log_dir / "audit.yaml"
             _story_audit_path.parent.mkdir(parents=True, exist_ok=True)
             with open(_story_audit_path, "w", encoding="utf-8") as f:
                 yaml.dump(audit_data, f, default_flow_style=False, sort_keys=False)

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -9,31 +9,13 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
-import yaml
-
+from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.pid import _is_pid_alive
 
 
 def _is_escalated_worktree(worktree_path: Path) -> bool:
-    """Return True when the worktree's audit marks it as an escalated, preserved run.
-
-    Escalated worktrees are intentionally kept for human triage after the
-    coordinator terminates in the ESCALATE phase.  They are not collisions.
-    """
-    audit_path = worktree_path / ".forge" / "audit.yaml"
-    if not audit_path.exists():
-        return False
-    try:
-        with open(audit_path, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-    except (OSError, yaml.YAMLError):
-        return False
-    if not isinstance(data, dict):
-        return False
-    outcome = data.get("outcome")
-    if not isinstance(outcome, dict):
-        return False
-    return outcome.get("final_phase") == "ESCALATE"
+    """Return True when the worktree is marked as an escalated, preserved run."""
+    return (worktree_path / ESCALATED_MARKER_PATH).exists()
 
 
 class SprintConflictError(Exception):

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -21,6 +21,7 @@ from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
 from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from ..coordinator.util import _fmt_duration, _generate_run_id
+from ..coordinator.workspace import sweep_orphan_worktrees
 from ..log_util import _log_line
 from ..task import TaskStory
 from .audit import (
@@ -727,6 +728,7 @@ def run_sprint(
 
     # Defensive scrub for the root checkout used by sprint commands.
     _scrub_root_forge_artifacts(config)
+    sweep_orphan_worktrees(config.project_root, config)
 
     max_parallel = (
         resolved.max_parallel if resolved.max_parallel is not None else config.sprint.max_parallel

--- a/tests/test_coord_state.py
+++ b/tests/test_coord_state.py
@@ -804,6 +804,7 @@ class TestCampaignAuditWrites:
         from theforge.review import ReviewResult
 
         state = CoordinatorState()
+        state.log_dir = tmp_path / ".forge" / "logs" / "Test Campaign" / "my-spec"
         meta = ReviewCycleMetadata(
             pool_models=["opus", "codex"],
             successful=["opus"],
@@ -833,8 +834,8 @@ class TestCampaignAuditWrites:
         )
 
     @patch("theforge.sprint.runner.run_task")
-    def test_campaign_writes_worktree_audit(self, mock_run_task, tmp_path):
-        """After run_sprint(), the spec worktree contains .forge/audit.yaml."""
+    def test_campaign_writes_durable_story_audit(self, mock_run_task, tmp_path):
+        """After run_sprint(), the durable per-story log contains audit.yaml."""
         from theforge.sprint import run_sprint
 
         config = _make_config(tmp_path)
@@ -853,8 +854,8 @@ class TestCampaignAuditWrites:
         manifest_path = self._make_manifest(tmp_path, ["spec.md"])
         run_sprint(config, manifest_path)
 
-        audit_path = workspace / ".forge" / "audit.yaml"
-        assert audit_path.exists(), ".forge/audit.yaml not written to worktree"
+        audit_path = tmp_path / ".forge" / "logs" / "Test Campaign" / "my-spec" / "audit.yaml"
+        assert audit_path.exists(), "durable per-story audit.yaml not written to log dir"
         audit = yaml.safe_load(audit_path.read_text(encoding="utf-8")) or {}
         assert "reviews" in audit
         assert len(audit["reviews"]) == 1

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -221,14 +221,11 @@ class TestCheckActiveWorktrees:
 
     def test_escalated_worktree_is_not_active(self, tmp_path: Path) -> None:
         """Worktrees with final_phase == ESCALATE are preserved, not collisions."""
-        import yaml as _yaml
+        from theforge.artifacts import ESCALATED_MARKER_PATH
 
         worktree = tmp_path / ".forge" / "worktrees" / "story-a"
-        (worktree / ".forge").mkdir(parents=True)
-        (worktree / ".forge" / "audit.yaml").write_text(
-            _yaml.dump({"outcome": {"final_phase": "ESCALATE"}}),
-            encoding="utf-8",
-        )
+        (worktree / ESCALATED_MARKER_PATH).parent.mkdir(parents=True)
+        (worktree / ESCALATED_MARKER_PATH).write_text("final_phase: ESCALATE\n", encoding="utf-8")
         # Worktree has commits ahead — git check would report "active" if reached.
         completed = MagicMock(returncode=0, stdout="5\n")
         with patch("theforge.sprint.lock.subprocess.run", return_value=completed) as mock_run:

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1009,6 +1009,7 @@ class TestParallelMergeOrderingParallelMode:
         )
 
         state = CoordinatorState()
+        state.log_dir = tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a"
         state.preflight_verdict = "PROCEED"
         mock_preflight = MagicMock()
         mock_preflight.cost_usd = 1.0
@@ -1061,7 +1062,11 @@ class TestParallelMergeOrderingParallelMode:
             sprint = run_sprint(config, manifest_path, auto_merge=True)
 
         assert sprint.specs_succeeded == 1
-        audit = yaml.safe_load((tmp_path / "story-a" / ".forge" / "audit.yaml").read_text())
+        audit = yaml.safe_load(
+            (
+                tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a" / "audit.yaml"
+            ).read_text()
+        )
         assert audit["merge"]["merged"] is True
         assert audit["landing_status"] == "landed"
         assert audit["error"] is None
@@ -1138,7 +1143,7 @@ class TestParallelMergeOrderingParallelMode:
         ):
             sprint = run_sprint(config, manifest_path)
 
-        audit_path = tmp_path / "story-a" / ".forge" / "audit.yaml"
+        audit_path = tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a" / "audit.yaml"
         audit = yaml.safe_load(audit_path.read_text(encoding="utf-8")) or {}
         assert sprint.specs_succeeded == 0
         assert sprint.specs_failed == 1
@@ -1171,6 +1176,7 @@ class TestParallelMergeOrderingParallelMode:
         )
 
         state = CoordinatorState()
+        state.log_dir = tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a"
         state.preflight_verdict = "PROCEED"
         mock_preflight = MagicMock()
         mock_preflight.cost_usd = 1.0
@@ -1221,7 +1227,7 @@ class TestParallelMergeOrderingParallelMode:
         ):
             sprint = run_sprint(config, manifest_path)
 
-        audit_path = tmp_path / "story-a" / ".forge" / "audit.yaml"
+        audit_path = tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a" / "audit.yaml"
         audit = yaml.safe_load(audit_path.read_text(encoding="utf-8")) or {}
         assert sprint.specs_succeeded == 1
         assert sprint.specs_failed == 0
@@ -1243,6 +1249,7 @@ class TestParallelMergeOrderingParallelMode:
         config = _make_config(tmp_path)
 
         state = CoordinatorState()
+        state.log_dir = tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a"
         state.preflight_verdict = "PROCEED"
         mock_preflight = MagicMock()
         mock_preflight.cost_usd = 1.0
@@ -1270,7 +1277,7 @@ class TestParallelMergeOrderingParallelMode:
         ):
             sprint = run_sprint(config, manifest_path, auto_merge=True)
 
-        audit_path = tmp_path / "story-a" / ".forge" / "audit.yaml"
+        audit_path = tmp_path / ".forge" / "logs" / "Parallel Sprint" / "story-a" / "audit.yaml"
         audit = yaml.safe_load(audit_path.read_text(encoding="utf-8")) or {}
         assert sprint.specs_succeeded == 0
         assert sprint.specs_failed == 1

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.sprint.launch_guard import acquire_launch_story_locks
 
 
@@ -31,12 +32,10 @@ def _mock_config(tmp_path: Path) -> MagicMock:
 def _make_worktree_with_audit(tmp_path: Path, slug: str, final_phase: str | None = None) -> Path:
     worktree = tmp_path / ".forge" / "worktrees" / slug
     worktree.mkdir(parents=True)
-    if final_phase is not None:
-        (worktree / ".forge").mkdir(parents=True, exist_ok=True)
-        (worktree / ".forge" / "audit.yaml").write_text(
-            yaml.dump({"outcome": {"final_phase": final_phase}}),
-            encoding="utf-8",
-        )
+    if final_phase == "ESCALATE":
+        marker = worktree / ESCALATED_MARKER_PATH
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("final_phase: ESCALATE\n", encoding="utf-8")
     return worktree
 
 

--- a/tests/test_worktree_lifecycle_hygiene.py
+++ b/tests/test_worktree_lifecycle_hygiene.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import dataclasses
+import subprocess
+from pathlib import Path
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.artifacts import ESCALATED_MARKER_PATH
+from theforge.cli.shared import _write_audit
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.coordinator.workspace import sweep_orphan_worktrees
+from theforge.sprint.audit import _write_story_audit
+from theforge.sprint.lock import _is_escalated_worktree
+
+
+def _make_result(
+    *, phase: Phase, workspace_path: Path | None = None, log_dir: Path | None = None
+) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.phase = phase
+    state.workspace_path = workspace_path
+    state.log_dir = log_dir
+    return CoordinatorResult(
+        success=phase == Phase.DONE, phase=phase, state=state, message=phase.name
+    )
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def test_write_audit_skips_worktree_audit_for_non_escalate(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir(parents=True)
+    log_dir = tmp_path / "logs" / task.slug
+    result = _make_result(phase=Phase.DONE, workspace_path=workspace, log_dir=log_dir)
+
+    _write_audit(result, config, task)
+
+    assert not (workspace / ".forge" / "audit.yaml").exists()
+    assert not (workspace / ESCALATED_MARKER_PATH).exists()
+    assert (log_dir / "audit.yaml").exists()
+
+
+def test_escalate_writes_marker_and_detection_uses_it(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir(parents=True)
+    log_dir = tmp_path / "logs" / task.slug
+
+    escalate_result = _make_result(phase=Phase.ESCALATE, workspace_path=workspace, log_dir=log_dir)
+    _write_audit(escalate_result, config, task)
+
+    assert (workspace / ESCALATED_MARKER_PATH).exists()
+    assert _is_escalated_worktree(workspace) is True
+
+    clean_workspace = tmp_path / "clean"
+    clean_workspace.mkdir()
+    assert _is_escalated_worktree(clean_workspace) is False
+
+
+def test_sweep_orphan_worktrees_removes_orphan_and_merged_but_preserves_escalated(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("root\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "fetch", "origin", "main:refs/remotes/origin/main")
+
+    base_config = _make_config(repo)
+    config = dataclasses.replace(
+        base_config,
+        workspace=dataclasses.replace(
+            base_config.workspace,
+            path_pattern=".forge/worktrees/{slug}",
+            branch_pattern="forge/{slug}",
+            base_branch="main",
+        ),
+    )
+
+    worktrees_root = repo / ".forge" / "worktrees"
+    worktrees_root.mkdir(parents=True, exist_ok=True)
+
+    orphan = worktrees_root / "orphan"
+    (orphan / ".forge").mkdir(parents=True)
+    (orphan / ".forge" / "audit.yaml").write_text("outcome: {}\n", encoding="utf-8")
+
+    merged = worktrees_root / "merged"
+    _git(repo, "worktree", "add", "-b", "forge/merged", str(merged), "main")
+    (merged / "merged.txt").write_text("done\n", encoding="utf-8")
+    _git(merged, "add", "merged.txt")
+    _git(merged, "commit", "-m", "merged work")
+    _git(repo, "checkout", "main")
+    _git(repo, "merge", "--ff-only", "forge/merged")
+
+    escalated = worktrees_root / "escalated"
+    _git(repo, "worktree", "add", "-b", "forge/escalated", str(escalated), "main")
+    task = _make_task(repo)
+    task = dataclasses.replace(task, slug="escalated")
+    esc_result = _make_result(
+        phase=Phase.ESCALATE, workspace_path=escalated, log_dir=repo / "logs"
+    )
+    _write_story_audit(config, task, esc_result, sprint_id="sprint-1")
+
+    sweep_orphan_worktrees(repo, config)
+
+    assert not orphan.exists()
+    assert not merged.exists()
+    assert not any(
+        "forge/merged" in line
+        for line in subprocess.run(
+            ["git", "branch", "--list"], cwd=repo, check=True, capture_output=True, text=True
+        ).stdout.splitlines()
+    )
+    assert escalated.exists()
+    assert (escalated / ESCALATED_MARKER_PATH).exists()


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The implementation correctly addresses the worktree lifecycle hygiene issue by stopping audit.yaml writes on non-ESCALATE runs, introducing a minimal escalated marker, and adding a sweep function to clean up orphaned and merged worktrees. The changes are well-tested and comply with the spec. | [google-gemini-3.1-pro-preview] The implementation correctly stops writing audit.yaml to worktrees on success, introduces a minimal ESCALATE marker, and adds a safe cleanup sweep for orphaned/merged worktrees. | [claude-opus] Worktree lifecycle fix correctly gates worktree audit on ESCALATE, introduces a lightweight marker, and adds a sprint-start sweep that preserves escalated trees.

## Review

- **Verdict:** APPROVE (0 P1, 4 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $10.62
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/workspace.py:416`** The condition for removing orphaned directories checks if files are only AUDIT_PATH, but with the new logic, audit.yaml is only written on ESCALATE. This is safe for cleanup but could be clarified.
- **[P2] `src/theforge/coordinator/workspace.py:436`** git branch --merged parsing uses lstrip('* ') which handles the current-branch '*' and padding spaces but not the '+' prefix that modern git prints for branches checked out in another worktree. A merged branch still checked out in its own worktree would be listed as '+ forge/<slug>' and fail the membership check, so the worktree would not be swept until the branch stops being checked out elsewhere.
- **[P2] `src/theforge/sprint/audit.py:605`** Fallback sprint_name default of 'Parallel Sprint' is a magic string used to reconstruct a log_dir when state.log_dir is None. This is a heuristic that can silently land audits under a wrong path if a caller ever omits log_dir with a different sprint identity.
- **[P2] `src/theforge/coordinator/workspace.py:378`** sweep_orphan_worktrees is invoked from run_sprint but not from single-story entry points (forge run). The spec focuses on sprint start, so this is not a defect, but single-story invocations will not opportunistically clean up orphans left by earlier ctrl-C'd or failed runs.

## Story

Worktree lifecycle hygiene: stop leaving debris in .forge/worktrees/ (GitHub Issue #928)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #928