### PR TITLE
Sprint shape-check reads stale shape-check-v1 comment instead of live label state — issue with epic label removed still skipped

### DIFF
--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -156,6 +156,30 @@ def _blocking_codes(result: ShapeResult) -> list[str]:
     return [r.code for r in result.reasons if r.severity is Severity.BLOCKING]
 
 
+def _skip_detail(
+    result: ShapeResult,
+    fallback: str,
+    *,
+    include_advisory_when_no_blocking: bool = False,
+) -> str:
+    blocking_details = [
+        reason.detail.strip()
+        for reason in result.reasons
+        if reason.severity is Severity.BLOCKING and reason.detail.strip()
+    ]
+    if blocking_details:
+        return "; ".join(blocking_details)
+
+    if include_advisory_when_no_blocking:
+        reason_details = [
+            reason.detail.strip() for reason in result.reasons if reason.detail.strip()
+        ]
+        if reason_details:
+            return "; ".join(reason_details)
+
+    return fallback
+
+
 _VALID_CLASSIFIER_MODES = frozenset({"heuristic", "off", "llm"})
 
 
@@ -185,7 +209,6 @@ def apply_shape_gate(
     classifier_mode: str = "heuristic",
     force: bool = False,
     fetch_detail=_fetch_issue_detail,
-    fetch_bot_codes=_fetch_bot_reason_codes,
     llm_caller=None,
 ) -> ShapeGateResult:
     """Partition issues into runnable vs skipped before preflight runs.
@@ -193,12 +216,12 @@ def apply_shape_gate(
     Algorithm:
 
     1. For each ``{number, title}`` in *issues*, fetch labels + body.
-    2. If ``needs-grooming`` is present, skip with ``source='label'`` and
-       pull reason codes from the #806b bot comment; if that is absent,
-       re-derive the codes by running the local shape check.
-    3. Otherwise re-run the local shape check against the current body
-       (the defense-in-depth step that closes the stale-label loophole).
-       If the check returns a non-``RUNNABLE`` shape, skip with
+    2. Re-run the local shape check against the current body and labels for
+       every issue (the defense-in-depth step that closes the stale-comment
+       loophole).
+    3. If ``needs-grooming`` is present, skip with ``source='label'`` while
+       surfacing the live blocking findings that explain the current state.
+    4. Otherwise, if the check returns a non-``RUNNABLE`` shape, skip with
        ``source='local_check'``.
 
     ``force=True`` returns every input issue as runnable but still populates
@@ -220,29 +243,6 @@ def apply_shape_gate(
         labels = detail["labels"]
         title = detail["title"] or title_short
         body = detail["body"]
-
-        if NEEDS_GROOMING_LABEL in labels:
-            codes = fetch_bot_codes(number, project_root)
-            if not codes:
-                local = check(
-                    title,
-                    body,
-                    labels,
-                    classifier_mode=effective_mode,
-                    llm_caller=llm_caller,
-                )
-                codes = _blocking_codes(local) or ["needs_grooming_label"]
-            skipped.append(
-                SkippedIssue(
-                    issue_number=number,
-                    reason_codes=tuple(codes),
-                    source="label",
-                    title=title_short,
-                    detail=f"issue carries '{NEEDS_GROOMING_LABEL}' label",
-                )
-            )
-            continue
-
         local = check(
             title,
             body,
@@ -250,6 +250,23 @@ def apply_shape_gate(
             classifier_mode=effective_mode,
             llm_caller=llm_caller,
         )
+
+        if NEEDS_GROOMING_LABEL in labels:
+            codes = _blocking_codes(local) or ["needs_grooming_label"]
+            skipped.append(
+                SkippedIssue(
+                    issue_number=number,
+                    reason_codes=tuple(codes),
+                    source="label",
+                    title=title_short,
+                    detail=_skip_detail(
+                        local,
+                        fallback=f"issue carries '{NEEDS_GROOMING_LABEL}' label",
+                    ),
+                )
+            )
+            continue
+
         if local.shape is not Shape.RUNNABLE:
             codes = _blocking_codes(local) or [r.code for r in local.reasons]
             skipped.append(
@@ -258,7 +275,11 @@ def apply_shape_gate(
                     reason_codes=tuple(codes),
                     source="local_check",
                     title=title_short,
-                    detail=f"local shape check: {local.suggested_action.value}",
+                    detail=_skip_detail(
+                        local,
+                        fallback=f"local shape check: {local.suggested_action.value}",
+                        include_advisory_when_no_blocking=True,
+                    ),
                 )
             )
             continue
@@ -280,8 +301,7 @@ def format_skipped_warning(skipped: list[SkippedIssue]) -> str:
     lines = [f"[forge] {len(skipped)} issue(s) flagged by shape gate:"]
     for entry in skipped:
         codes = ", ".join(entry.reason_codes) or "<no codes>"
-        lines.append(
-            f"  - #{entry.issue_number} ({entry.source}): {codes}"
-            + (f" — {entry.title}" if entry.title else "")
-        )
+        title = f" — {entry.title}" if entry.title else ""
+        detail = f" [{entry.detail}]" if entry.detail else ""
+        lines.append(f"  - #{entry.issue_number} ({entry.source}): {codes}{title}{detail}")
     return "\n".join(lines)

--- a/tests/test_sprint_shape_gate.py
+++ b/tests/test_sprint_shape_gate.py
@@ -9,6 +9,7 @@ from theforge.sprint.shape_gate import (
     NEEDS_GROOMING_LABEL,
     ShapeGateResult,
     SkippedIssue,
+    _fetch_bot_reason_codes,
     apply_shape_gate,
     format_skipped_warning,
 )
@@ -39,47 +40,62 @@ def _fake_detail(body: str, labels: list[str], title: str = "Some issue"):
     return _fetch
 
 
-def _no_bot_codes(_number, _project_root) -> list[str]:
-    return []
-
-
 # ── Label-skip path ─────────────────────────────────────────────────────────
 
 
-def test_label_skip_uses_bot_reason_codes_when_available(tmp_path: Path) -> None:
-    issues = [{"number": 42, "title": "Flagged issue"}]
+def test_stale_bot_comment_does_not_affect_runnable_issue(tmp_path: Path) -> None:
+    issues = [{"number": 42, "title": "Runnable issue"}]
 
-    result = apply_shape_gate(
-        issues,
-        tmp_path,
-        fetch_detail=_fake_detail(_RUNNABLE_BODY, [NEEDS_GROOMING_LABEL]),
-        fetch_bot_codes=lambda _n, _r: ["too_many_behavioral_clusters", "missing_ac"],
-    )
+    with patch(
+        "theforge.sprint.shape_gate._fetch_bot_reason_codes",
+        side_effect=AssertionError("bot comment must not be consulted for verdicts"),
+    ):
+        result = apply_shape_gate(
+            issues,
+            tmp_path,
+            fetch_detail=_fake_detail(_RUNNABLE_BODY, ["enhancement"]),
+        )
 
-    assert result.runnable == []
-    assert len(result.skipped) == 1
-    entry = result.skipped[0]
-    assert entry.issue_number == 42
-    assert entry.source == "label"
-    assert entry.reason_codes == ("too_many_behavioral_clusters", "missing_ac")
+    assert result.runnable == issues
+    assert result.skipped == []
 
 
-def test_label_skip_falls_back_to_local_check_when_bot_silent(tmp_path: Path) -> None:
+def test_label_skip_uses_live_reason_details_when_issue_is_tracking_only(
+    tmp_path: Path,
+) -> None:
     issues = [{"number": 7, "title": "Stale label"}]
 
     result = apply_shape_gate(
         issues,
         tmp_path,
-        fetch_detail=_fake_detail(_BAD_BODY, [NEEDS_GROOMING_LABEL]),
-        fetch_bot_codes=_no_bot_codes,
+        fetch_detail=_fake_detail(_RUNNABLE_BODY, [NEEDS_GROOMING_LABEL, "epic"]),
     )
 
     assert result.runnable == []
     assert len(result.skipped) == 1
     entry = result.skipped[0]
     assert entry.source == "label"
-    # Must have at least one reason code, re-derived locally.
-    assert entry.reason_codes
+    assert entry.reason_codes == ("epic_or_tracking",)
+    assert "Label 'epic' present" in entry.detail
+
+
+def test_label_skip_falls_back_to_label_detail_when_live_check_is_runnable(
+    tmp_path: Path,
+) -> None:
+    issues = [{"number": 8, "title": "Label only"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_RUNNABLE_BODY, [NEEDS_GROOMING_LABEL, "enhancement"]),
+    )
+
+    assert result.runnable == []
+    assert len(result.skipped) == 1
+    entry = result.skipped[0]
+    assert entry.source == "label"
+    assert entry.reason_codes == ("needs_grooming_label",)
+    assert entry.detail == "issue carries 'needs-grooming' label"
 
 
 # ── Local-check-skip path ───────────────────────────────────────────────────
@@ -93,7 +109,6 @@ def test_local_check_skip_catches_stale_label_loophole(tmp_path: Path) -> None:
         issues,
         tmp_path,
         fetch_detail=_fake_detail(_BAD_BODY, []),
-        fetch_bot_codes=_no_bot_codes,
     )
 
     assert result.runnable == []
@@ -101,6 +116,7 @@ def test_local_check_skip_catches_stale_label_loophole(tmp_path: Path) -> None:
     entry = result.skipped[0]
     assert entry.source == "local_check"
     assert entry.reason_codes
+    assert "No acceptance criteria section" in entry.detail
 
 
 def test_local_check_allows_runnable_issue(tmp_path: Path) -> None:
@@ -110,7 +126,6 @@ def test_local_check_allows_runnable_issue(tmp_path: Path) -> None:
         issues,
         tmp_path,
         fetch_detail=_fake_detail(_RUNNABLE_BODY, ["enhancement"]),
-        fetch_bot_codes=_no_bot_codes,
     )
 
     assert result.runnable == issues
@@ -141,7 +156,6 @@ def test_force_override_returns_all_issues_runnable_but_keeps_skipped_list(
         issues,
         tmp_path,
         fetch_detail=fetch,
-        fetch_bot_codes=lambda _n, _r: ["needs-grooming-label"],
         force=True,
     )
 
@@ -178,7 +192,6 @@ def test_mixed_sprint_partitions_runnable_vs_skipped(tmp_path: Path) -> None:
         issues,
         tmp_path,
         fetch_detail=fetch,
-        fetch_bot_codes=_no_bot_codes,
     )
 
     assert [i["number"] for i in result.runnable] == [1]
@@ -197,7 +210,6 @@ def test_fetch_failure_leaves_issue_runnable(tmp_path: Path) -> None:
         issues,
         tmp_path,
         fetch_detail=lambda _n, _r: None,
-        fetch_bot_codes=_no_bot_codes,
     )
 
     assert result.runnable == issues
@@ -214,12 +226,14 @@ def test_format_skipped_warning_lists_every_issue() -> None:
             reason_codes=("too_many_behavioral_clusters",),
             source="local_check",
             title="Too big",
+            detail="Body covers multiple independent behaviors.",
         ),
         SkippedIssue(
             issue_number=12,
             reason_codes=("needs-grooming-label",),
             source="label",
             title="Stale",
+            detail="issue carries 'needs-grooming' label",
         ),
     ]
 
@@ -229,6 +243,7 @@ def test_format_skipped_warning_lists_every_issue() -> None:
     assert "local_check" in rendered
     assert "label" in rendered
     assert "too_many_behavioral_clusters" in rendered
+    assert "Body covers multiple independent behaviors." in rendered
 
 
 def test_format_skipped_warning_empty_returns_empty_string() -> None:
@@ -255,8 +270,6 @@ def test_skipped_issue_as_dict_is_machine_readable() -> None:
 
 
 def test_fetch_bot_reason_codes_parses_csv_marker(tmp_path: Path) -> None:
-    from theforge.sprint.shape_gate import _fetch_bot_reason_codes
-
     stdout = (
         '{"comments":[{"body":"some text\\n'
         "<!-- shape-check-reasons: too_many_behavioral_clusters,missing_ac -->"
@@ -269,8 +282,6 @@ def test_fetch_bot_reason_codes_parses_csv_marker(tmp_path: Path) -> None:
 
 
 def test_fetch_bot_reason_codes_parses_json_array(tmp_path: Path) -> None:
-    from theforge.sprint.shape_gate import _fetch_bot_reason_codes
-
     stdout = '{"comments":[{"body":"<!-- shape-check-reasons: [\\"a\\", \\"b\\"] -->"}]}'
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout=stdout, stderr="")
@@ -279,8 +290,6 @@ def test_fetch_bot_reason_codes_parses_json_array(tmp_path: Path) -> None:
 
 
 def test_fetch_bot_reason_codes_returns_empty_on_gh_failure(tmp_path: Path) -> None:
-    from theforge.sprint.shape_gate import _fetch_bot_reason_codes
-
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="fail")
         assert _fetch_bot_reason_codes(42, tmp_path) == []

--- a/tests/test_sprint_shape_gate_audit.py
+++ b/tests/test_sprint_shape_gate_audit.py
@@ -75,6 +75,7 @@ def test_sprint_summary_writes_skipped_issues(tmp_path: Path) -> None:
             reason_codes=("needs-grooming-label",),
             source="label",
             title="Stale",
+            detail="issue carries 'needs-grooming' label",
         ),
     ]
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -97,6 +98,7 @@ def test_sprint_summary_writes_skipped_issues(tmp_path: Path) -> None:
     assert entry["issue_number"] == 7
     assert entry["source"] == "label"
     assert entry["reason_codes"] == ["needs-grooming-label"]
+    assert entry["detail"] == "issue carries 'needs-grooming' label"
 
 
 def test_sprint_audit_skipped_empty_when_not_supplied(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Correctly inverts the gate ordering — check() runs unconditionally before any skip decision, bot-comment codes are fully excised from the verdict path, and live blocking details now surface to operators. All three ACs are met, 23 tests pass, and the only non-test caller (cli/sprint.py:421) never passed fetch_bot_codes.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $1.35
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint shape-check reads stale shape-check-v1 comment instead of live label state — issue with epic label removed still skipped (GitHub Issue #1186)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1186