### PR TITLE
Project-configurable allowed-paths convention — reviewers must reject root-level scratch (and clean up #382 leftovers)

### DIFF
--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -18,6 +18,7 @@ from theforge.config import (
 )
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.redact import redact
+from theforge.coordinator.review_context import hard_convention_review_kwargs
 from theforge.coordinator.state import CoordinatorResult
 from theforge.task import (
     TaskStory,
@@ -193,6 +194,7 @@ def _cmd_dry_run(config: ForgeConfig, task: TaskStory, story_path: Path) -> int:
         branch=branch_name,
         handoff_content="(dry run — no handoff available)",
         conventions=config.conventions_soft,
+        **hard_convention_review_kwargs(config),
     )
 
     sep = "=" * 60

--- a/src/theforge/coordinator/review_context.py
+++ b/src/theforge/coordinator/review_context.py
@@ -16,7 +16,26 @@ from theforge.devhandoff import DevHandoff, dev_handoff_to_reviewer_text, parse_
 from . import util as _cu
 
 if TYPE_CHECKING:
+    from theforge.config import ForgeConfig
+
     from .state import CoordinatorState
+
+
+def hard_convention_review_kwargs(config: ForgeConfig) -> dict[str, object]:
+    """Extract the hard-convention kwargs that build_review_prompt expects.
+
+    Centralizes the propagation of ``config.conventions_hard`` (allowed_root_files,
+    no_scratch_files) into the reviewer prompt so the reviewer can proactively
+    reject diffs that introduce repo-root scratch files instead of relying on
+    the runtime hygiene gate as the sole backstop.
+    """
+    hard = config.conventions_hard
+    if hard is None:
+        return {"allowed_root_files": None, "no_scratch_files": None}
+    return {
+        "allowed_root_files": hard.allowed_root_files,
+        "no_scratch_files": hard.no_scratch_files,
+    }
 
 
 def _latest_forge_handoff_path(state: CoordinatorState) -> Path | None:

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -54,6 +54,7 @@ from .review_context import (
     _get_handoff_commit_warning,
     _get_handoff_content,
     _latest_forge_handoff_path,
+    hard_convention_review_kwargs,
 )
 from .review_pool import _run_review_pool
 from .run_setup import save_trajectory_state
@@ -1179,6 +1180,7 @@ def _run_review_only_phase(
         dev_notes=dev_notes,
         cycle_history=None,
         conventions=config.conventions_soft,
+        **hard_convention_review_kwargs(config),
         assembled_context=review_context,
         sandboxed=state.sandboxed,
     )

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -43,6 +43,7 @@ from .review_context import (
     _get_handoff_content,
     _latest_forge_handoff_path,
     _parse_dev_handoff,
+    hard_convention_review_kwargs,
 )
 from .state import CoordinatorState, Phase, ReviewCycleMetadata
 
@@ -254,6 +255,7 @@ def _run_review_pool(
                     dev_notes=dev_notes,
                     cycle_history=state.cycle_history if state.cycle_history else None,
                     conventions=config.conventions_soft,
+                    **hard_convention_review_kwargs(config),
                     assembled_context=review_context,
                     sandboxed=state.sandboxed,
                     fix_claim_flags=fix_claim_flags,
@@ -276,6 +278,7 @@ def _run_review_pool(
                 dev_notes=dev_notes,
                 cycle_history=state.cycle_history if state.cycle_history else None,
                 conventions=config.conventions_soft,
+                **hard_convention_review_kwargs(config),
                 assembled_context=review_context,
                 sandboxed=state.sandboxed,
                 fix_claim_flags=fix_claim_flags,

--- a/src/theforge/task/__init__.py
+++ b/src/theforge/task/__init__.py
@@ -4,7 +4,7 @@ from .context_assembler import (
     ContextManifestEntry,
     ContextPack,
 )
-from .conventions import render_conventions_block
+from .conventions import render_conventions_block, render_hard_conventions_block
 from .dev_prompts import build_dev_prompt
 from .fix_prompts import build_fix_prompt
 from .plan_parser import PlanData, PlanStep, parse_plan_output
@@ -29,6 +29,7 @@ __all__ = [
     "ContextManifestEntry",
     "ContextPack",
     "render_conventions_block",
+    "render_hard_conventions_block",
     "build_dev_prompt",
     "build_fix_prompt",
     "PlanData",

--- a/src/theforge/task/conventions.py
+++ b/src/theforge/task/conventions.py
@@ -12,3 +12,49 @@ def render_conventions_block(conventions: list[str] | None) -> str:
         " and flag violations you observe.\n\n"
         f"{items}\n"
     )
+
+
+def render_hard_conventions_block(
+    *,
+    allowed_root_files: tuple[str, ...] | list[str] | None = None,
+    no_scratch_files: bool | None = None,
+) -> str:
+    """Render the hard (mechanically enforced) conventions block for reviewers.
+
+    Hard conventions are checked at runtime by the workspace hygiene gate.
+    Reviewers receive them so they can reject diffs that introduce violations
+    upfront, rather than letting the runtime gate be the only backstop.
+
+    Returns an empty string when no hard conventions are supplied.
+    """
+    sections: list[str] = []
+    if no_scratch_files:
+        if allowed_root_files:
+            allowed = ", ".join(f"`{p}`" for p in allowed_root_files)
+            allowed_note = f"The project additionally permits these repo-root files: {allowed}."
+        else:
+            allowed_note = "The project has not declared any additional permitted repo-root files."
+        sections.append(
+            "### No scratch files at the repo root\n\n"
+            "Files at the repository root are restricted to a canonical allowlist "
+            "(README, LICENSE, CHANGELOG, pyproject.toml, etc.) plus any files the "
+            "project explicitly declares as allowed. "
+            f"{allowed_note}\n\n"
+            "Any commit in this change that introduces a new repo-root file outside "
+            "this allowlist (for example: `test_*.py`, `*.lock` scratch files, "
+            "ad-hoc audit YAML, rename leftovers) is a **P1 finding**. Cite the "
+            "specific file path and the convention by name (`no_scratch_files`). "
+            "The runtime workspace hygiene gate will also reject these — your job "
+            "as reviewer is to catch them before they land."
+        )
+    if not sections:
+        return ""
+    body = "\n\n".join(sections)
+    return (
+        "\n## Project Conventions (Hard — Mechanically Enforced)\n\n"
+        "These conventions are declared by the project and enforced at runtime. "
+        "Violations introduced by these commits MUST be reported as P1 findings — "
+        "they will fail the hygiene gate and block the change regardless of your "
+        "verdict, so flagging them upfront keeps the pipeline moving.\n\n"
+        f"{body}\n"
+    )

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from theforge.coordinator.state import CycleHistory
 
 from .context_assembler import ContextPack
-from .conventions import render_conventions_block
+from .conventions import render_conventions_block, render_hard_conventions_block
 from .story import TaskStory
 
 _REVIEW_ROLE_SECTIONS: dict[str, str] = {
@@ -145,6 +145,8 @@ def build_review_prompt(
     dev_notes: str | None = None,
     cycle_history: list[CycleHistory] | None = None,
     conventions: list[str] | None = None,
+    allowed_root_files: tuple[str, ...] | list[str] | None = None,
+    no_scratch_files: bool | None = None,
     assembled_context: ContextPack | None = None,
     sandboxed: bool = True,
     fix_claim_flags: list[str] | None = None,
@@ -283,6 +285,10 @@ def build_review_prompt(
         """)
 
     sandbox_label = "enabled" if sandboxed else "DISABLED (unsandboxed — effects ran unconfined)"
+    _hard_block = render_hard_conventions_block(
+        allowed_root_files=allowed_root_files,
+        no_scratch_files=no_scratch_files,
+    )
 
     return dedent(f"""\
         You are reviewing an implementation of **{task.name}**.
@@ -294,7 +300,7 @@ def build_review_prompt(
         ## Spec
 
         {story_content}
-        {dev_notes_section}{context_section}{render_conventions_block(conventions)}
+        {dev_notes_section}{context_section}{_hard_block}{render_conventions_block(conventions)}
         ## Verified Git Metadata
 
         This section is coordinator-verified ground truth captured from git before review.

--- a/tests/test_soft_conventions.py
+++ b/tests/test_soft_conventions.py
@@ -22,7 +22,9 @@ from theforge.config import (
     WorkspaceConfig,
     load_config,
 )
+from theforge.config.types import HardConventionsConfig
 from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.review_context import hard_convention_review_kwargs
 from theforge.coordinator.state import (
     CoordinatorResult,
     CoordinatorState,
@@ -35,6 +37,7 @@ from theforge.task import (
     build_plan_prompt,
     build_review_prompt,
     render_conventions_block,
+    render_hard_conventions_block,
 )
 
 # ── Helpers ──────────────────────────────────────────────────────────────
@@ -266,6 +269,165 @@ class TestBuildReviewPromptConventions:
         )
         # The P2 severity definition should mention convention violations
         assert "convention" in prompt.lower()
+
+
+# ── Hard conventions rendering ────────────────────────────────────────────
+
+
+class TestRenderHardConventionsBlock:
+    def test_no_args_returns_empty_string(self):
+        assert render_hard_conventions_block() == ""
+
+    def test_no_scratch_files_false_returns_empty_string(self):
+        # Only render when no_scratch_files is enforced.
+        assert render_hard_conventions_block(no_scratch_files=False) == ""
+        assert (
+            render_hard_conventions_block(no_scratch_files=False, allowed_root_files=("foo.txt",))
+            == ""
+        )
+
+    def test_no_scratch_files_true_renders_block(self):
+        result = render_hard_conventions_block(no_scratch_files=True)
+        assert "Hard" in result
+        assert "P1" in result
+        assert "no_scratch_files" in result
+        assert "repo-root" in result.lower() or "repo root" in result.lower()
+
+    def test_allowed_root_files_listed(self):
+        result = render_hard_conventions_block(
+            no_scratch_files=True,
+            allowed_root_files=("pyproject.toml", "poetry.lock"),
+        )
+        assert "pyproject.toml" in result
+        assert "poetry.lock" in result
+
+    def test_no_allowed_files_still_renders_when_no_scratch_files(self):
+        result = render_hard_conventions_block(no_scratch_files=True, allowed_root_files=())
+        assert "Hard" in result
+        assert "not declared any additional permitted repo-root files" in result
+
+
+class TestBuildReviewPromptHardConventions:
+    def test_hard_conventions_block_included(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat: thing",
+            commit_diffs="diff --git a/foo.py b/foo.py",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+            no_scratch_files=True,
+            allowed_root_files=("pyproject.toml",),
+        )
+        assert "Hard — Mechanically Enforced" in prompt
+        assert "pyproject.toml" in prompt
+        assert "no_scratch_files" in prompt
+
+    def test_no_hard_conventions_no_block(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat: thing",
+            commit_diffs="diff --git a/foo.py b/foo.py",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+        )
+        assert "Hard — Mechanically Enforced" not in prompt
+
+    def test_hard_and_soft_both_rendered(self, tmp_path):
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat: thing",
+            commit_diffs="diff --git a/foo.py b/foo.py",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+            conventions=["Single concern per module"],
+            no_scratch_files=True,
+            allowed_root_files=("pyproject.toml",),
+        )
+        assert "Hard — Mechanically Enforced" in prompt
+        assert "## Project Conventions" in prompt
+        assert "Single concern per module" in prompt
+
+
+# ── Config → review prompt seam ───────────────────────────────────────────
+
+
+class TestHardConventionConfigPropagation:
+    """Seam tests that ForgeConfig.conventions_hard reaches build_review_prompt."""
+
+    def test_helper_extracts_hard_convention_kwargs(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        # Override conventions_hard via dataclasses.replace pattern.
+        import dataclasses
+
+        cfg = dataclasses.replace(
+            cfg,
+            conventions_hard=HardConventionsConfig(
+                no_scratch_files=True,
+                allowed_root_files=("pyproject.toml", "poetry.lock"),
+            ),
+        )
+        kwargs = hard_convention_review_kwargs(cfg)
+        assert kwargs == {
+            "allowed_root_files": ("pyproject.toml", "poetry.lock"),
+            "no_scratch_files": True,
+        }
+
+    def test_helper_returns_none_when_conventions_hard_absent(self, tmp_path):
+        cfg = _make_config(tmp_path)  # conventions_hard defaults to None
+        assert cfg.conventions_hard is None
+        kwargs = hard_convention_review_kwargs(cfg)
+        assert kwargs == {"allowed_root_files": None, "no_scratch_files": None}
+
+    def test_helper_kwargs_round_trip_into_review_prompt(self, tmp_path):
+        """The kwargs returned by the helper are accepted by build_review_prompt
+        and produce the hard-conventions block end-to-end."""
+        import dataclasses
+
+        cfg = _make_config(tmp_path)
+        cfg = dataclasses.replace(
+            cfg,
+            conventions_hard=HardConventionsConfig(
+                no_scratch_files=True,
+                allowed_root_files=("pyproject.toml",),
+            ),
+        )
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat",
+            commit_diffs="diff",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+            **hard_convention_review_kwargs(cfg),
+        )
+        assert "Hard — Mechanically Enforced" in prompt
+        assert "pyproject.toml" in prompt
+
+    def test_helper_kwargs_no_block_when_conventions_hard_none(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        prompt = build_review_prompt(
+            task,
+            story_content="# Spec",
+            commit_log="abc123 feat",
+            commit_diffs="diff",
+            workspace_path=str(tmp_path / "ws"),
+            branch="feat/test",
+            handoff_content="gate_result: PASS",
+            **hard_convention_review_kwargs(cfg),
+        )
+        assert "Hard — Mechanically Enforced" not in prompt
 
 
 # ── Audit inclusion ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Hard-conventions block wired to all three production call sites (review_phase, review_pool x2, cli dry-run) via a centralized helper; render function, integration, and seam tests are thorough.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $3.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Project-configurable allowed-paths convention — reviewers must reject root-level scratch (and clean up #382 leftovers) (GitHub Issue #1180)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1180