### PR TITLE
Workspace abort on 'git pull' failure escalates the story instead of recovering

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -490,6 +490,86 @@ def _deindex_forge_artifacts(workspace_path: Path, *, purge: bool = False) -> No
                 _cu._log(f"⚠ WORKSPACE  failed to delete {artifact}: {exc}")
 
 
+def _sync_base_branch(config: ForgeConfig, current_branch: str) -> tuple[bool, str]:
+    """Sync the local base branch from origin using the safest fast path."""
+    base_branch = config.workspace.base_branch
+    if current_branch == base_branch:
+        return _cu._run_shell(f"git pull --ff-only origin {base_branch}", config.project_root)
+    return _cu._run_shell(f"git fetch origin {base_branch}:{base_branch}", config.project_root)
+
+
+def _branch_sync_delta(config: ForgeConfig, base_branch: str) -> tuple[int | None, int | None]:
+    """Return (ahead, behind) for local base vs origin/base, or (None, None) if unavailable."""
+    try:
+        ok_a, a = _cu._run_shell(
+            f"git rev-list --count origin/{base_branch}..{base_branch}", config.project_root
+        )
+        ok_b, b = _cu._run_shell(
+            f"git rev-list --count {base_branch}..origin/{base_branch}", config.project_root
+        )
+        if ok_a and ok_b:
+            return int(a.strip()), int(b.strip())
+    except Exception:
+        pass
+    return None, None
+
+
+def _recover_base_branch_sync(
+    config: ForgeConfig,
+    *,
+    current_branch: str,
+    pull_out: str,
+    ahead: int | None,
+    behind: int | None,
+) -> tuple[bool, str]:
+    """Attempt a conservative recovery after a base-branch sync failure."""
+    base_branch = config.workspace.base_branch
+    if ahead not in (None, 0):
+        return (
+            False,
+            f"WORKSPACE abort: base branch '{base_branch}' has local commits and cannot be "
+            "auto-recovered safely. Resolve it manually before rerunning the sprint.",
+        )
+
+    ok_fetch, fetch_out = _cu._run_shell(f"git fetch origin {base_branch}", config.project_root)
+    if not ok_fetch:
+        return (
+            False,
+            f"WORKSPACE abort: pull failed for base branch '{base_branch}', and recovery fetch "
+            f"also failed — {fetch_out.strip() or pull_out.strip()}",
+        )
+
+    if current_branch == base_branch:
+        ok_status, status_out = _cu._run_shell("git status --porcelain", config.project_root)
+        if not ok_status:
+            return (
+                False,
+                f"WORKSPACE abort: pull failed for base branch '{base_branch}', and recovery "
+                f"could not verify a clean worktree — {status_out.strip() or pull_out.strip()}",
+            )
+        if status_out.strip():
+            return (
+                False,
+                f"WORKSPACE abort: pull failed for base branch '{base_branch}', but automatic "
+                "reset recovery was skipped because the project root has local changes. "
+                f"Clean the worktree or rebase onto origin/{base_branch} before rerunning.",
+            )
+        _cu._log(
+            f"⚠ WORKSPACE  pull failed while {base_branch} was checked out — "
+            f"recovering with fetch + reset to origin/{base_branch}"
+        )
+        return _cu._run_shell(f"git reset --hard origin/{base_branch}", config.project_root)
+
+    _cu._log(
+        f"⚠ WORKSPACE  ref update for {base_branch} failed — "
+        f"recovering with fetch + branch -f origin/{base_branch}"
+    )
+    return _cu._run_shell(
+        f"git branch -f {base_branch} origin/{base_branch}",
+        config.project_root,
+    )
+
+
 def pull_base_branch(config: ForgeConfig) -> bool:
     """Pull the base branch once before parallel workspace creation.
     Uses --ff-only (checked out) or fetch origin base:base (not checked out).
@@ -504,48 +584,31 @@ def pull_base_branch(config: ForgeConfig) -> bool:
 
     _, current_branch = _cu._run_shell("git rev-parse --abbrev-ref HEAD", config.project_root)
     with FETCH_LOCK:
-        if current_branch.strip() == base_branch:
-            ok_pull, pull_out = _cu._run_shell(
-                f"git pull --ff-only origin {base_branch}", config.project_root
-            )
-        else:
-            ok_pull, pull_out = _cu._run_shell(
-                f"git fetch origin {base_branch}:{base_branch}", config.project_root
-            )
+        current_branch = current_branch.strip()
+        ok_pull, pull_out = _sync_base_branch(config, current_branch)
         if not ok_pull and "incorrect old value" in pull_out:
             _cu._log("⚠ WORKSPACE  fetch race detected — retrying fetch once")
             time.sleep(1)
-            if current_branch.strip() == base_branch:
-                ok_pull, pull_out = _cu._run_shell(
-                    f"git pull --ff-only origin {base_branch}", config.project_root
-                )
-            else:
-                ok_pull, pull_out = _cu._run_shell(
-                    f"git fetch origin {base_branch}:{base_branch}", config.project_root
-                )
+            ok_pull, pull_out = _sync_base_branch(config, current_branch)
+        ahead, behind = _branch_sync_delta(config, base_branch)
+        if not ok_pull and ahead == 0 and behind and behind > 0:
+            ok_pull, pull_out = _recover_base_branch_sync(
+                config,
+                current_branch=current_branch,
+                pull_out=pull_out,
+                ahead=ahead,
+                behind=behind,
+            )
     if ok_pull:
         _cu._log(f"✓ WORKSPACE  pulled latest {base_branch}")
     else:
         _cu._log(f"⚠ WORKSPACE  pull failed (non-ff / offline): {pull_out.strip()}")
-        try:
-            ok_a, a = _cu._run_shell(
-                f"git rev-list --count origin/{base_branch}..{base_branch}", config.project_root
+        if ahead is not None and behind is not None and ahead > 0 and behind > 0:
+            raise RuntimeError(
+                f"WORKSPACE abort: base branch '{base_branch}' has diverged from origin"
+                f" (local is {ahead} ahead, {behind} behind)."
+                f" Run: git rebase origin/{base_branch}"
             )
-            ok_b, b = _cu._run_shell(
-                f"git rev-list --count {base_branch}..origin/{base_branch}", config.project_root
-            )
-            if ok_a and ok_b:
-                ahead, behind = int(a.strip()), int(b.strip())
-                if ahead > 0 and behind > 0:
-                    raise RuntimeError(
-                        f"WORKSPACE abort: base branch '{base_branch}' has diverged from origin"
-                        f" (local is {ahead} ahead, {behind} behind)."
-                        f" Run: git rebase origin/{base_branch}"
-                    )
-        except RuntimeError:
-            raise
-        except Exception:
-            pass
         raise RuntimeError(
             f"WORKSPACE abort: pull failed for base branch '{base_branch}' — {pull_out.strip()}"
         )

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -169,6 +169,90 @@ class TestFreshWorkspacePull:
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
+    def test_pull_non_ff_recovers_with_fetch_reset_on_clean_base(
+        self, mock_log, mock_shell, tmp_path
+    ):
+        """A clean checked-out base branch auto-recovers from a non-ff pull failure."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        issued: list[str] = []
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            issued.append(cmd)
+            if "rev-parse HEAD:src/theforge" in cmd:
+                return (True, "tree123\n")
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, config.workspace.base_branch)
+            if "pull --ff-only" in cmd:
+                return (False, "fatal: Not possible to fast-forward, aborting.")
+            if "rev-list --count origin/" in cmd and ".." + config.workspace.base_branch in cmd:
+                return (True, "0\n")
+            if "rev-list --count " + config.workspace.base_branch + "..origin/" in cmd:
+                return (True, "1\n")
+            if cmd == "git fetch origin main":
+                return (True, "From origin")
+            if cmd == "git status --porcelain":
+                return (True, "")
+            if cmd == "git reset --hard origin/main":
+                return (True, "HEAD is now at 9c2e778")
+            if "mkdir" in cmd:
+                (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        workspace_path, branch_name, err = _create_workspace(config, task, no_pull=False)
+
+        assert err is None
+        assert workspace_path is not None
+        assert branch_name == "forge/test-task"
+        assert "git fetch origin main" in issued
+        assert "git reset --hard origin/main" in issued
+        assert any(
+            "recovering with fetch + reset" in str(call) for call in mock_log.call_args_list
+        )
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_pull_non_ff_recovery_refuses_dirty_base(self, mock_log, mock_shell, tmp_path):
+        """A dirty checked-out base branch aborts with an actionable recovery error."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-parse HEAD:src/theforge" in cmd:
+                return (True, "tree123\n")
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, config.workspace.base_branch)
+            if "pull --ff-only" in cmd:
+                return (False, "fatal: Not possible to fast-forward, aborting.")
+            if "rev-list --count origin/" in cmd and ".." + config.workspace.base_branch in cmd:
+                return (True, "0\n")
+            if "rev-list --count " + config.workspace.base_branch + "..origin/" in cmd:
+                return (True, "1\n")
+            if cmd == "git fetch origin main":
+                return (True, "From origin")
+            if cmd == "git status --porcelain":
+                return (True, " M src/theforge/coordinator/workspace.py\n")
+            if "mkdir" in cmd:
+                (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        workspace_path, branch_name, err = _create_workspace(config, task, no_pull=False)
+
+        assert workspace_path is None
+        assert branch_name is None
+        assert err is not None
+        assert "local changes" in err
+        assert "rebase onto origin/main" in err
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
     def test_no_pull_skips_pull(self, mock_log, mock_shell, tmp_path):
         """When no_pull=True, no fetch or pull command is issued."""
         config = _make_config(tmp_path)

--- a/tests/test_coord_workspace_merge.py
+++ b/tests/test_coord_workspace_merge.py
@@ -54,6 +54,60 @@ class TestCoordinatorWorkspaceFailure:
         assert result.phase == Phase.ESCALATE
         assert "workspace" in result.message.lower() or "Workspace" in result.message
 
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_recoverable_pull_failure_proceeds_past_workspace(
+        self, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+    ):
+        """A recoverable base-branch pull failure should not escalate before agent work."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-parse HEAD:src/theforge" in cmd:
+                return (True, "tree123\n")
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, config.workspace.base_branch)
+            if "pull --ff-only" in cmd:
+                return (False, "fatal: Not possible to fast-forward, aborting.")
+            if "rev-list --count origin/" in cmd and ".." + config.workspace.base_branch in cmd:
+                return (True, "0\n")
+            if "rev-list --count " + config.workspace.base_branch + "..origin/" in cmd:
+                return (True, "1\n")
+            if cmd == "git fetch origin main":
+                return (True, "From origin")
+            if cmd == "git status --porcelain":
+                return (True, "")
+            if cmd == "git reset --hard origin/main":
+                return (True, "HEAD is now at 9c2e778")
+            if "gate" in cmd:
+                _write_handoff(Path(cwd), "PASS")
+                return (True, "OK")
+            if "mkdir -p" in cmd:
+                (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            stale_resp = _handle_stale_check_cmd(cmd)
+            if stale_resp is not None:
+                return stale_resp
+            return (True, "OK")
+
+        mock_shell.side_effect = shell_side_effect
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        mock_preflight.assert_called_once()
+        mock_dev.assert_called_once()
+        mock_pool.assert_called_once()
+
 
 # ── Auto-merge tests ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The implementation correctly addresses the acceptance criteria: recoverable pull failures now retry with fetch+reset or branch -f, actionable error messages are provided when recovery is unsafe, and the seam test verifies the full flow continues past WORKSPACE. Code logic is sound, thread safety is maintained via FETCH_LOCK, and test coverage includes clean recovery, dirty-root refusal, and end-to-end progression. | [google-gemini-3.1-pro-preview] The implementation safely recovers from base branch pull failures and includes excellent test coverage. | [claude-opus] Workspace base-branch sync now retries with conservative recovery (fetch + reset --hard for clean checked-out base, branch -f for non-checked-out base) before raising; refuses safely on dirty/ahead state with actionable messages, and a seam test confirms a recoverable pull failure now reaches preflight/dev/review.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.53
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/workspace.py:599`** When `_recover_base_branch_sync` returns a failure, its error message starts with 'WORKSPACE abort: '. This is then wrapped in another 'WORKSPACE abort: ' prefix when raising the RuntimeError on line 600, resulting in a slightly redundant error message.
- **[P2] `src/theforge/coordinator/workspace.py:597`** _branch_sync_delta() runs unconditionally inside FETCH_LOCK even when the pull/fetch already succeeded, executing two extra git rev-list calls on the success path. Minor wasted work, not incorrect.
- **[P2] `src/theforge/coordinator/workspace.py:611`** When _recover_base_branch_sync returns a 'WORKSPACE abort: ...' message and ok_pull stays False, the outer raise prefixes the message with another 'WORKSPACE abort: pull failed for base branch ...' producing a doubled prefix in the final RuntimeError. Cosmetic only — both unit tests still match on substrings.

## Story

Workspace abort on 'git pull' failure escalates the story instead of recovering (GitHub Issue #1048)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1048