### PR TITLE
Reviewers must verify acceptance criteria are actually fulfilled — not just that the diff is coherent — to catch silent-contract-swap merges

### DIFF
--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -98,6 +98,14 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                 }
                 for f in r.findings
             ]
+            ac_verification_list = [
+                {
+                    "criterion": ac.criterion,
+                    "status": ac.status,
+                    "evidence": ac.evidence,
+                }
+                for ac in r.ac_verification
+            ]
             entry.update(
                 {
                     "verdict": r.verdict,
@@ -105,6 +113,7 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                     "p1_count": sum(1 for f in r.findings if f.severity == "P1"),
                     "p2_count": sum(1 for f in r.findings if f.severity == "P2"),
                     "findings": findings_list,
+                    "ac_verification": ac_verification_list,
                 }
             )
         reviews.append(entry)

--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -31,6 +31,24 @@ def _coerce_line(value: object) -> int | None:
 
 
 @dataclass(frozen=True)
+class ACVerification:
+    """Per-AC verification entry: did the reviewer verify this criterion?
+
+    For story-type issues, ``criterion`` is the AC text from the spec.
+    For bug-type issues, ``criterion`` is the symptom resolution check
+    (e.g. "Symptom resolution: Codex 'usage limit' fallback").
+
+    ``evidence`` must point to the diff hunks implementing the criterion AND
+    test(s) covering the specific failure mode the issue describes — not a
+    generic test that could plausibly cover the category.
+    """
+
+    criterion: str
+    status: str  # VERIFIED | PARTIAL | NOT_VERIFIED
+    evidence: str
+
+
+@dataclass(frozen=True)
 class ReviewFinding:
     """A single review finding with severity and location."""
 
@@ -55,6 +73,7 @@ class ReviewResult:
     test_gaps: list[str]
     parse_errors: list[str]  # non-empty if parsing/validation failed
     raw_yaml: dict  # the parsed YAML data
+    ac_verification: tuple[ACVerification, ...] = ()  # per-AC verification table
 
 
 def _sanitize_yaml_text(yaml_text: str) -> str:
@@ -72,6 +91,30 @@ def _sanitize_yaml_text(yaml_text: str) -> str:
     # This prevents `foo: bar` from being parsed as a YAML mapping key.
     text = re.sub(r"`([^`\n]+)`", r"\1", text)
     return text
+
+
+def _extract_ac_verification(data: dict) -> tuple[ACVerification, ...]:
+    """Extract ac_verification entries from parsed review data."""
+    raw = data.get("ac_verification")
+    if not isinstance(raw, list):
+        return ()
+    out: list[ACVerification] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        criterion = entry.get("criterion")
+        status = entry.get("status")
+        evidence = entry.get("evidence")
+        if not isinstance(criterion, str) or not isinstance(status, str):
+            continue
+        out.append(
+            ACVerification(
+                criterion=criterion,
+                status=status,
+                evidence=evidence if isinstance(evidence, str) else "",
+            )
+        )
+    return tuple(out)
 
 
 def parse_review_json(data: dict) -> ReviewResult:
@@ -118,6 +161,7 @@ def parse_review_json(data: dict) -> ReviewResult:
         test_gaps=test_gaps if isinstance(test_gaps, list) else [],
         parse_errors=schema_errors,
         raw_yaml=data,
+        ac_verification=_extract_ac_verification(data),
     )
 
 
@@ -206,6 +250,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
         test_gaps=test_gaps if isinstance(test_gaps, list) else [],
         parse_errors=schema_errors,
         raw_yaml=data,
+        ac_verification=_extract_ac_verification(data),
     )
 
 
@@ -746,6 +791,8 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
         for g in r.test_gaps:
             test_gaps.append(f"[{name}] {g}")
 
+    merged_ac = _merge_ac_verification([r.ac_verification for _, r in valid])
+
     return ReviewResult(
         verdict=verdict,
         summary=summary,
@@ -756,7 +803,48 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
         test_gaps=test_gaps,
         parse_errors=[],  # valid reviewers had no errors
         raw_yaml={},
+        ac_verification=merged_ac,
     )
+
+
+def _merge_ac_verification(
+    per_reviewer: list[tuple[ACVerification, ...]],
+) -> tuple[ACVerification, ...]:
+    """Combine per-reviewer ac_verification tables into one canonical table.
+
+    Conservative rule: for the same criterion (case-insensitive normalized),
+    the merged status is the *worst* across reviewers
+    (NOT_VERIFIED > PARTIAL > VERIFIED). Evidence strings are joined by `;`.
+    Order follows first-appearance in the reviewer list.
+    """
+    rank = {"VERIFIED": 0, "PARTIAL": 1, "NOT_VERIFIED": 2}
+    by_key: dict[str, ACVerification] = {}
+    order: list[str] = []
+    for table in per_reviewer:
+        for entry in table:
+            key = entry.criterion.strip().lower()
+            if key not in by_key:
+                by_key[key] = entry
+                order.append(key)
+                continue
+            existing = by_key[key]
+            if rank.get(entry.status, 0) > rank.get(existing.status, 0):
+                merged_evidence = entry.evidence
+            else:
+                merged_evidence = existing.evidence
+            if existing.evidence and entry.evidence and existing.evidence != entry.evidence:
+                merged_evidence = f"{existing.evidence}; {entry.evidence}"
+            worst_status = (
+                entry.status
+                if rank.get(entry.status, 0) > rank.get(existing.status, 0)
+                else existing.status
+            )
+            by_key[key] = ACVerification(
+                criterion=existing.criterion,
+                status=worst_status,
+                evidence=merged_evidence,
+            )
+    return tuple(by_key[k] for k in order)
 
 
 def findings_to_markdown(findings: list[ReviewFinding]) -> str:

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -11,6 +11,7 @@ from typing import Any
 
 VALID_VERDICTS = ("APPROVE", "REQUEST_CHANGES")
 VALID_SEVERITIES = ("P1", "P2")
+VALID_AC_VERIFICATION_STATUSES = ("VERIFIED", "PARTIAL", "NOT_VERIFIED")
 
 
 def repair_review_yaml(data: Any) -> Any:
@@ -43,6 +44,13 @@ def repair_review_yaml(data: Any) -> Any:
     # ── test_coverage: fill if missing ──────────────────────────
     if "test_coverage" not in data:
         data["test_coverage"] = {"adequate": True, "gaps": []}
+
+    # ── ac_verification: ensure list ─────────────────────────────
+    # Missing or non-list → empty list. Cross-validation will reject
+    # APPROVE with empty/non-VERIFIED ac_verification, forcing a retry.
+    ac_v = data.get("ac_verification")
+    if ac_v is None or not isinstance(ac_v, list):
+        data["ac_verification"] = []
 
     return data
 
@@ -137,6 +145,55 @@ def validate_review_yaml(data: Any) -> list[str]:
         errors.append("test_coverage must be a mapping")
     elif "adequate" not in tests:
         errors.append("test_coverage.adequate is required (true/false)")
+
+    # ── ac_verification ───────────────────────────────────────────
+    # Per-AC verification table. Each entry must declare the criterion text
+    # (or "Symptom resolution" for bug-type issues), a status, and evidence.
+    # Cross-validation: APPROVE requires a non-empty table whose entries
+    # are all VERIFIED. PARTIAL or NOT_VERIFIED entries on an APPROVE verdict
+    # are a structural contradiction — same kind of rule as APPROVE+P1.
+    ac_v = data.get("ac_verification")
+    non_verified_count = 0
+    if ac_v is None:
+        ac_v = []
+    if not isinstance(ac_v, list):
+        errors.append("ac_verification must be a list")
+        ac_v = []
+    for i, entry in enumerate(ac_v):
+        if not isinstance(entry, dict):
+            errors.append(f"ac_verification[{i}] must be a mapping")
+            continue
+        criterion = entry.get("criterion")
+        if not isinstance(criterion, str) or not criterion.strip():
+            errors.append(f"ac_verification[{i}].criterion must be a non-empty string")
+        status = entry.get("status")
+        if status not in VALID_AC_VERIFICATION_STATUSES:
+            errors.append(
+                f"ac_verification[{i}].status must be one of "
+                f"{VALID_AC_VERIFICATION_STATUSES}, got: {status!r}"
+            )
+        evidence = entry.get("evidence")
+        if not isinstance(evidence, str) or not evidence.strip():
+            errors.append(
+                f"ac_verification[{i}].evidence must be a non-empty string "
+                f"(diff hunks + test pointers for VERIFIED, reason otherwise)"
+            )
+        if status in ("PARTIAL", "NOT_VERIFIED"):
+            non_verified_count += 1
+
+    if verdict == "APPROVE":
+        if not ac_v:
+            errors.append(
+                "verdict is APPROVE but ac_verification is empty — "
+                "reviewers must enumerate each acceptance criterion (or symptom for bugs) "
+                "and mark it VERIFIED with evidence pointers"
+            )
+        elif non_verified_count > 0:
+            errors.append(
+                f"verdict is APPROVE but {non_verified_count} ac_verification entry(ies) "
+                f"are PARTIAL or NOT_VERIFIED — cannot approve when any acceptance "
+                f"criterion is unverified"
+            )
 
     return errors
 
@@ -280,7 +337,14 @@ def review_json_schema() -> dict:
     return {
         "type": "object",
         "additionalProperties": False,
-        "required": ["verdict", "summary", "findings", "story_compliance", "test_coverage"],
+        "required": [
+            "verdict",
+            "summary",
+            "findings",
+            "story_compliance",
+            "test_coverage",
+            "ac_verification",
+        ],
         "properties": {
             "verdict": {
                 "type": "string",
@@ -330,6 +394,22 @@ def review_json_schema() -> dict:
                     "gaps": {
                         "type": "array",
                         "items": {"type": "string"},
+                    },
+                },
+            },
+            "ac_verification": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["criterion", "status", "evidence"],
+                    "properties": {
+                        "criterion": {"type": "string"},
+                        "status": {
+                            "type": "string",
+                            "enum": list(VALID_AC_VERIFICATION_STATUSES),
+                        },
+                        "evidence": {"type": "string"},
                     },
                 },
             },

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -117,12 +117,25 @@ def build_synthesis_prompt(
           adequate: true | false
           gaps:
             - "<description of missing test>"
+        ac_verification:
+          - criterion: "<verbatim AC text, or 'Symptom resolution: ...' for bug-type issues>"
+            status: VERIFIED | PARTIAL | NOT_VERIFIED
+            evidence: >-
+              <For VERIFIED: file:line diff hunks implementing the criterion AND
+              tests covering the issue's specific failure mode (signature, error
+              string, retry context). Pointers must be concrete, not generic.
+              For PARTIAL or NOT_VERIFIED: explain what is missing.>
         ```
 
         ## Rules
 
-        - verdict MUST be `APPROVE` if there are zero P1 findings
-        - verdict MUST be `REQUEST_CHANGES` if any P1 finding exists
+        - verdict MUST be `APPROVE` if there are zero P1 findings AND every
+          ac_verification entry is VERIFIED
+        - verdict MUST be `REQUEST_CHANGES` if any P1 finding exists OR any
+          ac_verification entry is PARTIAL or NOT_VERIFIED
+        - Reconcile per-AC verification across reviewers — if any reviewer
+          reported an AC as PARTIAL or NOT_VERIFIED, do NOT mark it VERIFIED
+          unless a counter-reviewer cited concrete evidence that resolves the gap.
         - Be concrete: cite file + line + what is wrong + how to fix
         - Do NOT invent issues. Only report findings with evidence from the reviews.
     """)
@@ -273,6 +286,14 @@ def build_review_prompt(
           adequate: true | false
           gaps:
             - "<description of missing test>"
+        ac_verification:
+          - criterion: "<verbatim AC text, or 'Symptom resolution: ...' for bug issues>"
+            status: VERIFIED | PARTIAL | NOT_VERIFIED
+            evidence: >-
+              <For VERIFIED: file:line diff hunks implementing the criterion AND
+              tests covering the issue's specific failure mode (signature, error
+              string, retry context). Pointers must be concrete, not generic.
+              For PARTIAL or NOT_VERIFIED: explain what is missing.>
         ```
     """)
     if mode == "api":
@@ -402,6 +423,28 @@ def build_review_prompt(
           AC depends on a function's output being consumed by its caller,
           verify the caller actually uses it — unused return values that are
           required to satisfy an AC are P1.
+        - **Per-AC verification table is mandatory**: You MUST emit an
+          `ac_verification:` entry for every acceptance criterion declared in
+          the spec — verbatim from the `## Acceptance criteria` section, in
+          order. For each entry, status is `VERIFIED` only when (a) you can
+          point to specific diff hunks that implement the criterion AND (b)
+          tests exist that exercise the **specific failure mode the issue was
+          filed against** (concrete signatures, error strings, paths from the
+          spec — not a generic "could plausibly cover this category" test).
+          A generic implementation without a test for the production-observed
+          symptom is `PARTIAL`, not `VERIFIED`. If you cannot find evidence,
+          mark it `NOT_VERIFIED` with an explanation. Do NOT mark VERIFIED
+          based on the dev's handoff claims — verify against the actual diff
+          and test files.
+        - **Bug issues** (no `## Acceptance criteria` section, only
+          observed/expected) get a single ac_verification entry with criterion
+          `"Symptom resolution: <one-line restatement of the observed symptom>"`,
+          status VERIFIED only when a test reproduces the original symptom and
+          would have caught it before the fix.
+        - **Cross-validation enforced**: APPROVE with any PARTIAL or
+          NOT_VERIFIED ac_verification entry will be rejected by the schema
+          validator and your review will be discarded — do not produce that
+          combination.
         - **YAML safety**: In `description` and `suggestion` fields, do NOT use
           backslashes or double-quote characters inside double-quoted strings —
           they break YAML parsing. Use single quotes or paraphrase instead.

--- a/tests/coord_test_helpers.py
+++ b/tests/coord_test_helpers.py
@@ -210,6 +210,10 @@ story_compliance:
   matches_spec: true
 test_coverage:
   adequate: true
+ac_verification:
+  - criterion: "Implementation satisfies the spec"
+    status: VERIFIED
+    evidence: "diff hunks present and tests cover the failure mode (test fixture default)"
 ```
 """
 

--- a/tests/test_complexity_timeouts.py
+++ b/tests/test_complexity_timeouts.py
@@ -224,6 +224,10 @@ story_compliance:
 test_coverage:
   adequate: true
   gaps: []
+ac_verification:
+  - criterion: "Implementation satisfies the spec"
+    status: VERIFIED
+    evidence: "diff hunks + tests (fixture default)"
 ```
 """
 

--- a/tests/test_coord_dev_phase_routing.py
+++ b/tests/test_coord_dev_phase_routing.py
@@ -539,6 +539,10 @@ story_compliance:
   matches_spec: true
 test_coverage:
   adequate: true
+ac_verification:
+  - criterion: "Implementation satisfies the spec"
+    status: VERIFIED
+    evidence: "diff hunks present and tests cover the failure mode (test fixture default)"
 ```
 """
         call_count = {"pool": 0}

--- a/tests/test_coord_notify_remote.py
+++ b/tests/test_coord_notify_remote.py
@@ -419,6 +419,10 @@ story_compliance:
   matches_spec: true
 test_coverage:
   adequate: true
+ac_verification:
+  - criterion: "Implementation satisfies the spec"
+    status: VERIFIED
+    evidence: "diff hunks + tests (fixture default)"
 ```
 """
         with (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -116,6 +116,10 @@ story_compliance:
   matches_spec: true
 test_coverage:
   adequate: true
+ac_verification:
+  - criterion: "Implementation satisfies the spec"
+    status: VERIFIED
+    evidence: "diff hunks present and tests cover the failure mode (test fixture default)"
 ```
 """
 
@@ -125,6 +129,13 @@ APPROVE_REVIEW_JSON = {
     "findings": [],
     "story_compliance": {"matches_spec": True},
     "test_coverage": {"adequate": True},
+    "ac_verification": [
+        {
+            "criterion": "Implementation satisfies the spec",
+            "status": "VERIFIED",
+            "evidence": "diff hunks present and tests cover the failure mode (fixture default)",
+        },
+    ],
 }
 
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -26,6 +26,10 @@ story_compliance:
 test_coverage:
   adequate: true
   gaps: []
+ac_verification:
+  - criterion: "It batches inputs"
+    status: VERIFIED
+    evidence: "src/batch.py:10-30 + tests/test_batch.py::test_batches"
 ```
 """
 
@@ -301,6 +305,10 @@ story_compliance:
 test_coverage:
   adequate: true
   gaps: []
+ac_verification:
+  - criterion: "It works"
+    status: VERIFIED
+    evidence: "src/foo.py:1 + tests/test_foo.py::test_works"
 ```
 """
 
@@ -321,12 +329,18 @@ class TestTryParseReview:
         assert result is None
 
     def test_schema_error_repaired_successfully(self):
-        # Valid YAML but missing required fields — repair layer fills them
+        # Valid YAML but missing optional fields — repair layer fills them.
+        # ac_verification must be supplied because APPROVE+missing/empty is a
+        # cross-validation failure (silent-contract-swap guard).
         bad = """\
 ```yaml
 verdict: APPROVE
 summary: "ok"
 findings: []
+ac_verification:
+  - criterion: "It works"
+    status: VERIFIED
+    evidence: "src/foo.py:1 + tests/test_foo.py::test_works"
 ```
 """
         result = _try_parse_review(bad)
@@ -335,6 +349,22 @@ findings: []
         assert result.story_matches is True  # inferred from verdict
         assert result.test_adequate is True  # default
 
+    def test_approve_without_ac_verification_returns_none(self):
+        """APPROVE missing ac_verification triggers cross-validation failure."""
+        bad = """\
+```yaml
+verdict: APPROVE
+summary: "ok"
+findings: []
+story_compliance:
+  matches_spec: true
+test_coverage:
+  adequate: true
+```
+"""
+        result = _try_parse_review(bad)
+        assert result is None  # parse_errors present → None
+
     def test_structured_data_path(self):
         data = {
             "verdict": "APPROVE",
@@ -342,14 +372,33 @@ findings: []
             "findings": [],
             "story_compliance": {"matches_spec": True, "mismatches": []},
             "test_coverage": {"adequate": True, "gaps": []},
+            "ac_verification": [
+                {
+                    "criterion": "It works",
+                    "status": "VERIFIED",
+                    "evidence": "src/foo.py:1 + tests/test_foo.py::test_works",
+                },
+            ],
         }
         result = _try_parse_review("", structured_data=data)
         assert result is not None
         assert result.verdict == "APPROVE"
 
     def test_structured_data_with_missing_fields_repaired(self):
-        # Missing required fields — repair layer fills them
-        data = {"verdict": "APPROVE", "summary": "ok", "findings": []}
+        # Missing optional fields — repair layer fills them. ac_verification
+        # must be supplied because APPROVE+missing fails cross-validation.
+        data = {
+            "verdict": "APPROVE",
+            "summary": "ok",
+            "findings": [],
+            "ac_verification": [
+                {
+                    "criterion": "It works",
+                    "status": "VERIFIED",
+                    "evidence": "src/foo.py:1 + tests/test_foo.py::test_works",
+                },
+            ],
+        }
         result = _try_parse_review("", structured_data=data)
         assert result is not None
         assert result.verdict == "APPROVE"

--- a/tests/test_review_ac_verification.py
+++ b/tests/test_review_ac_verification.py
@@ -1,0 +1,293 @@
+"""Tests for per-AC verification table on review output.
+
+Covers the silent-contract-swap guard introduced for #1224:
+- Reviewers must emit an ac_verification table mapping each acceptance
+  criterion to a status (VERIFIED / PARTIAL / NOT_VERIFIED) with concrete
+  evidence pointers.
+- APPROVE + any non-VERIFIED entry is a structural contradiction —
+  validate_review_yaml records a parse error so the parse-retry loop fires
+  and the reviewer's APPROVE is not silently accepted.
+- The audit output emits the per-AC verification table so post-hoc readers
+  can see which criteria were verified, by which evidence, at the time of
+  approval.
+- Bug-type issues (no ACs) record a single "Symptom resolution" entry.
+- Merging across reviewers downgrades to the worst per-criterion status.
+"""
+
+from __future__ import annotations
+
+from theforge.coordinator.audit_render import build_reviews
+from theforge.coordinator.state import CoordinatorState, ReviewCycleMetadata
+from theforge.review import (
+    ACVerification,
+    ReviewFinding,
+    ReviewResult,
+    _merge_ac_verification,
+    parse_review_output,
+)
+from theforge.schemas import validate_review_yaml
+
+# ── Schema cross-validation ──────────────────────────────────────────
+
+
+def _approve_with_ac(entries: list[dict]) -> dict:
+    return {
+        "verdict": "APPROVE",
+        "summary": "ok",
+        "findings": [],
+        "story_compliance": {"matches_spec": True, "mismatches": []},
+        "test_coverage": {"adequate": True, "gaps": []},
+        "ac_verification": entries,
+    }
+
+
+def test_approve_with_all_verified_passes() -> None:
+    data = _approve_with_ac(
+        [
+            {
+                "criterion": "Detection covers Codex 'usage limit' signature",
+                "status": "VERIFIED",
+                "evidence": (
+                    "src/theforge/runners/cli.py:147-180 + "
+                    "tests/test_cli.py::test_codex_usage_limit_falls_back"
+                ),
+            },
+            {
+                "criterion": "Resumed-retry path exercises fallback",
+                "status": "VERIFIED",
+                "evidence": (
+                    "src/theforge/runners/cli.py:220-260 + "
+                    "tests/test_cli.py::test_resumed_retry_fallback"
+                ),
+            },
+        ]
+    )
+    assert validate_review_yaml(data) == []
+
+
+def test_approve_with_partial_is_structural_error() -> None:
+    """The exact failure mode this story was filed for.
+
+    PR #402 review-style output: APPROVE with a generic implementation
+    claim but no test for the production-observed signature. Schema
+    validation must reject this so the parse-retry loop fires.
+    """
+    data = _approve_with_ac(
+        [
+            {
+                "criterion": "Detection covers Codex 'usage limit' signature",
+                "status": "PARTIAL",
+                "evidence": (
+                    "Generic CLI fallback exists at src/theforge/runners/cli.py:147 "
+                    "but no test exercises the 'usage limit' string"
+                ),
+            },
+        ]
+    )
+    errors = validate_review_yaml(data)
+    assert any("APPROVE" in e and "PARTIAL" in e for e in errors)
+
+
+def test_approve_with_not_verified_is_structural_error() -> None:
+    data = _approve_with_ac(
+        [
+            {
+                "criterion": "Resumed-retry path exercises fallback",
+                "status": "NOT_VERIFIED",
+                "evidence": "Could not locate runtime path that handles resumed retries",
+            },
+        ]
+    )
+    errors = validate_review_yaml(data)
+    assert any("APPROVE" in e and "NOT_VERIFIED" in e for e in errors)
+
+
+def test_request_changes_with_partial_ac_is_valid() -> None:
+    data = {
+        "verdict": "REQUEST_CHANGES",
+        "summary": "Symptom not exercised",
+        "findings": [
+            {
+                "severity": "P1",
+                "file": "tests/test_cli.py",
+                "line": 1,
+                "description": (
+                    "Missing test that exercises 'usage limit' string — "
+                    "production failure mode is not covered"
+                ),
+                "suggestion": "Add a test fixture replaying the Codex usage limit error",
+            },
+        ],
+        "story_compliance": {"matches_spec": False, "mismatches": ["test gap"]},
+        "test_coverage": {"adequate": False, "gaps": ["usage limit not tested"]},
+        "ac_verification": [
+            {
+                "criterion": "Detection covers Codex 'usage limit' signature",
+                "status": "PARTIAL",
+                "evidence": "Implementation present; concrete signature untested",
+            },
+        ],
+    }
+    assert validate_review_yaml(data) == []
+
+
+def test_bug_symptom_resolution_entry_passes() -> None:
+    """Bug issues use a single Symptom resolution entry instead of per-AC."""
+    data = _approve_with_ac(
+        [
+            {
+                "criterion": (
+                    "Symptom resolution: Codex 'You've hit your usage limit' "
+                    "now routes to API fallback"
+                ),
+                "status": "VERIFIED",
+                "evidence": (
+                    "src/theforge/runners/cli.py:147 (added 'usage limit' pattern) + "
+                    "tests/test_cli.py::test_codex_usage_limit_falls_back"
+                ),
+            }
+        ]
+    )
+    assert validate_review_yaml(data) == []
+
+
+# ── Parser extraction ────────────────────────────────────────────────
+
+
+def test_parse_review_output_extracts_ac_verification() -> None:
+    output = """\
+```yaml
+verdict: APPROVE
+summary: Good
+findings: []
+story_compliance:
+  matches_spec: true
+  mismatches: []
+test_coverage:
+  adequate: true
+  gaps: []
+ac_verification:
+  - criterion: It works
+    status: VERIFIED
+    evidence: src/foo.py:1 + tests/test_foo.py
+```
+"""
+    result = parse_review_output(output)
+    assert result.parse_errors == []
+    assert len(result.ac_verification) == 1
+    assert result.ac_verification[0].criterion == "It works"
+    assert result.ac_verification[0].status == "VERIFIED"
+
+
+# ── Merge across reviewers ───────────────────────────────────────────
+
+
+def test_merge_ac_verification_takes_worst_status() -> None:
+    """If any reviewer reports PARTIAL, the merged status is PARTIAL.
+
+    Conservative rule: a single reviewer flagging a gap is enough to
+    mark the criterion non-VERIFIED in the merged result.
+    """
+    a = (
+        ACVerification(
+            criterion="Detection covers Codex usage limit",
+            status="VERIFIED",
+            evidence="src/cli.py:147 + tests/test_cli.py::test_a",
+        ),
+    )
+    b = (
+        ACVerification(
+            criterion="Detection covers Codex usage limit",
+            status="PARTIAL",
+            evidence="No test for the actual signature",
+        ),
+    )
+    merged = _merge_ac_verification([a, b])
+    assert len(merged) == 1
+    assert merged[0].status == "PARTIAL"
+
+
+def test_merge_ac_verification_preserves_unique_criteria() -> None:
+    a = (ACVerification(criterion="Crit one", status="VERIFIED", evidence="e1"),)
+    b = (ACVerification(criterion="Crit two", status="VERIFIED", evidence="e2"),)
+    merged = _merge_ac_verification([a, b])
+    assert {ac.criterion for ac in merged} == {"Crit one", "Crit two"}
+
+
+# ── Audit emission ───────────────────────────────────────────────────
+
+
+def test_build_reviews_emits_ac_verification_table() -> None:
+    state = CoordinatorState()
+    state.review_cycle_metadata.append(
+        ReviewCycleMetadata(
+            pool_models=["opus"],
+            successful=["opus"],
+            failed=[],
+            synthesized=False,
+        )
+    )
+    state.review_results.append(
+        ReviewResult(
+            verdict="APPROVE",
+            summary="all good",
+            findings=[],
+            story_matches=True,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={},
+            ac_verification=(
+                ACVerification(
+                    criterion="Detection covers Codex usage limit",
+                    status="VERIFIED",
+                    evidence="src/cli.py:147 + tests/test_cli.py::test_usage_limit",
+                ),
+            ),
+        )
+    )
+    reviews = build_reviews(state)
+    assert reviews[0]["ac_verification"] == [
+        {
+            "criterion": "Detection covers Codex usage limit",
+            "status": "VERIFIED",
+            "evidence": "src/cli.py:147 + tests/test_cli.py::test_usage_limit",
+        }
+    ]
+
+
+def test_build_reviews_emits_empty_ac_verification_when_absent() -> None:
+    """REQUEST_CHANGES results may carry no AC table — audit emits []."""
+    state = CoordinatorState()
+    state.review_cycle_metadata.append(
+        ReviewCycleMetadata(
+            pool_models=["opus"],
+            successful=["opus"],
+            failed=[],
+            synthesized=False,
+        )
+    )
+    state.review_results.append(
+        ReviewResult(
+            verdict="REQUEST_CHANGES",
+            summary="bug",
+            findings=[
+                ReviewFinding(
+                    severity="P1",
+                    file="src/foo.py",
+                    line=10,
+                    description="bug",
+                    suggestion="fix",
+                )
+            ],
+            story_matches=False,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={},
+        )
+    )
+    reviews = build_reviews(state)
+    assert reviews[0]["ac_verification"] == []

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -11,6 +11,13 @@ def _valid_review() -> dict:
         "findings": [],
         "story_compliance": {"matches_spec": True, "mismatches": []},
         "test_coverage": {"adequate": True, "gaps": []},
+        "ac_verification": [
+            {
+                "criterion": "It does the thing",
+                "status": "VERIFIED",
+                "evidence": "src/foo.py:10-20 + tests/test_foo.py::test_thing",
+            },
+        ],
     }
 
 
@@ -139,6 +146,84 @@ class TestValidateReviewYaml:
         ]
         errors = validate_review_yaml(data)
         assert errors == []
+
+    def test_approve_without_ac_verification_is_error(self):
+        """APPROVE with empty ac_verification table fails cross-validation."""
+        data = _valid_review()
+        data["ac_verification"] = []
+        errors = validate_review_yaml(data)
+        assert any("APPROVE" in e and "ac_verification" in e for e in errors)
+
+    def test_approve_with_partial_ac_is_error(self):
+        """APPROVE with any PARTIAL entry fails — silent contract swap guard."""
+        data = _valid_review()
+        data["ac_verification"] = [
+            {
+                "criterion": "Detection patterns cover Codex 'usage limit' signature",
+                "status": "PARTIAL",
+                "evidence": "Generic CLI fallback exists but no test for 'usage limit' string",
+            },
+        ]
+        errors = validate_review_yaml(data)
+        assert any("APPROVE" in e and "PARTIAL" in e for e in errors)
+
+    def test_approve_with_not_verified_ac_is_error(self):
+        """APPROVE with any NOT_VERIFIED entry fails."""
+        data = _valid_review()
+        data["ac_verification"] = [
+            {
+                "criterion": "Per-AC verification table exists in audit",
+                "status": "NOT_VERIFIED",
+                "evidence": "Could not locate audit-render code path",
+            },
+        ]
+        errors = validate_review_yaml(data)
+        assert any("APPROVE" in e and "NOT_VERIFIED" in e for e in errors)
+
+    def test_request_changes_with_partial_ac_is_valid(self):
+        """REQUEST_CHANGES with PARTIAL entries is fine — that's the whole point."""
+        data = _valid_review()
+        data["verdict"] = "REQUEST_CHANGES"
+        data["findings"] = [
+            {
+                "severity": "P1",
+                "file": "src/foo.py",
+                "line": 5,
+                "description": "Missing coverage for the production-observed symptom",
+                "suggestion": "Add a test for the specific failure signature",
+            }
+        ]
+        data["ac_verification"] = [
+            {
+                "criterion": "Detection covers actual production symptom",
+                "status": "PARTIAL",
+                "evidence": "Implementation exists but production-observed signature untested",
+            },
+        ]
+        errors = validate_review_yaml(data)
+        assert errors == []
+
+    def test_ac_verification_invalid_status_is_error(self):
+        data = _valid_review()
+        data["ac_verification"] = [
+            {"criterion": "Foo", "status": "MAYBE", "evidence": "..."},
+        ]
+        errors = validate_review_yaml(data)
+        assert any("ac_verification" in e and "status" in e for e in errors)
+
+    def test_ac_verification_missing_evidence_is_error(self):
+        data = _valid_review()
+        data["ac_verification"] = [
+            {"criterion": "Foo", "status": "VERIFIED", "evidence": ""},
+        ]
+        errors = validate_review_yaml(data)
+        assert any("ac_verification" in e and "evidence" in e for e in errors)
+
+    def test_ac_verification_must_be_list(self):
+        data = _valid_review()
+        data["ac_verification"] = "all good"
+        errors = validate_review_yaml(data)
+        assert any("ac_verification" in e and "list" in e for e in errors)
 
     def test_p2_with_file_and_null_line_is_valid(self):
         """P2 findings are not subject to the line-enforcement rule."""


### PR DESCRIPTION
## Summary

Per-AC verification table is fully implemented: schema cross-validation, parser extraction, worst-status merge, audit emission, and prompt enforcement all present and tested.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $7.41
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/review.py:818`** The evidence-merging logic in _merge_ac_verification sets merged_evidence from the first branch (winner's evidence) and then unconditionally overwrites it in the second branch whenever both evidence strings are non-empty and different. The first branch's assignment is effectively dead code in the common case. The result is still correct (joined evidence, worst status), but the intent is obscured.

## Story

Reviewers must verify acceptance criteria are actually fulfilled — not just that the diff is coherent — to catch silent-contract-swap merges (GitHub Issue #1224)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1224