### PR TITLE
Codex resume runner passes -C/--cd flag that codex exec resume does not accept

### DIFF
--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -127,7 +127,7 @@ def _run_codex(
         ]
         if profile.reasoning_effort:
             cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
-        cmd += ["-C", str(working_dir), "-o", str(output_file), session_id, "-"]
+        cmd += ["-o", str(output_file), session_id, "-"]
         stdin_prompt: str | None = prompt
     else:
         cmd = [

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -129,6 +129,23 @@ class TestCodexSandboxFlag:
         assert "--sandbox" not in cmd
         assert "resume" in cmd
 
+    def test_resume_omits_working_dir_flag(self, tmp_path: Path) -> None:
+        """`codex exec resume` does not accept -C; working dir is passed via cwd= instead."""
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        with patch(
+            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
+        ) as mock_run:
+            _run_codex(
+                prompt="continue",
+                profile=profile,
+                working_dir=tmp_path,
+                session_id="sess-abc123",
+            )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "resume" in cmd
+        assert "-C" not in cmd
+
     def test_resume_orders_session_id_after_flags(self, tmp_path: Path) -> None:
         """Resume command keeps flags before the positional session id."""
         profile = _make_profile(sandbox_mode="workspace-write")


### PR DESCRIPTION
## Summary

Removes -C flag from codex exec resume command (not accepted by that subcommand); working dir is already passed via subprocess cwd=; adds regression test locking the absence of -C.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.22
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Codex resume runner passes -C/--cd flag that codex exec resume does not accept (GitHub Issue #1013)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1013