### PR TITLE
forge status --watch: live overlay column headers (ACT / ΔCOST / EVT AGE) are too cryptic

### DIFF
--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -208,7 +208,9 @@ def render_frame(
     overlay_lines.append("")
     title = f"── Live  refresh={interval:g}s  Ctrl-C to exit ──"
     overlay_lines.append(_c(title, DIM, color))
-    overlay_lines.append(f"{'STORY':<30}  {'ACT':<3}  {'ΔCOST':>8}  {'EVT AGE':>8}")
+    _ACT_COL = 10
+    hdr = f"{'STORY':<30}  {'ACTIVITY':<{_ACT_COL}}  {'ΔCOST':>8}  {'EVENT AGE':>9}"
+    overlay_lines.append(hdr)
 
     for e in entries:
         slug = getattr(e, "slug", "") or ""
@@ -229,17 +231,26 @@ def render_frame(
         status = getattr(e, "status", "waiting")
         if status == "running":
             if stalled:
-                act = _c(STALL_CHAR, DIM, color)
+                label = f"{STALL_CHAR} stalled"
+                act = _c(label, DIM, color)
             else:
-                act = _c(spinner, GREEN, color)
+                label = f"{spinner} live"
+                act = _c(label, GREEN, color)
         elif status == "done":
-            act = _c(DONE_CHAR, GREEN, color)
+            label = f"{DONE_CHAR} done"
+            act = _c(label, GREEN, color)
         elif status == "failed":
-            act = _c(FAIL_CHAR, RED, color)
-        elif status == "skipped" or status == "blocked":
-            act = _c(STALL_CHAR, DIM, color)
+            label = f"{FAIL_CHAR} failed"
+            act = _c(label, RED, color)
+        elif status == "skipped":
+            label = f"{STALL_CHAR} skipped"
+            act = _c(label, DIM, color)
+        elif status == "blocked":
+            label = f"{STALL_CHAR} blocked"
+            act = _c(label, DIM, color)
         else:
-            act = WAIT_CHAR
+            label = WAIT_CHAR
+            act = label
 
         delta_str = _format_delta(delta)
         if color and delta != 0 and abs(delta) >= 0.005:
@@ -247,8 +258,8 @@ def render_frame(
 
         path = getattr(e, "path", slug) or slug
         path_disp = path if len(path) <= 30 else path[:29] + "…"
-        act_pad = act + " " * 2
-        overlay_lines.append(f"{path_disp:<30}  {act_pad}  {delta_str:>8}  {age_str:>8}")
+        act_padded = act + " " * max(0, _ACT_COL - len(label))
+        overlay_lines.append(f"{path_disp:<30}  {act_padded}  {delta_str:>8}  {age_str:>9}")
 
     state["costs"] = new_costs
     return base + "\n".join(overlay_lines) + "\n", snapshot_ok, err_buf.getvalue()

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -321,6 +321,75 @@ class TestRenderFrame:
         # Spinner should NOT appear for a stalled story.
         assert status_watch.SPINNER_FRAMES[0] not in text
 
+    def _render(
+        self,
+        tmp_path: Path,
+        entries: list,
+        *,
+        now_fn=None,
+        last_mtime=None,
+        state: dict | None = None,
+    ) -> str:
+        if state is None:
+            state = {"costs": {}, "interval": 2.0}
+        with (
+            patch("theforge.cli.sprint_status.display_sprint_status", return_value=0),
+            patch("theforge.sprint.status_reader.read_live_status", return_value=entries),
+            patch.object(status_watch, "_last_audit_mtime", return_value=last_mtime),
+        ):
+            text, _ok, _err = status_watch.render_frame(
+                "run-x",
+                tmp_path,
+                state,
+                frame_idx=0,
+                color=False,
+                now_fn=now_fn,
+            )
+        return text
+
+    def test_header_uses_activity_and_event_age(self, tmp_path: Path) -> None:
+        text = self._render(tmp_path, [])
+        assert "ACTIVITY" in text
+        assert "EVENT AGE" in text
+        assert "ACT" not in text.split("ACTIVITY")[0]  # old short header gone
+        assert "EVT AGE" not in text
+
+    def test_running_live_label(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", status="running")]
+        text = self._render(
+            tmp_path,
+            entries,
+            now_fn=lambda: 1000.0,
+            last_mtime=999.0,
+        )
+        assert "live" in text
+
+    def test_running_stalled_label(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", status="running")]
+        text = self._render(
+            tmp_path,
+            entries,
+            now_fn=lambda: 1000.0,
+            last_mtime=900.0,  # 100s ago — past stall threshold
+        )
+        assert "stalled" in text
+
+    def test_done_label(self, tmp_path: Path) -> None:
+        text = self._render(tmp_path, [_entry("story-a", status="done")])
+        assert "done" in text
+
+    def test_failed_label(self, tmp_path: Path) -> None:
+        text = self._render(tmp_path, [_entry("story-a", status="failed")])
+        assert "failed" in text
+
+    def test_skipped_label(self, tmp_path: Path) -> None:
+        text = self._render(tmp_path, [_entry("story-a", status="skipped")])
+        assert "skipped" in text
+
+    def test_blocked_label(self, tmp_path: Path) -> None:
+        text = self._render(tmp_path, [_entry("story-a", status="blocked")])
+        assert "blocked" in text
+
 
 # ── run_watch_loop ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

All six ACs are met: headers updated to ACTIVITY/EVENT AGE, each status branch paired with a readable word label, ANSI-safe padding computed from raw label length, two-table layout untouched, ΔCOST unchanged. Tests cover every new label and the header check.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.81
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/cli/status_watch.py:209`** _ACT_COL is a local variable but named with a leading underscore, which by Python convention signals a module-level private name. Minor style inconsistency — no runtime impact.
- **[P2] `tests/test_cli_status_watch.py:None`** No test for the else/waiting branch — when status is anything other than running/done/failed/skipped/blocked, label is set to WAIT_CHAR with no word suffix. The spec does not require a label here, but the branch is exercisable and untested.

## Story

forge status --watch: live overlay column headers (ACT / ΔCOST / EVT AGE) are too cryptic (GitHub Issue #1081)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1081