### PR TITLE
forge status: ELAPSED column always blank, SKIPPED rows show no reason

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -221,7 +221,7 @@ def _print_story_line(entry: object, status_icons: dict, indent: int) -> None:
     if len(model_str) > 24:
         model_str = model_str[:24]
     cost_str = f"${cost_usd:.2f}" if cost_usd else "   —"
-    elapsed_str = f"{int(elapsed_s // 60)}m" if elapsed_s is not None else "—"
+    elapsed_str = _format_story_elapsed(elapsed_s)
 
     prefix = " " * indent
     detail_width = _detail_column_width(indent)
@@ -254,6 +254,18 @@ def _print_story_line(entry: object, status_icons: dict, indent: int) -> None:
             f"{detail_lines[index] if index < len(detail_lines) else ''}"
         )
         print(f"{prefix}{line}")
+
+
+def _format_story_elapsed(elapsed_s: float | None) -> str:
+    """Format story elapsed time for display."""
+    if elapsed_s is None:
+        return "—"
+    total_seconds = max(0, int(elapsed_s))
+    if total_seconds >= 3600:
+        hours = total_seconds // 3600
+        minutes = (total_seconds % 3600) // 60
+        return f"{hours}h {minutes}m"
+    return f"{total_seconds // 60}m"
 
 
 def _detail_column_width(indent: int) -> int:

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -64,7 +64,7 @@ from .manifest import (
 from .query import normalize_dependency_plan
 from .sources import StorySource
 from .state_writer import SprintStateWriter
-from .story_state import SprintStoryState, StoryOutcome
+from .story_state import SprintStoryState, StoryOutcome, coerce_outcome
 
 _UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"codex", "gemini"})
 
@@ -1129,6 +1129,9 @@ def run_sprint(
                 _story_state.register(slug, _key, canonical_ref=_ref)
             else:
                 _story_state.register(slug, slug)
+        canonical_outcome = coerce_outcome(outcome)
+        if canonical_outcome.is_terminal and "finished_at" not in fields:
+            fields["finished_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
         if _state_writer is not None:
             # Writer holds the same instance; this both transitions outcome
             # AND atomically rewrites the live .state file.
@@ -1743,7 +1746,11 @@ def run_sprint(
                     flush=True,
                 )
                 if _state_writer is not None:
-                    _state_writer.update(task.slug, status="running")
+                    _state_writer.update(
+                        task.slug,
+                        status="running",
+                        started_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                    )
 
                 # Create plan gate for fresh parallel runs
                 gate: threading.Event | None = None

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -156,6 +157,43 @@ def _nonempty_str(value: object) -> str | None:
     return stripped or None
 
 
+def _parse_status_timestamp(value: object) -> datetime.datetime | None:
+    """Parse persisted UTC timestamps from sprint summary or live state data."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _elapsed_seconds_from_bounds(started_at: object, finished_at: object) -> float | None:
+    started_at_dt = _parse_status_timestamp(started_at)
+    finished_at_dt = _parse_status_timestamp(finished_at)
+    if started_at_dt is None or finished_at_dt is None:
+        return None
+    elapsed = (finished_at_dt - started_at_dt).total_seconds()
+    return elapsed if elapsed >= 0 else None
+
+
+def _elapsed_seconds_from_live_story(story: dict) -> float | None:
+    """Compute elapsed time for a live state entry when timestamps are available."""
+    started_at_dt = _parse_status_timestamp(story.get("started_at"))
+    if started_at_dt is None:
+        return None
+
+    finished_at_dt = _parse_status_timestamp(story.get("finished_at"))
+    if finished_at_dt is not None:
+        elapsed = (finished_at_dt - started_at_dt).total_seconds()
+        return elapsed if elapsed >= 0 else None
+
+    if story.get("status") == "running":
+        elapsed = (datetime.datetime.now(datetime.timezone.utc) - started_at_dt).total_seconds()
+        return elapsed if elapsed >= 0 else None
+
+    return None
+
+
 def _format_usage_stage(used: object, maximum: object, label: str) -> str:
     if isinstance(used, int) and isinstance(maximum, int) and maximum > 0:
         return f"{label}={used}/{maximum}"
@@ -243,8 +281,17 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
 
     if status_val in {"done", "failed", "skipped", "preserved"}:
         final_outcome = detail_data.get("final_outcome")
+        skip_reason = _nonempty_str(story.get("reason")) if status_val == "skipped" else None
+        if (
+            skip_reason
+            and isinstance(final_outcome, str)
+            and final_outcome in {"SKIPPED", "DROPPED"}
+        ):
+            return "", skip_reason, complexity
         if isinstance(final_outcome, str) and final_outcome:
             return "", final_outcome, complexity
+        if skip_reason:
+            return "", skip_reason, complexity
         if status_val == "failed" and phase_val:
             return "", phase_val, complexity
         return "", "—", complexity
@@ -361,6 +408,12 @@ def _stage_and_detail_from_completed_story(
             detail = "APPROVE"
         elif verdict:
             detail = verdict
+        elif outcome in {"SKIPPED", "DROPPED"}:
+            detail = (
+                _nonempty_str(story.get("error"))
+                or _nonempty_str(story.get("drop_reason"))
+                or outcome
+            )
         elif outcome == "DONE":
             detail = "APPROVE"
         elif outcome == "ALREADY_DONE":
@@ -438,7 +491,10 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
                 cost_usd=cost_usd,
                 blocked_by=blocked_by,
                 bundle_candidate=bundle_candidate,
-                elapsed_seconds=None,
+                elapsed_seconds=_elapsed_seconds_from_bounds(
+                    story.get("started_at"),
+                    story.get("finished_at"),
+                ),
                 stage=stage,
                 detail=detail,
                 complexity=complexity,
@@ -501,7 +557,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                 cost_usd=float(story.get("cost_usd", 0.0)),
                 blocked_by=blocked_by_val,
                 bundle_candidate=bool(story.get("bundle_candidate", False)),
-                elapsed_seconds=None,
+                elapsed_seconds=_elapsed_seconds_from_live_story(story),
                 stage=stage,
                 detail=detail,
                 complexity=complexity,
@@ -519,21 +575,26 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
             slug = story.get("slug", "")
             if not slug or slug in seen_slugs:
                 continue
+            outcome = str(story.get("outcome", "SKIPPED"))
+            depends_on = list(story.get("depends_on") or [])
+            detail = _nonempty_str(story.get("verdict")) or outcome
+            if outcome in {"SKIPPED", "DROPPED"} or depends_on:
+                _, detail, _ = _stage_and_detail_from_completed_story(story, None)
             entries.append(
                 StoryStatusEntry(
                     slug=slug,
                     path=story.get("path", slug),
-                    status=_outcome_to_status(str(story.get("outcome", "SKIPPED"))),
-                    phase=_terminal_phase(
-                        str(story.get("outcome", "SKIPPED")),
-                        list(story.get("depends_on") or []),
-                    ),
+                    status=_outcome_to_status(outcome),
+                    phase=_terminal_phase(outcome, depends_on),
                     cost_usd=float(story.get("cost_usd", 0.0)),
-                    blocked_by=list(story.get("depends_on") or []),
+                    blocked_by=depends_on,
                     bundle_candidate=False,
-                    elapsed_seconds=None,
+                    elapsed_seconds=_elapsed_seconds_from_bounds(
+                        story.get("started_at"),
+                        story.get("finished_at"),
+                    ),
                     stage=_format_terminal_stage(story.get("iteration_usage")),
-                    detail=_nonempty_str(story.get("verdict")) or str(story.get("outcome", "")),
+                    detail=detail,
                     complexity=None,
                 )
             )

--- a/tests/test_status_reader_elapsed.py
+++ b/tests/test_status_reader_elapsed.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _write_summary(tmp_path: Path, stories: list[dict]) -> Path:
+    summary_dir = tmp_path / ".forge" / "logs" / "elapsed-sprint"
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = summary_dir / "sprint-summary.yaml"
+    summary_path.write_text(
+        yaml.dump(
+            {
+                "sprint": {
+                    "name": "elapsed-sprint",
+                    "run_id": "run-elapsed",
+                },
+                "stories": stories,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return summary_path
+
+
+def _write_live_state(
+    tmp_path: Path,
+    run_id: str,
+    stories: list[dict],
+    *,
+    sprint_id: str | None = None,
+) -> None:
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    state_path = runs_dir / f"{run_id}.state"
+    state_path.write_text(
+        yaml.dump(
+            {
+                "sprint_name": "elapsed-sprint",
+                "sprint_id": sprint_id,
+                "stories": stories,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_read_completed_status_populates_elapsed_seconds(tmp_path: Path) -> None:
+    from theforge.sprint.status_reader import read_completed_status
+
+    summary_path = _write_summary(
+        tmp_path,
+        [
+            {
+                "slug": "issue-1",
+                "path": "Issue #1",
+                "outcome": "DONE",
+                "started_at": "2026-04-29T10:00:00Z",
+                "finished_at": "2026-04-29T11:03:00Z",
+            }
+        ],
+    )
+
+    entries = read_completed_status(summary_path)
+
+    assert len(entries) == 1
+    assert entries[0].elapsed_seconds == pytest.approx(3780.0)
+
+
+def test_read_completed_status_leaves_elapsed_seconds_blank_without_timestamps(
+    tmp_path: Path,
+) -> None:
+    from theforge.sprint.status_reader import read_completed_status
+
+    summary_path = _write_summary(
+        tmp_path,
+        [{"slug": "issue-2", "path": "Issue #2", "outcome": "DONE"}],
+    )
+
+    entries = read_completed_status(summary_path)
+
+    assert len(entries) == 1
+    assert entries[0].elapsed_seconds is None
+
+
+def test_completed_skipped_story_prefers_persisted_reason() -> None:
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    stage, detail, complexity = _stage_and_detail_from_completed_story(
+        {
+            "slug": "issue-3",
+            "outcome": "SKIPPED",
+            "error": "budget exhausted ($6.00 >= $5.00)",
+            "drop_reason": "held by collision",
+        },
+        None,
+    )
+
+    assert stage == ""
+    assert detail == "budget exhausted ($6.00 >= $5.00)"
+    assert complexity is None
+
+
+def test_completed_skipped_story_with_dependencies_keeps_waiting_detail() -> None:
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    stage, detail, _ = _stage_and_detail_from_completed_story(
+        {
+            "slug": "issue-4",
+            "outcome": "SKIPPED",
+            "depends_on": ["issue-1"],
+            "drop_reason": "budget exhausted",
+        },
+        None,
+    )
+
+    assert stage == "dependency"
+    assert detail == "depends on issue-1"
+
+
+def test_live_skipped_story_uses_reason_detail() -> None:
+    from theforge.sprint.status_reader import _stage_and_detail_from_live_story
+
+    stage, detail, _ = _stage_and_detail_from_live_story(
+        {
+            "slug": "issue-5",
+            "status": "skipped",
+            "phase": "DONE",
+            "reason": "held by collision",
+            "detail": {"final_outcome": "SKIPPED"},
+        }
+    )
+
+    assert stage == ""
+    assert detail == "held by collision"
+
+
+def test_read_live_status_populates_elapsed_seconds_for_running_story(tmp_path: Path) -> None:
+    from datetime import datetime, timedelta, timezone
+
+    from theforge.sprint.status_reader import read_live_status
+
+    started_at = (datetime.now(timezone.utc) - timedelta(minutes=5, seconds=7)).isoformat()
+    _write_live_state(
+        tmp_path,
+        "run-live",
+        [
+            {
+                "slug": "issue-6",
+                "path": "Issue #6",
+                "status": "running",
+                "phase": "DEV",
+                "started_at": started_at,
+                "detail": {},
+            }
+        ],
+    )
+
+    entries = read_live_status("run-live", tmp_path)
+
+    assert entries is not None
+    assert len(entries) == 1
+    assert entries[0].elapsed_seconds is not None
+    assert 300.0 <= entries[0].elapsed_seconds <= 320.0
+
+
+def test_read_live_status_populates_elapsed_seconds_for_accumulated_story(tmp_path: Path) -> None:
+    from theforge.sprint.audit import persist_accumulated_story_state
+    from theforge.sprint.status_reader import read_live_status
+
+    _write_live_state(tmp_path, "run-reexec", [], sprint_id="sprint-123")
+    persist_accumulated_story_state(
+        "sprint-123",
+        "elapsed-sprint",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "issue:7",
+                "slug": "issue-7",
+                "path": "Issue #7",
+                "outcome": "DONE",
+                "started_at": "2026-04-29T10:00:00Z",
+                "finished_at": "2026-04-29T10:12:00Z",
+            }
+        ],
+    )
+
+    entries = read_live_status("run-reexec", tmp_path)
+
+    assert entries is not None
+    assert len(entries) == 1
+    assert entries[0].elapsed_seconds == pytest.approx(720.0)
+
+
+@pytest.mark.parametrize(
+    ("elapsed_s", "expected"),
+    [
+        (None, "—"),
+        (59, "0m"),
+        (3599, "59m"),
+        (3780, "1h 3m"),
+    ],
+)
+def test_format_story_elapsed(elapsed_s: float | None, expected: str) -> None:
+    from theforge.cli.sprint_status import _format_story_elapsed
+
+    assert _format_story_elapsed(elapsed_s) == expected


### PR DESCRIPTION
## Summary

All acceptance criteria met: elapsed populates from timestamps for completed/accumulated/live stories, skipped detail surfaces persisted reasons, formatter handles hour-range values, focused regression tests cover all paths.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $4.17
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:1710`** started_at is always overwritten when a story transitions to 'running', with no guard like 'if started_at not in fields'. On a resumed sprint where a story was mid-run, this resets the clock — elapsed for the current window only, not the full wall-clock span. Not a spec violation since the spec does not address resume semantics, but a latent accuracy gap.
- **[P2] `tests/test_status_reader_elapsed.py:193`** The parametrize case (59, '0m') is technically correct (integer division) but not immediately intuitive; a reader might expect sub-minute display. Not a bug — the pre-existing original code had the same truncation — but a comment or a test for 0 seconds explicitly would help future readers understand the intent.

## Story

forge status: ELAPSED column always blank, SKIPPED rows show no reason (GitHub Issue #1080)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1080