### PR TITLE
Lock sweep mistakes recycled PIDs for live forge runs — imagent, Google Drive hold forge locks forever

### DIFF
--- a/src/theforge/pid.py
+++ b/src/theforge/pid.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 
 
 def _is_pid_alive(pid: int) -> bool:
@@ -16,3 +17,43 @@ def _is_pid_alive(pid: int) -> bool:
     except OSError:
         return True
     return True
+
+
+def _pid_start_time(pid: int) -> str | None:
+    """Return a stable process start-time fingerprint for *pid*, if available.
+
+    Uses ``ps`` elapsed-start metadata rather than command names so callers can
+    distinguish a recycled PID from the original process that created a lock.
+    Returns ``None`` when the process does not exist or the start time cannot be
+    determined.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    start_time = result.stdout.strip()
+    return start_time or None
+
+
+def _current_process_fingerprint(pid: int) -> str | None:
+    """Return the current ownership fingerprint for *pid*, if the process exists."""
+    if not _is_pid_alive(pid):
+        return None
+    return _pid_start_time(pid)
+
+
+def _pid_matches_fingerprint(pid: int, fingerprint: str | None) -> bool:
+    """Return True when *pid* still belongs to the recorded process instance."""
+    if fingerprint is None:
+        return _is_pid_alive(pid)
+    current = _current_process_fingerprint(pid)
+    return current is not None and current == fingerprint

--- a/src/theforge/pid.py
+++ b/src/theforge/pid.py
@@ -56,4 +56,6 @@ def _pid_matches_fingerprint(pid: int, fingerprint: str | None) -> bool:
     if fingerprint is None:
         return _is_pid_alive(pid)
     current = _current_process_fingerprint(pid)
-    return current is not None and current == fingerprint
+    if current is None:
+        return _is_pid_alive(pid)
+    return current == fingerprint

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -10,7 +10,9 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from theforge.artifacts import ESCALATED_MARKER_PATH
-from theforge.pid import _is_pid_alive
+from theforge.pid import _current_process_fingerprint, _pid_matches_fingerprint
+
+_LOCK_METADATA_SEPARATOR = "|"
 
 
 def _is_escalated_worktree(worktree_path: Path) -> bool:
@@ -26,16 +28,34 @@ class SprintConflictError(Exception):
         super().__init__(f"Stories already running: {', '.join(conflicting_slugs)}")
 
 
-def _read_lock_pid(fd) -> int | None:
-    """Return the lock owner PID from the file, if present and valid."""
+def _read_lock_metadata(fd) -> tuple[int | None, str | None]:
+    """Return ``(pid, fingerprint)`` from a lock file, if present and valid."""
     fd.seek(0)
-    raw_pid = fd.read().strip()
-    if not raw_pid:
-        return None
+    raw = fd.read().strip()
+    if not raw:
+        return None, None
+
+    pid_text, separator, fingerprint = raw.partition(_LOCK_METADATA_SEPARATOR)
     try:
-        return int(raw_pid)
+        pid = int(pid_text)
     except ValueError:
-        return None
+        return None, None
+
+    normalized_fingerprint = fingerprint.strip() if separator else None
+    return pid, normalized_fingerprint or None
+
+
+def _write_lock_metadata(fd) -> None:
+    """Persist the current process PID plus a stable process fingerprint."""
+    pid = os.getpid()
+    fingerprint = _current_process_fingerprint(pid)
+    payload = str(pid)
+    if fingerprint:
+        payload = f"{payload}{_LOCK_METADATA_SEPARATOR}{fingerprint}"
+    fd.truncate(0)
+    fd.seek(0)
+    fd.write(payload)
+    fd.flush()
 
 
 def check_escalated_worktrees(
@@ -125,25 +145,22 @@ def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, lis
             fd = open(lock_path, "a+")  # noqa: WPS515,SIM115
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                fd.truncate(0)
-                fd.seek(0)
-                fd.write(str(os.getpid()))
-                fd.flush()
+                _write_lock_metadata(fd)
                 acquired_fd = fd
                 break
             except BlockingIOError:
-                owner_pid = _read_lock_pid(fd)
+                owner_pid, owner_fingerprint = _read_lock_metadata(fd)
                 fd.close()
-                if owner_pid is None or _is_pid_alive(owner_pid):
+                if owner_pid is None or _pid_matches_fingerprint(owner_pid, owner_fingerprint):
                     conflicted.append(slug)
                     break
                 # TOCTOU: a live process could acquire this lock and write its
-                # PID between the _is_pid_alive check above and unlink() below.
+                # metadata between the ownership check above and unlink() below.
                 # If that happens, we delete a valid lock file and two callers
-                # may briefly believe they hold the lock.  The risk is
-                # acceptable: the window is extremely narrow, and the 3-attempt
-                # retry loop means any caller that loses the race will re-detect
-                # the conflict on the next flock attempt and back off cleanly.
+                # may briefly believe they hold the lock. The risk is acceptable:
+                # the window is extremely narrow, and the 3-attempt retry loop
+                # means any caller that loses the race will re-detect the
+                # conflict on the next flock attempt and back off cleanly.
                 try:
                     lock_path.unlink()
                 except FileNotFoundError:
@@ -204,13 +221,10 @@ def integration_lock(
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True
-                fd.truncate(0)
-                fd.seek(0)
-                fd.write(str(os.getpid()))
-                fd.flush()
+                _write_lock_metadata(fd)
                 break
             except BlockingIOError:
-                owner_pid = _read_lock_pid(fd)
+                owner_pid, _owner_fingerprint = _read_lock_metadata(fd)
                 if time.monotonic() >= deadline:
                     owner_suffix = f" (held by pid {owner_pid})" if owner_pid is not None else ""
                     raise TimeoutError(

--- a/src/theforge/sprint/preflight.py
+++ b/src/theforge/sprint/preflight.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 from typing import Any
 
-from theforge.sprint.lock import check_active_worktrees
+from theforge.sprint.lock import _write_lock_metadata, check_active_worktrees
 
 _ACTIVE_WORKTREE_ABORT_PREFIX = "[forge] Stories already have active worktrees"
 _RUNNING_STORIES_ABORT_PREFIX = "[forge] Stories already running"
@@ -57,18 +56,14 @@ def reacquire_story_locks_in_daemon(
     project_root: Path,
     locked_fds: list,
 ) -> list:
-    """Update lock file PIDs to the daemon PID without releasing the inherited flocks.
+    """Update inherited lock metadata to the daemon process without dropping flocks.
 
     The parent process acquired the story locks before double-fork daemonizing.
     After fork(), the daemon inherits the same open file descriptions — and therefore
-    the same flocks — so no re-acquisition is needed.  We only need to overwrite the
-    PID recorded in each lock file so that stale-lock cleanup uses the daemon's PID
-    rather than the (soon-dead) parent's PID.
+    the same flocks — so no re-acquisition is needed. We only need to rewrite each
+    lock file's ownership metadata so stale-lock cleanup tracks the daemon's PID and
+    fingerprint rather than the (soon-dead) parent's process instance.
     """
-    daemon_pid = str(os.getpid())
     for fd in locked_fds:
-        fd.seek(0)
-        fd.truncate(0)
-        fd.write(daemon_pid)
-        fd.flush()
+        _write_lock_metadata(fd)
     return locked_fds

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from theforge.pid import _is_pid_alive
+from theforge.pid import _current_process_fingerprint, _is_pid_alive, _pid_matches_fingerprint
 
 
 def test_is_pid_alive_returns_false_for_missing_process() -> None:
@@ -25,3 +25,23 @@ def test_is_pid_alive_returns_true_for_other_os_error() -> None:
 def test_is_pid_alive_returns_true_when_kill_succeeds() -> None:
     with patch("theforge.pid.os.kill", return_value=None):
         assert _is_pid_alive(12345) is True
+
+
+def test_current_process_fingerprint_returns_ps_start_time() -> None:
+    completed = type("Completed", (), {"returncode": 0, "stdout": "Mon Apr 22 10:11:12 2026\n"})()
+    with (
+        patch("theforge.pid.os.kill", return_value=None),
+        patch("theforge.pid.subprocess.run", return_value=completed) as mock_run,
+    ):
+        assert _current_process_fingerprint(12345) == "Mon Apr 22 10:11:12 2026"
+    mock_run.assert_called_once()
+
+
+def test_pid_matches_fingerprint_detects_recycled_pid() -> None:
+    with patch("theforge.pid._current_process_fingerprint", return_value="new-start"):
+        assert _pid_matches_fingerprint(12345, "old-start") is False
+
+
+def test_pid_matches_fingerprint_accepts_matching_process_instance() -> None:
+    with patch("theforge.pid._current_process_fingerprint", return_value="same-start"):
+        assert _pid_matches_fingerprint(12345, "same-start") is True

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -45,3 +45,19 @@ def test_pid_matches_fingerprint_detects_recycled_pid() -> None:
 def test_pid_matches_fingerprint_accepts_matching_process_instance() -> None:
     with patch("theforge.pid._current_process_fingerprint", return_value="same-start"):
         assert _pid_matches_fingerprint(12345, "same-start") is True
+
+
+def test_pid_matches_fingerprint_falls_back_to_pid_liveness_when_ps_fails() -> None:
+    with (
+        patch("theforge.pid._current_process_fingerprint", return_value=None),
+        patch("theforge.pid._is_pid_alive", return_value=True),
+    ):
+        assert _pid_matches_fingerprint(12345, "same-start") is True
+
+
+def test_pid_matches_fingerprint_rejects_missing_process_when_ps_fails() -> None:
+    with (
+        patch("theforge.pid._current_process_fingerprint", return_value=None),
+        patch("theforge.pid._is_pid_alive", return_value=False),
+    ):
+        assert _pid_matches_fingerprint(12345, "same-start") is False

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -550,6 +550,8 @@ class TestCmdSprintConflictGuard:
 
         assert rc == 0
         mock_run.assert_called_once()
+        # Resume skips the active-worktree guard, but other git subprocesses may still
+        # run elsewhere in cmd_sprint. Filter specifically for the worktree collision check.
         git_calls_for_worktree = [
             call
             for call in mock_git.call_args_list

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -12,6 +12,7 @@ import pytest
 
 from theforge.sprint.lock import (
     SprintConflictError,
+    _read_lock_metadata,
     acquire_story_locks,
     check_active_worktrees,
     integration_lock,
@@ -38,7 +39,9 @@ class TestAcquireStoryLocks:
             assert conflicted == []
             assert len(fds) == 1
             lock_path = tmp_path / ".forge" / "locks" / "my-story.lock"
-            assert lock_path.read_text(encoding="utf-8").strip().isdigit()
+            pid_text, fingerprint = lock_path.read_text(encoding="utf-8").strip().split("|", 1)
+            assert pid_text.isdigit()
+            assert fingerprint
         finally:
             release_story_locks(fds)
 
@@ -147,7 +150,7 @@ class TestAcquireStoryLocks:
         """A conflicting lock with a dead PID is removed and retried."""
         lock_path = tmp_path / ".forge" / "locks" / "story-z.lock"
         lock_path.parent.mkdir(parents=True)
-        lock_path.write_text("424242", encoding="utf-8")
+        lock_path.write_text("424242|old-start", encoding="utf-8")
 
         flock_calls = []
 
@@ -159,7 +162,8 @@ class TestAcquireStoryLocks:
 
         with (
             patch("theforge.sprint.lock.fcntl.flock", side_effect=fake_flock),
-            patch("theforge.sprint.lock.os.kill", side_effect=ProcessLookupError),
+            patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False),
+            patch("theforge.sprint.lock._current_process_fingerprint", return_value="new-start"),
         ):
             fds, conflicted = acquire_story_locks(["story-z"], tmp_path)
 
@@ -167,7 +171,57 @@ class TestAcquireStoryLocks:
             assert conflicted == []
             assert len(fds) == 1
             assert len(flock_calls) == 2
-            assert lock_path.read_text(encoding="utf-8").strip().isdigit()
+            pid, fingerprint = _read_lock_metadata(fds[0])
+            assert pid is not None
+            assert fingerprint == "new-start"
+        finally:
+            release_story_locks(fds)
+
+    def test_recycled_pid_lock_is_removed_and_retried(self, tmp_path: Path) -> None:
+        """A lock whose PID is alive but fingerprint changed is treated as stale."""
+        lock_path = tmp_path / ".forge" / "locks" / "story-recycled.lock"
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text("424242|old-start", encoding="utf-8")
+
+        flock_calls = []
+
+        def fake_flock(_fd, _flags):
+            flock_calls.append(1)
+            if len(flock_calls) == 1:
+                raise BlockingIOError
+            return None
+
+        with (
+            patch("theforge.sprint.lock.fcntl.flock", side_effect=fake_flock),
+            patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False),
+            patch("theforge.sprint.lock._current_process_fingerprint", return_value="new-start"),
+        ):
+            fds, conflicted = acquire_story_locks(["story-recycled"], tmp_path)
+
+        try:
+            assert conflicted == []
+            assert len(fds) == 1
+            assert len(flock_calls) == 2
+            assert lock_path.read_text(encoding="utf-8").strip().endswith("|new-start")
+        finally:
+            release_story_locks(fds)
+
+    def test_live_matching_pid_lock_remains_conflict(self, tmp_path: Path) -> None:
+        """A lock owned by the same live process instance must remain a conflict."""
+        lock_path = tmp_path / ".forge" / "locks" / "story-live.lock"
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text("424242|same-start", encoding="utf-8")
+
+        with (
+            patch("theforge.sprint.lock.fcntl.flock", side_effect=BlockingIOError),
+            patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=True),
+        ):
+            fds, conflicted = acquire_story_locks(["story-live"], tmp_path)
+
+        try:
+            assert fds == []
+            assert conflicted == ["story-live"]
+            assert lock_path.read_text(encoding="utf-8") == "424242|same-start"
         finally:
             release_story_locks(fds)
 
@@ -300,7 +354,7 @@ class TestIntegrationLock:
             ),
             patch("theforge.sprint.lock.time.sleep"),
         ):
-            with patch("theforge.sprint.lock._read_lock_pid", return_value=424242):
+            with patch("theforge.sprint.lock._read_lock_metadata", return_value=(424242, None)):
                 with pytest.raises(TimeoutError, match="held by pid 424242"):
                     with integration_lock(
                         tmp_path,
@@ -496,4 +550,9 @@ class TestCmdSprintConflictGuard:
 
         assert rc == 0
         mock_run.assert_called_once()
-        mock_git.assert_not_called()
+        git_calls_for_worktree = [
+            call
+            for call in mock_git.call_args_list
+            if call.args and call.args[0][:3] == ["git", "-C", str(worktree)]
+        ]
+        assert git_calls_for_worktree == []

--- a/tests/test_sprint_preflight.py
+++ b/tests/test_sprint_preflight.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from theforge.sprint.lock import _read_lock_metadata
 from theforge.sprint.preflight import (
     abort_for_active_worktrees,
     abort_for_running_stories,
@@ -45,32 +47,28 @@ def test_check_active_worktrees_returns_abort_when_active(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_reacquire_story_locks_in_daemon_updates_pid_in_place() -> None:
-    # Simulate two inherited lock FDs (StringIO-like objects with seek/truncate/write/flush)
-    import io
-
+def test_reacquire_story_locks_in_daemon_updates_pid_and_fingerprint_in_place() -> None:
     fd_a = io.StringIO()
-    fd_a.write("11111")  # parent PID written before fork
+    fd_a.write("11111|parent-start")
     fd_b = io.StringIO()
-    fd_b.write("11111")
+    fd_b.write("11111|parent-start")
 
-    import os
-
-    returned = reacquire_story_locks_in_daemon(
-        ["story-a", "story-b"],
-        Path("/tmp/project"),
-        [fd_a, fd_b],
-    )
+    with patch("theforge.sprint.lock._current_process_fingerprint", return_value="daemon-start"):
+        returned = reacquire_story_locks_in_daemon(
+            ["story-a", "story-b"],
+            Path("/tmp/project"),
+            [fd_a, fd_b],
+        )
 
     # Same FD objects returned — no close, no re-acquire
     assert returned == [fd_a, fd_b]
 
-    # Each FD now contains the daemon's PID
-    daemon_pid = str(os.getpid())
-    fd_a.seek(0)
-    assert fd_a.read() == daemon_pid
-    fd_b.seek(0)
-    assert fd_b.read() == daemon_pid
+    pid_a, fingerprint_a = _read_lock_metadata(fd_a)
+    pid_b, fingerprint_b = _read_lock_metadata(fd_b)
+    assert pid_a is not None
+    assert pid_b is not None
+    assert fingerprint_a == "daemon-start"
+    assert fingerprint_b == "daemon-start"
 
 
 def test_reacquire_story_locks_in_daemon_does_not_close_fds() -> None:


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The changes successfully address recycled PID detection by adding process start-time fingerprinting. Both prior P1 findings are resolved, no regressions introduced, and the implementation satisfies the spec. | [claude-opus] Both prior P1s resolved; daemon writes full metadata via _write_lock_metadata, and _pid_matches_fingerprint now falls back to PID liveness when ps fails.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $10.31
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Lock sweep mistakes recycled PIDs for live forge runs — imagent, Google Drive hold forge locks forever (GitHub Issue #959)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #959