### PR TITLE
Runner subprocess failures are masked behind generic 'no changes' / 'convention violations' escalation messages

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -285,6 +285,9 @@ def _serialize_dev_iteration_metrics(state: CoordinatorState) -> list[dict]:
             "files_changed_count": item.files_changed_count,
             "tests_fixed_count": item.tests_fixed_count,
             "sandboxed": item.sandboxed,
+            "agent_exit_code": item.agent_exit_code,
+            "runner_failure_code": item.runner_failure_code,
+            "runner_failure_summary": item.runner_failure_summary,
         }
         for item in state.dev_iteration_telemetry
     ]

--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -40,7 +40,13 @@ def _agent_entry(r: object, role: str, profile_fallback: str, dur: float | None)
         "profile": r.profile_name or profile_fallback,
         "cost_usd": r.cost_usd,
         "duration_seconds": dur,
+        "success": r.success,
+        "exit_code": r.exit_code,
     }
+    if r.failure_code:
+        entry["failure_code"] = r.failure_code
+    if r.startup_failure:
+        entry["startup_failure"] = True
     if r.model_usage:
         entry["model_usage"] = _model_usage_entries(r)
     # model_used: prefer the explicit field (set by runners for CLI and preference-list

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -61,6 +61,7 @@ _RUNNER_FAILURE_SIGNATURES: tuple[tuple[str, tuple[str, ...]], ...] = (
         ("permission denied",),
     ),
 )
+_SHELL_ERROR_PREFIXES = ("bash:", "sh:", "zsh:")
 
 
 def _summarize_runner_failure(output: str, indicators: tuple[str, ...]) -> str:
@@ -77,12 +78,47 @@ def _summarize_runner_failure(output: str, indicators: tuple[str, ...]) -> str:
     return lines[0][:200] if lines else "(no output)"
 
 
-def classify_runner_subprocess_failure(output: str) -> tuple[str, str] | None:
+def _runner_failure_evidence(output: str, exit_code: int) -> list[str]:
+    """Return candidate shell-level crash lines from runner output."""
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if not lines:
+        return []
+    candidates = lines[:3]
+    if len(lines) > 3:
+        candidates.extend(lines[-2:])
+    lowered = [line.lower() for line in candidates]
+    if exit_code == 127:
+        return [
+            line
+            for line, lowered_line in zip(candidates, lowered, strict=False)
+            if lowered_line.startswith(_SHELL_ERROR_PREFIXES)
+            and "command not found" in lowered_line
+        ]
+    if exit_code == 126:
+        return [
+            line
+            for line, lowered_line in zip(candidates, lowered, strict=False)
+            if lowered_line.startswith(_SHELL_ERROR_PREFIXES)
+            and "permission denied" in lowered_line
+        ]
+    return candidates
+
+
+def classify_runner_subprocess_failure(output: str, exit_code: int) -> tuple[str, str] | None:
     """Classify a runner subprocess crash that occurred before agent execution."""
-    lowered = output.lower()
+    evidence_lines = _runner_failure_evidence(output, exit_code)
+    evidence_text = "\n".join(evidence_lines)
+    lowered = evidence_text.lower()
     for failure_code, indicators in _RUNNER_FAILURE_SIGNATURES:
+        if failure_code == "runner_command_not_found" and exit_code != 127:
+            continue
+        if failure_code == "runner_permission_denied" and exit_code != 126:
+            continue
+        if failure_code in {"runner_command_not_found", "runner_permission_denied"}:
+            if not evidence_lines:
+                continue
         if any(indicator in lowered for indicator in indicators):
-            return failure_code, _summarize_runner_failure(output, indicators)
+            return failure_code, _summarize_runner_failure(evidence_text, indicators)
     return None
 
 
@@ -474,7 +510,9 @@ def _run_dev_phase(
     )
     _runner_failure = None
     if not dev_result.success and not dev_result.startup_failure:
-        _runner_failure = classify_runner_subprocess_failure(dev_result.output)
+        _runner_failure = classify_runner_subprocess_failure(
+            dev_result.output, dev_result.exit_code
+        )
         if _runner_failure is not None:
             dev_result = _dc_replace(dev_result, failure_code=_runner_failure[0])
     _dev_elapsed = time.monotonic() - _dev_start

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -133,8 +133,6 @@ def record_dev_iteration_telemetry(
     gate_result: str | None,
     gate_output_tail: str = "",
     is_timeout: bool = False,
-    agent_exit_code: int | None = None,
-    runner_failure_code: str | None = None,
     runner_failure_summary: str | None = None,
 ) -> None:
     """Capture per-iteration dev telemetry after validation completes."""
@@ -175,8 +173,8 @@ def record_dev_iteration_telemetry(
             tests_fixed_count=tests_fixed_count,
             meaningful_progress=meaningful_progress,
             sandboxed=state.sandboxed,
-            agent_exit_code=agent_exit_code,
-            runner_failure_code=runner_failure_code,
+            agent_exit_code=dev_result.exit_code,
+            runner_failure_code=dev_result.failure_code,
             runner_failure_summary=runner_failure_summary,
         )
     )
@@ -477,7 +475,7 @@ def _run_dev_phase(
     _runner_failure = None
     if not dev_result.success and not dev_result.startup_failure:
         _runner_failure = classify_runner_subprocess_failure(dev_result.output)
-        if _runner_failure is not None and dev_result.failure_code is None:
+        if _runner_failure is not None:
             dev_result = _dc_replace(dev_result, failure_code=_runner_failure[0])
     _dev_elapsed = time.monotonic() - _dev_start
     write_trace(
@@ -522,19 +520,10 @@ def _run_dev_phase(
                 workspace_path,
                 max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
                 gate_result="RUNNER_CRASH",
-                agent_exit_code=dev_result.exit_code,
-                runner_failure_code=dev_result.failure_code,
                 runner_failure_summary=_runner_failure[1],
             )
             _log(f"✗ ESCALATE   {state.error}")
             if logger:
-                logger._safe_emit(
-                    "phase_end",
-                    phase="DEV",
-                    outcome="escalate",
-                    cost_usd=dev_result.cost_usd,
-                    duration_s=round(_dev_elapsed, 2),
-                )
                 logger._safe_emit("escalate", reason=state.error, phase="DEV")
             _escalate_notify(task, state, notify, config)
             return CoordinatorResult(

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -38,6 +38,58 @@ from .util import (
 run_agent = None
 log_agent_result = None
 
+_RUNNER_FAILURE_SIGNATURES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "runner_argument_error",
+        (
+            "error: unexpected argument",
+            "unexpected argument",
+            "unrecognized option",
+            "unknown option",
+            "invalid option",
+        ),
+    ),
+    (
+        "runner_command_not_found",
+        (
+            "command not found",
+            "no such file or directory",
+        ),
+    ),
+    (
+        "runner_permission_denied",
+        ("permission denied",),
+    ),
+)
+
+
+def _summarize_runner_failure(output: str, indicators: tuple[str, ...]) -> str:
+    """Return a short, operator-friendly summary line for a runner crash."""
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    lowered = tuple(line.lower() for line in lines)
+    for indicator in indicators:
+        for idx, line in enumerate(lowered):
+            if indicator in line:
+                return lines[idx][:200]
+    for idx, line in enumerate(lowered):
+        if not line.startswith("usage:"):
+            return lines[idx][:200]
+    return lines[0][:200] if lines else "(no output)"
+
+
+def classify_runner_subprocess_failure(output: str) -> tuple[str, str] | None:
+    """Classify a runner subprocess crash that occurred before agent execution."""
+    lowered = output.lower()
+    for failure_code, indicators in _RUNNER_FAILURE_SIGNATURES:
+        if any(indicator in lowered for indicator in indicators):
+            return failure_code, _summarize_runner_failure(output, indicators)
+    return None
+
+
+def _runner_display_name(config: ForgeConfig) -> str:
+    """Return a stable operator-facing runner label for escalation messages."""
+    return config.dev_profile.cli or config.dev_profile.provider or config.dev_profile.name
+
 
 def _extract_failed_tests(gate_output_tail: str) -> list[str]:
     """Best-effort extraction of failing test identifiers from gate output."""
@@ -81,6 +133,9 @@ def record_dev_iteration_telemetry(
     gate_result: str | None,
     gate_output_tail: str = "",
     is_timeout: bool = False,
+    agent_exit_code: int | None = None,
+    runner_failure_code: str | None = None,
+    runner_failure_summary: str | None = None,
 ) -> None:
     """Capture per-iteration dev telemetry after validation completes."""
     if not state.dev_results or not state.dev_durations:
@@ -120,6 +175,9 @@ def record_dev_iteration_telemetry(
             tests_fixed_count=tests_fixed_count,
             meaningful_progress=meaningful_progress,
             sandboxed=state.sandboxed,
+            agent_exit_code=agent_exit_code,
+            runner_failure_code=runner_failure_code,
+            runner_failure_summary=runner_failure_summary,
         )
     )
 
@@ -416,6 +474,11 @@ def _run_dev_phase(
         session_id=state.dev_session_id,
         secrets=config.secrets,
     )
+    _runner_failure = None
+    if not dev_result.success and not dev_result.startup_failure:
+        _runner_failure = classify_runner_subprocess_failure(dev_result.output)
+        if _runner_failure is not None and dev_result.failure_code is None:
+            dev_result = _dc_replace(dev_result, failure_code=_runner_failure[0])
     _dev_elapsed = time.monotonic() - _dev_start
     write_trace(
         workspace_path / ".forge/traces" / f"{state.dev_trace_count}-dev-output.txt",
@@ -447,6 +510,39 @@ def _run_dev_phase(
         )
 
     if not dev_result.success:
+        if _runner_failure is not None:
+            runner_name = _runner_display_name(config)
+            state.phase = Phase.ESCALATE
+            state.error_type = dev_result.failure_code
+            state.error = (
+                f"Runner crashed before agent execution: {runner_name}: {_runner_failure[1]}"
+            )
+            record_dev_iteration_telemetry(
+                state,
+                workspace_path,
+                max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
+                gate_result="RUNNER_CRASH",
+                agent_exit_code=dev_result.exit_code,
+                runner_failure_code=dev_result.failure_code,
+                runner_failure_summary=_runner_failure[1],
+            )
+            _log(f"✗ ESCALATE   {state.error}")
+            if logger:
+                logger._safe_emit(
+                    "phase_end",
+                    phase="DEV",
+                    outcome="escalate",
+                    cost_usd=dev_result.cost_usd,
+                    duration_s=round(_dev_elapsed, 2),
+                )
+                logger._safe_emit("escalate", reason=state.error, phase="DEV")
+            _escalate_notify(task, state, notify, config)
+            return CoordinatorResult(
+                success=False,
+                phase=state.phase,
+                state=state,
+                message=state.error,
+            )
         if dev_result.failure_code == "max_iterations_reached" and dev_result.dev_handoff is None:
             state.error_type = "max_iterations_no_submit"
             state.retry_reason = RetryReason.MAX_ITERATIONS_NO_SUBMIT

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -176,6 +176,9 @@ class DevIterationTelemetry:
     tests_fixed_count: int = 0
     meaningful_progress: bool | None = None
     sandboxed: bool = True
+    agent_exit_code: int | None = None
+    runner_failure_code: str | None = None
+    runner_failure_summary: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -24,6 +24,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.coordinator.dev_phase import classify_runner_subprocess_failure
 from theforge.coordinator.engine import run_task
 from theforge.coordinator.state import Phase, parse_phase_name
 from theforge.runners import AgentResult, LogLevel
@@ -1078,13 +1079,22 @@ class TestStartupFailureEscalation:
         phase_end_calls = [
             call
             for call in logger._safe_emit.call_args_list
-            if call.args
-            and call.args[0] == "phase_end"
-            and call.kwargs.get("phase") == "DEV"
+            if call.args and call.args[0] == "phase_end" and call.kwargs.get("phase") == "DEV"
         ]
         assert len(phase_end_calls) == 1
         assert phase_end_calls[0].kwargs["outcome"] == "failure"
         mock_pool.assert_not_called()
+
+    def test_runner_command_not_found_classifier_ignores_agent_tool_errors(self):
+        """Shell-style launcher evidence is required for command-not-found crashes."""
+        output = (
+            "I ran the build and got tool output:\n"
+            "ripgrep: command not found\n"
+            "no such file or directory: src/missing.py\n"
+        )
+
+        assert classify_runner_subprocess_failure(output, exit_code=1) is None
+        assert classify_runner_subprocess_failure(output, exit_code=127) is None
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,6 +4,7 @@ Uses mocked runner to test all state transitions without real agent calls.
 """
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -893,4 +894,63 @@ class TestStartupFailureEscalation:
         assert "agent launcher startup failed" in result.message
         # dev_agent called once; no VALIDATE or REVIEW
         assert mock_dev_agent.call_count == 1
+        mock_pool.assert_not_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_runner_argument_crash_escalates_with_runner_reason(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """Runner arg-parse crashes escalate immediately with runner-specific messaging."""
+        from theforge.runners import AgentResult
+
+        config = replace(
+            _make_config(tmp_path),
+            dev_profile=replace(DEFAULT_DEV_PROFILE, cli="codex"),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+
+        def shell_side(cmd, cwd=None, **kw):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            if "git diff --name-only" in cmd:
+                return (True, "")
+            if "git status --porcelain" in cmd:
+                return (True, "?? scratch.py")
+            return _shell_with_gate(workspace, "PASS")(cmd, cwd, **kw)
+
+        mock_shell.side_effect = shell_side
+        mock_dev_agent.return_value = AgentResult(
+            success=False,
+            output=(
+                "error: unexpected argument '-C' found\n"
+                "Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]\n"
+            ),
+            session_id=None,
+            cost_usd=None,
+            exit_code=2,
+            raw={},
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.error_type == "runner_argument_error"
+        assert "Runner crashed before agent execution: codex" in result.message
+        assert "unexpected argument '-C' found" in result.message
+        assert result.state.dev_iteration_telemetry[0].gate_result == "RUNNER_CRASH"
+        assert (
+            result.state.dev_iteration_telemetry[0].runner_failure_code == "runner_argument_error"
+        )
+        assert result.state.dev_iteration_telemetry[0].runner_failure_summary == (
+            "error: unexpected argument '-C' found"
+        )
+        assert result.state.dev_iteration_telemetry[0].files_changed == ["scratch.py"]
         mock_pool.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,7 +6,7 @@ Uses mocked runner to test all state transitions without real agent calls.
 import json
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from coord_test_helpers import (
@@ -954,3 +954,169 @@ class TestStartupFailureEscalation:
         )
         assert result.state.dev_iteration_telemetry[0].files_changed == ["scratch.py"]
         mock_pool.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("output", "exit_code", "expected_failure_code", "expected_summary"),
+        [
+            (
+                "bash: codex: command not found\n",
+                127,
+                "runner_command_not_found",
+                "bash: codex: command not found",
+            ),
+            (
+                "bash: /usr/local/bin/codex: Permission denied\n",
+                126,
+                "runner_permission_denied",
+                "bash: /usr/local/bin/codex: Permission denied",
+            ),
+        ],
+    )
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_runner_crash_signatures_escalate_with_specific_failure_codes(
+        self,
+        mock_shell,
+        mock_dev_agent,
+        mock_preflight,
+        mock_pool,
+        tmp_path,
+        output,
+        exit_code,
+        expected_failure_code,
+        expected_summary,
+    ):
+        """Known runner crash signatures must escalate through the runner-specific path."""
+        from theforge.runners import AgentResult
+
+        config = replace(
+            _make_config(tmp_path),
+            dev_profile=replace(DEFAULT_DEV_PROFILE, cli="codex"),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+
+        def shell_side(cmd, cwd=None, **kw):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            if "git diff --name-only" in cmd:
+                return (True, "")
+            if "git status --porcelain" in cmd:
+                return (True, "")
+            return _shell_with_gate(workspace, "PASS")(cmd, cwd, **kw)
+
+        mock_shell.side_effect = shell_side
+        mock_dev_agent.return_value = AgentResult(
+            success=False,
+            output=output,
+            session_id=None,
+            cost_usd=None,
+            exit_code=exit_code,
+            raw={},
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.error_type == expected_failure_code
+        assert result.state.dev_iteration_telemetry[0].agent_exit_code == exit_code
+        assert result.state.dev_iteration_telemetry[0].runner_failure_code == expected_failure_code
+        assert result.state.dev_iteration_telemetry[0].runner_failure_summary == expected_summary
+        mock_pool.assert_not_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_runner_crash_emits_single_failure_phase_end(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """Runner crash must emit one DEV phase_end event with failure outcome."""
+        from theforge.runners import AgentResult
+
+        config = replace(
+            _make_config(tmp_path),
+            dev_profile=replace(DEFAULT_DEV_PROFILE, cli="codex"),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+
+        def shell_side(cmd, cwd=None, **kw):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            if "git diff --name-only" in cmd:
+                return (True, "")
+            if "git status --porcelain" in cmd:
+                return (True, "")
+            return _shell_with_gate(workspace, "PASS")(cmd, cwd, **kw)
+
+        mock_shell.side_effect = shell_side
+        mock_dev_agent.return_value = AgentResult(
+            success=False,
+            output="error: unexpected argument '-C' found\n",
+            session_id=None,
+            cost_usd=None,
+            exit_code=2,
+            raw={},
+        )
+
+        logger = MagicMock()
+        logger._safe_emit = MagicMock()
+        with patch("theforge.coordinator.engine.StructuredLogger", return_value=logger):
+            result = run_task(config, task)
+
+        assert result.success is False
+        phase_end_calls = [
+            call
+            for call in logger._safe_emit.call_args_list
+            if call.args
+            and call.args[0] == "phase_end"
+            and call.kwargs.get("phase") == "DEV"
+        ]
+        assert len(phase_end_calls) == 1
+        assert phase_end_calls[0].kwargs["outcome"] == "failure"
+        mock_pool.assert_not_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_iteration_telemetry_records_agent_exit_code_on_normal_pass(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """Normal dev iterations should record the agent exit code, not leave it unset."""
+        from theforge.runners import AgentResult
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev_agent.return_value = AgentResult(
+            success=True,
+            output="Implemented.",
+            session_id="sess-1",
+            cost_usd=0.5,
+            exit_code=0,
+            raw={},
+        )
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.dev_iteration_telemetry[0].agent_exit_code == 0
+        assert result.state.dev_iteration_telemetry[0].runner_failure_code is None

--- a/tests/test_iteration_telemetry.py
+++ b/tests/test_iteration_telemetry.py
@@ -78,6 +78,44 @@ def test_story_audit_includes_iteration_loop_metrics(tmp_path):
     }
 
 
+def test_story_audit_includes_runner_failure_fields(tmp_path):
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.dev_iteration_telemetry = [
+        DevIterationTelemetry(
+            iteration=1,
+            max_iterations=3,
+            cost_usd=None,
+            duration_s=1.2,
+            gate_result="RUNNER_CRASH",
+            files_changed=["scratch.py"],
+            files_changed_count=1,
+            meaningful_progress=True,
+            agent_exit_code=2,
+            runner_failure_code="runner_argument_error",
+            runner_failure_summary="error: unexpected argument '-C' found",
+        )
+    ]
+
+    audit = generate_audit_log(
+        config,
+        task,
+        CoordinatorResult(
+            success=False,
+            phase=Phase.ESCALATE,
+            state=state,
+            message="runner crash",
+        ),
+    )
+
+    assert audit["iterations"]["dev_loop"][0]["agent_exit_code"] == 2
+    assert audit["iterations"]["dev_loop"][0]["runner_failure_code"] == "runner_argument_error"
+    assert audit["iterations"]["dev_loop"][0]["runner_failure_summary"] == (
+        "error: unexpected argument '-C' found"
+    )
+
+
 def test_sprint_summary_includes_iteration_usage_distribution(tmp_path):
     manifest = SprintManifest(name="demo-sprint", budget_usd=5.0, stories=["issue:123"])
     state = CoordinatorState(phase=Phase.DONE)


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] All prior P1 findings from Cycle 1 are resolved: the double phase_end emission has been removed (commit 5c623c9) and the agent_exit_code/runner_failure_code parameters are now derived internally from dev_result rather than passed as arguments. The fix correctly classifies runner subprocess crashes using exit-code-aware evidence filtering to avoid false positives from agent tool output. Tests pass (33/33). No regressions introduced. | [google-gemini-3.1-pro-preview] The prior P1 findings are fixed and the runner crash classification works correctly. | [claude-opus] Prior P1s resolved: the duplicate DEV phase_end emit was removed and record_dev_iteration_telemetry now sources agent_exit_code/runner_failure_code from dev_result so normal iterations are populated. The tightened classifier (exit-code + shell-prefix gating for command-not-found / permission-denied) is well-covered by new parametrized and false-positive tests; argument-error path remains intact.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.75
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/dev_phase.py:88`** If `len(lines) == 4`, `lines[:3]` and `lines[-2:]` overlap, causing the 3rd line to be duplicated in `candidates`.

## Story

Runner subprocess failures are masked behind generic 'no changes' / 'convention violations' escalation messages (GitHub Issue #1016)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1016