### PR TITLE
config: enable adaptive assignment in forge.yaml

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -72,6 +72,9 @@ conventions:
     - "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing."
     - "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
 
+assignment:
+  enabled: true
+
 retry:
   max_dev_iterations: 3
   max_review_cycles: 3


### PR DESCRIPTION
## Summary
- Adds `assignment: enabled: true` to forge.yaml so runs use complexity-driven adaptive routing instead of static `derive_roles()`
- Closes #1083

## Test plan
- Gate: 3620 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)