### PR TITLE
New findings on changed files are misclassified as regressions without description match

### DIFF
--- a/src/theforge/finding_classifier.py
+++ b/src/theforge/finding_classifier.py
@@ -103,12 +103,10 @@ def _matches_prior_agnostic(
 
 def _is_resolution_commentary(description: str) -> bool:
     """Return True for closure-style commentary that should not be treated as a regression."""
-    normalized = " ".join(_normalize_tokens(description))
-    resolution_terms = ("fixed", "resolved", "addressed")
-    reference_terms = ("prior", "previous", "cycle", "finding", "issue")
-    return any(term in normalized for term in resolution_terms) and any(
-        term in normalized for term in reference_terms
-    )
+    tokens = _normalize_tokens(description)
+    resolution_terms = frozenset({"fixed", "resolved", "addressed"})
+    reference_terms = frozenset({"prior", "previous", "cycle", "finding", "issue"})
+    return bool(tokens & resolution_terms) and bool(tokens & reference_terms)
 
 
 def _matches_fixed_finding_regression_candidate(

--- a/src/theforge/finding_classifier.py
+++ b/src/theforge/finding_classifier.py
@@ -16,9 +16,6 @@ Corroboration grouping uses a single-pass Jaccard similarity assignment:
 # A higher threshold (e.g. 0.7) is more conservative but may miss paraphrased duplicates.
 JACCARD_THRESHOLD = 0.5
 
-# "Near changed code" is interpreted as same-file only (not line-level proximity).
-# This keeps the classification deterministic without parsing diff hunks.
-# If line-level proximity is required in future, parse git diff unified output.
 """
 
 from __future__ import annotations
@@ -94,6 +91,36 @@ def _matches_prior_agnostic(
     tokens_new = _normalize_tokens(finding.description)
     tokens_prior = _normalize_tokens(prior.description)
     return _jaccard(tokens_new, tokens_prior) >= threshold
+
+
+def _is_resolution_commentary(description: str) -> bool:
+    """Return True for closure-style commentary that should not be treated as a regression."""
+    normalized = " ".join(_normalize_tokens(description))
+    resolution_terms = ("fixed", "resolved", "addressed")
+    reference_terms = ("prior", "previous", "cycle", "finding", "issue")
+    return any(term in normalized for term in resolution_terms) and any(
+        term in normalized for term in reference_terms
+    )
+
+
+def _matches_fixed_finding_regression_candidate(
+    finding: ReviewFinding,
+    prior: FindingRecord,
+) -> bool:
+    """Return True when a new finding looks like a reintroduced prior fixed finding."""
+    if prior.disposition != "fixed":
+        return False
+    if _is_resolution_commentary(finding.description):
+        return False
+    if _matches_prior(finding, prior):
+        return True
+    return (
+        finding.file == prior.file
+        and finding.severity == prior.severity
+        and finding.line is not None
+        and prior.line is not None
+        and finding.line == prior.line
+    )
 
 
 def _get_changed_files(workspace_path: Path, prev_commit: str | None) -> frozenset[str]:
@@ -191,23 +218,22 @@ def update_finding_registry(
 
     Called after every review cycle (including cycle 1).
     Cycle 1: all findings recorded as net_new (no prior registry to compare against).
-    Cycle 2+: compare against prior registry, correlate with changed files.
+    Cycle 2+: compare against prior registry and classify regressions only when a
+    new finding looks like a reintroduced prior fixed finding.
 
     Args:
         state: Mutable coordinator state (finding_registry mutated in-place).
         cycle_results: List of (reviewer_profile_name, ReviewResult) for this cycle.
-        workspace_path: Path to the worktree (for git diff).
+        workspace_path: Path to the worktree.
         cycle_num: Current review cycle number (1-indexed).
-        prev_commit: Commit hash of the start of the latest dev iteration (for git diff).
-                     Pass None to skip changed-file correlation.
+        prev_commit: Commit hash of the start of the latest dev iteration. Reserved for
+                     audit correlation with changed files; currently unused by classification.
 
     Returns:
         List of FindingRecord objects classified this cycle (all severities).
         Callers use this list for disposition-gated exit criteria.
     """
     from .coordinator.state import FindingRecord  # avoid circular at module level
-
-    changed_files = _get_changed_files(workspace_path, prev_commit)
 
     # Collect all findings across reviewers
     all_findings: list[tuple[str, ReviewFinding]] = []
@@ -289,7 +315,10 @@ def update_finding_registry(
                         is_severity_downgrade = True
                     break
 
-        in_changed_files = first_finding.file in changed_files if first_finding.file else False
+        has_regression_evidence = any(
+            _matches_fixed_finding_regression_candidate(first_finding, record)
+            for record in prior_registry
+        )
         num_reporters = len({r for r, _ in reports})  # unique reviewer count
 
         if prior_match is not None:
@@ -318,7 +347,7 @@ def update_finding_registry(
             classified_this_cycle.append(prior_match)
         else:
             # New finding this cycle
-            if in_changed_files:
+            if has_regression_evidence:
                 disposition = "regression"
             elif num_reporters >= 2:
                 disposition = "corroborated_new"

--- a/src/theforge/finding_classifier.py
+++ b/src/theforge/finding_classifier.py
@@ -67,7 +67,13 @@ def _matches_prior(
     prior: FindingRecord,
     threshold: float = JACCARD_THRESHOLD,
 ) -> bool:
-    """Return True if finding matches prior record (same file + same severity + token overlap)."""
+    """Return True if finding matches prior record (same file + same severity + token overlap).
+
+    Resolution commentary is intentionally excluded so "the prior finding is fixed"
+    language cannot revive or keep alive an older record just by quoting it.
+    """
+    if _is_resolution_commentary(finding.description):
+        return False
     if finding.file != prior.file:
         return False
     if finding.severity != prior.severity:
@@ -86,6 +92,8 @@ def _matches_prior_agnostic(
 
     Used to detect severity downgrades between cycles (e.g. P1 → P2).
     """
+    if _is_resolution_commentary(finding.description):
+        return False
     if finding.file != prior.file:
         return False
     tokens_new = _normalize_tokens(finding.description)

--- a/tests/test_coord_review_resolution_commentary.py
+++ b/tests/test_coord_review_resolution_commentary.py
@@ -61,6 +61,25 @@ test_coverage:
 ```
 """
 
+_CYCLE2_UNRESOLVED_WORDING = """\
+```yaml
+verdict: REQUEST_CHANGES
+summary: "Issue still open."
+findings:
+  - severity: P1
+    file: src/changed.py
+    line: 10
+    description: "The prior finding is unresolved: missing null handling in runtime path"
+    suggestion: "Still needs a null guard"
+story_compliance:
+  matches_spec: true
+  mismatches: []
+test_coverage:
+  adequate: true
+  gaps: []
+```
+"""
+
 
 def _in_process_worktree_eval(
     workspace_path: Path, command: str, payload: dict, timeout: int = 120
@@ -72,7 +91,7 @@ def _in_process_worktree_eval(
 
 
 class TestResolutionCommentaryBridge:
-    def _two_cycle_pool(self):
+    def _two_cycle_pool(self, cycle2_review: str):
         call_n = {"n": 0}
 
         def side_effect(**kwargs):
@@ -88,7 +107,7 @@ class TestResolutionCommentaryBridge:
             return [
                 _make_agent_result(
                     success=True,
-                    output=_CYCLE2_RESOLUTION_COMMENTARY,
+                    output=cycle2_review,
                     profile_name="review",
                 )
             ]
@@ -124,7 +143,7 @@ class TestResolutionCommentaryBridge:
         mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
         mock_dev.return_value = _make_agent_result(success=True, output="Fixed.")
         mock_preflight.return_value = _PREFLIGHT_RESULT
-        mock_pool.side_effect = self._two_cycle_pool()
+        mock_pool.side_effect = self._two_cycle_pool(_CYCLE2_RESOLUTION_COMMENTARY)
 
         result = run_from_review(config, task, workspace)
 
@@ -146,3 +165,42 @@ class TestResolutionCommentaryBridge:
         assert prior.cycle_last_seen == 1
         assert commentary.disposition == "net_new"
         assert commentary.cycle_first_seen == 2
+
+    @patch("theforge.coordinator.util._run_worktree_eval", side_effect=_in_process_worktree_eval)
+    @patch("theforge.finding_classifier._get_changed_files")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_unresolved_wording_still_tracks_prior_finding_across_cycles(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_changed_files,
+        mock_eval,
+        tmp_path,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_changed_files.return_value = frozenset(["src/changed.py"])
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Fixed.")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_pool.side_effect = self._two_cycle_pool(_CYCLE2_UNRESOLVED_WORDING)
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.review_cycle == 2
+        assert len(result.state.finding_registry) == 1
+
+        prior = result.state.finding_registry[0]
+        assert prior.description == "Missing null handling in runtime path"
+        assert prior.disposition == "unresolved"
+        assert prior.cycle_last_seen == 2

--- a/tests/test_coord_review_resolution_commentary.py
+++ b/tests/test_coord_review_resolution_commentary.py
@@ -1,0 +1,148 @@
+"""Coordinator review-cycle handling for resolution commentary findings.
+
+Covers the review-phase seam where finding classification runs through the
+worktree eval bridge and must not treat closure commentary as a surviving prior
+finding.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    _PREFLIGHT_RESULT,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.config import FindingClassifierConfig
+from theforge.coordinator.engine import run_from_review
+from theforge.coordinator.state import Phase
+
+_CYCLE1_REQUEST_CHANGES = """\
+```yaml
+verdict: REQUEST_CHANGES
+summary: "Validation missing."
+findings:
+  - severity: P1
+    file: src/changed.py
+    line: 10
+    description: "Missing null handling in runtime path"
+    suggestion: "Add null guard"
+story_compliance:
+  matches_spec: true
+  mismatches: []
+test_coverage:
+  adequate: true
+  gaps: []
+```
+"""
+
+_CYCLE2_RESOLUTION_COMMENTARY = """\
+```yaml
+verdict: REQUEST_CHANGES
+summary: "Prior issue confirmed fixed."
+findings:
+  - severity: P1
+    file: src/changed.py
+    line: 10
+    description: "Previous finding fixed: missing null handling in runtime path"
+    suggestion: "None"
+story_compliance:
+  matches_spec: true
+  mismatches: []
+test_coverage:
+  adequate: true
+  gaps: []
+```
+"""
+
+
+def _in_process_worktree_eval(
+    workspace_path: Path, command: str, payload: dict, timeout: int = 120
+) -> dict:
+    """Run subprocess-eval commands in-process so test patches stay active."""
+    from theforge.coordinator._subprocess_eval import _COMMANDS
+
+    return _COMMANDS[command](payload)
+
+
+class TestResolutionCommentaryBridge:
+    def _two_cycle_pool(self):
+        call_n = {"n": 0}
+
+        def side_effect(**kwargs):
+            call_n["n"] += 1
+            if call_n["n"] == 1:
+                return [
+                    _make_agent_result(
+                        success=True,
+                        output=_CYCLE1_REQUEST_CHANGES,
+                        profile_name="review",
+                    )
+                ]
+            return [
+                _make_agent_result(
+                    success=True,
+                    output=_CYCLE2_RESOLUTION_COMMENTARY,
+                    profile_name="review",
+                )
+            ]
+
+        return side_effect
+
+    @patch("theforge.coordinator.util._run_worktree_eval", side_effect=_in_process_worktree_eval)
+    @patch("theforge.finding_classifier._get_changed_files")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_resolution_commentary_does_not_revive_prior_finding_across_cycles(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_changed_files,
+        mock_eval,
+        tmp_path,
+    ):
+        base = _make_config(tmp_path)
+        config = dataclasses.replace(
+            base,
+            finding_classifier=FindingClassifierConfig(allow_net_new_bypass=True),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_changed_files.return_value = frozenset(["src/changed.py"])
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Fixed.")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_pool.side_effect = self._two_cycle_pool()
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.review_cycle == 2
+
+        prior = next(
+            r
+            for r in result.state.finding_registry
+            if r.description == "Missing null handling in runtime path"
+        )
+        commentary = next(
+            r
+            for r in result.state.finding_registry
+            if r.description == "Previous finding fixed: missing null handling in runtime path"
+        )
+        assert prior.disposition == "fixed"
+        assert prior.cycle_last_seen == 1
+        assert commentary.disposition == "net_new"
+        assert commentary.cycle_first_seen == 2

--- a/tests/test_finding_classifier.py
+++ b/tests/test_finding_classifier.py
@@ -9,7 +9,9 @@ import pytest
 from theforge.coordinator.state import CoordinatorState, FindingRecord
 from theforge.finding_classifier import (
     _fingerprint,
+    _is_resolution_commentary,
     _jaccard,
+    _matches_fixed_finding_regression_candidate,
     _matches_prior,
     _matches_prior_agnostic,
     _normalize_tokens,
@@ -193,6 +195,59 @@ class TestMatchesPriorAgnostic:
         finding = _make_finding("Completely different description about something else")
         record = self._make_record("Missing null check in handler method call")
         assert not _matches_prior_agnostic(finding, record)
+
+
+class TestRegressionCandidates:
+    def _make_record(
+        self,
+        description: str,
+        *,
+        disposition: str = "fixed",
+        file: str = "src/foo.py",
+        severity: str = "P1",
+        line: int | None = 10,
+    ) -> FindingRecord:
+        fp = _fingerprint(severity, file, description, line)
+        return FindingRecord(
+            finding_id=fp,
+            cycle_first_seen=1,
+            cycle_last_seen=1,
+            file=file,
+            line=line,
+            severity=severity,
+            description=description,
+            reporter="reviewer-a",
+            disposition=disposition,
+        )
+
+    def test_resolution_commentary_detected(self):
+        assert _is_resolution_commentary(
+            "Prior P1 from Cycle 1 is fixed: null handling is safe now"
+        )
+
+    def test_resolution_commentary_not_treated_as_regression_candidate(self):
+        prior = self._make_record("Missing null handling in runtime path")
+        finding = _make_finding(
+            "Prior P1 from Cycle 1 is fixed: runtime path now handles null safely",
+            file=prior.file or "src/foo.py",
+            line=prior.line,
+        )
+
+        assert not _matches_fixed_finding_regression_candidate(finding, prior)
+
+    def test_same_file_line_and_severity_fixed_finding_counts_as_regression_candidate(self):
+        prior = self._make_record(
+            "Missing null handling in runtime path",
+            file="src/runtime.py",
+            line=42,
+        )
+        finding = _make_finding(
+            "Value can still be None in runtime path branch",
+            file="src/runtime.py",
+            line=42,
+        )
+
+        assert _matches_fixed_finding_regression_candidate(finding, prior)
 
 
 class TestUpdateFindingRegistryCycle1:
@@ -462,9 +517,8 @@ class TestUpdateFindingRegistryCycle2:
 
         assert record.disposition == "fixed"
 
-    def test_new_finding_in_changed_file_is_regression(self, tmp_path):
+    def test_new_finding_in_changed_file_without_fixed_match_is_net_new(self, tmp_path):
         state = _make_state()
-        # No prior registry entries for this finding
 
         finding = _make_finding("Index out of bounds in new loop", file="src/changed.py")
         review = _make_review([finding])
@@ -477,7 +531,55 @@ class TestUpdateFindingRegistryCycle2:
             classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
 
         p1s = [r for r in classified if r.severity == "P1"]
+        assert p1s[0].disposition == "net_new"
+
+    def test_new_finding_matching_prior_fixed_finding_is_regression(self, tmp_path):
+        state = _make_state()
+        self._populate_cycle1(
+            state,
+            "Missing null check in handler",
+            file="src/changed.py",
+            disposition="fixed",
+        )
+
+        finding = _make_finding("Missing null check in handler", file="src/changed.py")
+        review = _make_review([finding])
+        cycle_results = [("reviewer-a", review)]
+
+        with patch(
+            "theforge.finding_classifier._get_changed_files",
+            return_value=frozenset(["src/changed.py"]),
+        ):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        p1s = [r for r in classified if r.severity == "P1"]
         assert p1s[0].disposition == "regression"
+
+    def test_new_resolution_commentary_on_changed_file_is_not_regression(self, tmp_path):
+        state = _make_state()
+        self._populate_cycle1(
+            state,
+            "Missing null handling in runtime path",
+            file="src/changed.py",
+            disposition="fixed",
+        )
+
+        finding = _make_finding(
+            "Prior P1 from Cycle 1 is fixed: runtime path now handles null safely",
+            file="src/changed.py",
+            line=10,
+        )
+        review = _make_review([finding])
+        cycle_results = [("reviewer-a", review)]
+
+        with patch(
+            "theforge.finding_classifier._get_changed_files",
+            return_value=frozenset(["src/changed.py"]),
+        ):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        p1s = [r for r in classified if r.severity == "P1"]
+        assert p1s[0].disposition == "net_new"
 
     def test_new_finding_not_in_changed_file_single_reviewer_is_net_new(self, tmp_path):
         state = _make_state()

--- a/tests/test_finding_classifier.py
+++ b/tests/test_finding_classifier.py
@@ -158,6 +158,13 @@ class TestMatchesPrior:
         record = self._make_record("Missing null check in handler method call")
         assert not _matches_prior(finding, record)
 
+    def test_resolution_commentary_does_not_match_even_with_high_overlap(self):
+        finding = _make_finding(
+            "Previous finding fixed: missing null check in handler",
+        )
+        record = self._make_record("Missing null check in handler")
+        assert not _matches_prior(finding, record)
+
 
 class TestMatchesPriorAgnostic:
     def _make_record(
@@ -194,6 +201,14 @@ class TestMatchesPriorAgnostic:
     def test_low_overlap_no_match(self):
         finding = _make_finding("Completely different description about something else")
         record = self._make_record("Missing null check in handler method call")
+        assert not _matches_prior_agnostic(finding, record)
+
+    def test_resolution_commentary_does_not_match_even_with_high_overlap(self):
+        finding = _make_finding(
+            "Previous finding fixed: missing null check in handler",
+            severity="P2",
+        )
+        record = self._make_record("Missing null check in handler", severity="P1")
         assert not _matches_prior_agnostic(finding, record)
 
 
@@ -557,7 +572,7 @@ class TestUpdateFindingRegistryCycle2:
 
     def test_new_resolution_commentary_on_changed_file_is_not_regression(self, tmp_path):
         state = _make_state()
-        self._populate_cycle1(
+        prior = self._populate_cycle1(
             state,
             "Missing null handling in runtime path",
             file="src/changed.py",
@@ -565,7 +580,7 @@ class TestUpdateFindingRegistryCycle2:
         )
 
         finding = _make_finding(
-            "Prior P1 from Cycle 1 is fixed: runtime path now handles null safely",
+            "Previous finding fixed: missing null handling in runtime path",
             file="src/changed.py",
             line=10,
         )
@@ -580,6 +595,36 @@ class TestUpdateFindingRegistryCycle2:
 
         p1s = [r for r in classified if r.severity == "P1"]
         assert p1s[0].disposition == "net_new"
+        assert prior.disposition == "fixed"
+        assert prior.cycle_last_seen == 1
+
+    def test_resolution_commentary_does_not_keep_unresolved_prior_open(self, tmp_path):
+        state = _make_state()
+        prior = self._populate_cycle1(
+            state,
+            "Missing null handling in runtime path",
+            file="src/changed.py",
+            disposition="unresolved",
+        )
+
+        finding = _make_finding(
+            "Previous finding fixed: missing null handling in runtime path",
+            file="src/changed.py",
+            line=10,
+        )
+        review = _make_review([finding])
+        cycle_results = [("reviewer-a", review)]
+
+        with patch(
+            "theforge.finding_classifier._get_changed_files",
+            return_value=frozenset(["src/changed.py"]),
+        ):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        p1s = [r for r in classified if r.severity == "P1"]
+        assert p1s[0].disposition == "net_new"
+        assert prior.disposition == "fixed"
+        assert prior.cycle_last_seen == 1
 
     def test_new_finding_not_in_changed_file_single_reviewer_is_net_new(self, tmp_path):
         state = _make_state()

--- a/tests/test_finding_classifier.py
+++ b/tests/test_finding_classifier.py
@@ -240,6 +240,16 @@ class TestRegressionCandidates:
             "Prior P1 from Cycle 1 is fixed: null handling is safe now"
         )
 
+    def test_unresolved_word_does_not_trigger_resolution_commentary(self):
+        assert not _is_resolution_commentary(
+            "The prior finding is unresolved: null handling still fails"
+        )
+
+    def test_unaddressed_word_does_not_trigger_resolution_commentary(self):
+        assert not _is_resolution_commentary(
+            "The previous issue is unaddressed in the runtime path"
+        )
+
     def test_resolution_commentary_not_treated_as_regression_candidate(self):
         prior = self._make_record("Missing null handling in runtime path")
         finding = _make_finding(
@@ -509,6 +519,20 @@ class TestUpdateFindingRegistryCycle2:
         self._populate_cycle1(state, "Missing null check in handler")
 
         finding = _make_finding("Missing null check in handler")
+        review = _make_review([finding])
+        cycle_results = [("reviewer-a", review)]
+
+        with patch("theforge.finding_classifier._get_changed_files", return_value=frozenset()):
+            classified = update_finding_registry(state, cycle_results, tmp_path, cycle_num=2)
+
+        assert classified[0].disposition == "unresolved"
+        assert classified[0].cycle_last_seen == 2
+
+    def test_unresolved_wording_still_matches_prior_finding(self, tmp_path):
+        state = _make_state()
+        self._populate_cycle1(state, "Missing null check in handler")
+
+        finding = _make_finding("The prior finding is unresolved: missing null check in handler")
         review = _make_review([finding])
         cycle_results = [("reviewer-a", review)]
 


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] All prior P1 findings are resolved; no regressions introduced. | [google-gemini-3.1-pro-preview] The implementation correctly classifies regressions based on description similarity or matching file+line+severity against a fixed prior. | [claude-opus] Both prior P1s resolved: _matches_prior/_matches_prior_agnostic now guard against resolution commentary, and _is_resolution_commentary uses set intersection on tokens (no substring false matches like 'unresolved'/'unaddressed'). Tests cover both fixes including a seam-level integration test.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $4.65
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/finding_classifier.py:132`** The function `_get_changed_files` is no longer used in `update_finding_registry` but is still defined in the module. It should be removed to keep the module clean.
- **[P2] `src/theforge/finding_classifier.py:104`** The `_is_resolution_commentary` function returns True for phrases like 'The prior issue is not fixed' because it only checks for the presence of terms like 'prior' and 'fixed' without considering negation. This causes unresolved findings to be misclassified as `net_new` instead of `unresolved`. This is a pre-existing issue.

## Story

New findings on changed files are misclassified as regressions without description match (GitHub Issue #997)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #997