### PR TITLE
forge status --watch silently falls back to one-shot snapshot during sprint startup window

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -13,6 +13,8 @@ from theforge.cli.shared import _find_config
 from theforge.config import load_config
 
 _SENTINEL_EOF = "[forge test sentinel EOF]"
+_WATCH_SPRINT_STARTUP_GRACE_SECONDS = 5.0
+_WATCH_SPRINT_STARTUP_POLL_SECONDS = 0.1
 
 
 def _follow_log_with_redirect(
@@ -93,6 +95,40 @@ def _is_sprint_run(run_id: str, project_root: Path) -> bool:
         except (OSError, ValueError, json.JSONDecodeError):
             pass
     return False
+
+
+def _await_watchable_sprint_run(
+    run_id: str,
+    project_root: Path,
+    *,
+    grace_seconds: float = _WATCH_SPRINT_STARTUP_GRACE_SECONDS,
+    poll_seconds: float = _WATCH_SPRINT_STARTUP_POLL_SECONDS,
+) -> bool:
+    """Wait briefly for a live run to become recognizable as a sprint.
+
+    `forge sprint` writes its PID file before the initial sprint `.state` file,
+    leaving a short startup window where `forge status --watch` would otherwise
+    misclassify the run as a single-run snapshot and exit immediately.
+
+    Only waits while the target run is still live. Historical runs and ordinary
+    `forge run` invocations continue to fall back immediately.
+    """
+    if _is_sprint_run(run_id, project_root):
+        return True
+
+    pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
+    if not pid_file.exists():
+        return False
+
+    deadline = time.monotonic() + max(0.0, grace_seconds)
+    while time.monotonic() < deadline:
+        time.sleep(max(0.0, poll_seconds))
+        if _is_sprint_run(run_id, project_root):
+            return True
+        if not pid_file.exists():
+            return False
+
+    return _is_sprint_run(run_id, project_root)
 
 
 def _find_most_recent_run(project_root: Path) -> tuple[str, bool] | None:
@@ -352,7 +388,7 @@ def cmd_status(args: object) -> int:
     if watch_interval is not None:
         from theforge.cli import status_watch
 
-        if status_watch.is_tty() and _is_sprint_run(target_run_id, project_root):
+        if status_watch.is_tty() and _await_watchable_sprint_run(target_run_id, project_root):
             color = status_watch.color_enabled(no_color)
             return status_watch.run_watch_loop(
                 target_run_id,

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -430,6 +430,48 @@ class TestIsSprintRun:
             assert _is_sprint_run("newrun", tmp_path) is False
 
 
+class TestAwaitWatchableSprintRun:
+    def test_returns_true_immediately_when_already_sprint(self, tmp_path: Path) -> None:
+        from theforge.cli.status import _await_watchable_sprint_run
+
+        with patch("theforge.cli.status._is_sprint_run", return_value=True):
+            assert _await_watchable_sprint_run("run-1", tmp_path) is True
+
+    def test_waits_for_live_run_to_become_sprint(self, tmp_path: Path) -> None:
+        from theforge.cli.status import _await_watchable_sprint_run
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-1.pid").write_text("123\nslug\n")
+
+        with (
+            patch("theforge.cli.status._is_sprint_run", side_effect=[False, False, True]),
+            patch("theforge.cli.status.time.sleep"),
+            patch("theforge.cli.status.time.monotonic", side_effect=[0.0, 0.01, 0.02]),
+        ):
+            assert _await_watchable_sprint_run("run-1", tmp_path, grace_seconds=1.0) is True
+
+    def test_returns_false_without_wait_for_non_live_run(self, tmp_path: Path) -> None:
+        from theforge.cli.status import _await_watchable_sprint_run
+
+        with patch("theforge.cli.status._is_sprint_run", return_value=False):
+            assert _await_watchable_sprint_run("run-1", tmp_path) is False
+
+    def test_returns_false_after_grace_window_expires(self, tmp_path: Path) -> None:
+        from theforge.cli.status import _await_watchable_sprint_run
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-1.pid").write_text("123\nslug\n")
+
+        with (
+            patch("theforge.cli.status._is_sprint_run", return_value=False),
+            patch("theforge.cli.status.time.sleep"),
+            patch("theforge.cli.status.time.monotonic", side_effect=[0.0, 0.2, 1.1]),
+        ):
+            assert _await_watchable_sprint_run("run-1", tmp_path, grace_seconds=1.0) is False
+
+
 def test_sprint_status_absent_from_cli_parser() -> None:
     """forge sprint-status must not appear in the built CLI parser."""
     from theforge.cli.main import build_parser

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -483,6 +483,35 @@ class TestCmdStatusWatchRouting:
         assert kwargs["color"] is False
         assert loop.call_args.args[2] == 3.0
 
+    def test_tty_watch_waits_through_sprint_startup_window(self, tmp_path: Path) -> None:
+        from theforge.cli import cmd_status
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = self._config(tmp_path)
+        args = argparse.Namespace(run_id=None, recent=False, last=False, watch=3, no_color=False)
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-1.pid").write_text("123\nissues-test\n")
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status._find_active_run_id", return_value="run-1"),
+            patch("theforge.cli.status._is_sprint_run", side_effect=[False, False, True]),
+            patch("theforge.cli.status.time.sleep"),
+            patch("theforge.cli.status.time.monotonic", side_effect=[0.0, 0.01, 0.02]),
+            patch("theforge.cli.status_watch.is_tty", return_value=True),
+            patch("theforge.cli.status_watch.run_watch_loop", return_value=0) as loop,
+            patch("theforge.pending.cleanup_stale"),
+            patch("theforge.pending.list_pending", return_value=[]),
+        ):
+            rc = cmd_status(args)
+
+        assert rc == 0
+        loop.assert_called_once()
+
     def test_tty_single_run_falls_back(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Summary

Grace-window polling logic is correct, tests cover all branches, and the one-line call-site change is exactly right.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.24
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status --watch silently falls back to one-shot snapshot during sprint startup window (GitHub Issue #1089)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1089