### PR TITLE
Gate must reject story branches that mutate forge.yaml outside an allowlist of story-mutable keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ test-parallel:
 gate:
 	@mkdir -p .forge/index .forge && \
 	forge index && \
+	forge check-story-config && \
 	$(SCRUBBED_GATE_CMD)
 
 # Transitional alias retained for one release while the scrubbed gate rolls out.

--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -14,7 +14,11 @@ import yaml
 
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
-from theforge.task import ALLOW_MUTATE_FORGE_YAML_KEY
+from theforge.task import (
+    ALLOW_MUTATE_FORGE_YAML_KEY,
+    frontmatter_allows_forge_yaml_mutation,
+    parse_story_frontmatter,
+)
 
 _ALLOWED_TOP_LEVEL_KEYS = frozenset({"assignment", "models"})
 
@@ -71,6 +75,51 @@ def _issue_number_from_branch(branch: str) -> int | None:
     return None
 
 
+def _branch_slug(branch: str) -> str:
+    """Return the branch leaf used for slug or filename matching."""
+    return branch.rsplit("/", 1)[-1]
+
+
+def _iter_local_story_paths(repo_root: Path) -> list[Path]:
+    """Return candidate local story files under the repository root."""
+    candidates: list[Path] = []
+    for path in repo_root.rglob("*.md"):
+        relative_parts = path.relative_to(repo_root).parts
+        if any(part.startswith(".") for part in relative_parts):
+            continue
+        candidates.append(path)
+    return sorted(candidates)
+
+
+def _matches_story_issue(frontmatter: dict[str, Any], issue_number: int) -> bool:
+    """Return whether story frontmatter references the current issue."""
+    raw_issue = frontmatter.get("github_issue")
+    try:
+        return int(raw_issue) == issue_number
+    except (TypeError, ValueError):
+        return False
+
+
+def _local_story_override_active(repo_root: Path, branch: str) -> bool:
+    """Return whether a matching local story file opts into forge.yaml mutations."""
+    issue_number = _issue_number_from_branch(branch)
+    slug = _branch_slug(branch)
+
+    for story_path in _iter_local_story_paths(repo_root):
+        frontmatter = parse_story_frontmatter(story_path)
+        if not frontmatter:
+            continue
+
+        if issue_number is not None and _matches_story_issue(frontmatter, issue_number):
+            return frontmatter_allows_forge_yaml_mutation(frontmatter)
+
+        story_slug = frontmatter.get("slug")
+        if story_slug == slug or story_path.stem == slug:
+            return frontmatter_allows_forge_yaml_mutation(frontmatter)
+
+    return False
+
+
 def _load_issue_metadata(repo_root: Path, issue_number: int) -> dict[str, Any]:
     """Best-effort fetch of issue body metadata for explicit guard overrides."""
     proc = subprocess.run(
@@ -108,6 +157,8 @@ def _issue_override_active(repo_root: Path) -> bool:
         branch = _current_branch(repo_root)
     except RuntimeError:
         return False
+    if _local_story_override_active(repo_root, branch):
+        return True
     issue_number = _issue_number_from_branch(branch)
     if issue_number is None:
         return False

--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -261,7 +261,7 @@ def cmd_check_story_config(args: argparse.Namespace) -> int:
         f"diff touches non-mutable keys: {violating}. "
         f"Allowed story-mutable top-level keys: {allowed}. "
         f"To override for this issue, add `{ALLOW_MUTATE_FORGE_YAML_KEY}: true` "
-        "to the issue's leading YAML metadata block.",
+        "to the issue's leading YAML metadata block or the local story file frontmatter.",
         file=sys.stderr,
     )
     return 1

--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -1,0 +1,216 @@
+"""Mechanical guard for story-branch mutations to forge.yaml."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from theforge.cli.shared import _find_config
+from theforge.config import load_config
+from theforge.task import ALLOW_MUTATE_FORGE_YAML_KEY
+
+_ALLOWED_TOP_LEVEL_KEYS = frozenset({"assignment", "models"})
+
+
+@dataclass(frozen=True)
+class ForgeYamlGuardResult:
+    """Outcome of the forge.yaml story-mutation guard."""
+
+    ok: bool
+    violating_keys: tuple[str, ...] = ()
+    override_active: bool = False
+    changed_keys: tuple[str, ...] = ()
+
+
+def _load_yaml_mapping(raw: str, *, source: str) -> dict[str, Any]:
+    """Parse YAML text as a mapping or raise ValueError."""
+    try:
+        data = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{source} is not valid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{source} must parse to a top-level mapping")
+    return data
+
+
+def _changed_top_level_keys(base: dict[str, Any], current: dict[str, Any]) -> tuple[str, ...]:
+    """Return sorted top-level keys whose values differ between two forge.yaml mappings."""
+    keys = set(base) | set(current)
+    changed = [key for key in keys if base.get(key) != current.get(key)]
+    return tuple(sorted(changed))
+
+
+def _current_branch(repo_root: Path) -> str:
+    """Return the current branch name."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=15,
+        check=False,
+    )
+    if proc.returncode != 0:
+        err = proc.stderr.strip() or proc.stdout.strip() or "git rev-parse failed"
+        raise RuntimeError(err)
+    return proc.stdout.strip()
+
+
+def _issue_number_from_branch(branch: str) -> int | None:
+    """Extract an issue number from a story branch name like feat/issue-283."""
+    for part in branch.split("/"):
+        if part.startswith("issue-") and part[6:].isdigit():
+            return int(part[6:])
+    return None
+
+
+def _load_issue_metadata(repo_root: Path, issue_number: int) -> dict[str, Any]:
+    """Best-effort fetch of issue body metadata for explicit guard overrides."""
+    proc = subprocess.run(
+        ["gh", "issue", "view", str(issue_number), "--json", "body"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {}
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {}
+    body = data.get("body", "")
+    if not isinstance(body, str) or not body.startswith("---"):
+        return {}
+    end = body.find("---", 3)
+    if end == -1:
+        return {}
+    try:
+        metadata = yaml.safe_load(body[3:end].strip()) or {}
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(metadata, dict):
+        return {}
+    return metadata
+
+
+def _issue_override_active(repo_root: Path) -> bool:
+    """Return whether the current story branch explicitly allows forge.yaml mutations."""
+    try:
+        branch = _current_branch(repo_root)
+    except RuntimeError:
+        return False
+    issue_number = _issue_number_from_branch(branch)
+    if issue_number is None:
+        return False
+    metadata = _load_issue_metadata(repo_root, issue_number)
+    return metadata.get(ALLOW_MUTATE_FORGE_YAML_KEY) is True
+
+
+def evaluate_forge_yaml_guard(repo_root: Path, *, base_branch: str) -> ForgeYamlGuardResult:
+    """Evaluate the forge.yaml mutation guard for the current branch."""
+    current_path = repo_root / "forge.yaml"
+    if not current_path.exists():
+        return ForgeYamlGuardResult(ok=True)
+
+    diff_proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_branch}...HEAD", "--", "forge.yaml"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=30,
+        check=False,
+    )
+    if diff_proc.returncode != 0:
+        err = diff_proc.stderr.strip() or diff_proc.stdout.strip() or "git diff failed"
+        raise RuntimeError(err)
+    if not diff_proc.stdout.strip():
+        return ForgeYamlGuardResult(ok=True)
+
+    current = _load_yaml_mapping(current_path.read_text(encoding="utf-8"), source="forge.yaml")
+    base_proc = subprocess.run(
+        ["git", "show", f"{base_branch}:forge.yaml"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=30,
+        check=False,
+    )
+    if base_proc.returncode != 0:
+        err = base_proc.stderr.strip() or base_proc.stdout.strip() or "git show failed"
+        raise RuntimeError(err)
+    base = _load_yaml_mapping(base_proc.stdout, source=f"{base_branch}:forge.yaml")
+
+    changed_keys = _changed_top_level_keys(base, current)
+    if not changed_keys:
+        return ForgeYamlGuardResult(ok=True)
+
+    override_active = _issue_override_active(repo_root)
+    violating_keys = tuple(key for key in changed_keys if key not in _ALLOWED_TOP_LEVEL_KEYS)
+    if override_active or not violating_keys:
+        return ForgeYamlGuardResult(
+            ok=True,
+            violating_keys=violating_keys,
+            override_active=override_active,
+            changed_keys=changed_keys,
+        )
+    return ForgeYamlGuardResult(
+        ok=False,
+        violating_keys=violating_keys,
+        override_active=False,
+        changed_keys=changed_keys,
+    )
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the guard subcommand."""
+    parser = subparsers.add_parser(
+        "check-story-config",
+        help="Reject story-branch forge.yaml edits outside the mutable allowlist",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to forge.yaml (defaults to nearest forge.yaml from cwd)",
+    )
+
+
+def cmd_check_story_config(args: argparse.Namespace) -> int:
+    """Run the story-branch forge.yaml mutation guard."""
+    config_path = Path(args.config).resolve() if args.config else _find_config()
+    if config_path is None:
+        print("forge.yaml not found", file=sys.stderr)
+        return 2
+
+    try:
+        config = load_config(config_path)
+        result = evaluate_forge_yaml_guard(
+            config.project_root,
+            base_branch=config.workspace.base_branch,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(f"forge.yaml story-mutation guard failed: {exc}", file=sys.stderr)
+        return 1
+
+    if result.ok:
+        return 0
+
+    allowed = ", ".join(sorted(_ALLOWED_TOP_LEVEL_KEYS))
+    violating = ", ".join(result.violating_keys)
+    print(
+        "forge.yaml story-mutation guard failed: "
+        f"diff touches non-mutable keys: {violating}. "
+        f"Allowed story-mutable top-level keys: {allowed}. "
+        f"To override for this issue, add `{ALLOW_MUTATE_FORGE_YAML_KEY}: true` "
+        "to the issue's leading YAML metadata block.",
+        file=sys.stderr,
+    )
+    return 1

--- a/src/theforge/cli/main.py
+++ b/src/theforge/cli/main.py
@@ -10,6 +10,7 @@ from theforge.cli import (
     check_config,
     daemon,
     eval_cmd,
+    forge_yaml_guard,
     hooks,
     ideate,
     index,
@@ -52,6 +53,7 @@ def build_parser() -> argparse.ArgumentParser:
     index.register_parser(subparsers)
     providers.register_parser(subparsers)
     check_config.register_parser(subparsers)
+    forge_yaml_guard.register_parser(subparsers)
     audit.register_parser(subparsers)
     telemetry.register_parser(subparsers)
     daemon.register_parser(subparsers)
@@ -85,6 +87,7 @@ def main() -> None:
         "index": index.cmd_index,
         "check-providers": providers.cmd_check_providers,
         "check-config": check_config.cmd_check_config,
+        "check-story-config": forge_yaml_guard.cmd_check_story_config,
         "audit": audit.cmd_audit,
         "telemetry": telemetry.cmd_telemetry,
         "daemon": daemon.cmd_daemon,

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -19,7 +19,14 @@ from theforge.config import (
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.redact import redact
 from theforge.coordinator.state import CoordinatorResult
-from theforge.task import TaskStory, build_dev_prompt, build_review_prompt, load_story
+from theforge.task import (
+    TaskStory,
+    build_dev_prompt,
+    build_review_prompt,
+    frontmatter_allows_forge_yaml_mutation,
+    load_story,
+    parse_story_frontmatter,
+)
 
 _SECRETS_FILE = ".forge/.env"
 
@@ -35,38 +42,8 @@ def _find_config(start: Path | None = None) -> Path | None:
 
 
 def _parse_story_frontmatter(story_path: Path) -> dict:
-    """Extract YAML frontmatter from a story file.
-
-    Story files can optionally have YAML frontmatter delimited by ---:
-
-        ---
-        name: Phase 6H: per-user export
-        slug: export-service
-        test_target: tests/test_export.py
-        ---
-
-        # Story content starts here...
-
-    If no frontmatter is present, returns empty dict.
-    """
-    text = story_path.read_text(encoding="utf-8")
-    if not text.startswith("---"):
-        return {}
-
-    # Find closing ---
-    end = text.find("---", 3)
-    if end == -1:
-        return {}
-
-    frontmatter = text[3:end].strip()
-    try:
-        result = yaml.safe_load(frontmatter) or {}
-    except yaml.YAMLError:
-        return {}
-
-    if not isinstance(result, dict):
-        return {}
-    return result
+    """Backward-compatible wrapper around the shared story frontmatter parser."""
+    return parse_story_frontmatter(story_path)
 
 
 def _build_task(story_path: Path, slug: str | None = None) -> TaskStory:
@@ -88,6 +65,7 @@ def _build_task(story_path: Path, slug: str | None = None) -> TaskStory:
         test_target=fm.get("test_target"),
         gate_override=fm.get("gate"),
         github_issue=github_issue,
+        allow_mutate_forge_yaml=frontmatter_allows_forge_yaml_mutation(fm),
     )
 
 

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from ..coordinator.state import CoordinatorResult
-from ..task import TaskStory
+from ..task import TaskStory, frontmatter_allows_forge_yaml_mutation, parse_story_frontmatter
 
 if TYPE_CHECKING:
     from .sources import StorySource
@@ -172,17 +172,7 @@ def _validate_story_paths(manifest: SprintManifest, project_root: Path) -> list[
 def _build_task_from_story(story_path: Path) -> TaskStory:
     """Build a TaskStory from a story file using frontmatter if available."""
     # Import here to avoid circular imports; cli._build_task is essentially the same logic
-    text = story_path.read_text(encoding="utf-8")
-    fm: dict = {}
-    if text.startswith("---"):
-        end = text.find("---", 3)
-        if end != -1:
-            try:
-                parsed = yaml.safe_load(text[3:end].strip()) or {}
-                if isinstance(parsed, dict):
-                    fm = parsed
-            except yaml.YAMLError:
-                pass
+    fm = parse_story_frontmatter(story_path)
 
     slug = fm.get("slug") or story_path.stem
     name = fm.get("name", story_path.stem.replace("_", " ").replace("-", " ").title())
@@ -206,6 +196,7 @@ def _build_task_from_story(story_path: Path) -> TaskStory:
         gate_override=fm.get("gate"),
         depends_on=depends_on,
         github_issue=github_issue,
+        allow_mutate_forge_yaml=frontmatter_allows_forge_yaml_mutation(fm),
     )
 
 

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import yaml
 
-from ..task import TaskStory
+from ..task import ALLOW_MUTATE_FORGE_YAML_KEY, TaskStory
 from .manifest import _build_task_from_story
 
 if TYPE_CHECKING:
@@ -99,6 +99,19 @@ class FileSource:
 class GitHubIssueSource:
     """Loads story specs from GitHub issues via the gh CLI."""
 
+    def _parse_issue_metadata(self, body: str) -> dict:
+        """Return parsed leading YAML metadata from an issue body, if present."""
+        metadata_match = _ISSUE_FRONTMATTER_RE.match(body)
+        if metadata_match is None:
+            return {}
+        try:
+            metadata = yaml.safe_load(metadata_match.group("yaml")) or {}
+        except yaml.YAMLError:
+            return {}
+        if not isinstance(metadata, dict):
+            return {}
+        return metadata
+
     def _fetch_issue_blockers(self, number: int, project_root: Path) -> list[int]:
         """Return issue numbers that block this issue.
 
@@ -167,14 +180,8 @@ class GitHubIssueSource:
 
         Free-form prose is intentionally excluded from this parser.
         """
-        metadata_match = _ISSUE_FRONTMATTER_RE.match(body)
-        if metadata_match is None:
-            return []
-        try:
-            metadata = yaml.safe_load(metadata_match.group("yaml")) or {}
-        except yaml.YAMLError:
-            return []
-        if not isinstance(metadata, dict):
+        metadata = self._parse_issue_metadata(body)
+        if not metadata:
             return []
 
         raw_deps = metadata.get("depends_on", [])
@@ -263,6 +270,7 @@ class GitHubIssueSource:
 
         title = data.get("title", f"Issue #{number}")
         body = data.get("body", "")
+        metadata = self._parse_issue_metadata(body)
         blockers = self._fetch_issue_blockers(number, project_root)
         if not blockers:
             blockers = self._parse_issue_blockers_from_body_metadata(body)
@@ -279,6 +287,7 @@ class GitHubIssueSource:
             inferred_dependencies=blocker_slugs,
             dependency_warnings=dependency_warnings,
             github_issue=number,
+            allow_mutate_forge_yaml=metadata.get(ALLOW_MUTATE_FORGE_YAML_KEY) is True,
         )
 
     def on_complete(

--- a/src/theforge/task/__init__.py
+++ b/src/theforge/task/__init__.py
@@ -11,8 +11,10 @@ from .plan_parser import PlanData, PlanStep, parse_plan_output
 from .plan_prompts import build_plan_prompt, build_plan_review_prompt, build_preflight_prompt
 from .review_prompts import build_review_prompt, build_synthesis_prompt
 from .story import (
+    ALLOW_MUTATE_FORGE_YAML_KEY,
     TaskSpec,
     TaskStory,
+    frontmatter_allows_forge_yaml_mutation,
     load_spec,
     load_story,
     parse_spec_frontmatter,
@@ -35,8 +37,10 @@ __all__ = [
     "build_preflight_prompt",
     "build_review_prompt",
     "build_synthesis_prompt",
+    "ALLOW_MUTATE_FORGE_YAML_KEY",
     "TaskSpec",
     "TaskStory",
+    "frontmatter_allows_forge_yaml_mutation",
     "load_spec",
     "load_story",
     "parse_spec_frontmatter",

--- a/src/theforge/task/story.py
+++ b/src/theforge/task/story.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import yaml
 
+ALLOW_MUTATE_FORGE_YAML_KEY = "allow_mutate_forge_yaml"
+
 
 @dataclass(frozen=True)
 class TaskStory:
@@ -20,6 +22,7 @@ class TaskStory:
     inferred_dependencies: list[str] = field(default_factory=list)  # inferred from GH blockers
     dependency_warnings: list[str] = field(default_factory=list)  # non-authoritative prose matches
     github_issue: int | None = None  # GH issue number; PR will include "Closes #N"
+    allow_mutate_forge_yaml: bool = False  # explicit opt-in for forge.yaml guard override
 
 
 # Backward-compat alias
@@ -71,8 +74,17 @@ def parse_story_frontmatter(story_path: Path) -> dict:
     # AttributeError when _is_gate_skip() calls .lower() on a non-string.
     if "gate" in result and not isinstance(result["gate"], str):
         result = {k: v for k, v in result.items() if k != "gate"}
+    if ALLOW_MUTATE_FORGE_YAML_KEY in result and not isinstance(
+        result[ALLOW_MUTATE_FORGE_YAML_KEY], bool
+    ):
+        result = {k: v for k, v in result.items() if k != ALLOW_MUTATE_FORGE_YAML_KEY}
 
     return result
+
+
+def frontmatter_allows_forge_yaml_mutation(frontmatter: dict) -> bool:
+    """Return whether story metadata explicitly opts into forge.yaml mutations."""
+    return frontmatter.get(ALLOW_MUTATE_FORGE_YAML_KEY) is True
 
 
 # Backward-compat alias

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -123,6 +123,35 @@ def test_evaluate_forge_yaml_guard_honors_issue_override(tmp_path: Path) -> None
     assert result.violating_keys == ("workspace",)
 
 
+def test_evaluate_forge_yaml_guard_honors_local_story_override(tmp_path: Path) -> None:
+    (tmp_path / "forge.yaml").write_text("workspace:\n  auto_push: false\n", encoding="utf-8")
+    story = tmp_path / "stories" / "backlog" / "config-story.md"
+    story.parent.mkdir(parents=True)
+    story.write_text(
+        (
+            "---\n"
+            "github_issue: 1001\n"
+            "allow_mutate_forge_yaml: true\n"
+            "---\n"
+            "# Config story\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
+            MagicMock(returncode=0, stdout="workspace:\n  auto_push: true\n", stderr=""),
+            MagicMock(returncode=0, stdout="feat/issue-1001\n", stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is True
+    assert result.override_active is True
+    assert result.violating_keys == ("workspace",)
+
+
 def test_cmd_check_story_config_prints_violating_keys(capsys, tmp_path: Path) -> None:
     config_path = tmp_path / "forge.yaml"
     config_path.write_text("project: test\n", encoding="utf-8")

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from theforge.cli.forge_yaml_guard import (
+    ForgeYamlGuardResult,
+    _changed_top_level_keys,
+    cmd_check_story_config,
+    evaluate_forge_yaml_guard,
+)
+from theforge.cli.shared import _build_task
+from theforge.sprint.manifest import _build_task_from_story
+from theforge.sprint.sources import GitHubIssueSource
+
+
+def test_build_task_parses_forge_yaml_override_frontmatter(tmp_path: Path) -> None:
+    story = tmp_path / "story.md"
+    story.write_text("---\nallow_mutate_forge_yaml: true\n---\n", encoding="utf-8")
+
+    task = _build_task(story)
+
+    assert task.allow_mutate_forge_yaml is True
+
+
+def test_build_task_from_story_parses_forge_yaml_override_frontmatter(tmp_path: Path) -> None:
+    story = tmp_path / "story.md"
+    story.write_text("---\nallow_mutate_forge_yaml: true\n---\n", encoding="utf-8")
+
+    task = _build_task_from_story(story)
+
+    assert task.allow_mutate_forge_yaml is True
+
+
+def test_github_issue_source_parses_forge_yaml_override_metadata(tmp_path: Path) -> None:
+    issue_data = json.dumps(
+        {
+            "title": "Config story",
+            "body": "---\nallow_mutate_forge_yaml: true\n---\n\nBody",
+            "state": "OPEN",
+        }
+    )
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=issue_data, stderr=""),
+            MagicMock(returncode=1, stdout="", stderr="preview unavailable"),
+        ]
+
+        task = GitHubIssueSource().fetch("42", tmp_path)
+
+    assert task.allow_mutate_forge_yaml is True
+
+
+def test_changed_top_level_keys_uses_top_level_sections() -> None:
+    base = {"models": ["a"], "validation": {"gate_command": "make gate"}}
+    current = {"models": ["b"], "validation": {"gate_command": "make gate"}, "retry": {"x": 1}}
+
+    changed = _changed_top_level_keys(base, current)
+
+    assert changed == ("models", "retry")
+
+
+def test_evaluate_forge_yaml_guard_passes_for_allowed_keys(tmp_path: Path) -> None:
+    (tmp_path / "forge.yaml").write_text("models:\n  - openai/gpt-5.4\n", encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
+            MagicMock(returncode=0, stdout="models:\n  - claude/sonnet\n", stderr=""),
+            MagicMock(returncode=0, stdout="feat/issue-1001\n", stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps({"body": ""}), stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is True
+    assert result.changed_keys == ("models",)
+    assert result.violating_keys == ()
+
+
+def test_evaluate_forge_yaml_guard_fails_for_non_allowlisted_keys(tmp_path: Path) -> None:
+    (tmp_path / "forge.yaml").write_text(
+        "models:\n  - claude/sonnet\nvalidation:\n  gate_command: make gate\n",
+        encoding="utf-8",
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
+            MagicMock(returncode=0, stdout="models:\n  - claude/sonnet\n", stderr=""),
+            MagicMock(returncode=0, stdout="feat/issue-1001\n", stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps({"body": ""}), stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is False
+    assert result.changed_keys == ("validation",)
+    assert result.violating_keys == ("validation",)
+
+
+def test_evaluate_forge_yaml_guard_honors_issue_override(tmp_path: Path) -> None:
+    (tmp_path / "forge.yaml").write_text("workspace:\n  auto_push: false\n", encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
+            MagicMock(returncode=0, stdout="workspace:\n  auto_push: true\n", stderr=""),
+            MagicMock(returncode=0, stdout="feat/issue-1001\n", stderr=""),
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps({"body": "---\nallow_mutate_forge_yaml: true\n---\n"}),
+                stderr="",
+            ),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is True
+    assert result.override_active is True
+    assert result.violating_keys == ("workspace",)
+
+
+def test_cmd_check_story_config_prints_violating_keys(capsys, tmp_path: Path) -> None:
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+    config = SimpleNamespace(project_root=tmp_path, workspace=SimpleNamespace(base_branch="main"))
+
+    with (
+        patch("theforge.cli.forge_yaml_guard._find_config", return_value=config_path),
+        patch("theforge.cli.forge_yaml_guard.load_config", return_value=config),
+        patch(
+            "theforge.cli.forge_yaml_guard.evaluate_forge_yaml_guard",
+            return_value=ForgeYamlGuardResult(
+                ok=False,
+                violating_keys=("validation", "workspace"),
+            ),
+        ),
+    ):
+        rc = cmd_check_story_config(SimpleNamespace(config=None))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "validation, workspace" in err
+    assert "allow_mutate_forge_yaml: true" in err

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -128,13 +128,7 @@ def test_evaluate_forge_yaml_guard_honors_local_story_override(tmp_path: Path) -
     story = tmp_path / "stories" / "backlog" / "config-story.md"
     story.parent.mkdir(parents=True)
     story.write_text(
-        (
-            "---\n"
-            "github_issue: 1001\n"
-            "allow_mutate_forge_yaml: true\n"
-            "---\n"
-            "# Config story\n"
-        ),
+        ("---\ngithub_issue: 1001\nallow_mutate_forge_yaml: true\n---\n# Config story\n"),
         encoding="utf-8",
     )
 
@@ -143,6 +137,31 @@ def test_evaluate_forge_yaml_guard_honors_local_story_override(tmp_path: Path) -
             MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
             MagicMock(returncode=0, stdout="workspace:\n  auto_push: true\n", stderr=""),
             MagicMock(returncode=0, stdout="feat/issue-1001\n", stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is True
+    assert result.override_active is True
+    assert result.violating_keys == ("workspace",)
+
+
+def test_evaluate_forge_yaml_guard_honors_slug_matched_local_story_override(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "forge.yaml").write_text("workspace:\n  auto_push: false\n", encoding="utf-8")
+    story = tmp_path / "stories" / "backlog" / "config-story.md"
+    story.parent.mkdir(parents=True)
+    story.write_text(
+        ("---\nslug: config-story\nallow_mutate_forge_yaml: true\n---\n# Config story\n"),
+        encoding="utf-8",
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
+            MagicMock(returncode=0, stdout="workspace:\n  auto_push: true\n", stderr=""),
+            MagicMock(returncode=0, stdout="feat/config-story\n", stderr=""),
         ]
 
         result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
@@ -174,3 +193,4 @@ def test_cmd_check_story_config_prints_violating_keys(capsys, tmp_path: Path) ->
     err = capsys.readouterr().err
     assert "validation, workspace" in err
     assert "allow_mutate_forge_yaml: true" in err
+    assert "local story file frontmatter" in err

--- a/tests/test_makefile_gate.py
+++ b/tests/test_makefile_gate.py
@@ -8,11 +8,18 @@ def test_gate_runs_index_before_pytest() -> None:
     gate_block = makefile[gate_start:gate_end]
 
     index_cmd = "forge index"
+    guard_cmd = "forge check-story-config"
     scrubbed_invocation = "$(SCRUBBED_GATE_CMD)"
     pytest_cmd = "PYTHONPATH=src python -m pytest tests/ -q -n auto --dist worksteal"
 
     assert index_cmd in gate_block
+    assert guard_cmd in gate_block
     assert scrubbed_invocation in gate_block
     assert gate_block.index(index_cmd) < gate_block.index(scrubbed_invocation)
+    assert (
+        gate_block.index(index_cmd)
+        < gate_block.index(guard_cmd)
+        < gate_block.index(scrubbed_invocation)
+    )
     # The scrubbed gate command itself carries the pytest invocation.
     assert pytest_cmd in makefile


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] All acceptance criteria are met; the prior P1 finding about local story file overrides is resolved; no regressions introduced. | [google-gemini-3.1-pro-preview] The prior P1 finding regarding local story file overrides has been resolved. The implementation correctly checks both local story files and GitHub issue metadata for the override flag. | [claude-opus] Cycle-1 P1 (local file-backed story override) is resolved: _local_story_override_active now scans local .md files for matching github_issue or slug/filename and honors allow_mutate_forge_yaml; failure message updated to mention local frontmatter; new tests cover both issue-number and slug-matched local overrides. No regressions introduced — guard logic, CLI exit codes, and Makefile ordering remain correct, and all six ACs are still met.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.36
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Gate must reject story branches that mutate forge.yaml outside an allowlist of story-mutable keys (GitHub Issue #1001)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1001