### PR TITLE
Collision-derived DAG edges should be soft — drop them when upstream escalates without merging

### DIFF
--- a/src/theforge/sprint/collision.py
+++ b/src/theforge/sprint/collision.py
@@ -263,6 +263,6 @@ def inject_synthetic_deps(
         if task.slug not in synthetic:
             augmented.append(task)
             continue
-        merged = sorted(set(task.depends_on) | set(synthetic[task.slug]))
-        augmented.append(replace(task, depends_on=merged))
+        merged = sorted(set(task.collision_deps) | set(synthetic[task.slug]))
+        augmented.append(replace(task, collision_deps=merged))
     return augmented

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -230,19 +230,30 @@ class StoryDAG:
 
     def __init__(self, tasks: list[TaskStory], satisfied: set[str] | None = None) -> None:
         self._tasks: dict[str, TaskStory] = {t.slug: t for t in tasks}
-        self._deps: dict[str, set[str]] = {t.slug: set(t.depends_on) for t in tasks}
+        self._hard_deps: dict[str, set[str]] = {t.slug: set(t.depends_on) for t in tasks}
+        self._soft_deps: dict[str, set[str]] = {t.slug: set(t.collision_deps) for t in tasks}
         self._completed: set[str] = (
             set(satisfied) if satisfied else set()
         )  # satisfied: merged or ALREADY_DONE
         self._finished: set[str] = set()  # all done: any outcome
 
     def ready(self) -> list[TaskStory]:
-        """Return tasks that are not finished and whose deps are all completed."""
+        """Return tasks that are not finished and whose deps are all released.
+
+        Hard deps (``depends_on``) must be in ``_completed``. Soft deps
+        (``collision_deps``) release on any terminal state — completed OR
+        finished — because the upstream reaching a terminal-but-not-merged
+        state means the collision the synthetic edge guarded against does
+        not exist on disk, so the downstream can proceed.
+        """
         return [
             task
             for slug, task in self._tasks.items()
             if slug not in self._finished
-            and all(dep in self._completed for dep in self._deps[slug])
+            and all(dep in self._completed for dep in self._hard_deps[slug])
+            and all(
+                dep in self._completed or dep in self._finished for dep in self._soft_deps[slug]
+            )
         ]
 
     def mark_complete(self, slug: str) -> None:
@@ -260,8 +271,19 @@ class StoryDAG:
         return len(self._finished) == len(self._tasks)
 
     def unmet_deps(self, slug: str) -> list[str]:
-        """Dependency slugs that are not yet completed (for skip messages)."""
-        return [dep for dep in self._deps[slug] if dep not in self._completed]
+        """Dependency slugs that genuinely block this story (for skip messages).
+
+        Hard deps are unmet when not yet completed. Soft (collision) deps are
+        unmet only when their upstream has not reached any terminal state —
+        a terminal-but-not-merged upstream releases the soft edge.
+        """
+        unmet = [dep for dep in self._hard_deps[slug] if dep not in self._completed]
+        unmet.extend(
+            dep
+            for dep in self._soft_deps[slug]
+            if dep not in self._completed and dep not in self._finished
+        )
+        return unmet
 
     def remaining(self) -> list[TaskStory]:
         """Tasks not yet finished (not in _finished)."""

--- a/src/theforge/task/story.py
+++ b/src/theforge/task/story.py
@@ -19,6 +19,9 @@ class TaskStory:
     test_target: str | None = None  # stack-neutral test target substituted into gate_command
     gate_override: str | None = None  # from frontmatter "gate" key; "none" skips gate
     depends_on: list[str] = field(default_factory=list)  # slugs that must have merged first
+    collision_deps: list[str] = field(
+        default_factory=list
+    )  # slugs injected by collision detection; soft edges that release on any terminal upstream
     inferred_dependencies: list[str] = field(default_factory=list)  # inferred from GH blockers
     dependency_warnings: list[str] = field(default_factory=list)  # non-authoritative prose matches
     github_issue: int | None = None  # GH issue number; PR will include "Closes #N"

--- a/tests/test_sprint_collision.py
+++ b/tests/test_sprint_collision.py
@@ -42,7 +42,7 @@ def test_compute_synthetic_edges_example_chain() -> None:
     }
 
 
-def test_inject_synthetic_deps_merges_without_duplicates() -> None:
+def test_inject_synthetic_deps_writes_to_collision_deps() -> None:
     tasks = [
         _task("story-12", 12),
         _task("story-15", 15, depends_on=["base", "story-12"]),
@@ -50,7 +50,10 @@ def test_inject_synthetic_deps_merges_without_duplicates() -> None:
 
     augmented = inject_synthetic_deps(tasks, {"story-15": ["story-12", "extra"]})
 
-    assert augmented[1].depends_on == ["base", "extra", "story-12"]
+    # depends_on (hard edges) must be untouched; collision edges land in
+    # collision_deps so the DAG can release them on terminal-but-not-merged.
+    assert augmented[1].depends_on == ["base", "story-12"]
+    assert augmented[1].collision_deps == ["extra", "story-12"]
 
 
 def test_compute_synthetic_edges_ignores_missing_likely_files() -> None:

--- a/tests/test_sprint_dag_soft_edges.py
+++ b/tests/test_sprint_dag_soft_edges.py
@@ -1,0 +1,159 @@
+"""Soft (collision-derived) dependency edge semantics in StoryDAG.
+
+Collision-derived edges sit in ``TaskStory.collision_deps`` and have weaker
+release semantics than explicit ``depends_on``: a soft upstream that reaches
+any terminal state (mark_skipped or mark_complete) releases its downstream,
+because main is unchanged at terminal-but-not-merged and the collision the
+synthetic edge guarded against does not exist.
+"""
+
+from pathlib import Path
+
+from theforge.coordinator.state import CoordinatorState
+from theforge.sprint.collision import compute_synthetic_edges, inject_synthetic_deps
+from theforge.sprint.dag import StoryDAG, build_dag
+from theforge.task import TaskStory
+
+
+def _task(
+    slug: str,
+    *,
+    depends_on: list[str] | None = None,
+    collision_deps: list[str] | None = None,
+) -> TaskStory:
+    return TaskStory(
+        name=slug,
+        slug=slug,
+        story_path=Path(f"stories/{slug}.md"),
+        depends_on=depends_on or [],
+        collision_deps=collision_deps or [],
+    )
+
+
+def test_soft_dep_released_when_upstream_skipped() -> None:
+    upstream = _task("up")
+    down = _task("down", collision_deps=["up"])
+    dag = StoryDAG([upstream, down])
+
+    # Initially blocked (upstream not yet terminal).
+    assert {t.slug for t in dag.ready()} == {"up"}
+
+    dag.mark_skipped("up")
+
+    assert "down" in {t.slug for t in dag.ready()}
+
+
+def test_soft_dep_released_when_upstream_completed() -> None:
+    upstream = _task("up")
+    down = _task("down", collision_deps=["up"])
+    dag = StoryDAG([upstream, down])
+
+    dag.mark_complete("up")
+
+    assert "down" in {t.slug for t in dag.ready()}
+
+
+def test_hard_dep_blocks_when_upstream_skipped() -> None:
+    upstream = _task("up")
+    down = _task("down", depends_on=["up"])
+    dag = StoryDAG([upstream, down])
+
+    dag.mark_skipped("up")
+
+    # Hard edge stays blocking even when upstream reaches a terminal state.
+    assert "down" not in {t.slug for t in dag.ready()}
+
+
+def test_mixed_hard_and_soft_release_on_completion_and_skip() -> None:
+    hard_up = _task("hard-up")
+    soft_up = _task("soft-up")
+    down = _task("down", depends_on=["hard-up"], collision_deps=["soft-up"])
+    dag = StoryDAG([hard_up, soft_up, down])
+
+    # Neither upstream finished yet.
+    assert "down" not in {t.slug for t in dag.ready()}
+
+    dag.mark_skipped("soft-up")
+    # Soft released, but hard upstream not yet completed.
+    assert "down" not in {t.slug for t in dag.ready()}
+
+    dag.mark_complete("hard-up")
+    assert "down" in {t.slug for t in dag.ready()}
+
+
+def test_soft_dep_blocks_until_upstream_terminal() -> None:
+    upstream = _task("up")
+    down = _task("down", collision_deps=["up"])
+    dag = StoryDAG([upstream, down])
+
+    # Upstream not yet finished — soft dep still blocks.
+    assert "down" not in {t.slug for t in dag.ready()}
+
+
+def test_unmet_deps_excludes_terminal_soft_upstream() -> None:
+    hard_up = _task("hard-up")
+    soft_up = _task("soft-up")
+    down = _task("down", depends_on=["hard-up"], collision_deps=["soft-up"])
+    dag = StoryDAG([hard_up, soft_up, down])
+
+    dag.mark_skipped("soft-up")
+
+    # soft-up reached a terminal state, so it is no longer reported as unmet.
+    # hard-up is still pending and stays in unmet.
+    assert dag.unmet_deps("down") == ["hard-up"]
+
+
+def test_unmet_deps_includes_pending_soft_upstream() -> None:
+    soft_up = _task("soft-up")
+    down = _task("down", collision_deps=["soft-up"])
+    dag = StoryDAG([soft_up, down])
+
+    # Until upstream is finished, the soft edge is genuinely blocking.
+    assert dag.unmet_deps("down") == ["soft-up"]
+
+
+def test_collision_seam_soft_release_on_skipped_upstream() -> None:
+    """Seam-level integration: runner pipeline (compute → inject → build_dag).
+
+    Stories that collide on likely_files get collision_deps (not depends_on).
+    A skipped upstream releases the downstream; an explicit depends_on edge
+    in the same flow still hard-blocks.
+    """
+    a = _task("issue-1", depends_on=[])
+    b = _task("issue-2", depends_on=[])
+    c = _task("issue-3", depends_on=["issue-2"])  # explicit hard edge to b
+    tasks = [a, b, c]
+    states = {
+        "issue-1": CoordinatorState(preflight_likely_files=["src/runner.py"]),
+        "issue-2": CoordinatorState(preflight_likely_files=["src/runner.py"]),
+        "issue-3": CoordinatorState(preflight_likely_files=["src/other.py"]),
+    }
+
+    synthetic = compute_synthetic_edges(states, tasks)
+    augmented = inject_synthetic_deps(tasks, synthetic)
+    dag = build_dag(augmented)
+
+    augmented_by_slug = {t.slug: t for t in augmented}
+    # issue-2 collided with issue-1, so issue-2 has a soft (collision) edge to issue-1.
+    assert augmented_by_slug["issue-2"].collision_deps == ["issue-1"]
+    assert augmented_by_slug["issue-2"].depends_on == []
+    # issue-3's explicit dep stays in depends_on.
+    assert augmented_by_slug["issue-3"].depends_on == ["issue-2"]
+    assert augmented_by_slug["issue-3"].collision_deps == []
+
+    # Initial: issue-1 is the only ready story.
+    assert {t.slug for t in dag.ready()} == {"issue-1"}
+
+    # Skipping issue-1 (terminal-not-merged) releases issue-2 via the soft edge.
+    dag.mark_skipped("issue-1")
+    assert "issue-2" in {t.slug for t in dag.ready()}
+    # issue-3 still hard-blocked on issue-2.
+    assert "issue-3" not in {t.slug for t in dag.ready()}
+
+    # Skipping issue-2 must NOT release issue-3 — that edge is hard.
+    dag.mark_skipped("issue-2")
+    assert "issue-3" not in {t.slug for t in dag.ready()}
+
+    # Only completion of issue-2 releases issue-3.
+    dag.mark_complete("issue-2")
+    assert "issue-3" in {t.slug for t in dag.ready()}


### PR DESCRIPTION
## Summary

Clean, minimal implementation — collision_deps field threaded correctly through collision→DAG seam with proper hard/soft semantics and comprehensive tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.48
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Collision-derived DAG edges should be soft — drop them when upstream escalates without merging (GitHub Issue #1112)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1112