### PR TITLE
forge status --watch: live-update mode like top/htop

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -305,6 +305,8 @@ def cmd_status(args: object) -> int:
     recent = getattr(args, "recent", False)
     last = getattr(args, "last", False)
     explicit_run_id: str | None = getattr(args, "run_id", None)
+    watch_interval: int | None = getattr(args, "watch", None)
+    no_color: bool = getattr(args, "no_color", False)
 
     # ── --recent: compact run list ────────────────────────────────────────
     if recent:
@@ -338,6 +340,21 @@ def cmd_status(args: object) -> int:
         _pending.cleanup_stale(project_root)
         _show_pending_decisions(_pending, project_root)
         return 0
+
+    # ── Watch mode (TTY-only; falls back to snapshot otherwise) ───────────
+    if watch_interval is not None:
+        from theforge.cli import status_watch
+
+        if status_watch.is_tty() and _is_sprint_run(target_run_id, project_root):
+            color = status_watch.color_enabled(no_color)
+            return status_watch.run_watch_loop(
+                target_run_id,
+                project_root,
+                float(watch_interval),
+                color=color,
+            )
+        # Non-TTY or non-sprint run: silently fall back to single snapshot so
+        # piped/redirected output and CI captures stay clean.
 
     # ── Display run status ────────────────────────────────────────────────
     if _is_sprint_run(target_run_id, project_root):
@@ -683,6 +700,25 @@ def register_parsers(subparsers: object) -> None:
         action="store_true",
         default=False,
         help="Show the most recent completed or failed run",
+    )
+    status_parser.add_argument(
+        "--watch",
+        nargs="?",
+        const=2,
+        type=int,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Live-update mode: re-render every SECONDS (default 2). "
+            "Falls back to single snapshot if stdout is not a TTY."
+        ),
+    )
+    status_parser.add_argument(
+        "--no-color",
+        dest="no_color",
+        action="store_true",
+        default=False,
+        help="Disable ANSI color in watch mode (NO_COLOR env var also honored).",
     )
 
     # forge logs

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -308,6 +308,13 @@ def cmd_status(args: object) -> int:
     watch_interval: int | None = getattr(args, "watch", None)
     no_color: bool = getattr(args, "no_color", False)
 
+    if watch_interval is not None and watch_interval <= 0:
+        print(
+            f"--watch interval must be a positive integer (got {watch_interval}).",
+            file=sys.stderr,
+        )
+        return 2
+
     # ── --recent: compact run list ────────────────────────────────────────
     if recent:
         return _show_recent_runs(project_root)
@@ -676,6 +683,28 @@ def cmd_decide(args: object) -> int:
     return 0
 
 
+def _positive_watch_interval(raw: str) -> int:
+    """argparse type for ``--watch SECONDS``: require a positive integer.
+
+    Rejects 0 and negatives so the watch loop never sleeps for a non-positive
+    duration (which would crash on ``time.sleep(-1)``) and never busy-loops at
+    interval 0.
+    """
+    import argparse  # noqa: PLC0415
+
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"--watch requires an integer number of seconds, got {raw!r}"
+        ) from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError(
+            f"--watch interval must be a positive integer (got {value})"
+        )
+    return value
+
+
 def register_parsers(subparsers: object) -> None:
     """Register status/logs/stop/decide subcommand parsers."""
     # forge status
@@ -705,12 +734,13 @@ def register_parsers(subparsers: object) -> None:
         "--watch",
         nargs="?",
         const=2,
-        type=int,
+        type=_positive_watch_interval,
         default=None,
         metavar="SECONDS",
         help=(
-            "Live-update mode: re-render every SECONDS (default 2). "
-            "Falls back to single snapshot if stdout is not a TTY."
+            "Live-update mode: re-render every SECONDS (must be a positive "
+            "integer; default 2). Falls back to single snapshot if stdout is "
+            "not a TTY."
         ),
     )
     status_parser.add_argument(

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -1,0 +1,250 @@
+"""Live-update (`--watch`) mode for `forge status`.
+
+Re-renders the sprint status table on a fixed interval using ANSI cursor
+positioning so the operator can monitor a running sprint without re-issuing
+the command. Per-row deltas surface cost-change since the last refresh and
+time since the most recent audit event; a spinner distinguishes running
+stories that are emitting events from ones that have stalled.
+
+Non-TTY output (pipes, redirects, CI captures) falls back to the
+single-snapshot path — the watch loop is opt-in and TTY-only.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+STALL_CHAR = "·"
+DONE_CHAR = "✓"
+FAIL_CHAR = "✗"
+WAIT_CHAR = " "
+
+HIDE_CURSOR = "\x1b[?25l"
+SHOW_CURSOR = "\x1b[?25h"
+CLEAR_SCREEN = "\x1b[2J"
+CURSOR_HOME = "\x1b[H"
+
+GREEN = "\x1b[32m"
+RED = "\x1b[31m"
+DIM = "\x1b[2m"
+BOLD = "\x1b[1m"
+RESET = "\x1b[0m"
+
+
+def is_tty(stream: Any = None) -> bool:
+    """Return True when stream is a real terminal."""
+    if stream is None:
+        stream = sys.stdout
+    try:
+        return bool(stream.isatty())
+    except Exception:
+        return False
+
+
+def color_enabled(no_color_flag: bool, stream: Any = None) -> bool:
+    """Decide whether to emit ANSI color sequences."""
+    if no_color_flag:
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return is_tty(stream)
+
+
+def _c(text: str, code: str, color: bool) -> str:
+    return f"{code}{text}{RESET}" if color else text
+
+
+def _format_age(seconds: float) -> str:
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m{int(seconds % 60):02d}s"
+    return f"{int(seconds // 3600)}h{int((seconds % 3600) // 60):02d}m"
+
+
+def _format_delta(delta: float) -> str:
+    if abs(delta) < 0.005:
+        return "—"
+    sign = "+" if delta > 0 else "-"
+    return f"{sign}${abs(delta):.2f}"
+
+
+def _last_audit_mtime(slug: str, project_root: Path) -> float | None:
+    """Most recent mtime of any per-story audit.yaml under .forge/logs/*/<slug>/."""
+    if not slug:
+        return None
+    logs_dir = project_root / ".forge" / "logs"
+    if not logs_dir.exists():
+        return None
+    best: float | None = None
+    for audit in logs_dir.glob(f"*/{slug}/audit.yaml"):
+        try:
+            m = audit.stat().st_mtime
+        except OSError:
+            continue
+        if best is None or m > best:
+            best = m
+    return best
+
+
+def render_frame(
+    run_id: str,
+    project_root: Path,
+    state: dict,
+    frame_idx: int,
+    *,
+    color: bool,
+    now_fn: Any = None,
+) -> str:
+    """Return the full text for one watch-mode frame.
+
+    Mutates ``state`` to record per-slug cost and audit-event timestamps so the
+    next frame can compute deltas. ``state`` should be reused across frames.
+    """
+    from theforge.cli.sprint_status import display_sprint_status
+    from theforge.sprint.status_reader import read_live_status
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        display_sprint_status(run_id, project_root)
+    base = buf.getvalue()
+
+    entries = read_live_status(run_id, project_root) or []
+    now = (now_fn or time.time)()
+    spinner = SPINNER_FRAMES[frame_idx % len(SPINNER_FRAMES)]
+    interval = float(state.get("interval", 2.0))
+    stall_threshold = max(5.0, interval * 2)
+
+    prev_costs = dict(state.get("costs", {}))
+    new_costs: dict[str, float] = {}
+
+    overlay_lines: list[str] = []
+    overlay_lines.append("")
+    title = f"── Live  refresh={interval:g}s  Ctrl-C to exit ──"
+    overlay_lines.append(_c(title, DIM, color))
+    overlay_lines.append(f"{'STORY':<30}  {'ACT':<3}  {'ΔCOST':>8}  {'EVT AGE':>8}")
+
+    for e in entries:
+        slug = getattr(e, "slug", "") or ""
+        cost = float(getattr(e, "cost_usd", 0.0) or 0.0)
+        prev = prev_costs.get(slug, cost)
+        delta = cost - prev
+        new_costs[slug] = cost
+
+        last_evt = _last_audit_mtime(slug, project_root)
+        if last_evt is None:
+            age_str = "—"
+            stalled = False
+        else:
+            age = max(0.0, now - last_evt)
+            age_str = _format_age(age)
+            stalled = age > stall_threshold
+
+        status = getattr(e, "status", "waiting")
+        if status == "running":
+            if stalled:
+                act = _c(STALL_CHAR, DIM, color)
+            else:
+                act = _c(spinner, GREEN, color)
+        elif status == "done":
+            act = _c(DONE_CHAR, GREEN, color)
+        elif status == "failed":
+            act = _c(FAIL_CHAR, RED, color)
+        elif status == "skipped" or status == "blocked":
+            act = _c(STALL_CHAR, DIM, color)
+        else:
+            act = WAIT_CHAR
+
+        delta_str = _format_delta(delta)
+        if color and delta != 0 and abs(delta) >= 0.005:
+            delta_str = _c(delta_str, DIM, True)
+
+        path = getattr(e, "path", slug) or slug
+        path_disp = path if len(path) <= 30 else path[:29] + "…"
+        # ``act`` may contain ANSI codes; pad based on visible width (1 char).
+        act_pad = act + " " * 2
+        overlay_lines.append(f"{path_disp:<30}  {act_pad}  {delta_str:>8}  {age_str:>8}")
+
+    state["costs"] = new_costs
+    return base + "\n".join(overlay_lines) + "\n"
+
+
+def _validate_target(run_id: str, project_root: Path) -> tuple[bool, str | None]:
+    """Confirm the run can be located and is a sprint.
+
+    Returns (ok, error_message). Watch mode requires a sprint run; single
+    runs and unresolvable IDs fall back to the snapshot path.
+    """
+    from theforge.cli.status import _is_sprint_run, _resolve_run_id
+
+    if not _resolve_run_id(run_id, project_root):
+        return False, f"No run found with ID {run_id!r}."
+    if not _is_sprint_run(run_id, project_root):
+        return False, "Watch mode is only available for sprint runs."
+    return True, None
+
+
+def run_watch_loop(
+    run_id: str,
+    project_root: Path,
+    interval: float,
+    *,
+    color: bool,
+    sleep_fn: Any = None,
+    max_frames: int | None = None,
+) -> int:
+    """Drive the watch redraw loop.
+
+    Returns 0 on clean exit (Ctrl-C or max_frames reached) and non-zero if the
+    sprint state cannot be read at all on the first attempt.
+    """
+    sleep = sleep_fn or time.sleep
+
+    state: dict = {"costs": {}, "interval": float(interval)}
+    frame = 0
+    cursor_hidden = False
+    try:
+        if color or is_tty():
+            sys.stdout.write(HIDE_CURSOR)
+            sys.stdout.flush()
+            cursor_hidden = True
+        while True:
+            try:
+                body = render_frame(run_id, project_root, state, frame, color=color)
+            except Exception as exc:  # noqa: BLE001
+                if frame == 0:
+                    print(
+                        f"forge status --watch: failed to read sprint state: {exc}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                # Transient failure mid-loop — keep the previous frame on screen.
+                body = None
+
+            if body is not None:
+                sys.stdout.write(CLEAR_SCREEN + CURSOR_HOME + body)
+                sys.stdout.flush()
+
+            frame += 1
+            if max_frames is not None and frame >= max_frames:
+                return 0
+            try:
+                sleep(interval)
+            except KeyboardInterrupt:
+                return 0
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        if cursor_hidden:
+            try:
+                sys.stdout.write(SHOW_CURSOR)
+                sys.stdout.flush()
+            except Exception:
+                pass

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -40,8 +40,10 @@ def CURSOR_UP(n: int) -> str:
 GREEN = "\x1b[32m"
 RED = "\x1b[31m"
 DIM = "\x1b[2m"
-BOLD = "\x1b[1m"
 RESET = "\x1b[0m"
+
+# Terminals that don't support ANSI color sequences.
+COLORLESS_TERMS = frozenset({"dumb", "unknown", ""})
 
 
 def is_tty(stream: Any = None) -> bool:
@@ -55,12 +57,24 @@ def is_tty(stream: Any = None) -> bool:
 
 
 def color_enabled(no_color_flag: bool, stream: Any = None) -> bool:
-    """Decide whether to emit ANSI color sequences."""
+    """Decide whether to emit ANSI color sequences.
+
+    Disables color when:
+    - ``--no-color`` was passed,
+    - the ``NO_COLOR`` environment variable is set (https://no-color.org),
+    - stdout is not a TTY,
+    - or ``TERM`` indicates a colorless terminal (``dumb``, ``unknown``, unset).
+    """
     if no_color_flag:
         return False
     if os.environ.get("NO_COLOR"):
         return False
-    return is_tty(stream)
+    if not is_tty(stream):
+        return False
+    term = os.environ.get("TERM", "").strip().lower()
+    if term in COLORLESS_TERMS:
+        return False
+    return True
 
 
 def _c(text: str, code: str, color: bool) -> str:

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -170,13 +170,16 @@ def render_frame(
     *,
     color: bool,
     now_fn: Any = None,
-) -> tuple[str, bool]:
-    """Return ``(text, ok)`` for one watch-mode frame.
+) -> tuple[str, bool, str]:
+    """Return ``(text, ok, captured_stderr)`` for one watch-mode frame.
 
     ``ok`` is False when the underlying snapshot reported it could not read
     sprint state (non-zero return) — the caller propagates that as a
-    non-zero exit on the first frame. ``state`` is mutated to record per-slug
-    cost so the next frame can compute deltas.
+    non-zero exit on the first frame and forwards ``captured_stderr`` to
+    the real ``sys.stderr`` so the operator sees the diagnostic. Mid-loop
+    callers must NOT print the stderr buffer or it will scroll past the
+    in-place CURSOR_UP redraw region. ``state`` is mutated to record
+    per-slug cost so the next frame can compute deltas.
     """
     from theforge.cli.sprint_status import display_sprint_status
     from theforge.sprint.status_reader import read_live_status
@@ -248,7 +251,7 @@ def render_frame(
         overlay_lines.append(f"{path_disp:<30}  {act_pad}  {delta_str:>8}  {age_str:>8}")
 
     state["costs"] = new_costs
-    return base + "\n".join(overlay_lines) + "\n", snapshot_ok
+    return base + "\n".join(overlay_lines) + "\n", snapshot_ok, err_buf.getvalue()
 
 
 def run_watch_loop(
@@ -284,7 +287,9 @@ def run_watch_loop(
             cursor_hidden = True
         while True:
             try:
-                body, snapshot_ok = render_frame(run_id, project_root, state, frame, color=color)
+                body, snapshot_ok, captured_err = render_frame(
+                    run_id, project_root, state, frame, color=color
+                )
             except Exception as exc:  # noqa: BLE001
                 if frame == 0:
                     print(
@@ -295,9 +300,23 @@ def run_watch_loop(
                 # Transient failure mid-loop — keep the previous frame on screen.
                 body = None
                 snapshot_ok = True
+                captured_err = ""
 
             if frame == 0 and not snapshot_ok:
-                # display_sprint_status already wrote its diagnostic to stderr.
+                # First frame failed: forward the snapshot's diagnostic that
+                # render_frame captured. There is no in-place redraw region
+                # yet, so printing to stderr is safe. (Mid-loop captures stay
+                # discarded so they can't scroll past the CURSOR_UP region.)
+                if captured_err:
+                    sys.stderr.write(captured_err)
+                    if not captured_err.endswith("\n"):
+                        sys.stderr.write("\n")
+                    sys.stderr.flush()
+                else:
+                    print(
+                        "forge status --watch: failed to read sprint state.",
+                        file=sys.stderr,
+                    )
                 return 1
 
             if body is not None:

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -28,8 +28,14 @@ WAIT_CHAR = " "
 
 HIDE_CURSOR = "\x1b[?25l"
 SHOW_CURSOR = "\x1b[?25h"
-CLEAR_SCREEN = "\x1b[2J"
-CURSOR_HOME = "\x1b[H"
+CLEAR_BELOW = "\x1b[0J"  # erase from cursor to end of screen
+CARRIAGE_RETURN = "\r"
+
+
+def CURSOR_UP(n: int) -> str:
+    """ANSI: move cursor up N lines (no-op when N<=0)."""
+    return f"\x1b[{n}A" if n > 0 else ""
+
 
 GREEN = "\x1b[32m"
 RED = "\x1b[31m"
@@ -76,22 +82,70 @@ def _format_delta(delta: float) -> str:
     return f"{sign}${abs(delta):.2f}"
 
 
-def _last_audit_mtime(slug: str, project_root: Path) -> float | None:
-    """Most recent mtime of any per-story audit.yaml under .forge/logs/*/<slug>/."""
-    if not slug:
-        return None
+def _resolve_sprint_log_dir(run_id: str, project_root: Path) -> Path | None:
+    """Return the per-run log directory `.forge/logs/<sprint_name>/` for run_id.
+
+    Resolution order:
+    1. The live `.state` file at `.forge/runs/<run_id>.state` records
+       ``sprint_name`` — that is the canonical mapping for in-flight runs.
+    2. Otherwise, scan `.forge/logs/*/sprint-summary.yaml` for an entry whose
+       ``sprint.run_id`` matches (covers completed sprints).
+
+    Returns ``None`` when no directory can be resolved (e.g. logs not yet
+    created on the very first frame). Restricting the audit-mtime lookup to
+    this directory prevents stale events from previous sprint runs that
+    happened to use the same story slug from leaking into the live display.
+    """
+    import yaml  # noqa: PLC0415
+
     logs_dir = project_root / ".forge" / "logs"
+    state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
+    if state_path.exists():
+        try:
+            with open(state_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            sprint_name = data.get("sprint_name", "") if isinstance(data, dict) else ""
+            if sprint_name:
+                candidate = logs_dir / sprint_name
+                if candidate.exists():
+                    return candidate
+        except Exception:
+            pass
+
     if not logs_dir.exists():
         return None
-    best: float | None = None
-    for audit in logs_dir.glob(f"*/{slug}/audit.yaml"):
-        try:
-            m = audit.stat().st_mtime
-        except OSError:
-            continue
-        if best is None or m > best:
-            best = m
-    return best
+    try:
+        for summary in logs_dir.glob("*/sprint-summary.yaml"):
+            try:
+                with open(summary, encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+                if not isinstance(data, dict):
+                    continue
+                sp = data.get("sprint", {})
+                if isinstance(sp, dict) and sp.get("run_id") == run_id:
+                    return summary.parent
+            except Exception:
+                continue
+    except OSError:
+        return None
+    return None
+
+
+def _last_audit_mtime(
+    slug: str, run_id: str, project_root: Path, sprint_log_dir: Path | None
+) -> float | None:
+    """Most recent mtime of `<sprint_log_dir>/<slug>/audit.yaml` for the active run.
+
+    Restricted to the resolved sprint log directory so a story that ran in a
+    prior sprint with the same slug cannot surface its old timestamp here.
+    """
+    if not slug or sprint_log_dir is None:
+        return None
+    audit = sprint_log_dir / slug / "audit.yaml"
+    try:
+        return audit.stat().st_mtime
+    except OSError:
+        return None
 
 
 def render_frame(
@@ -102,19 +156,24 @@ def render_frame(
     *,
     color: bool,
     now_fn: Any = None,
-) -> str:
-    """Return the full text for one watch-mode frame.
+) -> tuple[str, bool]:
+    """Return ``(text, ok)`` for one watch-mode frame.
 
-    Mutates ``state`` to record per-slug cost and audit-event timestamps so the
-    next frame can compute deltas. ``state`` should be reused across frames.
+    ``ok`` is False when the underlying snapshot reported it could not read
+    sprint state (non-zero return) — the caller propagates that as a
+    non-zero exit on the first frame. ``state`` is mutated to record per-slug
+    cost so the next frame can compute deltas.
     """
     from theforge.cli.sprint_status import display_sprint_status
     from theforge.sprint.status_reader import read_live_status
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        display_sprint_status(run_id, project_root)
+        rc = display_sprint_status(run_id, project_root)
     base = buf.getvalue()
+    snapshot_ok = rc == 0
+
+    sprint_log_dir = _resolve_sprint_log_dir(run_id, project_root)
 
     entries = read_live_status(run_id, project_root) or []
     now = (now_fn or time.time)()
@@ -138,7 +197,7 @@ def render_frame(
         delta = cost - prev
         new_costs[slug] = cost
 
-        last_evt = _last_audit_mtime(slug, project_root)
+        last_evt = _last_audit_mtime(slug, run_id, project_root, sprint_log_dir)
         if last_evt is None:
             age_str = "—"
             stalled = False
@@ -168,12 +227,11 @@ def render_frame(
 
         path = getattr(e, "path", slug) or slug
         path_disp = path if len(path) <= 30 else path[:29] + "…"
-        # ``act`` may contain ANSI codes; pad based on visible width (1 char).
         act_pad = act + " " * 2
         overlay_lines.append(f"{path_disp:<30}  {act_pad}  {delta_str:>8}  {age_str:>8}")
 
     state["costs"] = new_costs
-    return base + "\n".join(overlay_lines) + "\n"
+    return base + "\n".join(overlay_lines) + "\n", snapshot_ok
 
 
 def run_watch_loop(
@@ -187,13 +245,20 @@ def run_watch_loop(
 ) -> int:
     """Drive the watch redraw loop.
 
-    Returns 0 on clean exit (Ctrl-C or max_frames reached) and non-zero if the
-    sprint state cannot be read at all on the first attempt.
+    Returns 0 on clean exit (Ctrl-C or max_frames reached) and non-zero when
+    the underlying sprint snapshot cannot be read on the first frame.
+
+    Redraws are in-place: after the first frame we record the line count and
+    on each subsequent frame issue ``CURSOR_UP(n) + CARRIAGE_RETURN +
+    CLEAR_BELOW`` to overwrite only the previously-rendered region. The
+    operator's terminal scrollback is preserved and the visible screen is
+    never cleared.
     """
     sleep = sleep_fn or time.sleep
 
     state: dict = {"costs": {}, "interval": float(interval)}
     frame = 0
+    prev_lines = 0
     cursor_hidden = False
     try:
         if color or is_tty():
@@ -202,7 +267,7 @@ def run_watch_loop(
             cursor_hidden = True
         while True:
             try:
-                body = render_frame(run_id, project_root, state, frame, color=color)
+                body, snapshot_ok = render_frame(run_id, project_root, state, frame, color=color)
             except Exception as exc:  # noqa: BLE001
                 if frame == 0:
                     print(
@@ -212,10 +277,19 @@ def run_watch_loop(
                     return 1
                 # Transient failure mid-loop — keep the previous frame on screen.
                 body = None
+                snapshot_ok = True
+
+            if frame == 0 and not snapshot_ok:
+                # display_sprint_status already wrote its diagnostic to stderr.
+                return 1
 
             if body is not None:
-                sys.stdout.write(CLEAR_SCREEN + CURSOR_HOME + body)
+                if frame == 0:
+                    sys.stdout.write(body)
+                else:
+                    sys.stdout.write(CURSOR_UP(prev_lines) + CARRIAGE_RETURN + CLEAR_BELOW + body)
                 sys.stdout.flush()
+                prev_lines = body.count("\n")
 
             frame += 1
             if max_frames is not None and frame >= max_frames:

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -182,7 +182,10 @@ def render_frame(
     from theforge.sprint.status_reader import read_live_status
 
     buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
+    err_buf = io.StringIO()
+    # Capture stderr too: a mid-loop failure (e.g. state file just removed)
+    # would otherwise scroll the terminal and break the in-place redraw math.
+    with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(err_buf):
         rc = display_sprint_status(run_id, project_root)
     base = buf.getvalue()
     snapshot_ok = rc == 0
@@ -309,7 +312,10 @@ def run_watch_loop(
             if max_frames is not None and frame >= max_frames:
                 return 0
             try:
-                sleep(interval)
+                # Defense-in-depth: argparse already rejects non-positive
+                # intervals, but clamp here so a programmatic caller can't
+                # crash the loop with time.sleep(-1).
+                sleep(max(0.0, float(interval)))
             except KeyboardInterrupt:
                 return 0
     except KeyboardInterrupt:

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -176,21 +176,6 @@ def render_frame(
     return base + "\n".join(overlay_lines) + "\n"
 
 
-def _validate_target(run_id: str, project_root: Path) -> tuple[bool, str | None]:
-    """Confirm the run can be located and is a sprint.
-
-    Returns (ok, error_message). Watch mode requires a sprint run; single
-    runs and unresolvable IDs fall back to the snapshot path.
-    """
-    from theforge.cli.status import _is_sprint_run, _resolve_run_id
-
-    if not _resolve_run_id(run_id, project_root):
-        return False, f"No run found with ID {run_id!r}."
-    if not _is_sprint_run(run_id, project_root):
-        return False, "Watch mode is only available for sprint runs."
-    return True, None
-
-
 def run_watch_loop(
     run_id: str,
     project_root: Path,

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -133,9 +134,12 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=None),
         ):
-            text = status_watch.render_frame("run-x", tmp_path, state, frame_idx=0, color=False)
+            text, ok = status_watch.render_frame(
+                "run-x", tmp_path, state, frame_idx=0, color=False
+            )
 
         # First frame: no prior cost recorded → delta is 0 → rendered as em-dash.
+        assert ok is True
         assert "story-a" in text
         assert state["costs"] == {"story-a": 1.50}
 
@@ -154,7 +158,9 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=None),
         ):
-            text = status_watch.render_frame("run-x", tmp_path, state, frame_idx=1, color=False)
+            text, _ok = status_watch.render_frame(
+                "run-x", tmp_path, state, frame_idx=1, color=False
+            )
 
         assert "+$0.60" in text
         assert state["costs"] == {"story-a": 2.10}
@@ -176,7 +182,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
         ):
-            text = status_watch.render_frame(
+            text, _ok = status_watch.render_frame(
                 "run-x",
                 tmp_path,
                 state,
@@ -204,7 +210,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
         ):
-            text = status_watch.render_frame(
+            text, _ok = status_watch.render_frame(
                 "run-x",
                 tmp_path,
                 state,
@@ -232,7 +238,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
         ):
-            text = status_watch.render_frame(
+            text, _ok = status_watch.render_frame(
                 "run-x",
                 tmp_path,
                 state,
@@ -257,7 +263,7 @@ class TestRunWatchLoop:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value="frame-body\n",
+                return_value=("frame-body\n", True),
             ),
             patch.object(status_watch, "is_tty", return_value=False),
         ):
@@ -285,7 +291,7 @@ class TestRunWatchLoop:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value="frame-body\n",
+                return_value=("frame-body\n", True),
             ),
             patch.object(status_watch, "is_tty", return_value=False),
         ):
@@ -330,7 +336,7 @@ class TestRunWatchLoop:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value="frame-body\n",
+                return_value=("frame-body\n", True),
             ),
             patch.object(status_watch, "is_tty", return_value=True),
         ):
@@ -433,3 +439,102 @@ class TestCmdStatusWatchRouting:
 
         assert rc == 0
         loop.assert_not_called()
+
+
+# ── Review-feedback regression coverage ──────────────────────────────────────
+
+
+class TestSnapshotFailurePropagates:
+    """display_sprint_status returning non-zero on first frame must exit non-zero."""
+
+    def test_first_frame_snapshot_failure_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(
+                status_watch,
+                "render_frame",
+                return_value=("", False),
+            ),
+            patch.object(status_watch, "is_tty", return_value=False),
+        ):
+            rc = status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=lambda _s: None,
+                max_frames=1,
+            )
+
+        assert rc == 1
+
+
+class TestNoFullScreenClear:
+    """Redraw must not issue ANSI clear-screen (\\x1b[2J)."""
+
+    def test_redraw_uses_cursor_up_not_clear_screen(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(
+                status_watch,
+                "render_frame",
+                return_value=("line1\nline2\n", True),
+            ),
+            patch.object(status_watch, "is_tty", return_value=False),
+        ):
+            status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=lambda _s: None,
+                max_frames=3,
+            )
+
+        out = capsys.readouterr().out
+        # No full-screen clear sequence anywhere in the redraw output.
+        assert "\x1b[2J" not in out
+        # In-place redraw uses cursor-up + erase-below on subsequent frames.
+        assert "\x1b[2A" in out  # CURSOR_UP(2) for the 2-line body
+        assert status_watch.CLEAR_BELOW in out
+
+
+class TestAuditMtimeRunScoping:
+    """`_last_audit_mtime` must look only inside the resolved sprint log dir."""
+
+    def test_returns_none_when_sprint_log_dir_is_none(self, tmp_path: Path) -> None:
+        result = status_watch._last_audit_mtime("story-a", "run-x", tmp_path, sprint_log_dir=None)
+        assert result is None
+
+    def test_reads_only_from_passed_sprint_dir(self, tmp_path: Path) -> None:
+        # Create two sibling sprint log dirs containing the same slug.
+        old_dir = tmp_path / ".forge" / "logs" / "old-sprint"
+        cur_dir = tmp_path / ".forge" / "logs" / "current-sprint"
+        (old_dir / "story-a").mkdir(parents=True)
+        (cur_dir / "story-a").mkdir(parents=True)
+        old_audit = old_dir / "story-a" / "audit.yaml"
+        cur_audit = cur_dir / "story-a" / "audit.yaml"
+        old_audit.write_text("old")
+        cur_audit.write_text("cur")
+
+        # Make the OLD audit newer than the current to prove scoping.
+        os.utime(old_audit, (2_000_000_000, 2_000_000_000))
+        os.utime(cur_audit, (1_000_000_000, 1_000_000_000))
+
+        result = status_watch._last_audit_mtime(
+            "story-a", "run-x", tmp_path, sprint_log_dir=cur_dir
+        )
+        assert result == 1_000_000_000
+
+    def test_resolve_sprint_log_dir_from_state_file(self, tmp_path: Path) -> None:
+        sprint_name = "sprint-2025-04-27"
+        sprint_dir = tmp_path / ".forge" / "logs" / sprint_name
+        sprint_dir.mkdir(parents=True)
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-x.state").write_text(f"sprint_name: {sprint_name}\n")
+
+        resolved = status_watch._resolve_sprint_log_dir("run-x", tmp_path)
+        assert resolved == sprint_dir

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -45,6 +45,44 @@ class TestWatchArgParsing:
         assert ns.watch == 3
         assert ns.no_color is True
 
+    def test_watch_zero_rejected(self) -> None:
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["status", "--watch", "0"])
+
+    def test_watch_negative_rejected(self) -> None:
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["status", "--watch", "-1"])
+
+    def test_watch_non_integer_rejected(self) -> None:
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["status", "--watch", "abc"])
+
+
+class TestCmdStatusInvalidWatch:
+    def test_negative_watch_via_namespace_returns_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Direct Namespace callers (bypassing argparse) still get rejected."""
+        from theforge.cli import cmd_status
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        from tests.test_cli_status import _make_forge_config
+
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=None, recent=False, last=False, watch=-1, no_color=False)
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            rc = cmd_status(args)
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "positive integer" in err
+
 
 # ── color_enabled ─────────────────────────────────────────────────────────────
 

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -69,12 +69,44 @@ class TestColorEnabled:
 
     def test_tty_with_no_overrides_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("TERM", "xterm-256color")
 
         class FakeStream:
             def isatty(self) -> bool:
                 return True
 
         assert status_watch.color_enabled(False, FakeStream()) is True
+
+    def test_term_dumb_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Colorless TTYs (TERM=dumb) must not receive ANSI color sequences."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("TERM", "dumb")
+
+        class FakeStream:
+            def isatty(self) -> bool:
+                return True
+
+        assert status_watch.color_enabled(False, FakeStream()) is False
+
+    def test_term_unset_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+
+        class FakeStream:
+            def isatty(self) -> bool:
+                return True
+
+        assert status_watch.color_enabled(False, FakeStream()) is False
+
+    def test_term_unknown_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("TERM", "unknown")
+
+        class FakeStream:
+            def isatty(self) -> bool:
+                return True
+
+        assert status_watch.color_enabled(False, FakeStream()) is False
 
 
 # ── Format helpers ────────────────────────────────────────────────────────────

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -1,0 +1,435 @@
+"""Tests for `forge status --watch` live-update mode."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from theforge.cli import status_watch
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+
+class TestWatchArgParsing:
+    def _build_parser(self) -> argparse.ArgumentParser:
+        from theforge.cli.status import register_parsers
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="cmd")
+        register_parsers(sub)
+        return parser
+
+    def test_no_watch_flag_default(self) -> None:
+        parser = self._build_parser()
+        ns = parser.parse_args(["status"])
+        assert ns.watch is None
+        assert ns.no_color is False
+
+    def test_watch_flag_default_interval(self) -> None:
+        parser = self._build_parser()
+        ns = parser.parse_args(["status", "--watch"])
+        assert ns.watch == 2
+
+    def test_watch_flag_explicit_interval(self) -> None:
+        parser = self._build_parser()
+        ns = parser.parse_args(["status", "--watch", "5"])
+        assert ns.watch == 5
+
+    def test_no_color_flag(self) -> None:
+        parser = self._build_parser()
+        ns = parser.parse_args(["status", "--watch", "3", "--no-color"])
+        assert ns.watch == 3
+        assert ns.no_color is True
+
+
+# ── color_enabled ─────────────────────────────────────────────────────────────
+
+
+class TestColorEnabled:
+    def test_no_color_flag_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        assert status_watch.color_enabled(no_color_flag=True) is False
+
+    def test_no_color_env_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert status_watch.color_enabled(no_color_flag=False) is False
+
+    def test_non_tty_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+
+        class FakeStream:
+            def isatty(self) -> bool:
+                return False
+
+        assert status_watch.color_enabled(False, FakeStream()) is False
+
+    def test_tty_with_no_overrides_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+
+        class FakeStream:
+            def isatty(self) -> bool:
+                return True
+
+        assert status_watch.color_enabled(False, FakeStream()) is True
+
+
+# ── Format helpers ────────────────────────────────────────────────────────────
+
+
+class TestFormatHelpers:
+    def test_age_seconds(self) -> None:
+        assert status_watch._format_age(5) == "5s"
+
+    def test_age_minutes(self) -> None:
+        assert status_watch._format_age(125) == "2m05s"
+
+    def test_age_hours(self) -> None:
+        assert status_watch._format_age(3725) == "1h02m"
+
+    def test_delta_zero(self) -> None:
+        assert status_watch._format_delta(0.0) == "—"
+
+    def test_delta_negligible(self) -> None:
+        assert status_watch._format_delta(0.001) == "—"
+
+    def test_delta_positive(self) -> None:
+        assert status_watch._format_delta(0.42) == "+$0.42"
+
+    def test_delta_negative(self) -> None:
+        assert status_watch._format_delta(-1.5) == "-$1.50"
+
+
+# ── render_frame: deltas and spinner ──────────────────────────────────────────
+
+
+def _entry(slug: str, status: str = "running", cost: float = 0.0):
+    from theforge.sprint.status_reader import StoryStatusEntry
+
+    return StoryStatusEntry(
+        slug=slug,
+        path=slug,
+        status=status,
+        phase="DEV",
+        cost_usd=cost,
+    )
+
+
+class TestRenderFrame:
+    def test_first_frame_has_zero_delta(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", cost=1.50)]
+        state: dict = {"costs": {}, "interval": 2.0}
+
+        with (
+            patch(
+                "theforge.cli.sprint_status.display_sprint_status",
+                return_value=0,
+            ),
+            patch(
+                "theforge.sprint.status_reader.read_live_status",
+                return_value=entries,
+            ),
+            patch.object(status_watch, "_last_audit_mtime", return_value=None),
+        ):
+            text = status_watch.render_frame("run-x", tmp_path, state, frame_idx=0, color=False)
+
+        # First frame: no prior cost recorded → delta is 0 → rendered as em-dash.
+        assert "story-a" in text
+        assert state["costs"] == {"story-a": 1.50}
+
+    def test_second_frame_shows_delta(self, tmp_path: Path) -> None:
+        state: dict = {"costs": {"story-a": 1.50}, "interval": 2.0}
+        entries = [_entry("story-a", cost=2.10)]
+
+        with (
+            patch(
+                "theforge.cli.sprint_status.display_sprint_status",
+                return_value=0,
+            ),
+            patch(
+                "theforge.sprint.status_reader.read_live_status",
+                return_value=entries,
+            ),
+            patch.object(status_watch, "_last_audit_mtime", return_value=None),
+        ):
+            text = status_watch.render_frame("run-x", tmp_path, state, frame_idx=1, color=False)
+
+        assert "+$0.60" in text
+        assert state["costs"] == {"story-a": 2.10}
+
+    def test_event_age_surfaces(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", status="running", cost=0.0)]
+        state: dict = {"costs": {}, "interval": 2.0}
+        fixed_now = 1000.0
+        evt_time = 970.0  # 30s ago
+
+        with (
+            patch(
+                "theforge.cli.sprint_status.display_sprint_status",
+                return_value=0,
+            ),
+            patch(
+                "theforge.sprint.status_reader.read_live_status",
+                return_value=entries,
+            ),
+            patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
+        ):
+            text = status_watch.render_frame(
+                "run-x",
+                tmp_path,
+                state,
+                frame_idx=0,
+                color=False,
+                now_fn=lambda: fixed_now,
+            )
+
+        assert "30s" in text
+
+    def test_running_uses_spinner_when_recent_event(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", status="running", cost=0.0)]
+        state: dict = {"costs": {}, "interval": 2.0}
+        fixed_now = 1000.0
+        evt_time = 999.0  # 1s ago — not stalled
+
+        with (
+            patch(
+                "theforge.cli.sprint_status.display_sprint_status",
+                return_value=0,
+            ),
+            patch(
+                "theforge.sprint.status_reader.read_live_status",
+                return_value=entries,
+            ),
+            patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
+        ):
+            text = status_watch.render_frame(
+                "run-x",
+                tmp_path,
+                state,
+                frame_idx=0,
+                color=False,
+                now_fn=lambda: fixed_now,
+            )
+
+        assert status_watch.SPINNER_FRAMES[0] in text
+
+    def test_running_shows_stall_when_stale(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", status="running", cost=0.0)]
+        state: dict = {"costs": {}, "interval": 2.0}
+        fixed_now = 1000.0
+        evt_time = 900.0  # 100s ago — well past stall threshold (max(5, 4))
+
+        with (
+            patch(
+                "theforge.cli.sprint_status.display_sprint_status",
+                return_value=0,
+            ),
+            patch(
+                "theforge.sprint.status_reader.read_live_status",
+                return_value=entries,
+            ),
+            patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
+        ):
+            text = status_watch.render_frame(
+                "run-x",
+                tmp_path,
+                state,
+                frame_idx=0,
+                color=False,
+                now_fn=lambda: fixed_now,
+            )
+
+        assert status_watch.STALL_CHAR in text
+        # Spinner should NOT appear for a stalled story.
+        assert status_watch.SPINNER_FRAMES[0] not in text
+
+
+# ── run_watch_loop ────────────────────────────────────────────────────────────
+
+
+class TestRunWatchLoop:
+    def test_runs_max_frames_then_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(
+                status_watch,
+                "render_frame",
+                return_value="frame-body\n",
+            ),
+            patch.object(status_watch, "is_tty", return_value=False),
+        ):
+            sleeps: list[float] = []
+            rc = status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=sleeps.append,
+                max_frames=3,
+            )
+
+        assert rc == 0
+        # Three frames rendered; sleep happens between frames, not after the last.
+        assert len(sleeps) == 2
+        out = capsys.readouterr().out
+        assert out.count("frame-body") == 3
+
+    def test_keyboard_interrupt_exits_zero(self, tmp_path: Path) -> None:
+        def raising_sleep(_seconds: float) -> None:
+            raise KeyboardInterrupt
+
+        with (
+            patch.object(
+                status_watch,
+                "render_frame",
+                return_value="frame-body\n",
+            ),
+            patch.object(status_watch, "is_tty", return_value=False),
+        ):
+            rc = status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=raising_sleep,
+            )
+
+        assert rc == 0
+
+    def test_first_frame_failure_returns_nonzero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(
+                status_watch,
+                "render_frame",
+                side_effect=RuntimeError("state unreadable"),
+            ),
+            patch.object(status_watch, "is_tty", return_value=False),
+        ):
+            rc = status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=lambda _s: None,
+                max_frames=1,
+            )
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "state unreadable" in err
+
+    def test_cursor_restored_on_tty_exit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(
+                status_watch,
+                "render_frame",
+                return_value="frame-body\n",
+            ),
+            patch.object(status_watch, "is_tty", return_value=True),
+        ):
+            status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=True,
+                sleep_fn=lambda _s: None,
+                max_frames=1,
+            )
+
+        out = capsys.readouterr().out
+        assert status_watch.HIDE_CURSOR in out
+        assert status_watch.SHOW_CURSOR in out
+
+
+# ── cmd_status routing ───────────────────────────────────────────────────────
+
+
+class TestCmdStatusWatchRouting:
+    def _config(self, tmp_path: Path):
+        from tests.test_cli_status import _make_forge_config
+
+        return _make_forge_config(tmp_path)
+
+    def test_non_tty_falls_back_to_snapshot(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from theforge.cli import cmd_status
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = self._config(tmp_path)
+        args = argparse.Namespace(run_id=None, recent=False, last=False, watch=2, no_color=False)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status._find_active_run_id", return_value="run-1"),
+            patch("theforge.cli.status._is_sprint_run", return_value=True),
+            patch("theforge.cli.status_watch.is_tty", return_value=False),
+            patch("theforge.cli.sprint_status.display_sprint_status", return_value=0) as snap,
+            patch("theforge.pending.cleanup_stale"),
+            patch("theforge.pending.list_pending", return_value=[]),
+        ):
+            rc = cmd_status(args)
+
+        assert rc == 0
+        snap.assert_called_once()
+
+    def test_tty_sprint_enters_watch_loop(self, tmp_path: Path) -> None:
+        from theforge.cli import cmd_status
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = self._config(tmp_path)
+        args = argparse.Namespace(run_id=None, recent=False, last=False, watch=3, no_color=True)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status._find_active_run_id", return_value="run-1"),
+            patch("theforge.cli.status._is_sprint_run", return_value=True),
+            patch("theforge.cli.status_watch.is_tty", return_value=True),
+            patch("theforge.cli.status_watch.run_watch_loop", return_value=0) as loop,
+        ):
+            rc = cmd_status(args)
+
+        assert rc == 0
+        loop.assert_called_once()
+        # interval propagated, color disabled by --no-color flag.
+        kwargs = loop.call_args.kwargs
+        assert kwargs["color"] is False
+        assert loop.call_args.args[2] == 3.0
+
+    def test_tty_single_run_falls_back(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from theforge.cli import cmd_status
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = self._config(tmp_path)
+        args = argparse.Namespace(run_id=None, recent=False, last=False, watch=2, no_color=False)
+        mock_status = {"phase": "DEV", "cost_usd": 0.5, "elapsed_seconds": 60}
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status._find_active_run_id", return_value="run-1"),
+            patch("theforge.cli.status._is_sprint_run", return_value=False),
+            patch("theforge.cli.status_watch.is_tty", return_value=True),
+            patch("theforge.detach.read_run_status", return_value=mock_status),
+            patch("theforge.cli.status_watch.run_watch_loop", return_value=0) as loop,
+            patch("theforge.pending.cleanup_stale"),
+            patch("theforge.pending.list_pending", return_value=[]),
+        ):
+            rc = cmd_status(args)
+
+        assert rc == 0
+        loop.assert_not_called()

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -204,7 +204,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=None),
         ):
-            text, ok = status_watch.render_frame(
+            text, ok, _err = status_watch.render_frame(
                 "run-x", tmp_path, state, frame_idx=0, color=False
             )
 
@@ -228,7 +228,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=None),
         ):
-            text, _ok = status_watch.render_frame(
+            text, _ok, _err = status_watch.render_frame(
                 "run-x", tmp_path, state, frame_idx=1, color=False
             )
 
@@ -252,7 +252,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
         ):
-            text, _ok = status_watch.render_frame(
+            text, _ok, _err = status_watch.render_frame(
                 "run-x",
                 tmp_path,
                 state,
@@ -280,7 +280,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
         ):
-            text, _ok = status_watch.render_frame(
+            text, _ok, _err = status_watch.render_frame(
                 "run-x",
                 tmp_path,
                 state,
@@ -308,7 +308,7 @@ class TestRenderFrame:
             ),
             patch.object(status_watch, "_last_audit_mtime", return_value=evt_time),
         ):
-            text, _ok = status_watch.render_frame(
+            text, _ok, _err = status_watch.render_frame(
                 "run-x",
                 tmp_path,
                 state,
@@ -333,7 +333,7 @@ class TestRunWatchLoop:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value=("frame-body\n", True),
+                return_value=("frame-body\n", True, ""),
             ),
             patch.object(status_watch, "is_tty", return_value=False),
         ):
@@ -361,7 +361,7 @@ class TestRunWatchLoop:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value=("frame-body\n", True),
+                return_value=("frame-body\n", True, ""),
             ),
             patch.object(status_watch, "is_tty", return_value=False),
         ):
@@ -406,7 +406,7 @@ class TestRunWatchLoop:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value=("frame-body\n", True),
+                return_value=("frame-body\n", True, ""),
             ),
             patch.object(status_watch, "is_tty", return_value=True),
         ):
@@ -524,7 +524,7 @@ class TestSnapshotFailurePropagates:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value=("", False),
+                return_value=("", False, "snapshot diag\n"),
             ),
             patch.object(status_watch, "is_tty", return_value=False),
         ):
@@ -538,6 +538,65 @@ class TestSnapshotFailurePropagates:
             )
 
         assert rc == 1
+        # The captured diagnostic from display_sprint_status must reach stderr
+        # so the operator sees WHY the watch session refused to start.
+        err = capsys.readouterr().err
+        assert "snapshot diag" in err
+
+    def test_first_frame_failure_falls_back_when_no_captured_diagnostic(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """If the snapshot returned non-zero but emitted nothing, we still surface a message."""
+        with (
+            patch.object(
+                status_watch,
+                "render_frame",
+                return_value=("", False, ""),
+            ),
+            patch.object(status_watch, "is_tty", return_value=False),
+        ):
+            rc = status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=lambda _s: None,
+                max_frames=1,
+            )
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "failed to read sprint state" in err
+
+
+class TestRenderFrameCapturesStderr:
+    """render_frame must keep stderr OUT of the terminal but RETURN it for the caller."""
+
+    def test_render_frame_returns_captured_stderr(self, tmp_path: Path) -> None:
+        def fake_display(_run_id: str, _project_root: Path) -> int:
+            import sys as _sys
+
+            print("boom: cannot read state", file=_sys.stderr)
+            return 1
+
+        with (
+            patch(
+                "theforge.cli.sprint_status.display_sprint_status",
+                side_effect=fake_display,
+            ),
+            patch(
+                "theforge.sprint.status_reader.read_live_status",
+                return_value=[],
+            ),
+        ):
+            text, ok, captured_err = status_watch.render_frame(
+                "run-x", tmp_path, {"costs": {}, "interval": 2.0}, 0, color=False
+            )
+
+        assert ok is False
+        assert "boom: cannot read state" in captured_err
+        # stdout/text path stays clean
+        assert "boom" not in text
 
 
 class TestNoFullScreenClear:
@@ -550,7 +609,7 @@ class TestNoFullScreenClear:
             patch.object(
                 status_watch,
                 "render_frame",
-                return_value=("line1\nline2\n", True),
+                return_value=("line1\nline2\n", True, ""),
             ),
             patch.object(status_watch, "is_tty", return_value=False),
         ):


### PR DESCRIPTION
## Summary

[openai-gpt-5.4] Prior P1s are resolved in the current code, and I found no new blocking regressions in the latest watch-mode iteration. | [deepseek-deepseek-reasoner] Both prior P1 findings are resolved: (1) --watch now rejects non-positive intervals via _positive_watch_interval type + cmd_status guard + sleep clamp; (2) render_frame returns (text, ok, captured_stderr) and run_watch_loop forwards the diagnostic to stderr on first-frame failure with a generic fallback. No regressions introduced by the fix commit. | [google-gemini-3.1-pro-preview] Fixes for watch mode interval validation and stderr capture are implemented correctly.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $7.47
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status --watch: live-update mode like top/htop (GitHub Issue #1036)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1036