### PR TITLE
fix: adaptive dev_budget under-funds LARGE stories; honour committed work on post-hoc overrun (#1148)

### DIFF
--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -39,6 +39,10 @@ _HISTORY_MAX_BYTES = 10 * 1024 * 1024  # 10 MiB
 
 _BAND_TO_SCORE = {"small": 2, "medium": 5, "large": 9}
 _HEADROOM_FACTOR = 1.5
+# Budget headroom is scaled by complexity band because strong-tier models on
+# large stories have higher cost variance than cheap-tier models on small ones.
+# Using a flat 1.5x average produced budgets ~2x too tight for LARGE stories.
+_BUDGET_HEADROOM_BY_BAND: dict[str, float] = {"small": 1.5, "medium": 2.0, "large": 2.5}
 _MIN_PROFILE_RUNS = 3
 
 
@@ -262,13 +266,17 @@ def derive_limits(
         chosen_dev = max(floor_dev, min(cap_dev, _ceil_int(raw_dev)))
         timeout_per_iteration = base_timeout_seconds / max(static_dev_max, 1)
         chosen_timeout = _ceil_int(chosen_dev * timeout_per_iteration)
-        chosen_budget = _round_money(profile_stats["avg_cost_usd"] * _HEADROOM_FACTOR)
+        _budget_headroom = _BUDGET_HEADROOM_BY_BAND.get(
+            (complexity_band or "").lower(), _HEADROOM_FACTOR
+        )
+        chosen_budget = _round_money(profile_stats["avg_cost_usd"] * _budget_headroom)
         audit["profile_raw_dev_max"] = round(raw_dev, 4)
+        audit["budget_headroom_factor"] = _budget_headroom
         dev_rationale = (
             f"derived dev limits from {profile_runs} "
             f"{complexity_band or 'unknown'}-band profile runs with "
-            f"{_HEADROOM_FACTOR}x headroom; timeout scaled from static "
-            "per-iteration baseline."
+            f"{_HEADROOM_FACTOR}x iteration headroom and {_budget_headroom}x "
+            "budget headroom; timeout scaled from static per-iteration baseline."
         )
     audit["chosen_dev_max"] = chosen_dev
     audit["chosen_dev_timeout_seconds"] = chosen_timeout

--- a/src/theforge/coordinator/commit_guard.py
+++ b/src/theforge/coordinator/commit_guard.py
@@ -37,3 +37,32 @@ def _has_commits_ahead_of_base(workspace_path: Path, base_branch: str) -> bool:
         except ValueError:
             continue
     return True
+
+
+def _commits_exist_strict(workspace_path: Path, base_branch: str) -> bool:
+    """Return True only when commits are positively confirmed ahead of base_branch.
+
+    Fail-closed: returns False on any git error or when the workspace is not a
+    real git repository. Used where a false positive (treating a no-commit
+    state as having commits) would be harmful — specifically, when deciding
+    whether to skip a post-hoc budget escalation for a run that may have
+    produced no observable work.
+    """
+    for ref in (f"origin/{base_branch}", base_branch):
+        try:
+            proc = subprocess.run(
+                ["git", "rev-list", "--count", f"{ref}..HEAD"],
+                cwd=str(workspace_path),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception:  # noqa: BLE001
+            continue
+        if proc.returncode != 0:
+            continue
+        try:
+            return int(proc.stdout.strip() or "0") > 0
+        except ValueError:
+            continue
+    return False

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -20,7 +20,7 @@ from theforge.sessions import save_sessions
 from theforge.task import ContextAssembler, TaskStory, build_dev_prompt, build_fix_prompt
 from theforge.traces import write_trace
 
-from .commit_guard import _has_commits_ahead_of_base
+from .commit_guard import _commits_exist_strict, _has_commits_ahead_of_base
 from .gate import _is_gate_skip
 from .logging import StructuredLogger
 from .notify import _escalate_notify
@@ -685,20 +685,27 @@ def _run_dev_phase(
         and state.total_dev_cost > (state.adaptive_dev_budget_usd or config.dev_profile.budget_usd)
     ):
         _budget_limit = state.adaptive_dev_budget_usd or config.dev_profile.budget_usd
-        state.phase = Phase.ESCALATE
-        state.error = (
+        _budget_msg = (
             f"Dev budget exceeded: spent ${state.total_dev_cost:.4f} (limit ${_budget_limit:.4f})"
         )
-        _log(f"✗ ESCALATE   {state.error}")
-        if logger:
-            logger._safe_emit("escalate", reason=state.error, phase="DEV")
-        _escalate_notify(task, state, notify, config)
-        return CoordinatorResult(
-            success=False,
-            phase=state.phase,
-            state=state,
-            message=state.error,
-        )
+        # If the dev agent successfully committed work, honour the result rather
+        # than retroactively escalating based on post-hoc accounting. The cost is
+        # already spent; blocking PR creation would silently orphan correct work.
+        if _commits_exist_strict(workspace_path, config.workspace.base_branch):
+            _log(f"⚠ DEV   {_budget_msg} — committed work found, proceeding to validate/review")
+        else:
+            state.phase = Phase.ESCALATE
+            state.error = _budget_msg
+            _log(f"✗ ESCALATE   {state.error}")
+            if logger:
+                logger._safe_emit("escalate", reason=state.error, phase="DEV")
+            _escalate_notify(task, state, notify, config)
+            return CoordinatorResult(
+                success=False,
+                phase=state.phase,
+                state=state,
+                message=state.error,
+            )
 
     if not dev_result.success:
         _log_verbose(f"Dev agent failed (exit={dev_result.exit_code})")

--- a/tests/test_adaptive_iterations.py
+++ b/tests/test_adaptive_iterations.py
@@ -24,6 +24,7 @@ def _policy(**kw) -> RetryPolicy:
 def _profiles(
     *,
     model: str = "dev",
+    band: str = "medium",
     runs: int = 3,
     avg_iterations: float = 4.0,
     avg_cost: float = 2.0,
@@ -33,7 +34,7 @@ def _profiles(
             model: {
                 "dev": {
                     "by_complexity": {
-                        "medium": {
+                        band: {
                             "runs": runs,
                             "avg_iterations": avg_iterations,
                             "avg_cost_usd": avg_cost,
@@ -95,10 +96,12 @@ def test_profile_history_derives_dev_limits_from_headroom(tmp_path: Path):
         model_profiles=_profiles(avg_iterations=3.2, avg_cost=1.2),
     )
     # ceil(3.2 * 1.5) = 5; timeout scales from 900 / 3 = 300s per iteration.
+    # Budget: medium band uses 2.0x headroom → 1.2 * 2.0 = 2.4
     assert result.dev_max == 5
     assert result.dev_timeout_seconds == 1500
-    assert result.dev_budget_usd == 1.8
+    assert result.dev_budget_usd == 2.4
     assert result.audit["profile_history_runs"] == 3
+    assert result.audit["budget_headroom_factor"] == 2.0
 
 
 def test_headroom_clamps_dev_iterations_to_cap(tmp_path: Path):
@@ -259,3 +262,94 @@ def test_insufficient_profile_history_still_uses_review_history_signal(tmp_path:
     assert result.audit["p75_review"] == 4
     assert result.audit["chosen_review_max"] == 4
     assert "review history raised review_max to 4" in result.audit["rationale"]
+
+
+# ── Budget headroom scaling by complexity band ────────────────────────────
+
+
+def test_budget_headroom_large_band_uses_2_5x(tmp_path: Path):
+    result = derive_limits(
+        9,
+        "large",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(band="large", avg_cost=4.0),
+    )
+    # large band: 4.0 * 2.5 = 10.0
+    assert result.dev_budget_usd == 10.0
+    assert result.audit["budget_headroom_factor"] == 2.5
+
+
+def test_budget_headroom_medium_band_uses_2_0x(tmp_path: Path):
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(band="medium", avg_cost=3.0),
+    )
+    # medium band: 3.0 * 2.0 = 6.0
+    assert result.dev_budget_usd == 6.0
+    assert result.audit["budget_headroom_factor"] == 2.0
+
+
+def test_budget_headroom_small_band_uses_1_5x(tmp_path: Path):
+    result = derive_limits(
+        2,
+        "small",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(band="small", avg_cost=1.0),
+    )
+    # small band: 1.0 * 1.5 = 1.5
+    assert result.dev_budget_usd == 1.5
+    assert result.audit["budget_headroom_factor"] == 1.5
+
+
+def test_budget_headroom_unknown_band_falls_back_to_default(tmp_path: Path):
+    result = derive_limits(
+        5,
+        None,
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(band="medium", avg_cost=2.0),
+    )
+    # No band → falls back to _HEADROOM_FACTOR (1.5x): 2.0 * 1.5 = 3.0
+    assert result.dev_budget_usd == 3.0
+    assert result.audit["budget_headroom_factor"] == 1.5
+
+
+def test_budget_headroom_concrete_large_scenario(tmp_path: Path):
+    # Reproduce the concrete failure from issue #1148:
+    # avg_cost $4.13, actual $8.44.  With old 1.5x: budget = $6.20 → escalate.
+    # With new 2.5x: budget = $10.33 → no escalation.
+    result = derive_limits(
+        9,
+        "large",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_budget_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(band="large", avg_cost=4.13),
+    )
+    assert result.dev_budget_usd >= 8.44, (
+        f"Budget {result.dev_budget_usd:.4f} would have escalated the $8.44 run from issue #1148"
+    )

--- a/tests/test_coord_adaptive_iterations.py
+++ b/tests/test_coord_adaptive_iterations.py
@@ -168,7 +168,7 @@ def test_profiles_inform_adaptive_dev_limits(tmp_path: Path):
     )
     assert result.dev_max == 5
     assert result.dev_timeout_seconds == 1500
-    assert result.dev_budget_usd == 1.8
+    assert result.dev_budget_usd == 2.4  # medium band: 1.2 * 2.0x headroom
     assert result.audit["profile_history_runs"] == 3
 
 

--- a/tests/test_coord_dev_phase_budget.py
+++ b/tests/test_coord_dev_phase_budget.py
@@ -198,6 +198,77 @@ class TestCoordinatorBudgetEnforcement:
         assert "review" in result.message
         assert len(result.state.review_agent_results) == 1
 
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.dev_phase._commits_exist_strict", return_value=True)
+    def test_dev_budget_exceeded_but_commits_present_proceeds(
+        self, mock_commits, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """Dev exceeds budget but committed work → honour the result, proceed to DONE."""
+        config = self._make_budget_config(tmp_path, dev_budget=0.40, review_budget=1.00)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+
+        expensive_result = AgentResult(
+            success=True,
+            output="Done.",
+            session_id="s1",
+            cost_usd=0.50,
+            exit_code=0,
+            raw={},
+            profile_name="dev",
+        )
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.return_value = expensive_result
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True, f"Expected DONE but got ESCALATE: {result.message}"
+        assert result.phase == Phase.DONE
+        mock_commits.assert_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.dev_phase._commits_exist_strict", return_value=False)
+    def test_dev_budget_exceeded_no_commits_escalates(
+        self, mock_commits, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """Dev exceeds budget with no commits → ESCALATE (no work to salvage)."""
+        config = self._make_budget_config(tmp_path, dev_budget=0.40, review_budget=1.00)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.return_value = (True, "OK")
+
+        expensive_result = AgentResult(
+            success=True,
+            output="Done.",
+            session_id="s1",
+            cost_usd=0.50,
+            exit_code=0,
+            raw={},
+            profile_name="dev",
+        )
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.return_value = expensive_result
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert "budget" in result.message.lower()
+
 
 # ── Dev notes and handoff validation tests ──────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #1148. Two compounding bugs fixed together:

- **Budget too tight (fix A):** `dev_budget` headroom was a flat 1.5× applied to `avg_cost_usd` for all complexity bands. For a LARGE story routed to a strong-tier model the concrete run spent \$8.44 against a \$6.20 budget. Headroom is now band-scaled: small=1.5×, medium=2.0×, large=2.5×. The same story now receives a ~\$10.33 budget.

- **Post-hoc flip (fix B):** when the dev agent exited successfully and committed work, the post-hoc accounting check still escalated the story and orphaned the commits in the worktree branch. The check now calls `_commits_exist_strict` (fail-closed) before escalating. If commits are confirmed ahead of base, it logs a warning and falls through to validate/review/PR creation instead.

New helper `_commits_exist_strict` added to `commit_guard.py` alongside the existing fail-open `_has_commits_ahead_of_base`; the different failure modes are intentional and the docstrings explain when each applies.

## Test plan

- [ ] `make gate` passes (3715 passed, 1 skipped)
- [ ] `test_budget_headroom_large_band_uses_2_5x` — large=2.5× formula
- [ ] `test_budget_headroom_medium_band_uses_2_0x` — medium=2.0× formula
- [ ] `test_budget_headroom_small_band_uses_1_5x` — small=1.5× (unchanged)
- [ ] `test_budget_headroom_unknown_band_falls_back_to_default` — None band → 1.5×
- [ ] `test_budget_headroom_concrete_large_scenario` — \$4.13 avg → budget ≥ \$8.44
- [ ] `test_dev_budget_exceeded_but_commits_present_proceeds` — commits present → DONE
- [ ] `test_dev_budget_exceeded_no_commits_escalates` — no commits → ESCALATE (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)