### PR TITLE
fix: enforce sprint worker timeout via cooperative cancellation (#1071)

### DIFF
--- a/src/theforge/coordinator/cancellation.py
+++ b/src/theforge/coordinator/cancellation.py
@@ -1,0 +1,15 @@
+"""Cooperative cancellation signal for sprint-driven worker timeouts.
+
+Sprint workers run inside a ThreadPoolExecutor. Future.cancel() cannot stop a
+running thread, so the sprint scheduler signals cancellation via a per-story
+threading.Event. The coordinator checks the event at phase boundaries and
+raises StoryCancelled, which entry points catch to bypass end-of-run
+persistence (escalation history, model profile updates) — the scheduler's
+synthetic timeout record is the only artifact for cancelled stories.
+"""
+
+from __future__ import annotations
+
+
+class StoryCancelled(Exception):
+    """Raised when a sprint-level stop_event signals worker cancellation."""

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import threading
 import time
 from collections.abc import Iterable
 from dataclasses import replace as _dc_replace
@@ -361,6 +362,7 @@ def _run_dev_phase(
     *,
     notify: bool,
     logger: StructuredLogger | None,
+    stop_event: "threading.Event | None" = None,
 ) -> CoordinatorResult | None:
     """Run one DEV iteration. Returns CoordinatorResult on budget escalation, else None.
 
@@ -577,6 +579,7 @@ def _run_dev_phase(
         working_dir=workspace_path,
         session_id=state.dev_session_id,
         secrets=config.secrets,
+        stop_event=stop_event,
     )
     _runner_failure = None
     if not dev_result.success and not dev_result.startup_failure:

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import datetime
 import signal
+import threading
 import time
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -49,6 +50,7 @@ from theforge.task import (
     parse_plan_output,
 )
 
+from .cancellation import StoryCancelled
 from .log_tee import (  # noqa: E402
     _begin_run_log_tee,
     _end_run_log_tee,
@@ -221,6 +223,25 @@ from .run_setup import _rebase_onto_main, _setup_resume_entry  # noqa: E402,I001
 from .validate_phase import _run_validate_phase, _ValidateOutcome  # noqa: E402
 
 
+def _cancelled_result(task: TaskStory, state: CoordinatorState) -> CoordinatorResult:
+    """Build a failed CoordinatorResult for a story aborted via stop_event.
+
+    Bypasses _record_run_memory() — the sprint scheduler has already written
+    the authoritative timeout audit record; writing a separate ESCALATE
+    record here would produce two contradictory failure narratives.
+    """
+    _log(f"INFO {task.slug}: cancelled by sprint stop_event")
+    state.phase = Phase.ESCALATE
+    state.error = "Story cancelled by sprint timeout"
+    state.error_type = "StoryCancelled"
+    return CoordinatorResult(
+        success=False,
+        phase=Phase.ESCALATE,
+        state=state,
+        message="Story cancelled by sprint timeout",
+    )
+
+
 def _coordinator_loop(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -235,6 +256,7 @@ def _coordinator_loop(
     logger: StructuredLogger | None = None,
     state_update_fn: "Callable[[dict], None] | None" = None,
     stop_phase: Phase | None = None,
+    stop_event: "threading.Event | None" = None,
 ) -> CoordinatorResult:
     """Shared DEV→VALIDATE→REVIEW loop used by run_task() and run_from_review().
 
@@ -347,6 +369,8 @@ def _coordinator_loop(
     state.budget.max_iterations = state.adaptive_dev_max
 
     while True:
+        if stop_event is not None and stop_event.is_set():
+            raise StoryCancelled()
         if not _skip_dev:
             # ── DEV ───────────────────────────────────────────────
             state.phase = Phase.DEV
@@ -375,6 +399,7 @@ def _coordinator_loop(
                 branch_name,
                 notify=notify,
                 logger=logger,
+                stop_event=stop_event,
             )
             if escalation is not None:
                 return escalation
@@ -415,6 +440,9 @@ def _coordinator_loop(
 
             # ── Scrub forge-artifact commits from branch history ──
             _scrub_forge_history(workspace_path, branch_name, config.workspace.base_branch)
+
+            if stop_event is not None and stop_event.is_set():
+                raise StoryCancelled()
 
             # ── VALIDATE ──────────────────────────────────────────
             _val_outcome, _val_result = _run_validate_phase(
@@ -541,6 +569,9 @@ def _coordinator_loop(
         if logger:
             logger._safe_emit("phase_end", phase="VALIDATE", outcome="pass")
 
+        if stop_event is not None and stop_event.is_set():
+            raise StoryCancelled()
+
         # ── REVIEW ────────────────────────────────────────────
         _rev_outcome, _rev_result, config = _run_review_phase(
             state,
@@ -556,6 +587,7 @@ def _coordinator_loop(
             logger=logger,
             run_id=logger._run_id if logger else "",
             state_update_fn=state_update_fn,
+            stop_event=stop_event,
         )
         if _rev_outcome in (_ReviewOutcome.DONE, _ReviewOutcome.ESCALATE):
             return _rev_result  # type: ignore[return-value]
@@ -588,6 +620,7 @@ def run_task(
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
+    stop_event: "threading.Event | None" = None,
 ) -> CoordinatorResult:
     """Execute the full coordinator state machine for a single task.
 
@@ -759,20 +792,24 @@ def run_task(
             # When starting at REVIEW (or later), skip DEV on the first iteration
             # so the existing worktree is reviewed before the dev agent is invoked.
             _skip_dev_first = start_phase.value >= Phase.REVIEW.value
-            result = _coordinator_loop(
-                state,
-                config,
-                task,
-                story_content,
-                _task_start,
-                interactive=interactive,
-                auto_merge=auto_merge,
-                skip_dev_first_iter=_skip_dev_first,
-                notify=notify,
-                logger=logger,
-                state_update_fn=state_update_fn,
-                stop_phase=stop_phase,
-            )
+            try:
+                result = _coordinator_loop(
+                    state,
+                    config,
+                    task,
+                    story_content,
+                    _task_start,
+                    interactive=interactive,
+                    auto_merge=auto_merge,
+                    skip_dev_first_iter=_skip_dev_first,
+                    notify=notify,
+                    logger=logger,
+                    state_update_fn=state_update_fn,
+                    stop_phase=stop_phase,
+                    stop_event=stop_event,
+                )
+            except StoryCancelled:
+                return _cancelled_result(task, state)
             _total_elapsed = time.monotonic() - _task_start
             _fire_post_run_hook(config, state, task, result, _run_id, _total_elapsed, logger)
             logger._safe_emit(
@@ -847,19 +884,23 @@ def run_task(
             return _pf_result
         if _pf_already_done_loop:
             # ALREADY_DONE override: commits on branch without prior APPROVE → resume REVIEW
-            result = _coordinator_loop(
-                state,
-                config,
-                task,
-                story_content,
-                _task_start,
-                interactive=interactive,
-                auto_merge=auto_merge,
-                skip_dev_first_iter=True,
-                notify=notify,
-                logger=logger,
-                state_update_fn=state_update_fn,
-            )
+            try:
+                result = _coordinator_loop(
+                    state,
+                    config,
+                    task,
+                    story_content,
+                    _task_start,
+                    interactive=interactive,
+                    auto_merge=auto_merge,
+                    skip_dev_first_iter=True,
+                    notify=notify,
+                    logger=logger,
+                    state_update_fn=state_update_fn,
+                    stop_event=stop_event,
+                )
+            except StoryCancelled:
+                return _cancelled_result(task, state)
             logger._safe_emit(
                 "run_end",
                 outcome="done" if result.success else "escalate",
@@ -899,19 +940,23 @@ def run_task(
             )
 
         # ── DEV→VALIDATE→REVIEW loop ─────────────────────────────────
-        result = _coordinator_loop(
-            state,
-            config,
-            task,
-            story_content,
-            _task_start,
-            interactive=interactive,
-            auto_merge=auto_merge,
-            notify=notify,
-            logger=logger,
-            state_update_fn=state_update_fn,
-            stop_phase=stop_phase,
-        )
+        try:
+            result = _coordinator_loop(
+                state,
+                config,
+                task,
+                story_content,
+                _task_start,
+                interactive=interactive,
+                auto_merge=auto_merge,
+                notify=notify,
+                logger=logger,
+                state_update_fn=state_update_fn,
+                stop_phase=stop_phase,
+                stop_event=stop_event,
+            )
+        except StoryCancelled:
+            return _cancelled_result(task, state)
 
         # ── Landing (single-story path) ───────────────────────────────
         # _finalize_approve defers all git operations and sets landing_status
@@ -1041,6 +1086,7 @@ def _run_resume_coordinator(
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
+    stop_event: "threading.Event | None" = None,
 ) -> CoordinatorResult:
     """Shared body for run_from_review and run_from_dev.
 
@@ -1130,19 +1176,23 @@ def _run_resume_coordinator(
                 message=state.escalate_reason,
             )
         logger._safe_emit("rebase", phase="RESUME_REBASE", base_branch=base_branch, outcome="ok")
-        result = _coordinator_loop(
-            state,
-            config,
-            task,
-            story_content,
-            _task_start,
-            interactive=interactive,
-            auto_merge=auto_merge,
-            skip_dev_first_iter=skip_dev_first_iter,
-            notify=notify,
-            logger=logger,
-            state_update_fn=state_update_fn,
-        )
+        try:
+            result = _coordinator_loop(
+                state,
+                config,
+                task,
+                story_content,
+                _task_start,
+                interactive=interactive,
+                auto_merge=auto_merge,
+                skip_dev_first_iter=skip_dev_first_iter,
+                notify=notify,
+                logger=logger,
+                state_update_fn=state_update_fn,
+                stop_event=stop_event,
+            )
+        except StoryCancelled:
+            return _cancelled_result(task, state)
 
         # ── Landing (single-story resume path) ───────────────────────
         # Skip when defer_landing=True (sprint worker): scheduler handles it.
@@ -1202,6 +1252,7 @@ def run_from_review(
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
+    stop_event: "threading.Event | None" = None,
 ) -> CoordinatorResult:
     """Start at REVIEW on an existing worktree, then iterate DEV→VALIDATE→REVIEW as needed.
 
@@ -1235,6 +1286,7 @@ def run_from_review(
         no_pull=no_pull,
         cached_preflight_state=cached_preflight_state,
         defer_landing=defer_landing,
+        stop_event=stop_event,
     )
 
 
@@ -1252,6 +1304,7 @@ def run_from_dev(
     no_pull: bool = False,
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
+    stop_event: "threading.Event | None" = None,
 ) -> CoordinatorResult:
     """Start at DEV on an existing worktree, skipping WORKSPACE and PREFLIGHT.
 
@@ -1282,6 +1335,7 @@ def run_from_dev(
         no_pull=no_pull,
         cached_preflight_state=cached_preflight_state,
         defer_landing=defer_landing,
+        stop_event=stop_event,
     )
 
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import replace as _dc_replace
@@ -516,6 +517,7 @@ def _run_review_phase(
     logger: StructuredLogger | None,
     run_id: str = "",
     state_update_fn: Callable[[dict], None] | None = None,
+    stop_event: "threading.Event | None" = None,
 ) -> tuple[_ReviewOutcome, CoordinatorResult | None, ForgeConfig]:
     """Run the full REVIEW phase: pool+synthesis, parse retries, verdict handling.
 
@@ -568,6 +570,7 @@ def _run_review_phase(
         pool_attempt=0,
         max_review_parse_retries=max_parse_retries,
         logger=logger,
+        stop_event=stop_event,
     )
     state.last_cycle_reviewer_results = _named_parsed
 

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -10,6 +10,7 @@ Orchestrates the multi-reviewer pool for a single review cycle:
 from __future__ import annotations
 
 import dataclasses
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -124,6 +125,7 @@ def _run_review_pool(
     pool_attempt: int = 0,
     max_review_parse_retries: int = 0,
     logger: Any | None = None,
+    stop_event: "threading.Event | None" = None,
 ) -> tuple[list, list, ReviewResult | None, list[ReviewResult], list[tuple[str, ReviewResult]]]:
     """Run the review pool and merge results.
 
@@ -291,6 +293,7 @@ def _run_review_pool(
         working_dir=workspace_path,
         session_ids=pool_session_ids,
         secrets=config.secrets,
+        stop_event=stop_event,
     )
     _pool_elapsed = time.monotonic() - _pool_start
     for profile, result in zip(pool, pool_results):
@@ -445,6 +448,7 @@ def _run_review_pool(
                 quiet=True,
                 secrets=config.secrets,
                 session_id=_original_result.session_id if _prof.mode == "cli" else None,
+                stop_event=stop_event,
             )
             meta.parse_retries += 1
             if not _retry_result.success:

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -378,6 +378,7 @@ def run_agent(
     is_pool: bool = False,
     secrets: dict[str, str] | None = None,
     plain_text: bool = False,
+    stop_event: "threading.Event | None" = None,
 ) -> AgentResult:
     """Run an agent using the transport specified in its profile.
 
@@ -417,6 +418,7 @@ def run_agent(
             fallback_to_file=fallback_to_file,
             quiet=quiet,
             secrets=secrets,
+            stop_event=stop_event,
         )
         result = _maybe_run_api_fallback(
             result=result,
@@ -507,6 +509,7 @@ def run_agent_pool(
     session_ids: list[str | None] | None = None,
     secrets: dict[str, str] | None = None,
     plain_text: bool = False,
+    stop_event: "threading.Event | None" = None,
 ) -> list[AgentResult]:
     """Run multiple agents concurrently, each with its own prompt or a shared prompt.
 
@@ -533,6 +536,7 @@ def run_agent_pool(
                 fallback_to_file=False,
                 secrets=secrets,
                 plain_text=plain_text,
+                stop_event=stop_event,
             )
         ]
 
@@ -557,6 +561,7 @@ def run_agent_pool(
                 is_pool=True,
                 secrets=secrets,
                 plain_text=plain_text,
+                stop_event=stop_event,
             )
         finally:
             agent_durations[idx] = time.monotonic() - t0

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -314,6 +314,7 @@ def _run_claude(
     fallback_to_file: bool = True,
     quiet: bool = False,
     secrets: dict[str, str] | None = None,
+    stop_event: "threading.Event | None" = None,
 ) -> AgentResult:
     """Invoke `claude -p --output-format stream-json --verbose` as a subprocess."""
     cmd: list[str] = [
@@ -386,11 +387,20 @@ def _run_claude(
         # proc.wait(timeout=...) only fires after stdout is drained, which never
         # happens if the agent streams indefinitely.
         def _watchdog() -> None:
-            remaining = deadline - time.monotonic()
-            if remaining > 0:
-                time.sleep(remaining)
-            if proc.poll() is None:
-                proc.kill()
+            # Wake periodically so a stop_event signal cancels the in-flight
+            # subprocess immediately rather than waiting for the deadline.
+            while True:
+                if proc.poll() is not None:
+                    return
+                if stop_event is not None and stop_event.is_set():
+                    proc.kill()
+                    return
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    if proc.poll() is None:
+                        proc.kill()
+                    return
+                time.sleep(min(0.5, remaining))
 
         watchdog = threading.Thread(target=_watchdog, daemon=True)
         watchdog.start()
@@ -412,6 +422,10 @@ def _run_claude(
                     f"{stuck_monitor.terminate_pattern}"
                 )
                 proc.kill()
+                break
+            if stop_event is not None and stop_event.is_set():
+                proc.kill()
+                timed_out = True
                 break
             if time.monotonic() > deadline:
                 proc.kill()

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -535,6 +535,8 @@ def _run_fresh(
     no_pull: bool,
     plan_gate: "threading.Event | None",
     preflight_states: dict[str, CoordinatorState] | None = None,
+    *,
+    stop_event: "threading.Event | None" = None,
 ) -> CoordinatorResult:
     """Run a fresh story, optionally splitting at PLAN_REVIEW for overlap gating."""
     if plan_gate is None:
@@ -568,6 +570,7 @@ def _run_fresh(
                 no_pull=no_pull,
                 cached_preflight_state=(preflight_states or {}).get(task.slug),
                 defer_landing=True,
+                stop_event=stop_event,
             )
         return run_task(
             config,
@@ -581,6 +584,7 @@ def _run_fresh(
             no_pull=no_pull,
             cached_preflight_state=(preflight_states or {}).get(task.slug),
             defer_landing=True,
+            stop_event=stop_event,
         )
 
     # Phase 1: run through PLAN only
@@ -597,6 +601,7 @@ def _run_fresh(
         stop_phase=Phase.PLAN_REVIEW,
         cached_preflight_state=(preflight_states or {}).get(task.slug),
         defer_landing=True,
+        stop_event=stop_event,
     )
 
     if not plan_result.success:
@@ -633,6 +638,7 @@ def _run_fresh(
         no_pull=no_pull,
         cached_preflight_state=(preflight_states or {}).get(task.slug),
         defer_landing=True,
+        stop_event=stop_event,
     )
 
 
@@ -650,6 +656,7 @@ def _run_single_story(
     no_pull: bool = False,
     plan_gate: "threading.Event | None" = None,
     preflight_states: dict[str, CoordinatorState] | None = None,
+    stop_event: "threading.Event | None" = None,
 ) -> "tuple[TaskStory, CoordinatorResult, float, datetime.datetime, datetime.datetime]":
     """Execute a single story and return (task, result, elapsed, started_at, finished_at).
 
@@ -685,6 +692,7 @@ def _run_single_story(
                     no_pull=no_pull,
                     cached_preflight_state=(preflight_states or {}).get(task.slug),
                     defer_landing=True,
+                    stop_event=stop_event,
                 )
             elif triage.action == "dev" and triage.worktree_path is not None:
                 result = run_from_dev(
@@ -700,6 +708,7 @@ def _run_single_story(
                     no_pull=no_pull,
                     cached_preflight_state=(preflight_states or {}).get(task.slug),
                     defer_landing=True,
+                    stop_event=stop_event,
                 )
             else:
                 result = _run_fresh(
@@ -714,6 +723,7 @@ def _run_single_story(
                     no_pull,
                     plan_gate,
                     preflight_states,
+                    stop_event=stop_event,
                 )
         else:
             result = _run_fresh(
@@ -728,6 +738,7 @@ def _run_single_story(
                 no_pull,
                 plan_gate,
                 preflight_states,
+                stop_event=stop_event,
             )
     except Exception as exc:
         _log(f"ERROR {task.slug}: worker thread raised {type(exc).__name__}: {exc}")
@@ -1546,6 +1557,10 @@ def run_sprint(
     queued_prs: dict[str, tuple[TaskStory, CoordinatorResult, str]] = {}
     _submission_counter = [0]  # mutable for closure capture; counts submitted stories
 
+    # Per-story cancellation events: set by the timeout handler so worker
+    # threads stop running instead of continuing past their deadline.
+    stop_events: dict[str, threading.Event] = {}
+
     # Overlap detection state (plan gates)
     file_footprints: dict[str, set[str]] = {}  # slug -> files from plan
     plan_gates: dict[str, threading.Event] = {}  # slug -> gate for PLAN→DEV pause
@@ -1768,6 +1783,8 @@ def run_sprint(
                     plan_done=plan_done if use_plan_gates else None,
                     state_writer=_state_writer,
                 )
+                stop_evt = threading.Event()
+                stop_events[task.slug] = stop_evt
                 fut = pool.submit(
                     _run_single_story,
                     worker_config,
@@ -1783,6 +1800,7 @@ def run_sprint(
                     no_pull,
                     gate,
                     preflight_states,
+                    stop_evt,
                 )
                 active[task.slug] = fut
                 story_deadlines[task.slug] = time.monotonic() + float(
@@ -1897,6 +1915,12 @@ def run_sprint(
                         del plan_gates[slug]
                     fut = active.pop(slug)
                     story_deadlines.pop(slug, None)
+                    # Set the cancellation event BEFORE cancel() so any in-flight
+                    # work stops at the next phase boundary or subprocess read.
+                    # Future.cancel() is a no-op for an already-running thread.
+                    _stop_evt = stop_events.pop(slug, None)
+                    if _stop_evt is not None:
+                        _stop_evt.set()
                     fut.cancel()
                     _log(
                         f"TIMEOUT {slug} (worker unresponsive after "
@@ -1939,6 +1963,7 @@ def run_sprint(
                     _log(f"ERROR {slug}: worker thread raised {type(exc).__name__}: {exc}")
                     del active[slug]
                     story_deadlines.pop(slug, None)
+                    stop_events.pop(slug, None)
                     spec_str = slug_to_spec[slug]
                     failed_at = datetime.datetime.now(datetime.timezone.utc)
                     story_started_at = story_times.get(slug, (failed_at, failed_at))[0]
@@ -1968,6 +1993,7 @@ def run_sprint(
                     continue
                 del active[slug]
                 story_deadlines.pop(slug, None)
+                stop_events.pop(slug, None)
                 story_times[slug] = (t0, t1)
 
                 with cost_lock:

--- a/tests/test_coord_cancellation.py
+++ b/tests/test_coord_cancellation.py
@@ -1,0 +1,121 @@
+"""Tests for cooperative cancellation via stop_event.
+
+When the sprint scheduler's per-story timeout fires, it sets a per-worker
+threading.Event. The coordinator must:
+  - check the event at every phase boundary in _coordinator_loop
+  - raise StoryCancelled instead of starting the next phase
+  - bypass _record_run_memory() so no conflicting escalation record is written
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.coordinator.cancellation import StoryCancelled
+from theforge.coordinator.engine import _coordinator_loop, run_task
+from theforge.coordinator.state import CoordinatorState
+
+
+def _seeded_state(tmp_path: Path) -> CoordinatorState:
+    state = CoordinatorState()
+    state.workspace_path = tmp_path
+    state.branch_name = "feat/test"
+    # Skip adaptive resolution by pre-populating
+    state.adaptive_dev_max = 2
+    state.adaptive_review_max = 2
+    state.adaptive_dev_timeout_seconds = 600
+    state.adaptive_dev_budget_usd = 1.0
+    return state
+
+
+def test_pre_set_stop_event_raises_story_cancelled_before_any_phase(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = _seeded_state(tmp_path)
+    stop = threading.Event()
+    stop.set()
+
+    with (
+        patch("theforge.coordinator.engine._run_dev_phase") as mock_dev,
+        patch("theforge.coordinator.engine._run_validate_phase") as mock_val,
+        patch("theforge.coordinator.engine._run_review_phase") as mock_rev,
+    ):
+        with pytest.raises(StoryCancelled):
+            _coordinator_loop(state, config, task, "story", task_start=0.0, stop_event=stop)
+
+    mock_dev.assert_not_called()
+    mock_val.assert_not_called()
+    mock_rev.assert_not_called()
+
+
+def test_stop_event_set_after_dev_skips_validate_and_review(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = _seeded_state(tmp_path)
+    stop = threading.Event()
+
+    def _dev_then_set(*args, **kwargs):
+        # Simulate timeout firing during DEV
+        stop.set()
+        return None  # no escalation
+
+    with (
+        patch("theforge.coordinator.engine._run_dev_phase", side_effect=_dev_then_set) as mock_dev,
+        patch("theforge.coordinator.engine._run_validate_phase") as mock_val,
+        patch("theforge.coordinator.engine._run_review_phase") as mock_rev,
+        patch("theforge.coordinator.engine._scrub_forge_history"),
+    ):
+        with pytest.raises(StoryCancelled):
+            _coordinator_loop(state, config, task, "story", task_start=0.0, stop_event=stop)
+
+    mock_dev.assert_called_once()
+    mock_val.assert_not_called()
+    mock_rev.assert_not_called()
+
+
+def test_run_task_bypasses_record_run_memory_on_cancellation(tmp_path: Path) -> None:
+    """When _coordinator_loop raises StoryCancelled, run_task must NOT write
+    the end-of-run escalation record. The sprint scheduler's synthetic timeout
+    record is the only artifact for cancelled stories.
+    """
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "wt"
+    workspace.mkdir()
+
+    stop = threading.Event()
+
+    def _raise_cancelled(*args, **kwargs):
+        raise StoryCancelled()
+
+    with (
+        patch(
+            "theforge.coordinator.workspace._create_workspace",
+            return_value=(workspace, "feat/test", None),
+        ),
+        patch(
+            "theforge.coordinator.engine._create_workspace",
+            return_value=(workspace, "feat/test", None),
+        ),
+        patch("theforge.coordinator.engine._run_preflight_phase", create=True),
+        patch("theforge.coordinator.preflight_flow._run_preflight_phase") as mock_preflight,
+        patch("theforge.coordinator.plan_flow._run_plan_phase", return_value=None),
+        patch("theforge.coordinator.engine._coordinator_loop", side_effect=_raise_cancelled),
+        patch("theforge.coordinator.engine._record_run_memory") as mock_record,
+        patch("theforge.coordinator.engine._fire_post_run_hook"),
+    ):
+        # preflight returns (config, None, False) → continue to plan/loop
+        mock_preflight.return_value = (config, None, False)
+        # set the event so even early checks would trigger
+        stop.set()
+        result = run_task(config, task, stop_event=stop)
+
+    assert result.success is False
+    assert result.message == "Story cancelled by sprint timeout"
+    # The critical assertion: no escalation record was written
+    mock_record.assert_not_called()

--- a/tests/test_sprint_timeout_cancellation.py
+++ b/tests/test_sprint_timeout_cancellation.py
@@ -1,0 +1,70 @@
+"""Seam test: sprint timeout sets the per-story stop_event so worker threads
+stop running, and no conflicting escalation record is written for the slug.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+from tests.test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+from theforge.sprint import run_sprint
+
+
+def test_sprint_timeout_sets_stop_event_for_worker(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    spec = _make_spec_file(tmp_path, "Feature A", "feature-a")
+    manifest = _make_manifest(tmp_path, [spec.name])
+
+    captured: dict[str, threading.Event | None] = {"stop_event": None}
+
+    class _NeverDoneFuture:
+        def cancel(self):
+            return True
+
+        def result(self):
+            raise AssertionError("should not be called")
+
+    class _FakeExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            # _run_single_story signature ends with stop_event (positional).
+            if args:
+                captured["stop_event"] = args[-1]
+            return _NeverDoneFuture()
+
+    with (
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
+        patch("theforge.sprint.runner.wait", return_value=(set(), set())),
+        patch("theforge.sprint.runner.time.monotonic", side_effect=[0.0, 4000.0, 4000.0]),
+    ):
+        run_sprint(config, manifest)
+
+    # The scheduler must have passed a stop_event into the worker AND set it
+    # when the timeout fired. Without this, the worker keeps running after
+    # the synthetic FAILED audit is written, eventually writing its own
+    # escalation record — exactly the bug this story fixes.
+    assert captured["stop_event"] is not None, "scheduler did not pass stop_event to worker"
+    assert isinstance(captured["stop_event"], threading.Event)
+    assert captured["stop_event"].is_set(), "timeout handler did not signal stop_event"
+
+    # Sanity: only the synthetic timeout audit exists; no second
+    # ESCALATE record was appended (the worker never ran past _run_single_story
+    # in this fake harness, so escalation history must be empty).
+    esc_path = tmp_path / ".forge" / "assignment_history.yaml"
+    assert not esc_path.exists() or "feature-a" not in esc_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Sprint worker timeout now propagates through a cooperative cancellation signal rather than just calling \`Future.cancel()\` (which is a no-op on running threads)
- New \`StoryCancelled\` exception threaded from sprint runner timeout handler through coordinator state machine, every phase function, and the runner subprocess layer
- Timeout handler now actually stops in-flight LLM calls and prevents orphaned threads from writing contradictory ESCALATE audit records after a story has already been recorded as failed

## Test plan
- [x] New \`tests/test_coord_cancellation.py\` — coordinator-loop cancellation tests
- [x] New \`tests/test_sprint_timeout_cancellation.py\` — sprint-level timeout-to-cancellation propagation
- [x] Full gate: 3707 passed, 1 skipped, no regressions

Note: dev exited cleanly (\`[DEV] OK | exit=0\`) but coordinator escalated post-hoc because actual cost (\$7.48) exceeded adaptive dev_budget cap (\$6.27) — bug filed as #1148, work committed and complete regardless.

Closes #1071