### PR TITLE
PRESERVED state applied to empty worktrees — sprint refuses to re-run a story whose 'preserved' worktree contains no work

### DIFF
--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -67,6 +67,8 @@ def acquire_launch_story_locks(
         escalated_slugs = check_escalated_worktrees(
             slugs,
             config.workspace.path_pattern,
+            config.workspace.branch_pattern,
+            config.workspace.base_branch,
             config.project_root,
         )
     dropped: dict[str, str] = {s: REASON_PRESERVED_ESCALATED for s in escalated_slugs}

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fcntl
 import os
+import shutil
 import subprocess
 import time
 from contextlib import contextmanager
@@ -20,6 +21,80 @@ _UNAVAILABLE_FINGERPRINT = "unavailable"
 def _is_escalated_worktree(worktree_path: Path) -> bool:
     """Return True when the worktree is marked as an escalated, preserved run."""
     return (worktree_path / ESCALATED_MARKER_PATH).exists()
+
+
+def _remove_leftover_worktree_dir(path: Path) -> None:
+    """Best-effort cleanup for leftover forge-only directories after removal."""
+    if not path.exists():
+        return
+    forge_dir = path / ".forge"
+    if not forge_dir.exists():
+        return
+    for child in path.iterdir():
+        if child.name != ".forge":
+            return
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _worktree_has_preserved_evidence(worktree_path: Path, base_branch: str) -> bool | None:
+    """Return whether an escalated worktree contains commits or dirty files.
+
+    Returns ``None`` when git state cannot be determined, so the caller can
+    fail closed and keep the worktree preserved.
+    """
+    ahead_result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(worktree_path),
+            "rev-list",
+            "--count",
+            f"{base_branch}..HEAD",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if ahead_result.returncode != 0:
+        return None
+    try:
+        ahead_count = int(ahead_result.stdout.strip())
+    except ValueError:
+        return None
+
+    status_result = subprocess.run(
+        ["git", "-C", str(worktree_path), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+    )
+    if status_result.returncode != 0:
+        return None
+
+    return ahead_count > 0 or bool(status_result.stdout.strip())
+
+
+def _cleanup_empty_worktree(
+    worktree_path: Path,
+    branch_name: str,
+    project_root: Path,
+) -> bool:
+    """Remove an empty worktree/branch pair. Returns True on full success."""
+    remove_result = subprocess.run(
+        ["git", "worktree", "remove", "--force", str(worktree_path)],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if remove_result.returncode != 0:
+        return False
+    _remove_leftover_worktree_dir(worktree_path)
+
+    branch_result = subprocess.run(
+        ["git", "branch", "-D", branch_name],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    return branch_result.returncode == 0
 
 
 class SprintConflictError(Exception):
@@ -61,6 +136,8 @@ def _write_lock_metadata(fd) -> None:
 def check_escalated_worktrees(
     slugs: list[str],
     path_pattern: str,
+    branch_pattern: str,
+    base_branch: str,
     project_root: Path,
 ) -> list[str]:
     """Return slugs whose on-disk worktree is marked escalated (preserved).
@@ -75,7 +152,17 @@ def check_escalated_worktrees(
         worktree_path = project_root / path_pattern.format(slug=slug)
         if not worktree_path.exists():
             continue
-        if _is_escalated_worktree(worktree_path):
+        if not _is_escalated_worktree(worktree_path):
+            continue
+        has_evidence = _worktree_has_preserved_evidence(worktree_path, base_branch)
+        if has_evidence is True:
+            escalated.append(slug)
+            continue
+        if has_evidence is None:
+            escalated.append(slug)
+            continue
+        branch_name = branch_pattern.format(slug=slug)
+        if not _cleanup_empty_worktree(worktree_path, branch_name, project_root):
             escalated.append(slug)
     return escalated
 

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -26,6 +26,7 @@ def _mock_config(tmp_path: Path) -> MagicMock:
     config.project_root = tmp_path
     config.workspace.path_pattern = ".forge/worktrees/{slug}"
     config.workspace.base_branch = "main"
+    config.workspace.branch_pattern = "forge/{slug}"
     return config
 
 
@@ -40,13 +41,70 @@ def _make_worktree_with_audit(tmp_path: Path, slug: str, final_phase: str | None
 
 
 class TestEscalatedWorktreeNotTreatedAsCollision:
+    def test_empty_escalated_worktree_is_cleaned_up_and_rescheduled(self, tmp_path: Path) -> None:
+        """An escalated-but-empty worktree is removed instead of being preserved."""
+        worktree = _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
+        config = _mock_config(tmp_path)
+
+        git_results = [
+            MagicMock(returncode=0, stdout="0\n"),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout="Deleted branch forge/issue-829\n"),
+        ]
+        with (
+            patch("theforge.sprint.lock.subprocess.run", side_effect=git_results) as mock_git,
+            patch("theforge.sprint.lock._current_process_fingerprint", return_value="test-fp"),
+        ):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829"],
+                config=config,
+                resume=False,
+                allow_drop=False,
+            )
+
+        try:
+            assert launch_error is None
+            assert dropped == {}
+            assert len(locked_fds) == 1
+            assert mock_git.call_args_list[0].args[0] == [
+                "git",
+                "-C",
+                str(worktree),
+                "rev-list",
+                "--count",
+                "main..HEAD",
+            ]
+            assert mock_git.call_args_list[1].args[0] == [
+                "git",
+                "-C",
+                str(worktree),
+                "status",
+                "--porcelain",
+            ]
+            assert mock_git.call_args_list[2].args[0][:4] == [
+                "git",
+                "worktree",
+                "remove",
+                "--force",
+            ]
+            assert mock_git.call_args_list[3].args[0] == ["git", "branch", "-D", "forge/issue-829"]
+            assert not worktree.exists()
+        finally:
+            from theforge.sprint.lock import release_story_locks
+
+            release_story_locks(locked_fds)
+
     def test_escalated_worktree_is_preserved_not_scheduled(self, tmp_path: Path) -> None:
         """An escalated worktree is excluded from scheduling — no lock, no rerun."""
         _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
         config = _mock_config(tmp_path)
 
-        completed = MagicMock(returncode=0, stdout="7\n")
-        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+        git_results = [
+            MagicMock(returncode=0, stdout="7\n"),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        with patch("theforge.sprint.lock.subprocess.run", side_effect=git_results):
             locked_fds, launch_error, dropped = acquire_launch_story_locks(
                 slugs=["issue-829"],
                 config=config,
@@ -70,8 +128,13 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
         config = _mock_config(tmp_path)
 
         # issue-267 and issue-268 have no worktree; issue-829 is escalated.
-        completed = MagicMock(returncode=0, stdout="0\n")
-        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+        git_results = [
+            MagicMock(returncode=0, stdout="0\n"),
+            MagicMock(returncode=0, stdout=" M keep-me.py\n"),
+            MagicMock(returncode=0, stdout="0\n"),
+            MagicMock(returncode=0, stdout="0\n"),
+        ]
+        with patch("theforge.sprint.lock.subprocess.run", side_effect=git_results):
             locked_fds, launch_error, dropped = acquire_launch_story_locks(
                 slugs=["issue-829", "issue-267", "issue-268"],
                 config=config,


### PR DESCRIPTION
## Summary

Clean, conservative implementation: fail-closed on git errors, correct evidence checks, adequate test coverage for the two key paths.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.55
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_sprint_reexec_collision.py:None`** No test covers the fail-closed path where _worktree_has_preserved_evidence returns None (git command fails). The None branch in check_escalated_worktrees is exercised indirectly by the status mock having stdout='' in test_reexec_with_escalated_and_pending_story, but that returns False not None — the None path (non-zero returncode) has no coverage.
- **[P2] `src/theforge/sprint/lock.py:72`** Partial-cleanup state: if git worktree remove succeeds but git branch -D fails, _cleanup_empty_worktree returns False and the slug is appended to escalated — but the worktree directory is already gone. On the very next sprint launch worktree_path.exists() is False, so the slug skips the escalated check entirely and proceeds normally. This self-heals in one launch but silently leaves an orphaned feature branch with no warning to the operator.

## Story

PRESERVED state applied to empty worktrees — sprint refuses to re-run a story whose 'preserved' worktree contains no work (GitHub Issue #1201)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1201