### PR TITLE
Stuck-pattern detector's no-file-modifications arm false-terminates legitimate exploration — demote to telemetry, terminate only on high-confidence signals

### DIFF
--- a/src/theforge/runners/stuck_detection.py
+++ b/src/theforge/runners/stuck_detection.py
@@ -2,14 +2,21 @@
 
 Tracks three observable patterns across loop iterations:
   - "repeat": identical (tool name + arguments) signatures repeated
-  - "no_progress": consecutive iterations with no successful file modification
   - "error_loop": identical error tool-result content repeated
+  - "no_progress": consecutive iterations with no successful file modification
+    — TELEMETRY ONLY. This signal is too imprecise to terminate on (it cannot
+    distinguish a real loop from legitimate exploration), so it never fires a
+    nudge or terminate. The counter is recorded in the audit so operators can
+    still observe long no-modification stretches without the system killing
+    work it should not.
 
-On detection the tracker emits a one-shot nudge for the active pattern KIND.
-If the SAME kind persists for ``post_nudge_iterations`` more iterations, the
-tracker emits a termination reason. If the pattern changes or breaks after a
-nudge, the post-nudge counter resets and the tracker re-arms so a fresh
-incident can be nudged again later.
+On detection of a defensible pattern (repeat / error_loop) the tracker emits a
+one-shot nudge for the active pattern KIND. If the SAME kind persists for
+``post_nudge_iterations`` more iterations, the tracker emits a termination
+reason with structured evidence (per-iteration tool-call fingerprints, the
+iteration where the loop began, and the supporting counter value). If the
+pattern changes or breaks after a nudge, the post-nudge counter resets and the
+tracker re-arms so a fresh incident can be nudged again later.
 
 The tracker is gated by ``profile.phase == "dev"`` so review/preflight loops
 remain unaffected. The runner translates raw turn data into an
@@ -19,18 +26,39 @@ remain unaffected. The runner translates raw turn data into an
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from theforge.config import ModelProfile
 
 PATTERN_REPEAT = "repeat"
-PATTERN_NO_PROGRESS = "no_progress"
+PATTERN_NO_PROGRESS = "no_progress"  # telemetry only — never returned as active pattern
 PATTERN_ERROR_LOOP = "error_loop"
 
 # Modify-capable tool names (CLI form and API-registry form).
 MODIFY_TOOL_NAMES: frozenset[str] = frozenset({"write_file", "edit_file", "Write", "Edit"})
+
+# Read/search/navigation tool names — distinct calls in this set count as
+# exploration progress for telemetry purposes.
+EXPLORATION_TOOL_NAMES: frozenset[str] = frozenset(
+    {"read_file", "Read", "glob", "Glob", "grep", "Grep", "list_dir", "ls"}
+)
+
+# Argument names whose values may carry large or sensitive content; redacted
+# in the audit fingerprint of every tool call so the trace stays compact and
+# does not leak file bodies or edit payloads.
+_SENSITIVE_ARG_NAMES: frozenset[str] = frozenset(
+    {"content", "new_content", "old_string", "new_string", "input"}
+)
+
+# Cap the number of history entries kept per run; recent iterations are what
+# matter for diagnosing a loop, and unbounded growth would bloat the audit.
+_MAX_HISTORY_ENTRIES = 50
+
+# Cap the per-iteration tool-call list emitted in evidence so a runaway turn
+# (model emits 100 tool calls in one go) doesn't dominate the audit reason.
+_MAX_CALLS_PER_ITER_IN_EVIDENCE = 8
 
 
 def make_signature(name: str | None, arguments: dict | None) -> str:
@@ -42,6 +70,24 @@ def make_signature(name: str | None, arguments: dict | None) -> str:
     return f"{name or ''}|{args_str}"
 
 
+def _redact_arguments(arguments: dict | None) -> dict:
+    """Return a shallow copy of *arguments* with sensitive values masked."""
+    if not isinstance(arguments, dict):
+        return {}
+    return {k: "<redacted>" if k in _SENSITIVE_ARG_NAMES else v for k, v in arguments.items()}
+
+
+def _fingerprint(name: str | None, arguments: dict | None) -> str:
+    """Compact human-readable per-call fingerprint for the audit trail."""
+    try:
+        args_str = json.dumps(_redact_arguments(arguments), sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        args_str = repr(arguments)
+    if len(args_str) > 200:
+        args_str = args_str[:197] + "..."
+    return f"{name or ''}({args_str})"
+
+
 @dataclass(frozen=True)
 class IterationObservation:
     """One agent iteration distilled into the inputs the tracker needs.
@@ -51,12 +97,16 @@ class IterationObservation:
     iff at least one Write/Edit call returned a non-error result — failed
     write attempts do not count as progress. ``error_content`` is the first
     error tool-result content from this iteration (truncated), used to detect
-    repeated identical errors across iterations.
+    repeated identical errors across iterations. ``call_fingerprints`` is the
+    redacted per-call fingerprint list used for audit only. ``exploration_sigs``
+    is the subset of signatures whose tool name is in EXPLORATION_TOOL_NAMES.
     """
 
     signatures: frozenset[str]
     successful_modify: bool
     error_content: str | None
+    call_fingerprints: tuple[str, ...] = ()
+    exploration_sigs: frozenset[str] = field(default_factory=frozenset)
 
 
 def build_observation(
@@ -70,11 +120,17 @@ def build_observation(
     ``id``, ``name``, ``content``.
     """
     sigs: set[str] = set()
+    exploration_sigs: set[str] = set()
+    fingerprints: list[str] = []
     for c in calls:
         name = getattr(c, "name", None)
         args = getattr(c, "arguments", None)
         if name and isinstance(args, dict):
-            sigs.add(make_signature(name, args))
+            sig = make_signature(name, args)
+            sigs.add(sig)
+            if name in EXPLORATION_TOOL_NAMES:
+                exploration_sigs.add(sig)
+            fingerprints.append(_fingerprint(name, args))
 
     successful_modify = False
     error_content: str | None = None
@@ -91,6 +147,8 @@ def build_observation(
         signatures=frozenset(sigs),
         successful_modify=successful_modify,
         error_content=error_content,
+        call_fingerprints=tuple(fingerprints),
+        exploration_sigs=frozenset(exploration_sigs),
     )
 
 
@@ -110,14 +168,23 @@ class StuckTracker:
         self._has_modify_tools = bool(
             profile.allowed_tools and any(t in profile.allowed_tools for t in MODIFY_TOOL_NAMES)
         )
+        self._iteration = 0
         self._last_sig: frozenset[str] | None = None
         self._repeat_count = 0
-        self._iters_without_mod = 0
+        self._repeat_start_iter: int | None = None
+        self._iters_without_mod = 0  # telemetry only — does not trigger nudge/terminate
+        self._distinct_exploration_sigs: set[str] = set()
+        self._exploration_progress_iters = 0  # telemetry: iters that added a new exploration sig
         self._last_error: str | None = None
         self._error_count = 0
+        self._error_start_iter: int | None = None
         self._nudge_sent = False
         self._nudge_kind: str | None = None
         self._post_nudge_iters = 0
+        # Bounded ring of recent per-iteration records, used as audit evidence
+        # when a termination fires. Each entry: dict with iteration index and
+        # the redacted call fingerprints that ran in that iteration.
+        self._history: list[dict] = []
 
     @property
     def enabled(self) -> bool:
@@ -127,30 +194,64 @@ class StuckTracker:
     def nudge_kind(self) -> str | None:
         return self._nudge_kind
 
+    @property
+    def iters_without_modification(self) -> int:
+        """Telemetry: consecutive iterations with no successful file modification."""
+        return self._iters_without_mod
+
+    @property
+    def distinct_exploration_count(self) -> int:
+        """Telemetry: distinct (name, args) read/search calls seen this run."""
+        return len(self._distinct_exploration_sigs)
+
+    @property
+    def exploration_progress_iters(self) -> int:
+        """Telemetry: number of iterations that added a new distinct exploration sig."""
+        return self._exploration_progress_iters
+
     def observe(self, obs: IterationObservation) -> tuple[str | None, str | None, str | None]:
         if not self._enabled or self._cfg is None:
             return (None, None, None)
 
+        self._iteration += 1
         sig = obs.signatures
+
+        # Repeat detection: identical signature set across consecutive iterations.
         if self._last_sig is not None and sig == self._last_sig and sig:
+            if self._repeat_count == 0:
+                self._repeat_start_iter = self._iteration - 1
             self._repeat_count += 1
         else:
             self._repeat_count = 1 if sig else 0
+            self._repeat_start_iter = self._iteration if sig else None
         self._last_sig = sig
 
-        # No-progress arm: only a *successful* modify call counts as progress.
-        # Iterations with no tool calls at all are also progress-neutral.
+        # No-progress arm (telemetry only): only a *successful* modify call
+        # counts as progress. Iterations with no tool calls at all are also
+        # progress-neutral.
         if obs.successful_modify or not sig:
             self._iters_without_mod = 0
         else:
             self._iters_without_mod += 1
 
+        # Exploration-progress telemetry: distinct read/search calls across
+        # iterations are real work even when no edit landed.
+        new_exploration = obs.exploration_sigs - self._distinct_exploration_sigs
+        if new_exploration:
+            self._exploration_progress_iters += 1
+            self._distinct_exploration_sigs.update(new_exploration)
+
         cur_error = obs.error_content
         if cur_error and cur_error == self._last_error:
+            if self._error_count <= 1:
+                self._error_start_iter = self._iteration - 1
             self._error_count += 1
         else:
             self._error_count = 1 if cur_error else 0
+            self._error_start_iter = self._iteration if cur_error else None
         self._last_error = cur_error
+
+        self._record_history(obs)
 
         active_kind, active_text = self._active_pattern()
 
@@ -169,7 +270,7 @@ class StuckTracker:
             self._post_nudge_iters += 1
             if self._post_nudge_iters >= self._cfg.post_nudge_iterations:
                 assert active_text is not None
-                return (None, self._build_terminate_reason(active_text), active_text)
+                return (None, self._build_terminate_reason(active_kind, active_text), active_text)
             return (None, None, None)
 
         # Pattern broke or changed kind — re-arm.
@@ -177,6 +278,17 @@ class StuckTracker:
         self._nudge_sent = False
         self._nudge_kind = None
         return (None, None, None)
+
+    def _record_history(self, obs: IterationObservation) -> None:
+        entry = {
+            "iteration": self._iteration,
+            "calls": list(obs.call_fingerprints[:_MAX_CALLS_PER_ITER_IN_EVIDENCE]),
+            "successful_modify": obs.successful_modify,
+            "had_error": obs.error_content is not None,
+        }
+        self._history.append(entry)
+        if len(self._history) > _MAX_HISTORY_ENTRIES:
+            del self._history[: len(self._history) - _MAX_HISTORY_ENTRIES]
 
     def _active_pattern(self) -> tuple[str | None, str | None]:
         if self._cfg is None:
@@ -187,16 +299,14 @@ class StuckTracker:
                 PATTERN_REPEAT,
                 f"repeated identical tool calls ({self._repeat_count}x): {preview}",
             )
-        if self._has_modify_tools and self._iters_without_mod >= self._cfg.no_progress_iterations:
-            return (
-                PATTERN_NO_PROGRESS,
-                f"no file modifications over {self._iters_without_mod} consecutive iterations",
-            )
         if self._error_count >= self._cfg.error_threshold and self._last_error:
             return (
                 PATTERN_ERROR_LOOP,
                 f"error loop ({self._error_count}x): {self._last_error[:120]}",
             )
+        # PATTERN_NO_PROGRESS is intentionally NOT returned: the
+        # no-modification heuristic is too imprecise to terminate on. It is
+        # tracked in self._iters_without_mod purely for telemetry.
         return (None, None)
 
     @staticmethod
@@ -208,9 +318,52 @@ class StuckTracker:
             "behavior will cause this run to be terminated."
         )
 
-    def _build_terminate_reason(self, pattern: str) -> str:
+    def _build_terminate_reason(self, kind: str, pattern: str) -> str:
         assert self._cfg is not None
-        return (
+        loop_start = self._repeat_start_iter if kind == PATTERN_REPEAT else self._error_start_iter
+        evidence_lines = [
             f"stuck pattern persisted for {self._post_nudge_iters} iterations after nudge: "
-            f"{pattern}"
+            f"{pattern}",
+            f"  signal: {kind}",
+        ]
+        if loop_start is not None:
+            evidence_lines.append(f"  loop began at iteration {loop_start} (see dev log)")
+        evidence_lines.append(f"  iterations observed: {self._iteration}")
+        evidence_lines.append(
+            "  no-modification streak (telemetry, not termination cause): "
+            f"{self._iters_without_mod}"
         )
+        recent = self._history[-min(8, self._iteration) :]
+        if recent:
+            evidence_lines.append("  recent iteration tool calls:")
+            for entry in recent:
+                calls_str = "; ".join(entry["calls"]) if entry["calls"] else "<no tool calls>"
+                evidence_lines.append(f"    iter {entry['iteration']}: {calls_str}")
+        return "\n".join(evidence_lines)
+
+    def evidence(self) -> dict:
+        """Structured snapshot of detector state for the audit trail.
+
+        Always safe to call. Returns a dict with the bounded iteration history
+        (redacted call fingerprints), counter values, and the loop-start
+        pointer if a defensible pattern is currently active.
+        """
+        loop_start: int | None = None
+        active_kind: str | None = None
+        if self._repeat_count >= 2:
+            loop_start = self._repeat_start_iter
+            active_kind = PATTERN_REPEAT
+        elif self._error_count >= 2:
+            loop_start = self._error_start_iter
+            active_kind = PATTERN_ERROR_LOOP
+        return {
+            "iterations_observed": self._iteration,
+            "iters_without_modification": self._iters_without_mod,
+            "distinct_exploration_calls": len(self._distinct_exploration_sigs),
+            "exploration_progress_iters": self._exploration_progress_iters,
+            "repeat_count": self._repeat_count,
+            "error_count": self._error_count,
+            "active_kind": active_kind,
+            "loop_start_iteration": loop_start,
+            "history": list(self._history),
+        }

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -333,78 +333,23 @@ class TestStuckDetectionDisabled:
         assert result.success
 
 
-class TestNoProgressDetection:
-    """no_progress_iterations triggers when modify-capable agents stop modifying files."""
+class TestNoProgressIsTelemetryOnly:
+    """no_progress_iterations is recorded as telemetry but never nudges or terminates."""
 
-    def test_no_modifications_triggers_nudge(self, tmp_path):
+    def test_no_modifications_does_not_terminate_or_nudge(self, tmp_path):
+        # Aggressive thresholds: even with no_progress_iterations=2, the run must
+        # complete normally because exploration is no longer a kill signal.
         cfg = StuckDetectionConfig(
             enabled=True,
             repeat_threshold=99,
-            no_progress_iterations=3,
-            error_threshold=99,
-            post_nudge_iterations=99,
-        )
-        profile = _dev_profile(stuck=cfg)
-        messages_seen: list[list[dict]] = []
-        call_count = [0]
-        # Vary the args so repeat_threshold doesn't fire instead.
-        patterns = ["*.py", "*.md", "*.txt", "src/*", "tests/*"]
-
-        def adapter(messages, tools):
-            messages_seen.append(list(messages))
-            call_count[0] += 1
-            if call_count[0] <= len(patterns):
-                return _glob_turn(call_count[0], pattern=patterns[call_count[0] - 1])
-            return LoopTurn(
-                tool_calls=[
-                    ToolCallRequest(
-                        id="submit",
-                        name=SUBMIT_REVIEW,
-                        arguments={"verdict": "APPROVE", "summary": "ok"},
-                    )
-                ],
-                text_output=None,
-                structured_data=None,
-                usage=_usage(),
-            )
-
-        manager = _make_manager(profile, tmp_path, adapter)
-        manager.run(
-            initial_messages=[{"role": "user", "content": "go"}],
-            tool_schemas=[],
-        )
-        all_msgs = [m for msgs in messages_seen for m in msgs]
-        nudges = [
-            m
-            for m in all_msgs
-            if m.get("role") == "user" and "no file modifications" in m.get("content", "")
-        ]
-        assert len(nudges) >= 1
-
-
-class TestPostNudgeSamePatternRequired:
-    """Post-nudge termination requires the SAME pattern kind to persist."""
-
-    def test_pattern_change_after_nudge_resets_and_rearm(self, tmp_path):
-        # repeat fires first; switch to varied calls (pattern breaks); the
-        # tracker must re-arm rather than terminate. Configure thresholds so
-        # the second pattern (no-progress) would otherwise hit terminate
-        # immediately if the kind check were absent.
-        cfg = StuckDetectionConfig(
-            enabled=True,
-            repeat_threshold=2,
             no_progress_iterations=2,
             error_threshold=99,
-            # Loose post-nudge window so the test isolates the re-arm behavior.
-            post_nudge_iterations=99,
+            post_nudge_iterations=2,
         )
         profile = _dev_profile(stuck=cfg)
         messages_seen: list[list[dict]] = []
         call_count = [0]
-        # First two iterations identical → repeat nudge at iter 2.
-        # Then varied iterations break repeat; tracker must re-arm and emit a
-        # fresh no-progress nudge rather than terminating without one.
-        patterns = ["x", "x", "a", "b", "c", "d", "e", "f"]
+        patterns = ["*.py", "*.md", "*.txt", "src/*", "tests/*", "docs/*", "README*"]
 
         def adapter(messages, tools):
             messages_seen.append(list(messages))
@@ -429,23 +374,99 @@ class TestPostNudgeSamePatternRequired:
             initial_messages=[{"role": "user", "content": "go"}],
             tool_schemas=[],
         )
-        # The run should not terminate on stuck pattern: repeat broke before
-        # post-nudge persistence threshold was reached.
         assert result.success, result.output
-        # Two distinct nudges expected: one for repeat, one for no-progress.
-        last_msgs = messages_seen[-1]
-        nudges = [
+        all_msgs = [m for msgs in messages_seen for m in msgs]
+        progress_nudges = [
             m
-            for m in last_msgs
+            for m in all_msgs
             if m.get("role") == "user" and "Progress check" in m.get("content", "")
         ]
-        # At least the repeat nudge must have been issued; the no-progress
-        # arm needs >=2 iterations without modifications, satisfied by the
-        # varied glob iterations. Both kinds should produce a nudge.
-        kinds = {("repeated" in n["content"], "no file" in n["content"]) for n in nudges}
-        assert any(repeat for repeat, _ in kinds)
-        assert any(noprog for _, noprog in kinds), (
-            "expected a fresh no-progress nudge after the repeat pattern broke"
+        assert progress_nudges == [], (
+            "no-modification streak must not produce a stuck-detection nudge"
+        )
+
+    def test_tracker_records_no_progress_streak_as_telemetry(self):
+        from theforge.runners.stuck_detection import (
+            IterationObservation,
+            StuckTracker,
+        )
+
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=99,
+            no_progress_iterations=3,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        tracker = StuckTracker(profile)
+        for i in range(5):
+            obs = IterationObservation(
+                signatures=frozenset({f"glob|{i}"}),
+                successful_modify=False,
+                error_content=None,
+            )
+            assert tracker.observe(obs) == (None, None, None)
+        assert tracker.iters_without_modification == 5
+        ev = tracker.evidence()
+        assert ev["iters_without_modification"] == 5
+        assert ev["iterations_observed"] == 5
+        assert ev["active_kind"] is None  # no defensible pattern firing
+
+
+class TestPostNudgeSamePatternRequired:
+    """Post-nudge termination requires the SAME pattern kind to persist."""
+
+    def test_pattern_change_after_nudge_resets_and_rearm(self, tmp_path):
+        # repeat fires first; switch to varied calls (pattern breaks); the
+        # tracker must re-arm rather than terminate. The second pattern is
+        # error_loop (the other defensible signal still in scope), proving
+        # that re-arm allows a fresh nudge for a different kind.
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=2,
+            # Loose post-nudge window so the test isolates the re-arm behavior.
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        # iters 1,2: identical glob → repeat nudge fires at iter 2.
+        # iters 3,4: distinct glob args, but each result errors with the same
+        # message → error_loop must trigger a fresh nudge after the kind
+        # change resets the post-nudge counter.
+        scripts: list[tuple[str, str | None]] = [
+            ("x", None),
+            ("x", None),
+            ("a", "Error: same boom"),
+            ("b", "Error: same boom"),
+            ("c", None),
+            ("d", None),
+        ]
+
+        from theforge.runners.stuck_detection import (
+            IterationObservation,
+            StuckTracker,
+        )
+
+        tracker = StuckTracker(profile)
+        nudge_kinds: list[str] = []
+        for i, (pattern, err) in enumerate(scripts, start=1):
+            obs = IterationObservation(
+                signatures=frozenset({f"glob|{pattern}"}),
+                successful_modify=False,
+                error_content=err,
+            )
+            nudge, terminate, _ = tracker.observe(obs)
+            assert terminate is None, f"terminate fired unexpectedly at iter {i}"
+            if nudge is not None:
+                if "repeated" in nudge:
+                    nudge_kinds.append("repeat")
+                elif "error loop" in nudge:
+                    nudge_kinds.append("error_loop")
+        assert "repeat" in nudge_kinds
+        assert "error_loop" in nudge_kinds, (
+            f"expected a fresh error_loop nudge after the repeat pattern broke; got {nudge_kinds}"
         )
 
     def test_no_terminate_when_post_nudge_pattern_breaks(self, tmp_path):
@@ -488,12 +509,147 @@ class TestPostNudgeSamePatternRequired:
         assert result.success, result.output
 
 
-class TestFailedModifyDoesNotResetNoProgress:
-    """A write/edit that returns an error must not count as progress."""
+class TestAuditObservability:
+    """When the detector fires, the audit must include per-iteration evidence."""
 
-    def test_failed_edit_calls_count_as_no_progress(self, tmp_path):
-        # write_file with missing required arg → tool returns Error, so the
-        # call should NOT reset the no-progress counter.
+    def test_termination_reason_includes_per_iteration_calls_and_loop_start(self, tmp_path):
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=2,
+        )
+        profile = _dev_profile(stuck=cfg)
+        call_count = [0]
+
+        def adapter(messages, tools):
+            call_count[0] += 1
+            return _glob_turn(call_count[0], pattern="*.py")  # identical args every iter
+
+        manager = _make_manager(profile, tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "go"}],
+            tool_schemas=[],
+        )
+        assert not result.success
+        out = result.output
+        # New evidence block must appear in the audit reason.
+        assert "signal: repeat" in out, out
+        assert "loop began at iteration" in out, out
+        assert "recent iteration tool calls:" in out, out
+        # Per-iteration fingerprint shows the redacted/recorded call.
+        assert "iter 1:" in out, out
+
+    def test_evidence_redacts_sensitive_arguments(self):
+        from theforge.runners.stuck_detection import (
+            StuckTracker,
+            build_observation,
+        )
+
+        class _Call:
+            def __init__(self, name, arguments):
+                self.name = name
+                self.arguments = arguments
+
+        # Build one observation with a Write call that has a large `content` arg.
+        obs = build_observation(
+            calls=[_Call("Write", {"path": "x.py", "content": "secret-body" * 50})],
+            results=[{"id": "c1", "name": "Write", "content": "ok"}],
+        )
+        # The audit fingerprint must mask the `content` value.
+        assert any("redacted" in fp for fp in obs.call_fingerprints), obs.call_fingerprints
+        assert all("secret-body" not in fp for fp in obs.call_fingerprints)
+
+        # The internal signature (used for repeat detection) is still
+        # discriminative — redaction is audit-only.
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=2,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        tracker = StuckTracker(profile)
+        tracker.observe(obs)
+        ev = tracker.evidence()
+        assert ev["history"][0]["calls"]
+        assert "redacted" in ev["history"][0]["calls"][0]
+
+
+class TestExplorationTelemetry:
+    """Distinct file reads / searches across iterations are recorded as exploration."""
+
+    def test_distinct_reads_advance_exploration_counter(self):
+        from theforge.runners.stuck_detection import (
+            IterationObservation,
+            StuckTracker,
+        )
+
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=99,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        tracker = StuckTracker(profile)
+        files = ["a.py", "b.py", "c.py", "d.py"]
+        for i, f in enumerate(files):
+            sig = f"Read|{f}"
+            obs = IterationObservation(
+                signatures=frozenset({sig}),
+                successful_modify=False,
+                error_content=None,
+                exploration_sigs=frozenset({sig}),
+            )
+            tracker.observe(obs)
+        assert tracker.distinct_exploration_count == len(files)
+        assert tracker.exploration_progress_iters == len(files)
+
+    def test_repeat_reads_do_not_advance_exploration_counter(self):
+        from theforge.runners.stuck_detection import (
+            IterationObservation,
+            StuckTracker,
+        )
+
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=99,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        tracker = StuckTracker(profile)
+        for _ in range(4):
+            sig = "Read|same.py"
+            obs = IterationObservation(
+                signatures=frozenset({sig}),
+                successful_modify=False,
+                error_content=None,
+                exploration_sigs=frozenset({sig}),
+            )
+            tracker.observe(obs)
+        assert tracker.distinct_exploration_count == 1
+        assert tracker.exploration_progress_iters == 1
+
+
+class TestFailedModifyTelemetry:
+    """A write/edit that returns an error must not count as modification progress.
+
+    The no-progress arm is telemetry-only now, so this asserts the counter is
+    incremented (not that termination/nudge fires).
+    """
+
+    def test_failed_edit_calls_increment_no_progress_counter(self, tmp_path):
+        from theforge.runners.stuck_detection import (
+            IterationObservation,
+            StuckTracker,
+        )
+
         cfg = StuckDetectionConfig(
             enabled=True,
             repeat_threshold=99,
@@ -502,56 +658,17 @@ class TestFailedModifyDoesNotResetNoProgress:
             post_nudge_iterations=99,
         )
         profile = _dev_profile(stuck=cfg)
-        messages_seen: list[list[dict]] = []
-        call_count = [0]
-        # Each iteration calls write_file with a different (still-invalid)
-        # path argument so signatures vary (no repeat) and the tool errors
-        # (no successful modify). After 3 such iterations, no-progress
-        # nudge must fire.
-        paths = ["a.py", "b.py", "c.py", "d.py", "e.py"]
-
-        def adapter(messages, tools):
-            messages_seen.append(list(messages))
-            call_count[0] += 1
-            if call_count[0] <= len(paths):
-                # Missing required `content` → tool reports an Error result.
-                return LoopTurn(
-                    tool_calls=[
-                        ToolCallRequest(
-                            id=f"c{call_count[0]}",
-                            name="write_file",
-                            arguments={"path": paths[call_count[0] - 1]},
-                        )
-                    ],
-                    text_output=None,
-                    structured_data=None,
-                    usage=_usage(),
-                )
-            return LoopTurn(
-                tool_calls=[
-                    ToolCallRequest(
-                        id="submit",
-                        name=SUBMIT_REVIEW,
-                        arguments={"verdict": "APPROVE", "summary": "done"},
-                    )
-                ],
-                text_output=None,
-                structured_data=None,
-                usage=_usage(),
+        tracker = StuckTracker(profile)
+        for i in range(5):
+            obs = IterationObservation(
+                signatures=frozenset({f"write_file|p{i}"}),
+                successful_modify=False,  # write returned Error
+                error_content=None,
             )
-
-        manager = _make_manager(profile, tmp_path, adapter)
-        manager.run(
-            initial_messages=[{"role": "user", "content": "go"}],
-            tool_schemas=[],
-        )
-        all_msgs = [m for msgs in messages_seen for m in msgs]
-        nudges = [
-            m
-            for m in all_msgs
-            if m.get("role") == "user" and "no file modifications" in m.get("content", "")
-        ]
-        assert len(nudges) >= 1, "failed write_file calls should count as no-progress"
+            nudge, terminate, _ = tracker.observe(obs)
+            assert nudge is None
+            assert terminate is None
+        assert tracker.iters_without_modification == 5
 
 
 class TestClaudeCliStuckDetection:


### PR DESCRIPTION
## Summary

No-progress arm correctly demoted to telemetry; repeat and error_loop termination intact; per-iteration audit evidence wired through termination reason string. Two minor P2 findings, no P1s.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $2.81
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/runners/stuck_detection.py:219`** The 'if self._repeat_count == 0' guard inside the repeat-increment branch is dead code. _repeat_count reaches the if-branch only after the else-branch has already set it to 1 (first iteration with a new sig), so the condition is never true. _repeat_start_iter is already correctly set by the else-branch.
- **[P2] `src/theforge/runners/stuck_detection.py:352`** evidence() reports active_kind using a hardcoded threshold of >= 2, while the actual nudge/terminate path uses the profile-configured repeat_threshold / error_threshold. For a config with repeat_threshold=5, evidence() will report active_kind=PATTERN_REPEAT after 2 identical iterations even though the detector has not triggered. This creates a misleading snapshot for audit consumers.

## Story

Stuck-pattern detector's no-file-modifications arm false-terminates legitimate exploration — demote to telemetry, terminate only on high-confidence signals (GitHub Issue #1215)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1215