### PR TITLE
Gate scrub leaves agent CLI binaries on PATH — auth check disagrees between dev and CI

### DIFF
--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -19,7 +19,7 @@ from .defaults import (
     SUPPORTED_CLIS,
     generate_default_config,
 )
-from .gate_scrub import SCRUBBED_ENV_VARS, SCRUBBED_HOME_PATHS
+from .gate_scrub import SCRUBBED_CLI_LAUNCHERS, SCRUBBED_ENV_VARS, SCRUBBED_HOME_PATHS
 from .load import _validate_plan_provider, load_config
 from .models import (
     AGENT_REGISTRY,
@@ -100,6 +100,7 @@ __all__ = [
     "PROVIDER_SDK_MAP",
     "SUPPORTED_CLIS",
     "generate_default_config",
+    "SCRUBBED_CLI_LAUNCHERS",
     "SCRUBBED_ENV_VARS",
     "SCRUBBED_HOME_PATHS",
     # load

--- a/src/theforge/config/gate_scrub.py
+++ b/src/theforge/config/gate_scrub.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .auth import PROVIDER_API_KEY_MAP
+from .defaults import SUPPORTED_CLIS
 from .models import AGENT_REGISTRY
 
 _PROVIDER_ENV_ALIASES: dict[str, tuple[str, ...]] = {
@@ -39,4 +40,6 @@ SCRUBBED_HOME_PATHS: tuple[Path, ...] = (
     Path(".gemini"),
 )
 
-__all__ = ["SCRUBBED_ENV_VARS", "SCRUBBED_HOME_PATHS"]
+SCRUBBED_CLI_LAUNCHERS: tuple[str, ...] = tuple(sorted({*SUPPORTED_CLIS, "npx"}))
+
+__all__ = ["SCRUBBED_CLI_LAUNCHERS", "SCRUBBED_ENV_VARS", "SCRUBBED_HOME_PATHS"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
+import shutil
 import socket as _socket_module
 import tempfile
 from pathlib import Path
@@ -11,7 +12,12 @@ from unittest.mock import patch
 
 import pytest
 
-from theforge.config import SCRUBBED_ENV_VARS, SCRUBBED_HOME_PATHS, ModelProfile
+from theforge.config import (
+    SCRUBBED_CLI_LAUNCHERS,
+    SCRUBBED_ENV_VARS,
+    SCRUBBED_HOME_PATHS,
+    ModelProfile,
+)
 
 # ---------------------------------------------------------------------------
 # Global network guard — installed at conftest load time
@@ -79,6 +85,9 @@ def _gate_scrub_enabled() -> bool:
     return os.environ.get("THEFORGE_ALLOW_AGENT_CREDS") != "1"
 
 
+_REAL_WHICH = shutil.which
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _scrub_agent_credentials_for_gate():
     """Strip agent credentials/auth state unless explicitly opted out.
@@ -93,6 +102,12 @@ def _scrub_agent_credentials_for_gate():
     stripped = sorted(name for name in SCRUBBED_ENV_VARS if name in os.environ)
     original_env = {name: os.environ.get(name) for name in SCRUBBED_ENV_VARS}
     original_home = os.environ.get("HOME")
+    scrubbed_launchers = frozenset(SCRUBBED_CLI_LAUNCHERS)
+
+    def _scrubbed_which(cmd, mode: int = os.F_OK | os.X_OK, path: str | None = None):
+        if os.path.basename(os.fsdecode(cmd)) in scrubbed_launchers:
+            return None
+        return _REAL_WHICH(cmd, mode=mode, path=path)
 
     for name in SCRUBBED_ENV_VARS:
         os.environ.pop(name, None)
@@ -112,18 +127,19 @@ def _scrub_agent_credentials_for_gate():
             "[theforge-test-guard] scrubbed agent credentials: "
             + (", ".join(stripped) if stripped else "none")
         )
-        try:
-            yield
-        finally:
-            if original_home is None:
-                os.environ.pop("HOME", None)
-            else:
-                os.environ["HOME"] = original_home
-            for name, value in original_env.items():
-                if value is None:
-                    os.environ.pop(name, None)
+        with patch("shutil.which", side_effect=_scrubbed_which):
+            try:
+                yield
+            finally:
+                if original_home is None:
+                    os.environ.pop("HOME", None)
                 else:
-                    os.environ[name] = value
+                    os.environ["HOME"] = original_home
+                for name, value in original_env.items():
+                    if value is None:
+                        os.environ.pop(name, None)
+                    else:
+                        os.environ[name] = value
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -232,7 +232,8 @@ class TestModelsKeyConfig:
             },
             tmp_path,
         )
-        config = load_config(config_path)
+        with patch("theforge.config.load.check_agent_auth", return_value=(True, "")):
+            config = load_config(config_path)
         assert config.assignment.enabled is True
         assert len(config.agents) == 3
         tiers = {a.tier for a in config.agents}

--- a/tests/test_gate_scrub.py
+++ b/tests/test_gate_scrub.py
@@ -5,8 +5,19 @@ from pathlib import Path
 
 import pytest
 
-from theforge.config import SCRUBBED_ENV_VARS, SCRUBBED_HOME_PATHS
-from theforge.config.gate_scrub import SCRUBBED_ENV_VARS as MODULE_ENV_VARS
+from theforge.config import (
+    SCRUBBED_CLI_LAUNCHERS,
+    SCRUBBED_ENV_VARS,
+    SCRUBBED_HOME_PATHS,
+    ModelProfile,
+)
+from theforge.config.auth import check_agent_auth
+from theforge.config.gate_scrub import (
+    SCRUBBED_CLI_LAUNCHERS as MODULE_CLI_LAUNCHERS,
+)
+from theforge.config.gate_scrub import (
+    SCRUBBED_ENV_VARS as MODULE_ENV_VARS,
+)
 
 
 def test_scrubbed_env_vars_cover_expected_credentials():
@@ -34,11 +45,44 @@ def test_scrubbed_home_paths_cover_cli_auth_locations():
     assert Path(".gemini") in scrubbed
 
 
+def test_scrubbed_cli_launchers_cover_supported_auth_probes():
+    expected = {"claude", "codex", "gemini", "npx"}
+    assert expected == set(SCRUBBED_CLI_LAUNCHERS)
+    assert SCRUBBED_CLI_LAUNCHERS == MODULE_CLI_LAUNCHERS
+
+
 def test_gate_scrub_fixture_sets_dotenv_disable_and_rehomes_home():
     assert os.environ["PYTHON_DOTENV_DISABLED"] == "1"
     scrubbed_home = Path(os.environ["HOME"])
     for rel_path in SCRUBBED_HOME_PATHS:
         assert (scrubbed_home / rel_path).exists()
+
+
+def test_gate_scrub_fixture_hides_cli_auth_launchers():
+    claude_profile = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    codex_profile = ModelProfile(
+        name="dev",
+        cli="codex",
+        model="gpt-5.4",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+
+    ok, reason = check_agent_auth(claude_profile, {})
+    assert ok is False
+    assert reason == "'claude' not found in PATH"
+
+    ok, reason = check_agent_auth(codex_profile, {})
+    assert ok is False
+    assert reason == "npx not found in PATH"
 
 
 def test_real_runner_sentinel_message_is_gate_specific():


### PR DESCRIPTION
## Summary

Clean, targeted fix: SCRUBBED_CLI_LAUNCHERS derived from SUPPORTED_CLIS, patch target matches auth.py call site, regression tests cover the scrubbed contract, and the stale test_config_models fixture is properly isolated.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.26
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Gate scrub leaves agent CLI binaries on PATH — auth check disagrees between dev and CI (GitHub Issue #1119)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1119