### PR TITLE
Remove language-specific fields from shared orchestrator models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Stack-neutral story schema:** the `TaskStory.pytest_target` field and
+  `{pytest_target}` gate placeholder have been renamed to `test_target` and
+  `{test_target}`. Story frontmatter and sprint manifest overrides now use
+  `test_target`. This is a breaking change — update story files and any
+  `forge.yaml` gate commands that reference `{pytest_target}`. Story
+  scaffolding and ideation output no longer emit the field at all; gate
+  scoping belongs in `forge.yaml`. (#930)
+
 
 ## [0.8.0] — 2026-04-20
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -160,7 +160,6 @@ Copy `stories/TEMPLATE.md` to `stories/my-feature.md` and fill it in:
 ---
 name: "Add health check endpoint"
 slug: add-health-check
-pytest_target: tests/
 ---
 
 # Add Health Check Endpoint

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -16,7 +16,6 @@ is simply the default directory created by `forge init`.
 ---
 name: "Short human-readable title"
 slug: my-feature-slug
-pytest_target: tests/
 ---
 
 # Story Title
@@ -44,7 +43,7 @@ background, not as requirements.
 |-------|----------|---------|-------------|
 | `name` | Yes | — | Human-readable title. Shows in logs and audit. |
 | `slug` | Yes | — | Branch name (`forge/{slug}`), worktree path. Lowercase-with-dashes. |
-| `pytest_target` | No | `tests/` | Path passed to pytest in the gate command. |
+| `test_target` | No | `tests/` | Stack-neutral test target substituted for `{test_target}` in the gate command. |
 | `file_scope` | No | `[]` (unrestricted) | Restrict dev agent to these files/directories. Empty = no restriction. |
 | `gate` | No | project default | Override gate: `"none"` (skip), `"lint"`, or custom command. |
 | `depends_on` | No | `[]` | Slugs that must be merged before this story runs (sprint mode). |
@@ -102,7 +101,7 @@ stories:
 | `{issue: 123}` | Pull story body from GitHub issue #123 |
 | `{issue: 123, slug: my-slug}` | Override the slug derived from the issue title |
 | `{issue: 123, depends_on: [other-slug]}` | Declare a dependency on another story in the sprint |
-| `{issue: 123, pytest_target: tests/test_foo.py}` | Override the pytest target for this story |
+| `{issue: 123, test_target: tests/test_foo.py}` | Override the test target substituted into the gate command for this story |
 
 ### Declaring dependencies in GitHub issue bodies
 

--- a/examples/hello-forge/specs/add-farewell.md
+++ b/examples/hello-forge/specs/add-farewell.md
@@ -1,7 +1,6 @@
 ---
 name: "Add farewell endpoint"
 slug: add-farewell
-pytest_target: tests/
 ---
 
 # Add Farewell Endpoint

--- a/examples/hello-forge/specs/add-greeting.md
+++ b/examples/hello-forge/specs/add-greeting.md
@@ -1,7 +1,6 @@
 ---
 name: "Add greeting endpoint"
 slug: add-greeting
-pytest_target: tests/
 ---
 
 # Add Greeting Endpoint

--- a/src/theforge/cli/init_commands.py
+++ b/src/theforge/cli/init_commands.py
@@ -18,7 +18,6 @@ _STORY_TEMPLATE = """\
 # Story frontmatter — required fields
 name: "Short human-readable title"
 slug: my-feature-slug        # used for branch and worktree names
-pytest_target: tests/        # path passed to pytest for gate
 ---
 
 # Story title

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -42,7 +42,7 @@ def _parse_story_frontmatter(story_path: Path) -> dict:
         ---
         name: Phase 6H: per-user export
         slug: export-service
-        pytest_target: tests/test_export.py
+        test_target: tests/test_export.py
         ---
 
         # Story content starts here...
@@ -85,7 +85,7 @@ def _build_task(story_path: Path, slug: str | None = None) -> TaskStory:
         name=fm.get("name", story_path.stem.replace("_", " ").replace("-", " ").title()),
         story_path=story_path.resolve(),
         slug=resolved_slug,
-        pytest_target=fm.get("pytest_target"),
+        test_target=fm.get("test_target"),
         gate_override=fm.get("gate"),
         github_issue=github_issue,
     )

--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -85,8 +85,8 @@ def _run_gate_full(
     else:
         gate_cmd = config.validation.gate_command
         if task is not None:
-            pytest_target = task.pytest_target or "tests/"
-            gate_cmd = gate_cmd.replace("{pytest_target}", pytest_target)
+            test_target = task.test_target or "tests/"
+            gate_cmd = gate_cmd.replace("{test_target}", test_target)
             gate_cmd = gate_cmd.replace("{slug}", task.slug)
 
     _cu._log_verbose(f"Running gate: {gate_cmd}")

--- a/src/theforge/ideate.py
+++ b/src/theforge/ideate.py
@@ -12,7 +12,6 @@ The coordinator remains fully deterministic. Only the ideation agents are LLMs.
 
 from __future__ import annotations
 
-import shlex
 import sys
 import time
 from dataclasses import dataclass
@@ -56,30 +55,6 @@ class IdeationResult:
 # ── Prompt builders ──────────────────────────────────────────────────
 
 
-def _extract_pytest_target(config: "ForgeConfig | None") -> str:
-    """Derive pytest target path from config gate_command, defaulting to 'tests/'.
-
-    This is a best-effort heuristic. Gate commands like 'make test' or 'make gate'
-    silently fall back to 'tests/'. The '-m' token can also match ambiguously
-    (e.g. 'python -m pytest tests/'). The spec hardcodes 'pytest_target: tests/'
-    but this heuristic reflects the actual project configuration when it can be
-    inferred from the gate command.
-    """
-    if config is None:
-        return "tests/"
-    gate_cmd = config.validation.gate_command
-    try:
-        tokens = shlex.split(gate_cmd)
-        # Walk all tokens: any token that starts with "tests" and is not a flag
-        # is the pytest target, regardless of what precedes it (handles -q, -v, etc.)
-        for tok in tokens:
-            if tok.startswith("tests") and not tok.startswith("-"):
-                return tok
-    except ValueError:
-        pass
-    return "tests/"
-
-
 def _build_phase1_prompt(brief: str) -> str:
     return f"""You are participating in a structured ideation process.
 
@@ -110,7 +85,7 @@ def _build_single_model_prompt(brief: str, *, config: "ForgeConfig | None" = Non
     (synthesis). For a single-model pool there is no cross-review and no
     separate synthesis step — one model produces the full spec directly.
     """
-    pytest_target = _extract_pytest_target(config)
+    del config  # retained for API compatibility; no stack-specific fields are injected
 
     return f"""You are writing a structured implementation spec.
 
@@ -136,7 +111,6 @@ SPEC:
 ---
 name: "<derived from brief>"
 slug: "<kebab-case slug>"
-pytest_target: {pytest_target}
 ---
 
 # <Spec Title>
@@ -194,7 +168,7 @@ def _build_synthesis_prompt(
     *,
     config: "ForgeConfig | None" = None,
 ) -> str:
-    pytest_target = _extract_pytest_target(config)
+    del config  # retained for API compatibility; no stack-specific fields are injected
 
     phase1_section = "\n\n".join(
         f"### {model_name} (Phase 1)\n{output}" for model_name, output in phase1_outputs.items()
@@ -250,7 +224,6 @@ Keep the spec body under 150 lines.
 ---
 name: "<derived from brief>"
 slug: "<kebab-case slug>"
-pytest_target: {pytest_target}
 ---
 
 # <title>

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -201,7 +201,7 @@ def _build_task_from_story(story_path: Path) -> TaskStory:
         name=name,
         story_path=story_path,
         slug=slug,
-        pytest_target=fm.get("pytest_target"),
+        test_target=fm.get("test_target"),
         gate_override=fm.get("gate"),
         depends_on=depends_on,
         github_issue=github_issue,
@@ -279,8 +279,8 @@ def build_tasks_from_manifest(
                         f"'depends_on' must be a string or list, got "
                         f"{type(raw_deps).__name__}: {entry!r}"
                     )
-            if "pytest_target" in entry:
-                overrides["pytest_target"] = entry["pytest_target"]
+            if "test_target" in entry:
+                overrides["test_target"] = entry["test_target"]
             if overrides:
                 from dataclasses import replace
 

--- a/src/theforge/task/story.py
+++ b/src/theforge/task/story.py
@@ -14,7 +14,7 @@ class TaskStory:
     slug: str  # workspace slug, e.g. "export-service"
     story_path: Path | None = None  # path to the story file (None for issue-sourced stories)
     story_text: str | None = None  # inline story content (used when story_path is None)
-    pytest_target: str | None = None  # specific test target, or None for all
+    test_target: str | None = None  # stack-neutral test target substituted into gate_command
     gate_override: str | None = None  # from frontmatter "gate" key; "none" skips gate
     depends_on: list[str] = field(default_factory=list)  # slugs that must have merged first
     inferred_dependencies: list[str] = field(default_factory=list)  # inferred from GH blockers

--- a/stories/backlog/gemini-thinking-mode.md
+++ b/stories/backlog/gemini-thinking-mode.md
@@ -1,7 +1,6 @@
 ---
 name: "Gemini thinking mode — thinking_budget config support"
 slug: gemini-thinking-mode
-pytest_target: tests/
 ---
 
 # Gemini thinking mode — thinking_budget config support

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -126,7 +126,7 @@ class TestParseFrontmatter:
             "---\n"
             "name: Phase 6H\n"
             "slug: export-svc\n"
-            "pytest_target: tests/test_export.py\n"
+            "test_target: tests/test_export.py\n"
             "---\n\n"
             "# Spec content\n",
             encoding="utf-8",

--- a/tests/test_coord_gate_modes.py
+++ b/tests/test_coord_gate_modes.py
@@ -1,6 +1,6 @@
-"""Tests for exit-code gate mode, pytest_target substitution, and gate overrides.
+"""Tests for exit-code gate mode, test_target substitution, and gate overrides.
 
-Covers: TestExitCodeGateMode, TestPytestTargetSubstitution, TestGateOverride.
+Covers: TestExitCodeGateMode, TestTestTargetSubstitution, TestGateOverride.
 """
 
 from pathlib import Path
@@ -42,7 +42,7 @@ def _make_exit_code_config(tmp_path: Path) -> ForgeConfig:
             branch_pattern="forge/{slug}",
         ),
         validation=ValidationConfig(
-            gate_command="pytest {pytest_target} -q",
+            gate_command="pytest {test_target} -q",
             gate_timeout=120,
         ),
         dev_profile=DEFAULT_DEV_PROFILE,
@@ -366,20 +366,20 @@ class TestExitCodeGateMode:
         assert result.state.dev_iteration == 2  # was retried
 
 
-# ── Pytest target substitution tests ─────────────────────────────────
+# ── Test target substitution tests ───────────────────────────────────
 
 
-class TestPytestTargetSubstitution:
-    """Test that {pytest_target} in gate_command is replaced from TaskStory."""
+class TestTestTargetSubstitution:
+    """Test that {test_target} in gate_command is replaced from TaskStory."""
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_pytest_target_substituted(
+    def test_test_target_substituted(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
-        """Gate command should contain the task's pytest_target, not the placeholder."""
+        """Gate command should contain the task's test_target, not the placeholder."""
         config = _make_exit_code_config(tmp_path)
         spec = tmp_path / "spec.md"
         spec.write_text("# Test", encoding="utf-8")
@@ -387,7 +387,7 @@ class TestPytestTargetSubstitution:
             name="Test",
             story_path=spec,
             slug="test-task",
-            pytest_target="tests/test_specific.py",
+            test_target="tests/test_specific.py",
         )
         workspace = tmp_path / "test-task"
         workspace.mkdir()
@@ -418,18 +418,18 @@ class TestPytestTargetSubstitution:
         gate_cmds = [c for c in captured_cmds if "pytest" in c and "worktree" not in c]
         assert gate_cmds, "No gate command captured"
         assert "tests/test_specific.py" in gate_cmds[0]
-        assert "{pytest_target}" not in gate_cmds[0]
+        assert "{test_target}" not in gate_cmds[0]
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_pytest_target_defaults_to_tests(
+    def test_test_target_defaults_to_tests(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
-        """When pytest_target is None, defaults to 'tests/'."""
+        """When test_target is None, defaults to 'tests/'."""
         config = _make_exit_code_config(tmp_path)
-        task = _make_task(tmp_path)  # pytest_target=None by default
+        task = _make_task(tmp_path)  # test_target=None by default
         workspace = tmp_path / "test-task"
         workspace.mkdir()
 
@@ -458,6 +458,66 @@ class TestPytestTargetSubstitution:
         gate_cmds = [c for c in captured_cmds if "pytest" in c and "worktree" not in c]
         assert gate_cmds
         assert "tests/" in gate_cmds[0]
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_test_target_non_python_gate_command(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """A non-Python gate command (e.g. `go test {test_target}`) substitutes correctly.
+
+        Seam-level coverage that the `{test_target}` placeholder is language-neutral and
+        propagates the story's test_target into whatever gate command the project configures.
+        """
+        config = _make_exit_code_config(tmp_path)
+        # Replace the default Python gate command with a Go-style command.
+        from dataclasses import replace
+
+        config = replace(
+            config,
+            validation=replace(config.validation, gate_command="go test {test_target}"),
+        )
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Test", encoding="utf-8")
+        task = TaskStory(
+            name="Test",
+            story_path=spec,
+            slug="test-task",
+            test_target="./internal/foo/...",
+        )
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        captured_cmds: list[str] = []
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            captured_cmds.append(cmd)
+            stale_resp = _handle_stale_check_cmd(cmd)
+            if stale_resp is not None:
+                return stale_resp
+            if "go test" in cmd and "worktree" not in cmd:
+                return (True, "ok")
+            if "git status --porcelain" in cmd:
+                return (True, "")
+            return (True, "OK")
+
+        mock_shell.side_effect = shell_side_effect
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.return_value = _make_agent_result()
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        run_task(config, task)
+
+        gate_cmds = [c for c in captured_cmds if "go test" in c and "worktree" not in c]
+        assert gate_cmds, f"No gate command captured: {captured_cmds}"
+        assert "./internal/foo/..." in gate_cmds[0]
+        assert "{test_target}" not in gate_cmds[0]
+        # pytest-specific terminology must not appear in the substituted command.
+        assert "pytest" not in gate_cmds[0]
 
 
 # ── Gate override tests ──────────────────────────────────────────────

--- a/tests/test_ideate_flow.py
+++ b/tests/test_ideate_flow.py
@@ -79,7 +79,7 @@ _VALID_SPEC = """\
 ---
 name: "Test Feature"
 slug: test-feature
-pytest_target: tests/
+test_target: tests/
 ---
 
 # Test Feature
@@ -201,7 +201,7 @@ def _make_long_spec(line_count: int = 160) -> str:
 ---
 name: "Test Feature"
 slug: test-feature
-pytest_target: tests/
+test_target: tests/
 ---
 
 # Test Feature
@@ -793,7 +793,7 @@ SPEC:
 ---
 name: "Test"
 slug: test
-pytest_target: tests/
+test_target: tests/
 ---
 # Test
 """

--- a/tests/test_ideate_prompts.py
+++ b/tests/test_ideate_prompts.py
@@ -118,7 +118,7 @@ _VALID_SPEC = """\
 ---
 name: "Test Feature"
 slug: test-feature
-pytest_target: tests/
+test_target: tests/
 ---
 
 # Test Feature
@@ -236,7 +236,7 @@ def test_round_trip_ideate_to_dev_prompt(tmp_path: Path) -> None:
         name=fm.get("name", "test"),
         story_path=output_path,
         slug=fm.get("slug", "test"),
-        pytest_target=fm.get("pytest_target", "tests/"),
+        test_target=fm.get("test_target", "tests/"),
     )
     spec_content = output_path.read_text(encoding="utf-8")
     dev_prompt = build_dev_prompt(
@@ -260,7 +260,7 @@ def _make_long_spec(line_count: int = 160) -> str:
 ---
 name: "Test Feature"
 slug: test-feature
-pytest_target: tests/
+test_target: tests/
 ---
 
 # Test Feature

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -275,7 +275,7 @@ def test_prompt_contains_p1_impl_definition(tmp_path):
         name="Test Task",
         story_path=spec,
         slug="test-task",
-        pytest_target="tests/",
+        test_target="tests/",
     )
     prompt = build_plan_review_prompt(
         task,
@@ -297,7 +297,7 @@ def test_prompt_yaml_severity_enum_includes_p1_impl(tmp_path):
         name="Test Task",
         story_path=spec,
         slug="test-task",
-        pytest_target="tests/",
+        test_target="tests/",
     )
     prompt = build_plan_review_prompt(
         task,
@@ -357,7 +357,7 @@ def test_plan_review_prompt_api_mode_uses_submit_tool(tmp_path):
         name="Test Task",
         story_path=spec,
         slug="test-task",
-        pytest_target="tests/",
+        test_target="tests/",
     )
     prompt = build_plan_review_prompt(
         task,
@@ -381,7 +381,7 @@ def test_plan_review_prompt_cli_mode_uses_yaml_block(tmp_path):
         name="Test Task",
         story_path=spec,
         slug="test-task",
-        pytest_target="tests/",
+        test_target="tests/",
     )
     prompt = build_plan_review_prompt(
         task,


### PR DESCRIPTION
## Summary

[openai-api-gpt-5.4] Renames the shared schema and gate placeholder to stack-neutral test_target, removes ideation injection of Python-specific fields, and adds seam coverage for non-Python gate commands with no blocking issues found. | [deepseek-deepseek-reasoner] Implementation successfully removes Python-specific bias from shared orchestrator models, renaming pytest_target to stack-neutral test_target across schema, gate substitution, CLI templates, and ideation prompts. | [google-gemini-3.1-pro-preview] The implementation successfully removes language-specific fields from shared orchestrator models.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $12.73
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Remove language-specific fields from shared orchestrator models (GitHub Issue #930)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #930