### PR TITLE
Worktree cleanup leaves empty .forge/ subdirectories behind — stale shells accumulate in .forge/worktrees/

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -11,7 +11,7 @@ import sys
 import time
 from pathlib import Path
 
-from theforge.artifacts import AUDIT_PATH, ESCALATED_MARKER_PATH
+from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.config import ForgeConfig
 from theforge.detach import find_run_id_for_pid as _find_run_id_for_pid
 from theforge.task import TaskStory
@@ -296,6 +296,7 @@ def _merge_branch(
         _cu._log(f"Warning: worktree cleanup failed: {rm_out}")
     else:
         _cu._log(f"Worktree removed: {worktree_rel}")
+        _remove_leftover_worktree_dir(workspace_path)
 
     return info
 
@@ -313,6 +314,38 @@ def _fmt_age(seconds: int) -> str:
         return f"{h} hour{'s' if h != 1 else ''}"
     d = seconds // 86400
     return f"{d} day{'s' if d != 1 else ''}"
+
+
+def _is_forge_owned_worktree_leftover(path: Path) -> bool:
+    """Return True when a leftover worktree path is empty or contains only .forge/ content."""
+    try:
+        for child in path.rglob("*"):
+            rel = child.relative_to(path)
+            if not rel.parts or rel.parts[0] != ".forge":
+                return False
+    except FileNotFoundError:
+        return True
+    return True
+
+
+def _remove_leftover_worktree_dir(path: Path) -> None:
+    """Remove a leftover worktree shell when only Forge-owned artifacts remain."""
+    if not path.exists():
+        return
+    if not path.is_dir():
+        _cu._log(f"  Warning: leftover worktree path is not a directory: {path}")
+        return
+    if not _is_forge_owned_worktree_leftover(path):
+        _cu._log(f"  Warning: leftover worktree has unexpected contents, preserving: {path}")
+        return
+    try:
+        shutil.rmtree(path)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        _cu._log(f"  Warning: failed to delete leftover worktree directory {path}: {exc}")
+    else:
+        _cu._log(f"  Removed leftover worktree directory: {path}")
 
 
 def _is_stale_worktree(path: Path, base_branch: str, config: ForgeConfig) -> tuple[bool, str]:
@@ -361,6 +394,7 @@ def _remove_worktree(path: Path, branch: str, project_root: Path, info_line: str
         _cu._log(f"  Warning: git worktree remove failed: {out}")
     else:
         _cu._log(f"  Removed stale worktree: {path}")
+        _remove_leftover_worktree_dir(path)
 
     ok2, out2 = _cu._run_shell(f"git branch -D {branch}", project_root)
     if not ok2:
@@ -419,10 +453,7 @@ def sweep_orphan_worktrees(project_root: Path, config: ForgeConfig) -> None:
         resolved_candidate = candidate.resolve()
         branch_name = registered.get(resolved_candidate)
         if branch_name is None and resolved_candidate not in registered:
-            files = [
-                p.relative_to(candidate).as_posix() for p in candidate.rglob("*") if p.is_file()
-            ]
-            if not files or set(files) <= {AUDIT_PATH.as_posix()}:
+            if _is_forge_owned_worktree_leftover(candidate):
                 shutil.rmtree(candidate, ignore_errors=True)
             continue
 

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -8,6 +8,7 @@ PLAN/DEV — exactly as it does for freshly-run preflight in single-story mode.
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -30,6 +31,9 @@ def _shell_with_matching_cache(cmd, cwd, **kwargs):
     rendered = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
     if rendered.startswith("git rev-parse "):
         return (True, "OK")
+    if rendered.startswith("mkdir -p "):
+        Path(cwd, rendered.removeprefix("mkdir -p ").strip()).mkdir(parents=True, exist_ok=True)
+        return (True, "")
     return (True, "")
 
 
@@ -224,6 +228,11 @@ criteria_checked: []
             rendered = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
             if rendered.startswith("git rev-parse "):
                 return (True, "new-head" if str(cwd) == str(workspace) else "base-head")
+            if rendered.startswith("mkdir -p "):
+                Path(cwd, rendered.removeprefix("mkdir -p ").strip()).mkdir(
+                    parents=True, exist_ok=True
+                )
+                return (True, "")
             return (True, "")
 
         with (

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -590,6 +590,44 @@ def test_merge_branch_deindexes_workspace_before_merge(mock_shell, mock_deindex,
     mock_deindex.assert_called_once_with(workspace, purge=True)
 
 
+@patch("theforge.coordinator.workspace._cu._run_shell")
+def test_merge_branch_removes_leftover_forge_shell_after_git_worktree_remove(mock_shell, tmp_path):
+    """_merge_branch deletes a leftover worktree shell when only .forge/ content remains."""
+    from theforge.coordinator.workspace import _merge_branch
+
+    workspace = tmp_path / "wt"
+    (workspace / ".forge" / "traces").mkdir(parents=True)
+    (workspace / ".forge" / "traces" / "1-dev.txt").write_text("trace\n", encoding="utf-8")
+
+    def shell_side_effect(cmd, cwd, **kwargs):
+        if "git branch --list" in cmd:
+            return (True, "* main")
+        if "git status --porcelain" in cmd:
+            return (True, "")
+        if "git log main..forge/issue-1 --oneline" in cmd:
+            return (True, "abc123 feat: change")
+        if "git checkout main" in cmd:
+            return (True, "")
+        if "git merge --ff-only forge/issue-1" in cmd:
+            return (True, "")
+        if "git worktree remove --force .forge/worktrees/issue-1" in cmd:
+            return (True, "")
+        return (True, "")
+
+    mock_shell.side_effect = shell_side_effect
+
+    info = _merge_branch(
+        project_root=tmp_path,
+        base_branch="main",
+        branch_name="forge/issue-1",
+        slug="issue-1",
+        workspace_path=workspace,
+    )
+
+    assert info["merged"] is True
+    assert not workspace.exists()
+
+
 class TestDeindexRunsOnAllReturnPaths:
     """_create_workspace calls _deindex_forge_artifacts on every successful return path."""
 

--- a/tests/test_coord_workspace_merge.py
+++ b/tests/test_coord_workspace_merge.py
@@ -365,6 +365,9 @@ class TestCoordinatorAutoMerge:
                 return (True, "main")
             if "git log" in cmd and ".." in cmd:
                 return (True, "")  # no commits ahead
+            if cmd == f"mkdir -p {task.slug}":
+                workspace.mkdir(parents=True, exist_ok=True)
+                return (True, "OK")
             return (True, "OK")
 
         mock_shell.side_effect = shell_side_effect

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -277,6 +277,26 @@ class TestStaleWorktree:
         captured = capsys.readouterr()
         assert "Warning" in captured.err
 
+    @patch("theforge.coordinator.util._run_shell")
+    def test_remove_worktree_deletes_leftover_forge_shell(self, mock_shell, tmp_path):
+        """Successful removal deletes a leftover worktree shell with only Forge metadata."""
+        workspace = tmp_path / "my-spec"
+        (workspace / ".forge" / "traces").mkdir(parents=True)
+        (workspace / ".forge" / "traces" / "1-dev.txt").write_text("trace\n", encoding="utf-8")
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "git worktree remove" in cmd:
+                return (True, "")
+            if "git branch -D" in cmd:
+                return (True, "")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        _remove_worktree(workspace, "feat/my-spec", tmp_path)
+
+        assert not workspace.exists()
+
     # -- Integration: _create_workspace stale detection --
 
     @patch("theforge.coordinator.util._run_shell")

--- a/tests/test_worktree_lifecycle_hygiene.py
+++ b/tests/test_worktree_lifecycle_hygiene.py
@@ -63,7 +63,7 @@ def test_escalate_writes_marker_and_detection_uses_it(tmp_path: Path) -> None:
     assert _is_escalated_worktree(clean_workspace) is False
 
 
-def test_sweep_orphan_worktrees_removes_orphan_and_merged_but_preserves_escalated(
+def test_sweep_orphan_worktrees_removes_forge_only_orphans_and_merged_but_preserves_escalated(
     tmp_path: Path,
 ) -> None:
     repo = tmp_path / "repo"
@@ -92,8 +92,13 @@ def test_sweep_orphan_worktrees_removes_orphan_and_merged_but_preserves_escalate
     worktrees_root.mkdir(parents=True, exist_ok=True)
 
     orphan = worktrees_root / "orphan"
-    (orphan / ".forge").mkdir(parents=True)
+    (orphan / ".forge" / "traces").mkdir(parents=True)
     (orphan / ".forge" / "audit.yaml").write_text("outcome: {}\n", encoding="utf-8")
+    (orphan / ".forge" / "traces" / "1-dev.txt").write_text("trace\n", encoding="utf-8")
+
+    unexpected = worktrees_root / "unexpected"
+    unexpected.mkdir()
+    (unexpected / "README.txt").write_text("keep me\n", encoding="utf-8")
 
     merged = worktrees_root / "merged"
     _git(repo, "worktree", "add", "-b", "forge/merged", str(merged), "main")
@@ -115,6 +120,7 @@ def test_sweep_orphan_worktrees_removes_orphan_and_merged_but_preserves_escalate
     sweep_orphan_worktrees(repo, config)
 
     assert not orphan.exists()
+    assert unexpected.exists()
     assert not merged.exists()
     assert not any(
         "forge/merged" in line


### PR DESCRIPTION
## Summary

Clean, conservative implementation: forge-owned leftover removal is added at all three removal sites, the safety check is correct, and all three ACs have regression tests.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.40
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/workspace.py:322`** The 'if not rel.parts' branch in _is_forge_owned_worktree_leftover is dead code. Path.rglob('*') never yields the root path itself, so child.relative_to(path) always has at least one part. Harmless but misleading.
- **[P2] `src/theforge/coordinator/workspace.py:319`** FileNotFoundError caught in _is_forge_owned_worktree_leftover will also swallow errors raised by rglob mid-traversal (e.g., a disappearing symlink target), silently returning True and allowing rmtree to run. In practice this is extremely unlikely to matter, but the intent was to handle the directory-not-found case only.

## Story

Worktree cleanup leaves empty .forge/ subdirectories behind — stale shells accumulate in .forge/worktrees/ (GitHub Issue #1190)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1190