### PR TITLE
forge stop surrenders silently on SIGTERM timeout — leaves zombie process holding locks

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -8,6 +8,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import cast
 
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
@@ -444,11 +445,27 @@ def cmd_logs(args: object) -> int:
     return 0
 
 
+def _cleanup_stopped_run(
+    run_id: str,
+    project_root: Path,
+    slug: str,
+    *,
+    pid: int | None = None,
+) -> None:
+    from theforge import detach as _detach
+    from theforge.sprint.lock import cleanup_story_locks
+
+    _detach.remove_pid(run_id, project_root)
+    _detach.write_run_ended(run_id, project_root, "stopped", force=True)
+    cleanup_story_locks([slug], project_root, pid=pid)
+
+
 def cmd_stop(args: object) -> int:
     """Send SIGTERM to a running forge process."""
     import signal as _signal
 
     from theforge import detach as _detach
+    from theforge.sprint.lock import cleanup_story_locks
 
     config_path = _find_config()
     if config_path is None or not config_path.exists():
@@ -456,7 +473,8 @@ def cmd_stop(args: object) -> int:
         return 1
     config = load_config(config_path)
     project_root = config.project_root
-    run_id = args.run_id
+    ns = cast(object, args)
+    run_id = ns.run_id
 
     pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
     if not pid_file.exists():
@@ -474,30 +492,56 @@ def cmd_stop(args: object) -> int:
         print(f"[forge] Sent SIGTERM to run {run_id} (PID {pid})")
     except ProcessLookupError:
         print(f"Process {pid} not found — cleaning up stale PID file")
-        _detach.remove_pid(run_id, project_root)
-        _detach.write_run_ended(run_id, project_root, "stopped", force=True)
+        _cleanup_stopped_run(run_id, project_root, slug, pid=pid)
         return 1
     except OSError as exc:
         print(f"Could not signal process {pid}: {exc}", file=sys.stderr)
         return 1
 
-    if args.no_wait:
+    if ns.no_wait:
         return 0
 
     start = time.monotonic()
-    while time.monotonic() - start < args.timeout:
+    while time.monotonic() - start < ns.timeout:
         if not _detach._is_pid_alive(pid):
+            _cleanup_stopped_run(run_id, project_root, slug, pid=pid)
             print(f"[forge] Run {run_id} has stopped.")
             return 0
         time.sleep(0.1)
 
     if not _detach._is_pid_alive(pid):
-        _detach.write_run_ended(run_id, project_root, "stopped", force=True)
+        _cleanup_stopped_run(run_id, project_root, slug, pid=pid)
         print(f"[forge] Run {run_id} has stopped.")
         return 0
 
+    try:
+        os.kill(pid, _signal.SIGKILL)
+        print(f"[forge] SIGTERM timed out for run {run_id}; sent SIGKILL to PID {pid}")
+    except ProcessLookupError:
+        _cleanup_stopped_run(run_id, project_root, slug, pid=pid)
+        print(f"[forge] Run {run_id} has stopped.")
+        return 0
+    except OSError as exc:
+        print(f"Could not SIGKILL process {pid}: {exc}", file=sys.stderr)
+        print(
+            f"Timed out waiting for run {run_id} to stop (PID {pid} still alive). "
+            f"Kill it manually and remove stale locks for {slug} if needed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    kill_start = time.monotonic()
+    while time.monotonic() - kill_start < 5.0:
+        if not _detach._is_pid_alive(pid):
+            _cleanup_stopped_run(run_id, project_root, slug, pid=pid)
+            print(f"[forge] Run {run_id} has stopped.")
+            return 0
+        time.sleep(0.1)
+
+    cleanup_story_locks([slug], project_root, pid=pid)
     print(
-        f"Timed out waiting for run {run_id} to stop (PID {pid} still alive)",
+        f"Timed out waiting for run {run_id} to stop after SIGKILL (PID {pid} still alive). "
+        f"Kill it manually and remove stale locks for {slug} if needed.",
         file=sys.stderr,
     )
     return 1

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -455,7 +455,6 @@ def _stopped_run_lock_slugs(run_id: str, project_root: Path, slug: str) -> list[
     return [slug]
 
 
-
 def _cleanup_stopped_run(
     run_id: str,
     project_root: Path,
@@ -477,7 +476,6 @@ def cmd_stop(args: object) -> int:
     import signal as _signal
 
     from theforge import detach as _detach
-    from theforge.sprint.lock import cleanup_story_locks
 
     config_path = _find_config()
     if config_path is None or not config_path.exists():

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -8,7 +8,6 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import cast
 
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
@@ -445,6 +444,18 @@ def cmd_logs(args: object) -> int:
     return 0
 
 
+def _stopped_run_lock_slugs(run_id: str, project_root: Path, slug: str) -> list[str]:
+    from theforge.sprint.status_reader import read_live_status
+
+    entries = read_live_status(run_id, project_root)
+    if entries:
+        story_slugs = [entry.slug for entry in entries if entry.slug]
+        if story_slugs:
+            return story_slugs
+    return [slug]
+
+
+
 def _cleanup_stopped_run(
     run_id: str,
     project_root: Path,
@@ -455,9 +466,10 @@ def _cleanup_stopped_run(
     from theforge import detach as _detach
     from theforge.sprint.lock import cleanup_story_locks
 
+    lock_slugs = _stopped_run_lock_slugs(run_id, project_root, slug)
     _detach.remove_pid(run_id, project_root)
     _detach.write_run_ended(run_id, project_root, "stopped", force=True)
-    cleanup_story_locks([slug], project_root, pid=pid)
+    cleanup_story_locks(lock_slugs, project_root, pid=pid)
 
 
 def cmd_stop(args: object) -> int:
@@ -473,8 +485,7 @@ def cmd_stop(args: object) -> int:
         return 1
     config = load_config(config_path)
     project_root = config.project_root
-    ns = cast(object, args)
-    run_id = ns.run_id
+    run_id = args.run_id
 
     pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
     if not pid_file.exists():
@@ -498,11 +509,11 @@ def cmd_stop(args: object) -> int:
         print(f"Could not signal process {pid}: {exc}", file=sys.stderr)
         return 1
 
-    if ns.no_wait:
+    if args.no_wait:
         return 0
 
     start = time.monotonic()
-    while time.monotonic() - start < ns.timeout:
+    while time.monotonic() - start < args.timeout:
         if not _detach._is_pid_alive(pid):
             _cleanup_stopped_run(run_id, project_root, slug, pid=pid)
             print(f"[forge] Run {run_id} has stopped.")
@@ -538,7 +549,6 @@ def cmd_stop(args: object) -> int:
             return 0
         time.sleep(0.1)
 
-    cleanup_story_locks([slug], project_root, pid=pid)
     print(
         f"Timed out waiting for run {run_id} to stop after SIGKILL (PID {pid} still alive). "
         f"Kill it manually and remove stale locks for {slug} if needed.",

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -207,7 +207,9 @@ def cleanup_story_locks(
 
     When ``pid`` is provided, only lock files whose metadata still points at that
     process instance are removed. Empty/corrupt lock files are also removed as
-    stale. Returns the list of slugs whose lock files were deleted.
+    stale. If the owning PID matches ``pid`` but the process is no longer alive,
+    the lock file is also removed so a freshly stopped run does not leave stale
+    lock files behind. Returns the list of slugs whose lock files were deleted.
     """
     if not slugs:
         return []
@@ -227,8 +229,10 @@ def cleanup_story_locks(
                 should_remove = owner_pid is None
                 if pid is None:
                     should_remove = True
-                elif owner_pid == pid and _pid_matches_fingerprint(owner_pid, owner_fingerprint):
-                    should_remove = True
+                elif owner_pid == pid:
+                    should_remove = not _is_pid_alive(owner_pid) or _pid_matches_fingerprint(
+                        owner_pid, owner_fingerprint
+                    )
             if should_remove:
                 lock_path.unlink(missing_ok=True)
                 cleaned.append(slug)

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from theforge.artifacts import ESCALATED_MARKER_PATH
+from theforge.detach import _is_pid_alive
 from theforge.pid import _current_process_fingerprint, _pid_matches_fingerprint
 
 _LOCK_METADATA_SEPARATOR = "|"
@@ -230,9 +231,12 @@ def cleanup_story_locks(
                 if pid is None:
                     should_remove = True
                 elif owner_pid == pid:
-                    should_remove = not _is_pid_alive(owner_pid) or _pid_matches_fingerprint(
-                        owner_pid, owner_fingerprint
-                    )
+                    if owner_fingerprint is None:
+                        should_remove = True
+                    else:
+                        should_remove = not _is_pid_alive(owner_pid) or _pid_matches_fingerprint(
+                            owner_pid, owner_fingerprint
+                        )
             if should_remove:
                 lock_path.unlink(missing_ok=True)
                 cleaned.append(slug)

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -197,6 +197,47 @@ def release_story_locks(fds: list) -> None:
             pass
 
 
+def cleanup_story_locks(
+    slugs: list[str],
+    project_root: Path,
+    *,
+    pid: int | None = None,
+) -> list[str]:
+    """Best-effort removal of stale story lock files for a stopped or killed run.
+
+    When ``pid`` is provided, only lock files whose metadata still points at that
+    process instance are removed. Empty/corrupt lock files are also removed as
+    stale. Returns the list of slugs whose lock files were deleted.
+    """
+    if not slugs:
+        return []
+
+    cleaned: list[str] = []
+    lock_dir = project_root / ".forge" / "locks"
+    if not lock_dir.exists():
+        return cleaned
+
+    for slug in slugs:
+        lock_path = lock_dir / f"{slug}.lock"
+        if not lock_path.exists():
+            continue
+        try:
+            with open(lock_path, "a+") as fd:
+                owner_pid, owner_fingerprint = _read_lock_metadata(fd)
+                should_remove = owner_pid is None
+                if pid is None:
+                    should_remove = True
+                elif owner_pid == pid and _pid_matches_fingerprint(owner_pid, owner_fingerprint):
+                    should_remove = True
+            if should_remove:
+                lock_path.unlink(missing_ok=True)
+                cleaned.append(slug)
+        except OSError:
+            continue
+
+    return cleaned
+
+
 @contextmanager
 def integration_lock(
     forge_root: Path,

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -6,7 +6,7 @@ import argparse
 import signal as _signal
 import warnings
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from theforge.cli import cmd_run
 from theforge.config import (
@@ -589,8 +589,49 @@ class TestCmdStop:
         assert result == 0
         mock_sleep.assert_called_once_with(0.1)
 
-    def test_timeout_returns_nonzero(self, tmp_path):
-        """forge stop returns 1 when the process does not exit before timeout."""
+    def test_timeout_escalates_to_sigkill_and_cleans_up(self, tmp_path):
+        """forge stop escalates to SIGKILL after SIGTERM timeout and cleans up locks."""
+        from theforge.cli import cmd_stop
+
+        run_id = "abc123"
+        target_pid = 54321
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nmy-slug\n")
+        lock_dir = tmp_path / ".forge" / "locks"
+        lock_dir.mkdir(parents=True)
+        (lock_dir / "my-slug.lock").write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, no_wait=False, timeout=60)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status.os.kill") as mock_kill,
+            patch("theforge.cli.status.time.sleep"),
+            patch(
+                "theforge.cli.status.time.monotonic",
+                side_effect=[0.0, 0.0, 61.0, 61.0, 61.1],
+            ),
+            patch("theforge.detach._is_pid_alive", side_effect=[True, True, False]),
+            patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=True),
+        ):
+            result = cmd_stop(args)
+
+        assert result == 0
+        assert mock_kill.call_args_list == [
+            call(target_pid, _signal.SIGTERM),
+            call(target_pid, _signal.SIGKILL),
+        ]
+        assert not (runs_dir / f"{run_id}.pid").exists()
+        assert (runs_dir / f"{run_id}.ended").read_text(encoding="utf-8") == "stopped"
+        assert not (lock_dir / "my-slug.lock").exists()
+
+    def test_sigkill_failure_returns_nonzero_with_manual_instruction(self, tmp_path, capsys):
+        """forge stop returns 1 with explicit escalation guidance when SIGKILL fails."""
         from theforge.cli import cmd_stop
 
         run_id = "abc123"
@@ -604,17 +645,23 @@ class TestCmdStop:
         config = _make_forge_config(tmp_path)
         args = argparse.Namespace(run_id=run_id, no_wait=False, timeout=60)
 
+        def fake_kill(pid, sig):
+            if sig == _signal.SIGKILL:
+                raise OSError("permission denied")
+
         with (
             patch("theforge.cli.status._find_config", return_value=forge_yaml),
             patch("theforge.cli.status.load_config", return_value=config),
-            patch("theforge.cli.status.os.kill"),
+            patch("theforge.cli.status.os.kill", side_effect=fake_kill),
             patch("theforge.cli.status.time.sleep"),
             patch("theforge.cli.status.time.monotonic", side_effect=[0.0, 0.0, 61.0]),
             patch("theforge.detach._is_pid_alive", return_value=True),
         ):
             result = cmd_stop(args)
 
+        captured = capsys.readouterr()
         assert result == 1
+        assert "Kill it manually" in captured.err
 
     def test_no_wait_skips_polling(self, tmp_path):
         """forge stop --no-wait returns immediately without polling."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -600,7 +600,8 @@ class TestCmdStop:
         (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nmy-slug\n")
         lock_dir = tmp_path / ".forge" / "locks"
         lock_dir.mkdir(parents=True)
-        (lock_dir / "my-slug.lock").write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
+        lock_path = lock_dir / "my-slug.lock"
+        lock_path.write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
 
         forge_yaml = tmp_path / "forge.yaml"
         forge_yaml.write_text("project:\n  root: .\n")
@@ -616,18 +617,23 @@ class TestCmdStop:
                 "theforge.cli.status.time.monotonic",
                 side_effect=[0.0, 0.0, 61.0, 61.0, 61.1],
             ),
-            patch("theforge.detach._is_pid_alive", side_effect=[True, True, False, False]),
+            patch(
+                "theforge.detach._is_pid_alive",
+                side_effect=[True, True, False, False],
+            ),
         ):
             result = cmd_stop(args)
 
         assert result == 0
-        assert mock_kill.call_args_list == [
+        expected_calls = [
             call(target_pid, _signal.SIGTERM),
             call(target_pid, _signal.SIGKILL),
         ]
+        assert mock_kill.call_args_list[:2] == expected_calls
         assert not (runs_dir / f"{run_id}.pid").exists()
-        assert (runs_dir / f"{run_id}.ended").read_text(encoding="utf-8") == "stopped"
-        assert not (lock_dir / "my-slug.lock").exists()
+        ended_path = runs_dir / f"{run_id}.ended"
+        assert ended_path.read_text(encoding="utf-8") == "stopped"
+        assert not lock_path.exists()
 
     def test_timeout_after_sigkill_keeps_lock_when_process_still_alive(self, tmp_path, capsys):
         """forge stop must not remove locks if the process survives the SIGKILL wait."""
@@ -663,17 +669,18 @@ class TestCmdStop:
 
         captured = capsys.readouterr()
         assert result == 1
-        assert mock_kill.call_args_list == [
+        expected_calls = [
             call(target_pid, _signal.SIGTERM),
             call(target_pid, _signal.SIGKILL),
         ]
+        assert mock_kill.call_args_list == expected_calls
         assert (runs_dir / f"{run_id}.pid").exists()
         assert not (runs_dir / f"{run_id}.ended").exists()
         assert lock_path.exists()
         assert "still alive" in captured.err
 
-    def test_timeout_escalates_to_sigkill_and_cleans_up_sprint_story_locks(self, tmp_path):
-        """forge stop cleans up per-story locks for sprint runs using the live state file."""
+    def test_timeout_escalates_to_sigkill_and_cleans_up_sprint_locks(self, tmp_path):
+        """forge stop cleans up sprint locks via the live state file."""
         from theforge.cli import cmd_stop
 
         run_id = "abc123"
@@ -682,15 +689,16 @@ class TestCmdStop:
         runs_dir.mkdir(parents=True)
         (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nsprint-slug\n")
         (runs_dir / f"{run_id}.state").write_text(
-            "stories:\n"
-            "  - slug: story-a\n"
-            "  - slug: story-b\n",
+            "stories:\n  - slug: story-a\n  - slug: story-b\n",
             encoding="utf-8",
         )
         lock_dir = tmp_path / ".forge" / "locks"
         lock_dir.mkdir(parents=True)
-        (lock_dir / "story-a.lock").write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
-        (lock_dir / "story-b.lock").write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
+        story_a_lock = lock_dir / "story-a.lock"
+        story_b_lock = lock_dir / "story-b.lock"
+        lock_contents = f"{target_pid}|fingerprint\n"
+        story_a_lock.write_text(lock_contents, encoding="utf-8")
+        story_b_lock.write_text(lock_contents, encoding="utf-8")
 
         forge_yaml = tmp_path / "forge.yaml"
         forge_yaml.write_text("project:\n  root: .\n")
@@ -706,13 +714,16 @@ class TestCmdStop:
                 "theforge.cli.status.time.monotonic",
                 side_effect=[0.0, 0.0, 61.0, 61.0, 61.1],
             ),
-            patch("theforge.detach._is_pid_alive", side_effect=[True, True, False, False, False]),
+            patch(
+                "theforge.detach._is_pid_alive",
+                side_effect=[True, True, False, False, False],
+            ),
         ):
             result = cmd_stop(args)
 
         assert result == 0
-        assert not (lock_dir / "story-a.lock").exists()
-        assert not (lock_dir / "story-b.lock").exists()
+        assert not story_a_lock.exists()
+        assert not story_b_lock.exists()
 
     def test_sigkill_failure_returns_nonzero_with_manual_instruction(self, tmp_path, capsys):
         """forge stop returns 1 with explicit escalation guidance when SIGKILL fails."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -616,8 +616,7 @@ class TestCmdStop:
                 "theforge.cli.status.time.monotonic",
                 side_effect=[0.0, 0.0, 61.0, 61.0, 61.1],
             ),
-            patch("theforge.detach._is_pid_alive", side_effect=[True, True, False]),
-            patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=True),
+            patch("theforge.detach._is_pid_alive", side_effect=[True, True, False, False]),
         ):
             result = cmd_stop(args)
 
@@ -629,6 +628,91 @@ class TestCmdStop:
         assert not (runs_dir / f"{run_id}.pid").exists()
         assert (runs_dir / f"{run_id}.ended").read_text(encoding="utf-8") == "stopped"
         assert not (lock_dir / "my-slug.lock").exists()
+
+    def test_timeout_after_sigkill_keeps_lock_when_process_still_alive(self, tmp_path, capsys):
+        """forge stop must not remove locks if the process survives the SIGKILL wait."""
+        from theforge.cli import cmd_stop
+
+        run_id = "abc123"
+        target_pid = 54321
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nmy-slug\n")
+        lock_dir = tmp_path / ".forge" / "locks"
+        lock_dir.mkdir(parents=True)
+        lock_path = lock_dir / "my-slug.lock"
+        lock_path.write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, no_wait=False, timeout=60)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status.os.kill") as mock_kill,
+            patch("theforge.cli.status.time.sleep"),
+            patch(
+                "theforge.cli.status.time.monotonic",
+                side_effect=[0.0, 0.0, 61.0, 61.0, 61.1, 66.2],
+            ),
+            patch("theforge.detach._is_pid_alive", return_value=True),
+        ):
+            result = cmd_stop(args)
+
+        captured = capsys.readouterr()
+        assert result == 1
+        assert mock_kill.call_args_list == [
+            call(target_pid, _signal.SIGTERM),
+            call(target_pid, _signal.SIGKILL),
+        ]
+        assert (runs_dir / f"{run_id}.pid").exists()
+        assert not (runs_dir / f"{run_id}.ended").exists()
+        assert lock_path.exists()
+        assert "still alive" in captured.err
+
+    def test_timeout_escalates_to_sigkill_and_cleans_up_sprint_story_locks(self, tmp_path):
+        """forge stop cleans up per-story locks for sprint runs using the live state file."""
+        from theforge.cli import cmd_stop
+
+        run_id = "abc123"
+        target_pid = 54321
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.pid").write_text(f"{target_pid}\nsprint-slug\n")
+        (runs_dir / f"{run_id}.state").write_text(
+            "stories:\n"
+            "  - slug: story-a\n"
+            "  - slug: story-b\n",
+            encoding="utf-8",
+        )
+        lock_dir = tmp_path / ".forge" / "locks"
+        lock_dir.mkdir(parents=True)
+        (lock_dir / "story-a.lock").write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
+        (lock_dir / "story-b.lock").write_text(f"{target_pid}|fingerprint\n", encoding="utf-8")
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, no_wait=False, timeout=60)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status.os.kill"),
+            patch("theforge.cli.status.time.sleep"),
+            patch(
+                "theforge.cli.status.time.monotonic",
+                side_effect=[0.0, 0.0, 61.0, 61.0, 61.1],
+            ),
+            patch("theforge.detach._is_pid_alive", side_effect=[True, True, False, False, False]),
+        ):
+            result = cmd_stop(args)
+
+        assert result == 0
+        assert not (lock_dir / "story-a.lock").exists()
+        assert not (lock_dir / "story-b.lock").exists()
 
     def test_sigkill_failure_returns_nonzero_with_manual_instruction(self, tmp_path, capsys):
         """forge stop returns 1 with explicit escalation guidance when SIGKILL fails."""

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -256,6 +256,20 @@ class TestCleanupStoryLocks:
         assert cleaned == ["story-a"]
         assert not lock_path.exists()
 
+    def test_removes_dead_matching_pid_lock_without_fingerprint_match(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / ".forge" / "locks" / "story-a.lock"
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text("424242|old-start\n", encoding="utf-8")
+
+        with (
+            patch("theforge.sprint.lock._is_pid_alive", return_value=False),
+            patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False),
+        ):
+            cleaned = cleanup_story_locks(["story-a"], tmp_path, pid=424242)
+
+        assert cleaned == ["story-a"]
+        assert not lock_path.exists()
+
     def test_keeps_nonmatching_pid_lock(self, tmp_path: Path) -> None:
         lock_path = tmp_path / ".forge" / "locks" / "story-a.lock"
         lock_path.parent.mkdir(parents=True)

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -256,7 +256,9 @@ class TestCleanupStoryLocks:
         assert cleaned == ["story-a"]
         assert not lock_path.exists()
 
-    def test_removes_dead_matching_pid_lock_without_fingerprint_match(self, tmp_path: Path) -> None:
+    def test_removes_dead_matching_pid_lock_without_fingerprint_match(
+        self, tmp_path: Path
+    ) -> None:
         lock_path = tmp_path / ".forge" / "locks" / "story-a.lock"
         lock_path.parent.mkdir(parents=True)
         lock_path.write_text("424242|old-start\n", encoding="utf-8")
@@ -270,12 +272,15 @@ class TestCleanupStoryLocks:
         assert cleaned == ["story-a"]
         assert not lock_path.exists()
 
-    def test_keeps_nonmatching_pid_lock(self, tmp_path: Path) -> None:
+    def test_keeps_live_matching_pid_with_different_fingerprint_lock(self, tmp_path: Path) -> None:
         lock_path = tmp_path / ".forge" / "locks" / "story-a.lock"
         lock_path.parent.mkdir(parents=True)
         lock_path.write_text("424242|other-start\n", encoding="utf-8")
 
-        with patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False):
+        with (
+            patch("theforge.sprint.lock._is_pid_alive", return_value=True),
+            patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False),
+        ):
             cleaned = cleanup_story_locks(["story-a"], tmp_path, pid=424242)
 
         assert cleaned == []

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -15,6 +15,7 @@ from theforge.sprint.lock import (
     _read_lock_metadata,
     acquire_story_locks,
     check_active_worktrees,
+    cleanup_story_locks,
     integration_lock,
     release_story_locks,
 )
@@ -241,6 +242,30 @@ class TestAcquireStoryLocks:
             assert lock_path.read_text(encoding="utf-8") == ""
         finally:
             release_story_locks(fds)
+
+
+class TestCleanupStoryLocks:
+    def test_removes_matching_pid_lock(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / ".forge" / "locks" / "story-a.lock"
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text("424242|same-start\n", encoding="utf-8")
+
+        with patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=True):
+            cleaned = cleanup_story_locks(["story-a"], tmp_path, pid=424242)
+
+        assert cleaned == ["story-a"]
+        assert not lock_path.exists()
+
+    def test_keeps_nonmatching_pid_lock(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / ".forge" / "locks" / "story-a.lock"
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text("424242|other-start\n", encoding="utf-8")
+
+        with patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False):
+            cleaned = cleanup_story_locks(["story-a"], tmp_path, pid=424242)
+
+        assert cleaned == []
+        assert lock_path.exists()
 
 
 class TestCheckActiveWorktrees:


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The implementation resolves all prior P1 findings: it escalates to SIGKILL after SIGTERM timeout, correctly identifies story slugs for sprint lock cleanup via live state reading, and ensures cleanup_story_locks only removes locks when the owning process is dead or matches the fingerprint. No regressions or new P1 issues were introduced. | [claude-opus] Prior P1s resolved: post-SIGKILL lock removal is gated on process death, sprint runs clean per-story locks from live state, and dead-owner cleanup no longer requires fingerprint match.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-api-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $15.65
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

forge stop surrenders silently on SIGTERM timeout — leaves zombie process holding locks (GitHub Issue #960)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #960