### PR TITLE
Sprint summary excludes tracked batch preflight cost when stories are skipped

### DIFF
--- a/src/theforge/coordinator/preflight_cache.py
+++ b/src/theforge/coordinator/preflight_cache.py
@@ -118,6 +118,7 @@ def apply_cached_preflight_state(
         if cached_state.preflight_likely_files is None
         else list(cached_state.preflight_likely_files)
     )
+    state.preflight_result = cached_state.preflight_result
     state.preflight_duration_s = cached_state.preflight_duration_s
     state.preflight_cached = True
     state.preflight_cached_original_verdict = cached_state.preflight_verdict

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import replace
 from unittest.mock import patch
 
+import pytest
 from coord_test_helpers import _make_agent_result, _make_config, _make_task
 
 from theforge.coordinator.engine import run_task
@@ -143,6 +144,46 @@ class TestCachedPreflightVerdictDispatch:
 
         assert result.state.preflight_complexity_score == 7
         assert result.state.preflight_complexity == "medium"
+
+    def test_cached_preflight_cost_flows_into_result_state(self, tmp_path):
+        """Batch preflight cost must appear in result.state.total_preflight_cost.
+
+        When a story uses a cached preflight state (e.g. ALREADY_DONE from batch
+        preflight), the cost recorded in the batch run must be carried into the
+        per-story result so the sprint accumulator counts it.
+        """
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        preflight_agent_result = _make_agent_result(cost_usd=0.349, profile_name="preflight")
+
+        cached_state = _with_cache_snapshot(
+            replace(
+                CoordinatorState(),
+                preflight_verdict="ALREADY_DONE",
+                preflight_reason="All acceptance criteria already satisfied.",
+                preflight_complexity="medium",
+                preflight_sufficiency="implementation_ready",
+                preflight_work_type="feature",
+                preflight_result=preflight_agent_result,
+            )
+        )
+
+        with (
+            patch("theforge.coordinator.util._run_shell", side_effect=_shell_with_matching_cache),
+            patch("theforge.coordinator.preflight_flow._is_branch_merged", return_value=True),
+            patch("theforge.coordinator.preflight_flow.run_agent"),
+            patch("theforge.coordinator.dev_phase.run_agent"),
+            patch("theforge.coordinator.plan_flow.run_agent"),
+            patch("theforge.coordinator.review_pool.run_agent_pool"),
+        ):
+            result = run_task(config, task, cached_preflight_state=cached_state)
+
+        assert result.state.preflight_result is preflight_agent_result
+        assert result.state.total_preflight_cost == pytest.approx(0.349)
+        assert result.state.total_cost == pytest.approx(0.349)
 
     def test_stale_cached_preflight_is_invalidated_and_rerun(self, tmp_path):
         """Changed git state must invalidate cached preflight and trigger a fresh run."""

--- a/tests/test_sprint_already_done_preflight_cost.py
+++ b/tests/test_sprint_already_done_preflight_cost.py
@@ -1,0 +1,118 @@
+"""Seam test: batch preflight cost flows into sprint total when stories are ALREADY_DONE.
+
+When batch preflight returns ALREADY_DONE for all stories, the sprint summary must
+reflect the preflight spend rather than reporting $0.00.
+
+Issue: https://github.com/fuzzypete/theforge/issues/995
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from coord_test_helpers import _make_agent_result
+
+from tests.test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+from theforge.sprint.runner import run_sprint
+
+ALREADY_DONE_OUTPUT = """\
+```yaml
+verdict: ALREADY_DONE
+complexity: small
+complexity_score: 2
+sufficiency: implementation_ready
+work_type: feature
+bundle_candidate: false
+likely_files:
+  - src/theforge/sprint/runner.py
+reason: "All acceptance criteria are already satisfied."
+criteria_checked:
+  - criterion: "Feature is complete"
+    satisfied: true
+    files_checked:
+      - src/theforge/sprint/runner.py
+    runtime_path: src/theforge/sprint/runner.py
+    evidence: "Function already exists and is complete."
+```
+"""
+
+PREFLIGHT_COST_USD = 0.349
+
+
+def _shell_side_effect(workspace_root: Path):
+    def side_effect(cmd, cwd, **kwargs):
+        rendered = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+        cwd_path = Path(cwd)
+
+        if rendered.startswith("mkdir -p "):
+            target = rendered.removeprefix("mkdir -p ").strip()
+            (workspace_root / target).mkdir(parents=True, exist_ok=True)
+            return (True, "")
+        if "git status --porcelain" in rendered:
+            return (True, "")
+        if "git worktree list --porcelain" in rendered:
+            return (True, "")
+        if "git branch --list" in rendered:
+            return (True, "")
+        if "git rev-parse --abbrev-ref HEAD" in rendered:
+            return (True, f"forge/{cwd_path.name}")
+        if "git rev-parse" in rendered:
+            return (True, "abc1234deadbeef")
+        if "git log" in rendered and "--format=%ct" in rendered:
+            return (True, "1713900000")
+        if "git log" in rendered:
+            return (True, "")
+        if "--is-ancestor" in rendered:
+            return (True, "")
+        if "rev-list" in rendered and "--count" in rendered:
+            return (True, "0")
+        return (True, "")
+
+    return side_effect
+
+
+class TestSprintAlreadyDonePreflightCost:
+    def test_sprint_total_includes_batch_preflight_cost_when_all_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """Sprint total must include batch preflight cost when all stories are ALREADY_DONE.
+
+        Seam boundary: batch preflight cost in CoordinatorState.preflight_result must
+        survive apply_cached_preflight_state() and appear in result.state.total_cost,
+        which the sprint accumulator then counts even for skipped stories.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
+        config = _make_config(tmp_path)
+
+        shell_side_effect = _shell_side_effect(tmp_path)
+
+        def fake_preflight(*args, **kwargs):
+            return _make_agent_result(
+                success=True,
+                output=ALREADY_DONE_OUTPUT,
+                cost_usd=PREFLIGHT_COST_USD,
+                profile_name="preflight",
+            )
+
+        with (
+            patch("theforge.sprint.runner._run_baseline_gate", return_value={"passed": True}),
+            patch("theforge.sprint.runner.resolve_satisfied_dependencies", return_value=set()),
+            patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+            patch("theforge.coordinator.util._run_shell", side_effect=shell_side_effect),
+            patch("theforge.coordinator.preflight_flow.run_agent", side_effect=fake_preflight),
+            patch("theforge.coordinator.preflight_flow._is_branch_merged", return_value=False),
+        ):
+            result = run_sprint(config, manifest_path, no_pull=True)
+
+        assert result.specs_skipped == 1, (
+            f"Expected 1 skipped story (ALREADY_DONE), got {result.specs_skipped}"
+        )
+        assert result.specs_succeeded == 0
+        assert result.specs_failed == 0
+        assert result.total_cost_usd == pytest.approx(PREFLIGHT_COST_USD, abs=1e-6), (
+            f"Sprint total ${result.total_cost_usd:.4f} must include batch preflight "
+            f"cost ${PREFLIGHT_COST_USD} — not $0.00"
+        )


### PR DESCRIPTION
## Summary

Cached batch preflight cost now flows through coordinator state into sprint totals and summary artifacts, including ALREADY_DONE stories.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.71
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint summary excludes tracked batch preflight cost when stories are skipped (GitHub Issue #995)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #995