### PR TITLE
fix: route lock cleanup through detach module to fix flaky CI gate (#1117)

### DIFF
--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -9,8 +9,8 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
+from theforge import detach as _detach_mod
 from theforge.artifacts import ESCALATED_MARKER_PATH
-from theforge.detach import _is_pid_alive
 from theforge.pid import _current_process_fingerprint, _pid_matches_fingerprint
 
 _LOCK_METADATA_SEPARATOR = "|"
@@ -233,9 +233,9 @@ def cleanup_story_locks(
                     if owner_fingerprint is None:
                         should_remove = True
                     else:
-                        should_remove = not _is_pid_alive(owner_pid) or _pid_matches_fingerprint(
-                            owner_pid, owner_fingerprint
-                        )
+                        should_remove = not _detach_mod._is_pid_alive(
+                            owner_pid
+                        ) or _pid_matches_fingerprint(owner_pid, owner_fingerprint)
             if should_remove:
                 lock_path.unlink(missing_ok=True)
                 cleaned.append(slug)

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -264,7 +264,7 @@ class TestCleanupStoryLocks:
         lock_path.write_text("424242|old-start\n", encoding="utf-8")
 
         with (
-            patch("theforge.sprint.lock._is_pid_alive", return_value=False),
+            patch("theforge.detach._is_pid_alive", return_value=False),
             patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False),
         ):
             cleaned = cleanup_story_locks(["story-a"], tmp_path, pid=424242)
@@ -278,7 +278,7 @@ class TestCleanupStoryLocks:
         lock_path.write_text("424242|other-start\n", encoding="utf-8")
 
         with (
-            patch("theforge.sprint.lock._is_pid_alive", return_value=True),
+            patch("theforge.detach._is_pid_alive", return_value=True),
             patch("theforge.sprint.lock._pid_matches_fingerprint", return_value=False),
         ):
             cleaned = cleanup_story_locks(["story-a"], tmp_path, pid=424242)


### PR DESCRIPTION
## Summary
- Fixes the non-deterministic \`TestCmdStop::test_timeout_escalates_to_sigkill_and_cleans_up\` failures that have been blocking every PR's CI
- Root cause: \`from theforge.detach import _is_pid_alive\` in \`sprint/lock.py\` binds the function at import time; test patches on \`theforge.detach._is_pid_alive\` don't reach the bound name, so cleanup runs the real \`_is_pid_alive\` against the test's hardcoded fake PID 54321. When that PID happens to be live on the host (true on CI under load), the cleanup safety check declines to remove the lock and the assertion fails
- Switch to \`from theforge import detach as _detach_mod\` and call \`_detach_mod._is_pid_alive(...)\` so the existing module-attr patch becomes effective. Update the two direct unit tests in \`test_sprint_lock.py\` to patch the same module-attr name

## Test plan
- [x] Reproduced the flake locally — main's \`make gate\` failed 6/6 with PID 54321 alive on host
- [x] After fix, \`make gate\` passed 3/3 consecutive runs
- [x] Full suite: 3641 passed, 1 skipped, no regressions
- [x] No production semantics changed — same safety logic, just a module-attr lookup instead of an import-time binding

Closes #1117