### PR TITLE
Route openai/gpt-5.4 via Codex CLI with API fallback (#980)

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -7,7 +7,7 @@ project: theforge
 models:
   - claude/sonnet
   - claude/opus
-  - openai-api/gpt-5.4
+  - openai/gpt-5.4
   - deepseek/deepseek-reasoner
   - google/gemini-3.1-pro-preview
 
@@ -25,6 +25,11 @@ plan_agent_review:
       budget_usd: 1.00
       timeout_seconds: 600
       
+provider_fallbacks:
+  openai:
+    model: gpt-5.4
+    timeout_seconds: 600
+
 budget_usd: 50.0
 
 workspace:


### PR DESCRIPTION
## Summary
- Switch forge.yaml's OpenAI entry from `openai-api/gpt-5.4` (API transport) to `openai/gpt-5.4` (Codex CLI transport).
- Add `provider_fallbacks.openai` block so the CLI runner falls through to the OpenAI API on quota/not-found failures (exercises the existing `ApiFallbackConfig` path in `runners/cli.py`).
- No code change.

Closes #980.

## Test plan
- [x] `make gate` passes in the worktree (3394 passed, 1 skipped)
- [ ] Post-merge: next sprint run confirms OpenAI traffic resolves to CLI transport (inspect audit / profile dump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)