### PR TITLE
Persistent-finding classifier matches on same-file alone — tags distinct bugs in the same module as persistent

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -527,34 +527,45 @@ def _persistent_p1_descriptions(
 
 
 def _p1_findings_match(current: ReviewFinding, previous: ReviewFinding) -> bool:
-    """Return True when two P1 findings should be treated as the same persistent issue."""
-    if (
-        current.file
-        and previous.file
-        and current.line is not None
-        and previous.line is not None
-        and current.file != "unknown"
-        and previous.file != "unknown"
-        and current.file == previous.file
-        and current.line == previous.line
-    ):
-        return True
+    """Return True when two P1 findings should be treated as the same persistent issue.
 
-    if (
-        current.description
-        and previous.description
-        and (
+    A match requires file-level evidence plus either:
+    - line proximity (within 10 lines of the same file), or
+    - meaningful description overlap (substring or >=60% token overlap) in the same file.
+
+    Description-only overlap without file evidence is rejected to avoid tagging distinct
+    bugs in the same module as persistent when they happen to share vocabulary.
+    When neither finding has a real file (both are "unknown"/null), description overlap
+    alone is accepted as a fallback.
+    """
+    curr_has_file = bool(current.file and current.file != "unknown")
+    prev_has_file = bool(previous.file and previous.file != "unknown")
+    same_real_file = curr_has_file and prev_has_file and current.file == previous.file
+
+    # Same file + line proximity (covers exact match and nearby edits)
+    if same_real_file and current.line is not None and previous.line is not None:
+        if abs(current.line - previous.line) <= 10:
+            return True
+
+    # Description-based matching
+    desc_match = False
+    if current.description and previous.description:
+        if (
             current.description in previous.description
             or previous.description in current.description
-        )
-    ):
-        return True
+        ):
+            desc_match = True
+        else:
+            curr_tokens = set(re.findall(r"\w+", current.description.lower()))
+            prev_tokens = set(re.findall(r"\w+", previous.description.lower()))
+            if curr_tokens and prev_tokens:
+                overlap = len(curr_tokens & prev_tokens) / max(len(curr_tokens), len(prev_tokens))
+                if overlap >= 0.6:
+                    desc_match = True
 
-    curr_tokens = set(re.findall(r"\w+", current.description.lower()))
-    prev_tokens = set(re.findall(r"\w+", previous.description.lower()))
-    if curr_tokens and prev_tokens:
-        overlap = len(curr_tokens & prev_tokens) / max(len(curr_tokens), len(prev_tokens))
-        if overlap >= 0.6:
+    if desc_match:
+        # Require same real file, or accept when neither has a known file location
+        if same_real_file or (not curr_has_file and not prev_has_file):
             return True
 
     return False

--- a/test_unknown.py
+++ b/test_unknown.py
@@ -1,7 +1,0 @@
-from theforge.coordinator.preflight import _p1_findings_match
-from theforge.review import ReviewFinding
-
-curr = ReviewFinding(severity="P1", file="unknown", line=None, description="foo", suggestion=None)
-prev = ReviewFinding(severity="P1", file="unknown", line=None, description="bar", suggestion=None)
-
-print(_p1_findings_match(curr, prev))

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -162,12 +162,12 @@ class TestHasPersistentP1:
         assert _has_persistent_p1(curr, prev) is True
 
     def test_persistent_p1_different_files(self):
-        """Same P1 description on different files → still detected as persistent."""
+        """Same description on different real files is NOT persistent (no file evidence)."""
         curr = [
             _make_review_finding(file="src/coordinator.py", description="extend resets session ID")
         ]
         prev = [_make_review_finding(file="src/task.py", description="extend resets session ID")]
-        assert _has_persistent_p1(curr, prev) is True
+        assert _has_persistent_p1(curr, prev) is False
 
     def test_p1_similarity_matching(self):
         """Substring containment and token overlap both match."""
@@ -203,6 +203,65 @@ class TestHasPersistentP1:
         """'unknown' file P1s with similar descriptions are still caught by text similarity."""
         curr = [_make_review_finding(file="unknown", description="gate_override never wired")]
         prev = [_make_review_finding(file="unknown", description="gate_override never wired in")]
+        assert _has_persistent_p1(curr, prev) is True
+
+    def test_same_file_far_apart_lines_distinct_descriptions_not_persistent(self):
+        """Two P1s in the same file at distant lines with distinct descriptions are not persistent.
+
+        Reproduces the v0.9.0 issue #169 scenario: cycle 1 finds a bug at engine.py:770,
+        dev fixes it, cycle 2 finds a different bug at engine.py:957. These must NOT be
+        tagged persistent even though both share the file name.
+        """
+        curr = [
+            _make_review_finding(
+                file="src/engine.py",
+                line=957,
+                description="resume entry points omit profile update",
+            )
+        ]
+        prev = [
+            _make_review_finding(
+                file="src/engine.py",
+                line=770,
+                description="model profiles nested under escalation_memory guard skips update",
+            )
+        ]
+        assert _has_persistent_p1(curr, prev) is False
+
+    def test_same_file_nearby_lines_is_persistent(self):
+        """Same file, lines within 10 of each other → persistent even with different wording."""
+        curr = [
+            _make_review_finding(
+                file="src/engine.py",
+                line=775,
+                description="profile update dropped after refactor",
+            )
+        ]
+        prev = [
+            _make_review_finding(
+                file="src/engine.py",
+                line=770,
+                description="model profile update skipped by guard",
+            )
+        ]
+        assert _has_persistent_p1(curr, prev) is True
+
+    def test_same_file_description_overlap_is_persistent(self):
+        """Same file + description overlap → persistent even without line numbers."""
+        curr = [
+            _make_review_finding(
+                file="src/engine.py",
+                line=None,
+                description="model profiles update skipped after escalation guard",
+            )
+        ]
+        prev = [
+            _make_review_finding(
+                file="src/engine.py",
+                line=None,
+                description="model profiles update missing in escalation guard path",
+            )
+        ]
         assert _has_persistent_p1(curr, prev) is True
 
 
@@ -272,7 +331,7 @@ summary: "New blocker in same file."
 findings:
   - severity: P1
     file: src/cli.py
-    line: 43
+    line: 957
     description: "cli.py now drops abandon handling after wiring gate_override"
     suggestion: "Preserve the abandon path"
 story_compliance:

--- a/tests/test_coord_review_phase_cycle.py
+++ b/tests/test_coord_review_phase_cycle.py
@@ -401,7 +401,8 @@ class TestHasPersistentP1:
             suggestion="fix it",
         )
 
-    def test_same_description_different_files_returns_true(self):
+    def test_same_description_different_files_returns_false(self):
+        """Same description on different real files is NOT persistent — no file evidence."""
         from theforge.coordinator.preflight import _has_persistent_p1
 
         curr = [
@@ -412,7 +413,7 @@ class TestHasPersistentP1:
         prev = [
             self._make_finding("P1", "coordinator routing ignores extend path", file="task.py")
         ]
-        assert _has_persistent_p1(curr, prev) is True
+        assert _has_persistent_p1(curr, prev) is False
 
     def test_same_description_same_files_returns_true(self):
         from theforge.coordinator.preflight import _has_persistent_p1


### PR DESCRIPTION
## Summary

Persistence matching now requires same-file evidence as specified, and the touched runtime path is covered by passing unit and integration tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.77
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Persistent-finding classifier matches on same-file alone — tags distinct bugs in the same module as persistent (GitHub Issue #956)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #956