### PR TITLE
Review summary's "(persistent)" tag renders next to P2 count but describes a P1 match — misleading

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1013,9 +1013,9 @@ def _run_review_phase(
         _prev_result = state.review_results[-2]
         _is_persistent_p1 = _has_persistent_p1(parsed_review.findings, _prev_result.findings)
 
-    _persistent_tag = " (persistent)" if _is_persistent_p1 else ""
+    _persistent_tag = " (persistent-P1)" if _is_persistent_p1 else ""
     _log(
-        f"  ✗ REVIEW   REQUEST_CHANGES  {_p1_count} P1  {_p2_count} P2{_persistent_tag}"
+        f"  ✗ REVIEW   REQUEST_CHANGES  {_p1_count} P1{_persistent_tag}  {_p2_count} P2"
         f"  ${_review_cost:.2f}  {_fmt_duration(_review_elapsed)}"
     )
 


### PR DESCRIPTION
## Summary

Minimal, correct fix — tag renamed to (persistent-P1) and repositioned immediately after P1 count, satisfying both acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.36
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Review summary's "(persistent)" tag renders next to P2 count but describes a P1 match — misleading (GitHub Issue #955)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #955