### PR TITLE
fix: prevent stale review/detail leak for re-run stories in forge status (#1128)

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1153,12 +1153,20 @@ def run_sprint(
             _mapped_outcome = _outcome_map.get(_prior_outcome)
             if _mapped_outcome is None:
                 continue
+            # Strip per-run terminal artifacts so an accumulated story cannot
+            # carry forward a stale review summary or final_outcome from an
+            # earlier generation. The current run must write these fresh.
+            _prior_detail_raw = _prior.get("detail")
+            _prior_detail = dict(_prior_detail_raw) if isinstance(_prior_detail_raw, dict) else {}
+            for _stale in ("final_outcome", "review_verdict", "review_p1", "review_p2"):
+                _prior_detail.pop(_stale, None)
             _story_state.register(
                 _prior_slug,
                 _prior.get("path", _prior_slug),
                 outcome=_mapped_outcome,
                 cost_usd=float(_prior.get("cost_usd", 0.0) or 0.0),
                 canonical_ref=_prior.get("canonical_ref"),
+                detail=_prior_detail,
             )
     _state_writer: SprintStateWriter | None = None
     stopped_reason: str | None = None

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -281,6 +281,13 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
 
     if status_val in {"done", "failed", "skipped", "preserved"}:
         final_outcome = detail_data.get("final_outcome")
+        # Defensive backstop: a failed/skipped story must never display a
+        # success outcome. If the detail dict still claims DONE/ALREADY_DONE
+        # (e.g. from a leaked prior-run artifact), reconcile by trusting the
+        # current run's status and use the canonical outcome from the entry.
+        if status_val in {"failed", "skipped"} and final_outcome in {"DONE", "ALREADY_DONE"}:
+            canonical_outcome = _nonempty_str(story.get("outcome"))
+            final_outcome = canonical_outcome.upper() if canonical_outcome else None
         skip_reason = _nonempty_str(story.get("reason")) if status_val == "skipped" else None
         if (
             skip_reason

--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -144,11 +144,31 @@ class StoryStateEntry:
         # canonical value for surfaces that want it.
         legacy_status = _CANONICAL_TO_LEGACY_STATUS.get(self.outcome, self.outcome.value)
         merged_detail = dict(self.detail)
-        # Surface ALREADY_DONE (and other canonical-only outcomes) as
-        # ``final_outcome`` in the detail so the live status renders the
-        # full canonical outcome the operator needs.
-        if self.outcome.is_terminal and "final_outcome" not in merged_detail:
-            merged_detail["final_outcome"] = self.outcome.name
+        # Project the canonical outcome into ``final_outcome`` for terminal
+        # stories. Preserve a more-specific final_outcome already in the detail
+        # (e.g. ALREADY_DONE while outcome=DONE) only when its success/failure
+        # bucket matches the current outcome — otherwise an in-run transition
+        # (seeded DONE → ESCALATE) would leave a stale success outcome behind.
+        if self.outcome.is_terminal:
+            existing = merged_detail.get("final_outcome")
+            existing_outcome = (
+                _STATUS_TO_OUTCOME.get(existing.strip().lower())
+                if isinstance(existing, str)
+                else None
+            )
+            if not (
+                existing_outcome is not None
+                and existing_outcome.is_succeeded == self.outcome.is_succeeded
+                and existing_outcome.is_failed == self.outcome.is_failed
+                and existing_outcome.is_skipped == self.outcome.is_skipped
+            ):
+                merged_detail["final_outcome"] = self.outcome.name
+            # review_verdict / review_p1 / review_p2 are per-run review artifacts.
+            # When a terminal outcome is not a success, any prior cycle's review
+            # summary must not bleed into the operator-facing detail.
+            if not self.outcome.is_succeeded:
+                for _stale in ("review_verdict", "review_p1", "review_p2"):
+                    merged_detail.pop(_stale, None)
         d: dict = {
             "slug": self.slug,
             "path": self.path,

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -977,3 +977,49 @@ def test_worker_phase_fn_forwards_coordinator_detail(tmp_path: Path) -> None:
     fn({"phase": "VALIDATE", "iteration": 3, "cost_usd": 1.0})
     data = yaml.safe_load(state_path.read_text())
     assert data["stories"][0]["detail"] == {"gate_status": "running"}
+
+
+def test_stage_and_detail_skipped_with_stale_approve_does_not_leak() -> None:
+    """A SKIPPED story whose detail still claims final_outcome=DONE must not show APPROVE."""
+    from theforge.sprint.status_reader import _stage_and_detail_from_live_story
+
+    story = {
+        "slug": "issue-1080",
+        "path": "Issue #1080",
+        "status": "skipped",
+        "outcome": "skipped",
+        "phase": None,
+        "detail": {
+            "final_outcome": "DONE",
+            "review_verdict": "APPROVE — All ACs met from prior run",
+            "review_p1": 0,
+            "review_p2": 0,
+        },
+        "reason": "depends on issue-1070",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_live_story(story)
+    assert "APPROVE" not in detail
+    # Either the skip reason or the canonical SKIPPED outcome is acceptable; both
+    # are correct, leak of APPROVE is not.
+    assert detail in {"depends on issue-1070", "SKIPPED"}
+
+
+def test_stage_and_detail_failed_with_stale_done_does_not_leak() -> None:
+    """An ESCALATED (failed) story with stale DONE detail must not show APPROVE."""
+    from theforge.sprint.status_reader import _stage_and_detail_from_live_story
+
+    story = {
+        "slug": "issue-1070",
+        "path": "Issue #1070",
+        "status": "failed",
+        "outcome": "escalated",
+        "phase": "ESCALATE",
+        "detail": {
+            "final_outcome": "DONE",
+            "review_verdict": "APPROVE — Adaptive timeout coverage gap closed",
+        },
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_live_story(story)
+    assert "APPROVE" not in detail
+    # The display should reflect the current run's escalation, not a stale APPROVE.
+    assert detail in {"ESCALATED", "ESCALATE"}

--- a/tests/test_sprint_story_state.py
+++ b/tests/test_sprint_story_state.py
@@ -107,3 +107,40 @@ def test_outcome_terminal_classification() -> None:
 def test_transition_unknown_slug_returns_none() -> None:
     state = SprintStoryState()
     assert state.transition("missing", outcome=StoryOutcome.DONE) is None
+
+
+def test_as_dict_overwrites_stale_final_outcome_on_terminal_transition() -> None:
+    """A re-run story that flips DONE → ESCALATE must not surface stale DONE detail."""
+    state = SprintStoryState()
+    state.register(
+        "a",
+        "Issue #1",
+        outcome=StoryOutcome.DONE,
+        detail={
+            "final_outcome": "DONE",
+            "review_verdict": "APPROVE — all ACs met",
+            "review_p1": 0,
+            "review_p2": 0,
+        },
+    )
+    state.transition("a", outcome=StoryOutcome.ESCALATED)
+    serialized = state.as_dict()[0]
+    assert serialized["detail"]["final_outcome"] == "ESCALATED"
+    # Stale review summary must not be carried forward to a non-success outcome.
+    assert "review_verdict" not in serialized["detail"]
+    assert "review_p1" not in serialized["detail"]
+    assert "review_p2" not in serialized["detail"]
+
+
+def test_as_dict_preserves_review_fields_for_success_outcomes() -> None:
+    state = SprintStoryState()
+    state.register(
+        "a",
+        "Issue #1",
+        outcome=StoryOutcome.DONE,
+        detail={"review_verdict": "APPROVE", "review_p1": 0, "review_p2": 1},
+    )
+    serialized = state.as_dict()[0]
+    assert serialized["detail"]["review_verdict"] == "APPROVE"
+    assert serialized["detail"]["review_p1"] == 0
+    assert serialized["detail"]["review_p2"] == 1


### PR DESCRIPTION
## Summary

- **Root cause**: `forge status` was displaying DETAIL/review-summary data from prior sprint runs on stories that were SKIPPED or ESCALATED in the current run — STATUS and DETAIL reflected different sources of truth.
- **Fix 1** (`story_state.py`): `as_dict()` now reconciles `final_outcome` against the live `outcome` bucket and strips `review_verdict`/`review_p1`/`review_p2` from any non-success terminal story, preventing stale review summaries from surfacing.
- **Fix 2** (`status_reader.py`): Defensive backstop in `_stage_and_detail_from_live_story` — failed/skipped stories whose detail still claims `DONE`/`ALREADY_DONE` are reconciled against the current run's canonical outcome.
- **Fix 3** (`runner.py`): When prior-sprint accumulated stories are seeded into the current run via `register()`, per-run terminal artifacts (`final_outcome`, `review_verdict`, `review_p1`, `review_p2`) are stripped so the new run must write them fresh.

## Test plan
- [x] `test_stage_and_detail_skipped_with_stale_approve_does_not_leak` — SKIPPED story with stale DONE/APPROVE detail renders skip reason, not APPROVE
- [x] `test_stage_and_detail_failed_with_stale_done_does_not_leak` — ESCALATED story with stale DONE detail renders ESCALATED, not APPROVE
- [x] `test_as_dict_overwrites_stale_final_outcome_on_terminal_transition` — story that transitions DONE→ESCALATE loses stale review fields
- [x] `test_as_dict_preserves_review_fields_for_success_outcomes` — DONE/APPROVE stories retain their review summary
- [x] `make gate` passes — 3723 passed

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)