### PR TITLE
Gate timeout with dev commits is a retryable validation failure, not a terminal escalation — hand back to dev with timeout evidence

### DIFF
--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -15,7 +15,7 @@ from theforge.config import ForgeConfig
 from theforge.task import TaskStory
 
 from . import util as _cu
-from .commit_guard import _has_commits_ahead_of_base
+from .commit_guard import _commits_exist_strict, _has_commits_ahead_of_base
 from .dev_phase import _extract_failed_tests, record_dev_iteration_telemetry
 from .gate import _is_gate_skip, _parse_dirty_files, _run_gate_debug_command, _run_gate_full
 from .logging import StructuredLogger
@@ -120,6 +120,78 @@ def _check_conventions_parallel(
         all_v = [types.SimpleNamespace(**d) for d in result["violations"]]
         net_v = all_v
     return all_v, net_v
+
+
+def _build_timeout_rca_packet(
+    *,
+    state: CoordinatorState,
+    config: ForgeConfig,
+    gate_cmd: str,
+    gate_output_tail: str,
+    workspace_path: Path,
+) -> str:
+    """Assemble the dev retry input for a gate-timeout-with-commits failure."""
+    gate_timeout_s = config.validation.gate_timeout or 600
+    tail_chars = config.validation.gate_output_tail_chars
+
+    head_sha = "(unknown)"
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        if proc.returncode == 0:
+            head_sha = proc.stdout.decode().strip() or "(unknown)"
+    except Exception:  # noqa: BLE001
+        pass
+
+    commits_log = ""
+    try:
+        log_proc = subprocess.run(
+            [
+                "git",
+                "log",
+                "--oneline",
+                f"{config.workspace.base_branch}..HEAD",
+            ],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        if log_proc.returncode == 0:
+            commits_log = log_proc.stdout.decode(errors="replace").strip()
+    except Exception:  # noqa: BLE001
+        pass
+
+    handoff_text = _get_handoff_content(forge_handoff_path=_latest_forge_handoff_path(state))
+
+    parts = [
+        f"The validation gate (`{gate_cmd}`) timed out after {gate_timeout_s}s while running"
+        " over your diff. Treat this as a normal dev failure: your diff almost certainly"
+        " caused the hang. RCA which test or product-code path is hanging, fix the underlying"
+        " bug, and re-run the gate. Do not increase the timeout or delete coverage as the"
+        " first move — the wall-clock guard is intentional.",
+        f"Configured gate_timeout: {gate_timeout_s}s",
+        f"HEAD commit under test: {head_sha}",
+    ]
+    if commits_log:
+        parts.append(f"Commits ahead of base:\n{commits_log}")
+    parts.append(
+        f"Gate output tail (last {tail_chars} chars; may be truncated at the kill"
+        f" boundary):\n{gate_output_tail or '(empty)'}"
+    )
+    if state.gate_debug_telemetry:
+        dbg = state.gate_debug_telemetry[-1]
+        parts.append(
+            f"Gate debug command (`{dbg.command}`) exit={dbg.exit_code}"
+            f" timeout={dbg.timeout_s}s output tail:\n{dbg.output_tail}"
+        )
+    parts.append(f"Current handoff:\n{handoff_text}")
+    return "\n\n".join(parts)
 
 
 def _run_validate_phase(
@@ -227,6 +299,34 @@ def _run_validate_phase(
             gate_output_tail=gate_output_tail or gate_err,
             is_timeout=is_timeout,
         )
+        # Timeout with dev commits is a retryable validation failure: hand back
+        # to dev with a timeout-RCA evidence packet rather than escalating
+        # terminally. Routes only when (a) the gate actually timed out, (b) the
+        # dev iteration produced commits ahead of base, (c) budget remains, and
+        # (d) the failure is not a consecutive-identical timeout (circuit
+        # breaker still owns that case). Infrastructure errors (state 4) and
+        # empty-worktree timeouts (state 1) continue to escalate.
+        if (
+            is_timeout
+            and not _is_identical_failure(state.dev_iteration_telemetry)
+            and not state.budget.is_exhausted()
+            and _commits_exist_strict(workspace_path, config.workspace.base_branch)
+        ):
+            state.human_feedback = _build_timeout_rca_packet(
+                state=state,
+                config=config,
+                gate_cmd=resolved_gate_cmd,
+                gate_output_tail=gate_output_tail,
+                workspace_path=workspace_path,
+            )
+            state.retry_reason = RetryReason.GATE_FAIL
+            _log(
+                f"  ✗ VALIDATE   TIMEOUT  (iter={state.dev_iteration}"
+                " → retrying dev with RCA packet)"
+            )
+            if logger:
+                logger._safe_emit("phase_end", phase="VALIDATE", outcome="fail")
+            return _ValidateOutcome.RETRY_DEV, None
         # Check consecutive identical failures (including timeouts) before escalating.
         if _is_identical_failure(state.dev_iteration_telemetry):
             state.phase = Phase.ESCALATE

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -275,6 +275,143 @@ def test_run_validate_phase_timeout_without_gate_debug_command_is_unchanged(
     assert state.gate_debug_telemetry == []
 
 
+def test_run_validate_phase_timeout_with_commits_routes_to_dev_retry(tmp_path: Path) -> None:
+    """Gate timeout with dev commits ahead of base → RETRY_DEV with RCA packet."""
+    from theforge.coordinator.state import RetryReason
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(2.0)
+    state.last_dev_start_commit = "HEAD"
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=(
+                None,
+                "Gate timed out after 45s",
+                "TIMEOUT after 45s: pytest tests/test_hang.py",
+                "make gate",
+            ),
+        ),
+        patch(
+            "theforge.coordinator.validate_phase._commits_exist_strict",
+            return_value=True,
+        ),
+        patch(
+            "theforge.coordinator.validate_phase._get_handoff_content",
+            return_value="summary: implemented all three ACs",
+        ),
+        patch("theforge.coordinator.validate_phase.subprocess.run") as subproc,
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        # Stub out git rev-parse / git log calls used inside the RCA packet.
+        def _fake_run(args, **kwargs):
+            class _R:
+                returncode = 0
+                stdout = b"abc1234\n"
+
+            if "log" in args:
+                _R.stdout = b"abc1234 fix: thing\n"
+            return _R
+
+        subproc.side_effect = _fake_run
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.RETRY_DEV
+    assert result is None
+    assert state.retry_reason is RetryReason.GATE_FAIL
+    assert state.human_feedback is not None
+    assert "timed out after" in state.human_feedback
+    assert "make gate" in state.human_feedback
+    assert "RCA" in state.human_feedback
+    assert "TIMEOUT after 45s" in state.human_feedback
+    # Telemetry recorded the timeout iteration.
+    assert len(state.dev_iteration_telemetry) == 1
+    assert state.dev_iteration_telemetry[0].is_timeout is True
+
+
+def test_run_validate_phase_timeout_without_commits_still_escalates(tmp_path: Path) -> None:
+    """Gate timeout with NO commits ahead of base remains terminal (state 1)."""
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.5)
+    state.last_dev_start_commit = "HEAD"
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=(None, "Gate timed out after 45s", "", "make gate"),
+        ),
+        patch(
+            "theforge.coordinator.validate_phase._commits_exist_strict",
+            return_value=False,
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert state.human_feedback is None
+
+
+def test_run_validate_phase_timeout_with_commits_but_budget_exhausted_escalates(
+    tmp_path: Path,
+) -> None:
+    """Even with commits, an exhausted retry budget terminates rather than retrying."""
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=2)
+    state.budget.max_iterations = config.retry.max_dev_iterations  # 2 → exhausted
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.5)
+    state.last_dev_start_commit = "HEAD"
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=(None, "Gate timed out after 45s", "", "make gate"),
+        ),
+        patch(
+            "theforge.coordinator.validate_phase._commits_exist_strict",
+            return_value=True,
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, _result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+
+
 def _git(repo: Path, *args: str) -> str:
     proc = subprocess.run(
         ["git", *args],


### PR DESCRIPTION
## Summary

Timeout-with-commits retry correctly implemented; two P2 observations on stderr gap in RCA packet and missing seam-level integration test

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $2.31
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/validate_phase.py:319`** _build_timeout_rca_packet receives gate_output_tail (stdout only), but record_dev_iteration_telemetry at line 299 uses 'gate_output_tail or gate_err' as a fallback. When stdout is empty but stderr has diagnostic content (e.g., pytest's fatal error channel), the RCA packet shows '(empty)' while the audit telemetry captured the stderr. The AC says 'last N lines of stdout/stderr' implying both channels should reach the dev agent.
- **[P2] `tests/test_validate_phase.py:None`** Convention 8 requires seam-level integration tests when phase boundary state handoff is changed. The new timeout-retry path routes _ValidateOutcome.RETRY_DEV and sets state.human_feedback; engine.py then re-enters the dev loop using that state. The three new tests exercise _run_validate_phase in isolation but none verify that engine.py correctly picks up state.human_feedback from a timeout-triggered RETRY_DEV and delivers it to the next dev phase call.

## Story

Gate timeout with dev commits is a retryable validation failure, not a terminal escalation — hand back to dev with timeout evidence (GitHub Issue #1216)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1216