### PR TITLE
Fix-readiness signal as structured intake input — symptom bugs vs diagnosed bugs vs fix-ready

### DIFF
--- a/src/theforge/shape_check/check.py
+++ b/src/theforge/shape_check/check.py
@@ -9,6 +9,7 @@ from theforge.shape_check.classifier import LlmCaller, classify
 from theforge.shape_check.heuristics import (
     DEFAULT_CLUSTER_THRESHOLD,
     SEED_VOCABULARY,
+    check_bug_missing_diagnosis,
     check_epic_or_tracking,
     check_implementation_design_dump,
     check_missing_acceptance_criteria,
@@ -54,6 +55,7 @@ def check(
         check_superseded,
         check_untriaged_finding,
         check_missing_type,
+        check_bug_missing_diagnosis,
         check_missing_acceptance_criteria,
         check_missing_example,
         check_no_observable_done_state,

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -209,6 +209,75 @@ def _find_tracking_body_declaration(body: str) -> tuple[str, str] | None:
     return None
 
 
+DIAGNOSIS_HEADING_PATTERN = r"diagnosis"
+REQUIRED_DIAGNOSIS_TOKENS: tuple[str, ...] = (
+    "observed symptom",
+    "evidence",
+    "ruled out",
+    "confirmed cause",
+    "affected code path",
+    "fix-success criterion",
+)
+
+# Status labels operators can apply to a bug to communicate fix-readiness intent.
+# These are advisory — the body's Diagnosis section is the authoritative signal.
+RECOGNIZED_STATUS_LABELS: frozenset[str] = frozenset(
+    {"status:triage", "status:investigating", "status:diagnosed"}
+)
+FIX_READY_STATUS_LABELS: frozenset[str] = frozenset({"status:diagnosed"})
+
+
+def diagnosis_completeness(body: str) -> tuple[bool, list[str]]:
+    """Return (is_complete, missing_tokens) for a bug's Diagnosis section.
+
+    Returns ``(False, ["missing Diagnosis section"])`` when the section is
+    absent. Returns ``(False, [...])`` when the section is present but lacks
+    one or more required tokens. Returns ``(True, [])`` only when every
+    required token appears within the section text (case-insensitive).
+    """
+    section = extract_section(body, DIAGNOSIS_HEADING_PATTERN)
+    if section is None:
+        return False, ["missing Diagnosis section"]
+    section_lower = section.lower()
+    missing = [tok for tok in REQUIRED_DIAGNOSIS_TOKENS if tok not in section_lower]
+    if missing:
+        return False, missing
+    return True, []
+
+
+def derive_fix_ready(
+    story_type: str | None, body: str, labels: Iterable[str] | None = None
+) -> tuple[bool | None, list[str]]:
+    """Compute the binary fix-readiness signal from structured type and body.
+
+    Rules:
+    - ``type=None`` → ``(None, [warning])`` (cannot determine).
+    - ``type='bug'`` → ``True`` iff the body contains a complete Diagnosis section
+      with every required component; otherwise ``False`` with explanatory warnings.
+    - Any other recognized type (enhancement, task, epic) → always fix-ready
+      since features/tasks are described by acceptance criteria, not diagnosis.
+
+    Status labels (e.g. ``status:diagnosed``) are operator intent and do not
+    override body content per AC: absence of the Diagnosis section flips a
+    bug to not-fix-ready regardless of label.
+    """
+    if story_type is None:
+        return None, ["fix-readiness undetermined: story type unknown"]
+    if story_type == "bug":
+        ok, missing = diagnosis_completeness(body)
+        if ok:
+            return True, []
+        if missing == ["missing Diagnosis section"]:
+            return False, [
+                "bug missing Diagnosis section — not fix-ready (run "
+                "`forge diagnose` or add diagnosis manually)"
+            ]
+        return False, [
+            f"bug Diagnosis section missing required component: {tok}" for tok in missing
+        ]
+    return True, []
+
+
 def is_bug_format_issue(body: str, labels: Iterable[str]) -> bool:
     """Return true for bug reports, which use observed/expected sections instead of AC."""
     if _lower_labels(labels) & _BUG_LABELS:
@@ -244,6 +313,42 @@ def check_missing_type(title: str, body: str, labels: Iterable[str]) -> Reason |
             ),
         )
     return None
+
+
+def check_bug_missing_diagnosis(title: str, body: str, labels: Iterable[str]) -> Reason | None:
+    """Block bug-typed issues that lack a complete Diagnosis section.
+
+    A symptom-only bug entering the sprint flow is the failure mode this
+    check exists to prevent: implementers hypothesize a cause, the PR
+    fixes the hypothesis, reviewers verify the implementation matches the
+    plan, the bug closes — and the original symptom persists because the
+    cause was elsewhere. Without a diagnosis, there is no contract for
+    reviewers to verify against.
+    """
+    if not is_bug_format_issue(body, labels):
+        return None
+    ok, missing = diagnosis_completeness(body)
+    if ok:
+        return None
+    if missing == ["missing Diagnosis section"]:
+        return Reason(
+            code="bug_missing_diagnosis",
+            severity=Severity.BLOCKING,
+            detail=(
+                "Bug has no Diagnosis section — not fix-ready. Add a '## Diagnosis' "
+                "section containing observed symptom, evidence, ruled-out hypotheses, "
+                "confirmed cause, affected code path, and fix-success criterion before "
+                "sprinting (or run `forge diagnose` when available)."
+            ),
+        )
+    return Reason(
+        code="bug_missing_diagnosis",
+        severity=Severity.BLOCKING,
+        detail=(
+            "Bug Diagnosis section is incomplete — missing required component(s): "
+            f"{', '.join(missing)}."
+        ),
+    )
 
 
 def check_epic_or_tracking(title: str, body: str, labels: Iterable[str]) -> Reason | None:

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from ..coordinator.state import CoordinatorResult
+from ..shape_check.heuristics import derive_fix_ready
 from ..task import TaskStory, frontmatter_allows_forge_yaml_mutation, parse_story_frontmatter
 
 if TYPE_CHECKING:
@@ -199,6 +200,24 @@ def _build_task_from_story(story_path: Path) -> TaskStory:
         import logging as _logging  # noqa: PLC0415
 
         _logging.getLogger(__name__).warning(warning)
+
+    body = story_path.read_text(encoding="utf-8")
+    fix_ready, readiness_warnings = derive_fix_ready(story_type, body)
+    fm_override = fm.get("fix_ready")
+    if isinstance(fm_override, bool):
+        if fm_override is True and fix_ready is False:
+            readiness_warnings = [
+                *readiness_warnings,
+                "frontmatter declares fix_ready: true but body lacks a complete "
+                "Diagnosis section — honoring frontmatter override",
+            ]
+        elif fm_override is False and fix_ready is True:
+            readiness_warnings = [
+                *readiness_warnings,
+                "frontmatter explicitly marks fix_ready: false despite a complete body",
+            ]
+        fix_ready = fm_override
+
     return TaskStory(
         name=name,
         story_path=story_path,
@@ -210,6 +229,8 @@ def _build_task_from_story(story_path: Path) -> TaskStory:
         allow_mutate_forge_yaml=frontmatter_allows_forge_yaml_mutation(fm),
         type=story_type,
         type_warnings=type_warnings,
+        fix_ready=fix_ready,
+        readiness_warnings=readiness_warnings,
     )
 
 

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -11,6 +11,11 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import yaml
 
+from ..shape_check.heuristics import (
+    FIX_READY_STATUS_LABELS,
+    RECOGNIZED_STATUS_LABELS,
+    derive_fix_ready,
+)
 from ..task import ALLOW_MUTATE_FORGE_YAML_KEY, RECOGNIZED_STORY_TYPES, StoryTypeError, TaskStory
 from .manifest import _build_task_from_story
 
@@ -321,6 +326,28 @@ class GitHubIssueSource:
             if isinstance(lbl, dict) and lbl.get("name")
         ]
         story_type, type_warnings = _derive_type_from_labels(label_names, number)
+        fix_ready, readiness_warnings = derive_fix_ready(story_type, body)
+        status_labels = sorted(set(label_names) & RECOGNIZED_STATUS_LABELS)
+        # Surface label/body disagreement for operator awareness — body is authoritative.
+        if (
+            story_type == "bug"
+            and fix_ready is False
+            and any(lbl in FIX_READY_STATUS_LABELS for lbl in label_names)
+        ):
+            readiness_warnings = [
+                *readiness_warnings,
+                "label claims fix-ready but body lacks a complete Diagnosis section",
+            ]
+        if (
+            story_type == "bug"
+            and fix_ready is True
+            and status_labels
+            and not (set(status_labels) & FIX_READY_STATUS_LABELS)
+        ):
+            readiness_warnings = [
+                *readiness_warnings,
+                f"body has complete Diagnosis but label is {status_labels[0]!r}",
+            ]
 
         slug = f"issue-{number}"
         return TaskStory(
@@ -335,6 +362,8 @@ class GitHubIssueSource:
             allow_mutate_forge_yaml=metadata.get(ALLOW_MUTATE_FORGE_YAML_KEY) is True,
             type=story_type,
             type_warnings=type_warnings,
+            fix_ready=fix_ready,
+            readiness_warnings=readiness_warnings,
         )
 
     def on_complete(

--- a/src/theforge/task/story.py
+++ b/src/theforge/task/story.py
@@ -34,6 +34,8 @@ class TaskStory:
     allow_mutate_forge_yaml: bool = False  # explicit opt-in for forge.yaml guard override
     type: str | None = None  # structured story type from frontmatter or GH label
     type_warnings: list[str] = field(default_factory=list)  # missing-type migration warnings
+    fix_ready: bool | None = None  # True iff bug has full Diagnosis section or non-bug type
+    readiness_warnings: list[str] = field(default_factory=list)  # why fix_ready is False/None
 
 
 # Backward-compat alias

--- a/tests/test_fix_readiness.py
+++ b/tests/test_fix_readiness.py
@@ -1,0 +1,294 @@
+"""Tests for the structured fix-readiness signal added in issue #1153.
+
+Fix-readiness is orthogonal to story type (#1142): every bug-typed issue must
+carry a complete Diagnosis section before sprinting; features are always
+fix-ready since they are described by acceptance criteria, not diagnoses.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from theforge.shape_check import Shape, check
+from theforge.shape_check.heuristics import (
+    REQUIRED_DIAGNOSIS_TOKENS,
+    check_bug_missing_diagnosis,
+    derive_fix_ready,
+    diagnosis_completeness,
+)
+from theforge.sprint.manifest import _build_task_from_story
+from theforge.sprint.shape_gate import apply_shape_gate
+from theforge.sprint.sources import GitHubIssueSource
+
+DIAGNOSIS_BODY = textwrap.dedent(
+    """\
+    ## Diagnosis
+
+    - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
+    - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
+    - **Ruled out.** Workspace creation actually succeeds (verified in logs).
+    - **Confirmed cause.** `_is_already_merged` requires at least one commit ahead.
+    - **Affected code path.** sprint.runner._is_already_merged.
+    - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.
+    """
+)
+
+
+class TestDiagnosisCompleteness:
+    def test_all_components_present(self) -> None:
+        ok, missing = diagnosis_completeness(DIAGNOSIS_BODY)
+        assert ok is True
+        assert missing == []
+
+    def test_missing_section(self) -> None:
+        ok, missing = diagnosis_completeness("## What\nprose only")
+        assert ok is False
+        assert missing == ["missing Diagnosis section"]
+
+    def test_partial_section(self) -> None:
+        partial = textwrap.dedent(
+            """\
+            ## Diagnosis
+
+            - Observed symptom: things happen.
+            - Evidence: a log line.
+            """
+        )
+        ok, missing = diagnosis_completeness(partial)
+        assert ok is False
+        # Partial section flags the specific missing tokens, not the whole section.
+        expected_missing = (
+            "ruled out",
+            "confirmed cause",
+            "affected code path",
+            "fix-success criterion",
+        )
+        for token in expected_missing:
+            assert token in missing
+
+
+class TestCheckBugMissingDiagnosis:
+    def test_bug_without_diagnosis_blocks(self) -> None:
+        reason = check_bug_missing_diagnosis("T", "## What\nprose", ["bug"])
+        assert reason is not None
+        assert reason.code == "bug_missing_diagnosis"
+        assert "Diagnosis" in reason.detail
+
+    def test_bug_with_complete_diagnosis_passes(self) -> None:
+        assert check_bug_missing_diagnosis("T", DIAGNOSIS_BODY, ["bug"]) is None
+
+    def test_non_bug_skipped(self) -> None:
+        assert check_bug_missing_diagnosis("T", "## What\nprose", ["enhancement"]) is None
+
+    def test_partial_diagnosis_lists_missing_components(self) -> None:
+        partial = "## Diagnosis\n- Observed symptom: x.\n"
+        reason = check_bug_missing_diagnosis("T", partial, ["bug"])
+        assert reason is not None
+        # Missing component names should appear in the operator-facing detail
+        assert "missing required component" in reason.detail
+        for tok in ("ruled out", "confirmed cause", "affected code path"):
+            assert tok in reason.detail
+
+    def test_check_pipeline_blocks_undiagnosed_bug(self) -> None:
+        result = check("Bug: foo", "## What\nprose only", ["bug"])
+        assert result.shape is Shape.NEEDS_GROOMING
+        assert any(r.code == "bug_missing_diagnosis" for r in result.reasons)
+
+    def test_check_pipeline_passes_diagnosed_bug(self) -> None:
+        result = check("Bug: foo", DIAGNOSIS_BODY, ["bug"])
+        assert result.shape is Shape.RUNNABLE
+        assert result.reasons == ()
+
+
+class TestDeriveFixReady:
+    def test_unknown_type_returns_none(self) -> None:
+        signal, warnings = derive_fix_ready(None, DIAGNOSIS_BODY)
+        assert signal is None
+        assert warnings and "type unknown" in warnings[0]
+
+    def test_feature_always_fix_ready(self) -> None:
+        # No diagnosis section needed for non-bug types per AC: "Features are
+        # always fix-ready (no diagnosis required for new functionality)."
+        signal, warnings = derive_fix_ready("enhancement", "## What\nDo a thing.")
+        assert signal is True
+        assert warnings == []
+
+    def test_task_type_always_fix_ready(self) -> None:
+        signal, warnings = derive_fix_ready("task", "## What\nDo it.")
+        assert signal is True
+        assert warnings == []
+
+    def test_bug_with_diagnosis_is_fix_ready(self) -> None:
+        signal, warnings = derive_fix_ready("bug", DIAGNOSIS_BODY)
+        assert signal is True
+        assert warnings == []
+
+    def test_bug_without_diagnosis_is_not_fix_ready(self) -> None:
+        signal, warnings = derive_fix_ready("bug", "## What\nprose only")
+        assert signal is False
+        assert warnings and "not fix-ready" in warnings[0]
+
+    def test_required_tokens_documented(self) -> None:
+        # Guard against drift between docstring and implementation.
+        assert "observed symptom" in REQUIRED_DIAGNOSIS_TOKENS
+        assert "fix-success criterion" in REQUIRED_DIAGNOSIS_TOKENS
+
+
+class TestGitHubFixReadyPropagation:
+    def _fetch_with(self, body: str, labels: list[str]):
+        issue_data = json.dumps(
+            {
+                "title": "Some bug",
+                "body": body,
+                "state": "OPEN",
+                "labels": [{"name": label} for label in labels],
+            }
+        )
+        return MagicMock(returncode=0, stdout=issue_data, stderr=""), MagicMock(
+            returncode=0, stdout="[]", stderr=""
+        )
+
+    def test_diagnosed_bug_propagates_fix_ready_true(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = self._fetch_with(DIAGNOSIS_BODY, ["bug"])
+            task = GitHubIssueSource().fetch("123", tmp_path)
+        assert task.fix_ready is True
+        assert task.readiness_warnings == []
+
+    def test_undiagnosed_bug_propagates_fix_ready_false(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = self._fetch_with("## What\nprose only", ["bug"])
+            task = GitHubIssueSource().fetch("123", tmp_path)
+        assert task.fix_ready is False
+        assert task.readiness_warnings
+
+    def test_enhancement_is_always_fix_ready(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = self._fetch_with("## What\nDo a thing.", ["enhancement"])
+            task = GitHubIssueSource().fetch("123", tmp_path)
+        assert task.fix_ready is True
+        assert task.readiness_warnings == []
+
+    def test_status_diagnosed_label_without_section_warns(self, tmp_path: Path) -> None:
+        # Operator's label intent (status:diagnosed) is informational; absence
+        # of the body section flips the issue to not-fix-ready and surfaces
+        # the disagreement as a warning per AC.
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = self._fetch_with("## What\nprose", ["bug", "status:diagnosed"])
+            task = GitHubIssueSource().fetch("123", tmp_path)
+        assert task.fix_ready is False
+        assert any("label claims fix-ready" in w for w in task.readiness_warnings)
+
+
+class TestFileFrontmatterFixReady:
+    def test_bug_frontmatter_with_diagnosis_section(self, tmp_path: Path) -> None:
+        story = tmp_path / "bug.md"
+        story.write_text(
+            "---\nname: B\nslug: b\ntype: bug\n---\n" + DIAGNOSIS_BODY,
+            encoding="utf-8",
+        )
+        task = _build_task_from_story(story)
+        assert task.type == "bug"
+        assert task.fix_ready is True
+        assert task.readiness_warnings == []
+
+    def test_bug_frontmatter_without_diagnosis(self, tmp_path: Path) -> None:
+        story = tmp_path / "bug.md"
+        story.write_text(
+            "---\nname: B\nslug: b\ntype: bug\n---\n## What\nprose only\n",
+            encoding="utf-8",
+        )
+        task = _build_task_from_story(story)
+        assert task.fix_ready is False
+        assert task.readiness_warnings
+
+    def test_enhancement_frontmatter_always_fix_ready(self, tmp_path: Path) -> None:
+        story = tmp_path / "f.md"
+        story.write_text(
+            "---\nname: F\nslug: f\ntype: enhancement\n---\n## What\nbuild it\n",
+            encoding="utf-8",
+        )
+        task = _build_task_from_story(story)
+        assert task.fix_ready is True
+
+    def test_frontmatter_fix_ready_override_honored_with_warning(self, tmp_path: Path) -> None:
+        # AC8: operators have a clear path to mark bugs fix-ready interactively.
+        # Frontmatter `fix_ready: true` is the file-sourced equivalent of the
+        # operator override. Body still drives derivation; operator override
+        # wins but emits a warning so the disagreement is auditable.
+        story = tmp_path / "bug.md"
+        story.write_text(
+            "---\nname: B\nslug: b\ntype: bug\nfix_ready: true\n---\n## What\nprose\n",
+            encoding="utf-8",
+        )
+        task = _build_task_from_story(story)
+        assert task.fix_ready is True
+        assert any("frontmatter declares fix_ready" in w for w in task.readiness_warnings)
+
+    def test_unknown_type_yields_none(self, tmp_path: Path) -> None:
+        story = tmp_path / "legacy.md"
+        story.write_text("---\nname: L\nslug: l\n---\nbody\n", encoding="utf-8")
+        task = _build_task_from_story(story)
+        assert task.fix_ready is None
+
+
+class TestSprintShapeGateRefusesUndiagnosedBugs:
+    """AC4 seam test: shape gate is the sprint-runner refusal point for
+    GH-sourced bugs that lack a Diagnosis section."""
+
+    def test_undiagnosed_bug_rejected_with_clear_message(self, tmp_path: Path) -> None:
+        issues = [{"number": 99, "title": "Symptom-only bug"}]
+
+        def fetch(_number, _root):
+            return {"title": "Symptom-only bug", "body": "## What\nprose only", "labels": ["bug"]}
+
+        result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
+        assert result.runnable == []
+        assert len(result.skipped) == 1
+        skipped = result.skipped[0]
+        assert "bug_missing_diagnosis" in skipped.reason_codes
+        assert "Diagnosis" in skipped.detail
+
+    def test_diagnosed_bug_passes_through(self, tmp_path: Path) -> None:
+        issues = [{"number": 100, "title": "Diagnosed bug"}]
+
+        def fetch(_number, _root):
+            return {"title": "Diagnosed bug", "body": DIAGNOSIS_BODY, "labels": ["bug"]}
+
+        result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
+        assert result.runnable == issues
+        assert result.skipped == []
+
+
+@pytest.mark.parametrize("label", ["enhancement", "task"])
+def test_features_pass_shape_gate_without_diagnosis(label: str, tmp_path: Path) -> None:
+    issues = [{"number": 5, "title": "Feature"}]
+
+    def fetch(_number, _root):
+        return {
+            "title": "Feature",
+            "body": textwrap.dedent(
+                """\
+                ## What
+                Build a thing.
+
+                ## Acceptance Criteria
+                - The CLI returns 0 on success.
+
+                ## Example
+                ```
+                forge thing --opt
+                ```
+                """
+            ),
+            "labels": [label],
+        }
+
+    result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
+    assert result.runnable == issues
+    assert result.skipped == []

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -38,6 +38,21 @@ WELL_FORMED_AC = textwrap.dedent(
     """
 )
 
+# A bug body that satisfies the fix-readiness contract (issue #1153): every
+# required Diagnosis component must be present for the issue to pass shape check.
+DIAGNOSED_BUG_BODY = textwrap.dedent(
+    """\
+    ## Diagnosis
+
+    - **Observed symptom.** Command exits 1 instead of 0 on success.
+    - **Evidence.** Reproduction in run id `abc123`.
+    - **Ruled out.** Config drift; verified config is loaded correctly.
+    - **Confirmed cause.** Off-by-one in exit-code computation at runner.py:42.
+    - **Affected code path.** runner.exit_code, cli.main return.
+    - **Fix-success criterion.** Command returns 0 on success path; existing tests pass.
+    """
+)
+
 
 # ----- per-reason unit tests -----------------------------------------------
 
@@ -336,7 +351,8 @@ class TestTooManyBehavioralClusters:
 
 class TestCheckAggregation:
     def test_runnable(self):
-        result = check("Fix thing", WELL_FORMED_AC, ["bug"])
+        # Bugs require a complete Diagnosis section to pass shape check (#1153).
+        result = check("Fix thing", DIAGNOSED_BUG_BODY, ["bug"])
         assert result.shape is Shape.RUNNABLE
         assert result.suggested_action is SuggestedAction.PROCEED
         assert result.reasons == ()
@@ -386,13 +402,15 @@ class TestCheckAggregation:
             r.code == "missing_example" and r.severity is Severity.ADVISORY for r in result.reasons
         )
 
-    def test_bug_label_without_ac_is_runnable(self):
+    def test_bug_label_without_diagnosis_is_blocked(self):
+        # Replaces the prior "bug without AC is runnable" assertion; #1153 flips
+        # bugs to not-fix-ready when the Diagnosis section is missing.
         result = check("Bug: command exits incorrectly", "## What\nprose only", ["bug"])
-        assert result.shape is Shape.RUNNABLE
-        assert result.suggested_action is SuggestedAction.PROCEED
-        assert result.reasons == ()
+        assert result.shape is Shape.NEEDS_GROOMING
+        assert result.suggested_action is SuggestedAction.CLARIFY
+        assert any(r.code == "bug_missing_diagnosis" for r in result.reasons)
 
-    def test_bug_report_headings_without_ac_are_runnable(self):
+    def test_bug_report_headings_without_diagnosis_are_blocked(self):
         body = textwrap.dedent(
             """\
             ## What happened
@@ -403,6 +421,11 @@ class TestCheckAggregation:
             """
         )
         result = check("Shape gate blocks bugs", body, ["bug"])
+        assert result.shape is Shape.NEEDS_GROOMING
+        assert any(r.code == "bug_missing_diagnosis" for r in result.reasons)
+
+    def test_bug_with_complete_diagnosis_is_runnable(self):
+        result = check("Bug: command exits incorrectly", DIAGNOSED_BUG_BODY, ["bug"])
         assert result.shape is Shape.RUNNABLE
         assert result.suggested_action is SuggestedAction.PROCEED
         assert result.reasons == ()


### PR DESCRIPTION
## Summary

All 8 ACs met; fix-readiness gate is correctly wired through shape check pipeline; two P2s: dead code in _merge_ac_verification and fix_ready/readiness_warnings not emitted to audit trail per convention #6.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $4.40
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/review.py:831`** Dead code in _merge_ac_verification: the first if/else block assigns merged_evidence based on the rank comparison, but the immediately following block unconditionally overwrites merged_evidence whenever both evidence strings exist and differ (the common case). The first assignment is dead in that path. This was flagged in the prior review cycle (#1251) as a P2 and not resolved.
- **[P2] `src/theforge/coordinator/audit_render.py:None`** Convention #6 violation: fix_ready and readiness_warnings are computed on TaskStory and flow through the coordinator, but are not emitted to the audit trail. Diagnosing why a story was rejected at the shape gate currently requires reconstructing this from shape check reason codes rather than reading the stored signal directly.
- **[P2] `src/theforge/shape_check/heuristics.py:248`** derive_fix_ready accepts a labels parameter that is never used in the function body. The docstring correctly explains that labels are advisory and do not override body content, but the parameter is accepted at the interface and simply ignored. No callers pass it.

## Story

Fix-readiness signal as structured intake input — symptom bugs vs diagnosed bugs vs fix-ready (GitHub Issue #1153)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1153