### PR TITLE
Reviewer prompt should forbid filing closure notes as P1 findings

### DIFF
--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -348,6 +348,7 @@ def build_plan_review_prompt(
 
         ```yaml
         verdict: APPROVE | REJECT
+        summary: "<one-line summary of your review>"
         criteria_coverage:
           - criterion: "<acceptance criterion text from the spec>"
             covered: true | false
@@ -422,6 +423,10 @@ def build_plan_review_prompt(
         - **List ALL issues in a single pass.** Multiple findings in one REJECT
           is far better than discovering new issues across multiple cycles.
         - APPROVE with P1-impl and P2 suggestions is valid and encouraged
+        - `findings[]` is only for current defects in the plan under review.
+          Do NOT use it for closure notes such as "Previous rejection is fixed".
+          If you want to acknowledge that a prior issue is now addressed, put it
+          in `summary` or omit it entirely.
         - Be specific: cite the plan section, the actual codebase function/file,
           and why it would fail
         - A plan does not need to be perfect — it needs to not be wrong

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -187,7 +187,9 @@ def build_review_prompt(
 
             ### Part 1 — Verify Fixes
             Confirm that each prior P1 finding listed below is now resolved. For each:
-            - If fixed: note it briefly (no need to re-report).
+            - If fixed: mention it briefly in `summary` if useful, or omit it entirely.
+              Do NOT put closure notes or acknowledgements of resolved prior bugs in
+              `findings[]`.
             - If still present: report it again as a P1 with its original description.
 
             Prior P1 findings:
@@ -377,6 +379,10 @@ def build_review_prompt(
         - Do NOT invent issues. Only report problems you can find in the source.
         - Do NOT flag the same issue that was already flagged and fixed in a
           previous review cycle.
+        - `findings[]` is only for defects in the current code under review.
+          Do NOT use it for closure notes such as "Prior P1 from Cycle 2 is fixed".
+          If you want to acknowledge a resolved prior issue, put it in `summary`
+          or omit it entirely.
         - This review may be merged with other reviewers' outputs. One speculative
           P1 from you blocks the entire pipeline. Be precise.
         - If the spec contains a **Notes** section, treat it as informal hints

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -47,6 +47,23 @@ class TestValidateReviewYaml:
         errors = validate_review_yaml(data)
         assert any("APPROVE" in e and "P1" in e for e in errors)
 
+    def test_approve_with_closure_style_p1_is_error(self):
+        """Closure-style acknowledgements in findings[] still trip APPROVE+P1 rejection."""
+        data = _valid_review()
+        data["verdict"] = "APPROVE"
+        data["summary"] = "Prior cycle issue appears resolved."
+        data["findings"] = [
+            {
+                "severity": "P1",
+                "file": "src/foo.py",
+                "line": 42,
+                "description": "Prior P1 from Cycle 3 is fixed: null check was added",
+                "suggestion": "Move this acknowledgement to summary or omit it",
+            }
+        ]
+        errors = validate_review_yaml(data)
+        assert any("APPROVE" in e and "P1" in e for e in errors)
+
     def test_request_changes_without_p1_is_error(self):
         data = _valid_review()
         data["verdict"] = "REQUEST_CHANGES"

--- a/tests/test_task_review.py
+++ b/tests/test_task_review.py
@@ -218,6 +218,17 @@ class TestBuildReviewPromptCycleHistory:
         assert "Missing null check in src/foo.py:42" in prompt
         assert "Cycle 1" in prompt
 
+    def test_cycle2_forbids_closure_notes_in_findings(self, review_task: TaskStory) -> None:
+        """Cycle-aware review prompt routes resolved-prior notes away from findings[]."""
+        prompt = build_review_prompt(
+            review_task,
+            **_REVIEW_COMMON_KWARGS,
+            cycle_history=self._make_history(),
+        )
+        assert "Do NOT put closure notes or acknowledgements of resolved prior bugs in" in prompt
+        assert "`findings[]`" in prompt
+        assert "put it in `summary`" in prompt
+
     def test_cycle2_shows_correct_cycle_number(self, review_task: TaskStory) -> None:
         """Cycle 2+: cycle number in header reflects current cycle."""
         history = self._make_history()  # 1 cycle → reviewing cycle 2
@@ -556,6 +567,20 @@ class TestBuildPlanReviewPrompt:
             rejection_findings=None,
         )
         assert "Previous Rejection Findings" not in prompt
+
+    def test_forbids_closure_notes_in_findings(self, tmp_path: Path) -> None:
+        task = _make_task(tmp_path)
+        prompt = build_plan_review_prompt(
+            task,
+            story_content="# Story",
+            plan_content="# Plan",
+            rejection_findings="- [P1] Prior API mismatch",
+        )
+        assert "`findings[]` is only for current defects in the plan under review." in prompt
+        assert 'Do NOT use it for closure notes such as "Previous rejection is fixed".' in prompt
+        assert "put it\n          in `summary` or omit it entirely" in prompt or (
+            "put it in `summary` or omit it entirely." in prompt
+        )
 
 
 # ── Notes section convention tests ──────────────────────────────────────


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Prompt changes explicitly forbid closure notes in findings[] and route them to summary or omission; all ACs met, all 70 tests pass. | [google-gemini-3.1-pro-preview] The implementation correctly updates the review and plan prompts to forbid closure notes in findings[] and adds a regression test. | [claude-opus] Prompt updates and regression tests cleanly satisfy all three ACs; closure-note guidance is explicit in both review and plan-review prompts.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Reviewer prompt should forbid filing closure notes as P1 findings (GitHub Issue #998)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #998