### PR TITLE
Sprint --resume manifest includes already-merged stories, then SKIPS them with misleading 'workspace creation failed' message

### DIFF
--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -45,6 +45,16 @@ class StoryTriage:
     slug: str = ""
 
 
+@dataclass(frozen=True)
+class MergeEvidence:
+    """Structured merge detection result for resume triage."""
+
+    merged: bool
+    source: str | None = None
+    pr_number: int | None = None
+    pr_url: str | None = None
+
+
 def _has_prior_review_approve(
     project_root: Path,
     slug: str,
@@ -104,36 +114,87 @@ def _has_base_commit_referencing_issue(
         return False
 
 
-def _is_branch_merged(
+def _lookup_merged_pr_for_branch(
+    branch: str,
+    project_root: Path,
+) -> MergeEvidence | None:
+    """Return merged PR metadata for ``branch`` when GitHub reports one."""
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "closed",
+                "--json",
+                "number,url,mergedAt",
+            ],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout or "[]")
+        if not isinstance(data, list):
+            return None
+        merged_prs: list[tuple[str, int, str | None]] = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            merged_at = item.get("mergedAt")
+            number = item.get("number")
+            url = item.get("url")
+            if not isinstance(merged_at, str) or not merged_at:
+                continue
+            if not isinstance(number, int):
+                continue
+            merged_prs.append((merged_at, number, url if isinstance(url, str) else None))
+        if not merged_prs:
+            return None
+        _merged_at, pr_number, pr_url = max(merged_prs, key=lambda item: item[0])
+        return MergeEvidence(
+            merged=True,
+            source="github_pr",
+            pr_number=pr_number,
+            pr_url=pr_url,
+        )
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+        return None
+
+
+def _with_pr_metadata(
+    evidence: MergeEvidence,
+    branch: str,
+    project_root: Path,
+    issue_number: int | None,
+) -> MergeEvidence:
+    """Attach merged-PR metadata when GitHub can identify the landing PR."""
+    if not evidence.merged or issue_number is None or evidence.pr_number is not None:
+        return evidence
+    merged_pr = _lookup_merged_pr_for_branch(branch, project_root)
+    if merged_pr is None:
+        return evidence
+    return MergeEvidence(
+        merged=True,
+        source=evidence.source,
+        pr_number=merged_pr.pr_number,
+        pr_url=merged_pr.pr_url,
+    )
+
+
+def _branch_merge_evidence(
     branch: str,
     base_branch: str,
     project_root: Path,
     slug: str | None = None,
-) -> bool:
-    """Return True if branch has been merged into base_branch.
-
-    Three detection paths handle the merge strategies theforge uses:
-
-    1. Regular merge commit (git merge --no-edit fallback):
-       --is-ancestor passes AND branch..base_branch count > 0 (base advanced
-       past the branch tip via a merge commit) AND base_branch..branch count > 0
-       (the branch had unique commits before merge).
-
-    2. Fast-forward merge (git merge --ff-only, preferred):
-       After an FF merge, branch and base point at the same commit, so
-       branch..base_branch count == 0.
-
-    3. Squash merge (configured default):
-       The feature branch tip remains an ancestor of base because it was based
-       on base, but the squash commit on base is a new commit with no parent
-       relationship to the branch. Git topology alone therefore cannot prove
-       the merge. Issue-backed branches first look for a base commit that
-       references the issue, then fall back to the forge APPROVE audit trail
-       when slug is provided.
-
-    A branch that was merely created at base HEAD (count == 0, no audit entry)
-    correctly returns False.
-    """
+) -> MergeEvidence:
+    """Return structured merge evidence for ``branch`` against ``base_branch``."""
+    no_merge = MergeEvidence(merged=False)
     issue_number = _issue_number_from_slug(slug) if slug is not None else None
     if issue_number is None:
         issue_number = _issue_number_from_ref(branch)
@@ -171,29 +232,86 @@ def _is_branch_merged(
                 if unique_count > 0:
                     # Regular merge: base has moved past branch and branch had
                     # unique work of its own.
-                    return issue_is_closed
+                    if issue_is_closed:
+                        return _with_pr_metadata(
+                            MergeEvidence(merged=True, source="topology"),
+                            branch,
+                            project_root,
+                            issue_number,
+                        )
+                    return no_merge
     except (subprocess.TimeoutExpired, OSError, ValueError):
         pass
 
     if not issue_is_closed:
-        return False
+        return no_merge
 
     if issue_number is not None and _has_base_commit_referencing_issue(
         project_root,
         base_branch,
         issue_number,
     ):
-        return True
+        return _with_pr_metadata(
+            MergeEvidence(merged=True, source="issue_commit"),
+            branch,
+            project_root,
+            issue_number,
+        )
 
     # Fast-forward merges at the same tip and squash merges both need the audit
     # trail fallback. In real squash merges, --is-ancestor returns non-zero, so
     # this check must live outside the topology-success branch above.
     if slug is not None:
         try:
-            return _has_prior_review_approve(project_root, slug, base_branch, branch)
+            if _has_prior_review_approve(project_root, slug, base_branch, branch):
+                return _with_pr_metadata(
+                    MergeEvidence(merged=True, source="audit"),
+                    branch,
+                    project_root,
+                    issue_number,
+                )
         except Exception:
-            return False
-    return False
+            return no_merge
+
+    merged_pr = (
+        _lookup_merged_pr_for_branch(branch, project_root) if issue_number is not None else None
+    )
+    if merged_pr is not None:
+        return merged_pr
+    return no_merge
+
+
+def _is_branch_merged(
+    branch: str,
+    base_branch: str,
+    project_root: Path,
+    slug: str | None = None,
+) -> bool:
+    """Return True if branch has been merged into base_branch.
+
+    Three detection paths handle the merge strategies theforge uses:
+
+    1. Regular merge commit (git merge --no-edit fallback):
+       --is-ancestor passes AND branch..base_branch count > 0 (base advanced
+       past the branch tip via a merge commit) AND base_branch..branch count > 0
+       (the branch had unique commits before merge).
+
+    2. Fast-forward merge (git merge --ff-only, preferred):
+       After an FF merge, branch and base point at the same commit, so
+       branch..base_branch count == 0.
+
+    3. Squash merge (configured default):
+       The feature branch tip remains an ancestor of base because it was based
+       on base, but the squash commit on base is a new commit with no parent
+       relationship to the branch. Git topology alone therefore cannot prove
+       the merge. Issue-backed branches first look for a base commit that
+       references the issue, then fall back to the forge APPROVE audit trail
+       when slug is provided.
+
+    A branch that was merely created at base HEAD (count == 0, no audit entry)
+    correctly returns False.
+    """
+    return _branch_merge_evidence(branch, base_branch, project_root, slug=slug).merged
 
 
 def _is_issue_closed(issue_number: int, project_root: Path) -> bool:
@@ -449,9 +567,12 @@ def _triage_spec(
     # 2. Check if already merged to base branch.
     # Pass slug so _is_branch_merged can use the audit trail as a tiebreaker
     # for fast-forward merges where branch and base land on the same commit.
-    if _is_branch_merged(branch, base_branch, project_root, slug=slug):
+    merge_evidence = _branch_merge_evidence(branch, base_branch, project_root, slug=slug)
+    if merge_evidence.merged:
         merged_reason = f"already merged to {base_branch}"
-        if _has_prior_review_approve(project_root, slug, base_branch, branch):
+        if merge_evidence.pr_number is not None:
+            merged_reason = f"already merged in PR #{merge_evidence.pr_number}, skipping"
+        elif merge_evidence.source == "audit":
             merged_reason = f"prior APPROVE in audit trail; already merged to {base_branch}"
         return StoryTriage(
             story_path=story_path,

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -326,6 +326,48 @@ class TestTriageSpec:
         assert triage.action == "skip_merged"
         assert "merged" in triage.reason
 
+    def test_triage_issue_merged_via_closed_pr_uses_pr_specific_reason(
+        self, tmp_path: Path
+    ) -> None:
+        """Closed merged PRs are skipped before workspace setup with a PR-specific reason."""
+        _make_spec_file(tmp_path, "Issue 1102", "issue-1102")
+        config = _make_config(tmp_path)
+
+        def _mock_run(cmd, **kwargs):
+            m = MagicMock()
+            if cmd[:3] == ["gh", "pr", "list"]:
+                m.returncode = 0
+                m.stdout = (
+                    '[{"number":1111,"url":"https://github.com/o/r/pull/1111",'
+                    '"mergedAt":"2026-05-01T12:34:56Z"}]'
+                )
+            elif cmd[:2] == ["git", "log"] and "--grep=(#1102)" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            elif "log" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            elif "rev-list" in cmd and "--count" in cmd:
+                m.returncode = 0
+                m.stdout = b"2"
+            elif "--is-ancestor" in cmd:
+                m.returncode = 1
+                m.stdout = b""
+            else:
+                m.returncode = 0
+                m.stdout = b""
+            return m
+
+        with (
+            patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run),
+            patch("theforge.sprint.dag._is_issue_closed", return_value=True),
+            patch("theforge.sprint.dag.has_review_approve", return_value=False),
+        ):
+            triage = _triage_spec("issue-1102.md", config, tmp_path)
+
+        assert triage.action == "skip_merged"
+        assert triage.reason == "already merged in PR #1111, skipping"
+
     def test_triage_same_tip_failed_landing_audit_stays_full(self, tmp_path: Path) -> None:
         """A zero-delta APPROVE with failed landing stays eligible during resume."""
         import json

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -540,6 +540,37 @@ def test_is_branch_merged_external_squash_merge_by_issue_commit(tmp_path: Path) 
     assert result is True
 
 
+def test_is_branch_merged_external_squash_merge_by_merged_pr_lookup(tmp_path: Path) -> None:
+    """A merged PR for the issue branch counts even without audit or commit grep."""
+
+    def _mock_external_pr(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if "--is-ancestor" in cmd:
+            m.returncode = 1
+            m.stdout = b""
+        elif cmd[:2] == ["git", "log"] and "--grep=(#1102)" in cmd:
+            m.returncode = 0
+            m.stdout = b""
+        elif cmd[:3] == ["gh", "pr", "list"]:
+            m.returncode = 0
+            m.stdout = (
+                '[{"number":1111,"url":"https://github.com/o/r/pull/1111",'
+                '"mergedAt":"2026-05-01T12:34:56Z"}]'
+            )
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_pr),
+        patch("theforge.sprint.dag._is_issue_closed", return_value=True),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+    ):
+        result = _is_branch_merged("feat/issue-1102", "main", tmp_path, slug="issue-1102")
+    assert result is True
+
+
 def test_is_branch_merged_issue_branch_without_base_commit_or_audit(tmp_path: Path) -> None:
     """Issue branch stays unmerged when base has no matching squash commit."""
 


### PR DESCRIPTION
## Summary

Clean refactor introducing MergeEvidence for structured merge detection; PR-lookup fallback correctly handles external squash merges; all ACs met with regression tests.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.92
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/dag.py:236`** _with_pr_metadata is called on every successful topology detection (regular merge path), adding a GitHub API call for every forge-internal merge, not just the external-PR fallback path. For the common case (forge runs its own sprint), this is an unnecessary network round-trip at triage time.
- **[P2] `tests/test_sprint_runner.py:None`** No test covers a closed-but-not-merged PR (mergedAt is null/empty in the GitHub response). The guard on line 152 of dag.py filters these correctly, but the behavior is untested.

## Story

Sprint --resume manifest includes already-merged stories, then SKIPS them with misleading 'workspace creation failed' message (GitHub Issue #1129)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1129