### PR TITLE
Model capability profiles — persist and aggregate run outcomes per model

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -118,16 +118,51 @@ def _agents_by_tier(agents: list[AgentDef], tier: str) -> list[AgentDef]:
     return sorted(matches, key=lambda a: a.budget_usd)
 
 
+def _rerank_by_profiles(
+    candidates: list[AgentDef],
+    model_profiles: dict | None,
+    role: str,
+    complexity: str | None,
+    min_runs: int = 3,
+) -> list[AgentDef]:
+    """Stable-sort candidates: high-success-rate first when enough data exists.
+
+    Only role="dev" is profile-aware today; other roles pass through unchanged.
+    Candidates without ``min_runs`` observations retain their original relative
+    order (sort is stable) so the cheapest-budget tie-break still wins when
+    nobody has a track record yet.
+    """
+    if not model_profiles or role != "dev":
+        return candidates
+    from theforge.model_profiles import get_dev_success_rate  # noqa: PLC0415
+
+    def _key(agent: AgentDef) -> tuple[int, float]:
+        rate = get_dev_success_rate(model_profiles, agent.name, complexity, min_runs)
+        if rate is None:
+            return (1, 0.0)
+        # Negative rate so higher success sorts first among observed agents.
+        return (0, -rate)
+
+    return sorted(candidates, key=_key)
+
+
 def _pick_agent(
     agents: list[AgentDef],
     tier: str,
     secrets: dict[str, str] | None = None,
+    model_profiles: dict | None = None,
+    role: str = "",
+    complexity: str | None = None,
 ) -> AgentDef | None:
     """Pick cheapest agent of the given tier that has usable auth.
 
     Skips API agents whose provider key is missing from the environment.
+    When ``model_profiles`` is provided and ``role == "dev"``, agents with a
+    higher observed success rate at the given complexity are preferred over
+    the budget-ordered default.
     """
     candidates = [a for a in _agents_by_tier(agents, tier) if _has_auth(a, secrets)]
+    candidates = _rerank_by_profiles(candidates, model_profiles, role, complexity)
     if not candidates:
         log.debug("No authed agents for tier %s — trying any tier with auth", tier)
     return candidates[0] if candidates else None
@@ -413,6 +448,7 @@ def assign_models(
     explicit_profiles: dict[str, ModelProfile] | None = None,
     sprint_promotions: dict[str, str] | None = None,
     secrets: dict[str, str] | None = None,
+    model_profiles: dict | None = None,
 ) -> AssignmentDecision:
     """Pure deterministic function — no LLM, no I/O.
 
@@ -437,7 +473,14 @@ def assign_models(
         rationale["dev"] = f"explicit override: {dev_profile.model}"
     else:
         # Check promotion
-        dev_agent_for_check: AgentDef | None = _pick_agent(agents, dev_base_tier, secrets)
+        dev_agent_for_check: AgentDef | None = _pick_agent(
+            agents,
+            dev_base_tier,
+            secrets,
+            model_profiles=model_profiles,
+            role="dev",
+            complexity=norm_complexity,
+        )
         dev_model_name = dev_agent_for_check.name if dev_agent_for_check else ""
         promoted = _check_promotion(norm_complexity, dev_model_name, history, sprint_promotions)
         effective_dev_tier = dev_base_tier
@@ -458,7 +501,20 @@ def assign_models(
         else:
             rationale["dev"] = f"{norm_complexity} complexity → tier {effective_dev_tier}"
 
-        dev_agent = _pick_agent(agents, effective_dev_tier, secrets)
+        dev_agent = _pick_agent(
+            agents,
+            effective_dev_tier,
+            secrets,
+            model_profiles=model_profiles,
+            role="dev",
+            complexity=norm_complexity,
+        )
+        if dev_agent is not None and model_profiles:
+            from theforge.model_profiles import get_dev_success_rate  # noqa: PLC0415
+
+            _rate = get_dev_success_rate(model_profiles, dev_agent.name, norm_complexity)
+            if _rate is not None:
+                rationale["dev"] += f" (profile success_rate={_rate:.2f} @ {norm_complexity})"
         if dev_agent is None:
             # Guardrail: dev tier floor prevents cheap models on MEDIUM/HIGH and
             # mid models on HIGH.  dev_base_tier is the floor (cheap/mid/strong

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -791,6 +791,21 @@ def run_task(
                 f"complexity={_esc_record.complexity} outcome={_esc_outcome}"
             )
 
+            # ── Model capability profiles ──────────────────────────────
+            try:
+                from .model_profiles_bridge import update_profiles_from_run  # noqa: PLC0415
+
+                _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
+                update_profiles_from_run(
+                    profiles_path=_profiles_path,
+                    history_path=_esc_path,
+                    config=config,
+                    state=state,
+                    success=result.success,
+                )
+            except Exception as exc:  # noqa: BLE001
+                _log_verbose(f"[model_profiles] update failed: {exc}")
+
         return result
 
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -766,56 +766,72 @@ def run_task(
             total_duration_s=round(_total_elapsed, 2),
         )
 
-        # ── Adaptive escalation memory ─────────────────────────────────
-        if config.assignment.escalation_memory and config.agents and state.preflight_complexity:
-            from theforge.assignment import (  # noqa: I001, PLC0415
-                EscalationRecord as _EscRec,
-                append_escalation_record as _append_esc,
-            )
-
-            _esc_path = config.project_root / ".forge" / "assignment_history.yaml"
-            _esc_outcome = "DONE" if result.success else "ESCALATE"
-            _esc_record = _EscRec(
-                story=task.slug,
-                complexity=state.preflight_complexity.upper()
-                if state.preflight_complexity in ("small", "medium", "large")
-                else state.preflight_complexity,
-                dev_model=config.dev_profile.name,
-                outcome=_esc_outcome,
-                reason=state.escalation_note or "",
-                timestamp=datetime.datetime.utcnow().isoformat() + "Z",
-            )
-            _append_esc(_esc_path, _esc_record)
-            _log_verbose(
-                f"[adaptive] Wrote escalation record: story={task.slug} "
-                f"complexity={_esc_record.complexity} outcome={_esc_outcome}"
-            )
-
-        # ── Model capability profiles (independent of escalation_memory) ──
-        # Runs every time so model_profiles.yaml reflects actual outcomes
-        # regardless of the escalation-memory feature flag. Backfills from
-        # assignment_history.yaml on first run when it exists.
-        if state.preflight_complexity:
-            try:
-                from .model_profiles_bridge import update_profiles_from_run  # noqa: PLC0415
-
-                _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
-                _history_path_for_profiles = (
-                    config.project_root / ".forge" / "assignment_history.yaml"
-                )
-                update_profiles_from_run(
-                    profiles_path=_profiles_path,
-                    history_path=_history_path_for_profiles
-                    if _history_path_for_profiles.exists()
-                    else None,
-                    config=config,
-                    state=state,
-                    success=result.success,
-                )
-            except Exception as exc:  # noqa: BLE001
-                _log_verbose(f"[model_profiles] update failed: {exc}")
-
+        _record_run_memory(config, task, state, result)
         return result
+
+
+# ── Post-run persistence (shared by run_task and resume paths) ────────
+
+
+def _record_run_memory(
+    config: "ForgeConfig",
+    task: "TaskStory",
+    state: "CoordinatorState",
+    result: "CoordinatorResult",
+) -> None:
+    """Persist end-of-run memory: escalation history + model profiles.
+
+    Called from both run_task() and _run_resume_coordinator() so a run started
+    via 'forge resume' or a sprint worker contributes the same telemetry as a
+    fresh run_task invocation. Changes to what we persist at run completion
+    belong in this one function — not duplicated at each entry point.
+    """
+    if not state.preflight_complexity:
+        _log_verbose(
+            f"[model_profiles] skipping update: preflight_complexity unset for story={task.slug}"
+        )
+        return
+
+    # ── Adaptive escalation memory ─────────────────────────────────────
+    if config.assignment.escalation_memory and config.agents:
+        from theforge.assignment import (  # noqa: I001, PLC0415
+            EscalationRecord as _EscRec,
+            append_escalation_record as _append_esc,
+        )
+
+        _esc_path = config.project_root / ".forge" / "assignment_history.yaml"
+        _esc_outcome = "DONE" if result.success else "ESCALATE"
+        _esc_record = _EscRec(
+            story=task.slug,
+            complexity=state.preflight_complexity.upper()
+            if state.preflight_complexity in ("small", "medium", "large")
+            else state.preflight_complexity,
+            dev_model=config.dev_profile.name,
+            outcome=_esc_outcome,
+            reason=state.escalation_note or "",
+            timestamp=datetime.datetime.utcnow().isoformat() + "Z",
+        )
+        _append_esc(_esc_path, _esc_record)
+        _log_verbose(
+            f"[adaptive] Wrote escalation record: story={task.slug} "
+            f"complexity={_esc_record.complexity} outcome={_esc_outcome}"
+        )
+
+    # ── Model capability profiles (independent of escalation_memory) ───
+    try:
+        from .model_profiles_bridge import update_profiles_from_run  # noqa: PLC0415
+
+        _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
+        _history_path = config.project_root / ".forge" / "assignment_history.yaml"
+        update_profiles_from_run(
+            profiles_path=_profiles_path,
+            history_path=_history_path if _history_path.exists() else None,
+            config=config,
+            state=state,
+            success=result.success,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log_verbose(f"[model_profiles] update failed: {exc}")
 
 
 # ── Shared resume coordinator (run_from_review / run_from_dev) ────────
@@ -954,6 +970,7 @@ def _run_resume_coordinator(
             total_cost_usd=round(state.total_cost, 6),
             total_duration_s=round(_total_elapsed, 2),
         )
+        _record_run_memory(config, task, state, result)
         return result
 
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -791,14 +791,23 @@ def run_task(
                 f"complexity={_esc_record.complexity} outcome={_esc_outcome}"
             )
 
-            # ── Model capability profiles ──────────────────────────────
+        # ── Model capability profiles (independent of escalation_memory) ──
+        # Runs every time so model_profiles.yaml reflects actual outcomes
+        # regardless of the escalation-memory feature flag. Backfills from
+        # assignment_history.yaml on first run when it exists.
+        if state.preflight_complexity:
             try:
                 from .model_profiles_bridge import update_profiles_from_run  # noqa: PLC0415
 
                 _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
+                _history_path_for_profiles = (
+                    config.project_root / ".forge" / "assignment_history.yaml"
+                )
                 update_profiles_from_run(
                     profiles_path=_profiles_path,
-                    history_path=_esc_path,
+                    history_path=_history_path_for_profiles
+                    if _history_path_for_profiles.exists()
+                    else None,
                     config=config,
                     state=state,
                     success=result.success,

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -1,0 +1,76 @@
+"""Bridge between CoordinatorState and the model_profiles aggregator.
+
+The coordinator records every run outcome in ``model_profiles.yaml`` so the
+assignment system can inform future decisions. This module extracts the
+per-role telemetry from ``CoordinatorState`` and hands a ``RunOutcome`` to
+:mod:`theforge.model_profiles`. Kept as a thin adapter to keep ``engine.py``
+free of aggregation logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.config import ForgeConfig
+from theforge.model_profiles import RunOutcome, update_from_run
+
+from .state import CoordinatorState
+
+
+def _extract_reviewers(
+    state: CoordinatorState,
+) -> dict[str, tuple[int, int, float]]:
+    """Per-reviewer ``(cycles, findings, cost)`` from cycle metadata + telemetry.
+
+    Findings are the per-cycle aggregate (shared view across reviewers); cost
+    is split evenly across successful reviewers in each cycle. Attribution is
+    approximate but reasonable without per-reviewer telemetry.
+    """
+    out: dict[str, tuple[int, int, float]] = {}
+    meta_list = state.review_cycle_metadata or []
+    tele_list = state.review_iteration_telemetry or []
+    for idx, meta in enumerate(meta_list):
+        tele = tele_list[idx] if idx < len(tele_list) else None
+        findings = sum(int(v) for v in tele.findings_by_severity.values()) if tele else 0
+        cost = float(tele.cost_usd) if tele else 0.0
+        participants = list(meta.successful or [])
+        if not participants:
+            continue
+        per_head_cost = cost / len(participants) if participants else 0.0
+        for name in participants:
+            prev = out.get(name, (0, 0, 0.0))
+            out[name] = (prev[0] + 1, prev[1] + findings, prev[2] + per_head_cost)
+    return out
+
+
+def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: bool) -> RunOutcome:
+    """Pure: assemble a :class:`RunOutcome` from coordinator state."""
+    complexity = state.preflight_complexity or "medium"
+    # ``dev_trace_count`` is the only monotonic dev-iteration counter (never reset
+    # on cycle boundaries) so it captures total dev attempts across the run.
+    dev_iterations = max(int(state.dev_trace_count or 0), 1)
+    return RunOutcome(
+        complexity=complexity,
+        dev_model=config.dev_profile.name,
+        dev_success=bool(success),
+        dev_iterations=dev_iterations,
+        dev_cost_usd=float(state.total_dev_cost or 0.0),
+        preflight_model=config.preflight_profile.name
+        if getattr(config, "preflight_profile", None)
+        else None,
+        preflight_cost_usd=float(state.total_preflight_cost or 0.0),
+        reviewers=_extract_reviewers(state),
+    )
+
+
+def update_profiles_from_run(
+    *,
+    profiles_path: Path,
+    history_path: Path | None,
+    config: ForgeConfig,
+    state: CoordinatorState,
+    success: bool,
+) -> dict:
+    """Extract telemetry and persist an updated ``model_profiles.yaml``."""
+    outcome = build_run_outcome(config, state, success)
+    return update_from_run(profiles_path, history_path, outcome)

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -735,6 +735,11 @@ def _apply_preflight_config(
     _history_path = config.project_root / ".forge" / "assignment_history.yaml"
     _esc_history = _load_esc_history(_history_path)
 
+    from theforge.model_profiles import load_profiles as _load_profiles  # noqa: PLC0415
+
+    _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
+    _model_profiles = _load_profiles(_profiles_path)
+
     _explicit: dict[str, object] = {}
     _explicit_roles: set[str] = set()
     if config.models is None:
@@ -759,6 +764,7 @@ def _apply_preflight_config(
         _explicit if _explicit else None,
         state.sprint_promotions,
         config.secrets,
+        model_profiles=_model_profiles,
     )
 
     _replace_kwargs: dict[str, object] = {

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -1,0 +1,270 @@
+"""Model capability profiles — aggregated per-model, per-role run outcomes.
+
+Maintains ``.forge/model_profiles.yaml`` with success rate, iteration count and
+cost averages for each model, broken down by role (dev, review, preflight) and
+— for the dev role — by complexity band. Updated after every run from
+``CoordinatorState``; seeded from ``assignment_history.yaml`` on first run.
+
+This module has a thin I/O surface (``load_profiles``/``save_profiles``); all
+aggregation is pure. No LLM calls.
+
+Schema on disk::
+
+    models:
+      <name>:
+        dev:
+          runs, success_rate, avg_iterations, avg_cost_usd
+          by_complexity:
+            small|medium|large: {runs, success_rate}
+        review:
+          runs, avg_findings, avg_cost_usd
+        preflight:
+          runs, avg_cost_usd
+
+Underscore-prefixed siblings (``_successes``, ``_iterations_sum``, ``_cost_sum``,
+``_findings_sum``) are the running accumulators used to update the derived
+fields in place. They are part of the persisted schema.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+ROLES = ("dev", "review", "preflight")
+COMPLEXITY_BANDS = ("small", "medium", "large")
+
+
+# ── Data carrier ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunOutcome:
+    """Everything ``update_from_run`` needs about one coordinator run.
+
+    ``reviewers`` maps each reviewer profile name to a
+    ``(cycles_participated, findings_observed, cost_usd)`` triple attributed to
+    that reviewer. Attribution at the per-reviewer level is approximate —
+    reviewers see the same code so findings_observed is the full per-cycle
+    aggregate and cost is divided evenly across successful reviewers in each
+    cycle.
+    """
+
+    complexity: str
+    dev_model: str
+    dev_success: bool
+    dev_iterations: int
+    dev_cost_usd: float
+    preflight_model: str | None = None
+    preflight_cost_usd: float = 0.0
+    reviewers: dict[str, tuple[int, int, float]] = field(default_factory=dict)
+
+
+# ── I/O ───────────────────────────────────────────────────────────────────
+
+
+def load_profiles(path: Path) -> dict[str, Any]:
+    """Read ``model_profiles.yaml``; return ``{"models": {}}`` if absent/bad."""
+    if not path.exists():
+        return {"models": {}}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[model_profiles] Failed to load %s: %s", path, exc)
+        return {"models": {}}
+    if not isinstance(data, dict):
+        return {"models": {}}
+    if not isinstance(data.get("models"), dict):
+        data["models"] = {}
+    return data
+
+
+def save_profiles(path: Path, data: dict[str, Any]) -> None:
+    """Write profiles to disk; best-effort (warns but doesn't raise)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=True)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[model_profiles] Failed to write %s: %s", path, exc)
+
+
+# ── Pure aggregation ──────────────────────────────────────────────────────
+
+
+def _normalize_band(complexity: str | None) -> str:
+    """Map legacy/alt complexity strings to small|medium|large."""
+    if not complexity:
+        return "medium"
+    cl = complexity.lower()
+    if cl in COMPLEXITY_BANDS:
+        return cl
+    return {"low": "small", "high": "large"}.get(cl, "medium")
+
+
+def _ensure_model(data: dict, name: str) -> dict:
+    models = data.setdefault("models", {})
+    return models.setdefault(name, {})
+
+
+def _update_dev(
+    entry: dict,
+    complexity: str,
+    success: bool,
+    iterations: int,
+    cost_usd: float,
+) -> None:
+    dev = entry.setdefault("dev", {})
+    runs = int(dev.get("runs", 0)) + 1
+    successes = int(dev.get("_successes", 0)) + (1 if success else 0)
+    iter_sum = float(dev.get("_iterations_sum", 0.0)) + float(iterations)
+    cost_sum = float(dev.get("_cost_sum", 0.0)) + float(cost_usd)
+    dev["runs"] = runs
+    dev["_successes"] = successes
+    dev["_iterations_sum"] = iter_sum
+    dev["_cost_sum"] = cost_sum
+    dev["success_rate"] = round(successes / runs, 4)
+    dev["avg_iterations"] = round(iter_sum / runs, 4)
+    dev["avg_cost_usd"] = round(cost_sum / runs, 6)
+
+    by = dev.setdefault("by_complexity", {})
+    bc = by.setdefault(complexity, {})
+    bc_runs = int(bc.get("runs", 0)) + 1
+    bc_successes = int(bc.get("_successes", 0)) + (1 if success else 0)
+    bc["runs"] = bc_runs
+    bc["_successes"] = bc_successes
+    bc["success_rate"] = round(bc_successes / bc_runs, 4)
+
+
+def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float) -> None:
+    if cycles <= 0:
+        return
+    rev = entry.setdefault("review", {})
+    runs = int(rev.get("runs", 0)) + cycles
+    find_sum = float(rev.get("_findings_sum", 0.0)) + float(findings)
+    cost_sum = float(rev.get("_cost_sum", 0.0)) + float(cost_usd)
+    rev["runs"] = runs
+    rev["_findings_sum"] = find_sum
+    rev["_cost_sum"] = cost_sum
+    rev["avg_findings"] = round(find_sum / runs, 4)
+    rev["avg_cost_usd"] = round(cost_sum / runs, 6)
+
+
+def _update_preflight(entry: dict, cost_usd: float) -> None:
+    pf = entry.setdefault("preflight", {})
+    runs = int(pf.get("runs", 0)) + 1
+    cost_sum = float(pf.get("_cost_sum", 0.0)) + float(cost_usd)
+    pf["runs"] = runs
+    pf["_cost_sum"] = cost_sum
+    pf["avg_cost_usd"] = round(cost_sum / runs, 6)
+
+
+def apply_run(data: dict, outcome: RunOutcome) -> dict:
+    """Pure: fold one run outcome into the profiles dict, returning it."""
+    band = _normalize_band(outcome.complexity)
+    dev_entry = _ensure_model(data, outcome.dev_model)
+    _update_dev(
+        dev_entry,
+        band,
+        outcome.dev_success,
+        outcome.dev_iterations,
+        outcome.dev_cost_usd,
+    )
+    if outcome.preflight_model:
+        pf_entry = _ensure_model(data, outcome.preflight_model)
+        _update_preflight(pf_entry, outcome.preflight_cost_usd)
+    for name, (cycles, findings, cost) in outcome.reviewers.items():
+        rev_entry = _ensure_model(data, name)
+        _update_review(rev_entry, cycles, findings, cost)
+    return data
+
+
+# ── Backfill ──────────────────────────────────────────────────────────────
+
+
+def backfill_from_history(history_path: Path) -> dict:
+    """Aggregate ``assignment_history.yaml`` into a profiles dict.
+
+    Only dev-role per-complexity success rates are derivable — the escalation
+    history doesn't record iteration counts or cost, so those remain zero until
+    fresh runs populate them.
+    """
+    data: dict = {"models": {}}
+    if not history_path.exists():
+        return data
+    try:
+        with open(history_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[model_profiles] Failed to read history %s: %s", history_path, exc)
+        return data
+    if not isinstance(raw, dict):
+        return data
+    records = raw.get("escalations") or []
+    if not isinstance(records, list):
+        return data
+    for r in records:
+        if not isinstance(r, dict):
+            continue
+        model = str(r.get("dev_model") or "").strip()
+        if not model:
+            continue
+        band = _normalize_band(str(r.get("complexity") or ""))
+        outcome = str(r.get("outcome") or "").strip().upper()
+        success = outcome == "DONE"
+        entry = _ensure_model(data, model)
+        _update_dev(entry, band, success, iterations=0, cost_usd=0.0)
+    return data
+
+
+# ── Convenience: load + update + save ─────────────────────────────────────
+
+
+def update_from_run(
+    profiles_path: Path,
+    history_path: Path | None,
+    outcome: RunOutcome,
+) -> dict:
+    """Load profiles (seeding from history on first run), apply, save."""
+    if not profiles_path.exists() and history_path is not None:
+        data = backfill_from_history(history_path)
+    else:
+        data = load_profiles(profiles_path)
+    data = apply_run(data, outcome)
+    save_profiles(profiles_path, data)
+    return data
+
+
+# ── Reader API for assignment ─────────────────────────────────────────────
+
+
+def get_dev_success_rate(
+    profiles: dict,
+    model: str,
+    complexity: str | None = None,
+    min_runs: int = 3,
+) -> float | None:
+    """Return dev success rate for (model, complexity) or None under min_runs."""
+    models = (profiles or {}).get("models") or {}
+    entry = models.get(model)
+    if not isinstance(entry, dict):
+        return None
+    dev = entry.get("dev")
+    if not isinstance(dev, dict):
+        return None
+    if complexity is None:
+        runs = int(dev.get("runs", 0))
+        return float(dev.get("success_rate", 0.0)) if runs >= min_runs else None
+    band = _normalize_band(complexity)
+    bc = (dev.get("by_complexity") or {}).get(band)
+    if not isinstance(bc, dict):
+        return None
+    runs = int(bc.get("runs", 0))
+    return float(bc.get("success_rate", 0.0)) if runs >= min_runs else None

--- a/tests/test_assignment_model_profiles.py
+++ b/tests/test_assignment_model_profiles.py
@@ -1,0 +1,114 @@
+"""assign_models honors model_profiles when ranking same-tier dev candidates."""
+
+from __future__ import annotations
+
+import pytest
+
+from theforge.assignment import AssignmentConfig, assign_models
+from theforge.config import AgentDef
+
+
+@pytest.fixture(autouse=True)
+def _mock_api_keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("GOOGLE_API_KEY", "k")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+
+
+def _agents_two_mid() -> list[AgentDef]:
+    # Both mid-tier, same tier. Without profiles, cheapest budget wins (budget=1).
+    return [
+        AgentDef(
+            name="cheap-mid",
+            provider="deepseek",
+            model="ds",
+            budget_usd=1.0,
+            timeout_seconds=300,
+            tier="mid",
+        ),
+        AgentDef(
+            name="proven-mid",
+            provider="anthropic",
+            model="sonnet",
+            budget_usd=5.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="opus",
+            provider="anthropic",
+            model="opus",
+            budget_usd=8.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+    ]
+
+
+def _cfg() -> AssignmentConfig:
+    return AssignmentConfig(
+        enabled=True,
+        min_reviewers=1,
+        max_reviewers=1,
+        prefer_cross_provider=False,
+        budget_per_story_usd=100.0,
+        escalation_memory=False,
+    )
+
+
+def test_dev_selection_without_profiles_uses_cheapest():
+    decision = assign_models(_agents_two_mid(), _cfg(), complexity="MEDIUM")
+    assert decision.dev.name == "cheap-mid"
+
+
+def test_dev_selection_prefers_high_success_rate_when_observed():
+    profiles = {
+        "models": {
+            "proven-mid": {
+                "dev": {
+                    "runs": 10,
+                    "success_rate": 0.9,
+                    "by_complexity": {"medium": {"runs": 10, "success_rate": 0.9}},
+                }
+            },
+            "cheap-mid": {
+                "dev": {
+                    "runs": 10,
+                    "success_rate": 0.2,
+                    "by_complexity": {"medium": {"runs": 10, "success_rate": 0.2}},
+                }
+            },
+        }
+    }
+    decision = assign_models(
+        _agents_two_mid(),
+        _cfg(),
+        complexity="MEDIUM",
+        model_profiles=profiles,
+    )
+    assert decision.dev.name == "proven-mid"
+    # Rationale annotated with the observed rate
+    assert "0.90" in decision.rationale["dev"]
+
+
+def test_dev_selection_ignores_profiles_below_min_runs():
+    profiles = {
+        "models": {
+            "proven-mid": {
+                "dev": {
+                    "runs": 1,
+                    "success_rate": 1.0,
+                    "by_complexity": {"medium": {"runs": 1, "success_rate": 1.0}},
+                }
+            },
+        }
+    }
+    decision = assign_models(
+        _agents_two_mid(),
+        _cfg(),
+        complexity="MEDIUM",
+        model_profiles=profiles,
+    )
+    # Insufficient data → fall back to budget-cheapest default
+    assert decision.dev.name == "cheap-mid"

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -182,3 +182,77 @@ def test_preflight_passes_model_profiles_to_assign_models(tmp_path, monkeypatch)
 
     assert "model_profiles" in captured
     assert captured["model_profiles"] == seeded
+
+
+def test_record_run_memory_is_called_from_resume_path(tmp_path):
+    """Both run_task and _run_resume_coordinator must call _record_run_memory.
+
+    Regression guard for cycle 2: resume entry points (run_from_review /
+    run_from_dev) previously skipped model_profiles.yaml updates because the
+    persistence logic lived inline in run_task. It now lives in a shared
+    helper — this test asserts the helper is referenced from both paths.
+    """
+    from theforge.coordinator import engine as _eng
+
+    source = Path(_eng.__file__).read_text(encoding="utf-8")
+    # Exactly one definition + at least two call sites (run_task + resume).
+    assert source.count("def _record_run_memory(") == 1
+    assert source.count("_record_run_memory(") >= 3  # 1 def + 2 calls
+
+
+def test_record_run_memory_writes_profiles_and_history(tmp_path):
+    """Unit test of the shared helper: both files written when gates are met."""
+    from dataclasses import replace as _replace
+
+    from theforge.coordinator.engine import _record_run_memory
+    from theforge.coordinator.state import CoordinatorResult, Phase
+
+    config = _replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="claude-sonnet",
+                provider=None,
+                model="sonnet",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="cheap",
+                cli="claude",
+            )
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=True,
+            budget_per_story_usd=30.0,
+        ),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    result = CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok")
+
+    _record_run_memory(config, task, state, result)
+
+    profiles_path = tmp_path / ".forge" / "model_profiles.yaml"
+    history_path = tmp_path / ".forge" / "assignment_history.yaml"
+    assert profiles_path.exists()
+    assert history_path.exists()
+
+
+def test_record_run_memory_skips_when_preflight_complexity_missing(tmp_path, caplog):
+    """Helper must no-op (and log) when preflight_complexity is unset."""
+    import logging
+
+    from theforge.coordinator.engine import _record_run_memory
+    from theforge.coordinator.state import CoordinatorResult, Phase
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState()  # preflight_complexity stays None
+    result = CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok")
+
+    with caplog.at_level(logging.DEBUG):
+        _record_run_memory(config, task, state, result)
+
+    profiles_path = tmp_path / ".forge" / "model_profiles.yaml"
+    assert not profiles_path.exists()

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -1,0 +1,184 @@
+"""Seam tests for the engine ↔ model_profiles + preflight ↔ assign_models paths.
+
+These cover the coordinator boundaries where model profile data flows:
+  1. engine.run_task writes model_profiles.yaml after a run regardless of the
+     escalation_memory feature flag (AC: "updated after each run").
+  2. preflight._apply_preflight_config loads model_profiles.yaml and hands it
+     to assign_models (AC: "assignment system reads profiles when making
+     decisions").
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from coord_test_helpers import (  # noqa: E402
+    _PREFLIGHT_RESULT,
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.config import (  # noqa: E402
+    AgentDef,
+    AssignmentConfig,
+)
+from theforge.coordinator.engine import run_task  # noqa: E402
+from theforge.coordinator.state import CoordinatorState  # noqa: E402
+
+
+def _cached_proceed_state_with_complexity(complexity: str = "medium") -> CoordinatorState:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    state.preflight_reason = "ok"
+    state.preflight_complexity = complexity
+    state.preflight_complexity_score = 5
+    state.preflight_sufficiency = "implementation_ready"
+    state.preflight_work_type = "feature"
+    return state
+
+
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+@patch("theforge.coordinator.plan_flow.run_agent")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.dev_phase.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+def test_model_profiles_written_even_when_escalation_memory_disabled(
+    mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+):
+    """AC: model_profiles.yaml is updated after every run, independent of
+    the escalation_memory flag."""
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="claude-sonnet",
+                provider=None,
+                model="sonnet",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="cheap",
+                cli="claude",
+            )
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=False,  # deliberately off — profiles must still write
+            budget_per_story_usd=30.0,
+        ),
+    )
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir()
+    cached_state = _cached_proceed_state_with_complexity()
+
+    mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+    mock_plan_agent.side_effect = mock_agent
+    mock_preflight.return_value = _PREFLIGHT_RESULT
+    mock_agent.return_value = _make_agent_result(success=True, output="implemented")
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+    ]
+
+    result = run_task(config, task, cached_preflight_state=cached_state)
+
+    assert result.success is True
+    profiles_path = tmp_path / ".forge" / "model_profiles.yaml"
+    assert profiles_path.exists(), "model_profiles.yaml should be written each run"
+
+    # And escalation_memory is OFF, so assignment_history.yaml should NOT exist.
+    history_path = tmp_path / ".forge" / "assignment_history.yaml"
+    assert not history_path.exists()
+
+    data = yaml.safe_load(profiles_path.read_text(encoding="utf-8"))
+    models = data.get("models") or {}
+    # The dev profile name from _make_config — whatever it is, it's recorded.
+    assert models, "at least one model should be recorded"
+    dev_entries = [m for m in models.values() if "dev" in m]
+    assert dev_entries, "the dev model's dev role should be aggregated"
+
+
+def test_preflight_passes_model_profiles_to_assign_models(tmp_path, monkeypatch):
+    """AC: the assignment system reads model_profiles when deciding.
+
+    Verifies preflight._apply_preflight_config loads model_profiles.yaml and
+    forwards it as the model_profiles kwarg to assign_models.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    from theforge.coordinator import preflight as _pf
+
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="claude-sonnet",
+                provider="anthropic",
+                model="sonnet",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="cheap",
+                cli="claude",
+            )
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=False,
+            budget_per_story_usd=30.0,
+            min_reviewers=1,
+            max_reviewers=1,
+        ),
+    )
+
+    # Seed a pre-existing model_profiles.yaml so we can assert it is what's passed.
+    profiles_path = tmp_path / ".forge" / "model_profiles.yaml"
+    profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    seeded = {
+        "models": {
+            "claude-sonnet": {
+                "dev": {
+                    "runs": 5,
+                    "success_rate": 0.8,
+                    "by_complexity": {"medium": {"runs": 5, "success_rate": 0.8}},
+                }
+            }
+        }
+    }
+    profiles_path.write_text(yaml.safe_dump(seeded), encoding="utf-8")
+
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 5
+
+    captured: dict = {}
+
+    def _fake_assign_models(*args, **kwargs):
+        captured["model_profiles"] = kwargs.get("model_profiles")
+        # Return a minimal decision with the configured dev profile to avoid
+        # exercising the real logic.
+        from theforge.assignment import AssignmentDecision
+
+        return AssignmentDecision(
+            preflight=config.preflight_profile,
+            planner=config.dev_profile,
+            plan_reviewers=[],
+            dev=config.dev_profile,
+            code_reviewers=[],
+            rationale={},
+        )
+
+    monkeypatch.setattr("theforge.assignment.assign_models", _fake_assign_models)
+
+    _pf._apply_preflight_config(config, state)
+
+    assert "model_profiles" in captured
+    assert captured["model_profiles"] == seeded

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -1,0 +1,311 @@
+"""Tests for src/theforge/model_profiles.py — pure aggregation + thin I/O."""
+
+from __future__ import annotations
+
+import yaml
+
+from theforge.model_profiles import (
+    COMPLEXITY_BANDS,
+    RunOutcome,
+    apply_run,
+    backfill_from_history,
+    get_dev_success_rate,
+    load_profiles,
+    save_profiles,
+    update_from_run,
+)
+
+# ── Pure aggregation ──────────────────────────────────────────────────────
+
+
+def test_apply_run_records_dev_stats():
+    data: dict = {"models": {}}
+    outcome = RunOutcome(
+        complexity="medium",
+        dev_model="sonnet",
+        dev_success=True,
+        dev_iterations=2,
+        dev_cost_usd=1.50,
+    )
+    apply_run(data, outcome)
+
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev["runs"] == 1
+    assert dev["success_rate"] == 1.0
+    assert dev["avg_iterations"] == 2.0
+    assert dev["avg_cost_usd"] == 1.5
+    assert dev["by_complexity"]["medium"]["runs"] == 1
+    assert dev["by_complexity"]["medium"]["success_rate"] == 1.0
+
+
+def test_apply_run_averages_across_runs():
+    data: dict = {"models": {}}
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="small",
+            dev_model="haiku",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=0.10,
+        ),
+    )
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="large",
+            dev_model="haiku",
+            dev_success=False,
+            dev_iterations=3,
+            dev_cost_usd=0.50,
+        ),
+    )
+    dev = data["models"]["haiku"]["dev"]
+    assert dev["runs"] == 2
+    assert dev["success_rate"] == 0.5
+    assert dev["avg_iterations"] == 2.0
+    assert dev["avg_cost_usd"] == 0.30
+    # Per-complexity breakdown
+    by = dev["by_complexity"]
+    assert by["small"]["runs"] == 1 and by["small"]["success_rate"] == 1.0
+    assert by["large"]["runs"] == 1 and by["large"]["success_rate"] == 0.0
+
+
+def test_apply_run_review_attribution():
+    data: dict = {"models": {}}
+    outcome = RunOutcome(
+        complexity="medium",
+        dev_model="sonnet",
+        dev_success=True,
+        dev_iterations=1,
+        dev_cost_usd=0.0,
+        reviewers={
+            "gemini": (2, 6, 0.40),  # participated in 2 cycles, 6 findings, $0.40
+            "opus": (1, 3, 0.25),
+        },
+    )
+    apply_run(data, outcome)
+
+    gem = data["models"]["gemini"]["review"]
+    assert gem["runs"] == 2
+    assert gem["avg_findings"] == 3.0
+    assert gem["avg_cost_usd"] == 0.20
+
+    opus = data["models"]["opus"]["review"]
+    assert opus["runs"] == 1
+    assert opus["avg_findings"] == 3.0
+
+
+def test_apply_run_preflight():
+    data: dict = {"models": {}}
+    outcome = RunOutcome(
+        complexity="small",
+        dev_model="haiku",
+        dev_success=True,
+        dev_iterations=1,
+        dev_cost_usd=0.1,
+        preflight_model="deepseek-r1",
+        preflight_cost_usd=0.30,
+    )
+    apply_run(data, outcome)
+    pf = data["models"]["deepseek-r1"]["preflight"]
+    assert pf["runs"] == 1
+    assert pf["avg_cost_usd"] == 0.30
+
+
+def test_complexity_normalization_handles_legacy_enums():
+    data: dict = {"models": {}}
+    # LOW / HIGH should map to small / large
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="LOW",
+            dev_model="m",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=0.0,
+        ),
+    )
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="HIGH",
+            dev_model="m",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=0.0,
+        ),
+    )
+    by = data["models"]["m"]["dev"]["by_complexity"]
+    assert "small" in by and "large" in by
+    assert by["small"]["runs"] == 1
+    assert by["large"]["runs"] == 1
+
+
+# ── I/O round-trip ────────────────────────────────────────────────────────
+
+
+def test_load_missing_returns_empty_skeleton(tmp_path):
+    path = tmp_path / "missing.yaml"
+    assert load_profiles(path) == {"models": {}}
+
+
+def test_save_then_load_roundtrip(tmp_path):
+    path = tmp_path / "profiles.yaml"
+    data = {"models": {"m1": {"dev": {"runs": 1}}}}
+    save_profiles(path, data)
+    assert path.exists()
+    reloaded = load_profiles(path)
+    assert reloaded == data
+
+
+def test_load_tolerates_malformed_yaml(tmp_path):
+    path = tmp_path / "profiles.yaml"
+    path.write_text("not a dict", encoding="utf-8")
+    # Scalar yaml → falls back to empty skeleton.
+    assert load_profiles(path) == {"models": {}}
+
+
+# ── Backfill from assignment_history.yaml ─────────────────────────────────
+
+
+def test_backfill_aggregates_dev_outcomes(tmp_path):
+    history = tmp_path / "assignment_history.yaml"
+    history.write_text(
+        yaml.safe_dump(
+            {
+                "escalations": [
+                    {
+                        "story": "a",
+                        "complexity": "MEDIUM",
+                        "dev_model": "sonnet",
+                        "outcome": "DONE",
+                    },
+                    {
+                        "story": "b",
+                        "complexity": "MEDIUM",
+                        "dev_model": "sonnet",
+                        "outcome": "ESCALATE",
+                    },
+                    {"story": "c", "complexity": "HIGH", "dev_model": "opus", "outcome": "DONE"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    data = backfill_from_history(history)
+    sonnet = data["models"]["sonnet"]["dev"]
+    assert sonnet["runs"] == 2
+    assert sonnet["success_rate"] == 0.5
+    assert sonnet["avg_iterations"] == 0.0  # history carries no iteration data
+    assert sonnet["avg_cost_usd"] == 0.0
+    assert sonnet["by_complexity"]["medium"]["runs"] == 2
+
+    opus = data["models"]["opus"]["dev"]
+    assert opus["by_complexity"]["large"]["runs"] == 1
+
+
+def test_backfill_missing_history_returns_empty(tmp_path):
+    data = backfill_from_history(tmp_path / "nope.yaml")
+    assert data == {"models": {}}
+
+
+# ── update_from_run: backfill on first run ────────────────────────────────
+
+
+def test_update_from_run_backfills_when_profiles_absent(tmp_path):
+    history = tmp_path / "assignment_history.yaml"
+    history.write_text(
+        yaml.safe_dump(
+            {
+                "escalations": [
+                    {"complexity": "small", "dev_model": "haiku", "outcome": "DONE"},
+                    {"complexity": "small", "dev_model": "haiku", "outcome": "DONE"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    profiles_path = tmp_path / "model_profiles.yaml"
+
+    data = update_from_run(
+        profiles_path,
+        history,
+        RunOutcome(
+            complexity="small",
+            dev_model="haiku",
+            dev_success=False,
+            dev_iterations=2,
+            dev_cost_usd=0.20,
+        ),
+    )
+    assert profiles_path.exists()
+    dev = data["models"]["haiku"]["dev"]
+    # 2 from backfill (DONE) + 1 new (failed)
+    assert dev["runs"] == 3
+    assert round(dev["success_rate"], 4) == round(2 / 3, 4)
+    # avg_iterations = (0 + 0 + 2) / 3
+    assert round(dev["avg_iterations"], 4) == round(2 / 3, 4)
+
+
+def test_update_from_run_uses_existing_profiles_not_history(tmp_path):
+    profiles_path = tmp_path / "model_profiles.yaml"
+    # Pre-existing profiles file: backfill should NOT run.
+    save_profiles(profiles_path, {"models": {"haiku": {"dev": {"runs": 5, "_successes": 5}}}})
+    history = tmp_path / "assignment_history.yaml"
+    history.write_text(
+        yaml.safe_dump(
+            {"escalations": [{"complexity": "small", "dev_model": "haiku", "outcome": "DONE"}]}
+        ),
+        encoding="utf-8",
+    )
+    data = update_from_run(
+        profiles_path,
+        history,
+        RunOutcome(
+            complexity="small",
+            dev_model="haiku",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=0.0,
+        ),
+    )
+    # Previous runs=5 + 1 new = 6 (not 5+1+1 from history)
+    assert data["models"]["haiku"]["dev"]["runs"] == 6
+
+
+# ── Reader helper ─────────────────────────────────────────────────────────
+
+
+def test_get_dev_success_rate_requires_min_runs():
+    profiles = {
+        "models": {
+            "sonnet": {
+                "dev": {
+                    "runs": 2,
+                    "success_rate": 1.0,
+                    "by_complexity": {
+                        "medium": {"runs": 2, "success_rate": 1.0},
+                    },
+                }
+            },
+            "opus": {
+                "dev": {
+                    "runs": 10,
+                    "success_rate": 0.8,
+                    "by_complexity": {
+                        "medium": {"runs": 10, "success_rate": 0.8},
+                    },
+                }
+            },
+        }
+    }
+    # sonnet has fewer runs than default min_runs=3 → None
+    assert get_dev_success_rate(profiles, "sonnet", "medium") is None
+    assert get_dev_success_rate(profiles, "opus", "medium") == 0.8
+    # Unknown model / role → None
+    assert get_dev_success_rate(profiles, "gemini", "medium") is None
+
+
+def test_complexity_bands_constant():
+    assert COMPLEXITY_BANDS == ("small", "medium", "large")

--- a/tests/test_model_profiles_bridge.py
+++ b/tests/test_model_profiles_bridge.py
@@ -1,0 +1,117 @@
+"""Seam test: CoordinatorState → model_profiles.yaml via the bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from theforge.coordinator.model_profiles_bridge import (
+    build_run_outcome,
+    update_profiles_from_run,
+)
+from theforge.coordinator.state import (
+    CoordinatorState,
+    ReviewCycleMetadata,
+    ReviewIterationTelemetry,
+)
+
+
+@dataclass
+class _Profile:
+    name: str
+
+
+@dataclass
+class _Cfg:
+    project_root: str = "."
+    dev_profile: _Profile = None  # type: ignore[assignment]
+    preflight_profile: _Profile = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.dev_profile is None:
+            self.dev_profile = _Profile(name="sonnet")
+        if self.preflight_profile is None:
+            self.preflight_profile = _Profile(name="deepseek-r1")
+
+
+def _make_state(*, review_cycles: int = 1) -> CoordinatorState:
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.dev_trace_count = 2
+    # Populate cost via synthetic AgentResult-like objects? total_dev_cost sums
+    # over dev_results; easier to set dev_results to []; we set cost via synthetic
+    # entries.
+
+    # We don't have AgentResult import here — set a minimal stand-in that matches
+    # the .cost_usd attribute summed by total_dev_cost. A simple dataclass works.
+    @dataclass
+    class _AR:
+        cost_usd: float | None = 0.0
+
+    state.dev_results = [_AR(cost_usd=0.30), _AR(cost_usd=0.20)]
+    # preflight_result left as None (total_preflight_cost has a complex raw shape
+    # that isn't relevant to what we're asserting here).
+    # Set review cycle metadata + telemetry
+    for i in range(review_cycles):
+        state.review_cycle_metadata.append(
+            ReviewCycleMetadata(
+                pool_models=["gemini", "opus"],
+                successful=["gemini", "opus"],
+                failed=[],
+                synthesized=False,
+            )
+        )
+        state.review_iteration_telemetry.append(
+            ReviewIterationTelemetry(
+                iteration=i + 1,
+                max_iterations=3,
+                cost_usd=0.40,
+                duration_s=5.0,
+                verdict="APPROVE",
+                findings_by_severity={"P1": 0, "P2": 2},
+                new_findings_by_severity={},
+                repeated_findings_by_severity={},
+                novel_findings=0,
+                restated_findings=0,
+            )
+        )
+    return state
+
+
+def test_build_run_outcome_captures_dev_preflight_and_reviewers():
+    state = _make_state(review_cycles=2)
+    cfg = _Cfg()
+
+    outcome = build_run_outcome(cfg, state, success=True)
+    assert outcome.complexity == "medium"
+    assert outcome.dev_model == "sonnet"
+    assert outcome.dev_success is True
+    assert outcome.dev_iterations == 2
+    assert outcome.dev_cost_usd == 0.5
+    assert outcome.preflight_model == "deepseek-r1"
+    assert outcome.preflight_cost_usd == 0.0
+    # Two reviewers, two cycles each.
+    assert set(outcome.reviewers.keys()) == {"gemini", "opus"}
+    cycles, findings, cost = outcome.reviewers["gemini"]
+    assert cycles == 2
+    assert findings == 4  # 2 P2 per cycle * 2 cycles
+    assert round(cost, 2) == 0.40  # $0.40/cycle split 2 ways * 2 cycles = 0.40
+
+
+def test_update_profiles_from_run_writes_file(tmp_path):
+    state = _make_state(review_cycles=1)
+    cfg = _Cfg(project_root=str(tmp_path))
+    profiles_path = tmp_path / "model_profiles.yaml"
+
+    data = update_profiles_from_run(
+        profiles_path=profiles_path,
+        history_path=None,
+        config=cfg,
+        state=state,
+        success=True,
+    )
+
+    assert profiles_path.exists()
+    assert data["models"]["sonnet"]["dev"]["runs"] == 1
+    assert data["models"]["deepseek-r1"]["preflight"]["runs"] == 1
+    assert data["models"]["gemini"]["review"]["runs"] == 1
+    assert data["models"]["opus"]["review"]["runs"] == 1


### PR DESCRIPTION
## Summary

[openai-api-gpt-5.4] Prior blocking issues are resolved, resume paths now persist model profiles, and I found no new P1 regressions in the touched code. | [deepseek-deepseek-reasoner] All prior P1 findings have been resolved. The implementation introduces a shared helper `_record_run_memory` that updates model profiles after every run (including resume paths), independent of the escalation_memory flag. The assignment system now loads and uses model profiles when making decisions. No new regressions were found. The acceptance criteria are satisfied, and comprehensive seam tests have been added.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $14.57
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/model_profiles.py:None`** The model_profiles module does not enforce a strict schema on the loaded YAML, relying instead on defensive dict access and fallbacks. While this is robust, it diverges from project convention 2 which states 'Schema validation is the integrity boundary'.

## Story

Model capability profiles — persist and aggregate run outcomes per model (GitHub Issue #169)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #169