### PR TITLE
Adaptive resource budgets — derive limits from complexity and run history

### DIFF
--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -251,32 +251,24 @@ def derive_limits(
     )
 
     if profile_stats is None:
-        audit["chosen_dev_max"] = static_dev_max
-        audit["chosen_dev_timeout_seconds"] = base_timeout_seconds
-        audit["chosen_dev_budget_usd"] = round(base_budget_usd, 4)
-        audit["review_history_sample_size"] = 0
-        audit["p75_review"] = 0
-        audit["chosen_review_max"] = floor_review
-        audit["rationale"] = (
-            "insufficient profile history for complexity band; using static configured limits"
+        chosen_dev = static_dev_max
+        chosen_timeout = base_timeout_seconds
+        chosen_budget = base_budget_usd
+        dev_rationale = "insufficient profile history for complexity band; using static configured dev limits"
+    else:
+        raw_dev = profile_stats["avg_iterations"] * _HEADROOM_FACTOR
+        chosen_dev = max(floor_dev, min(cap_dev, _ceil_int(raw_dev)))
+        timeout_per_iteration = base_timeout_seconds / max(static_dev_max, 1)
+        chosen_timeout = _ceil_int(chosen_dev * timeout_per_iteration)
+        chosen_budget = _round_money(profile_stats["avg_cost_usd"] * _HEADROOM_FACTOR)
+        audit["profile_raw_dev_max"] = round(raw_dev, 4)
+        dev_rationale = (
+            f"derived dev limits from {profile_runs} {complexity_band or 'unknown'}-band profile runs "
+            f"with {_HEADROOM_FACTOR}x headroom; timeout scaled from static per-iteration baseline."
         )
-        return AdaptiveLimits(
-            dev_max=static_dev_max,
-            review_max=floor_review,
-            dev_timeout_seconds=base_timeout_seconds,
-            dev_budget_usd=base_budget_usd,
-            audit=audit,
-        )
-
-    raw_dev = profile_stats["avg_iterations"] * _HEADROOM_FACTOR
-    chosen_dev = max(floor_dev, min(cap_dev, _ceil_int(raw_dev)))
-    timeout_per_iteration = base_timeout_seconds / max(static_dev_max, 1)
-    chosen_timeout = _ceil_int(chosen_dev * timeout_per_iteration)
-    chosen_budget = _round_money(profile_stats["avg_cost_usd"] * _HEADROOM_FACTOR)
-    audit["profile_raw_dev_max"] = round(raw_dev, 4)
     audit["chosen_dev_max"] = chosen_dev
     audit["chosen_dev_timeout_seconds"] = chosen_timeout
-    audit["chosen_dev_budget_usd"] = chosen_budget
+    audit["chosen_dev_budget_usd"] = round(chosen_budget, 4)
 
     # Review history: p75 of matching-complexity runs; records within ±1 of the score.
     history_sample = 0
@@ -306,11 +298,7 @@ def derive_limits(
         review_note = " review history stayed within the complexity-derived review base."
     else:
         review_note = " no matching review history; using complexity-derived review limit."
-    audit["rationale"] = (
-        f"derived dev limits from {profile_runs} {complexity_band or 'unknown'}-band profile runs "
-        f"with {_HEADROOM_FACTOR}x headroom; timeout scaled from static per-iteration baseline."
-        f"{review_note}"
-    )
+    audit["rationale"] = f"{dev_rationale}{review_note}"
 
     return AdaptiveLimits(
         dev_max=chosen_dev,

--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -254,7 +254,9 @@ def derive_limits(
         chosen_dev = static_dev_max
         chosen_timeout = base_timeout_seconds
         chosen_budget = base_budget_usd
-        dev_rationale = "insufficient profile history for complexity band; using static configured dev limits"
+        dev_rationale = (
+            "insufficient profile history for complexity band; using static configured dev limits"
+        )
     else:
         raw_dev = profile_stats["avg_iterations"] * _HEADROOM_FACTOR
         chosen_dev = max(floor_dev, min(cap_dev, _ceil_int(raw_dev)))
@@ -263,8 +265,10 @@ def derive_limits(
         chosen_budget = _round_money(profile_stats["avg_cost_usd"] * _HEADROOM_FACTOR)
         audit["profile_raw_dev_max"] = round(raw_dev, 4)
         dev_rationale = (
-            f"derived dev limits from {profile_runs} {complexity_band or 'unknown'}-band profile runs "
-            f"with {_HEADROOM_FACTOR}x headroom; timeout scaled from static per-iteration baseline."
+            f"derived dev limits from {profile_runs} "
+            f"{complexity_band or 'unknown'}-band profile runs with "
+            f"{_HEADROOM_FACTOR}x headroom; timeout scaled from static "
+            "per-iteration baseline."
         )
     audit["chosen_dev_max"] = chosen_dev
     audit["chosen_dev_timeout_seconds"] = chosen_timeout

--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -1,8 +1,9 @@
-"""Adaptive iteration limits: derive per-story dev/review budgets.
+"""Adaptive resource limits: derive per-story dev budgets and review-cycle caps.
 
-Pure-Python (stdlib only). Given a preflight complexity score (1-10) and the
-tail of ``.forge/audits/history.jsonl`` produced by prior runs, compute
-per-story ``max_dev_iterations`` / ``max_review_cycles``.
+Pure-Python (stdlib only). Given preflight complexity and model capability
+profiles, compute per-story dev ``max_iterations``, ``timeout_seconds``, and
+``budget_usd``. Review-cycle caps continue to use the existing complexity plus
+recent audit-history signal.
 
 Design:
 
@@ -10,17 +11,17 @@ Design:
   (never grant fewer iterations than the operator configured).
 - ``retry.max_dev_iterations_cap`` / ``retry.max_review_cycles_cap`` are the
   hard ceiling (safety rail) — adaptive growth never exceeds them.
-- Base grant scales with the 1-10 complexity score: higher score → more budget,
-  interpolated linearly between floor and cap.
-- Historical p75 usage for matching complexity (within ±1 of the score) bumps
-  the base when history shows recent runs at similar complexity ran long.
+- Dev limits are learned from per-complexity model profile averages with a
+  deterministic headroom factor.
+- Review-cycle caps keep the existing complexity + recent-history uplift path.
 - Deterministic: same inputs always yield the same limits.
-- Fallback: no score + no history → floor values from RetryPolicy verbatim.
+- Fallback: insufficient profile history → static configured dev limits.
 """
 
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -37,6 +38,8 @@ _HISTORY_TAIL = 50
 _HISTORY_MAX_BYTES = 10 * 1024 * 1024  # 10 MiB
 
 _BAND_TO_SCORE = {"small": 2, "medium": 5, "large": 9}
+_HEADROOM_FACTOR = 1.5
+_MIN_PROFILE_RUNS = 3
 
 
 @dataclass(frozen=True)
@@ -45,6 +48,8 @@ class AdaptiveLimits:
 
     dev_max: int
     review_max: int
+    dev_timeout_seconds: int
+    dev_budget_usd: float
     audit: dict = field(default_factory=dict)
 
 
@@ -63,9 +68,15 @@ def _scale_to_band(score: int, floor: int, cap: int) -> int:
     # Fraction of the (cap - floor) range allocated at this score.
     frac = (score - 1) / 9  # score 1..10 → 0.0..1.0
     frac = max(0.0, min(1.0, frac))
-    import math
-
     return floor + math.ceil(frac * (cap - floor))
+
+
+def _round_money(value: float) -> float:
+    return round(max(value, 0.01), 4)
+
+
+def _ceil_int(value: float) -> int:
+    return max(1, int(math.ceil(value)))
 
 
 def _read_history_tail(history_path: Path) -> list[dict]:
@@ -157,14 +168,20 @@ def derive_limits(
     complexity_score: int | None,
     complexity_band: str | None,
     retry_policy: "RetryPolicy",
-    history_path: Path | None,
+    *,
+    model_name: str,
+    base_timeout_seconds: int,
+    base_budget_usd: float,
+    static_dev_max: int,
+    review_history_path: Path | None,
+    model_profiles: dict | None,
 ) -> AdaptiveLimits:
-    """Compute per-story iteration limits.
+    """Compute per-story adaptive limits.
 
     Returns an :class:`AdaptiveLimits` with the chosen maximums and an audit
-    dict describing the inputs used, historical sample size, the p75 values
-    observed, and the final chosen limits. When ``adaptive_iterations`` is
-    disabled on the policy, returns the policy floors verbatim.
+    dict describing the inputs used, profile sample size, the learned averages,
+    any review-history uplift, and the final chosen limits. When adaptive
+    derivation is disabled on the policy, returns static config values verbatim.
     """
     floor_dev = max(1, retry_policy.max_dev_iterations)
     floor_review = max(1, retry_policy.max_review_cycles)
@@ -179,65 +196,126 @@ def derive_limits(
         "floor_review": floor_review,
         "cap_dev": cap_dev,
         "cap_review": cap_review,
+        "model_name": model_name,
+        "headroom_factor": _HEADROOM_FACTOR,
+        "min_profile_runs": _MIN_PROFILE_RUNS,
+        "base_timeout_seconds": base_timeout_seconds,
+        "base_budget_usd": base_budget_usd,
+        "static_dev_max": static_dev_max,
     }
 
     if not retry_policy.adaptive_iterations:
-        audit["rationale"] = "adaptive_iterations disabled; using policy floors"
-        return AdaptiveLimits(dev_max=floor_dev, review_max=floor_review, audit=audit)
+        audit["rationale"] = "adaptive_iterations disabled; using static configured limits"
+        return AdaptiveLimits(
+            dev_max=static_dev_max,
+            review_max=floor_review,
+            dev_timeout_seconds=base_timeout_seconds,
+            dev_budget_usd=base_budget_usd,
+            audit=audit,
+        )
 
     score = _score_from_inputs(complexity_score, complexity_band)
     audit["complexity_score_used"] = score
 
     if score is None:
-        audit["rationale"] = "no complexity score available; using policy floors"
-        return AdaptiveLimits(dev_max=floor_dev, review_max=floor_review, audit=audit)
+        audit["rationale"] = "no complexity score available; using static configured limits"
+        return AdaptiveLimits(
+            dev_max=static_dev_max,
+            review_max=floor_review,
+            dev_timeout_seconds=base_timeout_seconds,
+            dev_budget_usd=base_budget_usd,
+            audit=audit,
+        )
 
-    # Base: scale floor→cap by complexity score.
-    base_dev = _scale_to_band(score, floor_dev, cap_dev)
+    # Review-cycle adaptation stays on the existing complexity/history path.
     base_review = _scale_to_band(score, floor_review, cap_review)
-    audit["base_dev"] = base_dev
     audit["base_review"] = base_review
 
-    # History: p75 of matching-complexity runs; records within ±1 of the score.
+    profile_stats = None
+    if model_profiles:
+        from theforge.model_profiles import get_dev_complexity_stats  # noqa: PLC0415
+
+        profile_stats = get_dev_complexity_stats(
+            model_profiles,
+            model_name,
+            complexity_band,
+            min_runs=_MIN_PROFILE_RUNS,
+        )
+    profile_runs = int(profile_stats["runs"]) if profile_stats is not None else 0
+    audit["profile_history_runs"] = profile_runs
+    audit["profile_avg_iterations"] = (
+        round(float(profile_stats["avg_iterations"]), 4) if profile_stats is not None else None
+    )
+    audit["profile_avg_cost_usd"] = (
+        round(float(profile_stats["avg_cost_usd"]), 6) if profile_stats is not None else None
+    )
+
+    if profile_stats is None:
+        audit["chosen_dev_max"] = static_dev_max
+        audit["chosen_dev_timeout_seconds"] = base_timeout_seconds
+        audit["chosen_dev_budget_usd"] = round(base_budget_usd, 4)
+        audit["review_history_sample_size"] = 0
+        audit["p75_review"] = 0
+        audit["chosen_review_max"] = floor_review
+        audit["rationale"] = (
+            "insufficient profile history for complexity band; using static configured limits"
+        )
+        return AdaptiveLimits(
+            dev_max=static_dev_max,
+            review_max=floor_review,
+            dev_timeout_seconds=base_timeout_seconds,
+            dev_budget_usd=base_budget_usd,
+            audit=audit,
+        )
+
+    raw_dev = profile_stats["avg_iterations"] * _HEADROOM_FACTOR
+    chosen_dev = max(floor_dev, min(cap_dev, _ceil_int(raw_dev)))
+    timeout_per_iteration = base_timeout_seconds / max(static_dev_max, 1)
+    chosen_timeout = _ceil_int(chosen_dev * timeout_per_iteration)
+    chosen_budget = _round_money(profile_stats["avg_cost_usd"] * _HEADROOM_FACTOR)
+    audit["profile_raw_dev_max"] = round(raw_dev, 4)
+    audit["chosen_dev_max"] = chosen_dev
+    audit["chosen_dev_timeout_seconds"] = chosen_timeout
+    audit["chosen_dev_budget_usd"] = chosen_budget
+
+    # Review history: p75 of matching-complexity runs; records within ±1 of the score.
     history_sample = 0
-    p75_dev = 0
     p75_review = 0
-    if history_path is not None:
-        recs = _read_history_tail(history_path)
-        matching_dev: list[int] = []
+    if review_history_path is not None:
+        recs = _read_history_tail(review_history_path)
         matching_review: list[int] = []
         for rec in recs:
             rec_score = _extract_record_score(rec)
             if rec_score is None or abs(rec_score - score) > 1:
                 continue
-            d = _extract_dev_used(rec)
             r = _extract_review_used(rec)
-            if d is not None:
-                matching_dev.append(d)
             if r is not None:
                 matching_review.append(r)
-        history_sample = max(len(matching_dev), len(matching_review))
-        p75_dev = _percentile(matching_dev, 75)
+        history_sample = len(matching_review)
         p75_review = _percentile(matching_review, 75)
-    audit["history_sample_size"] = history_sample
-    audit["p75_dev"] = p75_dev
+    audit["review_history_sample_size"] = history_sample
     audit["p75_review"] = p75_review
 
-    # Combine base and p75 — use max(base, p75+1) so history can push the limit
-    # up but not below the complexity-derived base.  Clamp to [floor, cap].
-    raw_dev = max(base_dev, p75_dev + 1 if p75_dev > 0 else 0)
+    # Review limit remains bounded by the existing complexity-derived base.
     raw_review = max(base_review, p75_review + 1 if p75_review > 0 else 0)
-    chosen_dev = max(floor_dev, min(cap_dev, raw_dev))
     chosen_review = max(floor_review, min(cap_review, raw_review))
-    audit["chosen_dev_max"] = chosen_dev
     audit["chosen_review_max"] = chosen_review
-    if history_sample > 0 and (raw_dev > base_dev or raw_review > base_review):
-        audit["rationale"] = (
-            f"history p75 (dev={p75_dev}, review={p75_review}) raised limits above complexity base"
-        )
+    if history_sample > 0 and raw_review > base_review:
+        review_note = f" review history raised review_max to {chosen_review}."
     elif history_sample > 0:
-        audit["rationale"] = "history within complexity base; using complexity-derived limits"
+        review_note = " review history stayed within the complexity-derived review base."
     else:
-        audit["rationale"] = "no matching history; using complexity-derived limits"
+        review_note = " no matching review history; using complexity-derived review limit."
+    audit["rationale"] = (
+        f"derived dev limits from {profile_runs} {complexity_band or 'unknown'}-band profile runs "
+        f"with {_HEADROOM_FACTOR}x headroom; timeout scaled from static per-iteration baseline."
+        f"{review_note}"
+    )
 
-    return AdaptiveLimits(dev_max=chosen_dev, review_max=chosen_review, audit=audit)
+    return AdaptiveLimits(
+        dev_max=chosen_dev,
+        review_max=chosen_review,
+        dev_timeout_seconds=chosen_timeout,
+        dev_budget_usd=chosen_budget,
+        audit=audit,
+    )

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -496,18 +496,23 @@ def _run_dev_phase(
         prompt,
     )
 
-    _dev_timeout, _dev_override_active = resolve_timeout_with_active(
+    _resolved_timeout, _dev_override_active = resolve_timeout_with_active(
         config.dev_profile.timeout_seconds,
         config.dev_profile.timeout_medium_seconds,
         config.dev_profile.timeout_large_seconds,
         state.preflight_complexity,
         state.preflight_complexity_score,
     )
+    _dev_timeout = state.adaptive_dev_timeout_seconds or _resolved_timeout
     if _dev_override_active:
         _log(f"  Dev timeout: {_dev_timeout}s ({state.preflight_complexity} complexity)")
     else:
         _log(f"  Dev timeout: {_dev_timeout}s")
-    _dev_profile = _dc_replace(config.dev_profile, timeout_seconds=_dev_timeout)
+    _dev_profile = _dc_replace(
+        config.dev_profile,
+        timeout_seconds=_dev_timeout,
+        max_iterations=state.adaptive_dev_max or config.dev_profile.max_iterations,
+    )
 
     _dev_start = time.monotonic()
     dev_result = run_agent(
@@ -618,12 +623,12 @@ def _run_dev_phase(
     if (
         dev_result.success
         and state.error_type != "max_iterations_no_submit"
-        and state.total_dev_cost > config.dev_profile.budget_usd
+        and state.total_dev_cost > (state.adaptive_dev_budget_usd or config.dev_profile.budget_usd)
     ):
+        _budget_limit = state.adaptive_dev_budget_usd or config.dev_profile.budget_usd
         state.phase = Phase.ESCALATE
         state.error = (
-            f"Dev budget exceeded: spent ${state.total_dev_cost:.4f} "
-            f"(limit ${config.dev_profile.budget_usd:.4f})"
+            f"Dev budget exceeded: spent ${state.total_dev_cost:.4f} (limit ${_budget_limit:.4f})"
         )
         _log(f"✗ ESCALATE   {state.error}")
         if logger:

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -249,21 +249,74 @@ def _coordinator_loop(
     # Derive per-story adaptive iteration limits from preflight complexity and
     # historical usage.  RetryPolicy.adaptive_iterations=False returns the
     # policy floor values verbatim; floor and cap always bound the outcome.
-    from .adaptive_iterations import derive_limits  # noqa: PLC0415
+    from theforge.model_profiles import load_profiles  # noqa: PLC0415
 
-    if state.adaptive_dev_max == 0 or state.adaptive_review_max == 0:
+    from .adaptive_iterations import derive_limits  # noqa: PLC0415
+    from .util import resolve_timeout_with_active  # noqa: PLC0415
+
+    if (
+        state.adaptive_dev_max == 0
+        or state.adaptive_review_max == 0
+        or state.adaptive_dev_timeout_seconds == 0
+        or state.adaptive_dev_budget_usd == 0.0
+    ):
+        _static_dev_timeout, _timeout_override_active = resolve_timeout_with_active(
+            config.dev_profile.timeout_seconds,
+            config.dev_profile.timeout_medium_seconds,
+            config.dev_profile.timeout_large_seconds,
+            state.preflight_complexity,
+            state.preflight_complexity_score,
+        )
+        _static_dev_max = config.dev_profile.max_iterations or config.retry.max_dev_iterations
+        _static_dev_budget = config.dev_profile.budget_usd
+        _explicit_dev_override = "dev" in getattr(state, "_explicit_roles", set())
         _history_path = config.project_root / ".forge" / "audits" / "history.jsonl"
+        _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
+        _adaptive_resource_enabled = (
+            config.assignment.enabled
+            and config.assignment.adaptive_enabled
+            and not _explicit_dev_override
+        )
         _limits = derive_limits(
             state.preflight_complexity_score,
             state.preflight_complexity,
             config.retry,
-            _history_path,
+            model_name=config.dev_profile.name,
+            base_timeout_seconds=_static_dev_timeout,
+            base_budget_usd=_static_dev_budget,
+            static_dev_max=_static_dev_max,
+            review_history_path=_history_path,
+            model_profiles=load_profiles(_profiles_path) if _adaptive_resource_enabled else None,
         )
+        if not _adaptive_resource_enabled:
+            _audit = dict(_limits.audit)
+            _audit["enabled"] = False
+            _audit["explicit_dev_override"] = _explicit_dev_override
+            if _explicit_dev_override:
+                _audit["rationale"] = (
+                    "explicit dev forge.yaml override preserved over adaptive limits"
+                )
+            else:
+                _audit["rationale"] = (
+                    "adaptive assignment disabled; using static configured dev limits"
+                )
+            _limits = type(_limits)(
+                dev_max=_static_dev_max,
+                review_max=_limits.review_max,
+                dev_timeout_seconds=_static_dev_timeout,
+                dev_budget_usd=_static_dev_budget,
+                audit=_audit,
+            )
         state.adaptive_dev_max = _limits.dev_max
         state.adaptive_review_max = _limits.review_max
+        state.adaptive_dev_timeout_seconds = _limits.dev_timeout_seconds
+        state.adaptive_dev_budget_usd = _limits.dev_budget_usd
         state.adaptive_limits_audit = _limits.audit
         _log_verbose(
-            f"  adaptive limits: dev={_limits.dev_max} review={_limits.review_max} "
+            "  adaptive limits: "
+            f"dev_max={_limits.dev_max} review_max={_limits.review_max} "
+            f"dev_timeout={_limits.dev_timeout_seconds}s "
+            f"dev_budget=${_limits.dev_budget_usd:.4f} "
             f"({_limits.audit.get('rationale', '')})"
         )
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -300,6 +300,19 @@ def _coordinator_loop(
                 _audit["rationale"] = (
                     "adaptive assignment disabled; using static configured dev limits"
                 )
+            if _limits.audit.get("review_history_sample_size", 0) > 0:
+                if _limits.audit.get("chosen_review_max", 0) > _limits.audit.get("base_review", 0):
+                    _audit["rationale"] += (
+                        f" review history raised review_max to {_limits.review_max}."
+                    )
+                else:
+                    _audit["rationale"] += (
+                        " review history stayed within the complexity-derived review base."
+                    )
+            else:
+                _audit["rationale"] += (
+                    " no matching review history; using complexity-derived review limit."
+                )
             _limits = type(_limits)(
                 dev_max=_static_dev_max,
                 review_max=_limits.review_max,

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -971,7 +971,9 @@ def _run_review_phase(
         config.retry.auto_model_escalation
         and _is_persistent_p1
         and not state.dev_escalated
-        and (state.total_dev_cost < config.dev_profile.budget_usd)
+        and (
+            state.total_dev_cost < (state.adaptive_dev_budget_usd or config.dev_profile.budget_usd)
+        )
     ):
         _curr_key = _find_registry_key_for_profile(config.dev_profile)
         if _curr_key is not None:

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -403,6 +403,8 @@ class CoordinatorState:
     # to config.retry.max_dev_iterations / max_review_cycles in that case.
     adaptive_dev_max: int = 0
     adaptive_review_max: int = 0
+    adaptive_dev_timeout_seconds: int = 0
+    adaptive_dev_budget_usd: float = 0.0
     adaptive_limits_audit: dict = field(default_factory=dict)
     review_early_terminated: bool = False  # True when early-termination triggered
 

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -15,7 +15,7 @@ Schema on disk::
         dev:
           runs, success_rate, avg_iterations, avg_cost_usd
           by_complexity:
-            small|medium|large: {runs, success_rate}
+            small|medium|large: {runs, success_rate, avg_iterations, avg_cost_usd}
         review:
           runs, avg_findings, avg_cost_usd
         preflight:
@@ -138,9 +138,15 @@ def _update_dev(
     bc = by.setdefault(complexity, {})
     bc_runs = int(bc.get("runs", 0)) + 1
     bc_successes = int(bc.get("_successes", 0)) + (1 if success else 0)
+    bc_iter_sum = float(bc.get("_iterations_sum", 0.0)) + float(iterations)
+    bc_cost_sum = float(bc.get("_cost_sum", 0.0)) + float(cost_usd)
     bc["runs"] = bc_runs
     bc["_successes"] = bc_successes
+    bc["_iterations_sum"] = bc_iter_sum
+    bc["_cost_sum"] = bc_cost_sum
     bc["success_rate"] = round(bc_successes / bc_runs, 4)
+    bc["avg_iterations"] = round(bc_iter_sum / bc_runs, 4)
+    bc["avg_cost_usd"] = round(bc_cost_sum / bc_runs, 6)
 
 
 def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float) -> None:
@@ -268,3 +274,34 @@ def get_dev_success_rate(
         return None
     runs = int(bc.get("runs", 0))
     return float(bc.get("success_rate", 0.0)) if runs >= min_runs else None
+
+
+def get_dev_complexity_stats(
+    profiles: dict,
+    model: str,
+    complexity: str | None,
+    *,
+    min_runs: int = 3,
+) -> dict[str, float] | None:
+    """Return per-band dev averages when the complexity band has enough runs."""
+    models = (profiles or {}).get("models") or {}
+    entry = models.get(model)
+    if not isinstance(entry, dict):
+        return None
+    dev = entry.get("dev")
+    if not isinstance(dev, dict):
+        return None
+    band = _normalize_band(complexity)
+    bc = (dev.get("by_complexity") or {}).get(band)
+    if not isinstance(bc, dict):
+        return None
+    runs = int(bc.get("runs", 0))
+    if runs < min_runs:
+        return None
+    if "avg_iterations" not in bc or "avg_cost_usd" not in bc:
+        return None
+    return {
+        "runs": float(runs),
+        "avg_iterations": float(bc.get("avg_iterations", 0.0)),
+        "avg_cost_usd": float(bc.get("avg_cost_usd", 0.0)),
+    }

--- a/tests/test_adaptive_iterations.py
+++ b/tests/test_adaptive_iterations.py
@@ -132,7 +132,11 @@ def test_insufficient_profile_history_falls_back_to_static_limits(tmp_path: Path
     assert result.dev_max == 3
     assert result.dev_timeout_seconds == 900
     assert result.dev_budget_usd == 10.0
+    assert result.review_max == 3
+    assert result.audit["base_review"] == 3
     assert result.audit["profile_history_runs"] == 0
+    assert result.audit["chosen_review_max"] == 3
+    assert "complexity-derived review limit" in result.audit["rationale"]
 
 
 def test_deterministic_same_inputs_same_output(tmp_path: Path):
@@ -224,3 +228,34 @@ def test_oversized_history_skipped(tmp_path: Path, monkeypatch):
         model_profiles=_profiles(),
     )
     assert result.audit["review_history_sample_size"] == 0
+
+
+def test_insufficient_profile_history_still_uses_review_history_signal(tmp_path: Path):
+    history = tmp_path / "audit.jsonl"
+    history.write_text(
+        "\n".join(
+            [
+                '{"preflight":{"complexity_score":5},"iterations":{"review_cycles_total":3}}',
+                '{"preflight":{"complexity_score":6},"iterations":{"review_cycles_total":4}}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=history,
+        model_profiles=_profiles(runs=2, avg_iterations=9.0, avg_cost=9.0),
+    )
+    assert result.dev_max == 3
+    assert result.review_max == 4
+    assert result.audit["review_history_sample_size"] == 2
+    assert result.audit["p75_review"] == 4
+    assert result.audit["chosen_review_max"] == 4
+    assert "review history raised review_max to 4" in result.audit["rationale"]

--- a/tests/test_adaptive_iterations.py
+++ b/tests/test_adaptive_iterations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from theforge.config.types import RetryPolicy
@@ -22,146 +21,206 @@ def _policy(**kw) -> RetryPolicy:
     return RetryPolicy(**defaults)
 
 
+def _profiles(
+    *,
+    model: str = "dev",
+    runs: int = 3,
+    avg_iterations: float = 4.0,
+    avg_cost: float = 2.0,
+):
+    return {
+        "models": {
+            model: {
+                "dev": {
+                    "by_complexity": {
+                        "medium": {
+                            "runs": runs,
+                            "avg_iterations": avg_iterations,
+                            "avg_cost_usd": avg_cost,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
 def test_adaptive_disabled_returns_policy_floors(tmp_path: Path):
-    result = derive_limits(7, "medium", _policy(adaptive_iterations=False), tmp_path / "none")
+    result = derive_limits(
+        7,
+        "medium",
+        _policy(adaptive_iterations=False),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(),
+    )
     assert isinstance(result, AdaptiveLimits)
     assert result.dev_max == 3
     assert result.review_max == 2
+    assert result.dev_timeout_seconds == 900
+    assert result.dev_budget_usd == 10.0
     assert result.audit["enabled"] is False
 
 
-def test_no_score_no_history_returns_floors(tmp_path: Path):
-    result = derive_limits(None, None, _policy(), tmp_path / "missing.jsonl")
+def test_no_score_uses_static_limits(tmp_path: Path):
+    result = derive_limits(
+        None,
+        None,
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "missing.jsonl",
+        model_profiles=_profiles(),
+    )
     assert result.dev_max == 3
     assert result.review_max == 2
     assert result.audit["rationale"].startswith("no complexity score")
 
 
-def test_low_score_maps_near_floor(tmp_path: Path):
-    result = derive_limits(1, None, _policy(), tmp_path / "missing.jsonl")
-    # Score=1 → base is floor.
+def test_profile_history_derives_dev_limits_from_headroom(tmp_path: Path):
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "missing.jsonl",
+        model_profiles=_profiles(avg_iterations=3.2, avg_cost=1.2),
+    )
+    # ceil(3.2 * 1.5) = 5; timeout scales from 900 / 3 = 300s per iteration.
+    assert result.dev_max == 5
+    assert result.dev_timeout_seconds == 1500
+    assert result.dev_budget_usd == 1.8
+    assert result.audit["profile_history_runs"] == 3
+
+
+def test_headroom_clamps_dev_iterations_to_cap(tmp_path: Path):
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "missing.jsonl",
+        model_profiles=_profiles(avg_iterations=9.0, avg_cost=9.0),
+    )
+    assert result.dev_max == 6
+    assert result.dev_timeout_seconds == 1800
+
+
+def test_insufficient_profile_history_falls_back_to_static_limits(tmp_path: Path):
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "missing.jsonl",
+        model_profiles=_profiles(runs=2, avg_iterations=9.0, avg_cost=9.0),
+    )
     assert result.dev_max == 3
-    assert result.review_max == 2
-
-
-def test_high_score_maps_near_cap(tmp_path: Path):
-    result = derive_limits(10, None, _policy(), tmp_path / "missing.jsonl")
-    # Score=10 → full cap grant.
-    assert result.dev_max == 6
-    assert result.review_max == 4
-
-
-def test_limits_never_exceed_cap(tmp_path: Path):
-    # Build history where p75 dev usage is absurdly high; cap must still clamp.
-    history = tmp_path / "history.jsonl"
-    records = [
-        {
-            "preflight": {"complexity_score": 8},
-            "iterations": {
-                "dev_iterations_productive": 99,
-                "review_cycles_total": 50,
-            },
-        }
-        for _ in range(10)
-    ]
-    history.write_text("\n".join(json.dumps(r) for r in records) + "\n")
-    result = derive_limits(8, None, _policy(), history)
-    assert result.dev_max <= 6
-    assert result.review_max <= 4
-
-
-def test_limits_never_below_floor(tmp_path: Path):
-    # History p75 is lower than the complexity base — never decrease below
-    # complexity-derived base, and never below policy floor.
-    history = tmp_path / "history.jsonl"
-    records = [
-        {
-            "preflight": {"complexity_score": 8},
-            "iterations": {"dev_iterations_productive": 1, "review_cycles_total": 1},
-        }
-        for _ in range(5)
-    ]
-    history.write_text("\n".join(json.dumps(r) for r in records) + "\n")
-    result = derive_limits(8, None, _policy(), history)
-    assert result.dev_max >= 3  # floor
-    assert result.review_max >= 2
-
-
-def test_history_raises_above_base(tmp_path: Path):
-    # Score=5 base is mid-range; history p75=5 dev should push above the base.
-    history = tmp_path / "history.jsonl"
-    records = [
-        {
-            "preflight": {"complexity_score": 5},
-            "iterations": {"dev_iterations_productive": 5, "review_cycles_total": 3},
-        }
-        for _ in range(6)
-    ]
-    history.write_text("\n".join(json.dumps(r) for r in records) + "\n")
-    result = derive_limits(5, None, _policy(), history)
-    # p75 ≈ 5, so dev_max should be max(base, 6) clamped to cap=6.
-    assert result.dev_max == 6
-    assert result.audit["p75_dev"] == 5
-    assert result.audit["history_sample_size"] == 6
+    assert result.dev_timeout_seconds == 900
+    assert result.dev_budget_usd == 10.0
+    assert result.audit["profile_history_runs"] == 0
 
 
 def test_deterministic_same_inputs_same_output(tmp_path: Path):
-    history = tmp_path / "h.jsonl"
-    records = [
-        {"preflight": {"complexity_score": 6}, "iterations": {"dev_iterations_productive": 4}}
-        for _ in range(4)
-    ]
-    history.write_text("\n".join(json.dumps(r) for r in records) + "\n")
-    a = derive_limits(6, None, _policy(), history)
-    b = derive_limits(6, None, _policy(), history)
+    profiles = _profiles(avg_iterations=4.0, avg_cost=1.0)
+    a = derive_limits(
+        6,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "missing.jsonl",
+        model_profiles=profiles,
+    )
+    b = derive_limits(
+        6,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "missing.jsonl",
+        model_profiles=profiles,
+    )
     assert a.dev_max == b.dev_max
     assert a.review_max == b.review_max
     assert a.audit == b.audit
 
 
-def test_malformed_jsonl_lines_skipped(tmp_path: Path):
-    history = tmp_path / "h.jsonl"
-    lines = [
-        "not json",
-        json.dumps({"no_iterations": True}),
-        json.dumps(
-            {
-                "preflight": {"complexity_score": 5},
-                "iterations": {"dev_iterations_productive": 3},
-            }
-        ),
-        "{trailing garbage",
-    ]
-    history.write_text("\n".join(lines) + "\n")
-    result = derive_limits(5, None, _policy(), history)
-    # Only one valid matching record; should not crash and should reflect it.
-    assert result.audit["history_sample_size"] == 1
-
-
 def test_band_fallback_when_score_none(tmp_path: Path):
-    # band='large' → representative score 9 → near cap.
-    result = derive_limits(None, "large", _policy(), tmp_path / "none")
-    assert result.dev_max == 6
+    result = derive_limits(
+        None,
+        "large",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(),
+    )
+    assert result.dev_max == 3
     assert result.audit["complexity_score_used"] == 9
 
 
 def test_out_of_range_score_falls_back_to_band(tmp_path: Path):
-    result = derive_limits(99, "small", _policy(), tmp_path / "none")
-    # Score is invalid, band='small' → rep score 2 → near floor.
+    result = derive_limits(
+        99,
+        "small",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles={
+            "models": {
+                "dev": {
+                    "dev": {
+                        "by_complexity": {
+                            "small": {"runs": 3, "avg_iterations": 2.0, "avg_cost_usd": 0.5}
+                        }
+                    }
+                }
+            }
+        },
+    )
     assert result.audit["complexity_score_used"] == 2
-    # Score 2 is near the floor but just above — exact value depends on linear
-    # scale, but it must not exceed the score=10 cap value.
-    assert 3 <= result.dev_max <= 4
+    assert result.dev_max == 3
 
 
 def test_oversized_history_skipped(tmp_path: Path, monkeypatch):
-    # Simulate a huge history file by patching the byte cap.
     history = tmp_path / "h.jsonl"
-    records = [
-        {"preflight": {"complexity_score": 5}, "iterations": {"dev_iterations_productive": 5}}
-        for _ in range(3)
-    ]
-    history.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    history.write_text(
+        '{"preflight":{"complexity_score":5},"iterations":{"review_cycles_total":3}}\n'
+    )
     monkeypatch.setattr("theforge.coordinator.adaptive_iterations._HISTORY_MAX_BYTES", 1)
-    result = derive_limits(5, None, _policy(), history)
-    assert result.audit["history_sample_size"] == 0
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=history,
+        model_profiles=_profiles(),
+    )
+    assert result.audit["review_history_sample_size"] == 0

--- a/tests/test_coord_adaptive_iterations.py
+++ b/tests/test_coord_adaptive_iterations.py
@@ -307,6 +307,43 @@ def test_adaptive_off_produces_policy_values(tmp_path: Path):
     assert result.review_max == 2
 
 
+def test_adaptive_assignment_off_keeps_review_limits_adaptive(tmp_path: Path):
+    from theforge.coordinator.engine import _coordinator_loop
+
+    config = replace(
+        _make_adaptive_config(tmp_path),
+        assignment=AssignmentConfig(enabled=True, adaptive_enabled=False),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState()
+    state.preflight_complexity = "large"
+    state.preflight_complexity_score = 9
+    state.workspace_path = tmp_path
+    state.branch_name = "feat/test"
+    (tmp_path / ".forge").mkdir()
+    (tmp_path / ".forge" / "model_profiles.yaml").write_text("models: {}\n", encoding="utf-8")
+
+    class _StopLoop(Exception):
+        pass
+
+    def _fake_dev(*args, **kwargs):
+        raise _StopLoop()
+
+    with patch("theforge.coordinator.engine._run_dev_phase", _fake_dev):
+        try:
+            _coordinator_loop(state, config, task, "story", task_start=0.0)
+        except _StopLoop:
+            pass
+
+    assert state.adaptive_dev_max == (
+        config.dev_profile.max_iterations or config.retry.max_dev_iterations
+    )
+    assert state.adaptive_review_max == config.retry.max_review_cycles_cap
+    assert state.adaptive_limits_audit["base_review"] == config.retry.max_review_cycles_cap
+    assert state.adaptive_limits_audit["profile_history_runs"] == 0
+    assert "complexity-derived review limit" in state.adaptive_limits_audit["rationale"]
+
+
 def test_explicit_dev_override_wins_over_computed_limits(tmp_path: Path):
     from theforge.coordinator.engine import _coordinator_loop
 

--- a/tests/test_coord_adaptive_iterations.py
+++ b/tests/test_coord_adaptive_iterations.py
@@ -7,13 +7,13 @@ on consecutive zero-new-findings review cycles.
 
 from __future__ import annotations
 
-import json
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
 from coord_test_helpers import _make_config, _make_task
 
-from theforge.config.types import RetryPolicy
+from theforge.config.types import AssignmentConfig, RetryPolicy
 from theforge.coordinator.adaptive_iterations import derive_limits
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.state import (
@@ -35,9 +35,34 @@ def _make_adaptive_config(tmp_path: Path, **retry_overrides):
         review_zero_findings_stop=2,
     )
     defaults.update(retry_overrides)
-    from dataclasses import replace
+    return replace(
+        config,
+        retry=RetryPolicy(**defaults),
+        assignment=AssignmentConfig(enabled=True, adaptive_enabled=True),
+    )
 
-    return replace(config, retry=RetryPolicy(**defaults))
+
+def _profiles(*, runs: int = 3, avg_iterations: float = 4.0, avg_cost_usd: float = 1.0) -> dict:
+    return {
+        "models": {
+            "dev": {
+                "dev": {
+                    "by_complexity": {
+                        "medium": {
+                            "runs": runs,
+                            "avg_iterations": avg_iterations,
+                            "avg_cost_usd": avg_cost_usd,
+                        },
+                        "large": {
+                            "runs": runs,
+                            "avg_iterations": avg_iterations,
+                            "avg_cost_usd": avg_cost_usd,
+                        },
+                    }
+                }
+            }
+        }
+    }
 
 
 def test_adaptive_limits_populated_in_audit(tmp_path: Path):
@@ -48,10 +73,14 @@ def test_adaptive_limits_populated_in_audit(tmp_path: Path):
     state.preflight_complexity_score = 7
     state.adaptive_dev_max = 5
     state.adaptive_review_max = 3
+    state.adaptive_dev_timeout_seconds = 1500
+    state.adaptive_dev_budget_usd = 1.8
     state.adaptive_limits_audit = {
         "enabled": True,
         "chosen_dev_max": 5,
         "chosen_review_max": 3,
+        "chosen_dev_timeout_seconds": 1500,
+        "chosen_dev_budget_usd": 1.8,
         "rationale": "complexity-derived",
     }
     audit = generate_audit_log(
@@ -88,6 +117,8 @@ def test_engine_populates_adaptive_limits_before_dev_loop(tmp_path: Path):
     state.preflight_complexity_score = 9
     state.workspace_path = tmp_path
     state.branch_name = "feat/test"
+    (tmp_path / ".forge").mkdir()
+    (tmp_path / ".forge" / "model_profiles.yaml").write_text("models: {}\n", encoding="utf-8")
 
     # Short-circuit the loop by raising before DEV starts.
     class _StopLoop(Exception):
@@ -106,29 +137,14 @@ def test_engine_populates_adaptive_limits_before_dev_loop(tmp_path: Path):
     assert state.adaptive_review_max > 0
     assert state.adaptive_dev_max <= config.retry.max_dev_iterations_cap
     assert state.adaptive_review_max <= config.retry.max_review_cycles_cap
-    # Score 9 should bump the limits above the floor.
-    assert state.adaptive_dev_max >= config.retry.max_dev_iterations
+    assert state.adaptive_dev_timeout_seconds == config.dev_profile.timeout_seconds
+    assert state.adaptive_dev_budget_usd == config.dev_profile.budget_usd
     assert state.adaptive_limits_audit.get("enabled") is True
     assert state.adaptive_limits_audit.get("complexity_score_used") == 9
 
 
-def test_history_informs_adaptive_limits(tmp_path: Path):
-    """derive_limits reads .forge/audits/history.jsonl and bumps limits on heavy history."""
-    audits = tmp_path / ".forge" / "audits"
-    audits.mkdir(parents=True)
-    history = audits / "history.jsonl"
-    records = [
-        {
-            "preflight": {"complexity_score": 5},
-            "iterations": {
-                "dev_iterations_productive": 5,
-                "review_cycles_total": 3,
-            },
-        }
-        for _ in range(6)
-    ]
-    history.write_text("\n".join(json.dumps(r) for r in records) + "\n")
-
+def test_profiles_inform_adaptive_dev_limits(tmp_path: Path):
+    """derive_limits uses model capability profiles for dev budgeting."""
     policy = RetryPolicy(
         max_dev_iterations=3,
         max_review_cycles=2,
@@ -136,21 +152,25 @@ def test_history_informs_adaptive_limits(tmp_path: Path):
         max_review_cycles_cap=4,
         adaptive_iterations=True,
     )
-    result = derive_limits(5, None, policy, history)
-    # History p75=5 → dev_max raised above complexity-derived base.
-    assert result.dev_max == 6
-    assert result.audit["p75_dev"] == 5
-    assert result.audit["history_sample_size"] == 6
+    result = derive_limits(
+        5,
+        "medium",
+        policy,
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=None,
+        model_profiles=_profiles(avg_iterations=3.2, avg_cost_usd=1.2),
+    )
+    assert result.dev_max == 5
+    assert result.dev_timeout_seconds == 1500
+    assert result.dev_budget_usd == 1.8
+    assert result.audit["profile_history_runs"] == 3
 
 
 def test_determinism_seam(tmp_path: Path):
     """Same complexity + same history → identical adaptive limits."""
-    history = tmp_path / "history.jsonl"
-    records = [
-        {"preflight": {"complexity_score": 6}, "iterations": {"dev_iterations_productive": 4}}
-        for _ in range(5)
-    ]
-    history.write_text("\n".join(json.dumps(r) for r in records) + "\n")
     policy = RetryPolicy(
         max_dev_iterations=3,
         max_review_cycles=2,
@@ -158,8 +178,29 @@ def test_determinism_seam(tmp_path: Path):
         max_review_cycles_cap=4,
         adaptive_iterations=True,
     )
-    a = derive_limits(6, None, policy, history)
-    b = derive_limits(6, None, policy, history)
+    profiles = _profiles(avg_iterations=4.0, avg_cost_usd=1.0)
+    a = derive_limits(
+        6,
+        "medium",
+        policy,
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=None,
+        model_profiles=profiles,
+    )
+    b = derive_limits(
+        6,
+        "medium",
+        policy,
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=None,
+        model_profiles=profiles,
+    )
     assert a == b
 
 
@@ -251,6 +292,56 @@ def test_adaptive_off_produces_policy_values(tmp_path: Path):
         max_review_cycles_cap=4,
         adaptive_iterations=False,
     )
-    result = derive_limits(10, "large", policy, None)
+    result = derive_limits(
+        10,
+        "large",
+        policy,
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=None,
+        model_profiles=_profiles(),
+    )
     assert result.dev_max == 3
     assert result.review_max == 2
+
+
+def test_explicit_dev_override_wins_over_computed_limits(tmp_path: Path):
+    from theforge.coordinator.engine import _coordinator_loop
+
+    config = replace(
+        _make_adaptive_config(tmp_path),
+        dev_profile=replace(
+            _make_adaptive_config(tmp_path).dev_profile,
+            budget_usd=12.0,
+            timeout_seconds=1200,
+            max_iterations=4,
+        ),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 6
+    state.workspace_path = tmp_path
+    state.branch_name = "feat/test"
+    state._explicit_roles = {"dev"}
+    (tmp_path / ".forge").mkdir()
+    (tmp_path / ".forge" / "model_profiles.yaml").write_text("models: {}\n", encoding="utf-8")
+
+    class _StopLoop(Exception):
+        pass
+
+    def _fake_dev(*args, **kwargs):
+        raise _StopLoop()
+
+    with patch("theforge.coordinator.engine._run_dev_phase", _fake_dev):
+        try:
+            _coordinator_loop(state, config, task, "story", task_start=0.0)
+        except _StopLoop:
+            pass
+
+    assert state.adaptive_dev_max == 4
+    assert state.adaptive_dev_timeout_seconds == 1200
+    assert state.adaptive_dev_budget_usd == 12.0
+    assert "explicit dev forge.yaml override" in state.adaptive_limits_audit["rationale"]

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -9,6 +9,7 @@ from theforge.model_profiles import (
     RunOutcome,
     apply_run,
     backfill_from_history,
+    get_dev_complexity_stats,
     get_dev_success_rate,
     load_profiles,
     save_profiles,
@@ -36,6 +37,8 @@ def test_apply_run_records_dev_stats():
     assert dev["avg_cost_usd"] == 1.5
     assert dev["by_complexity"]["medium"]["runs"] == 1
     assert dev["by_complexity"]["medium"]["success_rate"] == 1.0
+    assert dev["by_complexity"]["medium"]["avg_iterations"] == 2.0
+    assert dev["by_complexity"]["medium"]["avg_cost_usd"] == 1.5
 
 
 def test_apply_run_averages_across_runs():
@@ -305,6 +308,48 @@ def test_get_dev_success_rate_requires_min_runs():
     assert get_dev_success_rate(profiles, "opus", "medium") == 0.8
     # Unknown model / role → None
     assert get_dev_success_rate(profiles, "gemini", "medium") is None
+
+
+def test_get_dev_complexity_stats_requires_band_averages():
+    profiles = {
+        "models": {
+            "sonnet": {
+                "dev": {
+                    "by_complexity": {
+                        "medium": {
+                            "runs": 3,
+                            "avg_iterations": 2.5,
+                            "avg_cost_usd": 1.25,
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert get_dev_complexity_stats(profiles, "sonnet", "medium") == {
+        "runs": 3.0,
+        "avg_iterations": 2.5,
+        "avg_cost_usd": 1.25,
+    }
+
+
+def test_get_dev_complexity_stats_returns_none_under_min_runs():
+    profiles = {
+        "models": {
+            "sonnet": {
+                "dev": {
+                    "by_complexity": {
+                        "medium": {
+                            "runs": 2,
+                            "avg_iterations": 2.5,
+                            "avg_cost_usd": 1.25,
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert get_dev_complexity_stats(profiles, "sonnet", "medium") is None
 
 
 def test_complexity_bands_constant():


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Prior P1 is fixed: profile_stats=None no longer short-circuits review-history uplift. No regressions introduced by fix commits. | [google-gemini-3.1-pro-preview] The prior P1 finding regarding the early return bypassing review history logic has been fixed. The code now correctly computes review limits even when dev limits fall back to static values. | [claude-opus] Cycle 1 P1 fixed — review-cycle adaptation now runs even when profile history is insufficient, adaptive assignment is disabled, or dev is explicitly overridden. Lint cleanup in 46cde6b is a pure reformat. No regressions found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.95
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Adaptive resource budgets — derive limits from complexity and run history (GitHub Issue #156)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #156