### PR TITLE
forge status --watch must attach to a live sprint and degrade gracefully — show whatever is knowable, not require perfect state

### DIFF
--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -44,6 +44,7 @@ RESET = "\x1b[0m"
 
 # Terminals that don't support ANSI color sequences.
 COLORLESS_TERMS = frozenset({"dumb", "unknown", ""})
+STALL_THRESHOLD_ENV = "FORGE_STATUS_WATCH_STALE_SECONDS"
 
 
 def is_tty(stream: Any = None) -> bool:
@@ -94,6 +95,25 @@ def _format_delta(delta: float) -> str:
         return "—"
     sign = "+" if delta > 0 else "-"
     return f"{sign}${abs(delta):.2f}"
+
+
+def _stall_threshold_seconds(interval: float, override: float | None = None) -> float:
+    if override is None:
+        raw = os.environ.get(STALL_THRESHOLD_ENV, "").strip()
+        if raw:
+            try:
+                override = float(raw)
+            except ValueError:
+                override = None
+    if override is not None:
+        return max(0.0, override)
+    return max(5.0, interval * 2)
+
+
+def _resolve_followed_run_id(run_id: str, project_root: Path) -> str:
+    from theforge.sprint.status_reader import _follow_redirect_chain
+
+    return _follow_redirect_chain(run_id, project_root)
 
 
 def _resolve_sprint_log_dir(run_id: str, project_root: Path) -> Path | None:
@@ -199,14 +219,18 @@ def render_frame(
     now = (now_fn or time.time)()
     spinner = SPINNER_FRAMES[frame_idx % len(SPINNER_FRAMES)]
     interval = float(state.get("interval", 2.0))
-    stall_threshold = max(5.0, interval * 2)
+    stall_threshold = _stall_threshold_seconds(
+        interval,
+        state.get("stale_after_seconds"),
+    )
 
     prev_costs = dict(state.get("costs", {}))
     new_costs: dict[str, float] = {}
+    stalled_paths: list[str] = []
 
     overlay_lines: list[str] = []
     overlay_lines.append("")
-    title = f"── Live  refresh={interval:g}s  Ctrl-C to exit ──"
+    title = f"── Live  run={run_id}  refresh={interval:g}s  Ctrl-C to exit ──"
     overlay_lines.append(_c(title, DIM, color))
     _ACT_COL = 10
     hdr = f"{'STORY':<30}  {'ACTIVITY':<{_ACT_COL}}  {'ΔCOST':>8}  {'EVENT AGE':>9}"
@@ -214,6 +238,7 @@ def render_frame(
 
     for e in entries:
         slug = getattr(e, "slug", "") or ""
+        path = getattr(e, "path", slug) or slug
         cost = float(getattr(e, "cost_usd", 0.0) or 0.0)
         prev = prev_costs.get(slug, cost)
         delta = cost - prev
@@ -233,6 +258,7 @@ def render_frame(
             if stalled:
                 label = f"{STALL_CHAR} stalled"
                 act = _c(label, DIM, color)
+                stalled_paths.append(path)
             else:
                 label = f"{spinner} live"
                 act = _c(label, GREEN, color)
@@ -256,10 +282,22 @@ def render_frame(
         if color and delta != 0 and abs(delta) >= 0.005:
             delta_str = _c(delta_str, DIM, True)
 
-        path = getattr(e, "path", slug) or slug
         path_disp = path if len(path) <= 30 else path[:29] + "…"
         act_padded = act + " " * max(0, _ACT_COL - len(label))
         overlay_lines.append(f"{path_disp:<30}  {act_padded}  {delta_str:>8}  {age_str:>9}")
+
+    if stalled_paths:
+        stalled_preview = ", ".join(stalled_paths[:2])
+        if len(stalled_paths) > 2:
+            stalled_preview += f" +{len(stalled_paths) - 2} more"
+        overlay_lines.append("")
+        overlay_lines.append(
+            _c(
+                f"Hint: {stalled_preview} stalled; see `forge logs {run_id}`",
+                DIM,
+                color,
+            )
+        )
 
     state["costs"] = new_costs
     return base + "\n".join(overlay_lines) + "\n", snapshot_ok, err_buf.getvalue()
@@ -271,6 +309,7 @@ def run_watch_loop(
     interval: float,
     *,
     color: bool,
+    stale_after_seconds: float | None = None,
     sleep_fn: Any = None,
     max_frames: int | None = None,
 ) -> int:
@@ -287,19 +326,28 @@ def run_watch_loop(
     """
     sleep = sleep_fn or time.sleep
 
-    state: dict = {"costs": {}, "interval": float(interval)}
+    state: dict = {
+        "costs": {},
+        "interval": float(interval),
+        "stale_after_seconds": stale_after_seconds,
+    }
     frame = 0
     prev_lines = 0
     cursor_hidden = False
+    current_run_id = run_id
     try:
         if color or is_tty():
             sys.stdout.write(HIDE_CURSOR)
             sys.stdout.flush()
             cursor_hidden = True
         while True:
+            followed_run_id = _resolve_followed_run_id(current_run_id, project_root)
+            if followed_run_id != current_run_id:
+                current_run_id = followed_run_id
+                state["costs"] = {}
             try:
                 body, snapshot_ok, captured_err = render_frame(
-                    run_id, project_root, state, frame, color=color
+                    current_run_id, project_root, state, frame, color=color
                 )
             except Exception as exc:  # noqa: BLE001
                 if frame == 0:

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -172,6 +172,14 @@ class TestFormatHelpers:
     def test_delta_negative(self) -> None:
         assert status_watch._format_delta(-1.5) == "-$1.50"
 
+    def test_stall_threshold_defaults_from_interval(self) -> None:
+        assert status_watch._stall_threshold_seconds(2.0) == 5.0
+        assert status_watch._stall_threshold_seconds(10.0) == 20.0
+
+    def test_stall_threshold_can_be_overridden(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(status_watch.STALL_THRESHOLD_ENV, "17")
+        assert status_watch._stall_threshold_seconds(2.0) == 17.0
+
 
 # ── render_frame: deltas and spinner ──────────────────────────────────────────
 
@@ -374,6 +382,16 @@ class TestRenderFrame:
         )
         assert "stalled" in text
 
+    def test_stalled_story_surfaces_logs_hint(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", status="running")]
+        text = self._render(
+            tmp_path,
+            entries,
+            now_fn=lambda: 1000.0,
+            last_mtime=900.0,
+        )
+        assert "forge logs run-x" in text
+
     def test_done_label(self, tmp_path: Path) -> None:
         text = self._render(tmp_path, [_entry("story-a", status="done")])
         assert "done" in text
@@ -491,6 +509,86 @@ class TestRunWatchLoop:
         out = capsys.readouterr().out
         assert status_watch.HIDE_CURSOR in out
         assert status_watch.SHOW_CURSOR in out
+
+    def test_follows_reexec_redirect_without_restarting_watch(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        seen_run_ids: list[str] = []
+
+        def fake_render_frame(
+            run_id: str,
+            _project_root: Path,
+            state: dict,
+            frame_idx: int,
+            *,
+            color: bool,
+            now_fn=None,
+        ) -> tuple[str, bool, str]:
+            del state, frame_idx, color, now_fn
+            seen_run_ids.append(run_id)
+            return f"{run_id}\n", True, ""
+
+        with (
+            patch.object(status_watch, "render_frame", side_effect=fake_render_frame),
+            patch.object(status_watch, "is_tty", return_value=False),
+            patch.object(
+                status_watch,
+                "_resolve_followed_run_id",
+                side_effect=["run-old", "run-new", "run-new"],
+            ),
+        ):
+            rc = status_watch.run_watch_loop(
+                "run-old",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=lambda _s: None,
+                max_frames=3,
+            )
+
+        assert rc == 0
+        assert seen_run_ids == ["run-old", "run-new", "run-new"]
+        out = capsys.readouterr().out
+        assert "run-old" in out
+        assert "run-new" in out
+
+    def test_reexec_redirect_resets_cost_deltas_for_new_run(self, tmp_path: Path) -> None:
+        seen_costs: list[dict[str, float]] = []
+
+        def fake_render_frame(
+            run_id: str,
+            _project_root: Path,
+            state: dict,
+            frame_idx: int,
+            *,
+            color: bool,
+            now_fn=None,
+        ) -> tuple[str, bool, str]:
+            del run_id, frame_idx, color, now_fn
+            seen_costs.append(dict(state["costs"]))
+            state["costs"]["story-a"] = 1.25
+            return "frame\n", True, ""
+
+        with (
+            patch.object(status_watch, "render_frame", side_effect=fake_render_frame),
+            patch.object(status_watch, "is_tty", return_value=False),
+            patch.object(
+                status_watch,
+                "_resolve_followed_run_id",
+                side_effect=["run-old", "run-new"],
+            ),
+        ):
+            rc = status_watch.run_watch_loop(
+                "run-old",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=lambda _s: None,
+                max_frames=2,
+            )
+
+        assert rc == 0
+        assert seen_costs == [{}, {}]
 
 
 # ── cmd_status routing ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Watch re-exec following, stall hints, and budget-scoping are correctly implemented; three P2 style/scope issues noted.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.62
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/cli/status.py:393`** The new stale_after_seconds parameter added to run_watch_loop is never passed from cmd_status — there is no CLI argument for it and cmd_status does not thread it through. The parameter is reachable only by tests and the env-var fallback path. Spec says 'configurable by environment override', so the AC is met via the env var, but the function parameter is dead from the production call path.
- **[P2] `src/theforge/sprint/runner.py:1351`** Commit 5569fde adds dependency_warnings and inferred_dependencies fields to current_story_entries_by_ref entries. This is beyond the scope of the budget-scoping fix and the naming of inferred_dependencies.manifest (meaning 'explicitly declared') vs github_blockers (meaning 'inferred') is counter-intuitive. These fields will be written to sprint-audit.yaml for budget-skipped stories via the audit.py fallback path.
- **[P2] `tests/test_cli_status_watch.py:None`** Dev handoff claims only commit 259df85; the coordinator-verified git history shows 5569fde also on this branch ahead of main. The budget-scoping commit has a PR number (#1229) in its message, suggesting it may have been intended as a separate merge. Including it here is not a bug but makes the branch's scope larger than the issue title implies.

## Story

forge status --watch must attach to a live sprint and degrade gracefully — show whatever is knowable, not require perfect state (GitHub Issue #1144)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1144