### PR TITLE
Adaptive timeout coverage gap — plan-phase and sprint-worker timeouts don't auto-derive from complexity (incomplete scope of #156/#290)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "hatchling.build"
 testpaths = ["tests"]
 norecursedirs = [".forge"]
 pythonpath = ["src", "tests"]
-addopts = "-n auto --dist worksteal"
+addopts = "-n auto --dist worksteal --timeout=10 --timeout-method=thread"
 markers = [
     "network_integration: marks tests that make real external network calls (requires THEFORGE_RUN_INTEGRATION=1)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.30"]
 google = ["google-genai>=1.0"]
 all = ["openai>=1.0", "anthropic>=0.30", "google-genai>=1.0"]
-dev = ["pytest", "pytest-xdist", "pytest-timeout", "ruff"]
+dev = ["pytest", "pytest-xdist", "ruff"]
 
 [project.scripts]
 forge = "theforge.cli:main"
@@ -27,7 +27,7 @@ build-backend = "hatchling.build"
 testpaths = ["tests"]
 norecursedirs = [".forge"]
 pythonpath = ["src", "tests"]
-addopts = "-n auto --dist worksteal --timeout=10 --timeout-method=thread"
+addopts = "-n auto --dist worksteal"
 markers = [
     "network_integration: marks tests that make real external network calls (requires THEFORGE_RUN_INTEGRATION=1)",
 ]

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -326,7 +326,19 @@ def _run_plan_phase(
         state.preflight_complexity_score,
     )
     if _plan_override_active:
-        _log(f"  Plan timeout: {_plan_timeout}s ({state.preflight_complexity} complexity)")
+        _derived_timeout = False
+        if state.preflight_complexity_score is not None:
+            if state.preflight_complexity_score >= 8:
+                _derived_timeout = config.plan.timeout_large is None
+            elif state.preflight_complexity_score >= 6:
+                _derived_timeout = config.plan.timeout_medium is None
+        elif state.preflight_complexity == "large":
+            _derived_timeout = config.plan.timeout_large is None
+        elif state.preflight_complexity == "medium":
+            _derived_timeout = config.plan.timeout_medium is None
+        _source = "derived" if _derived_timeout else "explicit override"
+        _detail = f"{state.preflight_complexity} complexity, {_source}"
+        _log(f"  Plan timeout: {_plan_timeout}s ({_detail})")
     else:
         _log(f"  Plan timeout: {_plan_timeout}s")
 

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -28,8 +28,13 @@ _subprocess_run = subprocess.run
 # coordinator's own version runs regardless of what the installed package provides.
 _SUBPROCESS_EVAL = Path(__file__).parent / "_subprocess_eval.py"
 
-MEDIUM_HEADROOM_FACTOR = 1.5
-LARGE_HEADROOM_FACTOR = 2.5
+# Adaptive timeout fallback uses the same default headroom factor across
+# surfaces when forge.yaml does not provide an explicit complexity-tier
+# override. Keep the legacy medium/large names as public aliases for tests and
+# existing call sites.
+DEFAULT_TIMEOUT_HEADROOM_FACTOR = 1.5
+MEDIUM_HEADROOM_FACTOR = DEFAULT_TIMEOUT_HEADROOM_FACTOR
+LARGE_HEADROOM_FACTOR = DEFAULT_TIMEOUT_HEADROOM_FACTOR
 
 # ── Log level ─────────────────────────────────────────────────────────
 

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -28,6 +28,9 @@ _subprocess_run = subprocess.run
 # coordinator's own version runs regardless of what the installed package provides.
 _SUBPROCESS_EVAL = Path(__file__).parent / "_subprocess_eval.py"
 
+MEDIUM_HEADROOM_FACTOR = 1.5
+LARGE_HEADROOM_FACTOR = 2.5
+
 # ── Log level ─────────────────────────────────────────────────────────
 
 _LOG_LEVEL: LogLevel = LogLevel.PROGRESS
@@ -114,22 +117,35 @@ def resolve_timeout_with_active(
 ) -> tuple[int, bool]:
     """Return ``(timeout, override_active)`` for the given complexity inputs.
 
-    Score-native routing must preserve the legacy fallback contract for each
-    threshold independently: large-score stories use the large override when it
-    exists, otherwise base; medium-score stories use the medium override when it
-    exists, otherwise base. Large stories must not cascade into the medium
-    override when the large override is unset.
+    Score-native routing preserves tier isolation: large-score stories use the
+    large tier and medium-score stories use the medium tier. When an explicit
+    tier override is absent, the timeout is derived from the base timeout using
+    the corresponding headroom factor instead of silently falling back to base.
+    Large stories must not cascade into the medium tier when the large tier is
+    unset.
     """
+
+    def _derived_timeout(factor: float) -> int:
+        return round(base * factor)
+
     if complexity_score is not None:
         if complexity_score >= 8:
-            return (large, True) if large is not None else (base, False)
+            if large is not None:
+                return large, True
+            return _derived_timeout(LARGE_HEADROOM_FACTOR), True
         if complexity_score >= 6:
-            return (medium, True) if medium is not None else (base, False)
+            if medium is not None:
+                return medium, True
+            return _derived_timeout(MEDIUM_HEADROOM_FACTOR), True
         return base, False
-    if complexity == "large" and large is not None:
-        return large, True
-    if complexity == "medium" and medium is not None:
-        return medium, True
+    if complexity == "large":
+        if large is not None:
+            return large, True
+        return _derived_timeout(LARGE_HEADROOM_FACTOR), True
+    if complexity == "medium":
+        if medium is not None:
+            return medium, True
+        return _derived_timeout(MEDIUM_HEADROOM_FACTOR), True
     return base, False
 
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -25,10 +25,9 @@ from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
 from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from ..coordinator.util import (
-    LARGE_HEADROOM_FACTOR,
-    MEDIUM_HEADROOM_FACTOR,
     _fmt_duration,
     _generate_run_id,
+    resolve_timeout,
 )
 from ..coordinator.workspace import sweep_orphan_worktrees
 from ..log_util import _log_line
@@ -89,17 +88,7 @@ def derive_worker_timeout(
     complexity_score: int | None = None,
 ) -> int:
     """Derive a per-story worker timeout from sprint defaults and complexity."""
-    if complexity_score is not None:
-        if complexity_score >= 8:
-            return round(base * LARGE_HEADROOM_FACTOR)
-        if complexity_score >= 6:
-            return round(base * MEDIUM_HEADROOM_FACTOR)
-        return base
-    if complexity == "large":
-        return round(base * LARGE_HEADROOM_FACTOR)
-    if complexity == "medium":
-        return round(base * MEDIUM_HEADROOM_FACTOR)
-    return base
+    return resolve_timeout(base, None, None, complexity, complexity_score)
 
 
 def _read_prior_sprint_cost(project_root: Path) -> float:
@@ -1195,15 +1184,30 @@ def run_sprint(
     for task, _src, _canonical_ref in task_entries:
         if resolved.worker_timeout_seconds is not None:
             story_worker_timeouts[task.slug] = resolved.worker_timeout_seconds
+            _log(
+                f"  Worker timeout {task.slug}: {resolved.worker_timeout_seconds}s "
+                "(manifest override)"
+            )
             continue
         _state = preflight_states.get(task.slug)
         if _state is None:
             story_worker_timeouts[task.slug] = base_worker_timeout_seconds
+            _log(
+                f"  Worker timeout {task.slug}: {base_worker_timeout_seconds}s "
+                "(base default; no preflight state)"
+            )
             continue
-        story_worker_timeouts[task.slug] = derive_worker_timeout(
+        _timeout_seconds = derive_worker_timeout(
             base_worker_timeout_seconds,
             _state.preflight_complexity,
             _state.preflight_complexity_score,
+        )
+        story_worker_timeouts[task.slug] = _timeout_seconds
+        _source = "derived" if _timeout_seconds != base_worker_timeout_seconds else "base default"
+        _complexity = _state.preflight_complexity or "unknown"
+        _log(
+            f"  Worker timeout {task.slug}: {_timeout_seconds}s "
+            f"({_complexity} complexity, {_source})"
         )
     if resume:
         _register_resumed_story_footprints(triages, preflight_states)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -24,7 +24,12 @@ from ..coordinator.logging import StructuredLogger
 from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
 from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
-from ..coordinator.util import _fmt_duration, _generate_run_id
+from ..coordinator.util import (
+    LARGE_HEADROOM_FACTOR,
+    MEDIUM_HEADROOM_FACTOR,
+    _fmt_duration,
+    _generate_run_id,
+)
 from ..coordinator.workspace import sweep_orphan_worktrees
 from ..log_util import _log_line
 from ..task import TaskStory
@@ -76,6 +81,25 @@ def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:
     from ..coordinator.workspace import _deindex_forge_artifacts  # noqa: PLC0415
 
     _deindex_forge_artifacts(config.project_root)
+
+
+def derive_worker_timeout(
+    base: int,
+    complexity: str | None,
+    complexity_score: int | None = None,
+) -> int:
+    """Derive a per-story worker timeout from sprint defaults and complexity."""
+    if complexity_score is not None:
+        if complexity_score >= 8:
+            return round(base * LARGE_HEADROOM_FACTOR)
+        if complexity_score >= 6:
+            return round(base * MEDIUM_HEADROOM_FACTOR)
+        return base
+    if complexity == "large":
+        return round(base * LARGE_HEADROOM_FACTOR)
+    if complexity == "medium":
+        return round(base * MEDIUM_HEADROOM_FACTOR)
+    return base
 
 
 def _read_prior_sprint_cost(project_root: Path) -> float:
@@ -958,11 +982,7 @@ def run_sprint(
     max_parallel = (
         resolved.max_parallel if resolved.max_parallel is not None else config.sprint.max_parallel
     )
-    worker_timeout_seconds = (
-        resolved.worker_timeout_seconds
-        if resolved.worker_timeout_seconds is not None
-        else config.sprint.worker_timeout_seconds
-    )
+    base_worker_timeout_seconds = config.sprint.worker_timeout_seconds
 
     # Build unified context mapping: (task, source, canonical_ref) per entry
     task_entries = resolved.stories
@@ -1171,6 +1191,20 @@ def run_sprint(
         max_parallel=max_parallel,
         notify=notify,
     )
+    story_worker_timeouts: dict[str, int] = {}
+    for task, _src, _canonical_ref in task_entries:
+        if resolved.worker_timeout_seconds is not None:
+            story_worker_timeouts[task.slug] = resolved.worker_timeout_seconds
+            continue
+        _state = preflight_states.get(task.slug)
+        if _state is None:
+            story_worker_timeouts[task.slug] = base_worker_timeout_seconds
+            continue
+        story_worker_timeouts[task.slug] = derive_worker_timeout(
+            base_worker_timeout_seconds,
+            _state.preflight_complexity,
+            _state.preflight_complexity_score,
+        )
     if resume:
         _register_resumed_story_footprints(triages, preflight_states)
     bundle_assignments = compute_bundle_assignments(preflight_states, normalized.tasks)
@@ -1494,6 +1528,7 @@ def run_sprint(
 
     # Parallel scheduling state
     active: dict[str, Future[object]] = {}
+    story_deadlines: dict[str, float] = {}
     cost_lock = threading.Lock()
     story_times: dict[str, tuple[datetime.datetime, datetime.datetime]] = {}
     batch_assignments: dict[str, int] = {}
@@ -1739,6 +1774,9 @@ def run_sprint(
                     preflight_states,
                 )
                 active[task.slug] = fut
+                story_deadlines[task.slug] = time.monotonic() + float(
+                    story_worker_timeouts[task.slug]
+                )
 
             _log(
                 f"[debug] post-submit: active={list(active.keys())}"
@@ -1813,39 +1851,45 @@ def run_sprint(
             # this, gated workers block in _run_fresh waiting for their gate
             # while the scheduler blocks here waiting for a future to finish
             # — a deadlock.
-            _wt_float = float(worker_timeout_seconds)
-            _poll_interval = 2.0 if plan_gates else _wt_float
-            _total_waited = 0.0
             done_futs: set = set()
-            while not done_futs and _total_waited < _wt_float:
-                _current_interval = _poll_interval
+            expired_slugs: list[str] = []
+            while not done_futs and not expired_slugs:
+                _now = time.monotonic()
+                _time_to_next_deadline = max(
+                    0.0,
+                    min(story_deadlines[slug] - _now for slug in active),
+                )
+                _poll_interval = 2.0 if plan_gates else _time_to_next_deadline
                 done_futs, _ = wait(
                     list(active.values()),
                     return_when=FIRST_COMPLETED,
-                    timeout=_current_interval,
+                    timeout=_poll_interval,
                 )
                 if not done_futs and use_plan_gates:
                     # Service plan gates while polling
                     _release_plan_gates(plan_done, file_footprints, plan_gates, active, phase_lock)
-                    # All gates released — switch to long poll
-                    if not plan_gates:
-                        _poll_interval = _wt_float
-                _total_waited += _current_interval
+                _now = time.monotonic()
+                expired_slugs = [
+                    slug
+                    for slug, fut in active.items()
+                    if fut not in done_futs and _now >= story_deadlines[slug]
+                ]
 
             _log(f"[debug] wait() returned: {len(done_futs)} done")
             batch_number += 1
 
-            if not done_futs:
-                # Timeout: all active workers hung for >worker_timeout_seconds — cancel and fail
-                for g_slug, _gate in plan_gates.items():
-                    _log(f"TIMEOUT releasing plan gate for {g_slug}")
-                    _gate.set()
-                plan_gates.clear()
-                for slug, fut in list(active.items()):
+            if expired_slugs:
+                for slug in expired_slugs:
+                    if slug in plan_gates:
+                        _log(f"TIMEOUT releasing plan gate for {slug}")
+                        plan_gates[slug].set()
+                        del plan_gates[slug]
+                    fut = active.pop(slug)
+                    story_deadlines.pop(slug, None)
                     fut.cancel()
                     _log(
                         f"TIMEOUT {slug} (worker unresponsive after "
-                        f"{worker_timeout_seconds}s — marking as failed)"
+                        f"{story_worker_timeouts[slug]}s — marking as failed)"
                     )
                     spec_str = slug_to_spec[slug]
                     timed_out_at = datetime.datetime.now(datetime.timezone.utc)
@@ -1857,14 +1901,14 @@ def run_sprint(
                             config.project_root / config.workspace.path_pattern.format(slug=slug)
                         ),
                         log_dir=_make_story_log_dir(config, slug, resolved.name),
-                        error=f"Worker timeout (>{worker_timeout_seconds}s)",
+                        error=f"Worker timeout (>{story_worker_timeouts[slug]}s)",
                         error_type="TimeoutError",
                     )
                     _timeout_result = CoordinatorResult(
                         success=False,
                         phase=Phase.ESCALATE,
                         state=_timeout_state,
-                        message=f"Worker thread timed out after {worker_timeout_seconds}s",
+                        message=f"Worker thread timed out after {story_worker_timeouts[slug]}s",
                     )
                     story_times[slug] = (story_started_at, timed_out_at)
                     results.append((spec_str, _timeout_result))
@@ -1873,8 +1917,6 @@ def run_sprint(
                     )
                     _set_outcome(slug, StoryOutcome.FAILED, phase="ESCALATE")
                     dag.mark_skipped(slug)
-                active.clear()
-                stopped_reason = stopped_reason or f"Worker timeout (>{worker_timeout_seconds}s)"
                 continue
 
             for slug, fut in list(active.items()):
@@ -1885,6 +1927,7 @@ def run_sprint(
                 except Exception as exc:
                     _log(f"ERROR {slug}: worker thread raised {type(exc).__name__}: {exc}")
                     del active[slug]
+                    story_deadlines.pop(slug, None)
                     spec_str = slug_to_spec[slug]
                     failed_at = datetime.datetime.now(datetime.timezone.utc)
                     story_started_at = story_times.get(slug, (failed_at, failed_at))[0]
@@ -1913,6 +1956,7 @@ def run_sprint(
                     dag.mark_skipped(slug)
                     continue
                 del active[slug]
+                story_deadlines.pop(slug, None)
                 story_times[slug] = (t0, t1)
 
                 with cost_lock:

--- a/tests/test_complexity_timeouts.py
+++ b/tests/test_complexity_timeouts.py
@@ -21,7 +21,12 @@ from theforge.config import (
     load_config,
 )
 from theforge.coordinator.engine import run_task
-from theforge.coordinator.util import resolve_timeout
+from theforge.coordinator.util import (
+    LARGE_HEADROOM_FACTOR,
+    MEDIUM_HEADROOM_FACTOR,
+    resolve_timeout,
+    resolve_timeout_with_active,
+)
 from theforge.runners import AgentResult
 from theforge.task import TaskStory
 
@@ -58,27 +63,42 @@ class TestResolveTimeout:
     def test_large_complexity_uses_large_override(self):
         assert resolve_timeout(600, 900, 1800, "large") == 1800
 
-    def test_medium_override_absent_falls_back_to_base(self):
-        assert resolve_timeout(600, None, 1800, "medium") == 600
+    def test_medium_override_absent_derives_from_base(self):
+        assert resolve_timeout(600, None, 1800, "medium") == round(600 * MEDIUM_HEADROOM_FACTOR)
 
-    def test_large_override_absent_falls_back_to_base(self):
-        assert resolve_timeout(600, 900, None, "large") == 600
+    def test_large_override_absent_derives_from_base(self):
+        assert resolve_timeout(600, 900, None, "large") == round(600 * LARGE_HEADROOM_FACTOR)
 
-    def test_large_score_without_large_override_falls_back_to_base_not_medium(self):
-        assert resolve_timeout(600, 900, None, "large", 8) == 600
-        assert resolve_timeout(600, 900, None, "large", 10) == 600
+    def test_large_score_without_large_override_derives_large_not_medium(self):
+        derived = round(600 * LARGE_HEADROOM_FACTOR)
+        assert resolve_timeout(600, 900, None, "large", 8) == derived
+        assert resolve_timeout(600, 900, None, "large", 10) == derived
 
     def test_large_score_ignores_medium_override_when_large_override_missing(self):
-        assert resolve_timeout(600, 900, None, "medium", 8) == 600
+        assert resolve_timeout(600, 900, None, "medium", 8) == round(600 * LARGE_HEADROOM_FACTOR)
 
-    def test_both_overrides_absent_always_returns_base(self):
-        assert resolve_timeout(600, None, None, "large") == 600
-        assert resolve_timeout(600, None, None, "medium") == 600
+    def test_both_overrides_absent_derives_for_medium_and_large(self):
+        assert resolve_timeout(600, None, None, "large") == round(600 * LARGE_HEADROOM_FACTOR)
+        assert resolve_timeout(600, None, None, "medium") == round(600 * MEDIUM_HEADROOM_FACTOR)
         assert resolve_timeout(600, None, None, "small") == 600
         assert resolve_timeout(600, None, None, None) == 600
 
     def test_unknown_complexity_falls_back_to_base(self):
         assert resolve_timeout(600, 900, 1800, "unknown") == 600
+
+    def test_resolve_timeout_with_active_marks_derived_tiers_active(self):
+        timeout, override_active = resolve_timeout_with_active(600, None, None, "large", 8)
+        assert timeout == round(600 * LARGE_HEADROOM_FACTOR)
+        assert override_active is True
+
+        timeout, override_active = resolve_timeout_with_active(600, None, None, "medium", 6)
+        assert timeout == round(600 * MEDIUM_HEADROOM_FACTOR)
+        assert override_active is True
+
+    def test_resolve_timeout_with_active_keeps_base_for_low_score(self):
+        timeout, override_active = resolve_timeout_with_active(600, None, None, "medium", 3)
+        assert timeout == 600
+        assert override_active is False
 
 
 # ── Shared test helpers ────────────────────────────────────────────────
@@ -415,10 +435,10 @@ class TestDevPhaseTimeout:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_dev_falls_back_to_base_when_no_override(
+    def test_dev_derives_large_timeout_when_no_override(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """run_agent uses base timeout when no complexity overrides are set."""
+        """run_agent derives a large timeout when no complexity overrides are set."""
         config = _make_config(tmp_path)  # DEFAULT_DEV_PROFILE has no medium/large overrides
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -438,7 +458,9 @@ class TestDevPhaseTimeout:
 
         assert result.success is True
         dev_profile_used = _get_call_profile(mock_agent, 0)
-        assert dev_profile_used.timeout_seconds == DEFAULT_DEV_PROFILE.timeout_seconds
+        assert dev_profile_used.timeout_seconds == round(
+            DEFAULT_DEV_PROFILE.timeout_seconds * LARGE_HEADROOM_FACTOR
+        )
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
@@ -594,10 +616,17 @@ class TestPlanPhaseTimeout:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_plan_falls_back_to_base_when_no_override(
-        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    def test_plan_derives_large_timeout_when_no_override(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+        capsys,
     ):
-        """PLAN phase uses base timeout when no medium/large overrides are configured."""
+        """PLAN phase derives a large timeout when no medium/large overrides are configured."""
         plan = PlanConfig(enabled=True, timeout=600, validate_spec=False)
         config = _make_config(tmp_path, plan=plan)
         task = _make_task(tmp_path)
@@ -620,7 +649,12 @@ class TestPlanPhaseTimeout:
         assert result.success is True
         # call[0]=plan (preflight now handled by mock_preflight)
         plan_profile_used = _get_call_profile(mock_agent, 0)
-        assert plan_profile_used.timeout_seconds == 600
+        assert plan_profile_used.timeout_seconds == round(600 * LARGE_HEADROOM_FACTOR)
+        stderr = capsys.readouterr().err
+        assert (
+            f"Plan timeout: {round(600 * LARGE_HEADROOM_FACTOR)}s (large complexity, derived)"
+            in stderr
+        )
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
@@ -659,7 +693,7 @@ class TestPlanPhaseTimeout:
 
         assert result.success is True
         stderr = capsys.readouterr().err
-        assert "Plan timeout: 600s (large complexity)" in stderr
+        assert "Plan timeout: 600s (large complexity, explicit override)" in stderr
 
 
 # ── load_config: new fields parsing ───────────────────────────────────

--- a/tests/test_coord_adaptive_iterations.py
+++ b/tests/test_coord_adaptive_iterations.py
@@ -22,6 +22,7 @@ from theforge.coordinator.state import (
     Phase,
     ReviewIterationTelemetry,
 )
+from theforge.coordinator.util import LARGE_HEADROOM_FACTOR, MEDIUM_HEADROOM_FACTOR
 
 
 def _make_adaptive_config(tmp_path: Path, **retry_overrides):
@@ -137,7 +138,9 @@ def test_engine_populates_adaptive_limits_before_dev_loop(tmp_path: Path):
     assert state.adaptive_review_max > 0
     assert state.adaptive_dev_max <= config.retry.max_dev_iterations_cap
     assert state.adaptive_review_max <= config.retry.max_review_cycles_cap
-    assert state.adaptive_dev_timeout_seconds == config.dev_profile.timeout_seconds
+    assert state.adaptive_dev_timeout_seconds == round(
+        config.dev_profile.timeout_seconds * LARGE_HEADROOM_FACTOR
+    )
     assert state.adaptive_dev_budget_usd == config.dev_profile.budget_usd
     assert state.adaptive_limits_audit.get("enabled") is True
     assert state.adaptive_limits_audit.get("complexity_score_used") == 9
@@ -379,6 +382,6 @@ def test_explicit_dev_override_wins_over_computed_limits(tmp_path: Path):
             pass
 
     assert state.adaptive_dev_max == 4
-    assert state.adaptive_dev_timeout_seconds == 1200
+    assert state.adaptive_dev_timeout_seconds == round(1200 * MEDIUM_HEADROOM_FACTOR)
     assert state.adaptive_dev_budget_usd == 12.0
     assert "explicit dev forge.yaml override" in state.adaptive_limits_audit["rationale"]

--- a/tests/test_sprint_timeout_audit.py
+++ b/tests/test_sprint_timeout_audit.py
@@ -32,9 +32,14 @@ def test_run_sprint_timeout_writes_story_audit(tmp_path: Path) -> None:
 
     with (
         patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
         patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
         patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
         patch("theforge.sprint.runner.wait", return_value=(set(), set())),
+        patch("theforge.sprint.runner.time.monotonic", side_effect=[0.0, 4000.0, 4000.0]),
     ):
         run_sprint(config, manifest)
 

--- a/tests/test_sprint_worker_timeout.py
+++ b/tests/test_sprint_worker_timeout.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,8 +15,33 @@ from tests.test_sprint_parallel import (
     _make_spec_file,
 )
 from theforge.config import SprintConfig
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.coordinator.util import LARGE_HEADROOM_FACTOR, MEDIUM_HEADROOM_FACTOR
 from theforge.sprint import run_sprint
 from theforge.sprint.manifest import ResolvedSprint, load_sprint_manifest
+from theforge.sprint.runner import derive_worker_timeout
+
+
+def _make_preflight_state(
+    complexity: str | None,
+    complexity_score: int | None = None,
+) -> CoordinatorState:
+    state = CoordinatorState()
+    state.preflight_complexity = complexity
+    state.preflight_complexity_score = complexity_score
+    return state
+
+
+def _make_done_story_result(success: bool = True) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.total_cost = 0.0
+    return CoordinatorResult(
+        success=success,
+        phase=Phase.DONE if success else Phase.ESCALATE,
+        state=state,
+        message="Done." if success else "Failed.",
+    )
+
 
 # ── SprintConfig defaults ─────────────────────────────────────────────────────
 
@@ -30,6 +56,24 @@ def test_sprint_config_custom_timeout() -> None:
     """SprintConfig accepts an explicit worker_timeout_seconds."""
     cfg = SprintConfig(worker_timeout_seconds=7200)
     assert cfg.worker_timeout_seconds == 7200
+
+
+class TestDeriveWorkerTimeout:
+    def test_large_complexity_uses_large_headroom(self) -> None:
+        assert derive_worker_timeout(3600, "large") == round(3600 * LARGE_HEADROOM_FACTOR)
+
+    def test_medium_complexity_uses_medium_headroom(self) -> None:
+        assert derive_worker_timeout(3600, "medium") == round(3600 * MEDIUM_HEADROOM_FACTOR)
+
+    def test_small_complexity_uses_base(self) -> None:
+        assert derive_worker_timeout(3600, "small") == 3600
+
+    def test_none_complexity_uses_base(self) -> None:
+        assert derive_worker_timeout(3600, None) == 3600
+
+    def test_score_based_path_matches_string_path(self) -> None:
+        assert derive_worker_timeout(3600, "medium", 6) == round(3600 * MEDIUM_HEADROOM_FACTOR)
+        assert derive_worker_timeout(3600, "large", 8) == round(3600 * LARGE_HEADROOM_FACTOR)
 
 
 # ── SprintManifest parsing ────────────────────────────────────────────────────
@@ -126,10 +170,29 @@ class TestWorkerTimeoutPrecedence:
         """Manifest worker_timeout_seconds=120 overrides config default of 3600."""
         _make_spec_file(tmp_path, "Story A", "story-a")
         manifest_path = self._make_manifest(tmp_path, timeout=120)
-        # Config uses the default 3600 but manifest says 120.
-        config = _make_config(tmp_path)
+        config = _make_config_with_sprint(tmp_path, sprint_max_parallel=1)
 
         wait_calls: list[float] = []
+
+        class _NeverDoneFuture:
+            def cancel(self):
+                return True
+
+            def result(self):
+                raise AssertionError("should not be called")
+
+        class _FakeExecutor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def submit(self, _fn, _config, task, *args, **kwargs):
+                return _NeverDoneFuture()
 
         def _fake_wait(futs, *, return_when, timeout):
             wait_calls.append(timeout)
@@ -137,13 +200,17 @@ class TestWorkerTimeoutPrecedence:
 
         with (
             patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+            patch(
+                "theforge.sprint.runner._run_baseline_gate",
+                return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+            ),
             patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
             patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+            patch("theforge.sprint.runner.time.monotonic", side_effect=[0.0, 0.0, 121.0]),
         ):
             run_sprint(config, manifest_path)
 
-        # The poll loop uses the configured timeout as its ceiling.
-        # At least one wait() call should use 120.0 (not 3600.0) as the timeout.
         assert any(t == pytest.approx(120.0) for t in wait_calls), (
             f"Expected a wait() call with timeout=120.0 but got: {wait_calls}"
         )
@@ -157,19 +224,99 @@ class TestWorkerTimeoutPrecedence:
 
         wait_calls: list[float] = []
 
+        class _NeverDoneFuture:
+            def cancel(self):
+                return True
+
+            def result(self):
+                raise AssertionError("should not be called")
+
+        class _FakeExecutor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def submit(self, _fn, _config, task, *args, **kwargs):
+                return _NeverDoneFuture()
+
         def _fake_wait(futs, *, return_when, timeout):
             wait_calls.append(timeout)
             return (set(), set())
 
         with (
             patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+            patch(
+                "theforge.sprint.runner._run_baseline_gate",
+                return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+            ),
             patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
             patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+            patch("theforge.sprint.runner.time.monotonic", side_effect=[0.0, 0.0, 3601.0]),
         ):
             run_sprint(config, manifest_path)
 
         assert any(t == pytest.approx(3600.0) for t in wait_calls), (
             f"Expected a wait() call with timeout=3600.0 but got: {wait_calls}"
+        )
+
+    def test_large_preflight_derives_timeout_when_manifest_omits(self, tmp_path: Path) -> None:
+        """A large story derives a larger worker timeout when no explicit override exists."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = self._make_manifest(tmp_path, timeout=None)
+        config = _make_config_with_sprint(tmp_path, sprint_max_parallel=1)
+        wait_calls: list[float] = []
+
+        class _DoneFuture:
+            def __init__(self, task):
+                self._task = task
+
+            def cancel(self):
+                return False
+
+            def result(self):
+                t0 = t1 = datetime.datetime.now(datetime.timezone.utc)
+                return (self._task, _make_done_story_result(), 0.0, t0, t1)
+
+        class _FakeExecutor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def submit(self, _fn, _config, task, *args, **kwargs):
+                return _DoneFuture(task)
+
+        def _fake_wait(futs, *, return_when, timeout):
+            wait_calls.append(timeout)
+            return ({next(iter(futs))}, set())
+
+        with (
+            patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+            patch(
+                "theforge.sprint.runner._run_baseline_gate",
+                return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+            ),
+            patch(
+                "theforge.sprint.runner.run_batch_preflight",
+                return_value={"story-a": _make_preflight_state("large", 8)},
+            ),
+            patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
+            patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+        ):
+            run_sprint(config, manifest_path)
+
+        assert any(t == pytest.approx(round(3600 * LARGE_HEADROOM_FACTOR)) for t in wait_calls), (
+            f"Expected wait() to use the derived large-story timeout, got: {wait_calls}"
         )
 
     def test_resolved_sprint_timeout_overrides_config(self, tmp_path: Path) -> None:
@@ -192,19 +339,99 @@ class TestWorkerTimeoutPrecedence:
 
         wait_calls: list[float] = []
 
+        class _NeverDoneFuture:
+            def cancel(self):
+                return True
+
+            def result(self):
+                raise AssertionError("should not be called")
+
+        class _FakeExecutor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def submit(self, _fn, _config, task, *args, **kwargs):
+                return _NeverDoneFuture()
+
         def _fake_wait(futs, *, return_when, timeout):
             wait_calls.append(timeout)
             return (set(), set())
 
         with (
             patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+            patch(
+                "theforge.sprint.runner._run_baseline_gate",
+                return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+            ),
             patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
             patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+            patch("theforge.sprint.runner.time.monotonic", side_effect=[0.0, 0.0, 61.0]),
         ):
             run_sprint(config, resolved)
 
         assert any(t == pytest.approx(60.0) for t in wait_calls), (
             f"Expected a wait() call with timeout=60.0 but got: {wait_calls}"
+        )
+
+    def test_manifest_timeout_wins_over_complexity_derivation(self, tmp_path: Path) -> None:
+        """A manifest timeout override wins even when preflight marks the story as large."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = self._make_manifest(tmp_path, timeout=7200)
+        config = _make_config_with_sprint(tmp_path, sprint_max_parallel=1)
+        wait_calls: list[float] = []
+
+        class _DoneFuture:
+            def __init__(self, task):
+                self._task = task
+
+            def cancel(self):
+                return False
+
+            def result(self):
+                t0 = t1 = datetime.datetime.now(datetime.timezone.utc)
+                return (self._task, _make_done_story_result(), 0.0, t0, t1)
+
+        class _FakeExecutor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def submit(self, _fn, _config, task, *args, **kwargs):
+                return _DoneFuture(task)
+
+        def _fake_wait(futs, *, return_when, timeout):
+            wait_calls.append(timeout)
+            return ({next(iter(futs))}, set())
+
+        with (
+            patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+            patch(
+                "theforge.sprint.runner._run_baseline_gate",
+                return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+            ),
+            patch(
+                "theforge.sprint.runner.run_batch_preflight",
+                return_value={"story-a": _make_preflight_state("large", 8)},
+            ),
+            patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
+            patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+        ):
+            run_sprint(config, manifest_path)
+
+        assert any(t == pytest.approx(7200.0) for t in wait_calls), (
+            f"Expected manifest override timeout=7200.0 but got: {wait_calls}"
         )
 
     def test_manifest_none_is_sentinel_for_config_fallback(self, tmp_path: Path) -> None:
@@ -232,7 +459,11 @@ def test_timeout_error_message_uses_configured_value(tmp_path: Path) -> None:
     config = _make_config(tmp_path)
 
     class _NeverDoneFuture:
+        def __init__(self):
+            self.cancel_called = False
+
         def cancel(self):
+            self.cancel_called = True
             return True
 
         def result(self):
@@ -253,19 +484,125 @@ def test_timeout_error_message_uses_configured_value(tmp_path: Path) -> None:
 
     with (
         patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
         patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
         patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
         patch("theforge.sprint.runner.wait", return_value=(set(), set())),
+        patch("theforge.sprint.runner.time.monotonic", side_effect=[0.0, 50.0, 50.0]),
     ):
         result = run_sprint(config, manifest)
 
-    assert result.stopped_reason is not None
-    assert "42" in result.stopped_reason, (
-        f"Expected '42' in stopped_reason, got: {result.stopped_reason!r}"
-    )
-    # Verify story result also has timeout message with configured value
     assert result.results
     _, story_result = result.results[0]
     assert "42" in story_result.message, (
         f"Expected '42' in story result message, got: {story_result.message!r}"
     )
+
+
+def test_per_story_deadline_expires_only_the_elapsed_future(tmp_path: Path, capsys) -> None:
+    """A timed-out story is cancelled independently while other active workers continue."""
+    spec_a = _make_spec_file(tmp_path, "Story A", "story-a")
+    spec_b = _make_spec_file(tmp_path, "Story B", "story-b")
+    manifest = tmp_path / "sprint.yaml"
+    manifest.write_text(
+        yaml.dump(
+            {
+                "name": "Parallel",
+                "budget_usd": 5.0,
+                "stories": [spec_a.name, spec_b.name],
+                "max_parallel": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = _make_config_with_sprint(tmp_path, sprint_max_parallel=2)
+
+    class _NeverDoneFuture:
+        def __init__(self):
+            self.cancel_called = False
+
+        def cancel(self):
+            self.cancel_called = True
+            return True
+
+        def result(self):
+            raise AssertionError("should not be called")
+
+    class _DoneFuture:
+        def __init__(self, task):
+            self._task = task
+            self.cancel_called = False
+
+        def cancel(self):
+            self.cancel_called = True
+            return False
+
+        def result(self):
+            t0 = t1 = datetime.datetime.now(datetime.timezone.utc)
+            return (self._task, _make_done_story_result(), 0.0, t0, t1)
+
+    hanging_future = _NeverDoneFuture()
+    completed_future = None
+
+    class _FakeExecutor:
+        def __init__(self, *args, **kwargs):
+            self._submitted = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def submit(self, _fn, _config, task, *args, **kwargs):
+            nonlocal completed_future
+            self._submitted += 1
+            if self._submitted == 1:
+                return hanging_future
+            completed_future = _DoneFuture(task)
+            return completed_future
+
+    wait_calls = 0
+
+    def _fake_wait(futs, *, return_when, timeout):
+        nonlocal wait_calls
+        wait_calls += 1
+        if wait_calls == 1:
+            return (set(), set())
+        return ({completed_future}, set())
+
+    with (
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight",
+            return_value={
+                "story-a": _make_preflight_state("small", 3),
+                "story-b": _make_preflight_state("large", 8),
+            },
+        ),
+        patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
+        patch("theforge.sprint.runner.wait", side_effect=_fake_wait),
+        patch(
+            "theforge.sprint.runner.time.monotonic",
+            side_effect=[0.0, 0.0, 4000.0, 4000.0, 4001.0, 4001.0],
+        ),
+    ):
+        result = run_sprint(config, manifest)
+
+    stderr = capsys.readouterr().err
+    assert "TIMEOUT story-a (worker unresponsive after 3600s — marking as failed)" in stderr
+    assert hanging_future.cancel_called is True
+    assert completed_future is not None
+    assert completed_future.cancel_called is False
+    assert len(result.results) == 2
+    assert {spec for spec, _res in result.results} == {"story-a.md", "story-b.md"}
+    by_spec = dict(result.results)
+    assert by_spec["story-a.md"].success is False
+    assert by_spec["story-b.md"].success is True

--- a/tests/test_sprint_worker_timeout.py
+++ b/tests/test_sprint_worker_timeout.py
@@ -34,7 +34,6 @@ def _make_preflight_state(
 
 def _make_done_story_result(success: bool = True) -> CoordinatorResult:
     state = CoordinatorState()
-    state.total_cost = 0.0
     return CoordinatorResult(
         success=success,
         phase=Phase.DONE if success else Phase.ESCALATE,


### PR DESCRIPTION
## Summary

Adaptive timeout coverage gap closed: resolve_timeout_with_active now derives complexity-tiered timeouts instead of silently returning base, sprint worker timeouts are per-story from preflight complexity, and both surfaces use the unified 1.5x headroom factor. Gate passes, all ACs satisfied.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.47
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:88`** derive_worker_timeout always passes None for medium/large overrides to resolve_timeout, so there is no way to thread per-story explicit medium/large timeout overrides through this function in the future. Current callers only ever use it with no explicit tier overrides, so this is not a bug today, but the abstraction is closed to extension without revisiting the signature.
- **[P2] `tests/test_coord_adaptive_iterations.py:382`** test_explicit_dev_override_wins_over_computed_limits now asserts adaptive_dev_timeout_seconds == round(1200 * MEDIUM_HEADROOM_FACTOR) = 1800, but the test name says 'explicit dev override wins'. The 1200 value is the base timeout passed to the resolver, which now derives 1800 for medium complexity. This is correct behavior but the test name is misleading — the 'explicit override' here means the forge.yaml timeout_seconds field, not an explicit medium override.

## Story

Adaptive timeout coverage gap — plan-phase and sprint-worker timeouts don't auto-derive from complexity (incomplete scope of #156/#290) (GitHub Issue #1070)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1070