### PR TITLE
fix: suppress complexity override for bug work_type

### DIFF
--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -383,22 +383,33 @@ def _run_preflight_phase(
                 "(cross-cutting blast radius)"
             )
 
-        large_story_categories = _detect_large_preflight_story_categories(story_content)
-        if large_story_categories and (
-            complexity != "large"
-            or state.preflight_complexity_score is None
-            or state.preflight_complexity_score < 8
-        ):
-            complexity = "large"
-            state.preflight_complexity = complexity
-            if state.preflight_complexity_score is None or state.preflight_complexity_score < 8:
-                state.preflight_complexity_score = 8
-            override_reason = (
-                "coordinator override: upgraded complexity to large for "
-                + ", ".join(large_story_categories)
-            )
-            state.preflight_warnings = list(state.preflight_warnings or []) + [override_reason]
-            _log(f"  ↑ {override_reason}")
+        # Bug stories describe symptom context (what went wrong, what was expected),
+        # not fix scope. The keyword patterns match domain vocabulary in the bug
+        # description, not the shape of the change required. Skip the override for
+        # bugs — the preflight LLM reads the codebase and should size bugs correctly.
+        # The override is load-bearing only for feature/refactor/mechanical stories
+        # where imperative spec language reflects genuine cross-cutting scope.
+        if work_type != "bug":
+            large_story_categories = _detect_large_preflight_story_categories(story_content)
+            if large_story_categories and (
+                complexity != "large"
+                or state.preflight_complexity_score is None
+                or state.preflight_complexity_score < 8
+            ):
+                complexity = "large"
+                state.preflight_complexity = complexity
+                score_too_low = (
+                    state.preflight_complexity_score is None
+                    or state.preflight_complexity_score < 8
+                )
+                if score_too_low:
+                    state.preflight_complexity_score = 8
+                override_reason = (
+                    "coordinator override: upgraded complexity to large for "
+                    + ", ".join(large_story_categories)
+                )
+                state.preflight_warnings = list(state.preflight_warnings or []) + [override_reason]
+                _log(f"  ↑ {override_reason}")
 
         _log(f"  Complexity: {complexity} (from preflight)")
         _log(f"  Sufficiency: {sufficiency}")

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -368,7 +368,7 @@ update the state machine handoff so cleanup does not emit duplicate terminal rec
 verdict: PROCEED
 complexity: medium
 complexity_score: 5
-work_type: bug
+work_type: feature
 contract_change: false
 reason: "Looks like a medium multi-file coordinator fix."
 sufficiency: implementation_ready
@@ -400,6 +400,80 @@ criteria_checked:
         assert audit["complexity"] == "large"
         assert audit["complexity_score"] == 8
         assert audit["derived_dev_model"] == "opus"
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_bug_story_with_lifecycle_vocabulary_not_upgraded_to_large(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Bug stories that mention lifecycle/cancellation context must not be upgraded.
+
+        Regression for issue #1150: the coordinator override was firing on bug *context*
+        (what the bug is about) rather than fix *shape* (what change is required). A
+        display fix in cli/status.py that describes 'prior terminal story state during
+        resumed run' should stay at MEDIUM — the preflight LLM rates the fix correctly
+        from the codebase; the keyword override must not re-classify it.
+        """
+        config = _make_smart_config(tmp_path)
+        task = _make_task(tmp_path)
+        task.story_path.write_text(
+            """# forge status MODEL column shows panel(N) during resumed run
+
+## What happened
+
+The MODEL column in forge status shows panel(N) instead of the model name when
+the sprint is resumed and reuses prior terminal story state from a previous run.
+The coordinator loop carries prior lifecycle state across phases, so the resumed
+run displays stale panel references from the earlier lifecycle/cancellation flow.
+
+## What was expected
+
+The MODEL column should always show the current model name from the active run,
+not a panel reference inherited from prior terminal state.
+""",
+            encoding="utf-8",
+        )
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True,
+            output="""```yaml
+verdict: PROCEED
+complexity: medium
+complexity_score: 5
+work_type: bug
+contract_change: false
+reason: "Single-file display fix in cli/status.py."
+sufficiency: implementation_ready
+sufficiency_reason: "Fix is localised to status rendering."
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "MODEL column shows model name"
+    satisfied: false
+    evidence: "Wrong value returned in status render path"
+```""",
+        )
+        mock_agent.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.preflight_complexity == "medium"
+        assert result.state.preflight_complexity_score == 5
+        assert not any(
+            "coordinator override: upgraded complexity to large" in warning
+            for warning in (result.state.preflight_warnings or [])
+        )
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")


### PR DESCRIPTION
## Summary

- Bug stories describe symptom context (what went wrong), not fix scope. The coordinator override introduced in #1136 was firing on domain vocabulary in the bug description ("lifecycle", "cancellation", "cross-module") even when the fix was a single-file change.
- Suppresses the `_detect_large_preflight_story_categories` override when `work_type == "bug"`. Feature/refactor/mechanical stories continue to get the override as intended.
- Fixes the concrete sprint-035 over-classifications: #1146 (display fix in `cli/status.py` → wrongly LARGE) and #1148 (budget formula in `assignment.py` → wrongly LARGE).

## Test plan

- [x] Existing `test_concurrency_multiphase_story_upgrades_medium_preflight_to_large_for_routing` — updated `work_type: bug` → `feature` to match the story's imperative language; override still fires correctly
- [x] New `test_bug_story_with_lifecycle_vocabulary_not_upgraded_to_large` — regression for #1150: bug story with lifecycle/coordinator vocabulary stays at MEDIUM
- [x] `make gate` passes (3720 passed)

Closes #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)