### PR TITLE
Dev phase has no retry on transient provider errors — one API hiccup escalates the story

### DIFF
--- a/src/theforge/config/defaults.py
+++ b/src/theforge/config/defaults.py
@@ -92,6 +92,7 @@ budget_usd: 50.0
 
 retry:
   max_dev_iterations: 3    # retries within a review cycle
+  max_dev_transport_retries: 1  # retry one transient dev provider failure
   max_review_cycles: 2     # full dev→review loops before escalation
 
 context:

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -421,6 +421,7 @@ def load_config(config_path: Path) -> ForgeConfig:
     retry_data = raw.get("retry", {})
     retry = RetryPolicy(
         max_dev_iterations=int(retry_data.get("max_dev_iterations", 3)),
+        max_dev_transport_retries=int(retry_data.get("max_dev_transport_retries", 1)),
         max_review_cycles=int(retry_data.get("max_review_cycles", 2)),
         max_review_parse_retries=int(retry_data.get("max_review_parse_retries", 2)),
         max_plan_review_transport_retries=int(

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -241,6 +241,9 @@ class RetryPolicy:
     """Retry limits before escalating to human."""
 
     max_dev_iterations: int = 3  # retries within a single review cycle
+    max_dev_transport_retries: int = (
+        1  # per-iteration retries on transient dev transport/provider failure
+    )
     max_review_cycles: int = 2  # full dev->review loops
     max_review_parse_retries: int = 2  # reviewer retries on parse/schema error per cycle
     max_plan_review_transport_retries: int = (

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -152,11 +152,17 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
     # ── dev ───────────────────────────────────────────────────────────────────
     dev_block: dict | None = None
     if state.dev_results:
+        _dev_transport_retries = [
+            event
+            for item in state.dev_iteration_telemetry
+            for event in item.transport_retry_events
+        ]
         dev_block = {
             "cost_usd": round(state.total_dev_cost, 6),
             "duration_s": round(sum(state.dev_durations), 2) if state.dev_durations else None,
             "iterations": len(state.dev_results),
-            "outcome": "success",
+            "outcome": "success" if state.dev_results[-1].success else "failure",
+            **({"transport_retries": _dev_transport_retries} if _dev_transport_retries else {}),
         }
 
     # ── validate ──────────────────────────────────────────────────────────────
@@ -299,6 +305,8 @@ def _serialize_dev_iteration_metrics(state: CoordinatorState) -> list[dict]:
             "agent_exit_code": item.agent_exit_code,
             "runner_failure_code": item.runner_failure_code,
             "runner_failure_summary": item.runner_failure_summary,
+            "transport_retry_count": item.transport_retry_count,
+            "transport_retry_events": item.transport_retry_events,
         }
         for item in state.dev_iteration_telemetry
     ]

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -66,6 +66,38 @@ _RUNNER_FAILURE_SIGNATURES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ),
 )
 _SHELL_ERROR_PREFIXES = ("bash:", "sh:", "zsh:")
+_DEV_TRANSPORT_RETRY_BACKOFF_BASE_SECONDS = 2
+_TRANSIENT_DEV_ERROR_PATTERNS = (
+    "429",
+    "rate limit",
+    "rate-limited",
+    "resource_exhausted",
+    "resource exhausted",
+    "quota exceeded",
+    "quota_exceeded",
+    "500",
+    "502",
+    "503",
+    "504",
+    "internal error",
+    "server error",
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "stream idle timeout",
+    "partial response received",
+    "mid-stream disconnect",
+    "stream disconnected",
+    "connection reset",
+    "connection-reset",
+    "econnreset",
+    "connection aborted",
+    "connection refused",
+    "peer closed connection",
+    "temporarily unavailable",
+    "try again later",
+    "timeout awaiting headers",
+)
 
 
 def _scale_stuck_for_complexity(
@@ -163,6 +195,43 @@ def _runner_display_name(config: ForgeConfig) -> str:
     return config.dev_profile.cli or config.dev_profile.provider or config.dev_profile.name
 
 
+def _is_transient_dev_failure(
+    result: object, runner_failure: tuple[str, str] | None = None
+) -> bool:
+    """Return True when a failed dev invocation looks transient and retryable."""
+    from theforge.agent_types import AgentResult as _AgentResult  # noqa: PLC0415
+
+    if not isinstance(result, _AgentResult):
+        raise TypeError(f"Expected AgentResult, got {type(result)}")
+    if result.success or result.startup_failure or runner_failure is not None:
+        return False
+    failure_code = (result.failure_code or "").lower()
+    if failure_code in {"rate_limit", "provider_internal_error", "connection_reset"}:
+        return True
+    output = (result.output or "").lower()
+    return any(pattern in output for pattern in _TRANSIENT_DEV_ERROR_PATTERNS)
+
+
+def _summarize_dev_transport_failure(result: object) -> str:
+    """Produce a compact summary for audit/logging when dev transport fails."""
+    from theforge.agent_types import AgentResult as _AgentResult  # noqa: PLC0415
+
+    if not isinstance(result, _AgentResult):
+        raise TypeError(f"Expected AgentResult, got {type(result)}")
+    parts = [f"exit={result.exit_code}"]
+    if result.failure_code:
+        parts.append(f"failure_code={result.failure_code}")
+    output = " ".join((result.output or "").split())
+    if output:
+        parts.append(output[:200])
+    return ": ".join((parts[0], " | ".join(parts[1:]))) if len(parts) > 1 else parts[0]
+
+
+def _dev_transport_retry_backoff_seconds(retry_count: int) -> int:
+    """Return the backoff delay before the next transient dev retry."""
+    return _DEV_TRANSPORT_RETRY_BACKOFF_BASE_SECONDS * (2 ** max(retry_count - 1, 0))
+
+
 def _extract_failed_tests(gate_output_tail: str) -> list[str]:
     """Best-effort extraction of failing test identifiers from gate output."""
     import re
@@ -219,8 +288,16 @@ def record_dev_iteration_telemetry(
     if not state.dev_results or not state.dev_durations:
         return
     iteration = state.dev_iteration
-    dev_result = state.dev_results[-1]
-    duration_s = state.dev_durations[-1]
+    attempt_count = state.pending_dev_transport_retry_count + 1
+    dev_attempts = state.dev_results[-attempt_count:]
+    duration_attempts = state.dev_durations[-attempt_count:]
+    dev_result = dev_attempts[-1]
+    duration_s = sum(duration_attempts)
+    cost_usd = (
+        sum(result.cost_usd or 0.0 for result in dev_attempts)
+        if any(result.cost_usd is not None for result in dev_attempts)
+        else None
+    )
     baseline = state.last_dev_start_commit or "HEAD"
     files_changed = _git_lines(workspace_path, ["diff", "--name-only", baseline, "HEAD"])
     dirty_files = [
@@ -241,7 +318,7 @@ def record_dev_iteration_telemetry(
         DevIterationTelemetry(
             iteration=iteration,
             max_iterations=max_iterations,
-            cost_usd=dev_result.cost_usd,
+            cost_usd=cost_usd,
             duration_s=duration_s,
             cycle=state.review_cycle,
             gate_result=gate_result,
@@ -256,8 +333,12 @@ def record_dev_iteration_telemetry(
             agent_exit_code=dev_result.exit_code,
             runner_failure_code=dev_result.failure_code,
             runner_failure_summary=runner_failure_summary,
+            transport_retry_count=state.pending_dev_transport_retry_count,
+            transport_retry_events=list(state.pending_dev_transport_retry_events),
         )
     )
+    state.pending_dev_transport_retry_count = 0
+    state.pending_dev_transport_retry_events = []
 
 
 def _still_open_p1s_for_dev_prompt(state: CoordinatorState) -> list:
@@ -370,6 +451,8 @@ def _run_dev_phase(
     Mutates state in-place (appends dev_results, updates dev_session_id, etc.).
     """
     _ensure_runners()
+    state.pending_dev_transport_retry_count = 0
+    state.pending_dev_transport_retry_events = []
     # Probe sandbox availability once per run (lru_cache-backed — cheap on repeat calls).
     state.sandboxed = sandbox_available_for_profile(config.dev_profile)
     if config.dev_profile.mode == "cli" and config.dev_profile.sandbox_mode == "none":
@@ -572,23 +655,73 @@ def _run_dev_phase(
         stuck_detection=_scaled_stuck,
     )
 
-    _dev_start = time.monotonic()
-    dev_result = run_agent(
-        prompt=prompt,
-        profile=_dev_profile,
-        working_dir=workspace_path,
-        session_id=state.dev_session_id,
-        secrets=config.secrets,
-        stop_event=stop_event,
-    )
+    _dev_total_start = time.monotonic()
+    _dev_results_this_iteration = []
+    _dev_durations_this_iteration = []
     _runner_failure = None
-    if not dev_result.success and not dev_result.startup_failure:
-        _runner_failure = classify_runner_subprocess_failure(
-            dev_result.output, dev_result.exit_code
+    _current_session_id = state.dev_session_id
+    _dev_retry_events: list[dict] = []
+    _max_transport_retries = max(0, config.retry.max_dev_transport_retries)
+
+    while True:
+        _attempt_start = time.monotonic()
+        dev_result = run_agent(
+            prompt=prompt,
+            profile=_dev_profile,
+            working_dir=workspace_path,
+            session_id=_current_session_id,
+            secrets=config.secrets,
+            stop_event=stop_event,
         )
-        if _runner_failure is not None:
-            dev_result = _dc_replace(dev_result, failure_code=_runner_failure[0])
-    _dev_elapsed = time.monotonic() - _dev_start
+        _attempt_elapsed = time.monotonic() - _attempt_start
+        _runner_failure = None
+        if not dev_result.success and not dev_result.startup_failure:
+            _runner_failure = classify_runner_subprocess_failure(
+                dev_result.output, dev_result.exit_code
+            )
+            if _runner_failure is not None:
+                dev_result = _dc_replace(dev_result, failure_code=_runner_failure[0])
+
+        if len(_dev_retry_events) < _max_transport_retries and _is_transient_dev_failure(
+            dev_result, _runner_failure
+        ):
+            retry_count = len(_dev_retry_events) + 1
+            _failure_summary = _summarize_dev_transport_failure(dev_result)
+            _dev_results_this_iteration.append(dev_result)
+            _dev_durations_this_iteration.append(_attempt_elapsed)
+            _dev_retry_events.append(
+                {
+                    "iteration": state.dev_iteration,
+                    "retry": retry_count,
+                    "error": _failure_summary,
+                }
+            )
+            _log(
+                f"  ↻ DEV   transient transport failure "
+                f"(retry {retry_count}/{_max_transport_retries})"
+            )
+            if state.log_dir is not None:
+                write_trace(
+                    state.log_dir
+                    / (
+                        f"dev-iter-{state.dev_iteration}-{config.dev_profile.name}"
+                        f"-retry{retry_count}.log"
+                    ),
+                    dev_result.output or "",
+                )
+            _current_session_id = dev_result.session_id if _dev_profile.mode == "cli" else None
+            _backoff_s = _dev_transport_retry_backoff_seconds(retry_count)
+            _log_verbose(f"  DEV retry backoff: {_backoff_s}s")
+            time.sleep(_backoff_s)
+            continue
+
+        _dev_results_this_iteration.append(dev_result)
+        _dev_durations_this_iteration.append(_attempt_elapsed)
+        _dev_elapsed = time.monotonic() - _dev_total_start
+        break
+
+    state.pending_dev_transport_retry_count = len(_dev_retry_events)
+    state.pending_dev_transport_retry_events = list(_dev_retry_events)
     write_trace(
         workspace_path / ".forge/traces" / f"{state.dev_trace_count}-dev-output.txt",
         dev_result.output,
@@ -599,14 +732,17 @@ def _run_dev_phase(
             state.log_dir / f"dev-iter-{state.dev_iteration}-{config.dev_profile.name}.log",
             dev_result.output or "",
         )
-    state.dev_results.append(dev_result)
-    state.dev_durations.append(_dev_elapsed)
+    state.dev_results.extend(_dev_results_this_iteration)
+    state.dev_durations.extend(_dev_durations_this_iteration)
     _capture_dev_handoff(state, config, task, workspace_path, dev_result)
     state.dev_session_id = dev_result.session_id or state.dev_session_id
     save_sessions(workspace_path, state.dev_session_id, state.reviewer_session_ids)
     log_agent_result(dev_result, "DEV")
+    _dev_cost_total = sum(result.cost_usd or 0.0 for result in _dev_results_this_iteration)
     _dev_cost_str = (
-        "${:.2f}".format(dev_result.cost_usd) if dev_result.cost_usd is not None else "unknown"
+        "${:.2f}".format(_dev_cost_total)
+        if any(result.cost_usd is not None for result in _dev_results_this_iteration)
+        else "unknown"
     )
     _log(f"  ✓ DEV   {_dev_cost_str}  {_fmt_duration(_dev_elapsed)}")
     if logger:
@@ -614,7 +750,7 @@ def _run_dev_phase(
             "phase_end",
             phase="DEV",
             outcome="success" if dev_result.success else "failure",
-            cost_usd=dev_result.cost_usd,
+            cost_usd=_dev_cost_total if _dev_cost_str != "unknown" else None,
             duration_s=round(_dev_elapsed, 2),
         )
 
@@ -718,6 +854,12 @@ def _run_dev_phase(
             state.error = (
                 f"Dev agent failed (exit={dev_result.exit_code}) and produced no commits "
                 "ahead of base — escalating to avoid an empty-diff APPROVE"
+            )
+            record_dev_iteration_telemetry(
+                state,
+                workspace_path,
+                max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
+                gate_result="DEV_FAILURE",
             )
             _log(f"✗ ESCALATE   {state.error}")
             if logger:

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -179,6 +179,8 @@ class DevIterationTelemetry:
     agent_exit_code: int | None = None
     runner_failure_code: str | None = None
     runner_failure_summary: str | None = None
+    transport_retry_count: int = 0
+    transport_retry_events: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -244,6 +246,8 @@ class CoordinatorState:
     workspace_path: Path | None = None
     branch_name: str | None = None
     dev_session_id: str | None = None
+    pending_dev_transport_retry_count: int = 0
+    pending_dev_transport_retry_events: list[dict[str, Any]] = field(default_factory=list)
     plan_session_id: str | None = None
     plan_review_session_ids: dict[str, str] = field(default_factory=dict)  # keyed by profile.name
     reviewer_session_ids: dict[str, str] = field(default_factory=dict)  # keyed by profile.name

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -95,11 +95,18 @@ class TestLoadConfig:
 
     def test_custom_retry(self, tmp_path):
         config_path = _write_config(
-            {"retry": {"max_dev_iterations": 5, "max_review_cycles": 4}},
+            {
+                "retry": {
+                    "max_dev_iterations": 5,
+                    "max_dev_transport_retries": 2,
+                    "max_review_cycles": 4,
+                }
+            },
             tmp_path,
         )
         config = load_config(config_path)
         assert config.retry.max_dev_iterations == 5
+        assert config.retry.max_dev_transport_retries == 2
         assert config.retry.max_review_cycles == 4
 
     def test_auto_model_escalation_defaults_false(self, tmp_path):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -24,6 +24,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.dev_phase import classify_runner_subprocess_failure
 from theforge.coordinator.engine import run_task
 from theforge.coordinator.state import Phase, parse_phase_name
@@ -1130,3 +1131,170 @@ class TestStartupFailureEscalation:
         assert result.success is True
         assert result.state.dev_iteration_telemetry[0].agent_exit_code == 0
         assert result.state.dev_iteration_telemetry[0].runner_failure_code is None
+
+    @patch("theforge.coordinator.dev_phase.time.sleep", return_value=None)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_transient_transport_failure_retries_and_succeeds(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_pool, _mock_sleep, tmp_path
+    ):
+        """A transient dev transport failure is retried once and surfaced in audit."""
+        config = replace(
+            _make_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_dev_transport_retries=1,
+                max_review_cycles=2,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev_agent.side_effect = [
+            AgentResult(
+                success=False,
+                output="API Error: Stream idle timeout - partial response received",
+                session_id="sess-partial",
+                cost_usd=0.75,
+                exit_code=1,
+                raw={},
+            ),
+            AgentResult(
+                success=True,
+                output="Implemented.",
+                session_id="sess-final",
+                cost_usd=1.10,
+                exit_code=0,
+                raw={},
+            ),
+        ]
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert mock_dev_agent.call_count == 2
+        assert len(result.state.dev_results) == 2
+        assert result.state.total_dev_cost == pytest.approx(1.85)
+        telemetry = result.state.dev_iteration_telemetry[0]
+        assert telemetry.transport_retry_count == 1
+        assert telemetry.transport_retry_events[0]["retry"] == 1
+        assert "stream idle timeout" in telemetry.transport_retry_events[0]["error"].lower()
+
+        audit = generate_audit_log(config, task, result)
+        assert audit["phases"]["dev"]["transport_retries"] == telemetry.transport_retry_events
+
+    @patch("theforge.coordinator.dev_phase._has_commits_ahead_of_base", return_value=False)
+    @patch("theforge.coordinator.dev_phase.time.sleep", return_value=None)
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_transient_transport_failure_exhausts_retries_then_escalates(
+        self,
+        mock_shell,
+        mock_dev_agent,
+        mock_preflight,
+        _mock_sleep,
+        _mock_has_commits,
+        tmp_path,
+    ):
+        """Transient dev failures stop retrying after the configured transport budget."""
+        config = replace(
+            _make_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_dev_transport_retries=1,
+                max_review_cycles=2,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev_agent.side_effect = [
+            AgentResult(
+                success=False,
+                output="API Error: Stream idle timeout - partial response received",
+                session_id="sess-partial",
+                cost_usd=0.75,
+                exit_code=1,
+                raw={},
+            ),
+            AgentResult(
+                success=False,
+                output="provider 503 service unavailable",
+                session_id="sess-final",
+                cost_usd=0.50,
+                exit_code=1,
+                raw={},
+            ),
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert mock_dev_agent.call_count == 2
+        telemetry = result.state.dev_iteration_telemetry[0]
+        assert telemetry.gate_result == "DEV_FAILURE"
+        assert telemetry.transport_retry_count == 1
+        assert len(result.state.dev_results) == 2
+        assert result.state.total_dev_cost == pytest.approx(1.25)
+        assert "produced no commits ahead of base" in (result.message or "")
+
+    @patch("theforge.coordinator.dev_phase._has_commits_ahead_of_base", return_value=False)
+    @patch("theforge.coordinator.dev_phase.time.sleep", return_value=None)
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_dev_non_transient_failure_does_not_retry(
+        self,
+        mock_shell,
+        mock_dev_agent,
+        mock_preflight,
+        _mock_sleep,
+        _mock_has_commits,
+        tmp_path,
+    ):
+        """Authentication/content errors escalate immediately without transport retry."""
+        config = replace(
+            _make_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_dev_transport_retries=1,
+                max_review_cycles=2,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev_agent.return_value = AgentResult(
+            success=False,
+            output="authentication failed: invalid api key",
+            session_id=None,
+            cost_usd=0.20,
+            exit_code=1,
+            raw={},
+            failure_code="auth_error",
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert mock_dev_agent.call_count == 1
+        telemetry = result.state.dev_iteration_telemetry[0]
+        assert telemetry.transport_retry_count == 0
+        assert telemetry.transport_retry_events == []

--- a/tests/test_generate_audit_log.py
+++ b/tests/test_generate_audit_log.py
@@ -19,6 +19,7 @@ from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.state import (
     CoordinatorResult,
     CoordinatorState,
+    DevIterationTelemetry,
     GateDebugTelemetry,
     Phase,
     ReviewCycleMetadata,
@@ -538,6 +539,53 @@ class TestPhasesBlock:
         assert dev["cost_usd"] == pytest.approx(3.26)
         assert dev["duration_s"] == pytest.approx(969.0)
         assert dev["iterations"] == 1
+
+    def test_dev_phase_includes_transport_retries(self, tmp_path: Path) -> None:
+        """Transient dev retries appear in both phase and iteration audit blocks."""
+        state = CoordinatorState()
+        state.dev_results.extend(
+            [
+                AgentResult(
+                    success=False,
+                    output="API Error: Stream idle timeout - partial response received",
+                    session_id="sess-partial",
+                    cost_usd=0.75,
+                    exit_code=1,
+                    raw={},
+                    profile_name="dev",
+                ),
+                _make_agent_result(cost_usd=1.10, profile_name="dev"),
+            ]
+        )
+        state.dev_durations.extend([120.0, 240.0])
+        state.dev_iteration_telemetry.append(
+            DevIterationTelemetry(
+                iteration=1,
+                max_iterations=3,
+                cost_usd=1.10,
+                duration_s=360.0,
+                gate_result="PASS",
+                transport_retry_count=1,
+                transport_retry_events=[
+                    {
+                        "iteration": 1,
+                        "retry": 1,
+                        "error": (
+                            "exit=1: API Error: Stream idle timeout - partial response received"
+                        ),
+                    }
+                ],
+            )
+        )
+        result = _make_coordinator_result(state)
+
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), result)
+
+        dev = log["phases"]["dev"]
+        assert dev is not None
+        assert len(dev["transport_retries"]) == 1
+        assert dev["transport_retries"][0]["retry"] == 1
+        assert log["iterations"]["dev_loop"][0]["transport_retry_count"] == 1
 
     def test_validate_phase_populated(self, tmp_path: Path) -> None:
         """phases.validate is populated when gate ran."""


### PR DESCRIPTION
## Summary

Retry logic for transient dev transport failures is correctly implemented with bounded backoff, error classification, audit surfacing, and seam-level tests covering all three paths (retry-success, retry-exhausted, non-transient).

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.62
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/audit.py:162`** 'iterations: len(state.dev_results)' now overcounts when transport retries occur. state.dev_results is extended with all attempts including failed retry attempts, so a single dev iteration with one transport retry reports iterations=2. The actual semantic iteration count is len(state.dev_iteration_telemetry).
- **[P2] `src/theforge/coordinator/dev_phase.py:72`** Bare numeric substrings '500', '502', '503', '504' in _TRANSIENT_DEV_ERROR_PATTERNS match any output containing those strings, including port numbers, token counts, or log lines that are not HTTP status codes. 'connection refused' is also included but generally indicates a misconfigured endpoint rather than a transient provider hiccup, so retrying it is unlikely to help.

## Story

Dev phase has no retry on transient provider errors — one API hiccup escalates the story (GitHub Issue #1196)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1196