### PR TITLE
Schema repair silently flips APPROVE+P1 to REQUEST_CHANGES instead of failing closed

### DIFF
--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -17,8 +17,10 @@ def repair_review_yaml(data: Any) -> Any:
     """Best-effort repair of common review YAML issues before validation.
 
     Fixes predictable errors from models that struggle with the schema
-    (especially DeepSeek): missing sections, verdict/finding contradictions,
-    findings as string instead of list. Mutates and returns the dict.
+    (especially DeepSeek): missing sections and findings as string instead of
+    list. Cross-field verdict/finding contradictions are schema violations and
+    must survive to validation so the reviewer output is retried instead of
+    silently rewritten. Mutates and returns the dict.
     """
     if not isinstance(data, dict):
         return data
@@ -41,18 +43,6 @@ def repair_review_yaml(data: Any) -> Any:
     # ── test_coverage: fill if missing ──────────────────────────
     if "test_coverage" not in data:
         data["test_coverage"] = {"adequate": True, "gaps": []}
-
-    # ── APPROVE + P1 → flip verdict to REQUEST_CHANGES ─────────
-    # This is a safe repair: the reviewer found blocking issues but
-    # contradicted itself. Flipping to REQUEST_CHANGES is conservative.
-    # We do NOT flip REQUEST_CHANGES→APPROVE (zero P1) because that
-    # would silently turn a rejection into approval — a schema integrity
-    # violation that should trigger retry, not be papered over.
-    findings = data.get("findings", [])
-    if isinstance(findings, list):
-        p1_count = sum(1 for f in findings if isinstance(f, dict) and f.get("severity") == "P1")
-        if data.get("verdict") == "APPROVE" and p1_count > 0:
-            data["verdict"] = "REQUEST_CHANGES"
 
     return data
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -308,6 +308,25 @@ findings: []
         assert result is not None
         assert result.verdict == "APPROVE"
 
+    def test_contradictory_approve_with_p1_returns_none(self):
+        data = {
+            "verdict": "APPROVE",
+            "summary": "Looks good",
+            "findings": [
+                {
+                    "severity": "P1",
+                    "file": "src/foo.py",
+                    "line": 12,
+                    "description": "Prior P1 from cycle 1 is fixed",
+                    "suggestion": "No action needed",
+                }
+            ],
+            "story_compliance": {"matches_spec": True, "mismatches": []},
+            "test_coverage": {"adequate": True, "gaps": []},
+        }
+        result = _try_parse_review("", structured_data=data)
+        assert result is None
+
 
 # ── Tests: _best_individual_result ───────────────────────────────────
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -163,11 +163,11 @@ class TestRepairReviewYaml:
         repair_review_yaml(data)
         assert data["test_coverage"] == {"adequate": True, "gaps": []}
 
-    def test_flips_approve_with_p1(self):
+    def test_does_not_flip_approve_with_p1(self):
         data = _valid_review()
         data["findings"] = [{"severity": "P1", "file": "foo.py", "line": 10, "description": "bug"}]
         repair_review_yaml(data)
-        assert data["verdict"] == "REQUEST_CHANGES"
+        assert data["verdict"] == "APPROVE"
 
     def test_does_not_flip_request_changes_without_p1(self):
         """REQUEST_CHANGES with zero P1s is a schema error, not repaired.
@@ -197,8 +197,8 @@ class TestRepairReviewYaml:
         assert data["story_compliance"] == original["story_compliance"]
         assert data["test_coverage"] == original["test_coverage"]
 
-    def test_repaired_data_passes_validation(self):
-        """DeepSeek-style output: APPROVE + P1 + missing sections."""
+    def test_contradictory_data_still_fails_validation(self):
+        """DeepSeek-style output: APPROVE + P1 + missing sections must retry."""
         data = {
             "verdict": "APPROVE",
             "summary": "Looks good",
@@ -214,5 +214,5 @@ class TestRepairReviewYaml:
         }
         repair_review_yaml(data)
         errors = validate_review_yaml(data)
-        assert errors == [], f"Repaired data should validate clean: {errors}"
-        assert data["verdict"] == "REQUEST_CHANGES"
+        assert any("APPROVE" in error and "P1" in error for error in errors)
+        assert data["verdict"] == "APPROVE"


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Change correctly removes the silent repair of APPROVE+P1 contradictions, making them fail validation and trigger retry. All acceptance criteria are met: contradictory payloads are preserved as schema violations, the retry path handles them, and the schema integrity invariant is applied symmetrically. Tests pass and the change is minimal and focused. | [google-gemini-3.1-pro-preview] The schema repair mutation was correctly removed, and contradictory verdicts now fail validation and trigger retries as expected. | [claude-opus] Removes the APPROVE+P1 verdict flip so contradictory reviewer payloads fail validation and route to the existing retry path; tests updated symmetrically.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.01
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Schema repair silently flips APPROVE+P1 to REQUEST_CHANGES instead of failing closed (GitHub Issue #996)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #996