### PR TITLE
Plan-review has no retry for transient provider errors — one 500 shrinks the reviewer pool

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -354,6 +354,9 @@ def load_config(config_path: Path) -> ForgeConfig:
         max_dev_iterations=int(retry_data.get("max_dev_iterations", 3)),
         max_review_cycles=int(retry_data.get("max_review_cycles", 2)),
         max_review_parse_retries=int(retry_data.get("max_review_parse_retries", 2)),
+        max_plan_review_transport_retries=int(
+            retry_data.get("max_plan_review_transport_retries", 2)
+        ),
         max_plan_regen_attempts=int(retry_data.get("max_plan_regen_attempts", 3)),
         demotion_threshold=int(retry_data.get("demotion_threshold", 2)),
         escalate_policy=str(retry_data.get("escalate_policy", "prompt")),

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -209,6 +209,9 @@ class RetryPolicy:
     max_dev_iterations: int = 3  # retries within a single review cycle
     max_review_cycles: int = 2  # full dev->review loops
     max_review_parse_retries: int = 2  # reviewer retries on parse/schema error per cycle
+    max_plan_review_transport_retries: int = (
+        2  # per-reviewer retries on transient plan-review transport/provider failure
+    )
     max_plan_regen_attempts: int = 3  # plan review rejection → regen cycles before escalating
     demotion_threshold: int = 2  # parse failures per reviewer per run before exclusion; 0 disables
     plan_escalation_threshold: int = (

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -523,6 +523,11 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                     else {}
                 ),
                 **(
+                    {"transport_retries": state.plan_review_transport_retries}
+                    if state.plan_review_transport_retries
+                    else {}
+                ),
+                **(
                     {"reviewer_failures": state.plan_review_failures}
                     if state.plan_review_failures
                     else {}

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -73,6 +73,34 @@ if TYPE_CHECKING:
 _log = _cu._log
 _log_verbose = _cu._log_verbose
 
+_TRANSIENT_PLAN_REVIEW_ERROR_PATTERNS = (
+    "429",
+    "rate limit",
+    "rate-limited",
+    "resource_exhausted",
+    "resource exhausted",
+    "quota exceeded",
+    "quota_exceeded",
+    "500",
+    "502",
+    "503",
+    "504",
+    "internal error",
+    "server error",
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "connection reset",
+    "connection-reset",
+    "econnreset",
+    "connection aborted",
+    "connection refused",
+    "peer closed connection",
+    "temporarily unavailable",
+    "try again later",
+    "timeout awaiting headers",
+)
+
 # ── Lazy runner slots ─────────────────────────────────────────────────
 # None until first call; tests may replace before calling run_task.
 # Patch targets:
@@ -92,6 +120,89 @@ def _ensure_runners() -> None:
         run_agent = _r.run_agent
     if run_agent_pool is None:
         run_agent_pool = _r.run_agent_pool
+
+
+def _is_transient_plan_review_failure(result: "AgentResult") -> bool:
+    """Return True when a failed plan-review invocation looks transient/retryable."""
+    if result.success:
+        return False
+    failure_code = (result.failure_code or "").lower()
+    if failure_code in {"rate_limit", "provider_internal_error", "connection_reset"}:
+        return True
+    output = (result.output or "").lower()
+    return any(pattern in output for pattern in _TRANSIENT_PLAN_REVIEW_ERROR_PATTERNS)
+
+
+def _summarize_plan_review_failure(result: "AgentResult") -> str:
+    """Produce a compact, audit-friendly failure summary."""
+    parts = [f"exit={result.exit_code}"]
+    if result.failure_code:
+        parts.append(f"failure_code={result.failure_code}")
+    output = " ".join((result.output or "").split())
+    if output:
+        parts.append(output[:200])
+    return ": ".join((parts[0], " | ".join(parts[1:]))) if len(parts) > 1 else parts[0]
+
+
+def _retry_transient_plan_review_failures(
+    *,
+    prompt: str,
+    profiles: list[ModelProfile],
+    results: list["AgentResult"],
+    state: CoordinatorState,
+    config: ForgeConfig,
+    workspace_path: Path,
+    attempt: int,
+) -> tuple[list["AgentResult"], list[dict]]:
+    """Retry transient plan-review transport failures per reviewer."""
+    max_retries = config.retry.max_plan_review_transport_retries
+    if max_retries <= 0:
+        return results, []
+
+    retried_results = list(results)
+    retry_events: list[dict] = []
+
+    for index, (profile, result) in enumerate(zip(profiles, retried_results)):
+        if not _is_transient_plan_review_failure(result):
+            continue
+
+        retry_count = 0
+        current = result
+        while retry_count < max_retries and _is_transient_plan_review_failure(current):
+            retry_count += 1
+            _log(
+                f"  ↻ PLAN_REVIEW   {profile.name} transient transport failure "
+                f"(retry {retry_count}/{max_retries})"
+            )
+            retried = run_agent(
+                prompt=prompt,
+                profile=profile,
+                working_dir=workspace_path,
+                quiet=True,
+                secrets=config.secrets,
+                session_id=current.session_id if profile.mode == "cli" else None,
+            )
+            if retried.session_id:
+                state.plan_review_session_ids[profile.name] = retried.session_id
+            state.plan_review_results.append(retried)
+            _write_log_artifact(
+                state.log_dir,
+                f"plan-review/attempt-{attempt}/{profile.name}-retry{retry_count}.yaml",
+                retried.output or "",
+            )
+            retry_events.append(
+                {
+                    "attempt": attempt,
+                    "reviewer": profile.name,
+                    "retry": retry_count,
+                    "error": _summarize_plan_review_failure(current),
+                }
+            )
+            current = retried
+
+        retried_results[index] = current
+
+    return retried_results, retry_events
 
 
 def _clean_stale_plan_files(workspace_path: Path) -> None:
@@ -464,6 +575,16 @@ def _run_plan_agent_review(
             session_ids=_pool_session_ids,
             secrets=config.secrets,
         )
+        pr_results, _transport_retry_events = _retry_transient_plan_review_failures(
+            prompt=pr_prompt,
+            profiles=par_profiles,
+            results=pr_results,
+            state=state,
+            config=config,
+            workspace_path=workspace_path,
+            attempt=_attempt,
+        )
+        state.plan_review_transport_retries.extend(_transport_retry_events)
         _pr_elapsed = time.monotonic() - _pr_start
         state.plan_review_durations.append(_pr_elapsed)
 
@@ -481,11 +602,16 @@ def _run_plan_agent_review(
         _parsed_prs: list[PlanReviewResult] = []
         for _prof, _res in zip(par_profiles, pr_results):
             if not _res.success:
+                _failure_summary = _summarize_plan_review_failure(_res)
                 _log(
                     f"  ✗ PLAN_REVIEW   {_prof.name} failed "
-                    f"(exit={_res.exit_code}) — treating as REJECT"
+                    f"({_failure_summary}) — treating as REJECT"
                 )
-                _parsed = parse_plan_review_output("")  # force parse error → REJECT
+                _parsed = PlanReviewResult(
+                    verdict="REJECT",
+                    findings=[],
+                    parse_errors=[f"Transport failure: {_failure_summary}"],
+                )
             else:
                 if not (_res.output or "").strip():
                     _log(
@@ -497,6 +623,12 @@ def _run_plan_agent_review(
                     _parsed = parse_plan_review_output(_res.output)
 
             if _parsed.parse_errors:
+                _failure_kind = "parse" if _res.success else "transport"
+                _retry_count = sum(
+                    1
+                    for _event in _transport_retry_events
+                    if _event["attempt"] == _attempt and _event["reviewer"] == _prof.name
+                )
                 _log(
                     f"  ⚠ PLAN_REVIEW   {_prof.name} parse issues: "
                     f"{'; '.join(_parsed.parse_errors)}"
@@ -505,6 +637,9 @@ def _run_plan_agent_review(
                     {
                         "attempt": _attempt,
                         "reviewer": _prof.name,
+                        "failure_kind": _failure_kind,
+                        "retry_count": _retry_count,
+                        "retryable": (_failure_kind == "transport"),
                         "errors": list(_parsed.parse_errors),
                     }
                 )

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -169,6 +169,7 @@ def _retry_transient_plan_review_failures(
         retry_count = 0
         current = result
         while retry_count < max_retries and _is_transient_plan_review_failure(current):
+            state.plan_review_results.append(current)
             retry_count += 1
             _log(
                 f"  ↻ PLAN_REVIEW   {profile.name} transient transport failure "
@@ -184,7 +185,6 @@ def _retry_transient_plan_review_failures(
             )
             if retried.session_id:
                 state.plan_review_session_ids[profile.name] = retried.session_id
-            state.plan_review_results.append(retried)
             _write_log_artifact(
                 state.log_dir,
                 f"plan-review/attempt-{attempt}/{profile.name}-retry{retry_count}.yaml",
@@ -601,6 +601,7 @@ def _run_plan_agent_review(
 
         _parsed_prs: list[PlanReviewResult] = []
         for _prof, _res in zip(par_profiles, pr_results):
+            _transport_failure = _is_transient_plan_review_failure(_res)
             if not _res.success:
                 _failure_summary = _summarize_plan_review_failure(_res)
                 _log(
@@ -623,7 +624,12 @@ def _run_plan_agent_review(
                     _parsed = parse_plan_review_output(_res.output)
 
             if _parsed.parse_errors:
-                _failure_kind = "parse" if _res.success else "transport"
+                if _res.success:
+                    _failure_kind = "parse"
+                elif _transport_failure:
+                    _failure_kind = "transport"
+                else:
+                    _failure_kind = _res.failure_code or "generic"
                 _retry_count = sum(
                     1
                     for _event in _transport_retry_events
@@ -639,7 +645,7 @@ def _run_plan_agent_review(
                         "reviewer": _prof.name,
                         "failure_kind": _failure_kind,
                         "retry_count": _retry_count,
-                        "retryable": (_failure_kind == "transport"),
+                        "retryable": _transport_failure,
                         "errors": list(_parsed.parse_errors),
                     }
                 )

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -322,9 +322,12 @@ class CoordinatorState:
     plan_review_results: list[AgentResult] = field(
         default_factory=list
     )  # separate from plan_results to avoid corrupting plan generation cost tracking
+    plan_review_transport_retries: list[dict] = field(
+        default_factory=list
+    )  # per-retry audit trail: {"attempt": int, "reviewer": str, "retry": int, "error": str}
     plan_review_failures: list[dict] = field(
         default_factory=list
-    )  # per-reviewer parse failures: {"attempt": int, "reviewer": str, "errors": list[str]}
+    )  # per-reviewer failures: {"attempt": int, "reviewer": str, "errors": list[str], ...}
     plan_attempt_metadata: list[dict] = field(
         default_factory=list
     )  # per-attempt: {files_touched, p1_count, p2_count, finding_themes}

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -1592,6 +1592,8 @@ class TestPlanReviewerFailureAudit:
         assert result.state.plan_review_decision == "approve"
         assert result.state.plan_review_failures == []
         assert len(result.state.plan_review_transport_retries) == 1
+        assert len(result.state.plan_review_results) == 3
+        assert result.state.total_plan_review_cost == pytest.approx(0.20)
         retry = result.state.plan_review_transport_retries[0]
         assert retry["reviewer"] == "reviewer-a"
         assert retry["retry"] == 1
@@ -1699,6 +1701,8 @@ class TestPlanReviewerFailureAudit:
         assert result.state.plan_review_decision == "reject"
         assert "minimum required is 2" in (result.message or "")
         assert len(result.state.plan_review_transport_retries) == 2
+        assert len(result.state.plan_review_results) == 4
+        assert result.state.total_plan_review_cost == pytest.approx(0.18)
         assert len(result.state.plan_review_failures) == 1
         failure = result.state.plan_review_failures[0]
         assert failure["reviewer"] == "reviewer-a"
@@ -1706,6 +1710,61 @@ class TestPlanReviewerFailureAudit:
         assert failure["retryable"] is True
         assert failure["retry_count"] == 2
         assert "Transport failure:" in failure["errors"][0]
+
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_non_transient_plan_review_failure_is_not_labeled_transport(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Non-retryable reviewer failures retain a non-transport failure kind."""
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_regen_attempts=0,
+                max_plan_review_transport_retries=2,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nA plan.", cost_usd=0.10),
+        ]
+        mock_pool.return_value = [
+            _make_agent_result(
+                success=False,
+                output="authentication failed",
+                cost_usd=0.08,
+                profile_name="plan-review",
+                session_id=None,
+            )
+        ]
+        mock_pool.return_value[0] = dataclasses.replace(
+            mock_pool.return_value[0], failure_code="auth_error"
+        )
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.plan_review_transport_retries == []
+        assert len(result.state.plan_review_failures) == 1
+        failure = result.state.plan_review_failures[0]
+        assert failure["reviewer"] == "plan-review"
+        assert failure["failure_kind"] == "auth_error"
+        assert failure["retryable"] is False
+        assert failure["retry_count"] == 0
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -1506,6 +1506,214 @@ class TestPlanReviewerFailureAudit:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
+    def test_transient_plan_review_failure_retries_and_preserves_pool(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_plan_pool,
+        mock_human_review,
+        mock_code_pool,
+        tmp_path,
+    ):
+        """A transient 500 is retried before min_reviewers gating shrinks the pool."""
+        pool_config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_review_transport_retries=2,
+            ),
+            plan_agent_review=PlanAgentReviewConfig(
+                enabled=True,
+                min_reviewers=2,
+                pool=[
+                    ModelProfile(
+                        name="reviewer-a",
+                        provider="google",
+                        model="gemini-2.5-pro",
+                        budget_usd=2.00,
+                        timeout_seconds=600,
+                        allowed_tools=("Read", "Glob"),
+                    ),
+                    ModelProfile(
+                        name="reviewer-b",
+                        provider="deepseek",
+                        model="deepseek-chat",
+                        budget_usd=1.00,
+                        timeout_seconds=300,
+                        allowed_tools=("Read", "Glob"),
+                    ),
+                ],
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nA plan.", cost_usd=0.10),
+            _make_agent_result(
+                success=True,
+                output=PLAN_AGENT_APPROVE,
+                cost_usd=0.08,
+                profile_name="reviewer-a",
+            ),
+            _make_agent_result(success=True, output="Implemented."),
+        ]
+        mock_plan_pool.return_value = [
+            _make_agent_result(
+                success=False,
+                output="google.genai.errors.ServerError: 500 INTERNAL",
+                cost_usd=0.08,
+                profile_name="reviewer-a",
+            ),
+            _make_agent_result(
+                success=True,
+                output=PLAN_AGENT_APPROVE,
+                cost_usd=0.04,
+                profile_name="reviewer-b",
+            ),
+        ]
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config=pool_config, task=task, interactive=True)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.plan_review_decision == "approve"
+        assert result.state.plan_review_failures == []
+        assert len(result.state.plan_review_transport_retries) == 1
+        retry = result.state.plan_review_transport_retries[0]
+        assert retry["reviewer"] == "reviewer-a"
+        assert retry["retry"] == 1
+
+        audit = generate_audit_log(pool_config, task, result)
+        assert (
+            audit["plan_review"]["transport_retries"] == result.state.plan_review_transport_retries
+        )
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_transient_plan_review_failure_exhausts_retries_then_escalates(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_plan_pool,
+        mock_human_review,
+        mock_code_pool,
+        tmp_path,
+    ):
+        """Transient transport failures only shrink the pool after retry exhaustion."""
+        pool_config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_review_transport_retries=2,
+            ),
+            plan_agent_review=PlanAgentReviewConfig(
+                enabled=True,
+                min_reviewers=2,
+                pool=[
+                    ModelProfile(
+                        name="reviewer-a",
+                        provider="google",
+                        model="gemini-2.5-pro",
+                        budget_usd=2.00,
+                        timeout_seconds=600,
+                        allowed_tools=("Read", "Glob"),
+                    ),
+                    ModelProfile(
+                        name="reviewer-b",
+                        provider="deepseek",
+                        model="deepseek-chat",
+                        budget_usd=1.00,
+                        timeout_seconds=300,
+                        allowed_tools=("Read", "Glob"),
+                    ),
+                ],
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nA plan.", cost_usd=0.10),
+            _make_agent_result(
+                success=False,
+                output="500 INTERNAL provider failure",
+                cost_usd=0.03,
+                profile_name="reviewer-a",
+            ),
+            _make_agent_result(
+                success=False,
+                output="connection reset by peer",
+                cost_usd=0.03,
+                profile_name="reviewer-a",
+            ),
+        ]
+        mock_plan_pool.return_value = [
+            _make_agent_result(
+                success=False,
+                output="google.genai.errors.ServerError: 500 INTERNAL",
+                cost_usd=0.08,
+                profile_name="reviewer-a",
+            ),
+            _make_agent_result(
+                success=True,
+                output=PLAN_AGENT_APPROVE,
+                cost_usd=0.04,
+                profile_name="reviewer-b",
+            ),
+        ]
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config=pool_config, task=task, interactive=True)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.plan_review_decision == "reject"
+        assert "minimum required is 2" in (result.message or "")
+        assert len(result.state.plan_review_transport_retries) == 2
+        assert len(result.state.plan_review_failures) == 1
+        failure = result.state.plan_review_failures[0]
+        assert failure["reviewer"] == "reviewer-a"
+        assert failure["failure_kind"] == "transport"
+        assert failure["retryable"] is True
+        assert failure["retry_count"] == 2
+        assert "Transport failure:" in failure["errors"][0]
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
     def test_reviewer_failures_appear_in_audit(
         self,
         mock_shell,


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The implementation correctly retries transient plan-review transport failures before shrinking the reviewer pool. The prior Cycle 1 finding about the initial failed result not being recorded and the final retried result being double-counted has been fixed in commit 8c1a051: the initial failed result is now appended via state.plan_review_results.append(current) inside the while loop, and the redundant state.plan_review_results.append(retried) was removed, so the final retried result is added only once (via the extend at line 594). Tests verify cost tracking, result counts, and audit trail. No regressions were introduced. | [google-gemini-3.1-pro-preview] The fix correctly addresses the previous P1 finding by appending the initial failed result to state.plan_review_results and avoiding duplicate appends of the retried result. | [claude-opus] Cycle-1 P1 (lost initial failure cost / double-appended retry) is fixed: append-before-retry pattern ensures each plan-review result is recorded exactly once, verified by new cost assertions (0.20 and 0.18). Non-transient failure classification correctly preserved via captured _transport_failure flag.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $5.36
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Plan-review has no retry for transient provider errors — one 500 shrinks the reviewer pool (GitHub Issue #951)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #951