### PR TITLE
Language-agnosticism convention with scoped mechanical check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,15 +104,46 @@ TheForge is a generic orchestrator — it must work for Python, Node, Go, Java, 
 or any other stack. Coordinator logic, prompt templates, task schemas, and CLI
 scaffolding must not assume a specific language, test framework, or build tool.
 
-- **No language-specific fields in shared data models.** `TaskStory`, `ForgeConfig`,
-  and coordinator state should not encode pytest, npm, go test, etc. as first-class
-  concepts. Use generic names (`test_target`, `gate_command`, `gate_debug_command`).
-- **No hardcoded tool commands in prompts.** Prompt templates should reference the
-  project's configured commands, not `make fmt`, `pytest`, or `npm test`.
-- **Stack-specific behavior belongs in `forge.yaml`.** Each project configures its
-  own gate command, debug command, setup command, etc. The coordinator just runs them.
-- **Self-hosting config is fine.** This repo's `forge.yaml`, `AGENTS.md`, and test
-  files are allowed to be Python-specific because this IS a Python project.
+#### Concrete convention rules
+- **Core orchestrator modules must be stack-neutral.** Code in shared coordinator,
+  task, sprint, and related config layers must not bake in assumptions about one
+  language, package manager, test runner, or repository layout.
+- **Shared schemas may not encode stack-specific concepts.** `TaskStory`,
+  `ForgeConfig`, coordinator state, and other shared models must not introduce
+  fields like `pytest_target`, `npm_script`, or similar stack-shaped concepts.
+  Use generic names such as `test_target`, `gate_command`, and
+  `gate_debug_command`.
+- **Prompt templates must reference configured commands, not literal tool
+  invocations.** Reusable prompts should talk about the configured gate/test
+  commands rather than embedding `make fmt`, `pytest`, `npm test`, `cargo test`,
+  or `go test`.
+- **Generated scaffolding must use generic names or omit the concept.** Reusable
+  examples and templates should prefer neutral placeholders like `test_target`
+  instead of assuming `tests/`, `src/`, `docs/`, or a language-specific layout.
+- **Stack-specific assumptions belong in `forge.yaml` or repo-local conventions,
+  not TheForge core.** Repo-local dogfooding config, self-hosting examples, and
+  clearly marked stack-specific docs may be specific; shared orchestrator code may
+  not.
+
+#### Reviewer smell list
+Treat the following as concrete smells in stack-neutral layers:
+- Shared models with `pytest_`, `npm_`, `cargo_`, `maven_`, or `gradle_` prefixes
+- Core prompt templates containing literal `make fmt`, `pytest`, `npm test`,
+  `cargo test`, or `go test`
+- Reusable prompt logic that hardcodes `src/`, `tests/`, or `docs/`
+- Language-specific story parsing in shared orchestrator code
+
+#### Mechanical enforcement scope
+The hard conventions check scans only stack-neutral layers:
+- `src/theforge/task/`
+- `src/theforge/coordinator/`
+- `src/theforge/sprint/`
+- shared schema modules
+- relevant shared config modules under `src/theforge/config/`
+
+It intentionally exempts repo-local dogfooding config such as `forge.yaml`,
+provider/adapter code, migration tests that mention old names, and docs/examples
+that are clearly marked as Python-specific examples.
 
 ## Pipeline Phases
 

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import ast
+import io
 import re
 import subprocess
 import tempfile
+import tokenize
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -455,7 +457,7 @@ _STACK_NEUTRALITY_RULES: tuple[_StackNeutralityRule, ...] = (
         ),
     ),
     _StackNeutralityRule(
-        pattern=re.compile(r"(?<![A-Za-z0-9_])(?:src/|tests/|docs/)(?![A-Za-z0-9_])"),
+        pattern=re.compile(r"(?<![A-Za-z0-9_])(?:src/|tests/|docs/)[^\s'\"]*"),
         violation_rule="stack_neutrality_hardcoded_layout",
         convention_rule=(
             "generated scaffolding must use generic names (e.g. test_target) or omit the concept"
@@ -465,7 +467,16 @@ _STACK_NEUTRALITY_RULES: tuple[_StackNeutralityRule, ...] = (
         ),
     ),
     _StackNeutralityRule(
-        pattern=re.compile(r"language-specific story parsing", re.IGNORECASE),
+        pattern=re.compile(
+            r"(?:"
+            r"(?:split|strip|replace|sub|match|search|findall|startswith|endswith)\b[^\n#]*"
+            r"(?:pytest|xdist|npm|cargo|maven|gradle|go\s+test)"
+            r"|"
+            r"(?:pytest|npm|cargo|maven|gradle|go\s+test)[^\n#]*"
+            r"(?:split|strip|replace|sub|match|search|findall|startswith|endswith)"
+            r")",
+            re.IGNORECASE,
+        ),
         violation_rule="stack_neutrality_language_specific_story_parsing",
         convention_rule="core orchestrator modules must be stack-neutral",
         description="story parsing must remain stack-neutral rather than language-specific",
@@ -480,28 +491,16 @@ _STACK_NEUTRALITY_EXEMPT_MARKERS: tuple[str, ...] = (
 
 def _check_stack_neutrality(project_root: Path) -> list[ConventionViolation]:
     violations: list[ConventionViolation] = []
-    for convention_rule, scoped_paths in _STACK_NEUTRALITY_SCOPES:
+    for _convention_rule, scoped_paths in _STACK_NEUTRALITY_SCOPES:
         for scoped_path in scoped_paths:
             path = project_root / scoped_path
             if not path.exists():
                 continue
             if path.is_file():
-                violations.extend(
-                    _scan_stack_neutrality_file(
-                        path,
-                        project_root=project_root,
-                        scoped_rule=convention_rule,
-                    )
-                )
+                violations.extend(_scan_stack_neutrality_file(path, project_root=project_root))
                 continue
             for py_file in sorted(path.rglob("*.py")):
-                violations.extend(
-                    _scan_stack_neutrality_file(
-                        py_file,
-                        project_root=project_root,
-                        scoped_rule=convention_rule,
-                    )
-                )
+                violations.extend(_scan_stack_neutrality_file(py_file, project_root=project_root))
     return violations
 
 
@@ -509,7 +508,6 @@ def _scan_stack_neutrality_file(
     path: Path,
     *,
     project_root: Path,
-    scoped_rule: str,
 ) -> list[ConventionViolation]:
     rel = str(path.relative_to(project_root))
     text = path.read_text(encoding="utf-8", errors="replace")
@@ -517,7 +515,7 @@ def _scan_stack_neutrality_file(
         return []
 
     violations: list[ConventionViolation] = []
-    for line_number, line in enumerate(text.splitlines(), start=1):
+    for line_number, line in _stack_neutrality_scan_lines(text):
         for rule in _STACK_NEUTRALITY_RULES:
             match = rule.pattern.search(line)
             if match is None:
@@ -534,6 +532,90 @@ def _scan_stack_neutrality_file(
                 )
             )
     return violations
+
+
+def _stack_neutrality_scan_lines(text: str) -> list[tuple[int, str]]:
+    """Return code-only lines for stack-neutrality scanning.
+
+    Comments, docstrings, and shell/git plumbing lines are excluded so the check
+    focuses on reusable orchestrator logic rather than explanatory prose or repo
+    maintenance commands.
+    """
+    lines = text.splitlines()
+    ignored_lines = (
+        _docstring_line_numbers(text)
+        | _comment_line_numbers(text)
+        | _shell_command_line_numbers(text)
+    )
+    return [
+        (line_number, line)
+        for line_number, line in enumerate(lines, start=1)
+        if line_number not in ignored_lines
+    ]
+
+
+def _docstring_line_numbers(text: str) -> set[int]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return set()
+
+    ignored: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first_stmt = body[0]
+        if not isinstance(first_stmt, ast.Expr):
+            continue
+        value = first_stmt.value
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        start = getattr(first_stmt, "lineno", None)
+        end = getattr(first_stmt, "end_lineno", start)
+        if start is None:
+            continue
+        ignored.update(range(start, (end or start) + 1))
+    return ignored
+
+
+def _comment_line_numbers(text: str) -> set[int]:
+    ignored: set[int] = set()
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(text).readline):
+            if token.type == tokenize.COMMENT:
+                ignored.add(token.start[0])
+    except tokenize.TokenError:
+        return ignored
+    return ignored
+
+
+def _shell_command_line_numbers(text: str) -> set[int]:
+    ignored: set[int] = set()
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return ignored
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "_run_shell":
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        if not isinstance(first_arg, ast.Constant) or not isinstance(first_arg.value, str):
+            continue
+        start = getattr(node, "lineno", None)
+        end = getattr(node, "end_lineno", start)
+        if start is None:
+            continue
+        ignored.update(range(start, (end or start) + 1))
+    return ignored
 
 
 def _is_stack_neutrality_exempt(rel_path: str, text: str) -> bool:

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -537,21 +537,22 @@ def _scan_stack_neutrality_file(
 def _stack_neutrality_scan_lines(text: str) -> list[tuple[int, str]]:
     """Return code-only lines for stack-neutrality scanning.
 
-    Comments, docstrings, and shell/git plumbing lines are excluded so the check
-    focuses on reusable orchestrator logic rather than explanatory prose or repo
-    maintenance commands.
+    Docstrings and shell/git plumbing lines are excluded entirely. Comments are
+    stripped from otherwise-scannable lines so inline code still participates in
+    the check.
     """
     lines = text.splitlines()
-    ignored_lines = (
-        _docstring_line_numbers(text)
-        | _comment_line_numbers(text)
-        | _shell_command_line_numbers(text)
-    )
-    return [
-        (line_number, line)
-        for line_number, line in enumerate(lines, start=1)
-        if line_number not in ignored_lines
-    ]
+    ignored_lines = _docstring_line_numbers(text) | _shell_command_line_numbers(text)
+    comment_spans = _comment_spans_by_line(text)
+    scanned_lines: list[tuple[int, str]] = []
+    for line_number, line in enumerate(lines, start=1):
+        if line_number in ignored_lines:
+            continue
+        stripped_line = _strip_comment_spans(line, comment_spans.get(line_number, ()))
+        if not stripped_line.strip():
+            continue
+        scanned_lines.append((line_number, stripped_line))
+    return scanned_lines
 
 
 def _docstring_line_numbers(text: str) -> set[int]:
@@ -581,15 +582,29 @@ def _docstring_line_numbers(text: str) -> set[int]:
     return ignored
 
 
-def _comment_line_numbers(text: str) -> set[int]:
-    ignored: set[int] = set()
+def _comment_spans_by_line(text: str) -> dict[int, list[tuple[int, int]]]:
+    spans: dict[int, list[tuple[int, int]]] = {}
     try:
         for token in tokenize.generate_tokens(io.StringIO(text).readline):
-            if token.type == tokenize.COMMENT:
-                ignored.add(token.start[0])
+            if token.type != tokenize.COMMENT:
+                continue
+            line_number = token.start[0]
+            spans.setdefault(line_number, []).append((token.start[1], token.end[1]))
     except tokenize.TokenError:
-        return ignored
-    return ignored
+        return spans
+    return spans
+
+
+def _strip_comment_spans(line: str, spans: list[tuple[int, int]] | tuple[tuple[int, int], ...]) -> str:
+    if not spans:
+        return line
+    kept: list[str] = []
+    cursor = 0
+    for start, end in sorted(spans):
+        kept.append(line[cursor:start])
+        cursor = end
+    kept.append(line[cursor:])
+    return "".join(kept)
 
 
 def _shell_command_line_numbers(text: str) -> set[int]:
@@ -603,12 +618,22 @@ def _shell_command_line_numbers(text: str) -> set[int]:
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        if not isinstance(func, ast.Attribute) or func.attr != "_run_shell":
-            continue
-        if not node.args:
+        if isinstance(func, ast.Attribute):
+            is_run_shell = func.attr == "_run_shell"
+        elif isinstance(func, ast.Name):
+            is_run_shell = func.id == "_run_shell"
+        else:
+            is_run_shell = False
+        if not is_run_shell or not node.args:
             continue
         first_arg = node.args[0]
-        if not isinstance(first_arg, ast.Constant) or not isinstance(first_arg.value, str):
+        if isinstance(first_arg, ast.Constant):
+            is_shell_text = isinstance(first_arg.value, str)
+        elif isinstance(first_arg, ast.JoinedStr):
+            is_shell_text = True
+        else:
+            is_shell_text = False
+        if not is_shell_text:
             continue
         start = getattr(node, "lineno", None)
         end = getattr(node, "end_lineno", start)

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import re
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -31,6 +32,7 @@ def check_hard_conventions(
         violations.extend(_check_test_mirrors(project_root))
     if config.no_scratch_files:
         violations.extend(_check_no_scratch_files(project_root, config.allowed_root_files))
+    violations.extend(_check_stack_neutrality(project_root))
     return violations
 
 
@@ -391,3 +393,154 @@ def _check_test_mirrors(project_root: Path) -> list[ConventionViolation]:
                 )
 
     return violations
+
+
+@dataclass(frozen=True)
+class _StackNeutralityRule:
+    pattern: re.Pattern[str]
+    violation_rule: str
+    convention_rule: str
+    description: str
+
+
+_STACK_NEUTRALITY_SCOPES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "core orchestrator modules must be stack-neutral",
+        (
+            "src/theforge/task",
+            "src/theforge/coordinator",
+            "src/theforge/sprint",
+        ),
+    ),
+    (
+        "shared schemas may not encode stack-specific concepts",
+        (
+            "src/theforge/schemas.py",
+            "src/theforge/config/types.py",
+            "src/theforge/config/schema.py",
+            "src/theforge/config/models.py",
+        ),
+    ),
+    (
+        "stack-specific assumptions belong in forge.yaml or repo-local conventions, "
+        "not TheForge core",
+        (
+            "src/theforge/config/load.py",
+            "src/theforge/config/defaults.py",
+            "src/theforge/config/bridge.py",
+            "src/theforge/config/role_derivation.py",
+        ),
+    ),
+)
+
+_STACK_NEUTRALITY_RULES: tuple[_StackNeutralityRule, ...] = (
+    _StackNeutralityRule(
+        pattern=re.compile(r"\b(?:pytest_|npm_|cargo_|maven_|gradle_)[A-Za-z0-9_]*\b"),
+        violation_rule="stack_neutrality_shared_model_prefix",
+        convention_rule="shared schemas may not encode stack-specific concepts",
+        description=(
+            "shared models must not use stack-specific prefixes like pytest_/npm_/cargo_/"
+            "maven_/gradle_"
+        ),
+    ),
+    _StackNeutralityRule(
+        pattern=re.compile(r"\b(?:make fmt|pytest|npm test|cargo test|go test)\b"),
+        violation_rule="stack_neutrality_literal_tool_command",
+        convention_rule=(
+            "prompt templates must reference configured commands, not literal tool invocations"
+        ),
+        description=(
+            "core prompt logic must reference configured commands instead of literal "
+            "tool invocations"
+        ),
+    ),
+    _StackNeutralityRule(
+        pattern=re.compile(r"(?<![A-Za-z0-9_])(?:src/|tests/|docs/)(?![A-Za-z0-9_])"),
+        violation_rule="stack_neutrality_hardcoded_layout",
+        convention_rule=(
+            "generated scaffolding must use generic names (e.g. test_target) or omit the concept"
+        ),
+        description=(
+            "reusable prompt logic must not hardcode src/, tests/, or docs/ layout assumptions"
+        ),
+    ),
+    _StackNeutralityRule(
+        pattern=re.compile(r"language-specific story parsing", re.IGNORECASE),
+        violation_rule="stack_neutrality_language_specific_story_parsing",
+        convention_rule="core orchestrator modules must be stack-neutral",
+        description="story parsing must remain stack-neutral rather than language-specific",
+    ),
+)
+
+_STACK_NEUTRALITY_EXEMPT_MARKERS: tuple[str, ...] = (
+    "python-specific example",
+    "python specific example",
+)
+
+
+def _check_stack_neutrality(project_root: Path) -> list[ConventionViolation]:
+    violations: list[ConventionViolation] = []
+    for convention_rule, scoped_paths in _STACK_NEUTRALITY_SCOPES:
+        for scoped_path in scoped_paths:
+            path = project_root / scoped_path
+            if not path.exists():
+                continue
+            if path.is_file():
+                violations.extend(
+                    _scan_stack_neutrality_file(
+                        path,
+                        project_root=project_root,
+                        scoped_rule=convention_rule,
+                    )
+                )
+                continue
+            for py_file in sorted(path.rglob("*.py")):
+                violations.extend(
+                    _scan_stack_neutrality_file(
+                        py_file,
+                        project_root=project_root,
+                        scoped_rule=convention_rule,
+                    )
+                )
+    return violations
+
+
+def _scan_stack_neutrality_file(
+    path: Path,
+    *,
+    project_root: Path,
+    scoped_rule: str,
+) -> list[ConventionViolation]:
+    rel = str(path.relative_to(project_root))
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if _is_stack_neutrality_exempt(rel, text):
+        return []
+
+    violations: list[ConventionViolation] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for rule in _STACK_NEUTRALITY_RULES:
+            match = rule.pattern.search(line)
+            if match is None:
+                continue
+            violations.append(
+                ConventionViolation(
+                    rule=rule.violation_rule,
+                    file=rel,
+                    detail=(
+                        f"line {line_number}: matched {match.group(0)!r}; "
+                        f"smell: {rule.description}; violates convention rule: "
+                        f"{rule.convention_rule}"
+                    ),
+                )
+            )
+    return violations
+
+
+def _is_stack_neutrality_exempt(rel_path: str, text: str) -> bool:
+    if rel_path == "forge.yaml":
+        return True
+    if "example" in rel_path.lower() and any(
+        marker in text.lower() for marker in _STACK_NEUTRALITY_EXEMPT_MARKERS
+    ):
+        return True
+    return False

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -595,7 +595,10 @@ def _comment_spans_by_line(text: str) -> dict[int, list[tuple[int, int]]]:
     return spans
 
 
-def _strip_comment_spans(line: str, spans: list[tuple[int, int]] | tuple[tuple[int, int], ...]) -> str:
+def _strip_comment_spans(
+    line: str,
+    spans: list[tuple[int, int]] | tuple[tuple[int, int], ...],
+) -> str:
     if not spans:
         return line
     kept: list[str] = []

--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -85,7 +85,7 @@ def _run_gate_full(
     else:
         gate_cmd = config.validation.gate_command
         if task is not None:
-            test_target = task.test_target or "tests/"
+            test_target = task.test_target or "."
             gate_cmd = gate_cmd.replace("{test_target}", test_target)
             gate_cmd = gate_cmd.replace("{slug}", task.slug)
 

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -486,13 +486,13 @@ def build_plan_prompt(
             - id: 1
               description: "<what this step does>"
               files:
-                - src/theforge/example.py
+                - path/to/example.file
               action: modify  # modify | create | delete
               details: "<concrete implementation details for this step>"
             - id: 2
               description: "<what this step does>"
               files:
-                - src/theforge/other.py
+                - path/to/other.file
               action: create
               details: "<concrete implementation details for this step>"
               depends_on: [1]

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -271,13 +271,36 @@ class TestStackNeutralityCheck:
     def test_hardcoded_layout_smell_reports_generic_scaffolding_rule(self, tmp_path):
         _write(
             tmp_path / "src" / "theforge" / "task" / "plan_prompts.py",
-            'template = "put tests in tests/"\n',
+            'template = "put tests in tests/unit"\n',
         )
         violations = _check_stack_neutrality(tmp_path)
         assert len(violations) == 1
         violation = violations[0]
         assert violation.rule == "stack_neutrality_hardcoded_layout"
         assert "generated scaffolding must use generic names" in violation.detail
+
+    def test_comments_and_docstrings_are_ignored(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "coordinator" / "neutral.py",
+            '"""Mention pytest and tests/unit in docs only."""\n\n'
+            'def helper():\n'
+            '    """Another docstring with src/theforge and npm test."""\n'
+            '    # pytest-xdist worker output may mention tests/unit\n'
+            '    return "ok"\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert violations == []
+
+    def test_language_specific_story_parsing_smell_is_detected(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "coordinator" / "story_parse.py",
+            'failed = line.replace("pytest ", "").split("::")\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert len(violations) == 2
+        rules = {violation.rule for violation in violations}
+        assert "stack_neutrality_literal_tool_command" in rules
+        assert "stack_neutrality_language_specific_story_parsing" in rules
 
     def test_provider_adapter_code_is_out_of_scope(self, tmp_path):
         _write(

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -13,6 +13,7 @@ from theforge.conventions import (
     _check_hard_conventions_at_git_ref,
     _check_line_counts,
     _check_no_scratch_files,
+    _check_stack_neutrality,
     _check_test_mirrors,
     check_hard_conventions,
     new_hard_convention_violations_since_ref,
@@ -238,6 +239,66 @@ def test_allowed_root_files_whitelist_is_stack_neutral() -> None:
     assert "yarn.lock" not in _ALLOWED_ROOT_FILES
     assert "pnpm-lock.yaml" not in _ALLOWED_ROOT_FILES
     assert "bun.lockb" not in _ALLOWED_ROOT_FILES
+
+
+class TestStackNeutralityCheck:
+    def test_shared_model_prefix_smell_reports_file_line_and_rule(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "config" / "types.py",
+            "pytest_target = None\n",
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert len(violations) == 1
+        violation = violations[0]
+        assert violation.rule == "stack_neutrality_shared_model_prefix"
+        assert violation.file == "src/theforge/config/types.py"
+        assert "line 1" in violation.detail
+        assert "pytest_target" in violation.detail
+        assert "shared schemas may not encode stack-specific concepts" in violation.detail
+
+    def test_literal_tool_command_smell_reports_prompt_rule(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "task" / "dev_prompts.py",
+            'prompt = "run pytest before finishing"\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert len(violations) == 1
+        violation = violations[0]
+        assert violation.rule == "stack_neutrality_literal_tool_command"
+        assert violation.file == "src/theforge/task/dev_prompts.py"
+        assert "configured commands" in violation.detail
+
+    def test_hardcoded_layout_smell_reports_generic_scaffolding_rule(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "task" / "plan_prompts.py",
+            'template = "put tests in tests/"\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert len(violations) == 1
+        violation = violations[0]
+        assert violation.rule == "stack_neutrality_hardcoded_layout"
+        assert "generated scaffolding must use generic names" in violation.detail
+
+    def test_provider_adapter_code_is_out_of_scope(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "runners" / "adapters" / "openai.py",
+            'cmd = "pytest"\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert violations == []
+
+    def test_forge_yaml_is_exempt(self, tmp_path):
+        _write(tmp_path / "forge.yaml", 'validation:\n  gate_command: "pytest tests/ -v"\n')
+        violations = _check_stack_neutrality(tmp_path)
+        assert violations == []
+
+    def test_python_specific_example_marker_is_exempt(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "config" / "python_example.py",
+            '# Python-specific example\ncmd = "pytest tests/ -v"\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert violations == []
 
 
 class TestCheckHardConventions:

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -283,9 +283,9 @@ class TestStackNeutralityCheck:
         _write(
             tmp_path / "src" / "theforge" / "coordinator" / "neutral.py",
             '"""Mention pytest and tests/unit in docs only."""\n\n'
-            'def helper():\n'
+            "def helper():\n"
             '    """Another docstring with src/theforge and npm test."""\n'
-            '    # pytest-xdist worker output may mention tests/unit\n'
+            "    # pytest-xdist worker output may mention tests/unit\n"
             '    return "ok"\n',
         )
         violations = _check_stack_neutrality(tmp_path)

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -291,6 +291,16 @@ class TestStackNeutralityCheck:
         violations = _check_stack_neutrality(tmp_path)
         assert violations == []
 
+    def test_inline_comments_do_not_hide_stack_specific_code(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "coordinator" / "neutral.py",
+            'pytest_target = "tests/"  # keep this generic later\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        rules = {violation.rule for violation in violations}
+        assert "stack_neutrality_shared_model_prefix" in rules
+        assert "stack_neutrality_hardcoded_layout" in rules
+
     def test_language_specific_story_parsing_smell_is_detected(self, tmp_path):
         _write(
             tmp_path / "src" / "theforge" / "coordinator" / "story_parse.py",
@@ -306,6 +316,24 @@ class TestStackNeutralityCheck:
         _write(
             tmp_path / "src" / "theforge" / "runners" / "adapters" / "openai.py",
             'cmd = "pytest"\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert violations == []
+
+    def test_direct_run_shell_calls_are_ignored(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "coordinator" / "neutral.py",
+            'def helper():\n'
+            '    return _run_shell("pytest tests/ -v", cwd)\n',
+        )
+        violations = _check_stack_neutrality(tmp_path)
+        assert violations == []
+
+    def test_fstring_run_shell_calls_are_ignored(self, tmp_path):
+        _write(
+            tmp_path / "src" / "theforge" / "coordinator" / "neutral.py",
+            'def helper(target):\n'
+            '    return _run_shell(f"pytest {target}", cwd)\n',
         )
         violations = _check_stack_neutrality(tmp_path)
         assert violations == []

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -323,8 +323,7 @@ class TestStackNeutralityCheck:
     def test_direct_run_shell_calls_are_ignored(self, tmp_path):
         _write(
             tmp_path / "src" / "theforge" / "coordinator" / "neutral.py",
-            'def helper():\n'
-            '    return _run_shell("pytest tests/ -v", cwd)\n',
+            'def helper():\n    return _run_shell("pytest tests/ -v", cwd)\n',
         )
         violations = _check_stack_neutrality(tmp_path)
         assert violations == []
@@ -332,8 +331,7 @@ class TestStackNeutralityCheck:
     def test_fstring_run_shell_calls_are_ignored(self, tmp_path):
         _write(
             tmp_path / "src" / "theforge" / "coordinator" / "neutral.py",
-            'def helper(target):\n'
-            '    return _run_shell(f"pytest {target}", cwd)\n',
+            'def helper(target):\n    return _run_shell(f"pytest {target}", cwd)\n',
         )
         violations = _check_stack_neutrality(tmp_path)
         assert violations == []

--- a/tests/test_coord_gate_modes.py
+++ b/tests/test_coord_gate_modes.py
@@ -424,10 +424,10 @@ class TestTestTargetSubstitution:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_test_target_defaults_to_tests(
+    def test_test_target_defaults_to_project_root(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
-        """When test_target is None, defaults to 'tests/'."""
+        """When test_target is None, defaults to the project root placeholder '.' ."""
         config = _make_exit_code_config(tmp_path)
         task = _make_task(tmp_path)  # test_target=None by default
         workspace = tmp_path / "test-task"
@@ -457,7 +457,7 @@ class TestTestTargetSubstitution:
 
         gate_cmds = [c for c in captured_cmds if "pytest" in c and "worktree" not in c]
         assert gate_cmds
-        assert "tests/" in gate_cmds[0]
+        assert "pytest . -q" == gate_cmds[0]
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The implementation successfully addresses all prior P1 findings and satisfies all acceptance criteria. The stack-neutrality check is now functional, scoped correctly, and produces zero violations on the current main branch. | [google-gemini-3.1-pro-preview] The implementation correctly enforces stack-neutral core smells and resolves all prior P1 findings. | [claude-opus] All prior P1 findings fixed; inline-code smells now caught while docstrings and shell calls are exempt; zero violations on HEAD.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $8.57
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/conventions.py:449`** The regex pattern for literal tool commands (\b(?:make fmt|pytest|npm test|cargo test|go test)\b) matches 'pytest' within hyphenated terms like 'pytest-xdist' due to word boundary semantics. While 'pytest-xdist' is stack-specific, this may cause unintended matches in some contexts.

## Story

Language-agnosticism convention with scoped mechanical check (GitHub Issue #931)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #931