### PR TITLE
fix: ignore stale verdict for non-success completed rows in forge status (#1166)

### DIFF
--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -410,7 +410,10 @@ def _stage_and_detail_from_completed_story(
                 detail = error
 
     if not detail:
-        verdict = _nonempty_str(story.get("verdict"))
+        # Only trust a top-level verdict for success outcomes. A stale APPROVE
+        # on a FAILED/ESCALATED/SKIPPED row from a prior run must not leak.
+        _success_outcome = outcome in {"DONE", "ALREADY_DONE"}
+        verdict = _nonempty_str(story.get("verdict")) if _success_outcome else None
         if verdict == "APPROVE":
             detail = "APPROVE"
         elif verdict:

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -1023,3 +1023,62 @@ def test_stage_and_detail_failed_with_stale_done_does_not_leak() -> None:
     assert "APPROVE" not in detail
     # The display should reflect the current run's escalation, not a stale APPROVE.
     assert detail in {"ESCALATED", "ESCALATE"}
+
+
+def test_completed_failed_story_with_stale_verdict_does_not_show_approve() -> None:
+    """Completed FAILED row with stale verdict=APPROVE must not render APPROVE."""
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    story = {
+        "slug": "issue-1070",
+        "path": "Issue #1070",
+        "outcome": "FAILED",
+        "verdict": "APPROVE",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
+    assert "APPROVE" not in detail
+    assert detail == "FAILED"
+
+
+def test_completed_escalated_story_with_stale_verdict_does_not_show_approve() -> None:
+    """Completed ESCALATED row with stale verdict=APPROVE must not render APPROVE."""
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    story = {
+        "slug": "issue-1070",
+        "path": "Issue #1070",
+        "outcome": "ESCALATED",
+        "verdict": "APPROVE",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
+    assert "APPROVE" not in detail
+    assert detail == "ESCALATED"
+
+
+def test_completed_skipped_story_with_stale_verdict_does_not_show_approve() -> None:
+    """Completed SKIPPED row with stale verdict=APPROVE must not render APPROVE."""
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    story = {
+        "slug": "issue-1080",
+        "path": "Issue #1080",
+        "outcome": "SKIPPED",
+        "verdict": "APPROVE",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
+    assert "APPROVE" not in detail
+    assert detail == "SKIPPED"
+
+
+def test_completed_done_story_verdict_is_preserved() -> None:
+    """Completed DONE row with verdict=APPROVE should still render APPROVE."""
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    story = {
+        "slug": "issue-1000",
+        "path": "Issue #1000",
+        "outcome": "DONE",
+        "verdict": "APPROVE",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
+    assert detail == "APPROVE"


### PR DESCRIPTION
## Summary

Completed/summary-file counterpart to the live-state leak fixed in #1128.

`_stage_and_detail_from_completed_story` read `story['verdict']` unconditionally as a fallback. A sprint-summary row with `outcome: FAILED`, `ESCALATED`, or `SKIPPED` carrying a stale `verdict: APPROVE` from a prior run would render `APPROVE` in the DETAIL column even after the live state file was gone.

Fix: guard the verdict lookup to success outcomes only (`DONE` / `ALREADY_DONE`). Non-success rows now skip the verdict entirely and fall through to the canonical outcome-based fallback.

## Test plan
- [x] `test_completed_failed_story_with_stale_verdict_does_not_show_approve` — FAILED + stale APPROVE → detail is FAILED
- [x] `test_completed_escalated_story_with_stale_verdict_does_not_show_approve` — ESCALATED + stale APPROVE → detail is ESCALATED
- [x] `test_completed_skipped_story_with_stale_verdict_does_not_show_approve` — SKIPPED + stale APPROVE → detail is SKIPPED
- [x] `test_completed_done_story_verdict_is_preserved` — DONE + APPROVE still renders APPROVE (no regression)
- [x] Focused suite: `pytest tests/test_sprint_story_state.py tests/test_cli_sprint_status.py -q` → 45 passed
- [x] `make gate` → 3736 passed, 1 skipped

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)