### PR TITLE
P1 persistence matcher uses file equality alone — distinct findings on same file collapse

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable
 from dataclasses import replace as _dc_replace
 from typing import TYPE_CHECKING
@@ -484,7 +485,7 @@ def _has_persistent_p1(
     """Return True if any P1 appears in both current and previous cycles.
 
     Matches when findings are text-similar (substring containment or
-    >=60% token overlap) or when they recur in the same file.
+    >=60% token overlap) or when they recur at the same file+line location.
     """
     current_p1s = [f for f in current_findings if f.severity == "P1"]
     previous_p1s = [f for f in previous_findings if f.severity == "P1"]
@@ -530,17 +531,27 @@ def _p1_findings_match(current: ReviewFinding, previous: ReviewFinding) -> bool:
     if (
         current.file
         and previous.file
+        and current.line is not None
+        and previous.line is not None
         and current.file != "unknown"
         and previous.file != "unknown"
         and current.file == previous.file
+        and current.line == previous.line
     ):
         return True
 
-    if current.description in previous.description or previous.description in current.description:
+    if (
+        current.description
+        and previous.description
+        and (
+            current.description in previous.description
+            or previous.description in current.description
+        )
+    ):
         return True
 
-    curr_tokens = set(current.description.lower().split())
-    prev_tokens = set(previous.description.lower().split())
+    curr_tokens = set(re.findall(r"\w+", current.description.lower()))
+    prev_tokens = set(re.findall(r"\w+", previous.description.lower()))
     if curr_tokens and prev_tokens:
         overlap = len(curr_tokens & prev_tokens) / max(len(curr_tokens), len(prev_tokens))
         if overlap >= 0.6:

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -39,10 +39,11 @@ from theforge.review import ReviewFinding
 def _make_review_finding(
     severity: str = "P1",
     file: str = "src/cli.py",
+    line: int | None = None,
     description: str = "cli.py never wires gate_override into TaskStory",
 ) -> ReviewFinding:
     return ReviewFinding(
-        severity=severity, file=file, line=None, description=description, suggestion=None
+        severity=severity, file=file, line=line, description=description, suggestion=None
     )
 
 
@@ -120,8 +121,8 @@ class TestHasPersistentP1:
         prev = [_make_review_finding(file="src/bar.py", description="Missing validation")]
         assert _has_persistent_p1(curr, prev) is False
 
-    def test_same_file_cascading_p1_is_persistent(self):
-        """Different descriptions in the same file still count as persistent."""
+    def test_same_file_cascading_p1_is_not_persistent(self):
+        """Different descriptions in the same file do not match without line/text evidence."""
         curr = [
             _make_review_finding(file="src/plan_flow.py", description="skip branch drops abandon")
         ]
@@ -129,6 +130,24 @@ class TestHasPersistentP1:
             _make_review_finding(
                 file="src/plan_flow.py",
                 description="skip branch wrong for refactor",
+            )
+        ]
+        assert _has_persistent_p1(curr, prev) is False
+
+    def test_same_file_and_line_is_persistent(self):
+        """Matching file+line is sufficient even when the wording changes."""
+        curr = [
+            _make_review_finding(
+                file="src/plan_flow.py",
+                line=88,
+                description="skip branch drops abandon path after refactor",
+            )
+        ]
+        prev = [
+            _make_review_finding(
+                file="src/plan_flow.py",
+                line=88,
+                description="refactor skip branch loses abandon handling",
             )
         ]
         assert _has_persistent_p1(curr, prev) is True
@@ -391,10 +410,10 @@ class TestDevModelEscalationIntegration:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_escalation_with_cascading_same_file_p1(
+    def test_escalation_not_triggered_for_distinct_same_file_p1(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """Escalation fires when a new P1 appears in the same file on the next cycle."""
+        """A new P1 in the same file does not escalate unless it matches by text or line."""
         config = _make_smart_config(tmp_path, max_review_cycles=3)
         task = _make_task(tmp_path)
         workspace = tmp_path / task.slug
@@ -434,7 +453,7 @@ class TestDevModelEscalationIntegration:
         result = run_task(config, task)
 
         assert result.success is True
-        assert result.state.dev_escalated is True
+        assert result.state.dev_escalated is False
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")

--- a/tests/test_coord_preflight_plan.py
+++ b/tests/test_coord_preflight_plan.py
@@ -86,10 +86,11 @@ def _make_smart_config(
 def _make_review_finding(
     severity: str = "P1",
     file: str = "src/cli.py",
+    line: int | None = None,
     description: str = "cli.py never wires gate_override into TaskStory",
 ) -> ReviewFinding:
     return ReviewFinding(
-        severity=severity, file=file, line=None, description=description, suggestion=None
+        severity=severity, file=file, line=line, description=description, suggestion=None
     )
 
 
@@ -563,8 +564,8 @@ class TestPersistentP1Descriptions:
         result = _persistent_p1_descriptions(curr, prev)
         assert result == []
 
-    def test_returns_match_for_same_file_cascading_p1(self):
-        """Different descriptions in the same file are reported as persistent."""
+    def test_returns_empty_for_distinct_same_file_p1(self):
+        """Different descriptions in the same file are not reported as persistent."""
         curr = [
             _make_review_finding(file="src/plan_flow.py", description="skip branch drops abandon")
         ]
@@ -575,7 +576,26 @@ class TestPersistentP1Descriptions:
             )
         ]
         result = _persistent_p1_descriptions(curr, prev)
-        assert result == ["skip branch drops abandon"]
+        assert result == []
+
+    def test_returns_match_for_same_file_and_line_p1(self):
+        """Matching file+line still reports the current finding as persistent."""
+        curr = [
+            _make_review_finding(
+                file="src/plan_flow.py",
+                line=88,
+                description="skip branch drops abandon path after refactor",
+            )
+        ]
+        prev = [
+            _make_review_finding(
+                file="src/plan_flow.py",
+                line=88,
+                description="refactor skip branch loses abandon handling",
+            )
+        ]
+        result = _persistent_p1_descriptions(curr, prev)
+        assert result == ["skip branch drops abandon path after refactor"]
 
     def test_returns_empty_when_no_current_p1s(self):
         """Returns empty list when there are no current P1 findings."""


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Changes correctly tighten persistent P1 matching to require description-level evidence (text similarity or exact file+line) instead of file equality alone, satisfying the acceptance criteria. Additional prompt changes forbid closure notes in findings[]. All 121 tests pass and integration coverage validates the new behavior. | [google-gemini-3.1-pro-preview] Tightened persistent P1 matcher to require line match or description overlap. | [claude-opus] Persistent-P1 matcher correctly tightened to require file+line or text-similarity; ACs met with good test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.18
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

P1 persistence matcher uses file equality alone — distinct findings on same file collapse (GitHub Issue #999)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #999