### PR TITLE
Split forge status DETAIL column into STAGE + DETAIL with per-phase signal mapping

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import shutil
 import sys
+import textwrap
 from pathlib import Path
 
 
@@ -129,11 +131,11 @@ def display_sprint_status(run_id: str, project_root: Path) -> int:
 
     # Column header
     header = (
-        f"  {'STORY':<28}  {'STATUS':<8}  {'PHASE':<12}  {'COMPLEXITY':<10}  "
-        f"{'COST':>7}  {'ELAPSED':>7}  DETAIL"
+        f"  {'STORY':<28}  {'STATUS':<8}  {'PHASE':<12}  {'STAGE':<16}  "
+        f"{'COMPLEXITY':<10}  {'COST':>7}  {'ELAPSED':>7}  DETAIL"
     )
     print(header)
-    print("  " + "-" * 96)
+    print("  " + "-" * (len(header) - 2))
 
     # Separate bundle candidates from regular stories
     bundle_entries = [e for e in entries if e.bundle_candidate]
@@ -204,22 +206,61 @@ def _print_story_line(entry: object, status_icons: dict, indent: int) -> None:
     path = getattr(entry, "path", getattr(entry, "slug", ""))
     status = getattr(entry, "status", "waiting")
     phase = getattr(entry, "phase", None)
+    stage = getattr(entry, "stage", "")
     cost_usd = getattr(entry, "cost_usd", 0.0)
     elapsed_s = getattr(entry, "elapsed_seconds", None)
     detail = getattr(entry, "detail", "")
     complexity = getattr(entry, "complexity", None)
 
     phase_str = phase if phase else "—"
+    stage_str = stage if stage else "—"
     complexity_str = complexity if complexity else "—"
     cost_str = f"${cost_usd:.2f}" if cost_usd else "   —"
     elapsed_str = f"{int(elapsed_s // 60)}m" if elapsed_s is not None else "—"
 
-    line = (
-        f"{icon} {path:<28}  {status:<8}  {phase_str:<12}  {complexity_str:<10}  "
-        f"{cost_str:>7}  {elapsed_str:>7}  {detail}"
-    )
     prefix = " " * indent
-    print(f"{prefix}{line}")
+    detail_width = _detail_column_width(indent)
+    path_lines = _wrap_cell(path, 28)
+    phase_lines = _wrap_cell(phase_str, 12)
+    stage_lines = _wrap_cell(stage_str, 16)
+    detail_lines = _wrap_cell(detail if detail else "—", detail_width)
+
+    line_count = max(len(path_lines), len(phase_lines), len(stage_lines), len(detail_lines))
+    for index in range(line_count):
+        icon_cell = icon if index == 0 else " "
+        status_cell = status if index == 0 else ""
+        complexity_cell = complexity_str if index == 0 else ""
+        cost_cell = cost_str if index == 0 else ""
+        elapsed_cell = elapsed_str if index == 0 else ""
+        line = (
+            f"{icon_cell} {path_lines[index] if index < len(path_lines) else '':<28}  "
+            f"{status_cell:<8}  "
+            f"{phase_lines[index] if index < len(phase_lines) else '':<12}  "
+            f"{stage_lines[index] if index < len(stage_lines) else '':<16}  "
+            f"{complexity_cell:<10}  {cost_cell:>7}  {elapsed_cell:>7}  "
+            f"{detail_lines[index] if index < len(detail_lines) else ''}"
+        )
+        print(f"{prefix}{line}")
+
+
+def _detail_column_width(indent: int) -> int:
+    """Return an adaptive width for DETAIL so values wrap instead of truncating."""
+    terminal_width = shutil.get_terminal_size((140, 20)).columns
+    fixed_width = indent + 2 + 28 + 2 + 8 + 2 + 12 + 2 + 16 + 2 + 10 + 2 + 7 + 2 + 7 + 2
+    return max(20, terminal_width - fixed_width)
+
+
+def _wrap_cell(value: str, width: int) -> list[str]:
+    """Wrap a cell value to the requested width without dropping content."""
+    if width <= 0:
+        return [value] if value else [""]
+    wrapped = textwrap.wrap(
+        value,
+        width=width,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+    return wrapped or [""]
 
 
 def register_parser(subparsers: object) -> None:

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -22,6 +22,7 @@ class StoryStatusEntry:
     blocked_by: list[str] = field(default_factory=list)
     bundle_candidate: bool = False
     elapsed_seconds: float | None = None
+    stage: str = ""
     detail: str = ""
     complexity: str | None = None
 
@@ -119,7 +120,73 @@ def _normalize_complexity(value: object) -> str | None:
     return value.strip().lower()
 
 
-def _detail_from_live_story(story: dict) -> tuple[str, str | None]:
+def _nonempty_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _format_usage_stage(used: object, maximum: object, label: str) -> str:
+    if isinstance(used, int) and isinstance(maximum, int) and maximum > 0:
+        return f"{label}={used}/{maximum}"
+    if isinstance(used, int) and used > 0:
+        return f"{label}={used}"
+    return ""
+
+
+def _format_terminal_stage(iteration_usage: dict | None) -> str:
+    if not isinstance(iteration_usage, dict):
+        return ""
+    review_raw = iteration_usage.get("review")
+    dev_raw = iteration_usage.get("dev")
+    review = review_raw if isinstance(review_raw, dict) else {}
+    dev = dev_raw if isinstance(dev_raw, dict) else {}
+    review_used = review.get("used")
+    dev_used = dev.get("used")
+
+    parts: list[str] = []
+    if isinstance(review_used, int) and review_used > 0:
+        parts.append(f"{review_used} cyc")
+    if isinstance(dev_used, int) and dev_used > 0:
+        parts.append(f"{dev_used} iter")
+    return " / ".join(parts)
+
+
+def _review_detail(verdict: object, p1: object, p2: object) -> str:
+    verdict_text = _nonempty_str(verdict)
+    if isinstance(p1, int) and isinstance(p2, int):
+        count_text = f"{p1}P1 {p2}P2"
+        return f"{verdict_text} {count_text}".strip() if verdict_text else count_text
+    return verdict_text or ""
+
+
+def _classify_wait_reason(blocked_by: list[str]) -> str:
+    if not blocked_by:
+        return ""
+    joined = " ".join(blocked_by).lower()
+    if "budget" in joined:
+        return "budget"
+    if "parallel" in joined or "saturated" in joined:
+        return "parallel cap"
+    return "dependency"
+
+
+def _waiting_detail(blocked_by: list[str]) -> str:
+    if not blocked_by:
+        return "waiting"
+    if all(item.startswith("issue-") for item in blocked_by):
+        return f"depends on {', '.join(blocked_by)}"
+    return "; ".join(blocked_by)
+
+
+def _terminal_phase(outcome: str, depends_on: list[str]) -> str | None:
+    if outcome == "SKIPPED" and depends_on:
+        return "waiting"
+    return outcome or None
+
+
+def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None]:
     phase_val = story.get("phase")
     status_val = story.get("status", "waiting")
     blocked_by_val = list(story.get("blocked_by") or [])
@@ -129,65 +196,150 @@ def _detail_from_live_story(story: dict) -> tuple[str, str | None]:
     if not isinstance(detail_data, dict):
         detail_data = {}
 
-    if status_val == "blocked" and blocked_by_val:
-        return f"blocked by: {', '.join(blocked_by_val)}", complexity
+    if status_val in {"waiting", "blocked"} and blocked_by_val:
+        return _classify_wait_reason(blocked_by_val), _waiting_detail(blocked_by_val), complexity
 
     if phase_val == "PREFLIGHT":
         verdict = detail_data.get("preflight_verdict")
         sufficiency = detail_data.get("preflight_sufficiency")
         parts = [part for part in (verdict, sufficiency) if isinstance(part, str) and part]
         if parts:
-            return " / ".join(parts), complexity
+            return "", " / ".join(parts), complexity
         if status_val == "waiting":
-            return "waiting", complexity
-        return "—", complexity
+            return "", "waiting", complexity
+        return "", "—", complexity
 
     if status_val == "waiting":
-        return "waiting", complexity
+        return "", "waiting", complexity
 
     if status_val in {"done", "failed", "skipped", "preserved"}:
         final_outcome = detail_data.get("final_outcome")
         if isinstance(final_outcome, str) and final_outcome:
-            return final_outcome, complexity
+            return "", final_outcome, complexity
         if status_val == "failed" and phase_val:
-            return phase_val, complexity
-        return "—", complexity
+            return "", phase_val, complexity
+        return "", "—", complexity
 
     if phase_val == "PLAN":
         current = detail_data.get("plan_attempt")
         maximum = detail_data.get("plan_max_attempts")
-        if isinstance(current, int) and isinstance(maximum, int) and maximum > 0:
-            return f"plan {current}/{maximum}", complexity
-        return "plan", complexity
+        stage = _format_usage_stage(current, maximum, "attempt")
+        return stage, "planning", complexity
 
     if phase_val == "DEV":
-        cycle = detail_data.get("review_cycle")
         iteration = detail_data.get("dev_iteration")
-        if isinstance(cycle, int) and isinstance(iteration, int):
-            return f"c{cycle + 1} i{iteration}", complexity
-        return "dev", complexity
+        stage = _format_usage_stage(iteration, detail_data.get("dev_max_iterations"), "iter")
+        if not stage and isinstance(iteration, int):
+            stage = f"iter={iteration}"
+        current_finding = _nonempty_str(detail_data.get("current_finding"))
+        files_touched = detail_data.get("files_touched")
+        last_gate = _nonempty_str(detail_data.get("last_gate_result"))
+        detail_parts: list[str] = []
+        if current_finding:
+            detail_parts.append(current_finding)
+        if isinstance(files_touched, int):
+            detail_parts.append(f"{files_touched} files touched")
+        if last_gate:
+            detail_parts.append(f"last gate {last_gate}")
+        return stage, " | ".join(detail_parts) or "running", complexity
 
     if phase_val == "REVIEW":
+        cycle = detail_data.get("review_cycle")
+        stage = _format_usage_stage(cycle, detail_data.get("review_max_cycles"), "cycle")
+        if not stage and isinstance(cycle, int):
+            stage = f"cycle={cycle}"
         p1 = detail_data.get("review_p1")
         p2 = detail_data.get("review_p2")
-        if isinstance(p1, int) and isinstance(p2, int):
-            return f"{p1} P1, {p2} P2", complexity
-        return "review", complexity
+        detail = _review_detail(detail_data.get("review_verdict"), p1, p2)
+        return stage, detail or "running", complexity
 
-    if phase_val == "VALIDATE":
+    if phase_val in {"GATE", "VALIDATE"}:
         gate = detail_data.get("gate_status")
         if isinstance(gate, str) and gate:
-            return gate, complexity
-        return "running", complexity
+            return "", gate, complexity
+        return "", "running", complexity
 
     if phase_val == "PLAN_REVIEW":
         current = detail_data.get("plan_attempt")
         maximum = detail_data.get("plan_max_attempts")
-        if isinstance(current, int) and isinstance(maximum, int) and maximum > 0:
-            return f"plan review {current}/{maximum}", complexity
-        return "plan review", complexity
+        stage = _format_usage_stage(current, maximum, "cycle")
+        detail = _review_detail(
+            detail_data.get("review_verdict"),
+            detail_data.get("review_p1"),
+            detail_data.get("review_p2"),
+        )
+        return stage, detail or "reviewing plan", complexity
 
-    return "", complexity
+    if phase_val == "WORKSPACE":
+        return (
+            _nonempty_str(detail_data.get("workspace_stage")) or "",
+            _nonempty_str(detail_data.get("command")) or "creating workspace",
+            complexity,
+        )
+
+    return "", "", complexity
+
+
+def _stage_and_detail_from_completed_story(
+    story: dict,
+    audit_data: dict | None,
+) -> tuple[str, str, str | None]:
+    outcome = str(story.get("outcome", ""))
+    depends_on = list(story.get("depends_on") or [])
+    preflight_data = (audit_data or {}).get("preflight")
+    preflight = preflight_data if isinstance(preflight_data, dict) else {}
+    if outcome == "SKIPPED" and depends_on:
+        return (
+            _classify_wait_reason(depends_on),
+            _waiting_detail(depends_on),
+            _normalize_complexity(preflight.get("complexity")),
+        )
+
+    complexity = _normalize_complexity(preflight.get("complexity"))
+    stage = _format_terminal_stage(story.get("iteration_usage"))
+
+    detail = ""
+    if isinstance(audit_data, dict):
+        reviews = audit_data.get("reviews")
+        if isinstance(reviews, list) and reviews:
+            last_review = reviews[-1]
+            if isinstance(last_review, dict):
+                finding_counts = last_review.get("findings_by_severity")
+                p1 = p2 = None
+                if isinstance(finding_counts, dict):
+                    p1 = finding_counts.get("P1", 0)
+                    p2 = finding_counts.get("P2", 0)
+                detail = _review_detail(last_review.get("verdict"), p1, p2)
+                summary = _nonempty_str(last_review.get("summary"))
+                if summary and not detail:
+                    detail = summary
+                elif summary and detail:
+                    detail = f"{detail} — {summary}"
+        if not detail:
+            outcome_block = audit_data.get("outcome")
+            if isinstance(outcome_block, dict):
+                message = _nonempty_str(outcome_block.get("message"))
+                if message:
+                    detail = message
+        if not detail:
+            error = _nonempty_str(audit_data.get("error"))
+            if error:
+                detail = error
+
+    if not detail:
+        verdict = _nonempty_str(story.get("verdict"))
+        if verdict == "APPROVE":
+            detail = "APPROVE"
+        elif verdict:
+            detail = verdict
+        elif outcome == "DONE":
+            detail = "APPROVE"
+        elif outcome == "ALREADY_DONE":
+            detail = "ALREADY_DONE"
+        else:
+            detail = outcome
+
+    return stage, detail, complexity
 
 
 def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
@@ -218,10 +370,11 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
         cost_usd = float(story.get("cost_usd", 0.0))
 
         status = _outcome_to_status(outcome)
-        phase = outcome if status in ("running", "failed") else None
+        phase = _terminal_phase(outcome, list(story.get("depends_on") or []))
 
         bundle_candidate = False
         complexity = None
+        audit_data: dict | None = None
         if slug:
             audit_path = sprint_log_dir / slug / "audit.yaml"
             if audit_path.exists():
@@ -238,17 +391,11 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
 
         raw_depends_on = story.get("depends_on") or []
         blocked_by = list(raw_depends_on) if status == "skipped" and raw_depends_on else []
-
-        if outcome == "ESCALATE":
-            detail = "ESCALATE"
-        elif outcome == "ALREADY_DONE":
-            detail = "ALREADY_DONE"
-        elif outcome == "DONE":
-            detail = "APPROVE"
-        elif status == "skipped" and raw_depends_on:
-            detail = f"blocked by: {', '.join(raw_depends_on)}"
-        else:
-            detail = ""
+        stage, detail, derived_complexity = _stage_and_detail_from_completed_story(
+            story, audit_data
+        )
+        if complexity is None:
+            complexity = derived_complexity
 
         entries.append(
             StoryStatusEntry(
@@ -260,6 +407,7 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
                 blocked_by=blocked_by,
                 bundle_candidate=bundle_candidate,
                 elapsed_seconds=None,
+                stage=stage,
                 detail=detail,
                 complexity=complexity,
             )
@@ -300,18 +448,22 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
         status_val = story.get("status", "waiting")
         phase_val = story.get("phase")
         blocked_by_val = list(story.get("blocked_by") or [])
-        detail, complexity = _detail_from_live_story(story)
+        phase_display = phase_val
+        if status_val in {"waiting", "blocked"} and blocked_by_val:
+            phase_display = "waiting"
+        stage, detail, complexity = _stage_and_detail_from_live_story(story)
 
         entries.append(
             StoryStatusEntry(
                 slug=slug,
                 path=story.get("path", slug),
                 status=status_val,
-                phase=phase_val,
+                phase=phase_display,
                 cost_usd=float(story.get("cost_usd", 0.0)),
                 blocked_by=blocked_by_val,
                 bundle_candidate=bool(story.get("bundle_candidate", False)),
                 elapsed_seconds=None,
+                stage=stage,
                 detail=detail,
                 complexity=complexity,
             )
@@ -332,12 +484,16 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                     slug=slug,
                     path=story.get("path", slug),
                     status=_outcome_to_status(str(story.get("outcome", "SKIPPED"))),
-                    phase=None,
+                    phase=_terminal_phase(
+                        str(story.get("outcome", "SKIPPED")),
+                        list(story.get("depends_on") or []),
+                    ),
                     cost_usd=float(story.get("cost_usd", 0.0)),
                     blocked_by=list(story.get("depends_on") or []),
                     bundle_candidate=False,
                     elapsed_seconds=None,
-                    detail=str(story.get("outcome", "")),
+                    stage=_format_terminal_stage(story.get("iteration_usage")),
+                    detail=_nonempty_str(story.get("verdict")) or str(story.get("outcome", "")),
                     complexity=None,
                 )
             )

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -80,7 +80,7 @@ def test_read_live_status_parses_state_file(tmp_path: Path) -> None:
                 "bundle_candidate": False,
                 "blocked_by": [],
                 "complexity": "medium",
-                "detail": {"review_cycle": 0, "dev_iteration": 2},
+                "detail": {"dev_iteration": 2, "dev_max_iterations": 3},
             },
             {
                 "slug": "issue-2",
@@ -106,12 +106,14 @@ def test_read_live_status_parses_state_file(tmp_path: Path) -> None:
     assert e1.cost_usd == pytest.approx(0.12)
     assert e1.bundle_candidate is False
     assert e1.complexity == "medium"
-    assert e1.detail == "c1 i2"
+    assert e1.stage == "iter=2/3"
+    assert e1.detail == "running"
 
     e2 = entries[1]
     assert e2.slug == "issue-2"
     assert e2.status == "waiting"
     assert e2.bundle_candidate is True
+    assert e2.stage == ""
     assert e2.detail == "waiting"
 
 
@@ -139,7 +141,10 @@ def test_read_live_status_blocked_story(tmp_path: Path) -> None:
     assert entries is not None
     assert len(entries) == 1
     assert entries[0].status == "blocked"
+    assert entries[0].phase == "waiting"
+    assert entries[0].stage == "dependency"
     assert entries[0].blocked_by == ["issue-98"]
+    assert entries[0].detail == "depends on issue-98"
 
 
 def test_read_live_status_merges_accumulated_prior_run_stories(tmp_path: Path) -> None:
@@ -272,9 +277,13 @@ def test_read_completed_status_outcome_mapping(tmp_path: Path) -> None:
 
     by_slug = {e.slug: e for e in entries}
     assert by_slug["s1"].status == "done"
+    assert by_slug["s1"].phase == "DONE"
     assert by_slug["s2"].status == "done"
+    assert by_slug["s2"].phase == "ALREADY_DONE"
     assert by_slug["s3"].status == "skipped"
+    assert by_slug["s3"].phase == "SKIPPED"
     assert by_slug["s4"].status == "failed"
+    assert by_slug["s4"].phase == "ESCALATE"
 
 
 def test_read_completed_status_bundle_candidate_from_audit(tmp_path: Path) -> None:
@@ -327,10 +336,54 @@ def test_read_completed_status_blocked_by_from_depends_on(tmp_path: Path) -> Non
     by_slug = {e.slug: e for e in entries}
 
     assert by_slug["issue-6"].status == "skipped"
+    assert by_slug["issue-6"].phase == "waiting"
+    assert by_slug["issue-6"].stage == "dependency"
     assert by_slug["issue-6"].blocked_by == ["issue-5"]
+    assert by_slug["issue-6"].detail == "depends on issue-5"
     # Non-skipped stories should not show depends_on as blocked_by
     assert by_slug["issue-5"].blocked_by == []
     assert by_slug["issue-7"].blocked_by == []
+
+
+def test_read_completed_status_uses_audit_for_terminal_stage_and_detail(tmp_path: Path) -> None:
+    from theforge.sprint.status_reader import read_completed_status
+
+    stories = [
+        {
+            "slug": "issue-8",
+            "path": "Issue #8",
+            "outcome": "DONE",
+            "cost_usd": 0.3,
+            "verdict": "APPROVE",
+            "iteration_usage": {
+                "dev": {"used": 1, "max": 3},
+                "review": {"used": 2, "max": 3},
+            },
+        }
+    ]
+    summary_path = _make_summary_file(tmp_path, "audit-sprint", "run-audit", stories)
+
+    audit_dir = tmp_path / ".forge" / "logs" / "audit-sprint" / "issue-8"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_data = {
+        "preflight": {"complexity": "medium"},
+        "reviews": [
+            {
+                "verdict": "APPROVE",
+                "summary": "No findings remain.",
+                "findings_by_severity": {"P1": 0, "P2": 0},
+            }
+        ],
+    }
+    with open(audit_dir / "audit.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(audit_data, f)
+
+    entries = read_completed_status(summary_path)
+
+    assert len(entries) == 1
+    assert entries[0].stage == "2 cyc / 1 iter"
+    assert entries[0].detail == "APPROVE 0P1 0P2 — No findings remain."
+    assert entries[0].complexity == "medium"
 
 
 # ── cmd_sprint_status (output) ───────────────────────────────────────────────
@@ -449,7 +502,7 @@ def test_cmd_sprint_status_live_sprint(tmp_path: Path) -> None:
                 "bundle_candidate": False,
                 "blocked_by": [],
                 "complexity": "medium",
-                "detail": {"review_cycle": 0, "dev_iteration": 2},
+                "detail": {"dev_iteration": 2, "dev_max_iterations": 3},
             },
             {
                 "slug": "issue-21",
@@ -474,9 +527,10 @@ def test_cmd_sprint_status_live_sprint(tmp_path: Path) -> None:
     assert "Issue #20" in output
     assert "DEV" in output
     assert "medium" in output
-    assert "c1 i2" in output
+    assert "iter=2/3" in output
     assert "Issue #21" in output
-    assert "PROCEED / needs_planning" in output
+    assert "PROCEED" in output
+    assert "needs_planning" in output
 
 
 def test_cmd_sprint_status_blocked_story_shows_dependency(tmp_path: Path) -> None:
@@ -582,6 +636,8 @@ def test_display_sprint_status_row_shows_status_and_detail(tmp_path: Path) -> No
     # status column
     assert "done" in output
     assert "failed" in output
+    assert "DONE" in output
+    assert "ESCALATE" in output
     # detail column for DONE → "APPROVE", for ESCALATE → "ESCALATE"
     assert "APPROVE" in output
     assert "ESCALATE" in output
@@ -625,6 +681,7 @@ def test_display_sprint_status_live_row_shows_phase_and_status(tmp_path: Path) -
     assert "running" in output
     assert "DEV" in output
     assert "blocked" in output
+    assert "dependency" in output
     assert "issue-10" in output  # blocked_by appears in detail
 
 
@@ -667,10 +724,50 @@ def test_display_sprint_status_column_header_present(tmp_path: Path) -> None:
     assert code == 0
     assert "STATUS" in output
     assert "PHASE" in output
+    assert "STAGE" in output
     assert "COMPLEXITY" in output
     assert "COST" in output
     assert "ELAPSED" in output
     assert "DETAIL" in output
+
+
+def test_display_sprint_status_wraps_long_detail_without_truncation(tmp_path: Path) -> None:
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "wrap-run.pid").write_text("99997\nwrap-sprint\n")
+
+    long_detail = (
+        "addressing 1P1 (plan_flow.py:187) while coordinating a long descriptive message "
+        "that should wrap onto a continuation line without losing any content"
+    )
+    _make_state_file(
+        tmp_path,
+        "wrap-run",
+        "wrap-sprint",
+        [
+            {
+                "slug": "issue-60",
+                "path": "Issue #60",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 0.11,
+                "bundle_candidate": False,
+                "blocked_by": [],
+                "detail": {
+                    "dev_iteration": 2,
+                    "current_finding": long_detail,
+                },
+            }
+        ],
+    )
+
+    code, output = _run_sprint_status(tmp_path, "wrap-run")
+
+    assert code == 0
+    assert "addressing 1P1" in output
+    assert "(plan_flow.py:187)" in output
+    assert "without losing any" in output
+    assert "content" in output
 
 
 # ── SprintStateWriter ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] The implementation fully satisfies all five acceptance criteria. The STAGE column is added and populated with phase-appropriate structural state (cycle/iteration numbers, waiting reason class, terminal cycle counts), while the DETAIL column shows the interpreted payload (review verdicts, findings, gate results, specific blockers). All columns are derived from existing live state or per-story audit.yaml without introducing new judgment. Long values wrap via textwrap with no truncation. All 27 tests pass. | [google-gemini-3.1-pro-preview] The implementation correctly splits the DETAIL column into STAGE and DETAIL, populates them with phase-appropriate signals from authoritative sources, and wraps long values without truncation. | [claude-opus] STAGE column added with phase-appropriate stage/detail mapping; long DETAIL values wrap without truncation; tests cover live, completed, blocked, and wrapping paths.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $2.08
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/status_reader.py:231`** Several detail_data keys read by the new mapping (dev_max_iterations, review_max_cycles, review_verdict, current_finding, files_touched, last_gate_result, workspace_stage) are not currently written anywhere in the coordinator. In production the DEV/REVIEW/PLAN_REVIEW/WORKSPACE rows will fall back to bare iter=N/cycle=N or generic 'running'/'creating workspace' detail until those events are emitted.
- **[P2] `src/theforge/sprint/status_reader.py:175`** _waiting_detail special-cases blocked_by entries that all start with 'issue-' to render 'depends on issue-...'. Other dependency formats (slugs, paths) take the '; '.join branch with no 'depends on' prefix, which makes the live waiting-row wording inconsistent across project types.
- **[P2] `src/theforge/cli/sprint_status.py:240`** textwrap.wrap collapses internal whitespace runs and strips leading whitespace. If a future detail string carries meaningful spacing (e.g., aligned tokens) it would be silently normalized. Not a problem for current detail values, but worth noting against the AC that values must not lose information.

## Story

Split forge status DETAIL column into STAGE + DETAIL with per-phase signal mapping (GitHub Issue #1035)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1035