### PR TITLE
Audit and remove score-to-band flattening at routing decision points

### DIFF
--- a/docs/issue-976-score-to-band-routing-audit.md
+++ b/docs/issue-976-score-to-band-routing-audit.md
@@ -1,0 +1,82 @@
+# Issue #976 audit: score-to-band flattening at routing decision points
+
+## score_to_band() callers
+
+1. `src/theforge/coordinator/preflight_flow.py:313`
+   - Classification: **(b) display/log only — leave as-is**
+   - Notes: this is the compatibility shim that stores `state.preflight_complexity` for legacy consumers after parsing `complexity_score`. It remains useful as a display/log artifact and fallback input for unconverted sites.
+
+## Band-keyed routing decisions audited
+
+### Converted in this issue
+
+1. `src/theforge/config/role_derivation.py`
+   - Site: dev-role tier selection in `derive_roles()`
+   - Previous routing: `small/medium/large -> cheap/mid/strong`
+   - Classification: **(a) meaningful routing decision — convert to numeric score**
+   - Change: added optional `complexity_score` input and now use `score_to_dev_tier()` when present, so score 6 and score 7 no longer route identically.
+
+2. `src/theforge/coordinator/dev_phase.py`
+   - Site: DEV timeout override selection via `resolve_timeout()`
+   - Previous routing: only `medium` and `large` bands could trigger timeout overrides
+   - Classification: **(a) meaningful routing decision — convert to numeric score**
+   - Change: timeout resolution now prefers numeric score thresholds (`6-7 -> medium override`, `8-10 -> large override`) so two `medium` stories can receive different DEV timeouts.
+
+3. `src/theforge/coordinator/plan_flow.py`
+   - Site: PLAN timeout override selection via `resolve_timeout()`
+   - Previous routing: only `medium` and `large` bands could trigger timeout overrides
+   - Classification: **(a) meaningful routing decision — convert to numeric score**
+   - Change: same numeric timeout policy as DEV, allowing same-band stories to diverge in PLAN timeout.
+
+4. `src/theforge/coordinator/preflight.py`
+   - Site: `_apply_complexity_adaptation()` dev model routing
+   - Classification: **(a) meaningful routing decision — already numeric**
+   - Notes: this site was already converted before this issue and uses `complexity_score` via `score_to_dev_tier()`.
+
+### Leave as display/log only
+
+1. `src/theforge/coordinator/dev_phase.py`
+   - Site: `"Dev timeout: ... ({state.preflight_complexity} complexity)"`
+   - Classification: **(b) display/log only — leave as-is**
+
+2. `src/theforge/coordinator/plan_flow.py`
+   - Site: `"Plan timeout: ... ({state.preflight_complexity} complexity)"`
+   - Classification: **(b) display/log only — leave as-is**
+
+3. `src/theforge/coordinator/audit.py`
+   - Site: audit payload includes both `complexity` and `complexity_score`
+   - Classification: **(b) display/log only — leave as-is**
+
+4. `src/theforge/coordinator/review_phase.py`
+   - Site: review audit payload includes `complexity`
+   - Classification: **(b) display/log only — leave as-is**
+
+5. `src/theforge/coordinator/validate_phase.py`
+   - Site: validate audit payload includes `complexity`
+   - Classification: **(b) display/log only — leave as-is**
+
+6. `src/theforge/coordinator/preflight_flow.py`
+   - Site: state update payload and preflight logs include `complexity`
+   - Classification: **(b) display/log only — leave as-is**
+
+### Out of scope / follow-up required
+
+1. `src/theforge/coordinator/preflight_flow.py:342-351`
+   - Site: contract-change upgrade `small -> medium` plus score bump to `5`
+   - Classification: **(c) out of scope — file follow-up**
+   - Rationale: this is policy coupling between contract-change detection and complexity escalation. It should likely become score-native, but changing it safely needs a separate policy decision.
+
+2. `src/theforge/coordinator/preflight_flow.py:410-416`
+   - Site: fallback contract-change upgrade in degraded preflight path
+   - Classification: **(c) out of scope — file follow-up**
+   - Rationale: same policy concern as above.
+
+3. `src/theforge/config/role_derivation.py`
+   - Site: plan-role and review-pool routing still keyed by normalized complexity band
+   - Classification: **(c) out of scope — file follow-up**
+   - Rationale: these are meaningful routing decisions, but widening them to score-native behavior changes more of the routing matrix and should be handled as a dedicated follow-up.
+
+## Follow-up issues filed from this audit
+
+- `#977` Convert contract-change complexity escalation in preflight flow from band bumping to score-native policy.
+- `#978` Extend score-native routing beyond dev tier/timeouts to plan and review routing matrices in role derivation.

--- a/docs/issue-976-score-to-band-routing-audit.md
+++ b/docs/issue-976-score-to-band-routing-audit.md
@@ -15,6 +15,7 @@
    - Previous routing: `small/medium/large -> cheap/mid/strong`
    - Classification: **(a) meaningful routing decision — convert to numeric score**
    - Change: added optional `complexity_score` input and now use `score_to_dev_tier()` when present, so score 6 and score 7 no longer route identically.
+   - Status note: this conversion is currently staged behind callers that pass `complexity_score`; runtime adaptive dev-tier routing in coordinator remains driven by `src/theforge/coordinator/preflight.py::_apply_complexity_adaptation()`.
 
 2. `src/theforge/coordinator/dev_phase.py`
    - Site: DEV timeout override selection via `resolve_timeout()`
@@ -71,12 +72,31 @@
    - Classification: **(c) out of scope — file follow-up**
    - Rationale: same policy concern as above.
 
-3. `src/theforge/config/role_derivation.py`
+3. `src/theforge/coordinator/plan_flow.py:145,179`
+   - Site: spec-validation and PLAN-phase gating via `state.preflight_complexity in ("medium", "large")`
+   - Classification: **(c) out of scope — file follow-up**
+   - Rationale: these are meaningful coordinator routing gates, but converting them to score-native policy changes when PLAN runs at all and needs a dedicated policy decision plus seam tests.
+   - Follow-up: `#977`
+
+4. `src/theforge/coordinator/preflight.py:614`
+   - Site: `_PHASE_COMPLEXITY_TIER["plan"][norm]` drives adaptive plan model routing
+   - Classification: **(c) out of scope — file follow-up**
+   - Rationale: meaningful plan routing still keyed by normalized band; converting it expands the routing matrix beyond the timeout/dev-tier scope of this issue.
+   - Follow-up: `#977`
+
+5. `src/theforge/coordinator/preflight.py:648`
+   - Site: `norm == "LOW"` drives single-reviewer vs broader review-pool routing
+   - Classification: **(c) out of scope — file follow-up**
+   - Rationale: meaningful review routing still keyed by normalized band; converting it requires a dedicated score-native review policy.
+   - Follow-up: `#977`
+
+6. `src/theforge/config/role_derivation.py`
    - Site: plan-role and review-pool routing still keyed by normalized complexity band
    - Classification: **(c) out of scope — file follow-up**
    - Rationale: these are meaningful routing decisions, but widening them to score-native behavior changes more of the routing matrix and should be handled as a dedicated follow-up.
+   - Follow-up: `#977`
 
 ## Follow-up issues filed from this audit
 
-- `#977` Convert contract-change complexity escalation in preflight flow from band bumping to score-native policy.
-- `#978` Extend score-native routing beyond dev tier/timeouts to plan and review routing matrices in role derivation.
+- `#978` Convert contract-change complexity escalation in preflight flow from band bumping to score-native policy.
+- `#977` Extend score-native routing beyond dev tier/timeouts to remaining plan and review routing matrices/gates.

--- a/docs/issue-976-score-to-band-routing-audit.md
+++ b/docs/issue-976-score-to-band-routing-audit.md
@@ -72,25 +72,30 @@
    - Classification: **(c) out of scope — file follow-up**
    - Rationale: same policy concern as above.
 
-3. `src/theforge/coordinator/plan_flow.py:145,179`
+3. `src/theforge/coordinator/engine.py:829-831`
+   - Site: escalation-memory persistence normalizes `small/medium/large` to uppercase assignment-history labels
+   - Classification: **(b) display/log only — leave as-is**
+   - Rationale: this affects persisted telemetry labels only; it does not influence coordinator routing.
+
+4. `src/theforge/coordinator/plan_flow.py:145,179`
    - Site: spec-validation and PLAN-phase gating via `state.preflight_complexity in ("medium", "large")`
    - Classification: **(c) out of scope — file follow-up**
    - Rationale: these are meaningful coordinator routing gates, but converting them to score-native policy changes when PLAN runs at all and needs a dedicated policy decision plus seam tests.
    - Follow-up: `#977`
 
-4. `src/theforge/coordinator/preflight.py:614`
+5. `src/theforge/coordinator/preflight.py:614`
    - Site: `_PHASE_COMPLEXITY_TIER["plan"][norm]` drives adaptive plan model routing
    - Classification: **(c) out of scope — file follow-up**
    - Rationale: meaningful plan routing still keyed by normalized band; converting it expands the routing matrix beyond the timeout/dev-tier scope of this issue.
    - Follow-up: `#977`
 
-5. `src/theforge/coordinator/preflight.py:648`
+6. `src/theforge/coordinator/preflight.py:648`
    - Site: `norm == "LOW"` drives single-reviewer vs broader review-pool routing
    - Classification: **(c) out of scope — file follow-up**
    - Rationale: meaningful review routing still keyed by normalized band; converting it requires a dedicated score-native review policy.
    - Follow-up: `#977`
 
-6. `src/theforge/config/role_derivation.py`
+7. `src/theforge/config/role_derivation.py`
    - Site: plan-role and review-pool routing still keyed by normalized complexity band
    - Classification: **(c) out of scope — file follow-up**
    - Rationale: these are meaningful routing decisions, but widening them to score-native behavior changes more of the routing matrix and should be handled as a dedicated follow-up.

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -49,6 +49,15 @@ _COMPLEXITY_NORM: dict[str, str] = {
 }
 
 
+def _score_to_dev_tier(score: int) -> str:
+    """Map a 1-10 complexity score to a dev-phase model tier."""
+    if score <= 3:
+        return "cheap"
+    if score <= 6:
+        return "mid"
+    return "strong"
+
+
 def _pick_by_tier(
     candidates: list[tuple[str, ModelInfo]],
     target_tier: str,
@@ -156,6 +165,7 @@ def derive_roles(
     *,
     budget_usd: float = 10.0,
     complexity: str | None = None,
+    complexity_score: int | None = None,
 ) -> RoleAssignment:
     """Map a simple model list to a RoleAssignment.
 
@@ -190,6 +200,9 @@ def derive_roles(
         budget_usd: Total budget to distribute across all roles. Defaults to $10.
         complexity: Optional complexity level; if supplied activates tier × complexity
             routing. Accepts "small"/"medium"/"large" or "LOW"/"MEDIUM"/"HIGH".
+        complexity_score: Optional 1-10 preflight complexity score. When present,
+            converted routing sites may use it to differentiate stories that share
+            the same legacy complexity band.
 
     Returns:
         A RoleAssignment holding the four derived role configs plus optional synthesis.
@@ -228,7 +241,11 @@ def derive_roles(
     _apply_tier_routing = norm_complexity is not None
 
     if _apply_tier_routing:
-        target_dev_tier = _COMPLEXITY_TIER["dev"][norm_complexity]
+        target_dev_tier = (
+            _score_to_dev_tier(complexity_score)
+            if complexity_score is not None
+            else _COMPLEXITY_TIER["dev"][norm_complexity]
+        )
         dev_key, dev_info = _pick_by_tier(dev_candidates, target_dev_tier)
     else:
         dev_key, dev_info = dev_candidates[0]

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -394,14 +394,25 @@ def _run_dev_phase(
         config.dev_profile.timeout_medium_seconds,
         config.dev_profile.timeout_large_seconds,
         state.preflight_complexity,
+        state.preflight_complexity_score,
     )
-    _dev_override_active = (
-        state.preflight_complexity == "large"
-        and config.dev_profile.timeout_large_seconds is not None
-    ) or (
-        state.preflight_complexity == "medium"
-        and config.dev_profile.timeout_medium_seconds is not None
-    )
+    _dev_override_active = False
+    if state.preflight_complexity_score is not None:
+        _dev_override_active = (
+            state.preflight_complexity_score >= 8
+            and config.dev_profile.timeout_large_seconds is not None
+        ) or (
+            state.preflight_complexity_score >= 6
+            and config.dev_profile.timeout_medium_seconds is not None
+        )
+    else:
+        _dev_override_active = (
+            state.preflight_complexity == "large"
+            and config.dev_profile.timeout_large_seconds is not None
+        ) or (
+            state.preflight_complexity == "medium"
+            and config.dev_profile.timeout_medium_seconds is not None
+        )
     if _dev_override_active:
         _log(f"  Dev timeout: {_dev_timeout}s ({state.preflight_complexity} complexity)")
     else:

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -22,7 +22,13 @@ from .logging import StructuredLogger
 from .notify import _escalate_notify
 from .preflight import _escalate_dev_model, _find_registry_key_for_profile
 from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase, RetryReason
-from .util import _fmt_duration, _log, _log_phase, _log_verbose, resolve_timeout
+from .util import (
+    _fmt_duration,
+    _log,
+    _log_phase,
+    _log_verbose,
+    resolve_timeout_with_active,
+)
 
 # ── Lazy runner slot ──────────────────────────────────────────────────
 # None until first call; tests may replace before calling run_task.
@@ -389,30 +395,13 @@ def _run_dev_phase(
         prompt,
     )
 
-    _dev_timeout = resolve_timeout(
+    _dev_timeout, _dev_override_active = resolve_timeout_with_active(
         config.dev_profile.timeout_seconds,
         config.dev_profile.timeout_medium_seconds,
         config.dev_profile.timeout_large_seconds,
         state.preflight_complexity,
         state.preflight_complexity_score,
     )
-    _dev_override_active = False
-    if state.preflight_complexity_score is not None:
-        _dev_override_active = (
-            state.preflight_complexity_score >= 8
-            and config.dev_profile.timeout_large_seconds is not None
-        ) or (
-            state.preflight_complexity_score >= 6
-            and config.dev_profile.timeout_medium_seconds is not None
-        )
-    else:
-        _dev_override_active = (
-            state.preflight_complexity == "large"
-            and config.dev_profile.timeout_large_seconds is not None
-        ) or (
-            state.preflight_complexity == "medium"
-            and config.dev_profile.timeout_medium_seconds is not None
-        )
     if _dev_override_active:
         _log(f"  Dev timeout: {_dev_timeout}s ({state.preflight_complexity} complexity)")
     else:

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -212,10 +212,17 @@ def _run_plan_phase(
         config.plan.timeout_medium,
         config.plan.timeout_large,
         state.preflight_complexity,
+        state.preflight_complexity_score,
     )
-    _plan_override_active = (
-        state.preflight_complexity == "large" and config.plan.timeout_large is not None
-    ) or (state.preflight_complexity == "medium" and config.plan.timeout_medium is not None)
+    _plan_override_active = False
+    if state.preflight_complexity_score is not None:
+        _plan_override_active = (
+            state.preflight_complexity_score >= 8 and config.plan.timeout_large is not None
+        ) or (state.preflight_complexity_score >= 6 and config.plan.timeout_medium is not None)
+    else:
+        _plan_override_active = (
+            state.preflight_complexity == "large" and config.plan.timeout_large is not None
+        ) or (state.preflight_complexity == "medium" and config.plan.timeout_medium is not None)
     if _plan_override_active:
         _log(f"  Plan timeout: {_plan_timeout}s ({state.preflight_complexity} complexity)")
     else:

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -64,7 +64,7 @@ from .plan_trajectory import (
 from .preflight import _escalate_dev_model, _find_registry_key_for_profile
 from .remote_gates import _plan_review_remote
 from .state import CoordinatorResult, CoordinatorState, Phase, PlanFindingRecord
-from .util import _fmt_cost, _fmt_duration, _log_phase, resolve_timeout
+from .util import _fmt_cost, _fmt_duration, _log_phase, resolve_timeout_with_active
 
 if TYPE_CHECKING:
     from theforge.agent_types import AgentResult
@@ -207,22 +207,13 @@ def _run_plan_phase(
                 },
             }
         )
-    _plan_timeout = resolve_timeout(
+    _plan_timeout, _plan_override_active = resolve_timeout_with_active(
         config.plan.timeout,
         config.plan.timeout_medium,
         config.plan.timeout_large,
         state.preflight_complexity,
         state.preflight_complexity_score,
     )
-    _plan_override_active = False
-    if state.preflight_complexity_score is not None:
-        _plan_override_active = (
-            state.preflight_complexity_score >= 8 and config.plan.timeout_large is not None
-        ) or (state.preflight_complexity_score >= 6 and config.plan.timeout_medium is not None)
-    else:
-        _plan_override_active = (
-            state.preflight_complexity == "large" and config.plan.timeout_large is not None
-        ) or (state.preflight_complexity == "medium" and config.plan.timeout_medium is not None)
     if _plan_override_active:
         _log(f"  Plan timeout: {_plan_timeout}s ({state.preflight_complexity} complexity)")
     else:

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -93,12 +93,21 @@ def resolve_timeout(
     medium: int | None,
     large: int | None,
     complexity: str | None,
+    complexity_score: int | None = None,
 ) -> int:
     """Return the appropriate timeout for the given preflight complexity.
 
-    Selects large/medium override when complexity matches and override is set;
-    falls back to base otherwise.
+    Converted routing sites prefer the numeric score when present so stories in
+    the same legacy band can still diverge. Current policy: 8-10 uses the large
+    override, 6-7 uses the medium override, and lower scores fall back to base.
+    When no score is available, legacy band-based behavior is preserved.
     """
+    if complexity_score is not None:
+        if complexity_score >= 8 and large is not None:
+            return large
+        if complexity_score >= 6 and medium is not None:
+            return medium
+        return base
     if complexity == "large" and large is not None:
         return large
     if complexity == "medium" and medium is not None:

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -112,12 +112,19 @@ def resolve_timeout_with_active(
     complexity: str | None,
     complexity_score: int | None = None,
 ) -> tuple[int, bool]:
-    """Return ``(timeout, override_active)`` for the given complexity inputs."""
+    """Return ``(timeout, override_active)`` for the given complexity inputs.
+
+    Score-native routing must preserve the legacy fallback contract for each
+    threshold independently: large-score stories use the large override when it
+    exists, otherwise base; medium-score stories use the medium override when it
+    exists, otherwise base. Large stories must not cascade into the medium
+    override when the large override is unset.
+    """
     if complexity_score is not None:
-        if complexity_score >= 8 and large is not None:
-            return large, True
-        if complexity_score >= 6 and medium is not None:
-            return medium, True
+        if complexity_score >= 8:
+            return (large, True) if large is not None else (base, False)
+        if complexity_score >= 6:
+            return (medium, True) if medium is not None else (base, False)
         return base, False
     if complexity == "large" and large is not None:
         return large, True

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -105,7 +105,6 @@ def resolve_timeout(
     return resolve_timeout_with_active(base, medium, large, complexity, complexity_score)[0]
 
 
-
 def resolve_timeout_with_active(
     base: int,
     medium: int | None,

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -102,17 +102,29 @@ def resolve_timeout(
     override, 6-7 uses the medium override, and lower scores fall back to base.
     When no score is available, legacy band-based behavior is preserved.
     """
+    return resolve_timeout_with_active(base, medium, large, complexity, complexity_score)[0]
+
+
+
+def resolve_timeout_with_active(
+    base: int,
+    medium: int | None,
+    large: int | None,
+    complexity: str | None,
+    complexity_score: int | None = None,
+) -> tuple[int, bool]:
+    """Return ``(timeout, override_active)`` for the given complexity inputs."""
     if complexity_score is not None:
         if complexity_score >= 8 and large is not None:
-            return large
+            return large, True
         if complexity_score >= 6 and medium is not None:
-            return medium
-        return base
+            return medium, True
+        return base, False
     if complexity == "large" and large is not None:
-        return large
+        return large, True
     if complexity == "medium" and medium is not None:
-        return medium
-    return base
+        return medium, True
+    return base, False
 
 
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:

--- a/tests/test_complexity_timeouts.py
+++ b/tests/test_complexity_timeouts.py
@@ -64,6 +64,13 @@ class TestResolveTimeout:
     def test_large_override_absent_falls_back_to_base(self):
         assert resolve_timeout(600, 900, None, "large") == 600
 
+    def test_large_score_without_large_override_falls_back_to_base_not_medium(self):
+        assert resolve_timeout(600, 900, None, "large", 8) == 600
+        assert resolve_timeout(600, 900, None, "large", 10) == 600
+
+    def test_large_score_ignores_medium_override_when_large_override_missing(self):
+        assert resolve_timeout(600, 900, None, "medium", 8) == 600
+
     def test_both_overrides_absent_always_returns_base(self):
         assert resolve_timeout(600, None, None, "large") == 600
         assert resolve_timeout(600, None, None, "medium") == 600

--- a/tests/test_complexity_timeouts.py
+++ b/tests/test_complexity_timeouts.py
@@ -503,15 +503,21 @@ class TestScorePropagationSeam:
         def _run_for_preflight_output(preflight_output: str) -> tuple[int, int]:
             workspace = tmp_path / f"test-task-{abs(hash(preflight_output))}"
             workspace.mkdir()
-            task_for_run = TaskStory(name="Test Task", story_path=task.story_path, slug=workspace.name)
+            task_for_run = TaskStory(
+                name="Test Task",
+                story_path=task.story_path,
+                slug=workspace.name,
+            )
             mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
             mock_plan_agent.side_effect = mock_agent
-            mock_preflight.return_value = _make_agent_result(output=preflight_output, cost_usd=0.05)
             mock_agent.reset_mock()
             mock_plan_agent.reset_mock()
             mock_preflight.reset_mock()
             mock_pool.reset_mock()
-            mock_preflight.return_value = _make_agent_result(output=preflight_output, cost_usd=0.05)
+            mock_preflight.return_value = _make_agent_result(
+                output=preflight_output,
+                cost_usd=0.05,
+            )
             mock_agent.side_effect = [
                 _make_agent_result(output="# Plan\n\nDo it.", cost_usd=0.10),
                 _make_agent_result(output="Implemented.", cost_usd=0.20),

--- a/tests/test_complexity_timeouts.py
+++ b/tests/test_complexity_timeouts.py
@@ -148,7 +148,28 @@ PREFLIGHT_PROCEED_MEDIUM = """\
 verdict: PROCEED
 complexity: medium
 complexity_score: 6
-sufficiency: implementation_ready
+reason: "Medium complexity spec."
+spec_issues: []
+criteria_checked: []
+```
+"""
+
+PREFLIGHT_PROCEED_MEDIUM_SCORE_5 = """\
+```yaml
+verdict: PROCEED
+complexity: medium
+complexity_score: 5
+reason: "Medium complexity spec."
+spec_issues: []
+criteria_checked: []
+```
+"""
+
+PREFLIGHT_PROCEED_MEDIUM_SCORE_7 = """\
+```yaml
+verdict: PROCEED
+complexity: medium
+complexity_score: 7
 reason: "Medium complexity spec."
 spec_issues: []
 criteria_checked: []
@@ -451,6 +472,68 @@ class TestDevPhaseTimeout:
 
 
 # ── PLAN phase timeout resolution ──────────────────────────────────────
+
+
+class TestScorePropagationSeam:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_same_band_scores_propagate_to_different_plan_and_dev_timeouts(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Preflight score propagates across phase boundaries and changes PLAN/DEV timeouts."""
+        dev_profile = dataclasses.replace(
+            DEFAULT_DEV_PROFILE,
+            timeout_seconds=600,
+            timeout_medium_seconds=900,
+            timeout_large_seconds=1800,
+        )
+        plan = PlanConfig(
+            enabled=True,
+            timeout=600,
+            timeout_medium=900,
+            timeout_large=1800,
+            validate_spec=False,
+        )
+        config = _make_config(tmp_path, dev_profile=dev_profile, plan=plan)
+        task = _make_task(tmp_path)
+
+        def _run_for_preflight_output(preflight_output: str) -> tuple[int, int]:
+            workspace = tmp_path / f"test-task-{abs(hash(preflight_output))}"
+            workspace.mkdir()
+            task_for_run = TaskStory(name="Test Task", story_path=task.story_path, slug=workspace.name)
+            mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+            mock_plan_agent.side_effect = mock_agent
+            mock_preflight.return_value = _make_agent_result(output=preflight_output, cost_usd=0.05)
+            mock_agent.reset_mock()
+            mock_plan_agent.reset_mock()
+            mock_preflight.reset_mock()
+            mock_pool.reset_mock()
+            mock_preflight.return_value = _make_agent_result(output=preflight_output, cost_usd=0.05)
+            mock_agent.side_effect = [
+                _make_agent_result(output="# Plan\n\nDo it.", cost_usd=0.10),
+                _make_agent_result(output="Implemented.", cost_usd=0.20),
+            ]
+            mock_pool.return_value = [
+                _make_agent_result(output=APPROVE_REVIEW, profile_name="review")
+            ]
+
+            result = run_task(config, task_for_run)
+
+            assert result.success is True
+            plan_profile_used = _get_call_profile(mock_agent, 0)
+            dev_profile_used = _get_call_profile(mock_agent, 1)
+            return plan_profile_used.timeout_seconds, dev_profile_used.timeout_seconds
+
+        plan_timeout_5, dev_timeout_5 = _run_for_preflight_output(PREFLIGHT_PROCEED_MEDIUM_SCORE_5)
+        plan_timeout_7, dev_timeout_7 = _run_for_preflight_output(PREFLIGHT_PROCEED_MEDIUM_SCORE_7)
+
+        assert plan_timeout_5 == 600
+        assert dev_timeout_5 == 600
+        assert plan_timeout_7 == 900
+        assert dev_timeout_7 == 900
 
 
 class TestPlanPhaseTimeout:

--- a/tests/test_complexity_timeouts.py
+++ b/tests/test_complexity_timeouts.py
@@ -45,6 +45,10 @@ class TestResolveTimeout:
     def test_small_complexity_uses_base(self):
         assert resolve_timeout(600, 900, 1800, "small") == 600
 
+    def test_same_band_scores_can_route_to_different_timeouts(self):
+        assert resolve_timeout(600, 900, 1800, "medium", 5) == 600
+        assert resolve_timeout(600, 900, 1800, "medium", 7) == 900
+
     def test_none_complexity_uses_base(self):
         assert resolve_timeout(600, 900, 1800, None) == 600
 
@@ -143,6 +147,8 @@ PREFLIGHT_PROCEED_MEDIUM = """\
 ```yaml
 verdict: PROCEED
 complexity: medium
+complexity_score: 6
+sufficiency: implementation_ready
 reason: "Medium complexity spec."
 spec_issues: []
 criteria_checked: []

--- a/tests/test_config_role_derivation_complexity.py
+++ b/tests/test_config_role_derivation_complexity.py
@@ -197,6 +197,14 @@ class TestDeriveRolesComplexityMatrix:
             f"(model={ra.dev.ref.model})"
         )
 
+    def test_same_band_scores_can_route_to_different_dev_tiers(self):
+        """Scores 6 and 7 are both medium band but should diverge after conversion."""
+        ra_score_6 = derive_roles(_GOLD_POOL, complexity="medium", complexity_score=6)
+        ra_score_7 = derive_roles(_GOLD_POOL, complexity="medium", complexity_score=7)
+
+        assert _tier_of(ra_score_6.dev.ref.cli, ra_score_6.dev.ref.model) == "mid"
+        assert _tier_of(ra_score_7.dev.ref.cli, ra_score_7.dev.ref.model) == "strong"
+
     def test_medium_complexity_plan_routes_to_strong_tier(self):
         """MEDIUM complexity → plan role uses strong-tier model (AC: plan medium→strong)."""
         ra = derive_roles(_GOLD_POOL, complexity="medium")


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Preserves numeric complexity at routing decision points for dev-tier selection and timeout resolution; audit doc, code changes, and tests are correct and satisfy all ACs. | [google-gemini-3.1-pro-preview] The PR successfully audits and converts score-to-band flattening at routing decision points. | [claude-opus] Audit doc enumerates score_to_band callers and band-keyed routing sites with proper (a)/(b)/(c) classification; dev/plan timeout overrides and dev-tier selection are score-native with seam test for cross-phase propagation and unit tests covering large-without-large-override fallback.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $4.70
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/config/role_derivation.py:52`** Duplicate dev-tier mapping: _score_to_dev_tier() in role_derivation.py and score_to_dev_tier() in preflight.py have identical logic (1-3->cheap, 4-6->mid, 7-10->strong). If thresholds are updated in one but not the other, the two routing paths will diverge.
- **[P2] `src/theforge/coordinator/preflight.py:313`** score_to_band() at this line uses bands 1-3->small, 4-7->medium, 8-10->large, which is a different boundary from the score_to_band used in preflight.py:44 (same function). Meanwhile the timeout thresholds use 6-7->medium and 8-10->large, and the dev-tier mapping uses 4-6->mid, 7-10->strong. The boundaries between these three mappings are inconsistent (score 4 is 'small' band but 'mid' tier; score 7 is 'medium' band but 'strong' tier). This is a conscious policy choice per the spec but worth documenting more explicitly.
- **[P2] `docs/issue-976-score-to-band-routing-audit.md:105`** Spec for this story explicitly states 'this story does not itself file GitHub issues' and out-of-scope sites are noted in the doc for the operator to file. The audit doc still includes a 'Follow-up issues filed from this audit' section referencing #977/#978. Not blocking — issues do exist on GitHub from prior cycles — but the framing diverges from the current spec text.

## Story

Audit and remove score-to-band flattening at routing decision points (GitHub Issue #976)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #976