### PR TITLE
Sprint-summary overwrites ALREADY_DONE outcome with ESCALATE on later run

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -213,6 +213,57 @@ def _load_story_summary_entry_from_audit(
     }
 
 
+def _parse_summary_timestamp(value: object) -> datetime.datetime | None:
+    """Parse sprint-summary timestamps of the form 2026-04-25T12:05:00Z."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _story_outcome_rank(entry: dict) -> int:
+    """Higher rank wins when timing information is unavailable or tied."""
+    outcome = entry.get("outcome")
+    if outcome == "DONE":
+        return 5
+    if outcome == "ALREADY_DONE":
+        return 4
+    if outcome in {"SKIPPED", "PRESERVED", "DROPPED"}:
+        return 3
+    if outcome == "ESCALATE":
+        return 1
+    return 2
+
+
+def _select_historical_story_entry(prior: dict | None, audit_entry: dict | None) -> dict | None:
+    """Choose the best historical story entry between accumulated state and audit.yaml."""
+    if prior is None:
+        return audit_entry
+    if audit_entry is None:
+        return prior
+
+    prior_finished = _parse_summary_timestamp(prior.get("finished_at"))
+    audit_finished = _parse_summary_timestamp(audit_entry.get("finished_at"))
+    if (
+        prior_finished is not None
+        and audit_finished is not None
+        and prior_finished != audit_finished
+    ):
+        return audit_entry if audit_finished > prior_finished else prior
+    if prior_finished is not None and audit_finished is None:
+        return prior
+    if audit_finished is not None and prior_finished is None:
+        return (
+            audit_entry if _story_outcome_rank(audit_entry) > _story_outcome_rank(prior) else prior
+        )
+
+    if _story_outcome_rank(audit_entry) > _story_outcome_rank(prior):
+        return audit_entry
+    return prior
+
+
 def _write_sprint_audit(
     manifest: SprintManifest | ResolvedSprint,
     result: SprintResult,
@@ -477,6 +528,7 @@ def _write_sprint_summary(
     dropped_slugs: "dict[str, str] | None" = None,
     skipped_issues: "list | None" = None,
     triage_actions_by_ref: "dict[str, str] | None" = None,
+    current_story_entries_by_ref: "dict[str, dict] | None" = None,
 ) -> None:
     """Write sprint-summary.yaml to <project_root>/.forge/logs/<sprint-name>/.
 
@@ -493,6 +545,7 @@ def _write_sprint_summary(
     dropped_slugs = dropped_slugs or {}
     skipped_issues = skipped_issues or []
     triage_actions_by_ref = triage_actions_by_ref or {}
+    current_story_entries_by_ref = current_story_entries_by_ref or {}
 
     # Load prior accumulated story entries from the sprint-level state file.
     # Keyed by canonical_ref so we can substitute them for stories not in
@@ -596,15 +649,22 @@ def _write_sprint_summary(
             entry["depends_on"] = list(getattr(tasks_by_slug.get(slug), "depends_on", None) or [])
             spec_entries.append(entry)
             accumulated_for_state.append({"canonical_ref": canonical_ref, **entry})
+        elif canonical_ref in current_story_entries_by_ref:
+            current_entry = dict(current_story_entries_by_ref[canonical_ref])
+            spec_entries.append(current_entry)
+            accumulated_for_state.append({"canonical_ref": canonical_ref, **current_entry})
         elif canonical_ref in prior_by_ref:
             # Story ran under an earlier run_id — use its accumulated data instead
             # of emitting a SKIPPED entry (which would hide a completed story).
-            prior = _load_story_summary_entry_from_audit(sprint_log_dir, canonical_ref, slug)
-            if prior is None:
-                prior = prior_by_ref[canonical_ref]
-            entry = {k: v for k, v in prior.items() if k != "canonical_ref"}
+            historical_entry = _select_historical_story_entry(
+                prior_by_ref[canonical_ref],
+                _load_story_summary_entry_from_audit(sprint_log_dir, canonical_ref, slug),
+            )
+            if historical_entry is None:
+                historical_entry = prior_by_ref[canonical_ref]
+            entry = {k: v for k, v in historical_entry.items() if k != "canonical_ref"}
             spec_entries.append(entry)
-            accumulated_for_state.append(prior)
+            accumulated_for_state.append({"canonical_ref": canonical_ref, **entry})
         else:
             drop_reason = dropped_slugs.get(slug)
             triage_action = triage_actions_by_ref.get(canonical_ref)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1125,6 +1125,42 @@ def run_sprint(
     except ValueError as exc:
         raise ValueError(f"{exc} Synthetic collision edges: {synthetic_edges}") from exc
 
+    current_story_entries_by_ref: dict[str, dict] = {}
+
+    def _record_current_story_entry(
+        slug: str,
+        outcome: str,
+        *,
+        error: str | None = None,
+        error_type: str | None = None,
+    ) -> None:
+        task_ctx = slug_to_context.get(slug)
+        if task_ctx is None:
+            return
+        task, _source, canonical_ref = task_ctx
+        display_key = (
+            f"Issue #{canonical_ref.split(':')[1]}"
+            if canonical_ref.startswith("issue:")
+            else canonical_ref
+        )
+        current_story_entries_by_ref[canonical_ref] = {
+            "path": display_key,
+            "slug": slug,
+            "outcome": outcome,
+            "verdict": None,
+            "cost_usd": 0.0,
+            "story_run_id": run_id,
+            "preflight": None,
+            "preflight_original_verdict": None,
+            "preflight_source_run_id": None,
+            "error": error,
+            "error_type": error_type,
+            "outcome_code": error_type or outcome.lower(),
+            "merge": False,
+            "batch": 0,
+            "depends_on": list(getattr(task, "depends_on", None) or []),
+        }
+
     # Dependencies already satisfied outside this sprint still count as landed
     # for deferred integration ordering.
     merged_slugs.update(satisfied_slugs)
@@ -1144,6 +1180,7 @@ def run_sprint(
                 else:
                     dag.mark_skipped(slug)
                     specs_skipped += 1
+                    _record_current_story_entry(slug, "SKIPPED", error=triage.reason)
 
     auto_enabled_dependency_merges = dependent_slugs - satisfied_slugs - merged_slugs
     if (
@@ -1163,6 +1200,7 @@ def run_sprint(
         _log(f"SKIPPED {slug} (blocked: {', '.join(blocked_by)})")
         dag.mark_skipped(slug)
         specs_skipped += 1
+        _record_current_story_entry(slug, "SKIPPED", error=f"blocked: {', '.join(blocked_by)}")
 
     # Stories dropped pre-launch (e.g. re-exec collision) never enter the DAG.
     # They surface with a distinct DROPPED/PRESERVED outcome in sprint-audit and
@@ -1179,10 +1217,12 @@ def run_sprint(
             _log(f"PRESERVED {slug} (escalated worktree held for review)")
             dag.mark_skipped(slug)
             specs_skipped += 1
+            _record_current_story_entry(slug, "PRESERVED", error=reason, error_type="dropped")
         else:
             _log(f"DROPPED {slug} (reason: {reason})")
             dag.mark_skipped(slug)
             specs_failed += 1
+            _record_current_story_entry(slug, "DROPPED", error=reason, error_type="dropped")
 
     # Persist resume-time already-completed stories before any possible re-exec
     # handoff so later generations can recover the full logical sprint history.
@@ -1521,6 +1561,13 @@ def run_sprint(
                                 " \u2014 remaining stories skipped",
                             )
                     _log(f"SKIPPED {task.slug} (budget exhausted)")
+                    _record_current_story_entry(
+                        task.slug,
+                        "SKIPPED",
+                        error=(
+                            f"budget exhausted (${cumulative:.2f} >= ${resolved.budget_usd:.2f})"
+                        ),
+                    )
                     if _state_writer is not None:
                         _state_writer.update(task.slug, status="skipped")
                     continue
@@ -1592,8 +1639,12 @@ def run_sprint(
                     if unmet:
                         dep_list = ", ".join(unmet)
                         _log(f"SKIPPED {t.slug} (dependency failed: {dep_list})")
+                        _record_current_story_entry(
+                            t.slug, "SKIPPED", error=f"dependency failed: {dep_list}"
+                        )
                     else:
                         _log(f"SKIPPED {t.slug} (blocked)")
+                        _record_current_story_entry(t.slug, "SKIPPED", error="blocked")
                     dag.mark_skipped(t.slug)
                     specs_skipped += 1
                     if _state_writer is not None:
@@ -1978,6 +2029,7 @@ def run_sprint(
             triage_actions_by_ref={
                 canonical_ref: triage.action for canonical_ref, triage in triages.items()
             },
+            current_story_entries_by_ref=current_story_entries_by_ref,
         )
 
     if _state_writer is not None:

--- a/tests/test_sprint_reexec_summary.py
+++ b/tests/test_sprint_reexec_summary.py
@@ -195,3 +195,186 @@ def test_write_sprint_summary_prefers_story_audit_over_stale_accumulated_state(
     assert story["verdict"] == "APPROVE"
     assert story["error"] is None
     assert story["merge"] is True
+
+
+def test_write_sprint_summary_prefers_newer_accumulated_state_over_stale_story_audit(
+    tmp_path: Path,
+) -> None:
+    sprint_log_dir = tmp_path / ".forge" / "logs" / "issues-1201"
+    sprint_log_dir.mkdir(parents=True, exist_ok=True)
+
+    persist_accumulated_story_state(
+        "sprint-1201",
+        "issues-1201",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "issue:1201",
+                "slug": "issue-1201",
+                "path": "Issue #1201",
+                "outcome": "DONE",
+                "verdict": "APPROVE",
+                "cost_usd": 3.95,
+                "story_run_id": "run-2",
+                "preflight": "PROCEED",
+                "error": None,
+                "error_type": None,
+                "merge": True,
+                "started_at": "2026-04-27T10:21:00Z",
+                "finished_at": "2026-04-27T11:05:12Z",
+                "depends_on": [],
+            }
+        ],
+    )
+
+    story_audit_dir = sprint_log_dir / "issue-1201"
+    story_audit_dir.mkdir(parents=True, exist_ok=True)
+    with open(story_audit_dir / "audit.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(
+            {
+                "run_id": "run-1",
+                "outcome": {
+                    "success": False,
+                    "final_phase": "ESCALATE",
+                    "message": "workspace failed",
+                    "error_type": "workspace_abort",
+                },
+                "timing": {
+                    "started_at": "2026-04-27T10:13:00Z",
+                    "finished_at": "2026-04-27T10:13:30Z",
+                },
+                "cost": {"total_usd": 0.0},
+                "preflight": {
+                    "verdict": "PROCEED",
+                    "original_verdict": None,
+                    "source_run_id": None,
+                },
+                "iterations": {"usage_summary": {"dev": {}, "review": {}}},
+                "reviews": [],
+                "merge": {"merged": False},
+                "error": "WORKSPACE abort: pull failed",
+                "error_type": "workspace_abort",
+            },
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+
+    result = SprintResult(
+        name="issues-1201",
+        specs_total=0,
+        specs_succeeded=0,
+        specs_failed=0,
+        specs_skipped=0,
+        total_cost_usd=0.0,
+        budget_usd=20.0,
+        results=[],
+        stopped_reason=None,
+    )
+    manifest = SimpleNamespace(name="issues-1201", budget_usd=20.0, max_parallel=1)
+    now = datetime.datetime(2026, 4, 27, tzinfo=datetime.timezone.utc)
+
+    _write_sprint_summary(
+        manifest=manifest,
+        result=result,
+        canonical_refs=["issue:1201"],
+        started_at=now,
+        finished_at=now,
+        duration=60.0,
+        sprint_log_dir=sprint_log_dir,
+        slug_map={"issue:1201": "issue-1201"},
+        run_id="run-3",
+        tasks_by_slug={"issue-1201": SimpleNamespace(depends_on=[])},
+        sprint_id="sprint-1201",
+        project_root=tmp_path,
+    )
+
+    summary = yaml.safe_load((sprint_log_dir / "sprint-summary.yaml").read_text(encoding="utf-8"))
+    story = summary["stories"][0]
+    assert story["outcome"] == "DONE"
+    assert story["story_run_id"] == "run-2"
+    assert story["cost_usd"] == 3.95
+    assert story["error"] is None
+
+
+def test_write_sprint_summary_prefers_current_skipped_entry_over_prior_escalate(
+    tmp_path: Path,
+) -> None:
+    sprint_log_dir = tmp_path / ".forge" / "logs" / "issues-359"
+    sprint_log_dir.mkdir(parents=True, exist_ok=True)
+
+    persist_accumulated_story_state(
+        "sprint-359",
+        "issues-359",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "issue:359",
+                "slug": "issue-359",
+                "path": "Issue #359",
+                "outcome": "ESCALATE",
+                "cost_usd": 0.0,
+                "story_run_id": "run-1",
+                "preflight": "PROCEED",
+                "error": "WORKSPACE abort: pull failed",
+                "error_type": "workspace_abort",
+                "depends_on": ["issue-157"],
+            }
+        ],
+    )
+
+    result = SprintResult(
+        name="issues-359",
+        specs_total=0,
+        specs_succeeded=0,
+        specs_failed=0,
+        specs_skipped=1,
+        total_cost_usd=0.0,
+        budget_usd=20.0,
+        results=[],
+        stopped_reason=None,
+    )
+    manifest = SimpleNamespace(name="issues-359", budget_usd=20.0, max_parallel=1)
+    now = datetime.datetime(2026, 4, 27, tzinfo=datetime.timezone.utc)
+
+    _write_sprint_summary(
+        manifest=manifest,
+        result=result,
+        canonical_refs=["issue:359"],
+        started_at=now,
+        finished_at=now,
+        duration=60.0,
+        sprint_log_dir=sprint_log_dir,
+        slug_map={"issue:359": "issue-359"},
+        run_id="run-3",
+        tasks_by_slug={"issue-359": SimpleNamespace(depends_on=["issue-157"])},
+        sprint_id="sprint-359",
+        project_root=tmp_path,
+        current_story_entries_by_ref={
+            "issue:359": {
+                "path": "Issue #359",
+                "slug": "issue-359",
+                "outcome": "SKIPPED",
+                "verdict": None,
+                "cost_usd": 0.0,
+                "story_run_id": "run-3",
+                "preflight": None,
+                "preflight_original_verdict": None,
+                "preflight_source_run_id": None,
+                "error": "dependency failed: issue-157",
+                "error_type": None,
+                "outcome_code": "skipped",
+                "merge": False,
+                "batch": 0,
+                "depends_on": ["issue-157"],
+            }
+        },
+    )
+
+    summary = yaml.safe_load((sprint_log_dir / "sprint-summary.yaml").read_text(encoding="utf-8"))
+    story = summary["stories"][0]
+    assert story["outcome"] == "SKIPPED"
+    assert story["story_run_id"] == "run-3"
+    assert story["error"] == "dependency failed: issue-157"
+    assert summary["sprint"]["specs_failed"] == 0
+    assert summary["sprint"]["specs_skipped"] == 1


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The change correctly implements terminal-precedence for sprint summaries. The `_record_current_story_entry` function in runner.py captures skipped/dropped outcomes for the current run, and `_select_historical_story_entry` in audit.py reconciles accumulated state with per-story audit logs by comparing timestamps and outcome rank. Both regression tests cover the exact scenarios from the bug (later SKIPPED over prior ESCALATE, later accumulated DONE over stale audit). The logic is invoked at runtime via `current_story_entries_by_ref` passed to `_write_sprint_summary`, and all acceptance criteria are met. | [google-gemini-3.1-pro-preview] The implementation correctly adds terminal-precedence handling for sprint summaries by comparing accumulated state and audit data. | [claude-opus] Sprint summary aggregator now reconciles accumulated state with per-story audit by recency + outcome rank, and runner records current-run skipped/dropped entries so later SKIPPED/DONE outcomes are not clobbered by stale earlier ESCALATEs. AC met with regression tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.88
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint-summary overwrites ALREADY_DONE outcome with ESCALATE on later run (GitHub Issue #1047)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1047