### PR TITLE
Shape-check forge-finding triage: use single needs-triage label, not invented triage-* vocabulary

### DIFF
--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -39,17 +39,7 @@ SEED_VOCABULARY: frozenset[str] = frozenset(
     }
 )
 
-_TERMINAL_TRIAGE_LABELS: frozenset[str] = frozenset(
-    {
-        "triage-accepted",
-        "triage-rejected",
-        "triage-dup",
-        "triage-closed",
-        "triage-fix-now",
-        "triage-fix-soon",
-        "triage-punt",
-    }
-)
+_NEEDS_TRIAGE_LABEL = "needs-triage"
 
 _TRACKING_PHRASES = (
     "tracking issue",
@@ -224,15 +214,12 @@ def check_untriaged_finding(title: str, body: str, labels: Iterable[str]) -> Rea
     lset = _lower_labels(labels)
     if "forge-finding" not in lset:
         return None
-    if lset & _TERMINAL_TRIAGE_LABELS:
+    if _NEEDS_TRIAGE_LABEL not in lset:
         return None
     return Reason(
         code="untriaged_finding",
         severity=Severity.BLOCKING,
-        detail=(
-            "forge-finding has no terminal triage label "
-            "(e.g. triage-accepted/rejected/dup/closed)."
-        ),
+        detail="finding still has needs-triage label; remove needs-triage after triage",
     )
 
 

--- a/tests/shape_check_fixtures/issue_717_pre_rewrite.md
+++ b/tests/shape_check_fixtures/issue_717_pre_rewrite.md
@@ -14,13 +14,13 @@ forced a triage decision. Findings accumulated forever.
 
 ## Acceptance Criteria
 
-- Forge findings are created with `forge-finding` + `needs-triage` labels; a
-  triage hook assigns one of `triage-fix-now` / `triage-fix-soon` /
-  `triage-punt` during intake, and the old `accepted-risk`, `release-risk`,
-  and `release-blocker` labels are retired from the label schema.
-- The release-readiness report lists counts for each triage label grouped by
-  milestone, writes a JSON report under the audit trail, and emits a prompt
-  summary for human review.
+- Forge findings are created with `forge-finding` + `needs-triage` labels,
+  and triage is represented by removing `needs-triage` once the finding has
+  been reviewed; the old `accepted-risk`, `release-risk`, and
+  `release-blocker` labels are retired from the label schema.
+- The release-readiness report lists counts for open `needs-triage`
+  forge-findings grouped by milestone, writes a JSON report under the audit
+  trail, and emits a prompt summary for human review.
 - Release cut fails (exit non-zero) when the target milestone contains any
   finding with the `needs-triage` label; the release workflow phase blocks
   until triage is complete.
@@ -35,5 +35,5 @@ forced a triage decision. Findings accumulated forever.
   proposer/reviewer/resolver model profiles, release-report thresholds, and
   per-label retention policy; config validation rejects unknown keys.
 - The sprint planning phase reads the latest release-readiness report and
-  refuses to include any finding whose triage label is `needs-triage`; it
-  emits a log line and an audit entry explaining each skipped issue.
+  refuses to include any finding that still carries `needs-triage`; it emits
+  a log line and an audit entry explaining each skipped issue.

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -167,14 +167,18 @@ class TestSuperseded:
 
 class TestUntriagedFinding:
     def test_untriaged(self):
-        r = check_untriaged_finding("T", "body", ["forge-finding"])
+        r = check_untriaged_finding("T", "body", ["forge-finding", "needs-triage"])
         assert r is not None and r.code == "untriaged_finding"
+        assert "needs-triage" in r.detail
 
     def test_triaged(self):
-        assert check_untriaged_finding("T", "body", ["forge-finding", "triage-accepted"]) is None
+        assert check_untriaged_finding("T", "body", ["forge-finding"]) is None
+
+    def test_other_labels_do_not_block_triaged_finding(self):
+        assert check_untriaged_finding("T", "body", ["forge-finding", "p2"]) is None
 
     def test_not_a_finding(self):
-        assert check_untriaged_finding("T", "body", ["bug"]) is None
+        assert check_untriaged_finding("T", "body", ["bug", "needs-triage"]) is None
 
 
 class TestImplementationDesignDump:
@@ -302,7 +306,7 @@ class TestCheckAggregation:
         assert result.suggested_action is SuggestedAction.CLOSE
 
     def test_untriaged_finding(self):
-        result = check("P2 something", WELL_FORMED_AC, ["forge-finding"])
+        result = check("P2 something", WELL_FORMED_AC, ["forge-finding", "needs-triage"])
         assert result.shape is Shape.NEEDS_GROOMING
         assert result.suggested_action is SuggestedAction.CLARIFY
         assert any(r.code == "untriaged_finding" for r in result.reasons)


### PR DESCRIPTION
## Summary

[deepseek-deepseek-reasoner] Shape-check untriaged finding heuristic correctly updated to use canonical `needs-triage` label. All acceptance criteria met, no remaining references to the old `triage-*` vocabulary in the touched code/tests/fixtures, and all 52 tests pass. | [claude-opus] Heuristic correctly switched to single needs-triage signal; tests cover untriaged, triaged-bare, triaged-with-other-labels, and non-finding cases; fixture text cleaned of obsolete vocabulary. All ACs met.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.65
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Shape-check forge-finding triage: use single needs-triage label, not invented triage-* vocabulary (GitHub Issue #1075)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1075