### PR TITLE
Sprint baseline gate runs against local main before pulling — false-negative when origin has critical fixes

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import yaml
 
 from ..config import ForgeConfig
+from ..coordinator import workspace as coordinator_workspace
 from ..coordinator.engine import run_from_dev, run_from_review, run_task
 from ..coordinator.gate import run_gate_full
 from ..coordinator.log_tee import _make_story_log_dir, get_worker_slug, set_worker_slug
@@ -104,17 +105,24 @@ def _read_prior_sprint_cost(project_root: Path) -> float:
         return 0.0
 
 
-def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[str, object]:
-    """Run the configured gate on the sprint merge base before any agent work starts."""
+def _project_root_is_git_checkout(project_root: Path) -> bool:
+    """Return True when the project root is inside a git checkout."""
 
     git_dir_check = subprocess.run(
         ["git", "rev-parse", "--git-dir"],
-        cwd=config.project_root,
+        cwd=project_root,
         capture_output=True,
         text=True,
         check=False,
     )
-    if git_dir_check.returncode != 0:
+    return git_dir_check.returncode == 0
+
+
+def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[str, object]:
+    """Run the configured gate on the sprint merge base before any agent work starts."""
+
+    base_branch = config.workspace.base_branch
+    if not _project_root_is_git_checkout(config.project_root):
         now = datetime.datetime.now(datetime.timezone.utc)
         return {
             "status": "skipped",
@@ -131,7 +139,7 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
     baseline_started_at = datetime.datetime.now(datetime.timezone.utc)
     started_monotonic = time.monotonic()
     merge_base = subprocess.run(
-        ["git", "merge-base", "HEAD", config.workspace.base_branch],
+        ["git", "merge-base", "HEAD", base_branch],
         cwd=config.project_root,
         capture_output=True,
         text=True,
@@ -151,7 +159,7 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
             "command": config.validation.gate_command,
             "message": (
                 "Broken baseline: unable to determine merge base against "
-                f"{config.workspace.base_branch}: {stderr or 'git merge-base failed'}"
+                f"{base_branch}: {stderr or 'git merge-base failed'}"
             ),
         }
 
@@ -169,7 +177,7 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
             "command": config.validation.gate_command,
             "message": (
                 "Broken baseline: unable to determine merge base against "
-                f"{config.workspace.base_branch}: empty merge-base result"
+                f"{base_branch}: empty merge-base result"
             ),
         }
 
@@ -263,6 +271,24 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
             "Broken baseline: configured gate failed on sprint merge base "
             f"{merge_base_ref} before any dev work started ({error or 'Gate returned FAIL'})"
         )
+        try:
+            local_sha = subprocess.check_output(
+                ["git", "rev-parse", base_branch],
+                cwd=config.project_root,
+                text=True,
+            ).strip()
+            origin_sha = subprocess.check_output(
+                ["git", "rev-parse", f"origin/{base_branch}"],
+                cwd=config.project_root,
+                text=True,
+            ).strip()
+        except subprocess.CalledProcessError:
+            local_sha = origin_sha = None
+        if local_sha and origin_sha and local_sha != origin_sha:
+            message += (
+                f" (local {base_branch} is at {local_sha[:12]}, origin is at {origin_sha[:12]}; "
+                f"local branch may be stale; run `git pull` on {base_branch} or omit --no-pull)"
+            )
         return {
             "status": "fail",
             "passed": False,
@@ -1042,6 +1068,9 @@ def run_sprint(
         _sprint_id = _get_or_create_sprint_id(resolved.name, config.project_root)
     except Exception:
         pass
+
+    if not no_pull and _project_root_is_git_checkout(config.project_root):
+        coordinator_workspace.pull_base_branch(config)
 
     baseline_started_at = datetime.datetime.now(datetime.timezone.utc)
     baseline_gate = _run_baseline_gate(config, resolved)

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -1,4 +1,4 @@
-"""Tests for sprint DAG satisfied-dependency handling.
+"""Tests for sprint DAG satisfied-dependency handling and runner seams.
 
 Covers the case where a depends_on slug references a story already merged to
 main (not present in the current sprint manifest).
@@ -6,18 +6,30 @@ main (not present in the current sprint manifest).
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
 from theforge.sprint.dag import (
     StoryDAG,
     _is_branch_merged,
     build_dag,
     resolve_satisfied_dependencies,
 )
-from theforge.sprint.runner import _refresh_external_satisfied
+from theforge.sprint.manifest import ResolvedSprint
+from theforge.sprint.runner import _refresh_external_satisfied, _run_baseline_gate, run_sprint
 from theforge.task import TaskStory
 
 
@@ -28,6 +40,29 @@ def _make_story(slug: str, depends_on: list[str] | None = None) -> TaskStory:
         story_path=f"specs/{slug}.md",
         depends_on=depends_on or [],
     )
+
+
+def _make_runner_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+            base_branch="main",
+        ),
+        validation=replace(DEFAULT_VALIDATION, gate_command="make gate"),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_empty_resolved() -> ResolvedSprint:
+    return ResolvedSprint(name="Test Sprint", budget_usd=10.0, stories=[], max_parallel=1)
 
 
 # ── build_dag: unknown slug handling ──────────────────────────────────
@@ -208,6 +243,145 @@ def test_scheduler_tick_unblocks_on_issue_close(tmp_path: Path) -> None:
     assert "issue-750" in merged_slugs
     assert {task.slug for task in dag.ready()} == {"issue-749", "issue-751"}
     assert not dag.is_done()
+
+
+def test_run_sprint_pulls_base_branch_before_baseline_by_default(tmp_path: Path) -> None:
+    config = _make_runner_config(tmp_path)
+    resolved = _make_empty_resolved()
+    call_order: list[str] = []
+
+    def _fake_pull(_config: ForgeConfig) -> None:
+        call_order.append("pull")
+
+    def _fake_baseline(_config: ForgeConfig, _resolved: ResolvedSprint) -> dict[str, object]:
+        call_order.append("baseline")
+        return {"passed": True, "message": "ok"}
+
+    with (
+        patch("theforge.sprint.runner._scrub_root_forge_artifacts"),
+        patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+        patch("theforge.sprint.runner._get_or_create_sprint_id", return_value=None),
+        patch("theforge.sprint.runner._project_root_is_git_checkout", return_value=True),
+        patch(
+            "theforge.coordinator.workspace.pull_base_branch",
+            side_effect=_fake_pull,
+        ) as mock_pull,
+        patch("theforge.sprint.runner._run_baseline_gate", side_effect=_fake_baseline),
+        patch("theforge.sprint.runner.resolve_satisfied_dependencies", return_value=set()),
+        patch(
+            "theforge.sprint.runner.normalize_dependency_plan",
+            return_value=SimpleNamespace(tasks=[], blocked={}),
+        ),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight",
+            side_effect=RuntimeError("stop after baseline"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="stop after baseline"):
+            run_sprint(config, resolved)
+
+    assert call_order == ["pull", "baseline"]
+    mock_pull.assert_called_once_with(config)
+
+
+def test_run_sprint_no_pull_skips_prebaseline_pull(tmp_path: Path) -> None:
+    config = _make_runner_config(tmp_path)
+    resolved = _make_empty_resolved()
+    call_order: list[str] = []
+
+    def _fake_baseline(_config: ForgeConfig, _resolved: ResolvedSprint) -> dict[str, object]:
+        call_order.append("baseline")
+        return {"passed": True, "message": "ok"}
+
+    with (
+        patch("theforge.sprint.runner._scrub_root_forge_artifacts"),
+        patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+        patch("theforge.sprint.runner._get_or_create_sprint_id", return_value=None),
+        patch("theforge.coordinator.workspace.pull_base_branch") as mock_pull,
+        patch("theforge.sprint.runner._run_baseline_gate", side_effect=_fake_baseline),
+        patch("theforge.sprint.runner.resolve_satisfied_dependencies", return_value=set()),
+        patch(
+            "theforge.sprint.runner.normalize_dependency_plan",
+            return_value=SimpleNamespace(tasks=[], blocked={}),
+        ),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight",
+            side_effect=RuntimeError("stop after baseline"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="stop after baseline"):
+            run_sprint(config, resolved, no_pull=True)
+
+    assert call_order == ["baseline"]
+    mock_pull.assert_not_called()
+
+
+def test_run_sprint_pull_base_branch_failure_aborts_before_baseline(tmp_path: Path) -> None:
+    config = _make_runner_config(tmp_path)
+    resolved = _make_empty_resolved()
+
+    with (
+        patch("theforge.sprint.runner._scrub_root_forge_artifacts"),
+        patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+        patch("theforge.sprint.runner._get_or_create_sprint_id", return_value=None),
+        patch("theforge.sprint.runner._project_root_is_git_checkout", return_value=True),
+        patch(
+            "theforge.coordinator.workspace.pull_base_branch",
+            side_effect=RuntimeError("WORKSPACE abort: pull failed"),
+        ),
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_baseline,
+    ):
+        with pytest.raises(RuntimeError, match="WORKSPACE abort: pull failed"):
+            run_sprint(config, resolved)
+
+    mock_baseline.assert_not_called()
+
+
+def test_run_baseline_gate_reports_local_origin_sha_gap(tmp_path: Path) -> None:
+    config = _make_runner_config(tmp_path)
+    resolved = _make_empty_resolved()
+    top_level = str(tmp_path)
+
+    def _completed_process(
+        returncode: int,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> MagicMock:
+        proc = MagicMock()
+        proc.returncode = returncode
+        proc.stdout = stdout
+        proc.stderr = stderr
+        return proc
+
+    run_calls = [
+        _completed_process(0, stdout=".git\n"),
+        _completed_process(0, stdout="abc123def456\n"),
+        _completed_process(0, stdout=f"{top_level}\n"),
+        _completed_process(0),
+        _completed_process(0),
+    ]
+
+    with (
+        patch("theforge.sprint.runner.subprocess.run", side_effect=run_calls),
+        patch(
+            "theforge.sprint.runner.run_gate_full",
+            return_value=("FAIL", "Gate returned FAIL", "tail", "make gate", 1),
+        ),
+        patch(
+            "theforge.sprint.runner.subprocess.check_output",
+            side_effect=[
+                "1111111111111111111111111111111111111111\n",
+                "2222222222222222222222222222222222222222\n",
+            ],
+        ),
+    ):
+        baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is False
+    assert "local main is at 111111111111" in str(baseline["message"])
+    assert "origin is at 222222222222" in str(baseline["message"])
+    assert "omit --no-pull" in str(baseline["message"])
 
 
 # ── _is_branch_merged: fast-forward merge regression ─────────────────


### PR DESCRIPTION
## Summary

Both ACs met: sprint-level pre-baseline pull is wired before baseline gate in run_sprint(), --no-pull skips it, pull failure aborts cleanly, and broken-baseline messages now include local-vs-origin SHA gap context; tests cover all four paths.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $2.35
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:271`** The SHA gap diagnostic uses subprocess.check_output without a timeout. git rev-parse is normally a fast local operation, but on a slow or stale filesystem a hung subprocess would freeze the sprint tear-down path. The broader CLAUDE.md testing rule against unbounded blocking I/O applies here even outside tests.
- **[P2] `src/theforge/sprint/runner.py:284`** The stale-branch hint appended to the broken-baseline message always says 'run git pull on {base_branch} or omit --no-pull', even when the operator deliberately passed --no-pull and the SHA gap is therefore expected. A user who intentionally pinned to a local SHA will find the 'omit --no-pull' advice confusing.

## Story

Sprint baseline gate runs against local main before pulling — false-negative when origin has critical fixes (GitHub Issue #1120)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1120