### PR TITLE
Progress-aware timeouts — detect stuck agents early

### DIFF
--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -51,6 +51,7 @@ from .types import (
     RetryPolicy,
     SlackConfig,
     SprintConfig,
+    StuckDetectionConfig,
     ValidationConfig,
     WorkspaceConfig,
 )
@@ -77,6 +78,7 @@ __all__ = [
     "RetryPolicy",
     "SlackConfig",
     "SprintConfig",
+    "StuckDetectionConfig",
     "SUPPORTED_PROVIDERS",
     "ValidationConfig",
     "WorkspaceConfig",

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -49,6 +49,7 @@ from .types import (
     RetryPolicy,
     ShapeCheckConfig,
     SprintConfig,
+    StuckDetectionConfig,
     ValidationConfig,
 )
 
@@ -163,6 +164,41 @@ def _validate_plan_provider(plan_cfg: "PlanConfig", secrets: dict[str, str]) -> 
     _ready, _reason = check_agent_auth(_stub, secrets)
     if not _ready:
         raise ValueError(f"plan section uses provider '{plan_cfg.provider}': {_reason}")
+
+
+def _parse_stuck_detection(raw: Any) -> "StuckDetectionConfig":
+    """Build a StuckDetectionConfig from the optional 'stuck_detection:' block.
+
+    Defaults are applied when keys are missing. Type errors raise ValueError so
+    misconfiguration surfaces at load time rather than mid-run.
+    """
+    if raw is None:
+        return StuckDetectionConfig()
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"forge.yaml 'stuck_detection' must be a mapping, got {type(raw).__name__}"
+        )
+    defaults = StuckDetectionConfig()
+    fields = {
+        "enabled": (bool, defaults.enabled),
+        "no_progress_iterations": (int, defaults.no_progress_iterations),
+        "repeat_threshold": (int, defaults.repeat_threshold),
+        "error_threshold": (int, defaults.error_threshold),
+        "post_nudge_iterations": (int, defaults.post_nudge_iterations),
+    }
+    kwargs: dict[str, Any] = {}
+    for key, (typ, default) in fields.items():
+        val = raw.get(key, default)
+        if typ is bool:
+            if not isinstance(val, bool):
+                raise ValueError(f"forge.yaml 'stuck_detection.{key}' must be bool, got {val!r}")
+        else:
+            if isinstance(val, bool) or not isinstance(val, int) or val < 1:
+                raise ValueError(
+                    f"forge.yaml 'stuck_detection.{key}' must be a positive int, got {val!r}"
+                )
+        kwargs[key] = val
+    return StuckDetectionConfig(**kwargs)
 
 
 def load_config(config_path: Path) -> ForgeConfig:
@@ -679,6 +715,8 @@ def load_config(config_path: Path) -> ForgeConfig:
         )
     finding_classifier_cfg = FindingClassifierConfig(allow_net_new_bypass=_allow_bypass)
 
+    stuck_detection_cfg = _parse_stuck_detection(raw.get("stuck_detection", {}))
+
     return ForgeConfig(
         project=raw.get("project", project_root.name),
         project_root=project_root,
@@ -712,6 +750,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         conventions_hard=conventions_hard_cfg,
         conventions_soft=conventions_soft_list,
         finding_classifier=finding_classifier_cfg,
+        stuck_detection=stuck_detection_cfg,
         models_budget_usd=budget_usd_val,
         models_overrides=_raw_overrides,
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -87,6 +87,28 @@ class GithubConfig:
 
 
 @dataclass(frozen=True)
+class StuckDetectionConfig:
+    """Thresholds for progress-aware stuck-agent detection.
+
+    The runner monitors per-iteration tool-call activity for three observable
+    stall patterns: repeated identical (name+arguments) tool calls, no file
+    modifications across consecutive iterations, and tool-result error loops.
+    On detection, the runner injects a one-shot nudge message; if the same
+    pattern continues for ``post_nudge_iterations`` more iterations, the run
+    is terminated with a structured failure log.
+
+    Detection is gated by profile.phase == "dev" so review/preflight loops
+    are unaffected.
+    """
+
+    enabled: bool = True
+    no_progress_iterations: int = 5  # N — iterations without file modification → stuck
+    repeat_threshold: int = 4  # consecutive identical (name+args) tool calls → stuck
+    error_threshold: int = 4  # consecutive identical error tool results → stuck
+    post_nudge_iterations: int = 3  # M — iterations after nudge before termination
+
+
+@dataclass(frozen=True)
 class ModelProfile:
     """Model configuration for a specific agent role (dev or review)."""
 
@@ -123,6 +145,9 @@ class ModelProfile:
     # small number of paths (e.g. raw dataclass constructions in tests) that
     # have not been migrated yet.
     transport: TransportSpec | None = None
+    # Per-profile stuck-detection thresholds; None falls back to the
+    # ForgeConfig-level default and only fires when phase == "dev".
+    stuck_detection: StuckDetectionConfig | None = None
 
     def __post_init__(self) -> None:
         if self.transport is None and (self.cli or self.provider):
@@ -428,6 +453,7 @@ class ForgeConfig:
     conventions_hard: HardConventionsConfig | None = None  # None = no section = no checks
     conventions_soft: list[str] = field(default_factory=list)  # [] = no soft conventions
     finding_classifier: FindingClassifierConfig = field(default_factory=FindingClassifierConfig)
+    stuck_detection: StuckDetectionConfig = field(default_factory=StuckDetectionConfig)
     models_budget_usd: float | None = None  # set when models: key is used (v0.8 path)
     models_overrides: dict[str, Any] | None = None  # raw overrides: dict from v0.8 YAML
 

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -512,6 +512,7 @@ def _run_dev_phase(
         config.dev_profile,
         timeout_seconds=_dev_timeout,
         max_iterations=state.adaptive_dev_max or config.dev_profile.max_iterations,
+        stuck_detection=config.stuck_detection,
     )
 
     _dev_start = time.monotonic()

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -55,6 +55,7 @@ from theforge.runners.schema_utils import (
     noop_finalizer,
     uses_openai_responses_api,
 )
+from theforge.runners.stuck_detection import StuckTracker, build_observation
 from theforge.runners.tool_runtime import TOOL_REGISTRY, ToolDef
 
 if TYPE_CHECKING:
@@ -169,161 +170,6 @@ class _UsageAccumulator:
         )
 
 
-_MODIFY_TOOL_NAMES = frozenset({"write_file", "edit_file"})
-
-
-def _signature(call: ToolCallRequest) -> str:
-    """Stable signature for a tool call: name + sorted-key JSON of arguments."""
-    try:
-        args_str = json.dumps(call.arguments, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        args_str = repr(call.arguments)
-    return f"{call.name}|{args_str}"
-
-
-def _signature_set(calls: list[ToolCallRequest]) -> frozenset[str]:
-    return frozenset(_signature(c) for c in calls if c.name and isinstance(c.arguments, dict))
-
-
-def _error_signatures(results: list[dict]) -> list[str]:
-    """Return tool-result content strings that look like errors."""
-    out = []
-    for r in results:
-        content = str(r.get("content", ""))
-        if content.startswith("Error"):
-            out.append(content[:200])
-    return out
-
-
-class _StuckTracker:
-    """Detect stuck-agent patterns across loop iterations.
-
-    Tracks three observable patterns:
-      1. Repeated identical (name+arguments) tool calls
-      2. No file-modifying tool calls over consecutive iterations
-      3. Repeated identical error tool results
-
-    When a pattern crosses its threshold, ``check`` returns a nudge message
-    once. If the same pattern persists for ``post_nudge_iterations`` more
-    iterations, ``check`` returns a termination reason instead.
-
-    Detection is gated by profile.phase == "dev" so review/preflight loops
-    are unaffected by default. False-positive guard: counters reset whenever
-    the observed pattern changes (different signature, file modified, or
-    different error content) — slow-but-real progress does not trigger.
-    """
-
-    def __init__(self, profile: "ModelProfile") -> None:
-        cfg = profile.stuck_detection
-        self._enabled = bool(
-            cfg and cfg.enabled and profile.phase == "dev"
-            # No-progress arm needs at least one modify tool to be meaningful;
-            # repeat/error arms always work, so we still enable when modify
-            # tools are present *or* when the agent has tool calls at all.
-        )
-        self._cfg = cfg
-        modify_names = ("Write", "Edit", "write_file", "edit_file")
-        self._has_modify_tools = bool(
-            profile.allowed_tools and any(t in profile.allowed_tools for t in modify_names)
-        )
-        self._last_sig: frozenset[str] | None = None
-        self._repeat_count = 0
-        self._iters_without_mod = 0
-        self._last_error: str | None = None
-        self._error_count = 0
-        self._nudge_sent = False
-        self._nudge_pattern: str | None = None
-        self._post_nudge_iters = 0
-
-    @property
-    def enabled(self) -> bool:
-        return self._enabled
-
-    def observe(
-        self, calls: list[ToolCallRequest], results: list[dict]
-    ) -> tuple[str | None, str | None, str | None]:
-        """Update state for one iteration. Returns (nudge_msg, terminate_reason, pattern).
-
-        At most one of nudge_msg/terminate_reason is non-None per call.
-        ``pattern`` is the human-readable detected pattern when either fires.
-        """
-        if not self._enabled or self._cfg is None:
-            return (None, None, None)
-
-        sig = _signature_set(calls)
-        if self._last_sig is not None and sig == self._last_sig and sig:
-            self._repeat_count += 1
-        else:
-            self._repeat_count = 1
-        self._last_sig = sig
-
-        # No-progress: any successful modify call resets the counter.
-        modified = any(c.name in _MODIFY_TOOL_NAMES for c in calls)
-        if modified or not calls:
-            self._iters_without_mod = 0
-        else:
-            self._iters_without_mod += 1
-
-        errors = _error_signatures(results)
-        # Use the first error in the iteration as the representative signature;
-        # if multiple identical errors persist across iterations we still detect.
-        cur_error = errors[0] if errors else None
-        if cur_error and cur_error == self._last_error:
-            self._error_count += 1
-        else:
-            self._error_count = 1 if cur_error else 0
-        self._last_error = cur_error
-
-        # Determine whether any pattern is currently active.
-        active_pattern = self._active_pattern()
-
-        if not self._nudge_sent:
-            if active_pattern is not None:
-                self._nudge_sent = True
-                self._nudge_pattern = active_pattern
-                self._post_nudge_iters = 0
-                return (self._build_nudge(active_pattern), None, active_pattern)
-            return (None, None, None)
-
-        # Already nudged: check whether the same pattern is still active.
-        if active_pattern is not None:
-            self._post_nudge_iters += 1
-            if self._post_nudge_iters >= self._cfg.post_nudge_iterations:
-                return (None, self._build_terminate_reason(active_pattern), active_pattern)
-        else:
-            # Pattern broke — reset the post-nudge counter; do not re-nudge.
-            self._post_nudge_iters = 0
-        return (None, None, None)
-
-    def _active_pattern(self) -> str | None:
-        if self._cfg is None:
-            return None
-        if self._repeat_count >= self._cfg.repeat_threshold and self._last_sig:
-            preview = next(iter(self._last_sig))[:120]
-            return f"repeated identical tool calls ({self._repeat_count}x): {preview}"
-        if self._has_modify_tools and self._iters_without_mod >= self._cfg.no_progress_iterations:
-            return f"no file modifications over {self._iters_without_mod} consecutive iterations"
-        if self._error_count >= self._cfg.error_threshold and self._last_error:
-            return f"error loop ({self._error_count}x): {self._last_error[:120]}"
-        return None
-
-    @staticmethod
-    def _build_nudge(pattern: str) -> str:
-        return (
-            "[SYSTEM] Progress check: you appear to be stuck — "
-            f"{pattern}. Try a different approach, gather more information with a "
-            "different tool, or submit your current best result. Continuing the same "
-            "behavior will cause this run to be terminated."
-        )
-
-    def _build_terminate_reason(self, pattern: str) -> str:
-        assert self._cfg is not None
-        return (
-            f"stuck pattern persisted for {self._post_nudge_iters} iterations after nudge: "
-            f"{pattern}"
-        )
-
-
 class AgentLoopManager:
     """Drives the multi-turn tool-use loop for API-mode agents.
 
@@ -359,7 +205,7 @@ class AgentLoopManager:
         self._deadline = time.monotonic() + profile.timeout_seconds
         self._iter_nudge_sent = False
         self._time_nudge_sent = False
-        self._stuck = _StuckTracker(profile)
+        self._stuck = StuckTracker(profile)
 
     def _timed_out(self) -> bool:
         return time.monotonic() > self._deadline
@@ -599,7 +445,7 @@ class AgentLoopManager:
             # On detection, inject a nudge; if the pattern persists after the nudge,
             # terminate with a structured failure log.
             stuck_nudge, stuck_terminate, stuck_pattern = self._stuck.observe(
-                turn.tool_calls, turn_results
+                build_observation(turn.tool_calls, turn_results)
             )
             if stuck_terminate is not None:
                 _log(

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -169,6 +169,161 @@ class _UsageAccumulator:
         )
 
 
+_MODIFY_TOOL_NAMES = frozenset({"write_file", "edit_file"})
+
+
+def _signature(call: ToolCallRequest) -> str:
+    """Stable signature for a tool call: name + sorted-key JSON of arguments."""
+    try:
+        args_str = json.dumps(call.arguments, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        args_str = repr(call.arguments)
+    return f"{call.name}|{args_str}"
+
+
+def _signature_set(calls: list[ToolCallRequest]) -> frozenset[str]:
+    return frozenset(_signature(c) for c in calls if c.name and isinstance(c.arguments, dict))
+
+
+def _error_signatures(results: list[dict]) -> list[str]:
+    """Return tool-result content strings that look like errors."""
+    out = []
+    for r in results:
+        content = str(r.get("content", ""))
+        if content.startswith("Error"):
+            out.append(content[:200])
+    return out
+
+
+class _StuckTracker:
+    """Detect stuck-agent patterns across loop iterations.
+
+    Tracks three observable patterns:
+      1. Repeated identical (name+arguments) tool calls
+      2. No file-modifying tool calls over consecutive iterations
+      3. Repeated identical error tool results
+
+    When a pattern crosses its threshold, ``check`` returns a nudge message
+    once. If the same pattern persists for ``post_nudge_iterations`` more
+    iterations, ``check`` returns a termination reason instead.
+
+    Detection is gated by profile.phase == "dev" so review/preflight loops
+    are unaffected by default. False-positive guard: counters reset whenever
+    the observed pattern changes (different signature, file modified, or
+    different error content) — slow-but-real progress does not trigger.
+    """
+
+    def __init__(self, profile: "ModelProfile") -> None:
+        cfg = profile.stuck_detection
+        self._enabled = bool(
+            cfg and cfg.enabled and profile.phase == "dev"
+            # No-progress arm needs at least one modify tool to be meaningful;
+            # repeat/error arms always work, so we still enable when modify
+            # tools are present *or* when the agent has tool calls at all.
+        )
+        self._cfg = cfg
+        modify_names = ("Write", "Edit", "write_file", "edit_file")
+        self._has_modify_tools = bool(
+            profile.allowed_tools and any(t in profile.allowed_tools for t in modify_names)
+        )
+        self._last_sig: frozenset[str] | None = None
+        self._repeat_count = 0
+        self._iters_without_mod = 0
+        self._last_error: str | None = None
+        self._error_count = 0
+        self._nudge_sent = False
+        self._nudge_pattern: str | None = None
+        self._post_nudge_iters = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def observe(
+        self, calls: list[ToolCallRequest], results: list[dict]
+    ) -> tuple[str | None, str | None, str | None]:
+        """Update state for one iteration. Returns (nudge_msg, terminate_reason, pattern).
+
+        At most one of nudge_msg/terminate_reason is non-None per call.
+        ``pattern`` is the human-readable detected pattern when either fires.
+        """
+        if not self._enabled or self._cfg is None:
+            return (None, None, None)
+
+        sig = _signature_set(calls)
+        if self._last_sig is not None and sig == self._last_sig and sig:
+            self._repeat_count += 1
+        else:
+            self._repeat_count = 1
+        self._last_sig = sig
+
+        # No-progress: any successful modify call resets the counter.
+        modified = any(c.name in _MODIFY_TOOL_NAMES for c in calls)
+        if modified or not calls:
+            self._iters_without_mod = 0
+        else:
+            self._iters_without_mod += 1
+
+        errors = _error_signatures(results)
+        # Use the first error in the iteration as the representative signature;
+        # if multiple identical errors persist across iterations we still detect.
+        cur_error = errors[0] if errors else None
+        if cur_error and cur_error == self._last_error:
+            self._error_count += 1
+        else:
+            self._error_count = 1 if cur_error else 0
+        self._last_error = cur_error
+
+        # Determine whether any pattern is currently active.
+        active_pattern = self._active_pattern()
+
+        if not self._nudge_sent:
+            if active_pattern is not None:
+                self._nudge_sent = True
+                self._nudge_pattern = active_pattern
+                self._post_nudge_iters = 0
+                return (self._build_nudge(active_pattern), None, active_pattern)
+            return (None, None, None)
+
+        # Already nudged: check whether the same pattern is still active.
+        if active_pattern is not None:
+            self._post_nudge_iters += 1
+            if self._post_nudge_iters >= self._cfg.post_nudge_iterations:
+                return (None, self._build_terminate_reason(active_pattern), active_pattern)
+        else:
+            # Pattern broke — reset the post-nudge counter; do not re-nudge.
+            self._post_nudge_iters = 0
+        return (None, None, None)
+
+    def _active_pattern(self) -> str | None:
+        if self._cfg is None:
+            return None
+        if self._repeat_count >= self._cfg.repeat_threshold and self._last_sig:
+            preview = next(iter(self._last_sig))[:120]
+            return f"repeated identical tool calls ({self._repeat_count}x): {preview}"
+        if self._has_modify_tools and self._iters_without_mod >= self._cfg.no_progress_iterations:
+            return f"no file modifications over {self._iters_without_mod} consecutive iterations"
+        if self._error_count >= self._cfg.error_threshold and self._last_error:
+            return f"error loop ({self._error_count}x): {self._last_error[:120]}"
+        return None
+
+    @staticmethod
+    def _build_nudge(pattern: str) -> str:
+        return (
+            "[SYSTEM] Progress check: you appear to be stuck — "
+            f"{pattern}. Try a different approach, gather more information with a "
+            "different tool, or submit your current best result. Continuing the same "
+            "behavior will cause this run to be terminated."
+        )
+
+    def _build_terminate_reason(self, pattern: str) -> str:
+        assert self._cfg is not None
+        return (
+            f"stuck pattern persisted for {self._post_nudge_iters} iterations after nudge: "
+            f"{pattern}"
+        )
+
+
 class AgentLoopManager:
     """Drives the multi-turn tool-use loop for API-mode agents.
 
@@ -204,6 +359,7 @@ class AgentLoopManager:
         self._deadline = time.monotonic() + profile.timeout_seconds
         self._iter_nudge_sent = False
         self._time_nudge_sent = False
+        self._stuck = _StuckTracker(profile)
 
     def _timed_out(self) -> bool:
         return time.monotonic() > self._deadline
@@ -438,6 +594,28 @@ class AgentLoopManager:
 
             # Append assistant turn + all tool results in a single history entry
             messages = self._append_tool_results(messages, turn.tool_calls, turn_results)
+
+            # Progress-aware stuck detection: observe this iteration's calls/results.
+            # On detection, inject a nudge; if the pattern persists after the nudge,
+            # terminate with a structured failure log.
+            stuck_nudge, stuck_terminate, stuck_pattern = self._stuck.observe(
+                turn.tool_calls, turn_results
+            )
+            if stuck_terminate is not None:
+                _log(
+                    f"  ⚠ {label} stuck-detection terminate after {iterations} iterations "
+                    f"({self._total_tool_calls} tool calls): {stuck_pattern}"
+                )
+                return self._failure_result(
+                    f"Agent loop terminated: {stuck_terminate} "
+                    f"(at iteration {iterations}, {self._total_tool_calls} tool calls)"
+                )
+            if stuck_nudge is not None:
+                messages = list(messages)
+                messages.append({"role": "user", "content": stuck_nudge})
+                _log(
+                    f"  ⚠ {label} stuck-detection nudge at iteration {iterations}: {stuck_pattern}"
+                )
 
             # Nudge: when approaching the iteration limit, tell the model to wrap up
             if not self._iter_nudge_sent:

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from theforge.agent_types import AgentResult, ModelUsage
 from theforge.log_util import _log_line
+from theforge.runners.stuck_detection import StuckTracker, build_observation
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
 from theforge.workspace_env import build_workspace_env
 
@@ -98,6 +99,128 @@ def _process_stream_event(line: str, label: str = "", *, label_prefix: str = "")
                 inp = item.get("input", {})
                 preview = _format_tool_input_preview(inp)
                 _log_verbose(f"  ↳ {label_prefix}{tool_name}: {preview}")
+
+
+class _StreamCall:
+    """Minimal duck-type for stuck_detection.build_observation()."""
+
+    __slots__ = ("name", "arguments")
+
+    def __init__(self, name: str, arguments: dict | None) -> None:
+        self.name = name
+        self.arguments = arguments if isinstance(arguments, dict) else {}
+
+
+class _ClaudeStreamMonitor:
+    """Group Claude stream events into iterations and feed a StuckTracker.
+
+    Claude emits ``assistant`` events with one or more ``tool_use`` items per
+    LLM turn, then ``user`` events with the matching ``tool_result`` items.
+    We treat one assistant turn (with its tool_results) as one agent
+    iteration. The monitor calls ``tracker.observe`` once per iteration.
+
+    On a stuck-pattern termination the monitor records a reason and the
+    runner kills the subprocess; the runner translates the reason into a
+    failure ``AgentResult`` (exit_code -2) so the coordinator can attribute
+    the early termination correctly.
+    """
+
+    def __init__(self, profile: ModelProfile) -> None:
+        self._tracker = StuckTracker(profile)
+        self._enabled = self._tracker.enabled
+        self._tool_name_by_id: dict[str, str] = {}
+        self._pending_calls: list[_StreamCall] = []
+        self._pending_results: list[dict] = []
+        self.terminate_reason: str | None = None
+        self.terminate_pattern: str | None = None
+        self.nudge_pattern: str | None = None  # last nudge for log/diagnostic
+        self.iteration_count = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def should_terminate(self) -> bool:
+        return self.terminate_reason is not None
+
+    def ingest(self, line: str) -> None:
+        if not self._enabled or not line:
+            return
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return
+        et = event.get("type")
+        if et == "assistant":
+            self._on_assistant(event)
+        elif et == "user":
+            self._on_user(event)
+        elif et == "result":
+            self._flush()
+
+    def finalize(self) -> None:
+        """Flush any unprocessed pending iteration at end of stream."""
+        if self._enabled:
+            self._flush()
+
+    def _on_assistant(self, event: dict) -> None:
+        msg = event.get("message", {}) or {}
+        content = msg.get("content", []) or []
+        new_calls: list[_StreamCall] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "tool_use":
+                tid = item.get("id", "")
+                name = item.get("name", "") or ""
+                args = item.get("input", {})
+                if tid:
+                    self._tool_name_by_id[tid] = name
+                new_calls.append(_StreamCall(name, args))
+        if not new_calls:
+            return
+        # If a previous iteration's results never arrived, flush what we have.
+        if self._pending_calls:
+            self._flush()
+        self._pending_calls = new_calls
+
+    def _on_user(self, event: dict) -> None:
+        msg = event.get("message", {}) or {}
+        content = msg.get("content", []) or []
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "tool_result":
+                continue
+            tid = item.get("tool_use_id", "")
+            tool_name = self._tool_name_by_id.get(tid, "")
+            raw_content = item.get("content", "")
+            if isinstance(raw_content, list):
+                parts = []
+                for piece in raw_content:
+                    if isinstance(piece, dict) and "text" in piece:
+                        parts.append(str(piece.get("text", "")))
+                    else:
+                        parts.append(str(piece))
+                text = " ".join(parts)
+            else:
+                text = str(raw_content)
+            is_error = bool(item.get("is_error"))
+            content_str = f"Error: {text}" if is_error and not text.startswith("Error") else text
+            self._pending_results.append({"name": tool_name, "content": content_str})
+        if self._pending_calls and len(self._pending_results) >= len(self._pending_calls):
+            self._flush()
+
+    def _flush(self) -> None:
+        if not self._pending_calls and not self._pending_results:
+            return
+        obs = build_observation(self._pending_calls, self._pending_results)
+        nudge_msg, terminate_reason, pattern = self._tracker.observe(obs)
+        self.iteration_count += 1
+        if nudge_msg is not None:
+            self.nudge_pattern = pattern
+        if terminate_reason is not None and self.terminate_reason is None:
+            self.terminate_reason = terminate_reason
+            self.terminate_pattern = pattern
+        self._pending_calls = []
+        self._pending_results = []
 
 
 def _try_parse_handoff(output: str) -> dict | None:
@@ -210,6 +333,7 @@ def _run_claude(
     start = time.monotonic()
     deadline = start + profile.timeout_seconds
     timed_out = False
+    stuck_monitor = _ClaudeStreamMonitor(profile)
     try:
         proc = subprocess.Popen(
             cmd,
@@ -243,12 +367,31 @@ def _run_claude(
         lp = f"[{label}] " if quiet else ""
         for line in proc.stdout:
             lines.append(line)
-            _process_stream_event(line.strip(), label_prefix=lp)
+            stripped = line.strip()
+            _process_stream_event(stripped, label_prefix=lp)
+            stuck_monitor.ingest(stripped)
+            if stuck_monitor.nudge_pattern is not None and not getattr(
+                stuck_monitor, "_nudge_logged", False
+            ):
+                _log(
+                    f"  ⚠ {label} stuck-detection nudge (CLI mode, log-only): "
+                    f"{stuck_monitor.nudge_pattern}"
+                )
+                stuck_monitor._nudge_logged = True
+            if stuck_monitor.should_terminate:
+                _log(
+                    f"  ⚠ {label} stuck-detection terminate after "
+                    f"{stuck_monitor.iteration_count} iterations: "
+                    f"{stuck_monitor.terminate_pattern}"
+                )
+                proc.kill()
+                break
             if time.monotonic() > deadline:
                 proc.kill()
                 timed_out = True
                 break
 
+        stuck_monitor.finalize()
         proc.wait()
     except FileNotFoundError:
         return AgentResult(
@@ -260,6 +403,28 @@ def _run_claude(
             raw={},
             profile_name=profile.name,
             startup_failure=True,
+        )
+
+    if stuck_monitor.should_terminate:
+        partial_output = "".join(lines)
+        return AgentResult(
+            success=False,
+            output=(
+                f"Agent loop terminated: {stuck_monitor.terminate_reason} "
+                f"(at iteration {stuck_monitor.iteration_count})"
+            ),
+            session_id=_get_claude_session_id(
+                partial_output,
+                working_dir,
+                fallback_to_file=fallback_to_file,
+                min_mtime=start_wall,
+            ),
+            cost_usd=None,
+            exit_code=-2,
+            raw={},
+            profile_name=profile.name,
+            failure_code="stuck_pattern",
+            dev_handoff=_try_parse_handoff(partial_output),
         )
 
     if timed_out or (time.monotonic() - start) >= profile.timeout_seconds * 1.05:

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -133,8 +133,15 @@ class _ClaudeStreamMonitor:
         self._pending_results: list[dict] = []
         self.terminate_reason: str | None = None
         self.terminate_pattern: str | None = None
-        self.nudge_pattern: str | None = None  # last nudge for log/diagnostic
+        self.nudge_pattern: str | None = None  # last nudge pattern (for logging)
+        self._pending_nudge: str | None = None  # nudge text awaiting delivery
         self.iteration_count = 0
+
+    def consume_pending_nudge(self) -> str | None:
+        """Return and clear the nudge message awaiting delivery, if any."""
+        msg = self._pending_nudge
+        self._pending_nudge = None
+        return msg
 
     @property
     def enabled(self) -> bool:
@@ -216,11 +223,30 @@ class _ClaudeStreamMonitor:
         self.iteration_count += 1
         if nudge_msg is not None:
             self.nudge_pattern = pattern
+            self._pending_nudge = nudge_msg
         if terminate_reason is not None and self.terminate_reason is None:
             self.terminate_reason = terminate_reason
             self.terminate_pattern = pattern
         self._pending_calls = []
         self._pending_results = []
+
+
+def _write_user_message(stdin: Any, text: str) -> None:
+    """Write a single user message to claude's stream-json input pipe.
+
+    Claude's ``--input-format stream-json`` reads one JSON object per line; each
+    line that is a ``user`` message is processed as another conversation turn.
+    Used both for the initial prompt and for stuck-detection nudges.
+    """
+    if stdin is None:
+        return
+    payload = {"type": "user", "message": {"role": "user", "content": text}}
+    try:
+        stdin.write(json.dumps(payload) + "\n")
+        stdin.flush()
+    except (BrokenPipeError, ValueError, OSError):
+        # Subprocess closed stdin (e.g. after kill); silently ignore.
+        pass
 
 
 def _try_parse_handoff(output: str) -> dict | None:
@@ -295,6 +321,8 @@ def _run_claude(
         "-p",
         "--output-format",
         "stream-json",
+        "--input-format",
+        "stream-json",
         "--verbose",
         "--model",
         profile.model,
@@ -345,8 +373,11 @@ def _run_claude(
             env=env,
         )
         assert proc.stdin is not None
-        proc.stdin.write(prompt)
-        proc.stdin.close()
+        # Send the initial prompt as a stream-json user message. stdin is kept
+        # open so stuck-detection nudges can be injected as additional user
+        # messages mid-run; it is closed only after the stream completes
+        # (or the run is killed).
+        _write_user_message(proc.stdin, prompt)
 
         lines: list[str] = []
         assert proc.stdout is not None
@@ -370,14 +401,10 @@ def _run_claude(
             stripped = line.strip()
             _process_stream_event(stripped, label_prefix=lp)
             stuck_monitor.ingest(stripped)
-            if stuck_monitor.nudge_pattern is not None and not getattr(
-                stuck_monitor, "_nudge_logged", False
-            ):
-                _log(
-                    f"  ⚠ {label} stuck-detection nudge (CLI mode, log-only): "
-                    f"{stuck_monitor.nudge_pattern}"
-                )
-                stuck_monitor._nudge_logged = True
+            pending_nudge = stuck_monitor.consume_pending_nudge()
+            if pending_nudge is not None:
+                _write_user_message(proc.stdin, pending_nudge)
+                _log(f"  ⚠ {label} stuck-detection nudge sent: {stuck_monitor.nudge_pattern}")
             if stuck_monitor.should_terminate:
                 _log(
                     f"  ⚠ {label} stuck-detection terminate after "
@@ -392,6 +419,13 @@ def _run_claude(
                 break
 
         stuck_monitor.finalize()
+        # Close stdin now that the stream is done (or the proc was killed) so
+        # any reader cleanup completes; ignore errors if stdin is already
+        # closed by the kill path.
+        try:
+            proc.stdin.close()
+        except (BrokenPipeError, ValueError, OSError):
+            pass
         proc.wait()
     except FileNotFoundError:
         return AgentResult(

--- a/src/theforge/runners/stuck_detection.py
+++ b/src/theforge/runners/stuck_detection.py
@@ -1,0 +1,216 @@
+"""Progress-aware stuck-agent detection shared by API and CLI runners.
+
+Tracks three observable patterns across loop iterations:
+  - "repeat": identical (tool name + arguments) signatures repeated
+  - "no_progress": consecutive iterations with no successful file modification
+  - "error_loop": identical error tool-result content repeated
+
+On detection the tracker emits a one-shot nudge for the active pattern KIND.
+If the SAME kind persists for ``post_nudge_iterations`` more iterations, the
+tracker emits a termination reason. If the pattern changes or breaks after a
+nudge, the post-nudge counter resets and the tracker re-arms so a fresh
+incident can be nudged again later.
+
+The tracker is gated by ``profile.phase == "dev"`` so review/preflight loops
+remain unaffected. The runner translates raw turn data into an
+``IterationObservation`` once per agent iteration.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from theforge.config import ModelProfile
+
+PATTERN_REPEAT = "repeat"
+PATTERN_NO_PROGRESS = "no_progress"
+PATTERN_ERROR_LOOP = "error_loop"
+
+# Modify-capable tool names (CLI form and API-registry form).
+MODIFY_TOOL_NAMES: frozenset[str] = frozenset({"write_file", "edit_file", "Write", "Edit"})
+
+
+def make_signature(name: str | None, arguments: dict | None) -> str:
+    """Stable (name, args) signature used to detect repeated identical calls."""
+    try:
+        args_str = json.dumps(arguments or {}, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        args_str = repr(arguments)
+    return f"{name or ''}|{args_str}"
+
+
+@dataclass(frozen=True)
+class IterationObservation:
+    """One agent iteration distilled into the inputs the tracker needs.
+
+    ``signatures`` is the set of (name, args) signatures of every well-formed
+    tool call the agent issued this iteration. ``successful_modify`` is True
+    iff at least one Write/Edit call returned a non-error result — failed
+    write attempts do not count as progress. ``error_content`` is the first
+    error tool-result content from this iteration (truncated), used to detect
+    repeated identical errors across iterations.
+    """
+
+    signatures: frozenset[str]
+    successful_modify: bool
+    error_content: str | None
+
+
+def build_observation(
+    calls: list,
+    results: list[dict],
+) -> IterationObservation:
+    """Build an IterationObservation from a list of tool-call requests and result dicts.
+
+    ``calls`` is a list of ToolCallRequest-like objects (need ``name``/``arguments``).
+    ``results`` is the dict list produced by the API runner: each entry has
+    ``id``, ``name``, ``content``.
+    """
+    sigs: set[str] = set()
+    for c in calls:
+        name = getattr(c, "name", None)
+        args = getattr(c, "arguments", None)
+        if name and isinstance(args, dict):
+            sigs.add(make_signature(name, args))
+
+    successful_modify = False
+    error_content: str | None = None
+    for r in results:
+        name = r.get("name", "")
+        content = str(r.get("content", ""))
+        is_error = content.startswith("Error")
+        if name in MODIFY_TOOL_NAMES and not is_error:
+            successful_modify = True
+        if error_content is None and is_error:
+            error_content = content[:200]
+
+    return IterationObservation(
+        signatures=frozenset(sigs),
+        successful_modify=successful_modify,
+        error_content=error_content,
+    )
+
+
+class StuckTracker:
+    """Per-run state machine for stuck-agent pattern detection.
+
+    Call ``observe`` once per agent iteration with an IterationObservation.
+    Returns ``(nudge_msg, terminate_reason, pattern_text)`` — at most one of
+    nudge_msg/terminate_reason is non-None per call. ``pattern_text`` is the
+    human-readable description of the active pattern when either fires.
+    """
+
+    def __init__(self, profile: ModelProfile) -> None:
+        cfg = profile.stuck_detection
+        self._enabled = bool(cfg and cfg.enabled and profile.phase == "dev")
+        self._cfg = cfg
+        self._has_modify_tools = bool(
+            profile.allowed_tools and any(t in profile.allowed_tools for t in MODIFY_TOOL_NAMES)
+        )
+        self._last_sig: frozenset[str] | None = None
+        self._repeat_count = 0
+        self._iters_without_mod = 0
+        self._last_error: str | None = None
+        self._error_count = 0
+        self._nudge_sent = False
+        self._nudge_kind: str | None = None
+        self._post_nudge_iters = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def nudge_kind(self) -> str | None:
+        return self._nudge_kind
+
+    def observe(self, obs: IterationObservation) -> tuple[str | None, str | None, str | None]:
+        if not self._enabled or self._cfg is None:
+            return (None, None, None)
+
+        sig = obs.signatures
+        if self._last_sig is not None and sig == self._last_sig and sig:
+            self._repeat_count += 1
+        else:
+            self._repeat_count = 1 if sig else 0
+        self._last_sig = sig
+
+        # No-progress arm: only a *successful* modify call counts as progress.
+        # Iterations with no tool calls at all are also progress-neutral.
+        if obs.successful_modify or not sig:
+            self._iters_without_mod = 0
+        else:
+            self._iters_without_mod += 1
+
+        cur_error = obs.error_content
+        if cur_error and cur_error == self._last_error:
+            self._error_count += 1
+        else:
+            self._error_count = 1 if cur_error else 0
+        self._last_error = cur_error
+
+        active_kind, active_text = self._active_pattern()
+
+        if not self._nudge_sent:
+            if active_kind is not None and active_text is not None:
+                self._nudge_sent = True
+                self._nudge_kind = active_kind
+                self._post_nudge_iters = 0
+                return (self._build_nudge(active_text), None, active_text)
+            return (None, None, None)
+
+        # Already nudged: only count post-nudge iterations when the SAME kind
+        # is still active. If the pattern broke or switched to a different
+        # kind, reset and re-arm so a future incident can be nudged again.
+        if active_kind is not None and active_kind == self._nudge_kind:
+            self._post_nudge_iters += 1
+            if self._post_nudge_iters >= self._cfg.post_nudge_iterations:
+                assert active_text is not None
+                return (None, self._build_terminate_reason(active_text), active_text)
+            return (None, None, None)
+
+        # Pattern broke or changed kind — re-arm.
+        self._post_nudge_iters = 0
+        self._nudge_sent = False
+        self._nudge_kind = None
+        return (None, None, None)
+
+    def _active_pattern(self) -> tuple[str | None, str | None]:
+        if self._cfg is None:
+            return (None, None)
+        if self._repeat_count >= self._cfg.repeat_threshold and self._last_sig:
+            preview = next(iter(self._last_sig))[:120]
+            return (
+                PATTERN_REPEAT,
+                f"repeated identical tool calls ({self._repeat_count}x): {preview}",
+            )
+        if self._has_modify_tools and self._iters_without_mod >= self._cfg.no_progress_iterations:
+            return (
+                PATTERN_NO_PROGRESS,
+                f"no file modifications over {self._iters_without_mod} consecutive iterations",
+            )
+        if self._error_count >= self._cfg.error_threshold and self._last_error:
+            return (
+                PATTERN_ERROR_LOOP,
+                f"error loop ({self._error_count}x): {self._last_error[:120]}",
+            )
+        return (None, None)
+
+    @staticmethod
+    def _build_nudge(pattern: str) -> str:
+        return (
+            "[SYSTEM] Progress check: you appear to be stuck — "
+            f"{pattern}. Try a different approach, gather more information with a "
+            "different tool, or submit your current best result. Continuing the same "
+            "behavior will cause this run to be terminated."
+        )
+
+    def _build_terminate_reason(self, pattern: str) -> str:
+        assert self._cfg is not None
+        return (
+            f"stuck pattern persisted for {self._post_nudge_iters} iterations after nudge: "
+            f"{pattern}"
+        )

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -190,8 +190,20 @@ class TestRunAgentClaude:
         assert "--allowedTools" in claude_cmd
         assert call_args[1]["cwd"] == str(tmp_path)
 
-        # Prompt written to stdin
-        mock_proc.stdin.write.assert_called_once_with("implement the thing")
+        # The runner uses --input-format stream-json and writes the initial
+        # prompt as a stream-json user message; stdin is kept open across the
+        # stream and closed only after the stream completes.
+        assert "--input-format" in claude_cmd
+        ifmt_idx = claude_cmd.index("--input-format")
+        assert claude_cmd[ifmt_idx + 1] == "stream-json"
+        write_calls = mock_proc.stdin.write.call_args_list
+        assert len(write_calls) == 1
+        written = write_calls[0][0][0]
+        assert written.endswith("\n")
+        payload = json.loads(written)
+        assert payload["type"] == "user"
+        assert payload["message"]["role"] == "user"
+        assert payload["message"]["content"] == "implement the thing"
         mock_proc.stdin.close.assert_called_once()
 
     def test_claudecode_env_stripped(self, dev_profile: ModelProfile, tmp_path: Path) -> None:

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -1,0 +1,432 @@
+"""Progress-aware stuck-agent detection in the API agent loop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.agent_types import ModelUsage
+from theforge.config import ModelProfile, StuckDetectionConfig
+from theforge.runners.api import AgentLoopManager
+from theforge.runners.schema_utils import (
+    SUBMIT_REVIEW,
+    LoopTurn,
+    ToolCallRequest,
+)
+from theforge.runners.tool_runtime import TOOL_REGISTRY
+
+
+def _dev_profile(
+    *,
+    stuck: StuckDetectionConfig | None,
+    allowed_tools: tuple[str, ...] = ("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
+    timeout_seconds: int = 300,
+) -> ModelProfile:
+    return ModelProfile(
+        name="test-dev",
+        provider="openai",
+        cli=None,
+        model="gpt-4o",
+        budget_usd=1.0,
+        timeout_seconds=timeout_seconds,
+        allowed_tools=allowed_tools,
+        phase="dev",
+        stuck_detection=stuck,
+    )
+
+
+def _usage() -> ModelUsage:
+    return ModelUsage(
+        model="gpt-4o",
+        input_tokens=10,
+        output_tokens=5,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        cost_usd=None,
+    )
+
+
+def _make_manager(profile: ModelProfile, working_dir: Path, adapter) -> AgentLoopManager:
+    return AgentLoopManager(
+        profile=profile,
+        provider="openai",
+        working_dir=working_dir,
+        tools=list(TOOL_REGISTRY.values()),
+        provider_adapter=adapter,
+        max_iterations=50,
+    )
+
+
+def _glob_call(idx: int, pattern: str = "*.py") -> ToolCallRequest:
+    return ToolCallRequest(id=f"c{idx}", name="glob", arguments={"pattern": pattern})
+
+
+def _glob_turn(idx: int, pattern: str = "*.py") -> LoopTurn:
+    return LoopTurn(
+        tool_calls=[_glob_call(idx, pattern=pattern)],
+        text_output=None,
+        structured_data=None,
+        usage=_usage(),
+    )
+
+
+class TestStuckDetectionTriggers:
+    """The runner injects a nudge once the repeat-call threshold is crossed."""
+
+    def test_repeated_identical_calls_trigger_nudge(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=3,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        messages_seen: list[list[dict]] = []
+        call_count = [0]
+
+        def adapter(messages, tools):
+            messages_seen.append(list(messages))
+            call_count[0] += 1
+            if call_count[0] <= 5:
+                return _glob_turn(call_count[0])
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "ok"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        # A stuck nudge should have been injected.
+        all_msgs = [m for msgs in messages_seen for m in msgs]
+        nudges = [
+            m
+            for m in all_msgs
+            if m.get("role") == "user" and "Progress check" in m.get("content", "")
+        ]
+        assert len(nudges) >= 1
+        assert "stuck" in nudges[0]["content"].lower()
+
+
+class TestStuckDetectionNudgeDelivery:
+    """Detection only fires once per run, regardless of how long the pattern persists."""
+
+    def test_nudge_sent_only_once(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=99,  # never terminate, just count nudges
+        )
+        profile = _dev_profile(stuck=cfg)
+        messages_seen: list[list[dict]] = []
+        call_count = [0]
+
+        def adapter(messages, tools):
+            messages_seen.append(list(messages))
+            call_count[0] += 1
+            if call_count[0] <= 8:
+                return _glob_turn(call_count[0])
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "done"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        # Use the final message list — the nudge user-message persists in history.
+        last_msgs = messages_seen[-1]
+        progress_nudges = [
+            m
+            for m in last_msgs
+            if m.get("role") == "user" and "Progress check" in m.get("content", "")
+        ]
+        assert len(progress_nudges) == 1
+
+
+class TestStuckDetectionTermination:
+    """Termination follows when the nudge does not break the pattern."""
+
+    def test_termination_after_nudge_persistence(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=3,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=2,
+        )
+        profile = _dev_profile(stuck=cfg)
+        call_count = [0]
+
+        def adapter(messages, tools):
+            call_count[0] += 1
+            return _glob_turn(call_count[0])
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+
+        assert not result.success
+        assert "stuck pattern" in result.output.lower()
+        assert "after nudge" in result.output.lower()
+        # nudge at iter 3, then 2 more identical iters → terminate at iter 5.
+        assert call_count[0] == 5
+
+    def test_termination_logs_pattern_and_counts(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=2,
+        )
+        profile = _dev_profile(stuck=cfg)
+        call_count = [0]
+
+        def adapter(messages, tools):
+            call_count[0] += 1
+            return _glob_turn(call_count[0])
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+
+        # Reason mentions iteration count + tool count + the pattern.
+        out = result.output
+        assert "repeated identical tool calls" in out
+        assert "iteration" in out
+
+
+class TestStuckDetectionNoFalsePositiveOnVariedIterations:
+    """Different tool calls per iteration are real progress, not a stuck pattern."""
+
+    def test_varied_signatures_do_not_trigger(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=3,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=2,
+        )
+        profile = _dev_profile(stuck=cfg)
+        messages_seen: list[list[dict]] = []
+        call_count = [0]
+        patterns = ["*.py", "*.md", "*.txt", "src/*", "tests/*", "*.json", "*.yaml"]
+
+        def adapter(messages, tools):
+            messages_seen.append(list(messages))
+            call_count[0] += 1
+            if call_count[0] <= len(patterns):
+                return _glob_turn(call_count[0], pattern=patterns[call_count[0] - 1])
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "ok"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        assert result.success
+
+        all_msgs = [m for msgs in messages_seen for m in msgs]
+        nudges = [
+            m
+            for m in all_msgs
+            if m.get("role") == "user" and "Progress check" in m.get("content", "")
+        ]
+        assert nudges == []
+
+
+class TestStuckDetectionDisabled:
+    """When stuck_detection is None or phase != 'dev', the runner is unaffected."""
+
+    def test_disabled_when_phase_not_dev(self, tmp_path):
+        cfg = StuckDetectionConfig(enabled=True, repeat_threshold=2, post_nudge_iterations=2)
+        # phase=None disables detection regardless of cfg.enabled.
+        profile = ModelProfile(
+            name="reviewer",
+            provider="openai",
+            cli=None,
+            model="gpt-4o",
+            budget_usd=1.0,
+            timeout_seconds=300,
+            allowed_tools=("Read", "Glob"),
+            phase=None,
+            stuck_detection=cfg,
+        )
+        call_count = [0]
+
+        def adapter(messages, tools):
+            call_count[0] += 1
+            if call_count[0] <= 5:
+                return _glob_turn(call_count[0])
+            return LoopTurn(
+                tool_calls=[],
+                text_output="done",
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        assert result.success
+
+    def test_disabled_when_cfg_none(self, tmp_path):
+        profile = _dev_profile(stuck=None)
+        call_count = [0]
+
+        def adapter(messages, tools):
+            call_count[0] += 1
+            if call_count[0] <= 5:
+                return _glob_turn(call_count[0])
+            return LoopTurn(
+                tool_calls=[],
+                text_output="done",
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        assert result.success
+
+
+class TestNoProgressDetection:
+    """no_progress_iterations triggers when modify-capable agents stop modifying files."""
+
+    def test_no_modifications_triggers_nudge(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=99,
+            no_progress_iterations=3,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        messages_seen: list[list[dict]] = []
+        call_count = [0]
+        # Vary the args so repeat_threshold doesn't fire instead.
+        patterns = ["*.py", "*.md", "*.txt", "src/*", "tests/*"]
+
+        def adapter(messages, tools):
+            messages_seen.append(list(messages))
+            call_count[0] += 1
+            if call_count[0] <= len(patterns):
+                return _glob_turn(call_count[0], pattern=patterns[call_count[0] - 1])
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "ok"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        all_msgs = [m for msgs in messages_seen for m in msgs]
+        nudges = [
+            m
+            for m in all_msgs
+            if m.get("role") == "user" and "no file modifications" in m.get("content", "")
+        ]
+        assert len(nudges) >= 1
+
+
+class TestStuckDetectionConfigParsing:
+    """Loader accepts and validates the forge.yaml stuck_detection block."""
+
+    def test_parse_defaults(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        cfg = _parse_stuck_detection({})
+        assert cfg == StuckDetectionConfig()
+
+    def test_parse_overrides(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        cfg = _parse_stuck_detection(
+            {
+                "enabled": False,
+                "no_progress_iterations": 7,
+                "repeat_threshold": 5,
+                "error_threshold": 6,
+                "post_nudge_iterations": 4,
+            }
+        )
+        assert cfg == StuckDetectionConfig(
+            enabled=False,
+            no_progress_iterations=7,
+            repeat_threshold=5,
+            error_threshold=6,
+            post_nudge_iterations=4,
+        )
+
+    def test_parse_rejects_non_int_threshold(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        try:
+            _parse_stuck_detection({"repeat_threshold": "lots"})
+        except ValueError as exc:
+            assert "repeat_threshold" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_parse_rejects_zero_threshold(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        try:
+            _parse_stuck_detection({"no_progress_iterations": 0})
+        except ValueError as exc:
+            assert "no_progress_iterations" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -671,6 +671,88 @@ class TestClaudeCliStuckDetection:
         assert result.exit_code == -2
         # Subprocess must have been killed once a stuck termination fired.
         mock_proc.kill.assert_called()
+        # Nudge must have been written to stdin as a stream-json user
+        # message before termination — verify by inspecting the writes.
+        import json as _json
+
+        stdin_writes = [_call.args[0] for _call in mock_proc.stdin.write.call_args_list]
+        # First write is the initial prompt; subsequent writes include the nudge.
+        decoded = []
+        for raw in stdin_writes:
+            for piece in raw.splitlines():
+                if not piece.strip():
+                    continue
+                try:
+                    decoded.append(_json.loads(piece))
+                except _json.JSONDecodeError:
+                    pass
+        user_contents = [
+            d.get("message", {}).get("content", "") for d in decoded if d.get("type") == "user"
+        ]
+        assert user_contents, "expected at least the initial prompt written to stdin"
+        assert user_contents[0] == "go"
+        # At least one nudge user-message must have been delivered.
+        nudge_msgs = [c for c in user_contents[1:] if "Progress check" in c]
+        assert nudge_msgs, "expected stuck-detection nudge to be written to stdin"
+
+    def test_cli_nudge_delivered_then_recovers(self, tmp_path):
+        """Nudge is delivered via stdin; if pattern breaks, run completes normally."""
+        from unittest.mock import MagicMock, patch
+
+        from theforge.runners.runner_claude import _run_claude
+
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=99,  # never terminate, isolate nudge delivery
+        )
+        profile = self._build_dev_profile(cfg)
+
+        # 3 identical iterations → repeat nudge fires; then result event ends
+        # the stream cleanly (no terminate because post_nudge=99).
+        stream: list[str] = []
+        for i in range(3):
+            cid = f"call-{i}"
+            stream.append(self._assistant_event(cid, "Glob", {"pattern": "*.py"}))
+            stream.append(self._user_result_event(cid, "[]"))
+        stream.append(self._result_event())
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(stream)
+        mock_proc.stdin = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read.return_value = ""
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+        mock_proc.poll.return_value = 0
+
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            _run_claude(prompt="go", profile=profile, working_dir=tmp_path)
+
+        import json as _json
+
+        stdin_writes = [c.args[0] for c in mock_proc.stdin.write.call_args_list]
+        decoded = []
+        for raw in stdin_writes:
+            for piece in raw.splitlines():
+                if not piece.strip():
+                    continue
+                try:
+                    decoded.append(_json.loads(piece))
+                except _json.JSONDecodeError:
+                    pass
+        user_msgs = [d["message"]["content"] for d in decoded if d.get("type") == "user"]
+        # Initial prompt + at least one nudge.
+        assert user_msgs[0] == "go"
+        assert any("Progress check" in m for m in user_msgs[1:]), (
+            f"expected nudge in stdin writes; got {user_msgs}"
+        )
+        # No kill since post_nudge=99 and the result event closed the stream.
+        mock_proc.kill.assert_not_called()
+        # stdin closed exactly once at end of stream.
+        mock_proc.stdin.close.assert_called()
 
     def test_cli_does_not_terminate_when_phase_not_dev(self, tmp_path):
         from unittest.mock import MagicMock, patch

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -382,6 +382,337 @@ class TestNoProgressDetection:
         assert len(nudges) >= 1
 
 
+class TestPostNudgeSamePatternRequired:
+    """Post-nudge termination requires the SAME pattern kind to persist."""
+
+    def test_pattern_change_after_nudge_resets_and_rearm(self, tmp_path):
+        # repeat fires first; switch to varied calls (pattern breaks); the
+        # tracker must re-arm rather than terminate. Configure thresholds so
+        # the second pattern (no-progress) would otherwise hit terminate
+        # immediately if the kind check were absent.
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=2,
+            error_threshold=99,
+            # Loose post-nudge window so the test isolates the re-arm behavior.
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        messages_seen: list[list[dict]] = []
+        call_count = [0]
+        # First two iterations identical → repeat nudge at iter 2.
+        # Then varied iterations break repeat; tracker must re-arm and emit a
+        # fresh no-progress nudge rather than terminating without one.
+        patterns = ["x", "x", "a", "b", "c", "d", "e", "f"]
+
+        def adapter(messages, tools):
+            messages_seen.append(list(messages))
+            call_count[0] += 1
+            if call_count[0] <= len(patterns):
+                return _glob_turn(call_count[0], pattern=patterns[call_count[0] - 1])
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "ok"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        # The run should not terminate on stuck pattern: repeat broke before
+        # post-nudge persistence threshold was reached.
+        assert result.success, result.output
+        # Two distinct nudges expected: one for repeat, one for no-progress.
+        last_msgs = messages_seen[-1]
+        nudges = [
+            m
+            for m in last_msgs
+            if m.get("role") == "user" and "Progress check" in m.get("content", "")
+        ]
+        # At least the repeat nudge must have been issued; the no-progress
+        # arm needs >=2 iterations without modifications, satisfied by the
+        # varied glob iterations. Both kinds should produce a nudge.
+        kinds = {("repeated" in n["content"], "no file" in n["content"]) for n in nudges}
+        assert any(repeat for repeat, _ in kinds)
+        assert any(noprog for _, noprog in kinds), (
+            "expected a fresh no-progress nudge after the repeat pattern broke"
+        )
+
+    def test_no_terminate_when_post_nudge_pattern_breaks(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=2,
+        )
+        profile = _dev_profile(stuck=cfg)
+        call_count = [0]
+        # iter 1,2: identical → nudge at iter 2.
+        # iter 3,4: different signatures → pattern broken, no terminate.
+        # iter 5: submit.
+        patterns = ["x", "x", "a", "b"]
+
+        def adapter(messages, tools):
+            call_count[0] += 1
+            if call_count[0] <= len(patterns):
+                return _glob_turn(call_count[0], pattern=patterns[call_count[0] - 1])
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "ok"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        assert result.success, result.output
+
+
+class TestFailedModifyDoesNotResetNoProgress:
+    """A write/edit that returns an error must not count as progress."""
+
+    def test_failed_edit_calls_count_as_no_progress(self, tmp_path):
+        # write_file with missing required arg → tool returns Error, so the
+        # call should NOT reset the no-progress counter.
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=99,
+            no_progress_iterations=3,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        messages_seen: list[list[dict]] = []
+        call_count = [0]
+        # Each iteration calls write_file with a different (still-invalid)
+        # path argument so signatures vary (no repeat) and the tool errors
+        # (no successful modify). After 3 such iterations, no-progress
+        # nudge must fire.
+        paths = ["a.py", "b.py", "c.py", "d.py", "e.py"]
+
+        def adapter(messages, tools):
+            messages_seen.append(list(messages))
+            call_count[0] += 1
+            if call_count[0] <= len(paths):
+                # Missing required `content` → tool reports an Error result.
+                return LoopTurn(
+                    tool_calls=[
+                        ToolCallRequest(
+                            id=f"c{call_count[0]}",
+                            name="write_file",
+                            arguments={"path": paths[call_count[0] - 1]},
+                        )
+                    ],
+                    text_output=None,
+                    structured_data=None,
+                    usage=_usage(),
+                )
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "done"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_usage(),
+            )
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        all_msgs = [m for msgs in messages_seen for m in msgs]
+        nudges = [
+            m
+            for m in all_msgs
+            if m.get("role") == "user" and "no file modifications" in m.get("content", "")
+        ]
+        assert len(nudges) >= 1, "failed write_file calls should count as no-progress"
+
+
+class TestClaudeCliStuckDetection:
+    """Stuck detection runs in the Claude CLI streaming loop, not just API mode."""
+
+    @staticmethod
+    def _assistant_event(call_id: str, name: str, args: dict) -> str:
+        import json as _json
+
+        return (
+            _json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": call_id,
+                                "name": name,
+                                "input": args,
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    @staticmethod
+    def _user_result_event(call_id: str, text: str, is_error: bool = False) -> str:
+        import json as _json
+
+        return (
+            _json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": call_id,
+                                "content": text,
+                                "is_error": is_error,
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    @staticmethod
+    def _result_event(text: str = "done") -> str:
+        import json as _json
+
+        return _json.dumps({"type": "result", "result": text, "session_id": "s1"}) + "\n"
+
+    def _build_dev_profile(self, cfg: StuckDetectionConfig | None) -> ModelProfile:
+        return ModelProfile(
+            name="dev",
+            cli="claude",
+            provider=None,
+            model="sonnet",
+            budget_usd=1.0,
+            timeout_seconds=120,
+            allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
+            phase="dev",
+            stuck_detection=cfg,
+        )
+
+    def _build_stream(self, n_iterations: int) -> list[str]:
+        """Build a Claude CLI stream of N identical Glob iterations."""
+        lines: list[str] = []
+        for i in range(n_iterations):
+            cid = f"call-{i}"
+            lines.append(self._assistant_event(cid, "Glob", {"pattern": "**/*.py"}))
+            lines.append(self._user_result_event(cid, "[]"))
+        lines.append(self._result_event())
+        return lines
+
+    def test_cli_terminates_on_stuck_pattern(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from theforge.runners.runner_claude import _run_claude
+
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=2,
+        )
+        profile = self._build_dev_profile(cfg)
+
+        # 10 identical Glob iterations is well past repeat(2) + post_nudge(2).
+        stream = self._build_stream(10)
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(stream)
+        mock_proc.stdin = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read.return_value = ""
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+        mock_proc.poll.return_value = 0
+
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = _run_claude(
+                prompt="go",
+                profile=profile,
+                working_dir=tmp_path,
+            )
+
+        assert result.success is False
+        assert result.failure_code == "stuck_pattern"
+        assert "stuck pattern persisted" in result.output
+        assert result.exit_code == -2
+        # Subprocess must have been killed once a stuck termination fired.
+        mock_proc.kill.assert_called()
+
+    def test_cli_does_not_terminate_when_phase_not_dev(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from theforge.runners.runner_claude import _run_claude
+
+        # phase=None disables stuck detection regardless of cfg.enabled.
+        cfg = StuckDetectionConfig(enabled=True, repeat_threshold=2, post_nudge_iterations=2)
+        profile = ModelProfile(
+            name="reviewer",
+            cli="claude",
+            provider=None,
+            model="sonnet",
+            budget_usd=1.0,
+            timeout_seconds=120,
+            allowed_tools=("Read", "Glob"),
+            phase=None,
+            stuck_detection=cfg,
+        )
+
+        stream = self._build_stream(10)
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(stream)
+        mock_proc.stdin = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read.return_value = ""
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+        mock_proc.poll.return_value = 0
+
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = _run_claude(
+                prompt="go",
+                profile=profile,
+                working_dir=tmp_path,
+            )
+        # No stuck termination should have fired for non-dev phase.
+        assert result.failure_code != "stuck_pattern"
+        # And the stream completes through the result event.
+        mock_proc.kill.assert_not_called()
+
+
 class TestStuckDetectionConfigParsing:
     """Loader accepts and validates the forge.yaml stuck_detection block."""
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.4] Prior Claude CLI P1s are resolved: the runner now uses stream-json input, keeps stdin open, sends nudges over stdin, and has test coverage for nudge delivery and stuck termination. | [deepseek-deepseek-reasoner] All prior P1 findings from Cycle 1 are fully resolved. The CLI runner now uses --input-format stream-json, keeps stdin open, and delivers nudges via _write_user_message. Test coverage confirms nudge delivery and termination for both runners. No regressions introduced. | [google-gemini-3.1-pro-preview] All prior P1 findings are resolved. The Claude CLI runner now correctly uses stream-json input to deliver nudges.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $7.25
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Progress-aware timeouts — detect stuck agents early (GitHub Issue #157)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #157