### PR TITLE
Forge plans trivial bounded work — sufficiency over-classifies as needs_planning, full plan + plan review pipeline runs unnecessarily

### DIFF
--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -411,6 +411,33 @@ def _run_preflight_phase(
                 state.preflight_warnings = list(state.preflight_warnings or []) + [override_reason]
                 _log(f"  ↑ {override_reason}")
 
+        # ── Bounded-bug planning skip ─────────────────────────────────
+        # Bounded, diagnosed bugs whose fix is localized to a single area
+        # do not benefit from the plan + plan-review pipeline. The plan
+        # agent's multi-step decomposition buys nothing when the dev would
+        # have made the same single-area fix without one. Downgrade
+        # needs_planning → implementation_ready when ALL hold:
+        #   - work_type is "bug"           (symptom + expected, not new feature)
+        #   - complexity is "small"        (bounded scope per preflight sizing)
+        #   - contract_change is False     (no shared-interface blast radius)
+        # The contract-change override above runs first and is load-bearing:
+        # contract_change=true forces needs_planning + ≥medium complexity, so
+        # this gate cannot accidentally skip planning for cross-cutting work.
+        if (
+            sufficiency == "needs_planning"
+            and work_type == "bug"
+            and complexity == "small"
+            and not contract_change
+        ):
+            sufficiency = "implementation_ready"
+            state.preflight_sufficiency = sufficiency
+            override_reason = (
+                "coordinator override: bounded bug (work_type=bug, complexity=small, "
+                "contract_change=false) → implementation_ready (skip plan pipeline)"
+            )
+            state.preflight_warnings = list(state.preflight_warnings or []) + [override_reason]
+            _log(f"  ↓ {override_reason}")
+
         _log(f"  Complexity: {complexity} (from preflight)")
         _log(f"  Sufficiency: {sufficiency}")
         _log(f"  Work type: {work_type}")

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -182,34 +182,57 @@ def build_preflight_prompt(
         When verdict is PROCEED, also assess whether this spec is
         **implementation-ready** or **needs planning**.
 
-        This is orthogonal to complexity — a large refactor can be
-        implementation-ready if the spec author documented every pitfall,
-        and a small feature can need planning if the spec is vague.
+        The gating signal is **fix-shape decomposition**, NOT spec quality.
+        Ask: "does the work require coordinated multi-step decomposition before
+        a dev agent can begin?" — not "does the spec have a detailed Notes
+        section?" A bounded single-area fix is implementation_ready even if
+        the spec is terse; a cross-cutting refactor needs_planning even if
+        the spec is verbose.
 
-        Classify as `implementation_ready` when ALL of the following hold:
-        - The spec has a detailed **Notes** section with specific file paths,
-          function names, patterns, or implementation pitfalls
-        - Implementation hints are concrete and actionable, not generic
+        `implementation_ready` is the **default** for bounded work. Classify
+        as `implementation_ready` when the fix shape is localized — a dev
+        agent can read the relevant code, make a single coordinated change,
+        and verify the acceptance criteria without first decomposing the
+        work into ordered steps. Typical signals:
+        - The change is contained to one module, one function, or one small
+          cluster of closely related call sites
+        - The work is a diagnosed bug fix where the symptom and expected
+          behavior already point at a single area
+        - No interface, schema, or shared-prompt field is being renamed,
+          removed, or migrated
         - Acceptance criteria describe **observable behaviors** that can be
-          verified by reading code or running tests (not implementation steps)
-        - The spec's detail density is high relative to the assessed complexity
+          verified by reading code or running tests
+        - Spec terseness alone is NOT a reason to escalate to needs_planning
+          — bounded work may legitimately have short specs
 
-        Classify as `needs_planning` when ANY of the following hold:
-        - No Notes section, or Notes is sparse/generic
-        - Implementation approach is unclear or underspecified
-        - Acceptance criteria describe HOW to implement rather than WHAT to observe
-        - Spec lacks enough detail for a dev agent to proceed without a plan
-        - Spec contains ambiguous acceptance criteria (add to spec_issues as well)
-        - The story is a **contract change** — it removes, renames, or migrates a
-          field or function name that is part of a shared interface (coordinator-agent
-          output schema, prompt template field, review YAML field, config field).
-          These always need planning to enumerate the full blast radius: callers,
-          parsers, prompt templates, fix prompts, and exact-string test assertions
-          that reference the old name. The change may look trivial but the dev agent
-          cannot safely discover all references within its iteration budget.
-        - The story modifies a **prompt template string or field name** that is
-          likely referenced in exact-string test assertions (e.g., tests that assert
-          specific text appears in a generated prompt).
+        Classify as `needs_planning` ONLY when the work genuinely requires
+        decomposition into ordered steps before dev can begin. Concrete
+        triggers:
+        - The fix spans multiple modules or coordinator phases that must
+          change together (cross-module surgery, phase-handoff changes)
+        - The story is a **contract change** — it removes, renames, or
+          migrates a field or function name that is part of a shared
+          interface (coordinator-agent output schema, prompt template field,
+          review YAML field, config field). The blast radius (callers,
+          parsers, prompt templates, fix prompts, exact-string test
+          assertions) cannot be safely enumerated by a dev agent within its
+          iteration budget.
+        - The story modifies a **prompt template string or field name** that
+          is likely referenced in exact-string test assertions
+        - Concurrency, cancellation, or lifecycle propagation across module
+          boundaries is in scope
+        - Multiple plausible implementation approaches exist and the choice
+          materially changes the blast radius (the plan agent must pick one)
+        - Acceptance criteria are mutually contradictory or fundamentally
+          ambiguous in a way the dev agent cannot resolve from the codebase
+          (also add to spec_issues with type `ambiguity`)
+
+        Do NOT escalate to needs_planning for any of these reasons alone:
+        - Sparse or missing Notes section (Notes are advisory, not required)
+        - Short spec body or terse acceptance criteria
+        - The dev agent will need to read a few files to find exact line
+          numbers (that is normal investigation, not decomposition)
+        - The spec wording is generic or domain-vocabulary-heavy
 
         ## Output Format
 

--- a/tests/test_coord_preflight_sufficiency.py
+++ b/tests/test_coord_preflight_sufficiency.py
@@ -551,3 +551,270 @@ class TestPreflightPromptContractChangeGuidance:
         assert "contract change" in prompt.lower()
         assert "blast radius" in prompt.lower()
         assert "exact-string" in prompt.lower() or "exact-string" in prompt
+
+
+# ── Bounded-bug planning skip tests ───────────────────────────────────
+
+_PREFLIGHT_BUG_SMALL_NEEDS_PLANNING = """\
+```yaml
+verdict: PROCEED
+complexity: small
+complexity_score: 3
+reason: "Status display reads wrong field — single-area bug fix."
+work_type: bug
+sufficiency: needs_planning
+sufficiency_reason: "Spec lacks Notes section."
+contract_change: false
+spec_issues: []
+warnings: []
+likely_files:
+  - src/foo.py
+criteria_checked:
+  - criterion: "Status displays the right field"
+    satisfied: false
+    evidence: "Reads stale value"
+```
+"""
+
+_PREFLIGHT_FEATURE_SMALL_NEEDS_PLANNING = """\
+```yaml
+verdict: PROCEED
+complexity: small
+complexity_score: 3
+reason: "New small feature."
+work_type: feature
+sufficiency: needs_planning
+sufficiency_reason: "Spec lacks Notes section."
+contract_change: false
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "Feature added"
+    satisfied: false
+    evidence: "Not present"
+```
+"""
+
+_PREFLIGHT_BUG_MEDIUM_NEEDS_PLANNING = """\
+```yaml
+verdict: PROCEED
+complexity: medium
+complexity_score: 6
+reason: "Multi-module bug fix."
+work_type: bug
+sufficiency: needs_planning
+sufficiency_reason: "Multiple modules involved."
+contract_change: false
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "Fix applied"
+    satisfied: false
+    evidence: "Not yet"
+```
+"""
+
+
+class TestBoundedBugPlanSkip:
+    """Coordinator skips planning for bounded bugs (work_type=bug, small, not contract_change)."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_bounded_bug_overrides_to_implementation_ready(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """work_type=bug + complexity=small + not contract_change → implementation_ready."""
+        config = _make_plan_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        preflight_result = _make_agent_result(
+            success=True, output=_PREFLIGHT_BUG_SMALL_NEEDS_PLANNING, cost_usd=0.05
+        )
+        dev_result = _make_agent_result(success=True, output="Done.", cost_usd=0.50)
+
+        mock_preflight.return_value = preflight_result
+        mock_dev_agent.return_value = dev_result
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        # Coordinator overrode needs_planning → implementation_ready
+        assert result.state.preflight_sufficiency == "implementation_ready"
+        # Plan agent must NOT have run
+        assert mock_plan_agent.call_count == 0
+        # Dev runs once
+        assert mock_dev_agent.call_count == 1
+        assert result.state.plan_output is None
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_feature_small_not_overridden(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """work_type=feature + small + needs_planning → no override; plan still runs."""
+        config = _make_plan_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        preflight_result = _make_agent_result(
+            success=True, output=_PREFLIGHT_FEATURE_SMALL_NEEDS_PLANNING, cost_usd=0.05
+        )
+        dev_result = _make_agent_result(success=True, output="Done.", cost_usd=0.50)
+
+        mock_preflight.return_value = preflight_result
+        mock_dev_agent.return_value = dev_result
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        # No bounded-bug override (work_type != bug). Sufficiency stays needs_planning.
+        assert result.state.preflight_sufficiency == "needs_planning"
+        # complexity=small means plan_flow gates plan off (gate is medium/large only).
+        # The new override only fires for bugs; features keep their original behavior.
+        assert mock_plan_agent.call_count == 0
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_medium_bug_not_overridden(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """work_type=bug + complexity=medium → no override; plan runs."""
+        config = _make_plan_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        preflight_result = _make_agent_result(
+            success=True, output=_PREFLIGHT_BUG_MEDIUM_NEEDS_PLANNING, cost_usd=0.05
+        )
+        plan_result = _make_agent_result(success=True, output="# Plan\n\nStep 1.", cost_usd=0.10)
+        dev_result = _make_agent_result(success=True, output="Done.", cost_usd=0.50)
+
+        call_idx = {"n": 0}
+        mock_preflight.return_value = preflight_result
+        results = [plan_result, dev_result]
+
+        def agent_side_effect(**kwargs):
+            idx = min(call_idx["n"], len(results) - 1)
+            call_idx["n"] += 1
+            return results[idx]
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_dev_agent
+        mock_dev_agent.side_effect = agent_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        # Medium bugs may genuinely need decomposition — no override.
+        assert result.state.preflight_sufficiency == "needs_planning"
+        assert mock_dev_agent.call_count == 2
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_contract_change_bug_keeps_planning(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """contract_change=true beats the bounded-bug skip — plan runs."""
+        contract_bug_yaml = """\
+```yaml
+verdict: PROCEED
+complexity: small
+complexity_score: 3
+reason: "Bug fix that renames a shared field."
+work_type: bug
+sufficiency: needs_planning
+sufficiency_reason: "Field rename across coordinator."
+contract_change: true
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "Field renamed"
+    satisfied: false
+    evidence: "Old name still in use"
+```
+"""
+        config = _make_plan_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        preflight_result = _make_agent_result(
+            success=True, output=contract_bug_yaml, cost_usd=0.05
+        )
+        plan_result = _make_agent_result(
+            success=True, output="# Plan\n\nStep 1: enumerate.", cost_usd=0.10
+        )
+        dev_result = _make_agent_result(success=True, output="Done.", cost_usd=0.50)
+
+        call_idx = {"n": 0}
+        mock_preflight.return_value = preflight_result
+        results = [plan_result, dev_result]
+
+        def agent_side_effect(**kwargs):
+            idx = min(call_idx["n"], len(results) - 1)
+            call_idx["n"] += 1
+            return results[idx]
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_dev_agent
+        mock_dev_agent.side_effect = agent_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        # contract_change forces needs_planning AND upgrades complexity to medium.
+        # The bounded-bug override does not fire because complexity is no longer small.
+        assert result.state.preflight_sufficiency == "needs_planning"
+        assert result.state.preflight_complexity == "medium"
+        assert mock_dev_agent.call_count == 2
+
+
+class TestPreflightPromptDecompositionAnchor:
+    """Preflight prompt anchors sufficiency on fix-shape decomposition, not spec quality."""
+
+    def test_prompt_emphasises_decomposition_signal(self, tmp_path: Path):
+        """The prompt must signal that decomposition need (not Notes density) drives the call."""
+        from theforge.task import build_preflight_prompt
+        from theforge.task.story import TaskStory
+
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Test\n\nDo something.", encoding="utf-8")
+        task = TaskStory(name="Test Task", story_path=spec, slug="test-task")
+        prompt = build_preflight_prompt(task, story_content="# Test\n\nDo something.")
+        lower = prompt.lower()
+        assert "decomposition" in lower
+        assert "fix-shape" in lower or "fix shape" in lower
+        # The prompt must explicitly state that sparse Notes alone is not grounds.
+        assert "sparse" in lower or "terse" in lower
+        # implementation_ready must be presented as the default for bounded work.
+        assert "default" in lower


### PR DESCRIPTION
## Summary

Clean two-part fix — deterministic coordinator gate is the backstop, prompt reframe is the secondary lever; all safety guards (contract-change ordering, complexity gate) verified correct.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.80
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_coord_preflight_sufficiency.py:664`** test_feature_small_not_overridden docstring says 'plan still runs' but the assertion immediately below checks mock_plan_agent.call_count == 0. The plan does NOT run because complexity=small hits the existing plan_flow complexity gate, not because of the new override. A future reader may trust the docstring over the assertion and be confused about what is actually under test.

## Story

Forge plans trivial bounded work — sufficiency over-classifies as needs_planning, full plan + plan review pipeline runs unnecessarily (GitHub Issue #1163)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1163