### PR TITLE
Hard convention violations are not propagated to dev retry input as actionable findings

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -13,6 +13,7 @@ import yaml
 from theforge.config import MODEL_REGISTRY, ForgeConfig, apply_model_info
 from theforge.config.auth import sandbox_available_for_profile
 from theforge.coordinator.context_scope import plan_file_list
+from theforge.review import append_convention_retry_findings
 from theforge.sessions import save_sessions
 from theforge.task import ContextAssembler, TaskStory, build_dev_prompt, build_fix_prompt
 from theforge.traces import write_trace
@@ -159,6 +160,14 @@ def _git_lines(workspace_path: Path, args: Iterable[str]) -> list[str]:
     if not ok and not output:
         return []
     return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _retry_review_findings_for_dev_prompt(state: CoordinatorState) -> str | None:
+    """Return current actionable findings for a validate-driven retry prompt."""
+    return append_convention_retry_findings(
+        state.last_review_findings,
+        state.convention_violations,
+    )
 
 
 def record_dev_iteration_telemetry(
@@ -415,7 +424,7 @@ def _run_dev_phase(
                 gate_command=_gate_cmd,
                 test_command=_test_cmd,
                 gate_skipped=_is_gate_skip(task.gate_override),
-                review_findings=state.last_review_findings,
+                review_findings=_retry_review_findings_for_dev_prompt(state),
                 human_feedback=state.human_feedback,
                 preflight_output=(
                     state.preflight_result.output if state.preflight_result else None
@@ -459,7 +468,7 @@ def _run_dev_phase(
                 gate_command=_gate_cmd,
                 test_command=_test_cmd,
                 gate_skipped=_is_gate_skip(task.gate_override),
-                review_findings=state.last_review_findings,
+                review_findings=_retry_review_findings_for_dev_prompt(state),
                 human_feedback=state.human_feedback,
                 preflight_output=(
                     state.preflight_result.output if state.preflight_result else None

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -12,6 +12,7 @@ from enum import Enum, auto
 from pathlib import Path
 
 from theforge.config import ForgeConfig
+from theforge.review import append_convention_retry_findings
 from theforge.task import TaskStory
 
 from . import util as _cu
@@ -391,6 +392,10 @@ def _run_validate_phase(
                 for v in _cv_violations
             ]
             if _blocking_cv2:
+                state.last_review_findings = append_convention_retry_findings(
+                    state.last_review_findings,
+                    state.convention_violations,
+                )
                 lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _blocking_cv2]
                 state.human_feedback += (
                     "\n\nAdditionally, hard convention violations were detected:\n"
@@ -456,6 +461,10 @@ def _run_validate_phase(
                     )
 
             if blocking_violations:
+                state.last_review_findings = append_convention_retry_findings(
+                    state.last_review_findings,
+                    state.convention_violations,
+                )
                 lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in blocking_violations]
                 human_feedback = "Hard convention violations detected:\n" + "\n".join(lines)
                 state.human_feedback = human_feedback

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -12,7 +12,6 @@ from enum import Enum, auto
 from pathlib import Path
 
 from theforge.config import ForgeConfig
-from theforge.review import append_convention_retry_findings
 from theforge.task import TaskStory
 
 from . import util as _cu
@@ -198,6 +197,10 @@ def _run_validate_phase(
 
     _cv_all: list = _cv_result_raw[0] if _cv_result_raw is not None else []
     _cv_violations: list = _cv_result_raw[1] if _cv_result_raw is not None else []
+    state.convention_violations = [
+        {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
+        for v in _cv_violations
+    ]
 
     if gate_err:
         is_timeout = "timed out" in (gate_err or "").lower()
@@ -387,15 +390,7 @@ def _run_validate_phase(
         if _cv_violations:
             _blocking_cv2 = [v for v in _cv_violations if v.blocking]
             _followup_cv2 = [v for v in _cv_violations if not v.blocking]
-            state.convention_violations = [
-                {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
-                for v in _cv_violations
-            ]
             if _blocking_cv2:
-                state.last_review_findings = append_convention_retry_findings(
-                    state.last_review_findings,
-                    state.convention_violations,
-                )
                 lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in _blocking_cv2]
                 state.human_feedback += (
                     "\n\nAdditionally, hard convention violations were detected:\n"
@@ -436,17 +431,6 @@ def _run_validate_phase(
             blocking_violations = [v for v in _cv_violations if v.blocking]
             followup_violations = [v for v in _cv_violations if not v.blocking]
 
-            # Record ALL violations on state — blocking flag preserved
-            state.convention_violations = [
-                {
-                    "rule": v.rule,
-                    "file": v.file,
-                    "detail": v.detail,
-                    "blocking": v.blocking,
-                }
-                for v in _cv_violations
-            ]
-
             # Log and emit follow-up (hygiene) violations — not blocking
             for v in followup_violations:
                 _log(f"  Convention follow-up [hygiene]: {v.rule} in {v.file} — {v.detail}")
@@ -461,10 +445,6 @@ def _run_validate_phase(
                     )
 
             if blocking_violations:
-                state.last_review_findings = append_convention_retry_findings(
-                    state.last_review_findings,
-                    state.convention_violations,
-                )
                 lines = [f"  - [{v.rule}] {v.file}: {v.detail}" for v in blocking_violations]
                 human_feedback = "Hard convention violations detected:\n" + "\n".join(lines)
                 state.human_feedback = human_feedback
@@ -492,7 +472,7 @@ def _run_validate_phase(
                     logger._safe_emit("phase_end", phase="VALIDATE", outcome="convention_fail")
                 return _ValidateOutcome.REVIEW_CONVENTION_BLOCK, None
             # Only follow-up violations — proceed to PASS
-        else:
+        elif _cv_all:
             state.convention_violations = [
                 {
                     "rule": v.rule,
@@ -502,9 +482,6 @@ def _run_validate_phase(
                 }
                 for v in _cv_all
             ]
-    else:
-        state.convention_violations = []
-
     return _ValidateOutcome.PASS, None
 
 

--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -602,6 +602,47 @@ def review_to_dev_handoff(result: ReviewResult) -> str:
     return "\n\n".join(parts)
 
 
+def convention_violations_to_review_findings(violations: list[dict] | None) -> list[ReviewFinding]:
+    """Convert blocking hard convention violations into actionable review-style findings."""
+    findings: list[ReviewFinding] = []
+    for violation in violations or []:
+        if not violation.get("blocking", False):
+            continue
+        file = str(violation.get("file") or "unknown")
+        rule = str(violation.get("rule") or "unknown")
+        detail = str(violation.get("detail") or "No details recorded.")
+        findings.append(
+            ReviewFinding(
+                severity="P1",
+                file=file,
+                line=None,
+                description=f"Hard convention violation [{rule}] in {file}: {detail}",
+                suggestion=f"Resolve the [{rule}] convention violation in {file}.",
+            )
+        )
+    return findings
+
+
+def append_convention_retry_findings(
+    existing_feedback: str | None, violations: list[dict] | None
+) -> str | None:
+    """Append blocking convention violations to dev retry findings in review format."""
+    convention_findings = convention_violations_to_review_findings(violations)
+    if not convention_findings:
+        return existing_feedback
+
+    convention_block = "\n".join(
+        [
+            "## Blocking Convention Violations",
+            "",
+            findings_to_markdown(convention_findings),
+        ]
+    )
+    if existing_feedback:
+        return f"{existing_feedback}\n\n{convention_block}"
+    return convention_block
+
+
 def _normalize_description(description: str) -> str:
     """Normalize a finding description for duplicate detection: lowercase + stripped."""
     return description.strip().lower()

--- a/tests/test_coord_convention_parallel.py
+++ b/tests/test_coord_convention_parallel.py
@@ -80,8 +80,7 @@ class TestConventionParallelCheck:
         # Convention violations are recorded on state
         assert len(state.convention_violations) == 1
         assert state.convention_violations[0]["rule"] == "max_module_lines"
-        assert "## Blocking Convention Violations" in state.last_review_findings
-        assert "`src/foo.py`" in state.last_review_findings
+        assert state.last_review_findings is None
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
@@ -127,8 +126,7 @@ class TestConventionParallelCheck:
         assert state.retry_reason == RetryReason.CONVENTION_VIOLATIONS
         assert len(state.convention_violations) == 1
         assert "Hard convention violations" in state.human_feedback
-        assert "## Blocking Convention Violations" in state.last_review_findings
-        assert "`src/foo.py`" in state.last_review_findings
+        assert state.last_review_findings is None
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")

--- a/tests/test_coord_convention_parallel.py
+++ b/tests/test_coord_convention_parallel.py
@@ -80,6 +80,8 @@ class TestConventionParallelCheck:
         # Convention violations are recorded on state
         assert len(state.convention_violations) == 1
         assert state.convention_violations[0]["rule"] == "max_module_lines"
+        assert "## Blocking Convention Violations" in state.last_review_findings
+        assert "`src/foo.py`" in state.last_review_findings
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
@@ -125,6 +127,8 @@ class TestConventionParallelCheck:
         assert state.retry_reason == RetryReason.CONVENTION_VIOLATIONS
         assert len(state.convention_violations) == 1
         assert "Hard convention violations" in state.human_feedback
+        assert "## Blocking Convention Violations" in state.last_review_findings
+        assert "`src/foo.py`" in state.last_review_findings
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")

--- a/tests/test_coord_dev_phase_routing.py
+++ b/tests/test_coord_dev_phase_routing.py
@@ -311,6 +311,79 @@ test_coverage:
         assert "Resolve the [no_scratch_files] convention violation" in retry_findings
         assert not mock_fix_prompt.called
 
+    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
+    @patch("theforge.coordinator.dev_phase.build_fix_prompt", wraps=None)
+    @patch("theforge.coordinator.dev_phase.build_dev_prompt", wraps=None)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_convention_violation_retry_does_not_duplicate_or_leak_stale_findings(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_pool,
+        mock_dev_prompt,
+        mock_fix_prompt,
+        mock_check_conventions,
+        tmp_path,
+    ):
+        """Retry prompts derive convention findings from the current validate result only."""
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            retry=RetryPolicy(max_dev_iterations=4, max_review_cycles=2),
+            conventions_hard=HardConventionsConfig(max_module_lines=500),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        violation = type(
+            "Violation",
+            (),
+            {
+                "rule": "no_scratch_files",
+                "file": "test_resolution_commentary.py",
+                "detail": "Unexpected root-level scratch file",
+                "blocking": True,
+            },
+        )()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "FAIL", "FAIL", "PASS"])
+        mock_check_conventions.side_effect = [
+            ([violation], [violation]),
+            ([violation], [violation]),
+            ([], []),
+            ([], []),
+        ]
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.side_effect = [
+            _make_agent_result(),
+            _make_agent_result(),
+            _make_agent_result(),
+            _make_agent_result(),
+        ]
+        mock_dev_prompt.return_value = "full dev prompt"
+        mock_fix_prompt.return_value = "fix prompt"
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert mock_dev_prompt.call_count == 4
+        first_retry_findings = mock_dev_prompt.call_args_list[1].kwargs["review_findings"]
+        second_retry_findings = mock_dev_prompt.call_args_list[2].kwargs["review_findings"]
+        third_retry_findings = mock_dev_prompt.call_args_list[3].kwargs["review_findings"]
+        assert first_retry_findings is not None
+        assert first_retry_findings.count("## Blocking Convention Violations") == 1
+        assert second_retry_findings is not None
+        assert second_retry_findings.count("## Blocking Convention Violations") == 1
+        assert third_retry_findings is None
+        assert not mock_fix_prompt.called
+
     @patch("theforge.coordinator.dev_phase.build_fix_prompt", wraps=None)
     @patch("theforge.coordinator.dev_phase.build_dev_prompt", wraps=None)
     @patch("theforge.coordinator.review_pool.run_agent_pool")

--- a/tests/test_coord_dev_phase_routing.py
+++ b/tests/test_coord_dev_phase_routing.py
@@ -5,6 +5,7 @@ Covers: prompt routing (fix vs dev prompt) and session resume/carry-through.
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from unittest.mock import patch
 
@@ -30,6 +31,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.config.types import HardConventionsConfig
 from theforge.coordinator.dev_phase import (
     _current_cycle_p1s_for_dev_prompt,
     _prior_open_p1s_for_dev_prompt,
@@ -244,6 +246,70 @@ test_coverage:
         assert result.state.dev_iteration == 2
         assert not mock_fix_prompt.called, "build_fix_prompt must NOT be called on gate_fail retry"
         assert mock_dev_prompt.call_count == 2, "build_dev_prompt should be called both times"
+
+    @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
+    @patch("theforge.coordinator.dev_phase.build_fix_prompt", wraps=None)
+    @patch("theforge.coordinator.dev_phase.build_dev_prompt", wraps=None)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_convention_violation_retry_injects_actionable_findings_into_dev_prompt(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_pool,
+        mock_dev_prompt,
+        mock_fix_prompt,
+        mock_check_conventions,
+        tmp_path,
+    ):
+        """Blocking convention violations are propagated into the next dev retry prompt."""
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            conventions_hard=HardConventionsConfig(max_module_lines=500),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        violation = type(
+            "Violation",
+            (),
+            {
+                "rule": "no_scratch_files",
+                "file": "test_resolution_commentary.py",
+                "detail": "Unexpected root-level scratch file",
+                "blocking": True,
+            },
+        )()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, ["PASS", "PASS"])
+        mock_check_conventions.side_effect = [
+            ([violation], [violation]),
+            ([], []),
+        ]
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.side_effect = [_make_agent_result(), _make_agent_result()]
+        mock_dev_prompt.return_value = "full dev prompt"
+        mock_fix_prompt.return_value = "fix prompt"
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert mock_dev_prompt.call_count == 2
+        retry_findings = mock_dev_prompt.call_args_list[1].kwargs["review_findings"]
+        assert retry_findings is not None
+        assert "## Blocking Convention Violations" in retry_findings
+        assert "[P1]" in retry_findings
+        assert "test_resolution_commentary.py" in retry_findings
+        assert "no_scratch_files" in retry_findings
+        assert "Resolve the [no_scratch_files] convention violation" in retry_findings
+        assert not mock_fix_prompt.called
 
     @patch("theforge.coordinator.dev_phase.build_fix_prompt", wraps=None)
     @patch("theforge.coordinator.dev_phase.build_dev_prompt", wraps=None)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -7,6 +7,8 @@ from theforge.review import (
     _coerce_line,
     _dedup_findings,
     _try_parse_review,
+    append_convention_retry_findings,
+    convention_violations_to_review_findings,
     findings_to_markdown,
     merge_review_results,
     parse_plan_review_output,
@@ -140,6 +142,50 @@ class TestFindingsToMarkdown:
         assert "**Fix:** Fix it" in md
         assert "[P2]" in md
         assert "`src/bar.py`" in md
+
+
+class TestConventionViolationsToReviewFindings:
+    def test_blocking_violations_are_converted_to_p1_findings(self):
+        findings = convention_violations_to_review_findings(
+            [
+                {
+                    "rule": "no_scratch_files",
+                    "file": "test_resolution_commentary.py",
+                    "detail": "Unexpected root-level scratch file",
+                    "blocking": True,
+                },
+                {
+                    "rule": "max_module_lines",
+                    "file": "src/large.py",
+                    "detail": "Module exceeds limit",
+                    "blocking": False,
+                },
+            ]
+        )
+
+        assert len(findings) == 1
+        assert findings[0].severity == "P1"
+        assert findings[0].file == "test_resolution_commentary.py"
+        assert "no_scratch_files" in findings[0].description
+        assert "Resolve the [no_scratch_files]" in findings[0].suggestion
+
+    def test_append_convention_retry_findings_preserves_existing_feedback(self):
+        output = append_convention_retry_findings(
+            "## Review Summary\nPrior review feedback",
+            [
+                {
+                    "rule": "no_scratch_files",
+                    "file": "test_resolution_commentary.py",
+                    "detail": "Unexpected root-level scratch file",
+                    "blocking": True,
+                }
+            ],
+        )
+
+        assert output is not None
+        assert "## Review Summary" in output
+        assert "## Blocking Convention Violations" in output
+        assert "`test_resolution_commentary.py`" in output
 
 
 class TestParsePlanReviewOutput:


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Fix correctly addresses prior P1: convention violations are now injected dynamically at dev prompt construction time via _retry_review_findings_for_dev_prompt(), without mutating state.last_review_findings. state.convention_violations is freshly set from each validate iteration. Tests verify no duplication or stale leakage. | [claude-opus] Prior P1 (mutated last_review_findings accumulating stale convention findings across retries) is resolved by deriving the retry findings on-demand in dev_phase from state.convention_violations, which is now reset each validate cycle. New seam test verifies no duplication across iterations and that findings clear once violations are gone.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $4.62
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Hard convention violations are not propagated to dev retry input as actionable findings (GitHub Issue #1017)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1017