### PR TITLE
Preflight under-sizes concurrent multi-phase coordinator work

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -36,6 +36,97 @@ _COMPLEXITY_TO_LEVEL: dict[str, str] = {
     "large": "HIGH",
 }
 
+_CONCURRENCY_CONTROL_TERMS = (
+    "thread",
+    "threads",
+    "process",
+    "processes",
+    "async",
+    "asynchronous",
+    "asyncio",
+    "concurrency",
+    "concurrent",
+    "inter thread",
+    "inter process",
+)
+
+_CANCELLATION_TERMS = (
+    "cancel",
+    "cancellation",
+    "abort signal",
+    "stop signal",
+    "shutdown",
+    "lifecycle",
+)
+
+_CROSS_BOUNDARY_TERMS = (
+    "propagate",
+    "propagation",
+    "thread through",
+    "threads through",
+    "threading through",
+    "across module",
+    "across modules",
+    "module boundaries",
+    "boundary",
+    "boundaries",
+    "handoff",
+    "handoffs",
+)
+
+_PHASE_TRANSITION_TERMS = (
+    "multi phase",
+    "multiple phases",
+    "phase transition",
+    "phase transitions",
+    "phase boundary",
+    "phase boundaries",
+    "phase handoff",
+    "phase handoffs",
+    "across phases",
+    "every phase",
+    "state machine",
+)
+
+_COORDINATOR_COMPONENT_TERMS = (
+    "runner",
+    "engine",
+    "coordinator",
+    "coordinator loop",
+    "phase",
+    "phases",
+)
+
+_COORDINATION_CHANGE_TERMS = (
+    "modify",
+    "modifies",
+    "modification",
+    "change",
+    "changes",
+    "changing",
+    "update",
+    "updates",
+    "thread",
+    "threads",
+    "propagate",
+    "propagation",
+    "coordinate",
+    "coordinated",
+    "together",
+    "all sites",
+    "correctness depends",
+)
+
+_CROSS_MODULE_TERMS = (
+    "cross module",
+    "cross modules",
+    "multi module",
+    "multi modules",
+    "module boundaries",
+    "all sites",
+    "correctness depends",
+)
+
 # Integer complexity scale bounds. Preflight emits a score in this range;
 # out-of-range or missing scores fall back to the legacy three-level enum.
 COMPLEXITY_SCORE_MIN = 1
@@ -68,6 +159,61 @@ def band_to_score(band: str) -> int:
     if norm == "large":
         return 9
     return 5  # medium or unknown
+
+
+def _normalize_story_text_for_match(text: str) -> str:
+    """Normalize free-form story text for coarse phrase matching."""
+    normalized = re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+    return f" {normalized} " if normalized else " "
+
+
+def _contains_any_phrase(normalized_text: str, phrases: tuple[str, ...]) -> bool:
+    """Return True when any normalized phrase appears in normalized_text."""
+    return any(
+        f" {_normalize_story_text_for_match(phrase).strip()} " in normalized_text
+        for phrase in phrases
+    )
+
+
+def _count_phrase_hits(normalized_text: str, phrases: tuple[str, ...]) -> int:
+    """Count how many distinct normalized phrases appear in normalized_text."""
+    return sum(
+        1
+        for phrase in phrases
+        if f" {_normalize_story_text_for_match(phrase).strip()} " in normalized_text
+    )
+
+
+def _detect_large_preflight_story_categories(story_content: str) -> list[str]:
+    """Return LARGE-trigger categories detected directly from story text.
+
+    These categories are deterministic coordinator-side guardrails for work that
+    tends to be under-sized by local edit count alone.
+    """
+    normalized = _normalize_story_text_for_match(story_content)
+    matched: list[str] = []
+
+    if _contains_any_phrase(normalized, _CONCURRENCY_CONTROL_TERMS):
+        matched.append("concurrency control")
+
+    if _contains_any_phrase(normalized, _CANCELLATION_TERMS) and (
+        _contains_any_phrase(normalized, _CROSS_BOUNDARY_TERMS)
+        or _count_phrase_hits(normalized, _COORDINATOR_COMPONENT_TERMS) >= 2
+    ):
+        matched.append("lifecycle/cancellation propagation across module boundaries")
+
+    if _contains_any_phrase(normalized, _PHASE_TRANSITION_TERMS) and _contains_any_phrase(
+        normalized, _COORDINATION_CHANGE_TERMS
+    ):
+        matched.append("multi-phase state-machine modifications")
+
+    if _count_phrase_hits(normalized, _COORDINATOR_COMPONENT_TERMS) >= 2 and (
+        _contains_any_phrase(normalized, _CROSS_MODULE_TERMS)
+        or _contains_any_phrase(normalized, _COORDINATION_CHANGE_TERMS)
+    ):
+        matched.append("cross-module coordinator surgery")
+
+    return list(dict.fromkeys(matched))
 
 
 def score_to_dev_tier(score: int) -> str:

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -38,6 +38,7 @@ from .log_tee import _write_log_artifact
 from .notify import _escalate_notify, _ntfy_done_notify
 from .preflight import (
     _apply_preflight_config,
+    _detect_large_preflight_story_categories,
     _parse_preflight_bundle_candidate,
     _parse_preflight_complexity,
     _parse_preflight_complexity_score,
@@ -367,6 +368,23 @@ def _run_preflight_phase(
                 "  ↑ contract_change=true: upgrading complexity small→medium "
                 "(cross-cutting blast radius)"
             )
+
+        large_story_categories = _detect_large_preflight_story_categories(story_content)
+        if large_story_categories and (
+            complexity != "large"
+            or state.preflight_complexity_score is None
+            or state.preflight_complexity_score < 8
+        ):
+            complexity = "large"
+            state.preflight_complexity = complexity
+            if state.preflight_complexity_score is None or state.preflight_complexity_score < 8:
+                state.preflight_complexity_score = 8
+            override_reason = (
+                "coordinator override: upgraded complexity to large for "
+                + ", ".join(large_story_categories)
+            )
+            state.preflight_warnings = list(state.preflight_warnings or []) + [override_reason]
+            _log(f"  ↑ {override_reason}")
 
         _log(f"  Complexity: {complexity} (from preflight)")
         _log(f"  Sufficiency: {sufficiency}")

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -142,6 +142,20 @@ def build_preflight_prompt(
           of a phase of the state machine, changes that touch >10 files or
           require coordinated migration across the codebase.
 
+        Treat the following as **LARGE (score 8+) even if the local edit count
+        looks modest**:
+        - Concurrency control: threads, processes, async cancellation,
+          inter-thread/inter-process coordination
+        - Lifecycle or cancellation propagation across module boundaries
+        - Multi-phase state-machine modifications, phase-boundary changes, or
+          phase handoff changes
+        - Cross-module coordinator surgery where correctness depends on runner /
+          engine / phase sites changing together
+
+        Size the **category of work**, not just the apparent line count. Apply
+        this rule regardless of provider model, story wording, product area, or
+        repository language.
+
         Keep the enum consistent with the score using the default mapping
         (1–3 → small, 4–7 → medium, 8–10 → large) unless you have a specific
         reason to diverge. If a change touches a shared interface field,

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -342,6 +342,70 @@ likely_files:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
+    def test_concurrency_multiphase_story_upgrades_medium_preflight_to_large_for_routing(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Concurrency-sensitive coordinator surgery is force-sized to LARGE."""
+        config = _make_smart_config(tmp_path)
+        task = _make_task(tmp_path)
+        task.story_path.write_text(
+            """# Test Spec
+
+Thread a per-story cancellation signal through the sprint runner, coordinator loop,
+and every phase function. Insert cancellation checks at each phase boundary and
+update the state machine handoff so cleanup does not emit duplicate terminal records.
+""",
+            encoding="utf-8",
+        )
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True,
+            output="""```yaml
+verdict: PROCEED
+complexity: medium
+complexity_score: 5
+work_type: bug
+contract_change: false
+reason: "Looks like a medium multi-file coordinator fix."
+sufficiency: implementation_ready
+sufficiency_reason: "Spec is detailed."
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "Cancellation signal reaches every phase boundary"
+    satisfied: false
+    evidence: "Not found in codebase"
+```""",
+        )
+        mock_agent.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.preflight_complexity == "large"
+        assert result.state.preflight_complexity_score == 8
+        assert any(
+            "coordinator override: upgraded complexity to large" in warning
+            for warning in result.state.preflight_warnings
+        )
+        audit = result.state.complexity_routing_audit
+        assert audit is not None
+        assert audit["complexity"] == "large"
+        assert audit["complexity_score"] == 8
+        assert audit["derived_dev_model"] == "opus"
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
     def test_preflight_cost_in_audit(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):

--- a/tests/test_preflight_complexity_score.py
+++ b/tests/test_preflight_complexity_score.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from theforge.config import (
     DEFAULT_VALIDATION,
     MODEL_REGISTRY,
@@ -22,6 +24,7 @@ from theforge.coordinator.preflight import (
     COMPLEXITY_SCORE_MAX,
     COMPLEXITY_SCORE_MIN,
     _apply_complexity_adaptation,
+    _detect_large_preflight_story_categories,
     _parse_preflight_complexity_score,
     band_to_score,
     score_to_band,
@@ -174,6 +177,39 @@ def test_parse_score_malformed_yaml_returns_none():
 def test_parse_score_non_numeric_value():
     # Non-integer value with no fallback — the field is effectively missing.
     assert _parse_preflight_complexity_score(_yaml_output(complexity_score="huge")) is None
+
+
+@pytest.mark.parametrize(
+    ("story_text", "expected_category"),
+    [
+        (
+            "Acceptance criteria require inter-thread coordination and concurrent worker"
+            " shutdown semantics across the runtime.",
+            "concurrency control",
+        ),
+        (
+            "Thread a cancellation signal through the sprint runner, coordinator loop,"
+            " and every phase function so lifecycle state propagates across module"
+            " boundaries.",
+            "lifecycle/cancellation propagation across module boundaries",
+        ),
+        (
+            "Modify phase handoffs at every phase boundary so the coordinator state"
+            " machine carries the new signal across phases.",
+            "multi-phase state-machine modifications",
+        ),
+        (
+            "Coordinate runner, engine, and phase-module changes together because"
+            " correctness depends on all sites changing in lockstep.",
+            "cross-module coordinator surgery",
+        ),
+    ],
+)
+def test_detect_large_preflight_story_categories_for_representative_stories(
+    story_text: str, expected_category: str
+):
+    matches = _detect_large_preflight_story_categories(story_text)
+    assert expected_category in matches
 
 
 # ── consumer: dev-tier routing diverges from enum-only routing ────────

--- a/tests/test_task_preflight_prompt.py
+++ b/tests/test_task_preflight_prompt.py
@@ -75,3 +75,16 @@ def test_build_preflight_prompt_output_under_uncertainty() -> None:
 
     assert "You MUST always produce output" in prompt
     assert "Withholding output" in prompt
+
+
+def test_build_preflight_prompt_marks_concurrency_and_multiphase_work_as_large() -> None:
+    task = TaskStory(name="Bug fix", slug="bug-fix")
+
+    prompt = build_preflight_prompt(task, story_content="## Spec\n\n- Example")
+
+    assert "Treat the following as **LARGE (score 8+) even if the local edit count" in prompt
+    assert "Concurrency control" in prompt
+    assert "Lifecycle or cancellation propagation across module boundaries" in prompt
+    assert "Multi-phase state-machine modifications" in prompt
+    assert "Cross-module coordinator surgery" in prompt
+    assert "regardless of provider model, story wording, product area, or" in prompt


### PR DESCRIPTION
## Summary

Deterministic coordinator-side heuristic correctly upgrades concurrency/multi-phase stories to LARGE; seam test confirms routing propagation; all four ACs met.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.45
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/preflight.py:39`** _CONCURRENCY_CONTROL_TERMS includes bare 'async', 'process', and 'thread' (verb form). Any story using Python async patterns, process-level concepts, or 'thread a value through config' will trigger the concurrency-control category regardless of whether the work is actually concurrent. Over-sizing is cheap, but this heuristic will fire on a wide class of non-concurrent stories.
- **[P2] `src/theforge/coordinator/preflight.py:83`** _COORDINATOR_COMPONENT_TERMS includes 'runner', 'engine', 'coordinator', 'phase', 'phases' — TheForge-internal architecture names. The cross-module surgery rule fires when any two of these appear together with a coordination-change verb. A story for a non-TheForge project that mentions 'runner' and 'phase' (common words in build/CI contexts) paired with 'update' would get a false LARGE. This is a stack-neutrality concern per the 'Core orchestrator modules must be stack-neutral' convention.
- **[P2] `src/theforge/coordinator/preflight.py:96`** _COORDINATION_CHANGE_TERMS includes 'change', 'changes', 'changing', 'update', 'updates' — extremely common verbs. The multi-phase and cross-module checks using this list require very low signal to trigger (e.g., any story mentioning 'state machine' + 'update' fires multi-phase). The catch is intentionally conservative, but the broad verbs reduce discriminative value.

## Story

Preflight under-sizes concurrent multi-phase coordinator work (GitHub Issue #1136)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1136