### PR TITLE
Dev agent that produces zero commits is treated as APPROVE/DONE instead of escalating

### DIFF
--- a/src/theforge/coordinator/commit_guard.py
+++ b/src/theforge/coordinator/commit_guard.py
@@ -1,0 +1,39 @@
+"""Zero-commit guards: detect empty branches before they reach DONE.
+
+A dev iteration that produces zero commits ahead of the base branch must not
+flow through to APPROVE/DONE. The guards in this module are invoked at the
+DEV → VALIDATE, VALIDATE → REVIEW, and REVIEW → DONE seams to escalate empty
+runs early instead of letting integration silently skip PR creation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _has_commits_ahead_of_base(workspace_path: Path, base_branch: str) -> bool:
+    """Return True if HEAD has commits not reachable from base_branch.
+
+    Tries `origin/{base_branch}` first, then falls back to the local ref. If
+    both git invocations fail, returns True (fail-open) so transient git
+    failures do not trigger spurious escalations on otherwise healthy runs.
+    """
+    for ref in (f"origin/{base_branch}", base_branch):
+        try:
+            proc = subprocess.run(
+                ["git", "rev-list", "--count", f"{ref}..HEAD"],
+                cwd=str(workspace_path),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception:  # noqa: BLE001
+            continue
+        if proc.returncode != 0:
+            continue
+        try:
+            return int(proc.stdout.strip() or "0") > 0
+        except ValueError:
+            continue
+    return True

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -18,6 +18,7 @@ from theforge.sessions import save_sessions
 from theforge.task import ContextAssembler, TaskStory, build_dev_prompt, build_fix_prompt
 from theforge.traces import write_trace
 
+from .commit_guard import _has_commits_ahead_of_base
 from .gate import _is_gate_skip
 from .logging import StructuredLogger
 from .notify import _escalate_notify
@@ -647,6 +648,26 @@ def _run_dev_phase(
 
     if not dev_result.success:
         _log_verbose(f"Dev agent failed (exit={dev_result.exit_code})")
+        # ── Zero-commit guard (any failed dev iteration) ─────────────────
+        # If the dev agent exited with failure (non-zero or signal-killed) and
+        # the worktree has no new commits ahead of base, escalate immediately
+        # rather than letting an empty diff flow through to a fake APPROVE.
+        if not _has_commits_ahead_of_base(workspace_path, config.workspace.base_branch):
+            state.phase = Phase.ESCALATE
+            state.error = (
+                f"Dev agent failed (exit={dev_result.exit_code}) and produced no commits "
+                "ahead of base — escalating to avoid an empty-diff APPROVE"
+            )
+            _log(f"✗ ESCALATE   {state.error}")
+            if logger:
+                logger._safe_emit("escalate", reason=state.error, phase="DEV")
+            _escalate_notify(task, state, notify, config)
+            return CoordinatorResult(
+                success=False,
+                phase=state.phase,
+                state=state,
+                message=state.error,
+            )
 
     # ── Zero-change guard (review-driven retry only) ─────────────────
     # If the coordinator retried DEV after review REQUEST_CHANGES and the dev

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -19,6 +19,7 @@ from theforge.review import (
 )
 from theforge.task import ContextAssembler, TaskStory, build_review_prompt
 
+from .commit_guard import _has_commits_ahead_of_base
 from .completion import _append_cycle_history, _finalize_approve
 from .logging import StructuredLogger
 from .notify import (
@@ -920,6 +921,33 @@ def _run_review_phase(
     _effective_approve = parsed_review.verdict == "APPROVE" or (
         parsed_review.verdict == "REQUEST_CHANGES" and not _blocking_p1
     )
+
+    # ── Empty-diff guard ────────────────────────────────────────────
+    # APPROVE on a branch with zero commits ahead of base is a workflow failure,
+    # not a real approval — refuse to advance to DONE.
+    if _effective_approve and not _has_commits_ahead_of_base(
+        workspace_path, config.workspace.base_branch
+    ):
+        state.phase = Phase.ESCALATE
+        state.error = (
+            "Review verdict APPROVE on a branch with no commits ahead of base — "
+            "refusing to mark DONE on an empty diff"
+        )
+        _log(f"✗ ESCALATE   {state.error}")
+        if logger:
+            logger._safe_emit("phase_end", phase="REVIEW", outcome="escalate")
+            logger._safe_emit("escalate", reason=state.error, phase="REVIEW")
+        _escalate_notify(task, state, notify, config)
+        return (
+            _ReviewOutcome.ESCALATE,
+            CoordinatorResult(
+                success=False,
+                phase=Phase.ESCALATE,
+                state=state,
+                message=state.error,
+            ),
+            config,
+        )
 
     if _effective_approve and _nonblocking_p1s:
         _nb_descs = "; ".join(r.description[:80] for r in _nonblocking_p1s)

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -15,6 +15,7 @@ from theforge.config import ForgeConfig
 from theforge.task import TaskStory
 
 from . import util as _cu
+from .commit_guard import _has_commits_ahead_of_base
 from .dev_phase import _extract_failed_tests, record_dev_iteration_telemetry
 from .gate import _is_gate_skip, _parse_dirty_files, _run_gate_debug_command, _run_gate_full
 from .logging import StructuredLogger
@@ -322,6 +323,25 @@ def _run_validate_phase(
                         state=state,
                         message=state.error,
                     )
+
+        # ── Zero-commits guard ──────────────────────────────────────
+        # A trivially passing gate over an empty worktree is not a real PASS;
+        # treat it as a missing-work failure rather than letting it advance to
+        # REVIEW where the empty diff would silently approve.
+        if not _has_commits_ahead_of_base(workspace_path, config.workspace.base_branch):
+            state.phase = Phase.ESCALATE
+            state.error = (
+                "Gate exited PASS but branch has no commits ahead of base — "
+                "treating empty worktree as missing-work failure"
+            )
+            _log(f"✗ ESCALATE   {state.error}")
+            if logger:
+                logger._safe_emit("phase_end", phase="VALIDATE", outcome="escalate")
+                logger._safe_emit("escalate", reason=state.error, phase="VALIDATE")
+            _escalate_notify(task, state, notify, config)
+            return _ValidateOutcome.ESCALATE, CoordinatorResult(
+                success=False, phase=state.phase, state=state, message=state.error
+            )
 
     elif gate_decision in ("FAIL", "BLOCKED"):
         if state.budget.is_exhausted():

--- a/tests/test_coord_commit_guard.py
+++ b/tests/test_coord_commit_guard.py
@@ -1,0 +1,196 @@
+"""Tests for the zero-commit guard at DEV→VALIDATE→REVIEW seams.
+
+A dev iteration that produces zero commits ahead of base must escalate at the
+DEV phase (on agent failure), at VALIDATE (gate PASS over empty worktree), and
+at REVIEW (refuse APPROVE on empty diff). Without these guards, a crashed dev
+agent silently flowed through to APPROVE/DONE because:
+- gate exits 0 (nothing to test)
+- review summarises "no commits — nothing to review" then APPROVEs
+- integration's no-commits check fires only at PR creation, after DONE.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.commit_guard import _has_commits_ahead_of_base
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.coordinator.validate_phase import _run_validate_phase, _ValidateOutcome
+from theforge.runners import AgentResult
+from theforge.task import TaskStory
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+            base_branch="main",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        preflight_fallback_profile=None,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+# ── Helper unit tests ──────────────────────────────────────────────────
+
+
+def test_has_commits_ahead_returns_false_for_empty_branch(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    assert _has_commits_ahead_of_base(tmp_path, "main") is False
+
+
+def test_has_commits_ahead_returns_true_with_new_commit(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "f.txt").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "x"], cwd=tmp_path, check=True)
+    assert _has_commits_ahead_of_base(tmp_path, "main") is True
+
+
+def test_has_commits_ahead_fails_open_when_git_unavailable(tmp_path: Path) -> None:
+    """Not a git repo at all — fail-open returns True so transient git issues
+    don't trigger spurious escalations on healthy runs."""
+    assert _has_commits_ahead_of_base(tmp_path, "main") is True
+
+
+# ── Seam test: VALIDATE escalates gate-PASS over empty branch ─────────
+
+
+def test_validate_escalates_on_pass_with_zero_commits(tmp_path: Path) -> None:
+    """VALIDATE must not advance an empty worktree to REVIEW."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md", gate_override="none")
+    state = CoordinatorState()
+
+    outcome, result = _run_validate_phase(state, config, task, tmp_path, notify=False, logger=None)
+    assert outcome == _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    assert "no commits ahead of base" in (state.error or "")
+
+
+def test_validate_passes_when_branch_has_commits(tmp_path: Path) -> None:
+    """Sanity: a branch with commits ahead of base does not trip the new guard."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "f.txt").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "x"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md", gate_override="none")
+    state = CoordinatorState()
+
+    outcome, _result = _run_validate_phase(
+        state, config, task, tmp_path, notify=False, logger=None
+    )
+    # Not escalated by the zero-commits guard.
+    assert outcome != _ValidateOutcome.ESCALATE or "no commits ahead of base" not in (
+        state.error or ""
+    )
+
+
+# ── DEV-phase guard: failed dev + no commits → ESCALATE ──────────────
+
+
+def _make_failed_agent_result() -> AgentResult:
+    """Simulate a dev agent that crashed (signal kill, exit -2) with no output."""
+    return AgentResult(
+        success=False,
+        output="",
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=-2,
+        raw={},
+        profile_name="dev",
+    )
+
+
+def test_dev_phase_escalates_on_failed_agent_with_no_commits(tmp_path: Path) -> None:
+    """A failed dev exit on an empty branch must escalate, not advance to VALIDATE."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+
+    spec = tmp_path / "specs" / "t.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# t\n", encoding="utf-8")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with (
+        patch(
+            "theforge.coordinator.dev_phase.run_agent", return_value=_make_failed_agent_result()
+        ),
+        patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock()),
+    ):
+        result = _run_dev_phase(
+            state,
+            config,
+            task,
+            "# t\n",
+            tmp_path,
+            "feat/x",
+            notify=False,
+            logger=None,
+        )
+
+    assert isinstance(result, CoordinatorResult)
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    assert "no commits ahead of base" in (state.error or "")
+
+
+# ── REVIEW-phase guard: documented via helper behaviour ─────────────
+
+
+def test_review_guard_helper_reports_empty_branch(tmp_path: Path) -> None:
+    """The REVIEW empty-diff guard at review_phase keys off this helper.
+
+    Verifying the helper's behaviour over an empty branch is the seam contract
+    the REVIEW guard relies on; full _run_review_phase exercises require the
+    review pool, synthesis, and audit machinery which are out of scope here.
+    """
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    assert _has_commits_ahead_of_base(tmp_path, "main") is False

--- a/tests/test_coord_gate_exec.py
+++ b/tests/test_coord_gate_exec.py
@@ -219,7 +219,6 @@ class TestCoordinatorDirtyWorktree:
         assert any(
             c[0][0] == ["git", "commit", "-m", mock.ANY] for c in mock_subprocess.call_args_list
         )
-        assert mock_subprocess.call_args[0][0] == ["git", "commit", "-m", mock.ANY]
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")
@@ -546,6 +545,12 @@ class TestDevZeroChangeGuard:
                     result.returncode = 0
                     result.stdout = b"abc123"
                     return result
+                if "rev-list" in cmd:
+                    # validate-phase zero-commits guard: pretend branch has commits ahead
+                    result = mock.Mock()
+                    result.returncode = 0
+                    result.stdout = "1\n"
+                    return result
                 if "diff" in cmd and "--quiet" in cmd:
                     result = mock.Mock()
                     result.returncode = 0  # no diff
@@ -612,6 +617,12 @@ class TestDevZeroChangeGuard:
                     result = mock.Mock()
                     result.returncode = 0
                     result.stdout = b"abc123"
+                    return result
+                if "rev-list" in cmd:
+                    # validate-phase zero-commits guard: pretend branch has commits ahead
+                    result = mock.Mock()
+                    result.returncode = 0
+                    result.stdout = "1\n"
                     return result
                 if "diff" in cmd and "--quiet" in cmd:
                     result = mock.Mock()
@@ -684,6 +695,11 @@ class TestDevZeroChangeGuard:
                     r = mock.Mock()
                     r.returncode = 0
                     r.stdout = b"abc123"
+                    return r
+                if "rev-list" in cmd:
+                    r = mock.Mock()
+                    r.returncode = 0
+                    r.stdout = "1\n"
                     return r
                 if "diff" in cmd and "--quiet" in cmd:
                     r = mock.Mock()
@@ -777,6 +793,11 @@ class TestDevZeroChangeGuard:
                     r = mock.Mock()
                     r.returncode = 0
                     r.stdout = f"commit{dev_trace['n']}".encode()
+                    return r
+                if "rev-list" in cmd:
+                    r = mock.Mock()
+                    r.returncode = 0
+                    r.stdout = "1\n"
                     return r
                 if "diff" in cmd and "--quiet" in cmd:
                     r = mock.Mock()

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -137,7 +137,10 @@ def test_run_validate_phase_records_dirty_pass_iteration_once(tmp_path: Path) ->
 
     assert outcome is _ValidateOutcome.PASS
     assert result is None
-    commit_run.assert_called_once()
+    # The dirty-worktree auto-commit must run exactly once; the new zero-commits
+    # guard adds follow-up `git rev-list` calls to the same patched subprocess.run.
+    commit_calls = [c for c in commit_run.call_args_list if c.args[0][:2] == ["git", "commit"]]
+    assert len(commit_calls) == 1
     assert len(state.dev_iteration_telemetry) == 1
     telemetry = state.dev_iteration_telemetry[0]
     assert telemetry.gate_result == "PASS"


### PR DESCRIPTION
## Summary

Prior P1 resolved — all three seam guards are implemented and wired; two minor test quality gaps remain as P2

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.99
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_coord_commit_guard.py:196`** Convention 8 violation: the REVIEW phase boundary (REVIEW to DONE seam) is covered only by a helper unit test that calls _has_commits_ahead_of_base directly. The guard in review_phase.py is not exercised by any integration-level test that drives _run_review_phase through to the guard branch. The dev agent explicitly deferred this, citing reviewer-pool plumbing complexity.
- **[P2] `tests/test_coord_commit_guard.py:138`** The assertion in test_validate_passes_when_branch_has_commits is logically weak: it passes if outcome is not ESCALATE OR if the error string does not contain 'no commits ahead of base'. This means an escalation for a different reason would not be caught, silently passing the test.

## Story

Dev agent that produces zero commits is treated as APPROVE/DONE instead of escalating (GitHub Issue #1127)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1127