### PR TITLE
fix: scale stuck-detection thresholds by complexity and plan size (#1130)

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import importlib
 import logging
+import math
 from pathlib import Path
 from typing import Any
 
@@ -218,9 +219,15 @@ def _parse_stuck_detection(raw: Any) -> "StuckDetectionConfig":
                     f"forge.yaml 'stuck_detection.{key}' keys must be strings, "
                     f"got {type(k).__name__}"
                 )
-            if isinstance(v, bool) or not isinstance(v, (int, float)) or v <= 0:
+            if (
+                isinstance(v, bool)
+                or not isinstance(v, (int, float))
+                or not math.isfinite(v)
+                or v <= 0
+            ):
                 raise ValueError(
-                    f"forge.yaml 'stuck_detection.{key}.{k}' must be a positive number, got {v!r}"
+                    f"forge.yaml 'stuck_detection.{key}.{k}' must be a finite positive number, "
+                    f"got {v!r}"
                 )
             parsed[k] = float(v)
         kwargs[key] = parsed

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -186,6 +186,10 @@ def _parse_stuck_detection(raw: Any) -> "StuckDetectionConfig":
         "error_threshold": (int, defaults.error_threshold),
         "post_nudge_iterations": (int, defaults.post_nudge_iterations),
     }
+    multiplier_fields = {
+        "no_progress_multipliers": defaults.no_progress_multipliers,
+        "post_nudge_multipliers": defaults.post_nudge_multipliers,
+    }
     kwargs: dict[str, Any] = {}
     for key, (typ, default) in fields.items():
         val = raw.get(key, default)
@@ -198,6 +202,28 @@ def _parse_stuck_detection(raw: Any) -> "StuckDetectionConfig":
                     f"forge.yaml 'stuck_detection.{key}' must be a positive int, got {val!r}"
                 )
         kwargs[key] = val
+    for key, default in multiplier_fields.items():
+        if key not in raw:
+            kwargs[key] = default
+            continue
+        val = raw[key]
+        if not isinstance(val, dict):
+            raise ValueError(
+                f"forge.yaml 'stuck_detection.{key}' must be a mapping, got {type(val).__name__}"
+            )
+        parsed: dict[str, float] = {}
+        for k, v in val.items():
+            if not isinstance(k, str):
+                raise ValueError(
+                    f"forge.yaml 'stuck_detection.{key}' keys must be strings, "
+                    f"got {type(k).__name__}"
+                )
+            if isinstance(v, bool) or not isinstance(v, (int, float)) or v <= 0:
+                raise ValueError(
+                    f"forge.yaml 'stuck_detection.{key}.{k}' must be a positive number, got {v!r}"
+                )
+            parsed[k] = float(v)
+        kwargs[key] = parsed
     return StuckDetectionConfig(**kwargs)
 
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -106,6 +106,15 @@ class StuckDetectionConfig:
     repeat_threshold: int = 4  # consecutive identical (name+args) tool calls → stuck
     error_threshold: int = 4  # consecutive identical error tool results → stuck
     post_nudge_iterations: int = 3  # M — iterations after nudge before termination
+    # Per-complexity multipliers applied to no_progress_iterations and post_nudge_iterations.
+    # LARGE/medium stories often need more pre-modification exploration; flat thresholds
+    # false-terminate competent dev agents. Scaling is applied in dev_phase.py.
+    no_progress_multipliers: dict[str, float] = field(
+        default_factory=lambda: {"small": 1.0, "medium": 1.5, "large": 2.5}
+    )
+    post_nudge_multipliers: dict[str, float] = field(
+        default_factory=lambda: {"small": 1.0, "medium": 1.5, "large": 2.0}
+    )
 
 
 @dataclass(frozen=True)

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -12,6 +12,7 @@ import yaml
 
 from theforge.config import MODEL_REGISTRY, ForgeConfig, apply_model_info
 from theforge.config.auth import sandbox_available_for_profile
+from theforge.config.types import StuckDetectionConfig
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.review import append_convention_retry_findings
 from theforge.sessions import save_sessions
@@ -64,6 +65,38 @@ _RUNNER_FAILURE_SIGNATURES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ),
 )
 _SHELL_ERROR_PREFIXES = ("bash:", "sh:", "zsh:")
+
+
+def _scale_stuck_for_complexity(
+    cfg: StuckDetectionConfig,
+    complexity: str | None,
+    plan_file_count: int,
+) -> StuckDetectionConfig:
+    """Return a StuckDetectionConfig with thresholds scaled by complexity and plan size.
+
+    LARGE/medium stories legitimately need more pre-modification exploration; flat
+    thresholds false-terminate competent dev agents. Scaling raises (never lowers)
+    no_progress_iterations and post_nudge_iterations:
+      - no_progress_iterations: base × multiplier(complexity), plus plan_file_count
+        so a plan touching many files gives the agent room to read each one.
+      - post_nudge_iterations: base × multiplier(complexity), giving complex stories
+        a meaningful grace window after the nudge.
+    """
+    np_mult = cfg.no_progress_multipliers.get(complexity or "", 1.0) if complexity else 1.0
+    pn_mult = cfg.post_nudge_multipliers.get(complexity or "", 1.0) if complexity else 1.0
+    scaled_no_progress = max(
+        cfg.no_progress_iterations,
+        round(cfg.no_progress_iterations * np_mult) + max(plan_file_count, 0),
+    )
+    scaled_post_nudge = max(
+        cfg.post_nudge_iterations,
+        round(cfg.post_nudge_iterations * pn_mult),
+    )
+    return _dc_replace(
+        cfg,
+        no_progress_iterations=scaled_no_progress,
+        post_nudge_iterations=scaled_post_nudge,
+    )
 
 
 def _summarize_runner_failure(output: str, indicators: tuple[str, ...]) -> str:
@@ -512,11 +545,29 @@ def _run_dev_phase(
         _log(f"  Dev timeout: {_dev_timeout}s ({state.preflight_complexity} complexity)")
     else:
         _log(f"  Dev timeout: {_dev_timeout}s")
+    _plan_files = plan_file_list(state.plan_structured)
+    _scaled_stuck = _scale_stuck_for_complexity(
+        config.stuck_detection,
+        state.preflight_complexity,
+        len(_plan_files),
+    )
+    if (
+        _scaled_stuck.no_progress_iterations != config.stuck_detection.no_progress_iterations
+        or _scaled_stuck.post_nudge_iterations != config.stuck_detection.post_nudge_iterations
+    ):
+        _log_verbose(
+            f"  Stuck-detection scaled for {state.preflight_complexity} "
+            f"({len(_plan_files)} plan files): "
+            f"no_progress={_scaled_stuck.no_progress_iterations} "
+            f"(base {config.stuck_detection.no_progress_iterations}), "
+            f"post_nudge={_scaled_stuck.post_nudge_iterations} "
+            f"(base {config.stuck_detection.post_nudge_iterations})"
+        )
     _dev_profile = _dc_replace(
         config.dev_profile,
         timeout_seconds=_dev_timeout,
         max_iterations=state.adaptive_dev_max or config.dev_profile.max_iterations,
-        stuck_detection=config.stuck_detection,
+        stuck_detection=_scaled_stuck,
     )
 
     _dev_start = time.monotonic()

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -894,3 +894,14 @@ class TestStuckDetectionConfigParsing:
                 assert "no_progress_multipliers" in str(exc) and "positive" in str(exc)
             else:
                 raise AssertionError(f"expected ValueError for {bad!r}")
+
+    def test_parse_rejects_non_finite_multiplier_value(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            try:
+                _parse_stuck_detection({"post_nudge_multipliers": {"large": bad}})
+            except ValueError as exc:
+                assert "post_nudge_multipliers" in str(exc) and "finite" in str(exc)
+            else:
+                raise AssertionError(f"expected ValueError for {bad!r}")

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -843,3 +843,54 @@ class TestStuckDetectionConfigParsing:
             assert "no_progress_iterations" in str(exc)
         else:
             raise AssertionError("expected ValueError")
+
+    def test_parse_multiplier_overrides(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        cfg = _parse_stuck_detection(
+            {
+                "no_progress_multipliers": {"small": 1.0, "medium": 2.0, "large": 3.5},
+                "post_nudge_multipliers": {"small": 1.0, "medium": 1.75, "large": 2.5},
+            }
+        )
+        assert cfg.no_progress_multipliers == {"small": 1.0, "medium": 2.0, "large": 3.5}
+        assert cfg.post_nudge_multipliers == {"small": 1.0, "medium": 1.75, "large": 2.5}
+
+    def test_parse_multiplier_defaults_when_absent(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        cfg = _parse_stuck_detection({"no_progress_iterations": 7})
+        defaults = StuckDetectionConfig()
+        assert cfg.no_progress_multipliers == defaults.no_progress_multipliers
+        assert cfg.post_nudge_multipliers == defaults.post_nudge_multipliers
+
+    def test_parse_rejects_non_mapping_multiplier(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        try:
+            _parse_stuck_detection({"no_progress_multipliers": [1.0, 2.0]})
+        except ValueError as exc:
+            assert "no_progress_multipliers" in str(exc) and "mapping" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_parse_rejects_non_string_multiplier_key(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        try:
+            _parse_stuck_detection({"post_nudge_multipliers": {3: 1.0}})
+        except ValueError as exc:
+            assert "post_nudge_multipliers" in str(exc) and "string" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_parse_rejects_non_positive_multiplier_value(self):
+        from theforge.config.load import _parse_stuck_detection
+
+        for bad in (0, -1.0, "fast", True):
+            try:
+                _parse_stuck_detection({"no_progress_multipliers": {"large": bad}})
+            except ValueError as exc:
+                assert "no_progress_multipliers" in str(exc) and "positive" in str(exc)
+            else:
+                raise AssertionError(f"expected ValueError for {bad!r}")

--- a/tests/test_stuck_detection_scaling.py
+++ b/tests/test_stuck_detection_scaling.py
@@ -1,0 +1,79 @@
+"""Tests for stuck-detection threshold scaling by story complexity and plan size."""
+
+from __future__ import annotations
+
+from theforge.config import StuckDetectionConfig
+from theforge.coordinator.dev_phase import _scale_stuck_for_complexity
+
+
+def test_scale_no_complexity_unchanged():
+    cfg = StuckDetectionConfig()
+    out = _scale_stuck_for_complexity(cfg, None, 0)
+    assert out.no_progress_iterations == cfg.no_progress_iterations
+    assert out.post_nudge_iterations == cfg.post_nudge_iterations
+
+
+def test_scale_small_unchanged():
+    cfg = StuckDetectionConfig()
+    out = _scale_stuck_for_complexity(cfg, "small", 0)
+    assert out.no_progress_iterations == cfg.no_progress_iterations
+    assert out.post_nudge_iterations == cfg.post_nudge_iterations
+
+
+def test_scale_medium_scales_up():
+    cfg = StuckDetectionConfig(no_progress_iterations=5, post_nudge_iterations=3)
+    out = _scale_stuck_for_complexity(cfg, "medium", 0)
+    assert out.no_progress_iterations == round(5 * 1.5)
+    assert out.post_nudge_iterations == round(3 * 1.5)
+
+
+def test_scale_large_scales_up():
+    cfg = StuckDetectionConfig(no_progress_iterations=5, post_nudge_iterations=3)
+    out = _scale_stuck_for_complexity(cfg, "large", 0)
+    assert out.no_progress_iterations == round(5 * 2.5)
+    assert out.post_nudge_iterations == round(3 * 2.0)
+
+
+def test_plan_file_count_added_to_no_progress():
+    cfg = StuckDetectionConfig(no_progress_iterations=5, post_nudge_iterations=3)
+    out = _scale_stuck_for_complexity(cfg, "large", 4)
+    assert out.no_progress_iterations == round(5 * 2.5) + 4
+
+
+def test_scale_never_lowers_thresholds():
+    # If a complexity is unknown or multiplier < 1.0, scaling must not reduce.
+    cfg = StuckDetectionConfig(
+        no_progress_iterations=10,
+        post_nudge_iterations=10,
+        no_progress_multipliers={"tiny": 0.1},
+        post_nudge_multipliers={"tiny": 0.1},
+    )
+    out = _scale_stuck_for_complexity(cfg, "tiny", 0)
+    assert out.no_progress_iterations == 10
+    assert out.post_nudge_iterations == 10
+
+
+def test_user_override_multipliers_flow_through():
+    cfg = StuckDetectionConfig(
+        no_progress_iterations=4,
+        post_nudge_iterations=2,
+        no_progress_multipliers={"large": 5.0},
+        post_nudge_multipliers={"large": 4.0},
+    )
+    out = _scale_stuck_for_complexity(cfg, "large", 0)
+    assert out.no_progress_iterations == round(4 * 5.0)
+    assert out.post_nudge_iterations == round(2 * 4.0)
+
+
+def test_default_multiplier_dicts():
+    cfg = StuckDetectionConfig()
+    assert cfg.no_progress_multipliers == {"small": 1.0, "medium": 1.5, "large": 2.5}
+    assert cfg.post_nudge_multipliers == {"small": 1.0, "medium": 1.5, "large": 2.0}
+
+
+def test_unchanged_fields_preserved():
+    cfg = StuckDetectionConfig(repeat_threshold=7, error_threshold=9, enabled=False)
+    out = _scale_stuck_for_complexity(cfg, "large", 2)
+    assert out.repeat_threshold == 7
+    assert out.error_threshold == 9
+    assert out.enabled is False


### PR DESCRIPTION
## Summary
- Stuck-detection was false-terminating dev agents on LARGE stories during legitimate codebase exploration. Caused #1071's full chain of false-success
- Adds per-complexity multipliers (small 1.0×, medium 1.5×, large 2.5×/2.0×) and a plan-file bonus

## Test plan
- [x] Unit tests for the scaling helper
- [x] Integration test: profile construction wires complexity + plan_files into the runner
- [x] Full gate: 3678 passed

Closes #1130