### PR TITLE
fix: preserve phase-style ESCALATE final_outcome in story_state reconciliation (#1128)

### DIFF
--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -100,6 +100,7 @@ _STATUS_TO_OUTCOME: dict[str, StoryOutcome] = {
     "already_done": StoryOutcome.ALREADY_DONE,
     "failed": StoryOutcome.FAILED,
     "escalated": StoryOutcome.ESCALATED,
+    "escalate": StoryOutcome.ESCALATED,  # phase-style alias seeded by runner
     "skipped": StoryOutcome.SKIPPED,
     "preserved": StoryOutcome.PRESERVED,
     "dropped": StoryOutcome.DROPPED,

--- a/tests/test_sprint_story_state.py
+++ b/tests/test_sprint_story_state.py
@@ -132,6 +132,20 @@ def test_as_dict_overwrites_stale_final_outcome_on_terminal_transition() -> None
     assert "review_p2" not in serialized["detail"]
 
 
+def test_as_dict_preserves_phase_style_escalate_final_outcome() -> None:
+    """Runner seeds detail.final_outcome='ESCALATE' (phase-style); must not be overwritten."""
+    state = SprintStoryState()
+    state.register(
+        "a",
+        "Issue #1",
+        outcome=StoryOutcome.ESCALATED,
+        detail={"final_outcome": "ESCALATE"},
+    )
+    serialized = state.as_dict()[0]
+    # Phase-style "ESCALATE" is in the same failure bucket as ESCALATED — preserve it.
+    assert serialized["detail"]["final_outcome"] == "ESCALATE"
+
+
 def test_as_dict_preserves_review_fields_for_success_outcomes() -> None:
     state = SprintStoryState()
     state.register(


### PR DESCRIPTION
## Summary

Follow-up to #1162 (P2 finding from code review).

- `_STATUS_TO_OUTCOME` recognized `"escalated"` but not `"escalate"` — the phase-style value the runner seeds as `detail.final_outcome` at lines 1493/1497 of `runner.py`.
- When `as_dict()` lowercased `"ESCALATE"` to look it up, the lookup returned `None`, so the reconciliation logic treated it as invalid and overwrote it with the coarser canonical `"ESCALATED"` name, losing the intended escalation detail.
- Fix: add `"escalate": StoryOutcome.ESCALATED` alias to `_STATUS_TO_OUTCOME`.

## Test plan
- [x] `test_as_dict_preserves_phase_style_escalate_final_outcome` — new regression test; a story registered with `outcome=ESCALATED` and `detail.final_outcome="ESCALATE"` retains `"ESCALATE"` after serialization
- [x] Focused suite: `pytest tests/test_sprint_story_state.py tests/test_cli_sprint_status.py -q` → 41 passed
- [x] `make gate` → 3724 passed, 1 skipped

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)