### PR TITLE
Preflight cache invalidation skips re-run, leaving downstream phases without preflight outputs

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1069,6 +1069,31 @@ def _run_resume_coordinator(
         if cache_valid:
             apply_cached_preflight_state(state, cached_preflight_state)
             config = _apply_preflight_config(config, state)
+        else:
+            # Cache invalidated mid-sprint (e.g., base branch advanced after a
+            # prior batch merged): re-run preflight against the current base so
+            # downstream phases get fresh complexity/work_type/likely_files
+            # rather than the default SKIPPED state. Without this, dev runs
+            # blind and typically loops without producing changes.
+            from .preflight_flow import _run_preflight_phase  # noqa: PLC0415
+
+            config, _pf_result, _pf_already_done_loop = _run_preflight_phase(
+                state,
+                config,
+                task,
+                story_content,
+                workspace_path,
+                branch_name,
+                notify=notify,
+                logger=logger,
+                task_start=_task_start,
+                state_update_fn=state_update_fn,
+                stop_phase=None,
+            )
+            if _pf_result is not None:
+                return _pf_result
+            if _pf_already_done_loop:
+                skip_dev_first_iter = True
 
     with _run_log_context(config, logger, task, state, _task_start):
         base_branch = config.workspace.base_branch

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 from coord_test_helpers import _make_agent_result, _make_config, _make_task
 
-from theforge.coordinator.engine import run_task
+from theforge.coordinator.engine import run_from_dev, run_task
 from theforge.coordinator.state import CoordinatorState, Phase
 
 
@@ -246,3 +246,77 @@ criteria_checked: []
         assert result.state.preflight_verdict == "PROCEED"
         assert result.state.preflight_cache_validation["status"] == "invalidated"
         assert result.state.preflight_cache_validation["reason"] == "worktree_head_changed"
+
+
+class TestResumeStaleCacheRerunsPreflight:
+    """Regression: resume path must re-run preflight when the cache is invalid.
+
+    The bug: in a multi-batch sprint, when a story resumes after the base branch
+    advanced (a prior batch merged), the cache is correctly detected as
+    invalidated — but ``_run_resume_coordinator`` previously had no else branch
+    to re-run preflight. The state stayed at its default ``preflight_verdict =
+    "SKIPPED"`` with no complexity / work_type / likely_files, and dev ran blind.
+    """
+
+    def test_run_from_dev_invalid_cache_reruns_preflight(self, tmp_path):
+        """run_from_dev with stale cache must re-run preflight, not leave it SKIPPED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        cached_state = replace(
+            CoordinatorState(),
+            preflight_verdict="PROCEED",
+            preflight_reason="Stale cached verdict.",
+            preflight_complexity="medium",
+            preflight_sufficiency="implementation_ready",
+            preflight_work_type="feature",
+            preflight_cache_snapshot={
+                "worktree_head": "old-head",
+                "evaluation_base_branch": "main",
+                "evaluation_base_branch_head": "old-base-head",
+            },
+        )
+
+        fresh_preflight = _make_agent_result(
+            output="""\
+```yaml
+verdict: BLOCKED
+complexity: large
+sufficiency: needs_planning
+work_type: feature
+reason: "Cannot proceed; spec ambiguous after base advance."
+criteria_checked: []
+```
+""",
+            profile_name="preflight",
+        )
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            rendered = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            if rendered.startswith("git rev-parse "):
+                # worktree HEAD differs from cached snapshot → invalidates cache
+                return (True, "new-head" if str(cwd) == str(workspace) else "new-base-head")
+            return (True, "")
+
+        with (
+            patch("theforge.coordinator.util._run_shell", side_effect=shell_side_effect),
+            patch(
+                "theforge.coordinator.preflight_flow.run_agent",
+                return_value=fresh_preflight,
+            ) as mock_preflight,
+            patch("theforge.coordinator.engine._check_behind_origin"),
+        ):
+            result = run_from_dev(config, task, workspace, cached_preflight_state=cached_state)
+
+        # Preflight was re-run (the bug: this was 0 before the fix).
+        assert mock_preflight.call_count == 1
+        # The fresh verdict replaces the stale SKIPPED default.
+        assert result.state.preflight_verdict == "BLOCKED"
+        assert result.state.preflight_complexity == "large"
+        assert result.state.preflight_work_type == "feature"
+        # Validation record reflects the invalidation reason.
+        assert result.state.preflight_cache_validation["status"] == "invalidated"
+        # BLOCKED → ESCALATE; the run terminates without dev/review.
+        assert result.phase == Phase.ESCALATE


### PR DESCRIPTION
## Summary

Clean fix that mirrors run_task's invalidation pattern in the resume path; regression test correctly exercises the BLOCKED branch and proves the re-run fires.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $4.89
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_coord_preflight_cached.py:None`** Convention 8 (seam-level integration tests for phase-boundary changes): the new test only covers the BLOCKED outcome after cache invalidation. The PROCEED path — where preflight re-runs with PROCEED and dev then continues — is the common production scenario and is untested here. ALREADY_DONE + skip_dev_first_iter=True is also uncovered.

## Story

Preflight cache invalidation skips re-run, leaving downstream phases without preflight outputs (GitHub Issue #1082)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1082