### PR TITLE
Timeout-triggered model escalation (#359)

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -556,6 +556,7 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             if result.landing_status is not None
             else None
         ),
+        "timeout_escalation": state.timeout_escalation_audit,
         "escalation": (
             {
                 "reason": state.escalate_reason,

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1028,6 +1028,16 @@ def _run_resume_coordinator(
         return setup
     state, logger, branch_name, story_content, _task_start = setup
     state.log_dir = _make_story_log_dir(config, task.slug, sprint_name=sprint_name)
+    state.sprint_name = sprint_name
+
+    # Mirror the sprint-sticky timeout-escalation guard from run_task so resumed
+    # stories see the flag written by an earlier story in the same sprint.
+    if sprint_name:
+        _sprint_esc_flag = (
+            config.project_root / ".forge" / "sprints" / sprint_name / "timeout_escalation_used"
+        )
+        if _sprint_esc_flag.exists():
+            state.timeout_escalation_used = True
 
     if cached_preflight_state is not None:
         from .preflight import _apply_preflight_config  # noqa: PLC0415

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -470,6 +470,18 @@ def _coordinator_loop(
                                 "new_timeout_seconds": _new_timeout,
                                 "reason": "timeout",
                             }
+                            # Persist sprint-level flag immediately so subsequent stories
+                            # in the same sprint see it even if this run crashes later.
+                            if state.sprint_name:
+                                _esc_flag = (
+                                    config.project_root
+                                    / ".forge"
+                                    / "sprints"
+                                    / state.sprint_name
+                                    / "timeout_escalation_used"
+                                )
+                                _esc_flag.parent.mkdir(parents=True, exist_ok=True)
+                                _esc_flag.touch()
                             _log(
                                 f"  Timeout escalation:"
                                 f" {_old_timeout_model} → {_new_timeout_model}"
@@ -566,6 +578,16 @@ def run_task(
     story_content = task.story_text if task.story_text is not None else load_story(task.story_path)
     state.story_content = story_content
     _sprint_name = sprint_name  # passed to _make_story_log_dir for sprint nesting
+    state.sprint_name = sprint_name
+
+    # Pre-populate timeout_escalation_used from sprint-level flag so only one escalation
+    # fires across all stories in the same sprint, not just within a single story run.
+    if sprint_name:
+        _sprint_esc_flag = (
+            config.project_root / ".forge" / "sprints" / sprint_name / "timeout_escalation_used"
+        )
+        if _sprint_esc_flag.exists():
+            state.timeout_escalation_used = True
 
     # ── Structured logger ──────────────────────────────────────────
     _run_id = run_id or _generate_run_id()

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -450,29 +450,14 @@ def _coordinator_loop(
                     if config.retry.auto_model_escalation and not state.timeout_escalation_used:
                         _esc = _perform_dev_model_escalation(config)
                         if _esc is not None:
-                            from .util import resolve_timeout_with_active  # noqa: PLC0415
-
-                            _old_timeout_model, _new_timeout_model, config = _esc
-                            _orig_timeout = state.adaptive_dev_timeout_seconds
-                            _new_timeout, _ = resolve_timeout_with_active(
-                                config.dev_profile.timeout_seconds,
-                                config.dev_profile.timeout_medium_seconds,
-                                config.dev_profile.timeout_large_seconds,
-                                state.preflight_complexity,
-                                state.preflight_complexity_score,
-                            )
-                            state.adaptive_dev_timeout_seconds = _new_timeout
-                            state.timeout_escalation_used = True
-                            state.timeout_escalation_audit = {
-                                "original_model": _old_timeout_model,
-                                "new_model": _new_timeout_model,
-                                "original_timeout_seconds": _orig_timeout,
-                                "new_timeout_seconds": _new_timeout,
-                                "reason": "timeout",
-                            }
-                            # Persist sprint-level flag immediately so subsequent stories
-                            # in the same sprint see it even if this run crashes later.
+                            # Atomically claim the sprint-level escalation slot
+                            # BEFORE mutating config/state so parallel sprint
+                            # workers cannot both escalate. O_CREAT|O_EXCL is the
+                            # claim primitive: FileExistsError ⇒ peer won race.
+                            _claimed = True
                             if state.sprint_name:
+                                import os  # noqa: PLC0415
+
                                 _esc_flag = (
                                     config.project_root
                                     / ".forge"
@@ -481,12 +466,45 @@ def _coordinator_loop(
                                     / "timeout_escalation_used"
                                 )
                                 _esc_flag.parent.mkdir(parents=True, exist_ok=True)
-                                _esc_flag.touch()
-                            _log(
-                                f"  Timeout escalation:"
-                                f" {_old_timeout_model} → {_new_timeout_model}"
-                                f" (timeout {_orig_timeout}s → {_new_timeout}s)"
-                            )
+                                try:
+                                    _fd = os.open(
+                                        str(_esc_flag),
+                                        os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                                        0o644,
+                                    )
+                                    os.close(_fd)
+                                except FileExistsError:
+                                    _claimed = False
+                            if not _claimed:
+                                # Peer worker already escalated — record the gate
+                                # and continue with timeout resume on current model.
+                                state.timeout_escalation_used = True
+                            else:
+                                from .util import resolve_timeout_with_active  # noqa: PLC0415
+
+                                _old_timeout_model, _new_timeout_model, config = _esc
+                                _orig_timeout = state.adaptive_dev_timeout_seconds
+                                _new_timeout, _ = resolve_timeout_with_active(
+                                    config.dev_profile.timeout_seconds,
+                                    config.dev_profile.timeout_medium_seconds,
+                                    config.dev_profile.timeout_large_seconds,
+                                    state.preflight_complexity,
+                                    state.preflight_complexity_score,
+                                )
+                                state.adaptive_dev_timeout_seconds = _new_timeout
+                                state.timeout_escalation_used = True
+                                state.timeout_escalation_audit = {
+                                    "original_model": _old_timeout_model,
+                                    "new_model": _new_timeout_model,
+                                    "original_timeout_seconds": _orig_timeout,
+                                    "new_timeout_seconds": _new_timeout,
+                                    "reason": "timeout",
+                                }
+                                _log(
+                                    f"  Timeout escalation:"
+                                    f" {_old_timeout_model} → {_new_timeout_model}"
+                                    f" (timeout {_orig_timeout}s → {_new_timeout}s)"
+                                )
                     _set_timeout_resume(state, gate_result)
                 continue
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -211,8 +211,13 @@ def _run_log_context(
 
 # ── Phase handlers ────────────────────────────────────────────────────
 from .dev_phase import _run_dev_phase  # noqa: E402
-from .review_phase import _ReviewOutcome, _run_review_only_phase, _run_review_phase  # noqa: E402
-from .run_setup import _rebase_onto_main, _setup_resume_entry  # noqa: E402
+from .review_phase import (  # noqa: E402
+    _perform_dev_model_escalation,
+    _ReviewOutcome,
+    _run_review_only_phase,
+    _run_review_phase,
+)
+from .run_setup import _rebase_onto_main, _setup_resume_entry  # noqa: E402,I001
 from .validate_phase import _run_validate_phase, _ValidateOutcome  # noqa: E402
 
 
@@ -442,6 +447,34 @@ def _coordinator_loop(
                         prefix = "Gate validation failed: "
                         if state.human_feedback.startswith(prefix):
                             gate_result = f"FAIL - {state.human_feedback.removeprefix(prefix)}"
+                    if config.retry.auto_model_escalation and not state.timeout_escalation_used:
+                        _esc = _perform_dev_model_escalation(config)
+                        if _esc is not None:
+                            from .util import resolve_timeout_with_active  # noqa: PLC0415
+
+                            _old_timeout_model, _new_timeout_model, config = _esc
+                            _orig_timeout = state.adaptive_dev_timeout_seconds
+                            _new_timeout, _ = resolve_timeout_with_active(
+                                config.dev_profile.timeout_seconds,
+                                config.dev_profile.timeout_medium_seconds,
+                                config.dev_profile.timeout_large_seconds,
+                                state.preflight_complexity,
+                                state.preflight_complexity_score,
+                            )
+                            state.adaptive_dev_timeout_seconds = _new_timeout
+                            state.timeout_escalation_used = True
+                            state.timeout_escalation_audit = {
+                                "original_model": _old_timeout_model,
+                                "new_model": _new_timeout_model,
+                                "original_timeout_seconds": _orig_timeout,
+                                "new_timeout_seconds": _new_timeout,
+                                "reason": "timeout",
+                            }
+                            _log(
+                                f"  Timeout escalation:"
+                                f" {_old_timeout_model} → {_new_timeout_model}"
+                                f" (timeout {_orig_timeout}s → {_new_timeout}s)"
+                            )
                     _set_timeout_resume(state, gate_result)
                 continue
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -67,6 +67,27 @@ from .state import (
 from .util import _fmt_duration, _log, _log_phase, _log_verbose, _run_worktree_eval
 
 
+def _perform_dev_model_escalation(
+    config: ForgeConfig,
+) -> tuple[str, str, ForgeConfig] | None:
+    """Bump the dev model to the next higher-capability model in the escalation chain.
+
+    Returns (old_model_name, new_model_name, new_config) or None when no larger
+    model is available. Callers are responsible for updating state flags and emitting
+    audit records appropriate to their escalation reason.
+    """
+    curr_key = _find_registry_key_for_profile(config.dev_profile)
+    if curr_key is None:
+        return None
+    next_key = _escalate_dev_model(curr_key, config.models)
+    if next_key is None:
+        return None
+    next_info = MODEL_REGISTRY[next_key]
+    old_model = config.dev_profile.model
+    new_dev = apply_model_info(config.dev_profile, next_info)
+    return old_model, next_info.model, _dc_replace(config, dev_profile=new_dev)
+
+
 def _build_reviewer_verdicts(state: CoordinatorState) -> dict[str, str]:
     """Build a profile_name → verdict dict from the last cycle's reviewer results."""
     verdicts: dict[str, str] = {}
@@ -975,33 +996,27 @@ def _run_review_phase(
             state.total_dev_cost < (state.adaptive_dev_budget_usd or config.dev_profile.budget_usd)
         )
     ):
-        _curr_key = _find_registry_key_for_profile(config.dev_profile)
-        if _curr_key is not None:
-            _next_key = _escalate_dev_model(_curr_key, config.models)
-            if _next_key is not None:
-                _next_info = MODEL_REGISTRY[_next_key]
-                _p1_file = next(
-                    (f.file for f in parsed_review.findings if f.severity == "P1"),
-                    "unknown",
-                )
-                _log(
-                    f"  Dev escalation: {config.dev_profile.model} → {_next_info.model}"
-                    f" (persistent P1 in {_p1_file})"
-                )
-                _old_model = config.dev_profile.model
-                _new_dev = apply_model_info(config.dev_profile, _next_info)
-                config = _dc_replace(config, dev_profile=_new_dev)
-                state.dev_escalated = True
-                _prev_result = state.review_results[-2]
-                _persistent_descs = _persistent_p1_descriptions(
-                    parsed_review.findings, _prev_result.findings
-                )
-                state.escalation_note = (
-                    f"MODEL ESCALATION: A P1 finding persisted across review cycles. "
-                    f"The previous model ({_old_model}) was unable to resolve it. "
-                    f"You are now running on an upgraded model ({_next_info.model}). "
-                    f"Persistent finding(s): {'; '.join(_persistent_descs)}"
-                )
+        _esc = _perform_dev_model_escalation(config)
+        if _esc is not None:
+            _old_model, _new_model_name, config = _esc
+            _p1_file = next(
+                (f.file for f in parsed_review.findings if f.severity == "P1"),
+                "unknown",
+            )
+            _log(
+                f"  Dev escalation: {_old_model} → {_new_model_name} (persistent P1 in {_p1_file})"
+            )
+            state.dev_escalated = True
+            _prev_result = state.review_results[-2]
+            _persistent_descs = _persistent_p1_descriptions(
+                parsed_review.findings, _prev_result.findings
+            )
+            state.escalation_note = (
+                f"MODEL ESCALATION: A P1 finding persisted across review cycles. "
+                f"The previous model ({_old_model}) was unable to resolve it. "
+                f"You are now running on an upgraded model ({_new_model_name}). "
+                f"Persistent finding(s): {'; '.join(_persistent_descs)}"
+            )
 
     if state.review_cycle >= _adaptive_review_max:
         if interactive:

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -239,6 +239,7 @@ class CoordinatorState:
     phase: Phase = Phase.INIT
     started_at: str | None = None  # ISO timestamp set at INIT
     run_id: str | None = None  # stable 12-char hex run identity; set at engine entry
+    sprint_name: str | None = None  # set when run is part of a sprint; used for cross-story flags
     story_content: str | None = None  # story text as loaded before any runtime mutation
     workspace_path: Path | None = None
     branch_name: str | None = None

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -338,6 +338,10 @@ class CoordinatorState:
     error_type: str | None = None
     sandboxed: bool = False  # True if sandbox isolation was available at dev-phase entry
     dev_escalated: bool = False  # True once model escalation has occurred this run
+    timeout_escalation_used: bool = (
+        False  # True once a timeout escalation has fired this sprint; gates re-escalation
+    )
+    timeout_escalation_audit: dict | None = None  # original/new model+timeout recorded for audit
     plan_escalated: bool = False  # True once plan model escalation has occurred this run
     plan_escalation_note: str | None = None  # escalation context injected into regen prompt
     retry_reason: RetryReason | None = None  # see RetryReason enum for valid values

--- a/tests/test_coord_dev_timeout_escalation.py
+++ b/tests/test_coord_dev_timeout_escalation.py
@@ -1,0 +1,263 @@
+"""Tests for timeout-triggered model escalation in the coordinator.
+
+Covers three scenarios:
+  (a) Dev times out with a larger model available → escalates, continues in DEV
+  (b) Dev times out with no larger model available → no escalation, falls through to existing path
+  (c) Second timeout in same sprint → does not re-escalate (timeout_escalation_used gate)
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    _PREFLIGHT_RESULT,
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.config import (
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    ModelProfile,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.engine import run_task
+from theforge.runners import AgentResult
+
+
+def _make_escalation_config(
+    tmp_path: Path,
+    models: list[str],
+    max_dev_iterations: int = 3,
+) -> ForgeConfig:
+    """Config with auto_model_escalation=True and sonnet as dev model."""
+    dev_profile = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=30.0,
+        timeout_seconds=900,
+        allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
+    )
+    review_profile = ModelProfile(
+        name="claude-opus",
+        cli="claude",
+        model="opus",
+        budget_usd=10.0,
+        timeout_seconds=300,
+        allowed_tools=("Read", "Bash", "Glob", "Grep"),
+    )
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev_profile,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[review_profile],
+        synthesis_profile=None,
+        retry=RetryPolicy(
+            max_dev_iterations=max_dev_iterations,
+            max_review_cycles=2,
+            auto_model_escalation=True,
+        ),
+        models=models,
+    )
+
+
+def _timeout_result(session_id: str = "sess-1") -> AgentResult:
+    """AgentResult representing a SIGKILL timeout (exit_code=-9)."""
+    return AgentResult(
+        success=False,
+        output="Partial progress before timeout.",
+        session_id=session_id,
+        cost_usd=0.10,
+        exit_code=-9,
+        raw={},
+        profile_name="dev",
+    )
+
+
+class TestTimeoutEscalationAvailable:
+    """Timeout with a larger model in the chain → escalate and continue."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_timeout_escalates_model_and_continues(
+        self, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+    ):
+        """Dev exits -9 once; larger model available → escalate, second dev succeeds."""
+        config = _make_escalation_config(tmp_path, models=["claude/sonnet", "claude/opus"])
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        # Gate: FAIL on first iteration (dev timed out), PASS on second (escalated model)
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
+
+        dev_call = {"n": 0}
+
+        def dev_side_effect(**kwargs):
+            dev_call["n"] += 1
+            if dev_call["n"] == 1:
+                return _timeout_result()
+            return _make_agent_result(success=True, output="Done.", session_id="sess-1")
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev.side_effect = dev_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.timeout_escalation_used is True
+        assert result.state.timeout_escalation_audit is not None
+        audit = result.state.timeout_escalation_audit
+        assert audit["original_model"] == "sonnet"
+        assert audit["new_model"] == "opus"
+        assert audit["reason"] == "timeout"
+        assert audit["original_timeout_seconds"] > 0
+        assert audit["new_timeout_seconds"] > 0
+        assert dev_call["n"] == 2
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_timeout_escalation_audit_in_state(
+        self, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+    ):
+        """After timeout escalation, timeout_escalation_audit contains all required keys."""
+        config = _make_escalation_config(tmp_path, models=["claude/sonnet", "claude/opus"])
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
+        dev_call = {"n": 0}
+
+        def dev_side_effect(**kwargs):
+            dev_call["n"] += 1
+            if dev_call["n"] == 1:
+                return _timeout_result()
+            return _make_agent_result(success=True, output="Done.", session_id="sess-1")
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev.side_effect = dev_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+        ]
+
+        result = run_task(config, task)
+
+        required_keys = {
+            "original_model",
+            "new_model",
+            "original_timeout_seconds",
+            "new_timeout_seconds",
+            "reason",
+        }
+        assert required_keys.issubset(result.state.timeout_escalation_audit.keys())
+
+
+class TestTimeoutNoLargerModel:
+    """Timeout with no larger model → no escalation, falls through to existing path."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_timeout_no_escalation_when_at_top(
+        self, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+    ):
+        """Dev times out, current model is already the largest → no escalation."""
+        # Use opus as dev model and only opus in models list → no larger model available
+        config = _make_escalation_config(tmp_path, models=["claude/opus"])
+        dev_profile = ModelProfile(
+            name="dev",
+            cli="claude",
+            model="opus",
+            budget_usd=30.0,
+            timeout_seconds=900,
+            allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
+        )
+        config = replace(config, dev_profile=dev_profile)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        # Gate always fails → eventually exhausts iterations → ESCALATE
+        mock_shell.side_effect = _shell_with_gate(workspace, "FAIL")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev.return_value = _timeout_result()
+        mock_pool.return_value = []
+
+        result = run_task(config, task)
+
+        assert result.state.timeout_escalation_used is False
+        assert result.state.timeout_escalation_audit is None
+        # Run should end in ESCALATE (max iterations exhausted with no gate pass)
+        assert result.success is False
+
+
+class TestTimeoutNoReEscalation:
+    """Second timeout in the same sprint does not trigger a second escalation."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_second_timeout_does_not_re_escalate(
+        self, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+    ):
+        """First timeout escalates; second timeout does not escalate again."""
+        config = _make_escalation_config(
+            tmp_path, models=["claude/sonnet", "claude/opus"], max_dev_iterations=4
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        # Gate: FAIL, FAIL, PASS (first two iterations timeout, third succeeds)
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "FAIL", "PASS"])
+
+        dev_call = {"n": 0}
+
+        def dev_side_effect(**kwargs):
+            dev_call["n"] += 1
+            if dev_call["n"] <= 2:
+                return _timeout_result()
+            return _make_agent_result(success=True, output="Done.", session_id="sess-1")
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev.side_effect = dev_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+        ]
+
+        result = run_task(config, task)
+
+        # Escalation should have fired exactly once
+        assert result.state.timeout_escalation_used is True
+        assert result.state.timeout_escalation_audit is not None
+        # Three dev calls: first times out (escalates), second times out (no re-escalate),
+        # third succeeds
+        assert dev_call["n"] == 3
+        # The audit records the first escalation only
+        assert result.state.timeout_escalation_audit["original_model"] == "sonnet"
+        assert result.state.timeout_escalation_audit["new_model"] == "opus"

--- a/tests/test_coord_dev_timeout_escalation.py
+++ b/tests/test_coord_dev_timeout_escalation.py
@@ -261,3 +261,71 @@ class TestTimeoutNoReEscalation:
         # The audit records the first escalation only
         assert result.state.timeout_escalation_audit["original_model"] == "sonnet"
         assert result.state.timeout_escalation_audit["new_model"] == "opus"
+
+
+class TestTimeoutEscalationSprintSticky:
+    """Timeout escalation is sprint-sticky: only one escalation fires per sprint
+    even across different stories (separate run_task calls with the same sprint_name)."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_second_story_in_sprint_does_not_escalate(
+        self, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+    ):
+        """Story A escalates; story B in the same sprint sees the flag and does not escalate."""
+        sprint_name = "test-sprint-sticky"
+        config_a = _make_escalation_config(tmp_path, models=["claude/sonnet", "claude/opus"])
+        config_b = _make_escalation_config(tmp_path, models=["claude/sonnet", "claude/opus"])
+
+        # Story A: times out once, escalates, then succeeds
+        task_a = _make_task(tmp_path)
+        workspace_a = tmp_path / task_a.slug
+        workspace_a.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace_a, ["FAIL", "PASS"])
+        dev_call_a = {"n": 0}
+
+        def dev_side_effect_a(**kwargs):
+            dev_call_a["n"] += 1
+            if dev_call_a["n"] == 1:
+                return _timeout_result()
+            return _make_agent_result(success=True, output="Done.", session_id="sess-a")
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev.side_effect = dev_side_effect_a
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+        ]
+
+        result_a = run_task(config_a, task_a, sprint_name=sprint_name)
+        assert result_a.state.timeout_escalation_used is True
+        assert result_a.state.timeout_escalation_audit is not None
+
+        # Story B: times out, but the sprint flag is set so no escalation should fire
+        task_b_name = tmp_path / "spec_b.md"
+        task_b_name.write_text("# Story B\n\nSecond story.", encoding="utf-8")
+        from theforge.task import TaskStory
+
+        task_b = TaskStory(name="Story B", story_path=task_b_name, slug="story-b")
+        workspace_b = tmp_path / "story-b"
+        workspace_b.mkdir()
+
+        # Reset mocks for story B: gate FAIL then PASS (timeout resume without escalation)
+        mock_shell.side_effect = _shell_with_gate(workspace_b, ["FAIL", "PASS"])
+        dev_call_b = {"n": 0}
+
+        def dev_side_effect_b(**kwargs):
+            dev_call_b["n"] += 1
+            if dev_call_b["n"] == 1:
+                return _timeout_result(session_id="sess-b")
+            return _make_agent_result(success=True, output="Done.", session_id="sess-b")
+
+        mock_dev.side_effect = dev_side_effect_b
+
+        result_b = run_task(config_b, task_b, sprint_name=sprint_name)
+
+        # Story B should NOT have triggered a new escalation (flag was already set)
+        assert result_b.state.timeout_escalation_used is True  # pre-populated from flag file
+        assert result_b.state.timeout_escalation_audit is None  # no new escalation fired

--- a/tests/test_coord_dev_timeout_escalation.py
+++ b/tests/test_coord_dev_timeout_escalation.py
@@ -329,3 +329,73 @@ class TestTimeoutEscalationSprintSticky:
         # Story B should NOT have triggered a new escalation (flag was already set)
         assert result_b.state.timeout_escalation_used is True  # pre-populated from flag file
         assert result_b.state.timeout_escalation_audit is None  # no new escalation fired
+
+
+class TestTimeoutEscalationParallelClaim:
+    """Parallel sprint workers race for the escalation slot: only one wins.
+
+    Simulates a race where worker A has already written the flag while worker B
+    is mid-run with timeout_escalation_used=False (entered before A's write).
+    The atomic O_CREAT|O_EXCL claim must reject worker B's escalation attempt
+    and fall through to timeout resume on the original model.
+    """
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_loser_of_claim_race_does_not_escalate(
+        self, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+    ):
+        """Peer wrote flag during the race window ⇒ this worker's claim fails."""
+        sprint_name = "test-parallel-claim"
+        config = _make_escalation_config(tmp_path, models=["claude/sonnet", "claude/opus"])
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        flag_path = tmp_path / ".forge" / "sprints" / sprint_name / "timeout_escalation_used"
+
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
+
+        # Inject the peer's flag write right before this worker tries to claim,
+        # by patching _perform_dev_model_escalation to write the flag (simulating
+        # peer A's claim landing during this worker's race window).
+        from theforge.coordinator import engine as _engine
+
+        real_perform = _engine._perform_dev_model_escalation
+
+        def perform_with_peer_claim(cfg):
+            flag_path.parent.mkdir(parents=True, exist_ok=True)
+            if not flag_path.exists():
+                flag_path.touch()  # peer A wins the race
+            return real_perform(cfg)
+
+        dev_call = {"n": 0, "profiles": []}
+
+        def dev_side_effect(**kwargs):
+            dev_call["n"] += 1
+            dev_call["profiles"].append(kwargs.get("profile"))
+            if dev_call["n"] == 1:
+                return _timeout_result()
+            return _make_agent_result(success=True, output="Done.", session_id="sess-1")
+
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev.side_effect = dev_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+        ]
+
+        with patch.object(_engine, "_perform_dev_model_escalation", perform_with_peer_claim):
+            # Pre-create the sprint dir but NOT the flag, so run_task entry sees
+            # timeout_escalation_used=False (race window). Peer write happens
+            # inside the patched perform call, racing the claim.
+            flag_path.parent.mkdir(parents=True, exist_ok=True)
+            result = run_task(config, task, sprint_name=sprint_name)
+
+        # Loser's claim failed: timeout_escalation_used set True (gate honored)
+        # but no audit recorded since this worker did not actually escalate.
+        assert result.state.timeout_escalation_used is True
+        assert result.state.timeout_escalation_audit is None
+        # Both dev calls used the original sonnet profile (no model swap)
+        assert all(p is None or p.model == "sonnet" for p in dev_call["profiles"])

--- a/tests/test_coord_seam_timeout_escalation.py
+++ b/tests/test_coord_seam_timeout_escalation.py
@@ -1,0 +1,149 @@
+"""Seam-level integration test for timeout escalation across the DEV→VALIDATE→DEV boundary.
+
+Drives a minimal coordinator run end-to-end: mocked runner exits -9 once, asserting
+the second DEV invocation uses the upgraded model+timeout and that the audit YAML
+contains the escalation record.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from coord_test_helpers import (  # noqa: E402
+    _PREFLIGHT_RESULT,
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.config import (  # noqa: E402
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    ModelProfile,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.audit import generate_audit_log  # noqa: E402
+from theforge.coordinator.engine import run_task  # noqa: E402
+from theforge.runners import AgentResult  # noqa: E402
+
+
+def _make_seam_config(tmp_path: Path) -> ForgeConfig:
+    dev_profile = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=30.0,
+        timeout_seconds=900,
+        timeout_medium_seconds=1200,
+        timeout_large_seconds=1800,
+        allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
+    )
+    review_profile = ModelProfile(
+        name="claude-opus",
+        cli="claude",
+        model="opus",
+        budget_usd=10.0,
+        timeout_seconds=300,
+        allowed_tools=("Read", "Bash", "Glob", "Grep"),
+    )
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev_profile,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[review_profile],
+        synthesis_profile=None,
+        retry=RetryPolicy(
+            max_dev_iterations=3,
+            max_review_cycles=2,
+            auto_model_escalation=True,
+        ),
+        models=["claude/sonnet", "claude/opus"],
+    )
+
+
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.dev_phase.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+def test_timeout_escalation_seam(mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path):
+    """Full DEV→VALIDATE→DEV seam: timeout on first dev, escalated model on second dev.
+
+    Asserts:
+    - Second DEV invocation runs after escalation (run continues rather than halting)
+    - state.timeout_escalation_audit is populated with original/new model and timeouts
+    - generate_audit_log includes timeout_escalation with the escalation details
+    """
+    config = _make_seam_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir()
+
+    # Gate: FAIL (dev timed out, no progress), then PASS (escalated dev succeeded)
+    mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
+
+    dev_calls: list[dict] = []
+
+    def dev_side_effect(**kwargs):
+        dev_calls.append({"profile": kwargs.get("profile")})
+        if len(dev_calls) == 1:
+            # First call: timeout
+            return AgentResult(
+                success=False,
+                output="Partial work.",
+                session_id="sess-1",
+                cost_usd=0.10,
+                exit_code=-9,
+                raw={},
+                profile_name="dev",
+            )
+        # Second call: escalated model succeeds
+        return _make_agent_result(success=True, output="Done.", session_id="sess-1")
+
+    mock_preflight.return_value = _PREFLIGHT_RESULT
+    mock_dev.side_effect = dev_side_effect
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+    ]
+
+    result = run_task(config, task)
+
+    # ── Boundary: run completes successfully after escalation ──────────
+    assert result.success is True, f"Expected success, got: {result.message}"
+
+    # ── Boundary: two DEV invocations occurred ─────────────────────────
+    assert len(dev_calls) == 2, f"Expected 2 dev calls, got {len(dev_calls)}"
+
+    # ── Boundary: escalation state fields set correctly ────────────────
+    assert result.state.timeout_escalation_used is True
+    assert result.state.timeout_escalation_audit is not None
+    audit_state = result.state.timeout_escalation_audit
+    assert audit_state["original_model"] == "sonnet"
+    assert audit_state["new_model"] == "opus"
+    assert audit_state["original_timeout_seconds"] > 0
+    assert audit_state["new_timeout_seconds"] > 0
+    assert audit_state["reason"] == "timeout"
+
+    # ── Boundary: audit YAML records the escalation ────────────────────
+    audit_log = generate_audit_log(config, task, result)
+    assert "timeout_escalation" in audit_log
+    te = audit_log["timeout_escalation"]
+    assert te is not None
+    assert te["original_model"] == "sonnet"
+    assert te["new_model"] == "opus"
+    assert te["reason"] == "timeout"
+    assert "original_timeout_seconds" in te
+    assert "new_timeout_seconds" in te

--- a/tests/test_coord_seam_timeout_escalation.py
+++ b/tests/test_coord_seam_timeout_escalation.py
@@ -30,7 +30,7 @@ from theforge.config import (  # noqa: E402
     WorkspaceConfig,
 )
 from theforge.coordinator.audit import generate_audit_log  # noqa: E402
-from theforge.coordinator.engine import run_task  # noqa: E402
+from theforge.coordinator.engine import run_from_dev, run_task  # noqa: E402
 from theforge.runners import AgentResult  # noqa: E402
 
 
@@ -147,3 +147,62 @@ def test_timeout_escalation_seam(mock_shell, mock_dev, mock_preflight, mock_pool
     assert te["reason"] == "timeout"
     assert "original_timeout_seconds" in te
     assert "new_timeout_seconds" in te
+
+
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.dev_phase.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+@patch("theforge.coordinator.engine._check_behind_origin")
+def test_resume_path_reads_sprint_flag(
+    mock_origin, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+):
+    """run_from_dev with sprint_name pre-set flag does not escalate again.
+
+    Simulates a sprint where story A already escalated (flag file exists) and
+    story B is resumed via run_from_dev. Story B times out but must not escalate.
+    """
+    config = _make_seam_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir()
+
+    # Write the sprint-level flag as if story A already escalated
+    sprint_name = "test-resume-sprint"
+    flag_path = tmp_path / ".forge" / "sprints" / sprint_name / "timeout_escalation_used"
+    flag_path.parent.mkdir(parents=True, exist_ok=True)
+    flag_path.touch()
+
+    mock_origin.return_value = None  # skip remote check
+    # Gate: FAIL (timeout resume), then PASS
+    mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
+
+    dev_call = {"n": 0}
+
+    def dev_side_effect(**kwargs):
+        dev_call["n"] += 1
+        if dev_call["n"] == 1:
+            return AgentResult(
+                success=False,
+                output="Partial work.",
+                session_id="sess-resume",
+                cost_usd=0.10,
+                exit_code=-9,
+                raw={},
+                profile_name="dev",
+            )
+        return _make_agent_result(success=True, output="Done.", session_id="sess-resume")
+
+    mock_preflight.return_value = _PREFLIGHT_RESULT
+    mock_dev.side_effect = dev_side_effect
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+    ]
+
+    result = run_from_dev(config, task, workspace, sprint_name=sprint_name, no_pull=True)
+
+    assert result.success is True
+    # Flag was pre-loaded: used=True but no new escalation fired
+    assert result.state.timeout_escalation_used is True
+    assert result.state.timeout_escalation_audit is None  # no new escalation
+    assert result.state.sprint_name == sprint_name


### PR DESCRIPTION
## Summary
- When dev exits with SIGKILL (-9) and a larger model is available in `models`, the coordinator escalates the dev profile, recomputes the adaptive timeout, and continues the run via the existing timeout-resume path.
- Sprint-sticky: only one timeout escalation fires per sprint. The flag is persisted at `.forge/sprints/<sprint_name>/timeout_escalation_used` and pre-loaded by both `run_task` and the resume entry points (`run_from_dev` / `run_from_review`).
- Parallel-safe: the sprint slot is claimed atomically with `O_CREAT|O_EXCL` *before* config/state mutation, so two parallel sprint workers cannot both escalate.
- Audit YAML records `timeout_escalation` with `original_model`, `new_model`, `original_timeout_seconds`, `new_timeout_seconds`, `reason`.

Closes #359.

## Test plan
- [x] `make gate` — 3513 passed
- [x] Unit: `tests/test_coord_dev_timeout_escalation.py` (escalate / no-larger-model / no-re-escalate / sprint-sticky / parallel-claim race)
- [x] Seam: `tests/test_coord_seam_timeout_escalation.py` (DEV→VALIDATE→DEV boundary; resume path reads sprint flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)