### PR TITLE
Sprint budget enforcement carries sunk cost from prior sprints — should be strictly per-sprint

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -280,6 +280,7 @@ def _write_sprint_audit(
     sprint_id: str | None = None,
     dropped_slugs: "dict[str, str] | None" = None,
     skipped_issues: "list | None" = None,
+    current_story_entries_by_ref: "dict[str, dict] | None" = None,
 ) -> None:
     """Write sprint-audit.yaml to the project root."""
     story_times = story_times or {}
@@ -288,6 +289,7 @@ def _write_sprint_audit(
     tasks_by_slug = tasks_by_slug or {}
     dropped_slugs = dropped_slugs or {}
     skipped_issues = skipped_issues or []
+    current_story_entries_by_ref = current_story_entries_by_ref or {}
 
     # Build per-spec entries
     spec_entries = []
@@ -402,6 +404,8 @@ def _write_sprint_audit(
                 entry["started_at"] = None
                 entry["finished_at"] = None
             entry["batch"] = batch_assignments.get(slug, 0)
+        elif canonical_ref in current_story_entries_by_ref:
+            entry = dict(current_story_entries_by_ref[canonical_ref])
         else:
             # Dropped by launch guard (active-worktree collision, lock held,
             # or preserved-escalated) takes precedence over the generic

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -92,15 +92,20 @@ def derive_worker_timeout(
     return resolve_timeout(base, None, None, complexity, complexity_score)
 
 
-def _read_prior_sprint_cost(project_root: Path) -> float:
-    """Read total_cost_usd from the prior sprint-audit.yaml, if it exists."""
+def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
+    """Read carry-forward cost for a same-sprint re-exec from sprint-audit.yaml."""
+    if not sprint_id or not os.environ.get("FORGE_PREV_RUN_ID"):
+        return 0.0
     audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
     if not audit_path.exists():
         return 0.0
     try:
         with open(audit_path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return float(data.get("sprint", {}).get("total_cost_usd", 0.0))
+        sprint_block = data.get("sprint", {})
+        if sprint_block.get("sprint_id") != sprint_id:
+            return 0.0
+        return float(sprint_block.get("total_cost_usd", 0.0))
     except (OSError, ValueError, TypeError):
         return 0.0
 
@@ -1229,7 +1234,7 @@ def run_sprint(
     # Resume mode: triage all stories and carry forward prior costs
     triages: dict[str, StoryTriage] = {}
     if resume:
-        prior_cost = _read_prior_sprint_cost(config.project_root)
+        prior_cost = _read_prior_sprint_cost(config.project_root, _sprint_id)
         if prior_cost > 0.0:
             _log(f"Resuming with prior cost: ${prior_cost:.2f}")
         _log("Triaging specs...")
@@ -1345,6 +1350,15 @@ def run_sprint(
             "merge": False,
             "batch": 0,
             "depends_on": list(getattr(task, "depends_on", None) or []),
+            "dependency_warnings": list(getattr(task, "dependency_warnings", None) or []),
+            "inferred_dependencies": {
+                "manifest": [
+                    dep
+                    for dep in (getattr(task, "depends_on", None) or [])
+                    if dep not in (getattr(task, "inferred_dependencies", None) or [])
+                ],
+                "github_blockers": list(getattr(task, "inferred_dependencies", None) or []),
+            },
         }
 
     # Dependencies already satisfied outside this sprint still count as landed
@@ -1792,30 +1806,27 @@ def run_sprint(
                 if cumulative >= resolved.budget_usd:
                     dag.mark_skipped(task.slug)
                     _budget_reason = (
-                        f"budget exhausted (${cumulative:.2f} >= ${resolved.budget_usd:.2f})"
+                        "budget exhausted "
+                        f"(sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} = "
+                        f"${cumulative:.2f} >= ${resolved.budget_usd:.2f})"
                     )
                     _set_outcome(task.slug, StoryOutcome.SKIPPED, reason=_budget_reason)
                     if stopped_reason is None:
-                        stopped_reason = (
-                            f"Budget exhausted (${cumulative:.2f} >= ${resolved.budget_usd:.2f})"
+                        _budget_math = (
+                            f"sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} = "
+                            f"${cumulative:.2f} >= ${resolved.budget_usd:.2f}"
                         )
+                        stopped_reason = f"Budget exhausted ({_budget_math})"
                         if notify and config.notifications.backend not in ("ntfy", "none"):
                             from ..notify_backends import send_notifications
 
                             send_notifications(
                                 config,
                                 f'TheForge: budget exceeded \u2014 "{resolved.name}"',
-                                f"${cumulative:.2f} >= ${resolved.budget_usd:.2f}"
-                                " \u2014 remaining stories skipped",
+                                f"{_budget_math} \u2014 remaining stories skipped",
                             )
-                    _log(f"SKIPPED {task.slug} (budget exhausted)")
-                    _record_current_story_entry(
-                        task.slug,
-                        "SKIPPED",
-                        error=(
-                            f"budget exhausted (${cumulative:.2f} >= ${resolved.budget_usd:.2f})"
-                        ),
-                    )
+                    _log(f"SKIPPED {task.slug} ({_budget_reason})")
+                    _record_current_story_entry(task.slug, "SKIPPED", error=_budget_reason)
                     if _state_writer is not None:
                         _state_writer.update(task.slug, status="skipped")
                     continue
@@ -2316,6 +2327,7 @@ def run_sprint(
         sprint_id=_sprint_id,
         dropped_slugs=_dropped_slugs,
         skipped_issues=skipped_issues,
+        current_story_entries_by_ref=current_story_entries_by_ref,
     )
 
     # Write sprint-summary.yaml to .forge/logs/<sprint-name>/

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -25,7 +25,7 @@ from theforge.sprint import run_sprint
 from theforge.sprint.dag import StoryTriage, _triage_spec
 from theforge.sprint.lock import acquire_story_locks, release_story_locks
 from theforge.sprint.manifest import ResolvedSprint, _build_task_from_story
-from theforge.sprint.runner import _run_fresh
+from theforge.sprint.runner import _read_prior_sprint_cost, _run_fresh
 from theforge.sprint.sources import GitHubIssueSource
 from theforge.task import TaskStory
 
@@ -80,6 +80,24 @@ def _make_manifest(tmp_path: Path, specs: list[str], budget: float = 10.0) -> Pa
         encoding="utf-8",
     )
     return manifest_path
+
+
+def _set_sprint_id(
+    tmp_path: Path,
+    sprint_name: str = "Test Sprint",
+    sprint_id: str = "sprint-123",
+) -> str:
+    sprint_dir = tmp_path / ".forge" / "logs" / sprint_name
+    sprint_dir.mkdir(parents=True, exist_ok=True)
+    (sprint_dir / ".sprint_id").write_text(sprint_id, encoding="utf-8")
+    return sprint_id
+
+
+def _write_prior_sprint_audit(tmp_path: Path, sprint_id: str, total_cost_usd: float) -> None:
+    audits_dir = tmp_path / ".forge" / "audits"
+    audits_dir.mkdir(parents=True, exist_ok=True)
+    with open(audits_dir / "sprint-audit.yaml", "w", encoding="utf-8") as f:
+        yaml.dump({"sprint": {"sprint_id": sprint_id, "total_cost_usd": total_cost_usd}}, f)
 
 
 def _make_coordinator_result(
@@ -285,6 +303,38 @@ class TestTriageSpec:
 
         assert triage.action == "full"
         assert triage.reason == "no worktree found"
+
+
+class TestReadPriorSprintCost:
+    def test_returns_zero_without_reexec_signal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sprint_id = _set_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 3.5)
+
+        monkeypatch.delenv("FORGE_PREV_RUN_ID", raising=False)
+
+        assert _read_prior_sprint_cost(tmp_path, sprint_id) == 0.0
+
+    def test_returns_zero_for_different_sprint_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sprint_id = _set_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, "other-sprint", 3.5)
+
+        monkeypatch.setenv("FORGE_PREV_RUN_ID", "run-prev-123")
+
+        assert _read_prior_sprint_cost(tmp_path, sprint_id) == 0.0
+
+    def test_returns_prior_cost_for_same_sprint_reexec(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sprint_id = _set_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 3.5)
+
+        monkeypatch.setenv("FORGE_PREV_RUN_ID", "run-prev-123")
+
+        assert _read_prior_sprint_cost(tmp_path, sprint_id) == pytest.approx(3.5)
 
     def test_triage_same_tip_missing_worktree_with_prior_approve_skips_when_squash_merged(
         self, tmp_path: Path
@@ -646,13 +696,10 @@ class TestResumeSprintIntegration:
         _make_spec_file(tmp_path, "Feature B", "feature-b")
         manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=1.0)
         config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
 
         # Prior run spent $2 — budget exhausted
-        audits_dir = tmp_path / ".forge" / "audits"
-        audits_dir.mkdir(parents=True)
-        prior_audit = {"sprint": {"total_cost_usd": 2.0}}
-        with open(audits_dir / "sprint-audit.yaml", "w") as f:
-            yaml.dump(prior_audit, f)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 2.0)
 
         merged_triage = StoryTriage(
             story_path="feature-a.md",
@@ -674,7 +721,8 @@ class TestResumeSprintIntegration:
 
         with patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect):
             with patch("theforge.sprint.runner.run_task") as mock_run:
-                result = run_sprint(config, manifest_path, resume=True)
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint(config, manifest_path, resume=True)
 
         # Merged spec should remain already-done/skipped, not budget-skipped.
         assert result.specs_succeeded == 0
@@ -710,17 +758,13 @@ class TestResumeSprintIntegration:
         assert result.specs_succeeded == 1
 
     def test_resume_cost_continuity(self, tmp_path: Path) -> None:
-        """Prior sprint cost is carried forward into total_cost_usd."""
+        """Same-sprint re-exec carries prior cost forward into total_cost_usd."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
         config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
 
-        # Write a prior sprint-audit.yaml with a known cost
-        audits_dir = tmp_path / ".forge" / "audits"
-        audits_dir.mkdir(parents=True)
-        prior_audit = {"sprint": {"total_cost_usd": 3.50}}
-        with open(audits_dir / "sprint-audit.yaml", "w") as f:
-            yaml.dump(prior_audit, f)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 3.50)
 
         full_triage = StoryTriage(
             story_path="feature-a.md",
@@ -732,23 +776,47 @@ class TestResumeSprintIntegration:
 
         with patch("theforge.sprint.runner._triage_spec", return_value=full_triage):
             with patch("theforge.sprint.runner.run_task", return_value=coord_result):
-                result = run_sprint(config, manifest_path, resume=True)
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint(config, manifest_path, resume=True)
 
         # total should be prior (3.50) + new (1.00)
         assert result.total_cost_usd == pytest.approx(4.50)
+
+    def test_resume_different_sprint_does_not_carry_prior_cost(self, tmp_path: Path) -> None:
+        """A new sprint starts at $0 even if a different sprint left audit cost behind."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=5.0)
+        config = _make_config(tmp_path)
+        _set_sprint_id(tmp_path, sprint_id="current-sprint")
+        _write_prior_sprint_audit(tmp_path, "older-sprint", 6.0)
+
+        full_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+        )
+        coord_result = _make_coordinator_result(success=True, cost=1.0)
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=full_triage):
+            with patch("theforge.sprint.runner.run_task", return_value=coord_result) as mock_run:
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint(config, manifest_path, resume=True)
+
+        mock_run.assert_called_once()
+        assert result.specs_succeeded == 1
+        assert result.total_cost_usd == pytest.approx(1.0)
+        assert result.stopped_reason is None
 
     def test_resume_prior_cost_exceeds_budget(self, tmp_path: Path) -> None:
         """When prior cost already meets/exceeds budget, first spec is skipped."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=5.0)
         config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
 
         # Prior run already spent $6 (over the $5 budget)
-        audits_dir = tmp_path / ".forge" / "audits"
-        audits_dir.mkdir(parents=True)
-        prior_audit = {"sprint": {"total_cost_usd": 6.0}}
-        with open(audits_dir / "sprint-audit.yaml", "w") as f:
-            yaml.dump(prior_audit, f)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
 
         full_triage = StoryTriage(
             story_path="feature-a.md",
@@ -759,13 +827,21 @@ class TestResumeSprintIntegration:
 
         with patch("theforge.sprint.runner._triage_spec", return_value=full_triage):
             with patch("theforge.sprint.runner.run_task") as mock_run:
-                result = run_sprint(config, manifest_path, resume=True)
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint(config, manifest_path, resume=True)
 
         # Spec should be skipped — prior cost alone exceeds budget
         mock_run.assert_not_called()
         assert result.specs_skipped == 1
-        assert result.stopped_reason is not None
-        assert "budget" in result.stopped_reason.lower()
+        assert (
+            result.stopped_reason
+            == "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
+        audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+        audit_data = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+        assert audit_data["specs"][0]["error"] == (
+            "budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
 
     def test_no_resume_flag_unchanged(self, tmp_path: Path) -> None:
         """Without --resume, behavior is unchanged (run_task called normally)."""


### PR DESCRIPTION
## Summary

Budget carry scoping is correctly gated on FORGE_PREV_RUN_ID + matching sprint_id; all three ACs are met with clean implementation and solid test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.50
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint budget enforcement carries sunk cost from prior sprints — should be strictly per-sprint (GitHub Issue #1053)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1053