### PR TITLE
forge status MODEL column shows 'panel(N)' for completed stories instead of the dev model

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -841,6 +841,29 @@ def _make_worker_phase_fn(
     return _update
 
 
+def _terminal_story_model(result: CoordinatorResult) -> str | None:
+    """Return the dev model to display for a terminal story row.
+
+    Live status uses ``current_model`` while a story is running. REVIEW
+    intentionally overwrites that with ``panel(N)`` for operator visibility, so
+    terminal transitions must restore the model that actually produced the work.
+    Prefer the explicit ``model_used`` recorded by the runner and fall back to
+    legacy ``model_usage`` data when needed.
+    """
+
+    dev_results = list(getattr(result.state, "dev_results", []) or [])
+    for dev_result in reversed(dev_results):
+        model_used = getattr(dev_result, "model_used", None)
+        if isinstance(model_used, str) and model_used:
+            return model_used
+        model_usage = tuple(getattr(dev_result, "model_usage", ()) or ())
+        if model_usage:
+            usage_model = getattr(model_usage[-1], "model", None)
+            if isinstance(usage_model, str) and usage_model:
+                return usage_model
+    return None
+
+
 def _poll_queued_pr(pr_url: str, project_root: Path, timeout_seconds: int) -> dict[str, str]:
     """Poll GitHub until a queued PR is merged, closed, or times out."""
     deadline = time.monotonic() + timeout_seconds
@@ -2080,12 +2103,14 @@ def run_sprint(
                 _classify_outcome = _classify_and_record(
                     task, result, dag, merged_slugs, story_state=_story_state
                 )
-                _set_outcome(
-                    task.slug,
-                    _classify_outcome,
-                    phase=result.phase.name,
-                    cost_usd=result.state.total_cost,
-                )
+                _terminal_model = _terminal_story_model(result)
+                _outcome_fields: dict[str, object] = {
+                    "phase": result.phase.name,
+                    "cost_usd": result.state.total_cost,
+                }
+                if _terminal_model is not None:
+                    _outcome_fields["current_model"] = _terminal_model
+                _set_outcome(task.slug, _classify_outcome, **_outcome_fields)
 
                 # Dependent stories in parallel mode need scheduler-side local merge
                 # even when on_approve is "none" and auto_merge is False.

--- a/tests/test_coord_model_status.py
+++ b/tests/test_coord_model_status.py
@@ -109,6 +109,18 @@ def test_review_panel_visible_in_live_status(tmp_path: Path) -> None:
     assert entries[0].model == "panel(3)"
 
 
+def test_terminal_live_status_restores_dev_model_after_review_panel(tmp_path: Path) -> None:
+    writer = _writer(tmp_path, "run-done-live")
+    writer.init([{"slug": "b", "path": "Issue #2", "status": "running"}])
+    writer.update("b", phase="REVIEW", current_model="panel(3)")
+    writer.update("b", status="done", phase="DONE", current_model="claude-opus-4-7")
+
+    entries = read_live_status("run-done-live", tmp_path)
+    assert entries is not None
+    assert entries[0].status == "done"
+    assert entries[0].model == "claude-opus-4-7"
+
+
 def test_skipped_story_has_none_model(tmp_path: Path) -> None:
     state = SprintStoryState()
     state.register("c", "Issue #3", outcome=StoryOutcome.SKIPPED, depends_on=["a"])

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from theforge.agent_types import AgentResult, ModelUsage
 from theforge.config import (
     DEFAULT_DEV_PROFILE,
     DEFAULT_PREFLIGHT_PROFILE,
@@ -22,6 +23,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint.dag import (
     StoryDAG,
     _is_branch_merged,
@@ -29,7 +31,12 @@ from theforge.sprint.dag import (
     resolve_satisfied_dependencies,
 )
 from theforge.sprint.manifest import ResolvedSprint
-from theforge.sprint.runner import _refresh_external_satisfied, _run_baseline_gate, run_sprint
+from theforge.sprint.runner import (
+    _refresh_external_satisfied,
+    _run_baseline_gate,
+    _terminal_story_model,
+    run_sprint,
+)
 from theforge.task import TaskStory
 
 
@@ -63,6 +70,17 @@ def _make_runner_config(tmp_path: Path) -> ForgeConfig:
 
 def _make_empty_resolved() -> ResolvedSprint:
     return ResolvedSprint(name="Test Sprint", budget_usd=10.0, stories=[], max_parallel=1)
+
+
+def _make_result_with_dev_runs(*dev_results: AgentResult) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.dev_results.extend(dev_results)
+    return CoordinatorResult(
+        success=True,
+        phase=Phase.DONE,
+        state=state,
+        message="done",
+    )
 
 
 # ── build_dag: unknown slug handling ──────────────────────────────────
@@ -335,6 +353,56 @@ def test_run_sprint_pull_base_branch_failure_aborts_before_baseline(tmp_path: Pa
             run_sprint(config, resolved)
 
     mock_baseline.assert_not_called()
+
+
+def test_terminal_story_model_prefers_last_dev_model_used() -> None:
+    first = AgentResult(
+        success=True,
+        output="",
+        session_id=None,
+        cost_usd=0.1,
+        exit_code=0,
+        raw={},
+        model_used="sonnet",
+    )
+    last = AgentResult(
+        success=True,
+        output="",
+        session_id=None,
+        cost_usd=0.2,
+        exit_code=0,
+        raw={},
+        model_used="opus",
+    )
+
+    result = _make_result_with_dev_runs(first, last)
+
+    assert _terminal_story_model(result) == "opus"
+
+
+def test_terminal_story_model_falls_back_to_model_usage_when_model_used_missing() -> None:
+    legacy = AgentResult(
+        success=True,
+        output="",
+        session_id=None,
+        cost_usd=0.1,
+        exit_code=0,
+        raw={},
+        model_usage=(
+            ModelUsage(
+                model="gpt-5.4",
+                input_tokens=10,
+                output_tokens=5,
+                cache_read_tokens=0,
+                cache_creation_tokens=0,
+                cost_usd=0.1,
+            ),
+        ),
+    )
+
+    result = _make_result_with_dev_runs(legacy)
+
+    assert _terminal_story_model(result) == "gpt-5.4"
 
 
 def test_run_baseline_gate_reports_local_origin_sha_gap(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Clean, minimal fix: _terminal_story_model extracts the last dev model from coordinator state and injects it as current_model at terminal write time; all three spec ACs are satisfied and the gate passes.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.82
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_sprint_runner.py:None`** ESCALATE terminal state is not covered by the new tests. The spec explicitly names ESCALATE alongside DONE as a terminal state that should show the dev model. The production code handles both identically (same code path), but there is no test asserting the ESCALATE case.
- **[P2] `src/theforge/sprint/runner.py:None`** When _terminal_story_model returns None (no dev results — e.g. an ESCALATE from PREFLIGHT before any dev run that also passed through a REVIEW phase), the panel(N) string persists into the terminal row. The spec says terminal states should show the dev model, but if there was no dev run there is nothing to restore. The behavior is defensible but undocumented.

## Story

forge status MODEL column shows 'panel(N)' for completed stories instead of the dev model (GitHub Issue #1113)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1113