### PR TITLE
Granular complexity scoring — 1-10 scale instead of LOW/MEDIUM/HIGH

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -425,6 +425,8 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             {
                 "verdict": ("cached" if state.preflight_cached else state.preflight_verdict),
                 "reason": state.preflight_reason,
+                "complexity": state.preflight_complexity,
+                "complexity_score": state.preflight_complexity_score,
                 "work_type": state.preflight_work_type,
                 "contract_change": state.preflight_contract_change,
                 "bundle_candidate": state.preflight_bundle_candidate,

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -605,6 +605,7 @@ def run_task(
             state.preflight_verdict = cached_preflight_state.preflight_verdict
             state.preflight_reason = cached_preflight_state.preflight_reason
             state.preflight_complexity = cached_preflight_state.preflight_complexity
+            state.preflight_complexity_score = cached_preflight_state.preflight_complexity_score
             state.preflight_sufficiency = cached_preflight_state.preflight_sufficiency
             state.preflight_work_type = cached_preflight_state.preflight_work_type
             state.preflight_contract_change = cached_preflight_state.preflight_contract_change
@@ -840,6 +841,7 @@ def _run_resume_coordinator(
         state.preflight_verdict = cached_preflight_state.preflight_verdict
         state.preflight_reason = cached_preflight_state.preflight_reason
         state.preflight_complexity = cached_preflight_state.preflight_complexity
+        state.preflight_complexity_score = cached_preflight_state.preflight_complexity_score
         state.preflight_sufficiency = cached_preflight_state.preflight_sufficiency
         state.preflight_work_type = cached_preflight_state.preflight_work_type
         state.preflight_contract_change = cached_preflight_state.preflight_contract_change

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -35,6 +35,54 @@ _COMPLEXITY_TO_LEVEL: dict[str, str] = {
     "large": "HIGH",
 }
 
+# Integer complexity scale bounds. Preflight emits a score in this range;
+# out-of-range or missing scores fall back to the legacy three-level enum.
+COMPLEXITY_SCORE_MIN = 1
+COMPLEXITY_SCORE_MAX = 10
+
+
+def score_to_band(score: int) -> str:
+    """Map a 1-10 complexity score to the legacy small/medium/large enum.
+
+    Bands: 1-3 → small, 4-7 → medium, 8-10 → large. This is the *compat shim*
+    used by consumers that still read the string enum. Final bucketing policy
+    belongs to each consumer — this function is just the default.
+    """
+    if score <= 3:
+        return "small"
+    if score <= 7:
+        return "medium"
+    return "large"
+
+
+def band_to_score(band: str) -> int:
+    """Map small/medium/large → a representative score (midpoint of each band).
+
+    Used only as a fallback when a preflight output lacks ``complexity_score``
+    so downstream code can treat the score as always-present.
+    """
+    norm = band.lower()
+    if norm == "small":
+        return 2
+    if norm == "large":
+        return 9
+    return 5  # medium or unknown
+
+
+def score_to_dev_tier(score: int) -> str:
+    """Map a 1-10 complexity score to a dev-phase model tier.
+
+    Bands: 1-3 → cheap, 4-6 → mid, 7-10 → strong. Finer-grained than the enum
+    mapping (which lumps score 7 in with 'medium' → mid) so a localized bug at
+    score=3 and a cross-module refactor at score=7 route to different tiers
+    even though they'd both be 'medium' under the three-level enum.
+    """
+    if score <= 3:
+        return "cheap"
+    if score <= 6:
+        return "mid"
+    return "strong"
+
 
 def _build_pool_entries(model_keys: list[str]) -> list[tuple[int, str, ModelInfo]]:
     """Build sorted (cost_rank, registry_key, ModelInfo) list from models."""
@@ -272,6 +320,46 @@ def _parse_preflight_complexity(output: str) -> str:
     return "medium"
 
 
+def _parse_preflight_complexity_score(output: str, fallback_band: str | None = None) -> int | None:
+    """Extract complexity_score from preflight agent output.
+
+    Returns an int in [COMPLEXITY_SCORE_MIN, COMPLEXITY_SCORE_MAX]. Clamps
+    out-of-range values to the bounds. When the field is absent or unparseable,
+    derives a score from ``fallback_band`` (the legacy string enum) if given,
+    else returns None so callers can detect the missing signal.
+    """
+    yaml_text = output
+    if "```yaml" in output:
+        start = output.index("```yaml") + len("```yaml")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+    elif "```" in output:
+        start = output.index("```") + len("```")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+
+    try:
+        parsed = yaml.safe_load(yaml_text)
+        if isinstance(parsed, dict) and "complexity_score" in parsed:
+            raw = parsed.get("complexity_score")
+            try:
+                score = int(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                score = None
+            if score is not None:
+                if score < COMPLEXITY_SCORE_MIN:
+                    return COMPLEXITY_SCORE_MIN
+                if score > COMPLEXITY_SCORE_MAX:
+                    return COMPLEXITY_SCORE_MAX
+                return score
+    except yaml.YAMLError:
+        pass
+
+    if fallback_band is not None:
+        return band_to_score(fallback_band)
+    return None
+
+
 def _parse_preflight_sufficiency(output: str) -> str:
     """Extract sufficiency from preflight agent output.
 
@@ -488,7 +576,11 @@ def _escalate_dev_model(
     return candidates[0][0]
 
 
-def _apply_complexity_adaptation(config: ForgeConfig, complexity: str) -> ForgeConfig:
+def _apply_complexity_adaptation(
+    config: ForgeConfig,
+    complexity: str,
+    complexity_score: int | None = None,
+) -> ForgeConfig:
     """Adjust model assignments based on preflight complexity using tier × complexity routing.
 
     Only applies when models is set. Per-role bypass flags guard each
@@ -528,7 +620,13 @@ def _apply_complexity_adaptation(config: ForgeConfig, complexity: str) -> ForgeC
     # ── dev ────────────────────────────────────────────────────────
     if config.dev_profile_is_default:
         dev_pool = [(r, k, i) for r, k, i in pool_entries if i.dev_capable] or pool_entries
-        target_dev_rank = _TIER_TO_RANK[_PHASE_COMPLEXITY_TIER["dev"][norm]]
+        # Prefer the finer-grained numeric score for dev tier selection so
+        # high-medium stories (score 7) route to strong instead of mid. Fall
+        # back to the enum-based tier when no score is present.
+        if complexity_score is not None:
+            target_dev_rank = _TIER_TO_RANK[score_to_dev_tier(complexity_score)]
+        else:
+            target_dev_rank = _TIER_TO_RANK[_PHASE_COMPLEXITY_TIER["dev"][norm]]
         target_dev_info = _pick_pool_entry_by_rank(dev_pool, target_dev_rank)
         if target_dev_info.model != config.dev_profile.model:
             new_dev = apply_model_info(config.dev_profile, target_dev_info)
@@ -590,12 +688,13 @@ def _apply_preflight_config(
 ) -> ForgeConfig:
     """Apply complexity-driven config updates using values already stored on state."""
     complexity = state.preflight_complexity or "medium"
+    complexity_score = state.preflight_complexity_score
     _log = log or (lambda _msg: None)
     _log_verbose = log_verbose or (lambda _msg: None)
 
     if config.models is not None:
         _config_before = config
-        config = _apply_complexity_adaptation(config, complexity)
+        config = _apply_complexity_adaptation(config, complexity, complexity_score)
         _dev_changed = config.dev_profile.model != _config_before.dev_profile.model
         _plan_changed = config.plan.model != _config_before.plan.model
         _review_changed = [p.model for p in config.review_pool] != [
@@ -604,6 +703,7 @@ def _apply_preflight_config(
         if _dev_changed or _plan_changed or _review_changed:
             state.complexity_routing_audit = {
                 "complexity": complexity,
+                "complexity_score": complexity_score,
                 "derived_plan_model": config.plan.model,
                 "derived_dev_model": config.dev_profile.model,
                 "derived_review_pool": [p.model for p in config.review_pool],

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -40,6 +40,7 @@ from .preflight import (
     _apply_preflight_config,
     _parse_preflight_bundle_candidate,
     _parse_preflight_complexity,
+    _parse_preflight_complexity_score,
     _parse_preflight_contract_change,
     _parse_preflight_criteria_checked,
     _parse_preflight_likely_files,
@@ -299,6 +300,10 @@ def _run_preflight_phase(
         state.preflight_likely_files = _likely_files
         complexity = _parse_preflight_complexity(preflight_result.output)
         state.preflight_complexity = complexity
+        complexity_score = _parse_preflight_complexity_score(
+            preflight_result.output, fallback_band=complexity
+        )
+        state.preflight_complexity_score = complexity_score
         sufficiency = _parse_preflight_sufficiency(preflight_result.output)
         state.preflight_sufficiency = sufficiency
         work_type = _parse_preflight_work_type(preflight_result.output)
@@ -327,6 +332,13 @@ def _run_preflight_phase(
         if contract_change and complexity == "small":
             complexity = "medium"
             state.preflight_complexity = complexity
+            # Also bump the score so downstream consumers that read the raw
+            # number see the upgrade, not just the enum.
+            if (
+                state.preflight_complexity_score is not None
+                and state.preflight_complexity_score < 4
+            ):
+                state.preflight_complexity_score = 5
             _log(
                 "  ↑ contract_change=true: upgrading complexity small→medium "
                 "(cross-cutting blast radius)"
@@ -387,11 +399,17 @@ def _run_preflight_phase(
                 # upgrade complexity to at least medium.
                 if state.preflight_complexity == "small":
                     state.preflight_complexity = "medium"
+                    if (
+                        state.preflight_complexity_score is not None
+                        and state.preflight_complexity_score < 4
+                    ):
+                        state.preflight_complexity_score = 5
                 state.preflight_sufficiency = "needs_planning"
     else:
         # Agent failed — skip all parsers; hard-set conservative values so
         # downstream phases plan carefully despite missing classification.
         state.preflight_complexity = "large"
+        state.preflight_complexity_score = 9
         state.preflight_sufficiency = "needs_planning"
         state.preflight_work_type = "feature"
         state.preflight_bundle_candidate = False
@@ -434,6 +452,7 @@ def _run_preflight_phase(
         "verdict": verdict,
         "reason": reason,
         "complexity": state.preflight_complexity,
+        "complexity_score": state.preflight_complexity_score,
         "sufficiency": state.preflight_sufficiency,
         "contract_change": state.preflight_contract_change,
         "cost_usd": preflight_result.cost_usd,

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -48,6 +48,7 @@ from .preflight import (
     _parse_preflight_verdict,
     _parse_preflight_warnings,
     _parse_preflight_work_type,
+    score_to_band,
 )
 from .state import CoordinatorResult, CoordinatorState, Phase
 from .util import _fmt_duration, _log_phase
@@ -298,12 +299,21 @@ def _run_preflight_phase(
         state.preflight_warnings = _warnings
         _likely_files = _parse_preflight_likely_files(preflight_result.output)
         state.preflight_likely_files = _likely_files
-        complexity = _parse_preflight_complexity(preflight_result.output)
-        state.preflight_complexity = complexity
+        complexity_enum_raw = _parse_preflight_complexity(preflight_result.output)
         complexity_score = _parse_preflight_complexity_score(
-            preflight_result.output, fallback_band=complexity
+            preflight_result.output, fallback_band=complexity_enum_raw
         )
         state.preflight_complexity_score = complexity_score
+        # Legacy consumers read state.preflight_complexity via the compat shim.
+        # When the agent emitted a numeric score, derive the enum from it so the
+        # score is the single source of truth — this is the shim required by AC
+        # "no consumer is silently broken". Fall back to the agent's raw enum
+        # only when no score is available (parser returned None with no band).
+        if complexity_score is not None:
+            complexity = score_to_band(complexity_score)
+        else:
+            complexity = complexity_enum_raw
+        state.preflight_complexity = complexity
         sufficiency = _parse_preflight_sufficiency(preflight_result.output)
         state.preflight_sufficiency = sufficiency
         work_type = _parse_preflight_work_type(preflight_result.output)

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -286,6 +286,7 @@ class CoordinatorState:
     preflight_verdict: str | None = None  # "PROCEED" | "ALREADY_DONE" | "BLOCKED"
     preflight_reason: str | None = None
     preflight_complexity: str | None = None  # "small" | "medium" | "large"
+    preflight_complexity_score: int | None = None  # 1-10 bounded integer score
     preflight_sufficiency: str | None = None  # "implementation_ready" | "needs_planning"
     preflight_work_type: str | None = None  # "feature" | "refactor" | "mechanical" | "bug"
     preflight_contract_change: bool = False  # story intentionally alters a tested contract

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -118,16 +118,38 @@ def build_preflight_prompt(
 
         ## Complexity Assessment
 
-        When verdict is PROCEED, also assess the implementation complexity:
+        When verdict is PROCEED, output BOTH a numeric `complexity_score` (integer
+        1–10) AND the three-level `complexity` enum. The score is the primary
+        signal; the enum is kept for compatibility.
 
-        - **small**: Config change, typo fix, single-file edit, <50 lines changed.
-          Do NOT classify as small if the change touches a shared interface field,
-          prompt template string, or schema field — those have wide blast radius
-          across callers, tests, and exact-string assertions even when conceptually trivial.
-        - **medium**: New feature, multi-file change, requires tests, 50–500 lines
-        - **large**: Cross-cutting refactor, architectural change, >500 lines, many modules
+        Anchor the score against these concrete examples so scores stay
+        comparable across stories and across model invocations:
 
-        When verdict is ALREADY_DONE or BLOCKED, set complexity to "small" as a placeholder.
+        - **1–2 (trivial)**: typo fix, single-word rename in one file, comment
+          tweak, adjusting a literal constant in a config file. No test changes.
+        - **3 (small)**: localized single-function bug fix within one module,
+          adding a new optional argument with a default, a config flag read.
+          Maybe one test updated.
+        - **4–5 (medium-small)**: new feature contained to 2–3 files, a new
+          helper plus its tests, a bug fix that spans caller and callee.
+        - **6–7 (medium-large)**: multi-module feature, changes that touch a
+          shared interface field consumed by a handful of callers, a contract
+          change with a small but non-trivial blast radius. Score 7 if the
+          change requires careful planning but is still localizable.
+        - **8 (large)**: cross-module refactor, a rename of a widely-referenced
+          field or function, schema migration with multiple consumers.
+        - **9–10 (very large)**: architectural change, new subsystem, a rewrite
+          of a phase of the state machine, changes that touch >10 files or
+          require coordinated migration across the codebase.
+
+        Keep the enum consistent with the score using the default mapping
+        (1–3 → small, 4–7 → medium, 8–10 → large) unless you have a specific
+        reason to diverge. If a change touches a shared interface field,
+        prompt template string, or schema field, do not score below 4 —
+        blast radius dominates conceptual simplicity.
+
+        When verdict is ALREADY_DONE or BLOCKED, set `complexity: small` and
+        `complexity_score: 2` as placeholders.
 
         ## Work-Type Classification
 
@@ -182,6 +204,7 @@ def build_preflight_prompt(
 
         ```yaml
         verdict: PROCEED | ALREADY_DONE | BLOCKED
+        complexity_score: <integer 1-10>
         complexity: small | medium | large
         work_type: feature | refactor | mechanical | bug
         contract_change: true | false

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -86,3 +86,38 @@ class TestCachedPreflightVerdictDispatch:
         assert mock_plan.call_count == 0
         mock_pool.assert_not_called()
         assert len(result.state.dev_results) == 0
+
+    def test_cached_preflight_restores_complexity_score(self, tmp_path):
+        """Cache restoration propagates preflight_complexity_score into new state.
+
+        Seam-level coverage for Convention 8: without this, cached runs silently
+        fall back to enum-only routing because the numeric score is lost at the
+        cache boundary.
+        """
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        cached_state = replace(
+            CoordinatorState(),
+            preflight_verdict="ALREADY_DONE",
+            preflight_reason="All acceptance criteria already satisfied.",
+            preflight_complexity="medium",
+            preflight_complexity_score=7,
+            preflight_sufficiency="implementation_ready",
+            preflight_work_type="feature",
+        )
+
+        with (
+            patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+            patch("theforge.coordinator.preflight_flow._is_branch_merged", return_value=True),
+            patch("theforge.coordinator.preflight_flow.run_agent"),
+            patch("theforge.coordinator.dev_phase.run_agent"),
+            patch("theforge.coordinator.plan_flow.run_agent"),
+            patch("theforge.coordinator.review_pool.run_agent_pool"),
+        ):
+            result = run_task(config, task, cached_preflight_state=cached_state)
+
+        assert result.state.preflight_complexity_score == 7
+        assert result.state.preflight_complexity == "medium"

--- a/tests/test_preflight_complexity_score.py
+++ b/tests/test_preflight_complexity_score.py
@@ -1,0 +1,204 @@
+"""Tests for numeric complexity scoring (1-10) emitted by preflight.
+
+Covers: parser bounds, determinism, compat-shim mapping to the legacy enum,
+and at least one consumer (dev-tier routing) producing a decision distinct
+from what the three-level enum would have produced.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.config import (
+    DEFAULT_VALIDATION,
+    MODEL_REGISTRY,
+    ForgeConfig,
+    ModelProfile,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.config.types import PlanConfig
+from theforge.coordinator.preflight import (
+    COMPLEXITY_SCORE_MAX,
+    COMPLEXITY_SCORE_MIN,
+    _apply_complexity_adaptation,
+    _parse_preflight_complexity_score,
+    band_to_score,
+    score_to_band,
+    score_to_dev_tier,
+)
+
+_GOLD_POOL = ["claude/sonnet", "openai/gpt-5.4", "claude/opus"]
+
+
+def _cost_rank(cli: str | None, model: str) -> int:
+    for info in MODEL_REGISTRY.values():
+        if info.cli == cli and info.model == model:
+            return info.cost_rank
+    return 2
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    dev = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=6.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    gpt = ModelProfile(
+        name="openai-gpt-5.4",
+        cli="codex",
+        model="gpt-5.4",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    opus = ModelProfile(
+        name="claude-opus",
+        cli="claude",
+        model="opus",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    synth = ModelProfile(
+        name="synthesis",
+        cli="claude",
+        model="opus",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    plan = PlanConfig(cli="claude", model="sonnet", budget_usd=0.5, timeout=600)
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev,
+        preflight_profile=dev,
+        review_pool=[gpt, opus],
+        synthesis_profile=synth,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        models=_GOLD_POOL,
+        plan=plan,
+        plan_model_is_default=True,
+        dev_profile_is_default=True,
+        review_pool_is_default=True,
+    )
+
+
+# ── score_to_band / band_to_score ─────────────────────────────────────
+
+
+def test_score_to_band_bands():
+    assert score_to_band(1) == "small"
+    assert score_to_band(3) == "small"
+    assert score_to_band(4) == "medium"
+    assert score_to_band(7) == "medium"
+    assert score_to_band(8) == "large"
+    assert score_to_band(10) == "large"
+
+
+def test_band_to_score_roundtrips_through_band():
+    for band in ("small", "medium", "large"):
+        assert score_to_band(band_to_score(band)) == band
+
+
+# ── score_to_dev_tier ─────────────────────────────────────────────────
+
+
+def test_score_to_dev_tier_distinguishes_within_medium_band():
+    """Score 4 and score 7 are both 'medium' under the enum but route to
+    different dev tiers under the numeric scale."""
+    assert score_to_dev_tier(4) == "mid"
+    assert score_to_dev_tier(7) == "strong"
+    # And the legacy enum mapping would collapse both to "mid".
+    assert score_to_band(4) == score_to_band(7) == "medium"
+
+
+# ── parser ────────────────────────────────────────────────────────────
+
+
+def _yaml_output(**fields: object) -> str:
+    body = "\n".join(f"{k}: {v}" for k, v in fields.items())
+    return f"```yaml\n{body}\n```"
+
+
+def test_parse_score_within_range():
+    for s in range(COMPLEXITY_SCORE_MIN, COMPLEXITY_SCORE_MAX + 1):
+        assert _parse_preflight_complexity_score(_yaml_output(complexity_score=s)) == s
+
+
+def test_parse_score_clamps_above():
+    assert (
+        _parse_preflight_complexity_score(_yaml_output(complexity_score=42))
+        == COMPLEXITY_SCORE_MAX
+    )
+
+
+def test_parse_score_clamps_below():
+    assert (
+        _parse_preflight_complexity_score(_yaml_output(complexity_score=-3))
+        == COMPLEXITY_SCORE_MIN
+    )
+
+
+def test_parse_score_deterministic_for_same_input():
+    output = _yaml_output(complexity_score=6, complexity="medium")
+    runs = {_parse_preflight_complexity_score(output) for _ in range(25)}
+    assert runs == {6}
+
+
+def test_parse_score_missing_falls_back_to_band_midpoint():
+    output = _yaml_output(complexity="large")
+    assert _parse_preflight_complexity_score(output, fallback_band="large") == 9
+    assert _parse_preflight_complexity_score(output, fallback_band="medium") == 5
+    assert _parse_preflight_complexity_score(output, fallback_band="small") == 2
+
+
+def test_parse_score_missing_no_fallback_returns_none():
+    assert _parse_preflight_complexity_score(_yaml_output(complexity="medium")) is None
+
+
+def test_parse_score_malformed_yaml_returns_none():
+    assert _parse_preflight_complexity_score("not yaml at all: [[[") is None
+
+
+def test_parse_score_non_numeric_value():
+    # Non-integer value with no fallback — the field is effectively missing.
+    assert _parse_preflight_complexity_score(_yaml_output(complexity_score="huge")) is None
+
+
+# ── consumer: dev-tier routing diverges from enum-only routing ────────
+
+
+def test_dev_routing_diverges_between_score_and_enum(tmp_path):
+    """Score 7 must route dev to 'strong' while enum 'medium' routes to 'mid'.
+
+    This is the AC that a consumer reads the numeric field and produces a
+    distinct decision from the three-level enum.
+    """
+    enum_only = _apply_complexity_adaptation(_make_config(tmp_path), "medium", None)
+    score_based = _apply_complexity_adaptation(_make_config(tmp_path), "medium", 7)
+
+    enum_rank = _cost_rank(enum_only.dev_profile.cli, enum_only.dev_profile.model)
+    score_rank = _cost_rank(score_based.dev_profile.cli, score_based.dev_profile.model)
+
+    assert enum_rank == 2, f"enum 'medium' should route dev to mid (rank 2), got {enum_rank}"
+    assert score_rank == 3, f"score 7 should route dev to strong (rank 3), got {score_rank}"
+
+
+def test_dev_routing_agrees_when_score_matches_band_center(tmp_path):
+    """Score 5 (center of medium) and enum 'medium' yield the same dev tier."""
+    enum_only = _apply_complexity_adaptation(_make_config(tmp_path), "medium", None)
+    score_based = _apply_complexity_adaptation(_make_config(tmp_path), "medium", 5)
+    assert _cost_rank(enum_only.dev_profile.cli, enum_only.dev_profile.model) == _cost_rank(
+        score_based.dev_profile.cli, score_based.dev_profile.model
+    )


### PR DESCRIPTION
## Summary

[openai-api-gpt-5.4] Prior P1s are fixed, no new blocking regressions were introduced, and the numeric complexity score is wired through runtime and audit paths with adequate coverage. | [deepseek-deepseek-reasoner] All three prior P1 findings from cycle 1 are resolved. The cache boundaries now copy preflight_complexity_score, and the compatibility shim (score_to_band) ensures legacy consumers read the derived enum. No regressions were introduced by the changes. The implementation satisfies every acceptance criterion: numeric score emitted, deterministic, anchored examples, compatibility shim, raw score in audit trail, language‑agnostic routing, and comprehensive tests. | [google-gemini-3.1-pro-preview] The implementation correctly addresses the P1 findings from cycle 1 and satisfies all acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $9.28
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Granular complexity scoring — 1-10 scale instead of LOW/MEDIUM/HIGH (GitHub Issue #119)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #119