### PR TITLE
forge status conflates ALREADY_DONE preflight verdict with 'missing-work failure' detail — operator sees contradictory state

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -907,7 +907,7 @@ def _classify_and_record(
     preflight_verdict = result.state.preflight_verdict
     landing_status = getattr(result, "landing_status", None)
 
-    if preflight_verdict == "ALREADY_DONE":
+    if preflight_verdict == "ALREADY_DONE" and result.success:
         outcome = StoryOutcome.ALREADY_DONE
         merged_slugs.add(task.slug)
         dag.mark_complete(task.slug)

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -383,8 +383,12 @@ def _stage_and_detail_from_completed_story(
 
     detail = ""
     if isinstance(audit_data, dict):
+        if outcome == "ALREADY_DONE":
+            reason = _nonempty_str(preflight.get("reason"))
+            if reason:
+                detail = f"Preflight verdict: {reason}"
         reviews = audit_data.get("reviews")
-        if isinstance(reviews, list) and reviews:
+        if not detail and isinstance(reviews, list) and reviews:
             last_review = reviews[-1]
             if isinstance(last_review, dict):
                 finding_counts = last_review.get("findings_by_severity")

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -386,6 +386,47 @@ def test_read_completed_status_uses_audit_for_terminal_stage_and_detail(tmp_path
     assert entries[0].complexity == "medium"
 
 
+def test_read_completed_status_already_done_prefers_preflight_reason(tmp_path: Path) -> None:
+    from theforge.sprint.status_reader import read_completed_status
+
+    stories = [
+        {
+            "slug": "issue-1186",
+            "path": "Issue #1186",
+            "outcome": "ALREADY_DONE",
+            "cost_usd": 0.65,
+        }
+    ]
+    summary_path = _make_summary_file(tmp_path, "already-done-sprint", "run-audit", stories)
+
+    audit_dir = tmp_path / ".forge" / "logs" / "already-done-sprint" / "issue-1186"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_data = {
+        "preflight": {
+            "verdict": "cached",
+            "original_verdict": "ALREADY_DONE",
+            "reason": "Main already satisfies all acceptance criteria.",
+        },
+        "outcome": {
+            "message": (
+                "Gate exited PASS but branch has no commits ahead of base — "
+                "treating empty worktree as missing-work failure"
+            )
+        },
+    }
+    with open(audit_dir / "audit.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(audit_data, f)
+
+    entries = read_completed_status(summary_path)
+
+    assert len(entries) == 1
+    assert entries[0].status == "done"
+    assert entries[0].phase == "ALREADY_DONE"
+    assert (
+        entries[0].detail == "Preflight verdict: Main already satisfies all acceptance criteria."
+    )
+
+
 # ── cmd_sprint_status (output) ───────────────────────────────────────────────
 
 
@@ -1082,3 +1123,30 @@ def test_completed_done_story_verdict_is_preserved() -> None:
     }
     _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
     assert detail == "APPROVE"
+
+
+def test_completed_already_done_story_prefers_preflight_reason_over_outcome_message() -> None:
+    """ALREADY_DONE rows should render the preflight reason, not a later gate message."""
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    story = {
+        "slug": "issue-1186",
+        "path": "Issue #1186",
+        "outcome": "ALREADY_DONE",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_completed_story(
+        story,
+        {
+            "preflight": {
+                "reason": "Main already satisfies all acceptance criteria.",
+            },
+            "outcome": {
+                "message": (
+                    "Gate exited PASS but branch has no commits ahead of base — "
+                    "treating empty worktree as missing-work failure"
+                )
+            },
+        },
+    )
+
+    assert detail == "Preflight verdict: Main already satisfies all acceptance criteria."

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -609,6 +609,28 @@ class TestClassifyAndRecord:
         assert "a" in merged_slugs
         assert {t.slug for t in dag.ready()} == {"b"}
 
+    def test_failed_result_does_not_get_promoted_to_already_done(self) -> None:
+        """An ALREADY_DONE preflight verdict must not mask a later failed result."""
+        from theforge.sprint.story_state import StoryOutcome
+
+        a = _make_task("a")
+        b = _make_task("b", depends_on=["a"])
+        dag = StoryDAG([a, b])
+        merged_slugs: set[str] = set()
+
+        result = _make_coordinator_result(
+            success=False,
+            cost=0.0,
+            preflight_verdict="ALREADY_DONE",
+            phase=Phase.ESCALATE,
+        )
+        outcome = _classify_and_record(a, result, dag, merged_slugs)
+
+        assert outcome is StoryOutcome.FAILED
+        assert outcome.is_succeeded is False
+        assert "a" not in merged_slugs
+        assert dag.ready() == []
+
     def test_failure_skips_for_dag(self) -> None:
         """Failure → FAILED, dag.mark_skipped."""
         from theforge.sprint.story_state import StoryOutcome


### PR DESCRIPTION
## Summary

Core fix is correct and well-tested; branch also carries an already-approved sibling commit (e771a21 / #1220) that was omitted from the handoff but adds no risk to this story's ACs.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.63
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/audit.py:435`** _build_plan_review_per_reviewer is called twice per generate_audit_log invocation — once inside _build_phases_block (line ~211) and once directly in generate_audit_log (line ~435). This re-parses the same AgentResult list on both calls. No correctness harm, but redundant work. Already flagged in the PR commit message as a known P2.
- **[P2] `src/theforge/coordinator/audit.py:None`** Dev-review per_reviewer uses a dict keyed by reviewer name (field 'cost'), while plan-review per_reviewer is a list of dicts (field 'cost_usd'). These shapes diverge enough to require distinct tooling or parsing logic for any consumer that wants uniform per-reviewer data. Also already noted in the PR commit message.

## Story

forge status conflates ALREADY_DONE preflight verdict with 'missing-work failure' detail — operator sees contradictory state (GitHub Issue #1200)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1200