### PR TITLE
Sprint dependency-prose parser fires false positives on code blocks and emits stale 'YAML frontmatter' guidance

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1055,7 +1055,8 @@ def run_sprint(
             _log(
                 "WARN: dependency-shaped prose ignored for "
                 f"{task.slug} ({task.name}): {phrase!r}; "
-                "declare dependencies in YAML frontmatter"
+                "declare dependencies with GitHub blocked-by relationships "
+                "or leading issue metadata"
             )
 
     # Sprint-level structured logger

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -35,6 +35,16 @@ _ISSUE_REF_RE = re.compile(r"(?:https?://github\.com/[^/\s]+/[^/\s]+/issues/|iss
 _ISSUE_FRONTMATTER_RE = re.compile(
     r"\A---[ \t]*\r?\n(?P<yaml>.*?)\r?\n---[ \t]*(?:\r?\n|\Z)", re.DOTALL
 )
+_FENCED_CODE_BLOCK_RE = re.compile(r"(?ms)^[ \t]*```.*?$.*?^[ \t]*```[ \t]*(?:\r?\n|$)")
+_BLOCKQUOTE_LINE_RE = re.compile(r"(?m)^[ \t]*>.*(?:\r?\n|$)")
+_INLINE_CODE_SPAN_RE = re.compile(r"(?<!`)`([^`\n]|``)*`(?!`)")
+
+
+def _strip_illustrative_markdown(text: str) -> str:
+    """Remove markdown regions that should not count as declarations."""
+    stripped = _FENCED_CODE_BLOCK_RE.sub("\n", text)
+    stripped = _BLOCKQUOTE_LINE_RE.sub("\n", stripped)
+    return _INLINE_CODE_SPAN_RE.sub("", stripped)
 
 
 def _derive_type_from_labels(labels: list[str], issue_number: int) -> tuple[str | None, list[str]]:
@@ -229,9 +239,13 @@ class GitHubIssueSource:
         """Return issue body with the structured metadata block removed."""
         return _ISSUE_FRONTMATTER_RE.sub("", body, count=1)
 
+    def _body_without_illustrative_markdown(self, body: str) -> str:
+        """Return issue body without non-declarative markdown examples."""
+        return _strip_illustrative_markdown(self._body_without_issue_metadata(body))
+
     def _find_prose_dependency_phrases(self, body: str) -> list[tuple[str, list[int]]]:
         """Return non-authoritative dependency-shaped prose phrases and refs."""
-        scan_body = self._body_without_issue_metadata(body)
+        scan_body = self._body_without_illustrative_markdown(body)
         matches: list[tuple[str, list[int]]] = []
         for match in _BLOCKED_BY_BODY_RE.finditer(scan_body):
             matches.append((match.group(0), [int(match.group("number"))]))

--- a/tests/test_sprint_lifecycle.py
+++ b/tests/test_sprint_lifecycle.py
@@ -559,6 +559,10 @@ class TestRunSprint:
         assert "dependency-shaped prose ignored" in captured.err
         assert "issue-2 (Issue B)" in captured.err
         assert "Depends on #265" in captured.err
+        assert (
+            "declare dependencies with GitHub blocked-by relationships or leading issue metadata"
+            in captured.err
+        )
 
 
 # ── Notification tests ────────────────────────────────────────────────

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -182,6 +182,30 @@ class TestGitHubIssueSource:
 
         assert warnings == []
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "```\nissue-1071 depends_on issue-1070\n```",
+            "Use `depends_on issue-1070` as an example in docs.",
+            "> issue-1071 depends_on issue-1070",
+        ],
+    )
+    def test_prose_dependency_phrases_ignore_illustrative_markdown(self, body: str) -> None:
+        warnings = GitHubIssueSource()._dependency_authoring_warnings(body, [])
+
+        assert warnings == []
+
+    def test_prose_dependency_phrases_still_detect_plain_text_outside_examples(self) -> None:
+        body = (
+            "```\nissue-1071 depends_on issue-1070\n```\n\n"
+            "This work depends_on issue-265.\n"
+            "> blocked by #12"
+        )
+
+        warnings = GitHubIssueSource()._dependency_authoring_warnings(body, [])
+
+        assert warnings == ["depends_on issue-265"]
+
     def test_fetch_raises_on_failure(self, tmp_path: Path) -> None:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")


### PR DESCRIPTION
## Summary

Both ACs met: illustrative markdown stripped before prose parsing, warning text updated to drop YAML-frontmatter reference. Two extra pre-reviewed commits (ab10a2a, 74dd471) are in-scope worktree and gate-scrub fixes with embedded APPROVE verdicts.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.39
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/workspace.py:322`** The 'if not rel.parts' branch in _is_forge_owned_worktree_leftover is dead code. Path.rglob('*') never yields the root itself, so child.relative_to(path) always has at least one part. Harmless but misleading.
- **[P2] `src/theforge/coordinator/workspace.py:319`** The FileNotFoundError catch in _is_forge_owned_worktree_leftover covers the entire rglob loop, so a disappearing symlink mid-traversal returns True and allows rmtree to proceed silently. Intent was to handle directory-not-found only.

## Story

Sprint dependency-prose parser fires false positives on code blocks and emits stale 'YAML frontmatter' guidance (GitHub Issue #1114)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1114