### PR TITLE
Plan file-count helper returns 0 for plans that declare target files

### DIFF
--- a/src/theforge/task/plan_parser.py
+++ b/src/theforge/task/plan_parser.py
@@ -31,6 +31,33 @@ class PlanData(_PlanDataRequired, total=False):
     risks: list[dict]
 
 
+def _extract_plan_block(text: str) -> str | None:
+    """Return the rooted ``plan:`` YAML block from mixed agent output."""
+
+    lines = text.strip().splitlines()
+    start_index: int | None = None
+    base_indent = 0
+
+    for index, line in enumerate(lines):
+        if line.lstrip().startswith("plan:"):
+            start_index = index
+            base_indent = len(line) - len(line.lstrip())
+            break
+
+    if start_index is None:
+        return None
+
+    block: list[str] = []
+    for index, line in enumerate(lines[start_index:], start=start_index):
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        if index > start_index and stripped and indent <= base_indent:
+            break
+        block.append(line[base_indent:] if len(line) >= base_indent else line)
+
+    return "\n".join(block).strip() or None
+
+
 def parse_plan_output(text: str) -> PlanData | None:
     """Parse structured YAML plan output from a plan agent.
 
@@ -38,23 +65,12 @@ def parse_plan_output(text: str) -> PlanData | None:
     structured plan YAML (e.g. freeform markdown fallback).
     """
     stripped = text.strip()
-
-    # Strip fenced code block if present (```yaml ... ```)
-    if stripped.startswith("```"):
-        lines = stripped.splitlines()
-        # Remove first line (```yaml or ```) and last line (```)
-        inner = lines[1:]
-        if inner and inner[-1].strip() == "```":
-            inner = inner[:-1]
-        stripped = "\n".join(inner).strip()
-
-    # Detect YAML plan: starts with 'plan:' or '---' followed by 'plan:'
-    if not (stripped.startswith("plan:") or stripped.startswith("---")):
+    if not stripped:
         return None
 
-    # Strip YAML document markers if present
-    if stripped.startswith("---"):
-        stripped = stripped[3:].strip()
+    stripped = _extract_plan_block(stripped)
+    if stripped is None:
+        return None
 
     try:
         data = yaml.safe_load(stripped)

--- a/tests/test_coord_context_assembly.py
+++ b/tests/test_coord_context_assembly.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from tests.coord_test_helpers import (
     APPROVE_REVIEW,
+    PREFLIGHT_PROCEED_MEDIUM,
     _make_agent_result,
     _make_config,
     _make_plan_config,
@@ -178,3 +179,76 @@ def test_run_task_invokes_context_assembler_for_all_phases(
         "tests/test_app.py",
         "docs/notes.md",
     ]
+
+
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+@patch("theforge.coordinator.plan_flow.run_agent")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.dev_phase.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+def test_prose_prefixed_plan_reaches_dev_file_count_and_scaling_log(
+    mock_shell, mock_dev, mock_preflight, mock_plan, mock_pool, tmp_path
+):
+    config = _make_plan_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir()
+
+    mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+    mock_preflight.return_value = _make_agent_result(
+        success=True,
+        output=PREFLIGHT_PROCEED_MEDIUM,
+        profile_name="preflight",
+    )
+    mock_plan.return_value = _make_agent_result(
+        success=True,
+        output=(
+            "I checked the codebase and the structured plan is below.\n\n"
+            "```yaml\n"
+            "plan:\n"
+            "  approach: Update code and tests together.\n"
+            "  steps:\n"
+            "    - id: 1\n"
+            "      description: Update implementation\n"
+            "      files:\n"
+            "        - src/app.py\n"
+            "      action: modify\n"
+            "      details: Apply the behavior change.\n"
+            "    - id: 2\n"
+            "      description: Add coverage\n"
+            "      files:\n"
+            "        - tests/test_app.py\n"
+            "        - src/app.py\n"
+            "      action: modify\n"
+            "      details: Verify the changed behavior.\n"
+            "      depends_on: [1]\n"
+            "```\n"
+        ),
+        profile_name="plan",
+    )
+    mock_dev.return_value = _make_agent_result(success=True, output="Done.", profile_name="dev")
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+    ]
+
+    verbose_messages: list[str] = []
+    _AssemblerSpy.calls = []
+
+    with (
+        patch("theforge.coordinator.preflight_flow.ContextAssembler", _AssemblerSpy),
+        patch("theforge.coordinator.plan_flow.ContextAssembler", _AssemblerSpy),
+        patch("theforge.coordinator.dev_phase.ContextAssembler", _AssemblerSpy),
+        patch("theforge.coordinator.review_pool.ContextAssembler", _AssemblerSpy, create=True),
+        patch(
+            "theforge.coordinator.dev_phase._log_verbose",
+            side_effect=lambda msg: verbose_messages.append(msg),
+        ),
+    ):
+        result = run_task(config, task)
+
+    assert result.success is True
+    assert _AssemblerSpy.calls[2]["phase"] == "dev"
+    assert _AssemblerSpy.calls[2]["file_list"] == ["src/app.py", "tests/test_app.py"]
+    assert any(
+        "Stuck-detection scaled for medium (2 plan files)" in msg for msg in verbose_messages
+    )

--- a/tests/test_task_plan.py
+++ b/tests/test_task_plan.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from theforge.coordinator.context_scope import plan_file_list
 from theforge.task import (
     PlanData,
     TaskStory,
@@ -36,6 +37,12 @@ def _minimal_plan_yaml(description: str = "do it") -> str:
         "      action: modify\n"
         "      details: change the code\n"
     )
+
+
+def _parse_plan_files(text: str) -> list[str]:
+    plan = parse_plan_output(text)
+    assert plan is not None
+    return plan_file_list(plan)
 
 
 class TestBuildDevPromptStructuredHandoff:
@@ -443,6 +450,127 @@ class TestParsePlanOutputYamlMarker:
         result = parse_plan_output(yaml_input)
         assert result is not None
         assert result["steps"][0]["description"] == "plain step"
+
+
+class TestParsePlanOutputFileCounting:
+    def test_prose_before_fenced_plan_still_counts_files(self):
+        plan_text = (
+            "I inspected the repo and here is the plan.\n\n"
+            "```yaml\n"
+            "plan:\n"
+            "  approach: Keep the change tight.\n"
+            "  steps:\n"
+            "    - id: 1\n"
+            "      description: Update the implementation\n"
+            "      files:\n"
+            "        - src/app.py\n"
+            "        - tests/test_app.py\n"
+            "      action: modify\n"
+            "      details: Make the behavior match the spec.\n"
+            "```\n"
+        )
+
+        assert _parse_plan_files(plan_text) == ["src/app.py", "tests/test_app.py"]
+
+    def test_prose_before_bare_plan_still_counts_files(self):
+        plan_text = (
+            "Plan follows.\n\n"
+            "plan:\n"
+            "  approach: Update the parser.\n"
+            "  steps:\n"
+            "    - id: 1\n"
+            "      description: Fix plan extraction\n"
+            "      files:\n"
+            "        - src/theforge/task/plan_parser.py\n"
+            "      action: modify\n"
+            "      details: Parse the structured block.\n"
+        )
+
+        assert _parse_plan_files(plan_text) == ["src/theforge/task/plan_parser.py"]
+
+    def test_distinct_file_count_survives_multi_step_plan_shapes(self):
+        plan_text = """\
+plan:
+  approach: Cover each caller with a small step.
+  steps:
+    - id: 1
+      description: Touch the parser
+      files:
+        - src/theforge/task/plan_parser.py
+      action: modify
+      details: Parse plan YAML more robustly.
+    - id: 2
+      description: Wire the coordinator path
+      files:
+        - src/theforge/coordinator/plan_flow.py
+        - src/theforge/coordinator/dev_phase.py
+      action: modify
+      details: Preserve the parsed plan across phases.
+      depends_on: [1]
+    - id: 3
+      description: Cover helper behavior
+      files:
+        - src/theforge/coordinator/context_scope.py
+        - tests/test_coord_context_assembly.py
+      action: modify
+      details: Assert deduped file extraction.
+      depends_on: [1]
+    - id: 4
+      description: Add parser coverage
+      files:
+        - tests/test_task_plan.py
+      action: modify
+      details: Cover prose-prefixed plans.
+      depends_on: [1]
+    - id: 5
+      description: Reuse the parser file in another step
+      files:
+        - src/theforge/task/plan_parser.py
+      action: modify
+      details: Reconfirm the same target is only counted once.
+      depends_on: [1]
+    - id: 6
+      description: Validate the end-to-end flow
+      files:
+        - tests/test_coord_context_assembly.py
+        - src/theforge/coordinator/dev_phase.py
+      action: modify
+      details: Confirm the scaled count reaches the audit log.
+      depends_on: [2, 3, 4]
+"""
+
+        assert _parse_plan_files(plan_text) == [
+            "src/theforge/task/plan_parser.py",
+            "src/theforge/coordinator/plan_flow.py",
+            "src/theforge/coordinator/dev_phase.py",
+            "src/theforge/coordinator/context_scope.py",
+            "tests/test_coord_context_assembly.py",
+            "tests/test_task_plan.py",
+        ]
+
+    def test_empty_or_null_file_lists_do_not_count(self):
+        plan_text = """\
+plan:
+  approach: Handle sparse steps safely.
+  steps:
+    - id: 1
+      description: Empty file list
+      files: []
+      action: modify
+      details: No targets declared yet.
+    - id: 2
+      description: Null file list
+      files: null
+      action: modify
+      details: Provider omitted the list value.
+    - id: 3
+      description: Real target
+      files: [src/real.py, tests/test_real.py]
+      action: modify
+      details: Only declared paths should count.
+"""
+
+        assert _parse_plan_files(plan_text) == ["src/real.py", "tests/test_real.py"]
 
 
 class TestPromptContextPack:


### PR DESCRIPTION
## Summary

Fix correctly extends _extract_plan_block to scan past prose preambles and fenced code delimiters before extracting the plan: YAML block; seam test and parser unit tests together satisfy both ACs.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.64
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Plan file-count helper returns 0 for plans that declare target files (GitHub Issue #1135)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1135