### PR TITLE
Sprint summary preserves stale escalation records when stories succeed in a subsequent run within the same sprint folder

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -105,6 +105,114 @@ def _save_accumulated_stories(
         pass
 
 
+def _load_story_summary_entry_from_audit(
+    sprint_log_dir: Path,
+    canonical_ref: str,
+    slug: str,
+) -> dict | None:
+    """Return a sprint-summary story entry derived from per-story audit.yaml."""
+    audit_path = sprint_log_dir / slug / "audit.yaml"
+    if not audit_path.exists():
+        return None
+
+    try:
+        with open(audit_path, encoding="utf-8") as f:
+            audit_data = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+
+    if not isinstance(audit_data, dict):
+        return None
+
+    outcome_block = audit_data.get("outcome")
+    timing_block = audit_data.get("timing")
+    preflight_block = audit_data.get("preflight")
+    cost_block = audit_data.get("cost")
+    iteration_block = audit_data.get("iterations")
+
+    if not isinstance(outcome_block, dict):
+        return None
+
+    final_phase = outcome_block.get("final_phase")
+    if not isinstance(final_phase, str) or not final_phase:
+        return None
+    if isinstance(preflight_block, dict) and preflight_block.get("verdict") == "ALREADY_DONE":
+        final_phase = "ALREADY_DONE"
+
+    display_key = (
+        f"Issue #{canonical_ref.split(':')[1]}"
+        if canonical_ref.startswith("issue:")
+        else canonical_ref
+    )
+
+    reviews = audit_data.get("reviews")
+    verdict = None
+    if isinstance(reviews, list) and reviews:
+        last_review = reviews[-1]
+        if isinstance(last_review, dict):
+            raw_verdict = last_review.get("verdict")
+            if isinstance(raw_verdict, str) and raw_verdict:
+                verdict = raw_verdict
+    if verdict is None and outcome_block.get("success") is True:
+        verdict = "APPROVE"
+
+    usage_summary = (
+        iteration_block.get("usage_summary") if isinstance(iteration_block, dict) else {}
+    )
+    if not isinstance(usage_summary, dict):
+        usage_summary = {}
+
+    dev_usage = usage_summary.get("dev") if isinstance(usage_summary.get("dev"), dict) else {}
+    review_usage = (
+        usage_summary.get("review") if isinstance(usage_summary.get("review"), dict) else {}
+    )
+
+    preflight_verdict = (
+        preflight_block.get("verdict") if isinstance(preflight_block, dict) else None
+    )
+
+    return {
+        "canonical_ref": canonical_ref,
+        "path": display_key,
+        "slug": slug,
+        "outcome": final_phase,
+        "verdict": verdict,
+        "cost_usd": round(float(cost_block.get("total_usd", 0.0)), 4)
+        if isinstance(cost_block, dict)
+        else 0.0,
+        "story_run_id": audit_data.get("run_id"),
+        "preflight": preflight_verdict,
+        "preflight_original_verdict": (
+            preflight_block.get("original_verdict") if isinstance(preflight_block, dict) else None
+        ),
+        "preflight_source_run_id": (
+            preflight_block.get("source_run_id") if isinstance(preflight_block, dict) else None
+        ),
+        "error": audit_data.get("error"),
+        "error_type": audit_data.get("error_type") or outcome_block.get("error_type"),
+        "outcome_code": (
+            audit_data.get("error_type") or outcome_block.get("error_type") or final_phase.lower()
+        ),
+        "merge": bool((audit_data.get("merge") or {}).get("merged", False)),
+        "iteration_usage": {
+            "dev": {
+                "used": dev_usage.get("used", 0),
+                "max": dev_usage.get("max"),
+                "hit_limit": bool(dev_usage.get("hit_limit", False)),
+                "early_finish": bool(dev_usage.get("early_finish", False)),
+            },
+            "review": {
+                "used": review_usage.get("used", 0),
+                "max": review_usage.get("max"),
+                "hit_limit": bool(review_usage.get("hit_limit", False)),
+                "early_finish": bool(review_usage.get("early_finish", False)),
+            },
+        },
+        "started_at": timing_block.get("started_at") if isinstance(timing_block, dict) else None,
+        "finished_at": timing_block.get("finished_at") if isinstance(timing_block, dict) else None,
+    }
+
+
 def _write_sprint_audit(
     manifest: SprintManifest | ResolvedSprint,
     result: SprintResult,
@@ -491,7 +599,9 @@ def _write_sprint_summary(
         elif canonical_ref in prior_by_ref:
             # Story ran under an earlier run_id — use its accumulated data instead
             # of emitting a SKIPPED entry (which would hide a completed story).
-            prior = prior_by_ref[canonical_ref]
+            prior = _load_story_summary_entry_from_audit(sprint_log_dir, canonical_ref, slug)
+            if prior is None:
+                prior = prior_by_ref[canonical_ref]
             entry = {k: v for k, v in prior.items() if k != "canonical_ref"}
             spec_entries.append(entry)
             accumulated_for_state.append(prior)

--- a/tests/test_sprint_reexec_summary.py
+++ b/tests/test_sprint_reexec_summary.py
@@ -81,3 +81,117 @@ def test_write_sprint_summary_merges_prior_run_story_and_counts_skip_correctly(
     by_slug = {story["slug"]: story for story in summary["stories"]}
     assert by_slug["issue-959"]["story_run_id"] == "run-old"
     assert by_slug["issue-960"]["outcome"] == "SKIPPED"
+
+
+def test_write_sprint_summary_prefers_story_audit_over_stale_accumulated_state(
+    tmp_path: Path,
+) -> None:
+    sprint_log_dir = tmp_path / ".forge" / "logs" / "issues-1015,1016"
+    sprint_log_dir.mkdir(parents=True, exist_ok=True)
+
+    persist_accumulated_story_state(
+        "sprint-xyz",
+        "issues-1015,1016",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "issue:1015",
+                "slug": "issue-1015",
+                "path": "Issue #1015",
+                "outcome": "ESCALATE",
+                "cost_usd": 0.0,
+                "story_run_id": "run-old-failed",
+                "preflight": "PROCEED",
+                "error": "WORKSPACE abort: base branch has diverged",
+                "error_type": "workspace_abort",
+                "depends_on": [],
+            }
+        ],
+    )
+
+    story_audit_dir = sprint_log_dir / "issue-1015"
+    story_audit_dir.mkdir(parents=True, exist_ok=True)
+    with open(story_audit_dir / "audit.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(
+            {
+                "run_id": "run-new-success",
+                "outcome": {
+                    "success": True,
+                    "final_phase": "DONE",
+                    "message": "done",
+                    "error_type": None,
+                },
+                "timing": {
+                    "started_at": "2026-04-25T12:00:00Z",
+                    "finished_at": "2026-04-25T12:05:00Z",
+                },
+                "cost": {"total_usd": 4.25},
+                "preflight": {
+                    "verdict": "PROCEED",
+                    "original_verdict": None,
+                    "source_run_id": None,
+                },
+                "iterations": {
+                    "usage_summary": {
+                        "dev": {"used": 1, "max": 3, "hit_limit": False, "early_finish": True},
+                        "review": {
+                            "used": 1,
+                            "max": 2,
+                            "hit_limit": False,
+                            "early_finish": True,
+                        },
+                    }
+                },
+                "reviews": [{"verdict": "APPROVE"}],
+                "merge": {"merged": True},
+                "error": None,
+                "error_type": None,
+            },
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+
+    result = SprintResult(
+        name="issues-1015,1016",
+        specs_total=1,
+        specs_succeeded=0,
+        specs_failed=0,
+        specs_skipped=1,
+        total_cost_usd=0.0,
+        budget_usd=20.0,
+        results=[],
+        stopped_reason=None,
+    )
+
+    manifest = SimpleNamespace(name="issues-1015,1016", budget_usd=20.0, max_parallel=2)
+    started_at = finished_at = datetime.datetime(
+        2026,
+        4,
+        25,
+        tzinfo=datetime.timezone.utc,
+    )
+
+    _write_sprint_summary(
+        manifest=manifest,
+        result=result,
+        canonical_refs=["issue:1015"],
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=60.0,
+        sprint_log_dir=sprint_log_dir,
+        slug_map={"issue:1015": "issue-1015"},
+        run_id="run-summary",
+        tasks_by_slug={"issue-1015": SimpleNamespace(depends_on=[])},
+        sprint_id="sprint-xyz",
+        project_root=tmp_path,
+    )
+
+    summary = yaml.safe_load((sprint_log_dir / "sprint-summary.yaml").read_text(encoding="utf-8"))
+    story = summary["stories"][0]
+
+    assert story["outcome"] == "DONE"
+    assert story["story_run_id"] == "run-new-success"
+    assert story["verdict"] == "APPROVE"
+    assert story["error"] is None
+    assert story["merge"] is True


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The change correctly implements sprint-summary hydration from per-story audit.yaml, satisfying both acceptance criteria. The new function _load_story_summary_entry_from_audit reads the authoritative per-story audit and uses its terminal outcome and run_id in preference to stale accumulated sprint state. The regression test directly covers the reported stale-ESCALATE scenario and passes. All 3474 existing tests also pass. | [google-gemini-3.1-pro-preview] Approved. The fix correctly loads the authoritative per-story audit to replace stale accumulated state for re-run stories. | [claude-opus] Hydration fix correctly prefers per-story audit.yaml over stale accumulated state when a story is absent from the current invocation; regression test covers the reported scenario and gate passes.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.19
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/sweagent/sprint_summary.py:None`** Audit-derived entry missing depends_on and batch fields. The _load_story_summary_entry_from_audit function returns a dictionary that lacks depends_on and batch keys, unlike regular entries from current runs or the prior accumulated state. If a re-run story had dependency metadata in its prior accumulated entry, that data is lost in the summary.
- **[P2] `src/theforge/sprint/audit.py:602`** The `_load_story_summary_entry_from_audit` function completely replaces the `prior` dictionary from `prior_by_ref`, which causes fields like `depends_on` and `batch` to be lost from the summary entry and the accumulated `state.yaml`. While not a critical failure, it is a regression in the summary output.
- **[P2] `src/theforge/sprint/audit.py:641`** The second loop in `_write_sprint_summary` (which processes stories in `prior_by_ref` that are not in `canonical_refs`) does not attempt to load from `audit.yaml`. If a subset of the sprint is run, the summary will still show stale state for stories not included in the current invocation.

## Story

Sprint summary preserves stale escalation records when stories succeed in a subsequent run within the same sprint folder (GitHub Issue #1030)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1030