### PR TITLE
Preflight can false-positive ALREADY_DONE for adaptive-routing stories by citing partial implementation

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -392,7 +392,7 @@ def _parse_preflight_criteria_checked(output: str) -> list[dict]:
     """Extract criteria_checked list from preflight agent output.
 
     Each entry should have: criterion (str), files_checked (list[str]),
-    satisfied (bool), evidence (str).
+    runtime_path (str), satisfied (bool), evidence (str).
 
     Returns [] on parse failure, missing key, or non-list value so that
     callers can treat an absent map as insufficient evidence (conservative).
@@ -422,6 +422,7 @@ def _parse_preflight_criteria_checked(output: str) -> list[dict]:
                 {
                     "criterion": str(entry.get("criterion", "")),
                     "files_checked": list(entry.get("files_checked") or []),
+                    "runtime_path": str(entry.get("runtime_path", "")),
                     "satisfied": bool(entry.get("satisfied", False)),
                     "evidence": str(entry.get("evidence", "")),
                 }

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -422,9 +422,9 @@ def _parse_preflight_criteria_checked(output: str) -> list[dict]:
                 {
                     "criterion": str(entry.get("criterion", "")),
                     "files_checked": list(entry.get("files_checked") or []),
-                    "runtime_path": str(entry.get("runtime_path", "")),
+                    "runtime_path": str(entry.get("runtime_path") or ""),
                     "satisfied": bool(entry.get("satisfied", False)),
-                    "evidence": str(entry.get("evidence", "")),
+                    "evidence": str(entry.get("evidence") or ""),
                 }
             )
         return result

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -69,6 +69,11 @@ _AMBIGUITY_TOKENS = (
 )
 
 
+def _evidence_is_too_thin(evidence: str) -> bool:
+    """Return True when evidence is too short to justify ALREADY_DONE."""
+    return len(evidence.strip()) < 20
+
+
 def _has_prior_execution_evidence(
     project_root: "Path", branch_name: str, base_branch: str
 ) -> bool:
@@ -363,6 +368,21 @@ def _run_preflight_phase(
             _log(f"  ⚠ PREFLIGHT warnings: {'; '.join(_warnings)}")
         if _likely_files is not None:
             _log(f"  Likely files: {', '.join(_likely_files)}")
+        for entry in criteria_checked:
+            criterion = entry.get("criterion", "(unnamed)")
+            files_checked = entry.get("files_checked") or []
+            runtime_path = entry.get("runtime_path", "")
+            evidence = " ".join(str(entry.get("evidence", "")).split())
+            if len(evidence) > 200:
+                evidence = f"{evidence[:197]}..."
+            _log_verbose(
+                "  Criteria checked: "
+                f"criterion={criterion!r} "
+                f"satisfied={entry.get('satisfied', False)} "
+                f"files_checked={files_checked!r} "
+                f"runtime_path={runtime_path!r} "
+                f"evidence={evidence!r}"
+            )
 
         # ── ALREADY_DONE evidence downgrade ───────────────────────────
         # Require that every AC has concrete file evidence (files_checked is
@@ -378,11 +398,26 @@ def _run_preflight_phase(
             else:
                 for entry in criteria_checked:
                     criterion = entry.get("criterion", "(unnamed)")
+                    runtime_path = str(entry.get("runtime_path", "")).strip()
+                    evidence = str(entry.get("evidence", "")).strip()
                     if not entry.get("satisfied"):
                         downgrade_reasons.append(f"AC '{criterion}' marked satisfied=false")
                     elif not entry.get("files_checked"):
                         downgrade_reasons.append(
                             f"AC '{criterion}' lacked concrete evidence (no files_checked)"
+                        )
+                    elif not runtime_path:
+                        downgrade_reasons.append(
+                            f"AC '{criterion}' lacked runtime-path evidence (runtime_path missing)"
+                        )
+                    elif not evidence:
+                        downgrade_reasons.append(
+                            f"AC '{criterion}' lacked concrete evidence (evidence missing)"
+                        )
+                    elif _evidence_is_too_thin(evidence):
+                        downgrade_reasons.append(
+                            f"AC '{criterion}' evidence too thin for ALREADY_DONE "
+                            f"(len={len(evidence)})"
                         )
             if downgrade_reasons:
                 verdict = "PROCEED"

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -222,8 +222,13 @@ def build_preflight_prompt(
           - criterion: "<acceptance criterion text>"
             files_checked:
               - "<repo-relative path[:line] inspected to check this criterion>"
+            runtime_path: >-
+              <path:line or function chain proving the live pipeline
+              executes this behavior>
             satisfied: true | false
-            evidence: "<conclusion: what confirms it is satisfied, or what is missing>"
+            evidence: >-
+              <conclusion: how the cited runtime path turns the relevant
+              input into the observable behavior/output, or what is missing>
         ```
 
         Use `spec_issues: []` if the spec is clean.
@@ -240,11 +245,24 @@ def build_preflight_prompt(
         The `files_checked` list is the evidence map: AC → files inspected → conclusion.
         A valid ALREADY_DONE verdict requires non-empty `files_checked` for every criterion.
         An empty `files_checked` means the criterion was not actually checked.
+        A valid ALREADY_DONE verdict also requires a non-empty `runtime_path` for every
+        criterion. `runtime_path` must cite the live orchestrator/coordinator/sprint call
+        path that actually exercises the behavior, not a related helper that merely exists.
 
         ## Rules
 
         - Check EVERY acceptance criterion individually. Do not shortcut.
         - "Related code exists" is NOT the same as "criterion is satisfied."
+        - For ALREADY_DONE, every `criteria_checked` entry must cite the actual runtime
+          path that executes the criterion on the configured pipeline. Naming a helper,
+          config field, or nearby module is insufficient unless you prove the live path
+          calls into it.
+        - For ALREADY_DONE, every `evidence` field must explain observable behavior:
+          input/state → executed runtime path → output/side effect that satisfies the
+          criterion. Merely saying a symbol exists is insufficient.
+        - Counter-example: "src/theforge/assignment.py defines assign_models()" does NOT
+          satisfy a routing acceptance criterion unless you also cite the coordinator or
+          sprint runtime path that actually invokes it for this story's configured flow.
         - Evaluate ALREADY_DONE against the configured target baseline branch
           content from `config.workspace.base_branch`, not the resumed worktree contents.
         - If even ONE criterion is unsatisfied, the verdict cannot be ALREADY_DONE.

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -260,9 +260,9 @@ def build_preflight_prompt(
         - For ALREADY_DONE, every `evidence` field must explain observable behavior:
           input/state → executed runtime path → output/side effect that satisfies the
           criterion. Merely saying a symbol exists is insufficient.
-        - Counter-example: "src/theforge/assignment.py defines assign_models()" does NOT
-          satisfy a routing acceptance criterion unless you also cite the coordinator or
-          sprint runtime path that actually invokes it for this story's configured flow.
+        - Counter-example: "a helper module defines `assign_models()`" does NOT satisfy
+          a routing acceptance criterion unless you also cite the coordinator or sprint
+          runtime path that actually invokes it for this story's configured flow.
         - Evaluate ALREADY_DONE against the configured target baseline branch
           content from `config.workspace.base_branch`, not the resumed worktree contents.
         - If even ONE criterion is unsatisfied, the verdict cannot be ALREADY_DONE.

--- a/tests/coord_test_helpers.py
+++ b/tests/coord_test_helpers.py
@@ -254,7 +254,10 @@ criteria_checked:
     satisfied: true
     files_checked:
       - "coordinator.py"
-    evidence: "Implemented in coordinator.py:42"
+    runtime_path: "run_task() -> _run_preflight_phase() -> coordinator execution path"
+    evidence: >-
+      The live coordinator path executes coordinator.py and produces the
+      expected observable behavior for Feature X.
 ```
 """
 

--- a/tests/test_coord_preflight_already_done_verification.py
+++ b/tests/test_coord_preflight_already_done_verification.py
@@ -150,6 +150,23 @@ criteria_checked:
 ```
 """
 
+PREFLIGHT_ALREADY_DONE_EMPTY_EVIDENCE = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "The code looks done."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    runtime_path: "run_task() -> _run_preflight_phase() -> engine execution path"
+    evidence: ""
+```
+"""
+
 PREFLIGHT_ALREADY_DONE_NO_RUNTIME_PATH_FIELD = """\
 ```yaml
 verdict: ALREADY_DONE
@@ -445,6 +462,42 @@ class TestPreflightAlreadyDoneVerification:
 
         assert result.state.preflight_verdict == "PROCEED"
         assert any("evidence too thin" in w for w in (result.state.preflight_warnings or []))
+        mock_dev.assert_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_empty_evidence_downgraded_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """AC with empty evidence → ALREADY_DONE downgraded to PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_EMPTY_EVIDENCE, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert any("evidence missing" in w for w in (result.state.preflight_warnings or []))
         mock_dev.assert_called()
 
     def test_parse_criteria_checked_captures_runtime_path(self) -> None:

--- a/tests/test_coord_preflight_already_done_verification.py
+++ b/tests/test_coord_preflight_already_done_verification.py
@@ -1,8 +1,11 @@
-"""Tests for preflight ALREADY_DONE AC-evidence downgrade logic (issue #705).
+"""Tests for preflight ALREADY_DONE AC-evidence downgrade logic.
 
 Acceptance criteria:
-- All ACs evidenced (files_checked non-empty, satisfied=true) → ALREADY_DONE honored
+- All ACs evidenced (files_checked non-empty, runtime_path present, satisfied=true)
+  → ALREADY_DONE honored
 - Any AC lacking files_checked evidence → verdict downgraded to PROCEED
+- Any AC lacking runtime_path evidence → verdict downgraded to PROCEED
+- Any AC with empty or thin evidence → verdict downgraded to PROCEED
 - Missing/empty criteria_checked → verdict downgraded to PROCEED
 - criteria_checked evidence map persists in the preflight.yaml artifact
 """
@@ -21,6 +24,7 @@ from coord_test_helpers import (
 )
 
 from theforge.coordinator.engine import run_task
+from theforge.coordinator.preflight import _parse_preflight_criteria_checked
 from theforge.coordinator.state import Phase
 
 # ── Test fixtures ─────────────────────────────────────────────────────────────
@@ -38,12 +42,18 @@ criteria_checked:
     satisfied: true
     files_checked:
       - "src/theforge/coordinator/engine.py"
-    evidence: "Found implementation at engine.py:42"
+    runtime_path: "run_task() -> _run_preflight_phase() -> engine execution path"
+    evidence: >-
+      The coordinator enters the runtime path in engine.py and executes the
+      behavior, producing the expected observable result for Feature X.
   - criterion: "Feature X has tests"
     satisfied: true
     files_checked:
       - "tests/test_coord_engine.py"
-    evidence: "Test coverage confirmed at test_coord_engine.py:100"
+    runtime_path: "run_task() -> validate/review path asserts the covered behavior"
+    evidence: >-
+      The covered runtime path is exercised by the test case, which verifies
+      the expected output and keeps the acceptance criterion observable.
 ```
 """
 
@@ -60,11 +70,17 @@ criteria_checked:
     satisfied: true
     files_checked:
       - "src/theforge/coordinator/engine.py"
-    evidence: "Confirmed at engine.py:42"
+    runtime_path: "run_task() -> _run_preflight_phase() -> engine execution path"
+    evidence: >-
+      The live coordinator path executes the implementation and yields the
+      expected behavior.
   - criterion: "Feature Y is implemented"
     satisfied: true
     files_checked: []
-    evidence: "Believed to be done but no file checked"
+    runtime_path: "run_task() -> _run_preflight_phase() -> engine execution path"
+    evidence: >-
+      The claim may be true, but there is no inspected file proving the live
+      path satisfies Feature Y.
 ```
 """
 
@@ -92,7 +108,63 @@ criteria_checked:
     satisfied: false
     files_checked:
       - "src/theforge/coordinator/engine.py"
-    evidence: "Found partial implementation"
+    runtime_path: "run_task() -> _run_preflight_phase() -> engine execution path"
+    evidence: >-
+      The live path reaches partial implementation only, so the observable
+      output does not satisfy the criterion.
+```
+"""
+
+PREFLIGHT_ALREADY_DONE_MISSING_RUNTIME_PATH = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "The code looks done."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    evidence: >-
+      The coordinator path executes the implementation and returns the
+      expected behavior for Feature X.
+```
+"""
+
+PREFLIGHT_ALREADY_DONE_THIN_EVIDENCE = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "The code looks done."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    runtime_path: "run_task() -> _run_preflight_phase() -> engine execution path"
+    evidence: "Implemented."
+```
+"""
+
+PREFLIGHT_ALREADY_DONE_NO_RUNTIME_PATH_FIELD = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "The code looks done."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    evidence: >-
+      The coordinator path executes the implementation and returns the
+      expected behavior for Feature X.
 ```
 """
 
@@ -139,6 +211,10 @@ class TestPreflightAlreadyDoneVerification:
             result.state.preflight_criteria_checked[0]["criterion"] == "Feature X is implemented"
         )
         assert result.state.preflight_criteria_checked[0]["satisfied"] is True
+        assert (
+            result.state.preflight_criteria_checked[0]["runtime_path"]
+            == "run_task() -> _run_preflight_phase() -> engine execution path"
+        )
         assert (
             "src/theforge/coordinator/engine.py"
             in result.state.preflight_criteria_checked[0]["files_checked"]
@@ -295,3 +371,94 @@ class TestPreflightAlreadyDoneVerification:
         assert len(criteria) == 2
         assert criteria[0]["criterion"] == "Feature X is implemented"
         assert "src/theforge/coordinator/engine.py" in criteria[0]["files_checked"]
+        assert criteria[0]["runtime_path"] == (
+            "run_task() -> _run_preflight_phase() -> engine execution path"
+        )
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_missing_runtime_path_downgraded_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """AC without runtime_path → ALREADY_DONE downgraded to PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_MISSING_RUNTIME_PATH, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert any("runtime_path missing" in w for w in (result.state.preflight_warnings or []))
+        mock_dev.assert_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_thin_evidence_downgraded_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """AC with evidence shorter than 20 chars → ALREADY_DONE downgraded to PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_ALREADY_DONE_THIN_EVIDENCE, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert any("evidence too thin" in w for w in (result.state.preflight_warnings or []))
+        mock_dev.assert_called()
+
+    def test_parse_criteria_checked_captures_runtime_path(self) -> None:
+        criteria = _parse_preflight_criteria_checked(PREFLIGHT_ALREADY_DONE_ALL_EVIDENCED)
+
+        assert len(criteria) == 2
+        assert criteria[0]["runtime_path"] == (
+            "run_task() -> _run_preflight_phase() -> engine execution path"
+        )
+        assert criteria[0]["evidence"].startswith("The coordinator enters the runtime path")
+
+    def test_parse_criteria_checked_defaults_runtime_path_when_absent(self) -> None:
+        criteria = _parse_preflight_criteria_checked(PREFLIGHT_ALREADY_DONE_NO_RUNTIME_PATH_FIELD)
+
+        assert len(criteria) == 1
+        assert criteria[0]["runtime_path"] == ""
+        assert criteria[0]["criterion"] == "Feature X is implemented"

--- a/tests/test_coord_preflight_already_done_verification.py
+++ b/tests/test_coord_preflight_already_done_verification.py
@@ -185,6 +185,23 @@ criteria_checked:
 ```
 """
 
+PREFLIGHT_ALREADY_DONE_NULL_RUNTIME_AND_EVIDENCE = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "The code looks done."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    runtime_path: null
+    evidence: null
+```
+"""
+
 
 class TestPreflightAlreadyDoneVerification:
     @patch("theforge.coordinator.review_pool.run_agent_pool")
@@ -500,6 +517,46 @@ class TestPreflightAlreadyDoneVerification:
         assert any("evidence missing" in w for w in (result.state.preflight_warnings or []))
         mock_dev.assert_called()
 
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_null_runtime_path_downgraded_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """Explicit YAML null runtime_path/evidence still downgrade ALREADY_DONE."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True,
+            output=PREFLIGHT_ALREADY_DONE_NULL_RUNTIME_AND_EVIDENCE,
+            cost_usd=0.05,
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_criteria_checked[0]["runtime_path"] == ""
+        assert result.state.preflight_criteria_checked[0]["evidence"] == ""
+        assert any("runtime_path missing" in w for w in (result.state.preflight_warnings or []))
+        mock_dev.assert_called()
+
     def test_parse_criteria_checked_captures_runtime_path(self) -> None:
         criteria = _parse_preflight_criteria_checked(PREFLIGHT_ALREADY_DONE_ALL_EVIDENCED)
 
@@ -515,3 +572,12 @@ class TestPreflightAlreadyDoneVerification:
         assert len(criteria) == 1
         assert criteria[0]["runtime_path"] == ""
         assert criteria[0]["criterion"] == "Feature X is implemented"
+
+    def test_parse_criteria_checked_normalizes_explicit_nulls(self) -> None:
+        criteria = _parse_preflight_criteria_checked(
+            PREFLIGHT_ALREADY_DONE_NULL_RUNTIME_AND_EVIDENCE
+        )
+
+        assert len(criteria) == 1
+        assert criteria[0]["runtime_path"] == ""
+        assert criteria[0]["evidence"] == ""


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The change hardens the preflight ALREADY_DONE evidence gate by requiring per-AC runtime_path and evidence fields, and downgrading weak evidence to PROCEED. All acceptance criteria are satisfied: the evidence checks are implemented in preflight_flow.py, the parser in preflight.py captures the new fields, the prompt in plan_prompts.py instructs the agent to provide them, and comprehensive tests cover missing/empty/thin runtime_path and evidence. The fix directly addresses the false-positive scenario described in the spec. No blocking issues found. | [google-gemini-3.1-pro-preview] The changes correctly harden the ALREADY_DONE evidence gate by requiring and validating a runtime_path and sufficient evidence. | [claude-opus] Preflight ALREADY_DONE gate now requires runtime_path + substantive evidence per AC, with null-safe parsing and seam tests covering each downgrade branch.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.64
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight can false-positive ALREADY_DONE for adaptive-routing stories by citing partial implementation (GitHub Issue #994)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #994