### PR TITLE
Routing policy SSOT — consolidate score-to-tier threshold logic from three files into one

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -23,6 +23,7 @@ from .config import (
     ModelProfile,
 )
 from .config.auth import check_agent_auth
+from .routing import score_to_dev_tier
 
 log = logging.getLogger(__name__)
 
@@ -133,11 +134,7 @@ def _dev_tier_for_score(complexity: str, complexity_score: int | None) -> str:
     score = _normalize_complexity_score(complexity_score)
     if score is None:
         return PHASE_TIER["dev"][complexity]
-    if score <= 3:
-        return "cheap"
-    if score <= 6:
-        return "mid"
-    return "strong"
+    return score_to_dev_tier(score)
 
 
 def _reviewer_target_for_score(

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
 from .defaults import DEFAULT_DEV_PROFILE, DEFAULT_PREFLIGHT_PROFILE, DEFAULT_REVIEW_PROFILE
 from .models import ModelInfo, _resolve_model_info
 from .schema import (
@@ -31,7 +32,7 @@ _DEFAULT_PLAN_TIMEOUT_SECONDS: int = 600
 # preflight is intentionally absent — it uses a static assignment regardless of complexity.
 _COMPLEXITY_TIER: dict[str, dict[str, str]] = {
     "plan": {"LOW": "mid", "MEDIUM": "strong", "HIGH": "strong"},
-    "dev": {"LOW": "cheap", "MEDIUM": "mid", "HIGH": "strong"},
+    "dev": DEV_COMPLEXITY_TIER,
     "review": {"LOW": "mid", "MEDIUM": "mid", "HIGH": "strong"},
 }
 
@@ -47,15 +48,6 @@ _COMPLEXITY_NORM: dict[str, str] = {
     "large": "HIGH",
     "high": "HIGH",
 }
-
-
-def _score_to_dev_tier(score: int) -> str:
-    """Map a 1-10 complexity score to a dev-phase model tier."""
-    if score <= 3:
-        return "cheap"
-    if score <= 6:
-        return "mid"
-    return "strong"
 
 
 def _pick_by_tier(
@@ -242,7 +234,7 @@ def derive_roles(
 
     if _apply_tier_routing:
         target_dev_tier = (
-            _score_to_dev_tier(complexity_score)
+            score_to_dev_tier(complexity_score)
             if complexity_score is not None
             else _COMPLEXITY_TIER["dev"][norm_complexity]
         )

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -12,6 +12,7 @@ import yaml
 
 from theforge.config import MODEL_REGISTRY, ForgeConfig, ModelInfo, ModelProfile, apply_model_info
 from theforge.review import ReviewFinding
+from theforge.routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
 
 if TYPE_CHECKING:
     from .state import CoordinatorState
@@ -20,10 +21,9 @@ _VALID_PREFLIGHT_VERDICTS = frozenset({"PROCEED", "ALREADY_DONE", "BLOCKED"})
 
 _log = logging.getLogger(__name__)
 
-# Tier × complexity routing table (mirrors role_derivation._COMPLEXITY_TIER).
-# Not imported from there to avoid coordinator ↔ config coupling.
+# Tier × complexity routing table for complexity-band fallbacks.
 _PHASE_COMPLEXITY_TIER: dict[str, dict[str, str]] = {
-    "dev": {"LOW": "cheap", "MEDIUM": "mid", "HIGH": "strong"},
+    "dev": DEV_COMPLEXITY_TIER,
     "plan": {"LOW": "mid", "MEDIUM": "strong", "HIGH": "strong"},
     "review": {"LOW": "mid", "MEDIUM": "mid", "HIGH": "strong"},
 }
@@ -214,21 +214,6 @@ def _detect_large_preflight_story_categories(story_content: str) -> list[str]:
         matched.append("cross-module coordinator surgery")
 
     return list(dict.fromkeys(matched))
-
-
-def score_to_dev_tier(score: int) -> str:
-    """Map a 1-10 complexity score to a dev-phase model tier.
-
-    Bands: 1-3 → cheap, 4-6 → mid, 7-10 → strong. Finer-grained than the enum
-    mapping (which lumps score 7 in with 'medium' → mid) so a localized bug at
-    score=3 and a cross-module refactor at score=7 route to different tiers
-    even though they'd both be 'medium' under the three-level enum.
-    """
-    if score <= 3:
-        return "cheap"
-    if score <= 6:
-        return "mid"
-    return "strong"
 
 
 def _build_pool_entries(model_keys: list[str]) -> list[tuple[int, str, ModelInfo]]:

--- a/src/theforge/routing.py
+++ b/src/theforge/routing.py
@@ -1,0 +1,38 @@
+"""Shared deterministic routing policy tables.
+
+The numeric complexity score path is the canonical dev-tier policy for adaptive
+assignment. It intentionally splits the legacy MEDIUM band so localized work can
+stay cheap while broader cross-module work escalates sooner:
+
+- scores 1-3 route to ``cheap``
+- scores 4-6 route to ``mid``
+- scores 7-10 route to ``strong``
+
+Keep score-threshold edits here so assignment, coordinator preflight, and
+static role derivation stay aligned. Raising the cheap-tier ceiling is a
+single-line change to ``DEV_SCORE_TIER_BUCKETS``.
+"""
+
+from __future__ import annotations
+
+# Ordered upper-bound buckets for the 1-10 dev complexity score.
+DEV_SCORE_TIER_BUCKETS: tuple[tuple[int, str], ...] = (
+    (3, "cheap"),
+    (6, "mid"),
+    (10, "strong"),
+)
+
+# Legacy enum fallback used when a numeric score is unavailable.
+DEV_COMPLEXITY_TIER: dict[str, str] = {
+    "LOW": "cheap",
+    "MEDIUM": "mid",
+    "HIGH": "strong",
+}
+
+
+def score_to_dev_tier(score: int) -> str:
+    """Return the dev-phase tier for a 1-10 complexity score."""
+    for max_score, tier in DEV_SCORE_TIER_BUCKETS:
+        if score <= max_score:
+            return tier
+    return DEV_SCORE_TIER_BUCKETS[-1][1]

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,23 @@
+"""Tests for the canonical adaptive routing policy helpers."""
+
+from __future__ import annotations
+
+from theforge.coordinator.preflight import score_to_dev_tier as preflight_score_to_dev_tier
+from theforge.routing import DEV_COMPLEXITY_TIER, DEV_SCORE_TIER_BUCKETS, score_to_dev_tier
+
+
+def test_dev_score_tier_buckets_are_canonical():
+    assert DEV_SCORE_TIER_BUCKETS == (
+        (3, "cheap"),
+        (6, "mid"),
+        (10, "strong"),
+    )
+    assert score_to_dev_tier(3) == "cheap"
+    assert score_to_dev_tier(4) == "mid"
+    assert score_to_dev_tier(6) == "mid"
+    assert score_to_dev_tier(7) == "strong"
+    assert DEV_COMPLEXITY_TIER == {"LOW": "cheap", "MEDIUM": "mid", "HIGH": "strong"}
+
+
+def test_preflight_reexports_canonical_score_to_dev_tier():
+    assert preflight_score_to_dev_tier is score_to_dev_tier


### PR DESCRIPTION
## Summary

Routing consolidation is clean and complete — all three modules import from the new canonical routing.py; all ACs met. Branch also carries the already-reviewed #1175 commit.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.41
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/routing.py:26`** DEV_COMPLEXITY_TIER is a plain mutable dict. When role_derivation.py assigns it directly into _COMPLEXITY_TIER['dev'], both variables share the same dict object. A future in-place mutation to either would silently affect the other. The constant reads as authoritative but is not protected.
- **[P2] `tests/test_routing.py:9`** Boundary cases score=10 (upper edge) and score=1 (lower edge) are not explicitly tested. The fallback path for out-of-range inputs (score > 10 returns 'strong' via the last-bucket fallback) is also untested.

## Story

Routing policy SSOT — consolidate score-to-tier threshold logic from three files into one (GitHub Issue #1107)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1107