### PR TITLE
Live sprint status reuses prior terminal story state during resumed run

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1092,14 +1092,26 @@ def run_sprint(
     _story_state = SprintStoryState()
     # Pre-populate from prior-run accumulated state so cross-process resume
     # invocations see the full logical sprint in counts and projections.
+    # Stories present in the current run are seeded only when their prior
+    # outcome is succeeded (DONE / ALREADY_DONE); the resume triage handler
+    # below preserves those terminal states. A non-succeeded terminal outcome
+    # (SKIPPED, DROPPED, FAILED, etc.) from a prior run must NOT be seeded
+    # for a story that re-enters the current run, because monotonicity would
+    # then reject the transition to RUNNING — producing a live row that shows
+    # the story as skipped/failed while phase, model, and cost continue to
+    # advance from the active run.
     if _sprint_id is not None:
         from .audit import _load_accumulated_stories as _preload  # noqa: PLC0415
 
+        _current_run_slugs = set(slug_to_context.keys())
+        _succeeded_outcomes = {"DONE", "ALREADY_DONE"}
         for _prior in _preload(_sprint_id, config.project_root):
             _prior_slug = _prior.get("slug")
             if not _prior_slug:
                 continue
             _prior_outcome = (_prior.get("outcome") or "").upper()
+            if _prior_slug in _current_run_slugs and _prior_outcome not in _succeeded_outcomes:
+                continue
             _outcome_map = {
                 "DONE": StoryOutcome.DONE,
                 "ALREADY_DONE": StoryOutcome.ALREADY_DONE,

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -727,6 +727,85 @@ class TestRedirectChainResolution:
         assert summary["sprint"]["specs_succeeded"] == 2
         assert summary["sprint"]["total_cost_usd"] == pytest.approx(10.44)
 
+    def test_live_state_does_not_show_running_story_as_skipped_from_prior_state(
+        self, tmp_path: Path
+    ) -> None:
+        """A story actively running in the current run must not be shown as
+        skipped due to a terminal outcome persisted from an earlier run.
+
+        Regression: when a prior resume left a story with outcome=SKIPPED in
+        the sprint-wide accumulated state (e.g. an unsatisfied dependency),
+        seeding the canonical structure with that terminal outcome locked
+        the story in SKIPPED via the monotonicity invariant. Subsequent
+        transitions to RUNNING were rejected, while phase/cost continued to
+        update, producing a live row that combined "skipped" status with
+        active phase and cost — the exact symptom from issue #1146.
+        """
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-b.md"])
+        config = _make_config(tmp_path)
+        sprint_name = "Test Sprint"
+
+        sprint_id = _get_or_create_sprint_id(sprint_name, tmp_path)
+        _save_accumulated_stories(
+            sprint_id,
+            sprint_name,
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-b.md",
+                    "slug": "feature-b",
+                    "path": "feature-b.md",
+                    "outcome": "SKIPPED",
+                    "verdict": None,
+                    "cost_usd": 0.31,
+                    "story_run_id": "run-prior",
+                    "preflight": None,
+                    "merge": False,
+                    "batch": 0,
+                    "depends_on": [],
+                }
+            ],
+        )
+
+        full_triage = StoryTriage(
+            story_path="feature-b.md",
+            action="full",
+            reason="ready to run",
+            worktree_path=None,
+            slug="feature-b",
+        )
+
+        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+            return full_triage
+
+        captured: dict[str, object] = {}
+
+        def _capture_live_state(*args, **kwargs):
+            entries = read_live_status("run-current", tmp_path)
+            assert entries is not None
+            by_slug = {entry.slug: entry for entry in entries}
+            captured["live"] = by_slug.get("feature-b")
+            return _make_coordinator_result(success=True, cost=2.5)
+
+        with (
+            patch("theforge.sprint.runner._triage_spec", side_effect=_mock_triage),
+            patch("theforge.sprint.runner.run_task", side_effect=_capture_live_state),
+        ):
+            run_sprint(config, manifest_path, resume=True, run_id="run-current")
+
+        live = captured.get("live")
+        assert live is not None, "feature-b should appear in live status while running"
+        # The running story must not display the terminal "skipped" status from
+        # the prior run's accumulated state.
+        assert live.status != "skipped", (
+            f"feature-b shown as skipped while actively running: {live!r}"
+        )
+        # Detail must not be the stale terminal "SKIPPED" carried from prior state.
+        assert live.detail != "SKIPPED", (
+            f"feature-b detail leaked stale terminal outcome: {live!r}"
+        )
+
     def test_live_state_includes_prior_run_skip_merged_story(self, tmp_path: Path) -> None:
         """Live status keeps prior-run completed stories visible after resume triage."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")


### PR DESCRIPTION
## Summary

Minimal, correct fix — skips seeding non-succeeded terminal outcomes for current-run slugs, preventing monotonicity from locking live stories in a stale terminal state; regression test directly exercises the reported scenario.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.22
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Live sprint status reuses prior terminal story state during resumed run (GitHub Issue #1146)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1146