### PR TITLE
Sprint resume treats zero-delta APPROVE history as merged work

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -42,6 +42,7 @@ def has_review_approve(
     branch: str | None = None,
     *,
     allow_unmerged_commits: bool = False,
+    require_landed: bool = False,
 ) -> bool:
     """Return True if any prior run for slug produced a review APPROVE.
 
@@ -60,6 +61,8 @@ def has_review_approve(
             formatted with slug). If None, defaults to 'feat/<slug>'.
         allow_unmerged_commits: When True, return APPROVE based solely on audit
             history without rejecting branches that still appear ahead of base.
+        require_landed: When True, only count APPROVE records whose landing
+            status shows story-specific work actually landed on the base branch.
     """
     history_path = project_root / ".forge" / "audits" / "history.jsonl"
     if not history_path.exists():
@@ -80,6 +83,14 @@ def has_review_approve(
                 task_info = record.get("task", {})
                 if task_info.get("slug") != slug:
                     continue
+                if require_landed:
+                    landing_status = record.get("landing_status")
+                    if landing_status is None:
+                        landing_event = record.get("landing_event")
+                        if isinstance(landing_event, dict) and landing_event.get("landed") is True:
+                            landing_status = "landed"
+                    if landing_status != "landed":
+                        continue
                 for review in record.get("reviews", []):
                     if review.get("verdict") == "APPROVE":
                         if not allow_unmerged_commits:

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -51,13 +51,14 @@ def _has_prior_review_approve(
     base_branch: str,
     branch: str,
 ) -> bool:
-    """Return True when audit history shows a prior APPROVE for this story.
+    """Return True when audit history shows a landed APPROVE for this story.
 
     Resume merged detection needs the persisted review outcome even when the
     feature branch still appears ahead of base (squash merges rewrite commits,
     so git topology alone cannot prove the merge). This helper intentionally
-    bypasses the stale-branch guard inside has_review_approve and only answers
-    the audit-history question.
+    bypasses the stale-branch guard inside has_review_approve, but it still
+    requires landing evidence so a zero-delta APPROVE or failed merge attempt
+    does not satisfy the story during resume.
     """
     return has_review_approve(
         project_root,
@@ -65,6 +66,7 @@ def _has_prior_review_approve(
         base_branch,
         branch,
         allow_unmerged_commits=True,
+        require_landed=True,
     )
 
 
@@ -132,6 +134,11 @@ def _is_branch_merged(
     A branch that was merely created at base HEAD (count == 0, no audit entry)
     correctly returns False.
     """
+    issue_number = _issue_number_from_slug(slug) if slug is not None else None
+    if issue_number is None:
+        issue_number = _issue_number_from_ref(branch)
+    issue_is_closed = issue_number is None or _is_issue_closed(issue_number, project_root)
+
     try:
         merge_result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", branch, base_branch],
@@ -164,13 +171,13 @@ def _is_branch_merged(
                 if unique_count > 0:
                     # Regular merge: base has moved past branch and branch had
                     # unique work of its own.
-                    return True
+                    return issue_is_closed
     except (subprocess.TimeoutExpired, OSError, ValueError):
         pass
 
-    issue_number = _issue_number_from_slug(slug) if slug is not None else None
-    if issue_number is None:
-        issue_number = _issue_number_from_ref(branch)
+    if not issue_is_closed:
+        return False
+
     if issue_number is not None and _has_base_commit_referencing_issue(
         project_root,
         base_branch,

--- a/tests/test_coord_audit.py
+++ b/tests/test_coord_audit.py
@@ -248,6 +248,30 @@ class TestHasReviewApprove:
         with patch("theforge.coordinator.audit.subprocess.run", return_value=mock_result):
             assert has_review_approve(tmp_path, "my-spec", "main") is True
 
+    def test_require_landed_rejects_failed_landing(self, tmp_path: Path) -> None:
+        """Landed-only mode ignores APPROVE records whose landing failed."""
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True)
+        record = {
+            "task": {"slug": "my-spec"},
+            "landing_status": "failed",
+            "reviews": [{"verdict": "APPROVE"}],
+        }
+        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        assert has_review_approve(tmp_path, "my-spec", require_landed=True) is False
+
+    def test_require_landed_accepts_landed_approve(self, tmp_path: Path) -> None:
+        """Landed-only mode keeps working for APPROVE records that actually landed."""
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True)
+        record = {
+            "task": {"slug": "my-spec"},
+            "landing_status": "landed",
+            "reviews": [{"verdict": "APPROVE"}],
+        }
+        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        assert has_review_approve(tmp_path, "my-spec", require_landed=True) is True
+
     def test_no_approve_record_with_base_branch(self, tmp_path: Path) -> None:
         """Returns False when no APPROVE record exists (baseline for new signature)."""
         audits = tmp_path / ".forge" / "audits"

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -299,6 +299,7 @@ class TestTriageSpec:
         audits_dir.mkdir(parents=True)
         record = {
             "task": {"slug": "feature-a"},
+            "landing_status": "landed",
             "reviews": [{"verdict": "APPROVE"}],
         }
         (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
@@ -325,6 +326,44 @@ class TestTriageSpec:
         assert triage.action == "skip_merged"
         assert "merged" in triage.reason
 
+    def test_triage_same_tip_failed_landing_audit_stays_full(self, tmp_path: Path) -> None:
+        """A zero-delta APPROVE with failed landing stays eligible during resume."""
+        import json
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        config = _make_config(tmp_path)
+
+        audits_dir = tmp_path / ".forge" / "audits"
+        audits_dir.mkdir(parents=True)
+        record = {
+            "task": {"slug": "feature-a"},
+            "landing_status": "failed",
+            "reviews": [{"verdict": "APPROVE"}],
+        }
+        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+        def _mock_run(cmd, **kwargs):
+            m = MagicMock()
+            if "log" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            elif "rev-list" in cmd and "--count" in cmd:
+                m.returncode = 0
+                m.stdout = b"0"
+            elif "--is-ancestor" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            else:
+                m.returncode = 0
+                m.stdout = b""
+            return m
+
+        with patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run):
+            triage = _triage_spec("feature-a.md", config, tmp_path)
+
+        assert triage.action == "full"
+        assert triage.reason == "branch is at main HEAD with 0 commits ahead"
+
     def test_triage_same_tip_worktree_with_prior_approve_skips_when_merged(
         self, tmp_path: Path
     ) -> None:
@@ -341,6 +380,7 @@ class TestTriageSpec:
         audits_dir.mkdir(parents=True)
         record = {
             "task": {"slug": "feature-a"},
+            "landing_status": "landed",
             "reviews": [{"verdict": "APPROVE"}],
         }
         (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
@@ -366,6 +406,47 @@ class TestTriageSpec:
 
         assert triage.action == "skip_merged"
         assert "merged" in triage.reason
+
+    def test_triage_open_issue_with_landed_audit_stays_full(self, tmp_path: Path) -> None:
+        """An open issue is contradictory evidence and must not be skipped as merged."""
+        import json
+
+        _make_spec_file(tmp_path, "Issue 1071", "issue-1071")
+        config = _make_config(tmp_path)
+
+        audits_dir = tmp_path / ".forge" / "audits"
+        audits_dir.mkdir(parents=True)
+        record = {
+            "task": {"slug": "issue-1071"},
+            "landing_status": "landed",
+            "reviews": [{"verdict": "APPROVE"}],
+        }
+        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+        def _mock_run(cmd, **kwargs):
+            m = MagicMock()
+            if "log" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            elif "rev-list" in cmd and "--count" in cmd:
+                m.returncode = 0
+                m.stdout = b"0"
+            elif "--is-ancestor" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            else:
+                m.returncode = 0
+                m.stdout = b""
+            return m
+
+        with (
+            patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run),
+            patch("theforge.sprint.dag._is_issue_closed", return_value=False),
+        ):
+            triage = _triage_spec("issue-1071.md", config, tmp_path)
+
+        assert triage.action == "full"
+        assert triage.reason == "branch is at main HEAD with 0 commits ahead"
 
     def test_triage_worktree_with_prior_approve(self, tmp_path: Path) -> None:
         """Worktree has commits ahead and prior APPROVE in audit trail → skip."""

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -358,7 +358,10 @@ def test_is_branch_merged_external_squash_merge_by_issue_commit(tmp_path: Path) 
             m.stdout = b""
         return m
 
-    with patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_squash):
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_squash),
+        patch("theforge.sprint.dag._is_issue_closed", return_value=True),
+    ):
         result = _is_branch_merged("feat/issue-265", "main", tmp_path)
     assert result is True
 
@@ -382,6 +385,30 @@ def test_is_branch_merged_issue_branch_without_base_commit_or_audit(tmp_path: Pa
     with (
         patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_no_external_squash),
         patch("theforge.sprint.dag.has_review_approve", return_value=False),
+    ):
+        result = _is_branch_merged("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert result is False
+
+
+def test_is_branch_merged_issue_branch_open_issue_blocks_merge_evidence(tmp_path: Path) -> None:
+    """Open GitHub issues stay eligible even when audit or git hints look merged."""
+
+    def _mock_external_squash(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if "--is-ancestor" in cmd:
+            m.returncode = 1
+            m.stdout = b""
+        elif cmd[:2] == ["git", "log"] and "--grep=(#265)" in cmd:
+            m.returncode = 0
+            m.stdout = b"abc123\n"
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_squash),
+        patch("theforge.sprint.dag._is_issue_closed", return_value=False),
     ):
         result = _is_branch_merged("feat/issue-265", "main", tmp_path, slug="issue-265")
     assert result is False
@@ -445,7 +472,14 @@ def test_is_branch_merged_squash_merge_reads_real_audit_history(tmp_path: Path) 
     audits_dir = tmp_path / ".forge" / "audits"
     audits_dir.mkdir(parents=True)
     (audits_dir / "history.jsonl").write_text(
-        json.dumps({"task": {"slug": "story-a"}, "reviews": [{"verdict": "APPROVE"}]}) + "\n",
+        json.dumps(
+            {
+                "task": {"slug": "story-a"},
+                "landing_status": "landed",
+                "reviews": [{"verdict": "APPROVE"}],
+            }
+        )
+        + "\n",
         encoding="utf-8",
     )
 
@@ -465,3 +499,39 @@ def test_is_branch_merged_squash_merge_reads_real_audit_history(tmp_path: Path) 
     with patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_squash):
         result = _is_branch_merged("forge/story-a", "main", tmp_path, slug="story-a")
     assert result is True
+
+
+def test_is_branch_merged_squash_merge_ignores_failed_landing_audit(tmp_path: Path) -> None:
+    """Failed landing history must not satisfy squash-merge detection."""
+    import json
+
+    audits_dir = tmp_path / ".forge" / "audits"
+    audits_dir.mkdir(parents=True)
+    (audits_dir / "history.jsonl").write_text(
+        json.dumps(
+            {
+                "task": {"slug": "story-a"},
+                "landing_status": "failed",
+                "reviews": [{"verdict": "APPROVE"}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def _mock_squash(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if "--is-ancestor" in cmd:
+            m.returncode = 1
+            m.stdout = b""
+        elif cmd[:2] == ["git", "rev-list"] and cmd[2] == "main..forge/story-a":
+            m.returncode = 0
+            m.stdout = b"2"
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    with patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_squash):
+        result = _is_branch_merged("forge/story-a", "main", tmp_path, slug="story-a")
+    assert result is False


### PR DESCRIPTION
## Summary

Stricter resume merge detection correctly gates on landed evidence and open-issue state; logic, tests, and existing test updates all look sound.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.64
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint resume treats zero-delta APPROVE history as merged work (GitHub Issue #1145)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1145