### PR TITLE
forge status and sprint-summary undercount stories when sprint re-execs mid-run

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -379,7 +379,9 @@ def _write_sprint_summary(
     accumulated_for_state: list[dict] = []
     results_by_spec = {spec_str: res for spec_str, res in result.results}
 
+    seen_refs: set[str] = set()
     for canonical_ref in canonical_refs:
+        seen_refs.add(canonical_ref)
         display_key = (
             f"Issue #{canonical_ref.split(':')[1]}"
             if canonical_ref.startswith("issue:")
@@ -425,6 +427,7 @@ def _write_sprint_summary(
                 "outcome": outcome,
                 "verdict": last_verdict or None,
                 "cost_usd": round(res.state.total_cost, 4),
+                "story_run_id": run_id,
                 "preflight": preflight,
                 "preflight_original_verdict": getattr(
                     res.state, "preflight_cached_original_verdict", None
@@ -494,6 +497,13 @@ def _write_sprint_summary(
             if drop_reason:
                 entry["drop_reason"] = drop_reason
             spec_entries.append(entry)
+
+    for canonical_ref, prior in prior_by_ref.items():
+        if canonical_ref in seen_refs:
+            continue
+        entry = {k: v for k, v in prior.items() if k != "canonical_ref"}
+        spec_entries.append(entry)
+        accumulated_for_state.append(prior)
 
     # Persist accumulated state so future runs can find stories from this invocation.
     if sprint_id and project_root:

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -56,11 +56,11 @@ def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
     After a run_id rollover the summary is written under the terminal run_id.
     Follows the redirect chain so earlier run_ids resolve to the same summary.
 
-    Also matches summaries whose sprint-level accumulated state records the
-    queried run_id in any story's ``preflight_source_run_id``. This covers
-    mid-run sprint re-execs where the final summary is written under the last
-    worker run_id but earlier worker run_ids still need to resolve to the same
-    logical sprint summary.
+    Also matches summaries whose story metadata records the queried run_id in
+    any story's ``story_run_id`` or legacy ``preflight_source_run_id`` field.
+    This covers mid-run sprint re-execs where the final summary is written
+    under the last worker run_id but earlier worker run_ids still need to
+    resolve to the same logical sprint summary.
 
     Returns the Path to the matching sprint-summary.yaml, or None if not found.
     """
@@ -91,6 +91,8 @@ def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
                 for story in stories:
                     if not isinstance(story, dict):
                         continue
+                    if story.get("story_run_id") in candidate_ids:
+                        return summary_path
                     if story.get("preflight_source_run_id") in candidate_ids:
                         return summary_path
         except Exception:

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -56,6 +56,12 @@ def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
     After a run_id rollover the summary is written under the terminal run_id.
     Follows the redirect chain so earlier run_ids resolve to the same summary.
 
+    Also matches summaries whose sprint-level accumulated state records the
+    queried run_id in any story's ``preflight_source_run_id``. This covers
+    mid-run sprint re-execs where the final summary is written under the last
+    worker run_id but earlier worker run_ids still need to resolve to the same
+    logical sprint summary.
+
     Returns the Path to the matching sprint-summary.yaml, or None if not found.
     """
     terminal_run_id = _follow_redirect_chain(run_id, project_root)
@@ -75,10 +81,18 @@ def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
         try:
             with open(summary_path, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
-            if isinstance(data, dict):
-                sprint_info = data.get("sprint", {})
-                if isinstance(sprint_info, dict) and sprint_info.get("run_id") in candidate_ids:
-                    return summary_path
+            if not isinstance(data, dict):
+                continue
+            sprint_info = data.get("sprint", {})
+            if isinstance(sprint_info, dict) and sprint_info.get("run_id") in candidate_ids:
+                return summary_path
+            stories = data.get("stories", [])
+            if isinstance(stories, list):
+                for story in stories:
+                    if not isinstance(story, dict):
+                        continue
+                    if story.get("preflight_source_run_id") in candidate_ids:
+                        return summary_path
         except Exception:
             continue
     return None

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -180,6 +180,7 @@ class TestRunIdRolloverReporting:
                 "outcome": "DONE",
                 "verdict": "APPROVE",
                 "cost_usd": 1.18,
+                "story_run_id": "run-a-test",
                 "preflight": "PROCEED",
                 "preflight_original_verdict": None,
                 "preflight_source_run_id": None,
@@ -279,6 +280,7 @@ class TestRunIdRolloverReporting:
                 "outcome": "DONE",
                 "verdict": "APPROVE",
                 "cost_usd": 1.18,
+                "story_run_id": "run-a-test",
                 "preflight": "PROCEED",
                 "preflight_original_verdict": None,
                 "preflight_source_run_id": None,
@@ -462,14 +464,14 @@ class TestRedirectChainResolution:
                             "path": "Issue #940",
                             "outcome": "DONE",
                             "cost_usd": 10.15,
-                            "preflight_source_run_id": "run-c6448a1795c0",
+                            "story_run_id": "run-c6448a1795c0",
                         },
                         {
                             "slug": "issue-930",
                             "path": "Issue #930",
                             "outcome": "DONE",
                             "cost_usd": 7.11,
-                            "preflight_source_run_id": "run-656d888893ec",
+                            "story_run_id": "run-656d888893ec",
                         },
                     ],
                 }
@@ -479,3 +481,51 @@ class TestRedirectChainResolution:
 
         found = find_sprint_summary("run-c6448a1795c0", tmp_path)
         assert found == summary_path
+
+    def test_summary_includes_removed_prior_run_stories(self, tmp_path: Path) -> None:
+        """Final summary retains prior-run stories removed from the resumed manifest."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-b.md"])
+        config = _make_config(tmp_path)
+        sprint_name = "Test Sprint"
+
+        sprint_id = _get_or_create_sprint_id(sprint_name, tmp_path)
+        prior_stories = [
+            {
+                "canonical_ref": "feature-a.md",
+                "slug": "feature-a",
+                "path": "feature-a.md",
+                "outcome": "DONE",
+                "verdict": "APPROVE",
+                "cost_usd": 1.18,
+                "story_run_id": "run-a-test",
+                "preflight": "PROCEED",
+                "preflight_original_verdict": None,
+                "preflight_source_run_id": None,
+                "error": None,
+                "error_type": None,
+                "merge": True,
+                "batch": 0,
+                "depends_on": [],
+            }
+        ]
+        _save_accumulated_stories(sprint_id, sprint_name, tmp_path, prior_stories)
+
+        result_b = _make_coordinator_result(success=True, cost=9.26)
+
+        with patch("theforge.sprint.runner.run_task", return_value=result_b):
+            run_sprint(config, manifest_path, resume=True, run_id="run-b-test")
+
+        summary_path = tmp_path / ".forge" / "logs" / sprint_name / "sprint-summary.yaml"
+        with open(summary_path, encoding="utf-8") as f:
+            summary = yaml.safe_load(f)
+
+        stories = {story["slug"]: story for story in summary["stories"]}
+        assert set(stories) == {"feature-a", "feature-b"}
+        assert stories["feature-a"]["outcome"] == "DONE"
+        assert stories["feature-a"]["story_run_id"] == "run-a-test"
+        assert stories["feature-b"]["story_run_id"] is not None
+        assert summary["sprint"]["specs_total"] == 2
+        assert summary["sprint"]["specs_succeeded"] == 2
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(10.44)

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -442,3 +442,40 @@ class TestRedirectChainResolution:
 
         found = find_sprint_summary("run-xyz", tmp_path)
         assert found == summary_path
+
+    def test_find_sprint_summary_matches_prior_worker_run_id_from_story_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        """Earlier worker run_ids still resolve to the terminal sprint summary."""
+        import yaml
+
+        sprint_log_dir = tmp_path / ".forge" / "logs" / "My Sprint"
+        sprint_log_dir.mkdir(parents=True)
+        summary_path = sprint_log_dir / "sprint-summary.yaml"
+        summary_path.write_text(
+            yaml.dump(
+                {
+                    "sprint": {"name": "My Sprint", "run_id": "run-terminal"},
+                    "stories": [
+                        {
+                            "slug": "issue-940",
+                            "path": "Issue #940",
+                            "outcome": "DONE",
+                            "cost_usd": 10.15,
+                            "preflight_source_run_id": "run-c6448a1795c0",
+                        },
+                        {
+                            "slug": "issue-930",
+                            "path": "Issue #930",
+                            "outcome": "DONE",
+                            "cost_usd": 7.11,
+                            "preflight_source_run_id": "run-656d888893ec",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        found = find_sprint_summary("run-c6448a1795c0", tmp_path)
+        assert found == summary_path


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Fix resolves sprint summary undercount by tracking story_run_id and merging prior-run stories | [google-gemini-3.1-pro-preview] The PR correctly addresses the Cycle 1 findings and implements the spec without introducing regressions. | [claude-opus] Prior-cycle P1s addressed — summary now retains prior-run stories via accumulated state, and lookup matches story_run_id. No regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $5.48
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status and sprint-summary undercount stories when sprint re-execs mid-run (GitHub Issue #965)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #965