### PR TITLE
fix(shape_check): gate forge-finding on canonical needs-triage label (#1075)

### DIFF
--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -39,17 +39,17 @@ SEED_VOCABULARY: frozenset[str] = frozenset(
     }
 )
 
-_TERMINAL_TRIAGE_LABELS: frozenset[str] = frozenset(
-    {
-        "triage-accepted",
-        "triage-rejected",
-        "triage-dup",
-        "triage-closed",
-        "triage-fix-now",
-        "triage-fix-soon",
-        "triage-punt",
-    }
-)
+# `needs-triage` is the canonical triage signal across the rest of the
+# project: the post-run hook applies it when a finding is filed, the
+# release script counts open findings carrying it, and operators add or
+# remove it when triaging. Earlier versions of this heuristic looked for
+# one of seven `triage-*` labels (triage-accepted / triage-rejected /
+# triage-dup / triage-closed / triage-fix-now / triage-fix-soon /
+# triage-punt) which were never created in the repository and had no
+# consumer outside this file — so the gate could never pass for any
+# real-world forge-finding. Use the single shared label instead.
+# See #1075.
+_NEEDS_TRIAGE_LABEL = "needs-triage"
 
 _TRACKING_PHRASES = (
     "tracking issue",
@@ -224,14 +224,16 @@ def check_untriaged_finding(title: str, body: str, labels: Iterable[str]) -> Rea
     lset = _lower_labels(labels)
     if "forge-finding" not in lset:
         return None
-    if lset & _TERMINAL_TRIAGE_LABELS:
+    # Triaged ⇔ `needs-triage` removed. See _NEEDS_TRIAGE_LABEL above for
+    # why this single label replaces the old triage-* vocabulary.
+    if _NEEDS_TRIAGE_LABEL not in lset:
         return None
     return Reason(
         code="untriaged_finding",
         severity=Severity.BLOCKING,
         detail=(
-            "forge-finding has no terminal triage label "
-            "(e.g. triage-accepted/rejected/dup/closed)."
+            "forge-finding still carries the `needs-triage` label; "
+            "an operator must remove it to mark the finding triaged."
         ),
     )
 

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -166,15 +166,30 @@ class TestSuperseded:
 
 
 class TestUntriagedFinding:
-    def test_untriaged(self):
-        r = check_untriaged_finding("T", "body", ["forge-finding"])
+    def test_untriaged_when_needs_triage_present(self):
+        # The post-run hook applies `needs-triage` when a forge-finding is
+        # filed; the heuristic must block until an operator removes it.
+        r = check_untriaged_finding(
+            "T", "body", ["forge-finding", "needs-triage"]
+        )
         assert r is not None and r.code == "untriaged_finding"
 
-    def test_triaged(self):
-        assert check_untriaged_finding("T", "body", ["forge-finding", "triage-accepted"]) is None
+    def test_triaged_when_needs_triage_absent(self):
+        # Operator-triaged finding (label removed) → no block.
+        assert (
+            check_untriaged_finding("T", "body", ["forge-finding"]) is None
+        )
 
     def test_not_a_finding(self):
         assert check_untriaged_finding("T", "body", ["bug"]) is None
+
+    def test_not_a_finding_with_needs_triage_does_not_block(self):
+        # `needs-triage` on a non-finding (e.g. a bug awaiting routing) is
+        # outside this heuristic's scope.
+        assert (
+            check_untriaged_finding("T", "body", ["bug", "needs-triage"])
+            is None
+        )
 
 
 class TestImplementationDesignDump:
@@ -302,7 +317,14 @@ class TestCheckAggregation:
         assert result.suggested_action is SuggestedAction.CLOSE
 
     def test_untriaged_finding(self):
-        result = check("P2 something", WELL_FORMED_AC, ["forge-finding"])
+        # Per #1075 the gate is now keyed on `needs-triage`: a finding still
+        # carrying the label is untriaged. (A finding without it has been
+        # operator-triaged.)
+        result = check(
+            "P2 something",
+            WELL_FORMED_AC,
+            ["forge-finding", "needs-triage"],
+        )
         assert result.shape is Shape.NEEDS_GROOMING
         assert result.suggested_action is SuggestedAction.CLARIFY
         assert any(r.code == "untriaged_finding" for r in result.reasons)


### PR DESCRIPTION
Closes #1075.

## What

`check_untriaged_finding` looked for one of seven `triage-*` labels
(`triage-accepted` / `triage-rejected` / `triage-dup` /
`triage-closed` / `triage-fix-now` / `triage-fix-soon` /
`triage-punt`) to decide whether a `forge-finding` was triaged.

Those labels were never created in the repository and have no
consumer outside this file. The rest of the project (post-run hook
that files findings, release script that counts open ones, operator
workflow) uses **`needs-triage`** as the canonical signal.

The gate therefore could not pass in either real-world state:

| State | Has `needs-triage`? | Has any `triage-*`? | Old gate | Correct |
|---|---|---|---|---|
| Freshly filed | yes | no | block ✓ | block |
| Operator-triaged | no | no | block ✗ | allow |

Operator-triaged findings were silently blocked from sprint entry.

## Fix

Replace `_TERMINAL_TRIAGE_LABELS` (the seven-label set) with a single
`_NEEDS_TRIAGE_LABEL = "needs-triage"` constant and flip the test:
**a finding is triaged ⇔ `needs-triage` is absent**. Updated the
user-visible `untriaged_finding` detail string accordingly.

## Tests

`tests/test_shape_check.py`:

- `TestUntriagedFinding` rewritten:
  - `test_untriaged_when_needs_triage_present` — `["forge-finding", "needs-triage"]` blocks.
  - `test_triaged_when_needs_triage_absent` — `["forge-finding"]` (label removed) passes.
  - `test_not_a_finding` — kept.
  - `test_not_a_finding_with_needs_triage_does_not_block` — new sanity test.
- `TestCheckAggregation::test_untriaged_finding` updated to pass
  `["forge-finding", "needs-triage"]` so the aggregation path sees
  the same shape.

## Verification

`pytest tests/test_shape_check.py` → **51 passed**, 1 pre-existing
failure (`test_shape_check_import_does_not_pull_in_coordinator` —
needs `pip install -e .` and fails identically on `main`; not
related to this PR).