### PR TITLE
Workspace hygiene gate — repo tree mutations outside DEV must be rejected (#1179)

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -475,6 +475,48 @@ def _run_dev_phase(
     if logger:
         logger._safe_emit("phase_start", phase="DEV", iteration=state.dev_iteration)
 
+    # ── Workspace hygiene gate (first DEV entry only) ─────────────────
+    # Reject or sanitise the worktree before the dev agent sees it for the
+    # first time. Stray untracked files at repo root (left behind by tracked-
+    # leftover files in main, or by a non-DEV phase that wrote where it
+    # shouldn't) silently sabotage dev runs — see issue #1179. Quarantine
+    # non-destructively into .forge/quarantine/<run-id>/iter-<n>/ so
+    # operators can recover originals.
+    #
+    # Iterations 2+ are not re-gated: validate-phase's auto-commit owns
+    # cleanup after the first iteration, and intermediate dirty state on a
+    # retry is a legitimate handoff between iterations rather than a stray
+    # phase mutation.
+    from .workspace_hygiene import enforce_pre_dev_hygiene, ensure_scratch_dir  # noqa: PLC0415
+
+    _hygiene_run_id = state.run_id or "unknown"
+    ensure_scratch_dir(workspace_path, _hygiene_run_id)
+    if state.dev_iteration <= 1:
+        _hygiene_ok, _hygiene_diag, _hygiene_audit = enforce_pre_dev_hygiene(
+            workspace_path,
+            _hygiene_run_id,
+            iteration=state.dev_iteration,
+        )
+        state.workspace_hygiene_audit.append({"phase": "PRE_DEV", **_hygiene_audit})
+        if _hygiene_audit.get("quarantined"):
+            _q_paths = ", ".join(_hygiene_audit["quarantined"])
+            _q_dir = _hygiene_audit.get("quarantine_dir")
+            _log(f"  ⚠ DEV   quarantined stray paths to {_q_dir}: {_q_paths}")
+        if not _hygiene_ok:
+            state.phase = Phase.ESCALATE
+            state.error = _hygiene_diag or "Workspace hygiene gate refused DEV entry"
+            _log(f"✗ ESCALATE   {state.error}")
+            if logger:
+                logger._safe_emit("phase_end", phase="DEV", outcome="escalate")
+                logger._safe_emit("escalate", reason=state.error, phase="DEV")
+            _escalate_notify(task, state, notify, config)
+            return CoordinatorResult(
+                success=False,
+                phase=state.phase,
+                state=state,
+                message=state.error,
+            )
+
     # Capture HEAD before the dev agent runs — used by finding_classifier for git diff.
     # Best-effort: any failure is silently ignored (non-critical for correctness).
     try:

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -399,6 +399,12 @@ def _run_plan_phase(
         work_type=state.preflight_work_type,
     )
 
+    from .workspace_hygiene import (  # noqa: PLC0415
+        check_phase_no_mutation,
+        snapshot_porcelain,
+    )
+
+    _plan_hygiene_before = snapshot_porcelain(workspace_path)
     _plan_start = time.monotonic()
     plan_result = run_agent(
         prompt=plan_prompt,
@@ -407,11 +413,27 @@ def _run_plan_phase(
         secrets=config.secrets,
     )
     _plan_elapsed = time.monotonic() - _plan_start
+    _plan_ok, _plan_diag, _plan_offending = check_phase_no_mutation(
+        workspace_path, _plan_hygiene_before, "PLAN"
+    )
+    state.workspace_hygiene_audit.append(
+        {"phase": "PLAN", "ok": _plan_ok, "offending_paths": _plan_offending}
+    )
     state.plan_durations.append(_plan_elapsed)
     state.plan_results.append(plan_result)
     state.plan_session_id = plan_result.session_id or state.plan_session_id
     write_trace(workspace_path / ".forge/traces" / "plan-attempt-0.txt", plan_result.output)
     _write_log_artifact(state.log_dir, "plan-attempt-0.txt", plan_result.output or "")
+    if not _plan_ok:
+        state.phase = Phase.ESCALATE
+        state.error = _plan_diag or "PLAN phase mutated the worktree"
+        _log(f"✗ ESCALATE   {state.error}")
+        logger._safe_emit("phase_end", phase="PLAN", outcome="escalate")
+        logger._safe_emit("escalate", reason=state.error, phase="PLAN")
+        _escalate_notify(task, state, notify, config)
+        return CoordinatorResult(
+            success=False, phase=state.phase, state=state, message=state.error
+        )
 
     if plan_result.success:
         plan_text = plan_result.output

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -559,6 +559,13 @@ def _run_review_phase(
     state.review_cycle_metadata.append(meta)
     _review_cost_before_cycle = sum(r.cost_usd or 0.0 for r in state.review_agent_results)
 
+    from .workspace_hygiene import (  # noqa: PLC0415
+        check_phase_no_mutation,
+        snapshot_porcelain,
+    )
+
+    _review_hygiene_before = snapshot_porcelain(workspace_path)
+
     successful, failed_results, _candidate, _individual_results, _named_parsed = _run_review_pool(
         state,
         config,
@@ -574,6 +581,26 @@ def _run_review_phase(
         stop_event=stop_event,
     )
     state.last_cycle_reviewer_results = _named_parsed
+
+    _review_ok, _review_diag, _review_offending = check_phase_no_mutation(
+        workspace_path, _review_hygiene_before, "REVIEW"
+    )
+    state.workspace_hygiene_audit.append(
+        {"phase": "REVIEW", "ok": _review_ok, "offending_paths": _review_offending}
+    )
+    if not _review_ok:
+        state.phase = Phase.ESCALATE
+        state.error = _review_diag or "REVIEW phase mutated the worktree"
+        _log(f"✗ ESCALATE   {state.error}")
+        if logger:
+            logger._safe_emit("phase_end", phase="REVIEW", outcome="escalate")
+            logger._safe_emit("escalate", reason=state.error, phase="REVIEW")
+        _escalate_notify(task, state, notify, config)
+        return (
+            _ReviewOutcome.ESCALATE,
+            CoordinatorResult(success=False, phase=state.phase, state=state, message=state.error),
+            config,
+        )
 
     if _candidate is None:
         # All reviewers failed or budget exceeded —

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -421,6 +421,10 @@ class CoordinatorState:
     adaptive_dev_budget_usd: float = 0.0
     adaptive_limits_audit: dict = field(default_factory=dict)
     review_early_terminated: bool = False  # True when early-termination triggered
+    workspace_hygiene_audit: list[dict] = field(default_factory=list)
+    # Per-phase hygiene gate audit entries. Each dict carries a "phase" key
+    # ("PRE_DEV" / "PLAN" / "PLAN_REVIEW" / "REVIEW") plus phase-specific fields
+    # (snapshot, modified, quarantined, quarantine_dir, offending_paths).
 
     def __post_init__(self, dev_iteration: int) -> None:
         # Sync the budget's per-cycle counter with the constructor kwarg.

--- a/src/theforge/coordinator/workspace_hygiene.py
+++ b/src/theforge/coordinator/workspace_hygiene.py
@@ -1,0 +1,214 @@
+"""Workspace hygiene gate.
+
+The coordinator owns deterministic phase boundaries. Some phases (PREFLIGHT,
+PLAN, PLAN_REVIEW, REVIEW) must not mutate the repo tree; others (DEV) own
+mutation. This module provides the mechanical enforcement: snapshot the tree
+before a phase, compare after, and either quarantine stray untracked files or
+fail loudly with the offending paths.
+
+Two layers:
+
+1. ``check_phase_no_mutation``: invoked around PLAN / PLAN_REVIEW / REVIEW.
+   Any change to the porcelain set fails the phase. ``.forge/`` is gitignored,
+   so coordinator-driven artifact writes are naturally excluded.
+
+2. ``enforce_pre_dev_hygiene``: invoked before DEV iteration 1. Unexpected
+   untracked paths are moved to ``.forge/quarantine/<run-id>/`` (audited, not
+   silently deleted) and DEV proceeds with a clean tree. If quarantine fails
+   or modifications to tracked files appear, DEV is rejected with a diagnostic
+   pointing at the offending paths instead of being handed to an agent that
+   will fail mysteriously.
+
+Sanctioned scratch space (``.forge/tmp/<run-id>/``) is provisioned by
+``ensure_scratch_dir``; ``.forge/`` is already gitignored so the directory is
+invisible to git.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+# Paths agents may legitimately leave at root without tripping the gate.
+# Restrict to operator-facing work artifacts; everything else is quarantined.
+_ALLOWED_ROOT_UNTRACKED: frozenset[str] = frozenset()
+
+
+def snapshot_porcelain(workspace_path: Path) -> set[str]:
+    """Return the porcelain entry set for ``workspace_path``.
+
+    Each entry is the raw two-character status code plus the path
+    (``"?? foo.py"``, ``" M src/x.py"``, ...). ``.forge/`` is gitignored so
+    Forge-managed artifacts do not appear. On git failure returns an empty
+    set; callers treat that as "no snapshot" rather than crashing.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain", "-z"],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if proc.returncode != 0:
+        return set()
+    raw = proc.stdout.decode("utf-8", errors="replace")
+    if not raw:
+        return set()
+    # -z entries are NUL-terminated; renames split across two NUL fields.
+    return {entry for entry in raw.split("\0") if entry}
+
+
+def _path_of(entry: str) -> str:
+    """Extract the path portion of a porcelain entry (status is 3 chars)."""
+    return entry[3:] if len(entry) > 3 else entry
+
+
+def unexpected_entries(before: set[str], after: set[str]) -> list[str]:
+    """Return entries present in ``after`` but not in ``before``, sorted by path."""
+    new = after - before
+    return sorted(new, key=_path_of)
+
+
+def check_phase_no_mutation(
+    workspace_path: Path,
+    before: set[str],
+    phase_name: str,
+) -> tuple[bool, str | None, list[str]]:
+    """Verify ``phase_name`` left the tree unchanged.
+
+    Returns ``(ok, diagnostic, offending_paths)``. When ``ok`` is False, the
+    diagnostic names the phase and lists every path the phase introduced or
+    modified — operator-grade language, no silent failures.
+    """
+    after = snapshot_porcelain(workspace_path)
+    new_entries = unexpected_entries(before, after)
+    if not new_entries:
+        return True, None, []
+    paths = [_path_of(e) for e in new_entries]
+    rendered = ", ".join(paths)
+    diagnostic = (
+        f"Workspace hygiene violation: phase {phase_name} is not authorized to mutate "
+        f"the repo tree, but introduced unexpected paths: {rendered}. "
+        "Remove or justify."
+    )
+    return False, diagnostic, paths
+
+
+def ensure_scratch_dir(workspace_path: Path, run_id: str) -> Path:
+    """Create ``.forge/tmp/<run-id>/`` and return it.
+
+    ``.forge/`` is already gitignored, so the directory is invisible to git
+    and safe for agents to use as exploratory scratch space.
+    """
+    scratch = workspace_path / ".forge" / "tmp" / run_id
+    scratch.mkdir(parents=True, exist_ok=True)
+    return scratch
+
+
+def _quarantine_root(workspace_path: Path, run_id: str, iteration: int) -> Path:
+    return workspace_path / ".forge" / "quarantine" / run_id / f"iter-{iteration}"
+
+
+def quarantine_paths(
+    workspace_path: Path,
+    paths: list[str],
+    quarantine_root: Path,
+) -> tuple[list[str], list[str]]:
+    """Move ``paths`` (workspace-relative) under ``quarantine_root``.
+
+    Returns ``(moved, failed)``. Moves preserve the relative tree so the
+    operator can locate originals. ``shutil.move`` is used so cross-device
+    moves degrade to copy+delete cleanly.
+    """
+    quarantine_root.mkdir(parents=True, exist_ok=True)
+    moved: list[str] = []
+    failed: list[str] = []
+    for rel_path in paths:
+        src = workspace_path / rel_path
+        if not src.exists() and not src.is_symlink():
+            # Path appeared in porcelain but is gone now (race or untracked dir
+            # that already lost its entries). Treat as moved — no work to do.
+            moved.append(rel_path)
+            continue
+        dest = quarantine_root / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.move(str(src), str(dest))
+            moved.append(rel_path)
+        except OSError:
+            failed.append(rel_path)
+    return moved, failed
+
+
+def enforce_pre_dev_hygiene(
+    workspace_path: Path,
+    run_id: str,
+    *,
+    iteration: int,
+) -> tuple[bool, str | None, dict]:
+    """Reject or sanitise the worktree before DEV starts.
+
+    Behaviour:
+      - Untracked paths (status ``??``) outside the allow-list → quarantined
+        to ``.forge/quarantine/<run-id>/iter-<n>/``. Audit-trail preserved,
+        worktree returned to a clean baseline, DEV proceeds. This is the
+        primary motivator: stray scratch at repo root that silently sabotages
+        dev runs (issue #1179).
+      - Modified tracked files (status M/A/D/...) → audited and left in
+        place. These are legitimate worktree-reuse state (work-in-progress
+        from a prior interrupted run); validate-phase's auto-commit owns
+        cleanup. Silent quarantine of tracked changes would qualify as
+        "forge ate my work".
+      - If quarantine fails for any untracked path → reject with the
+        offending paths so the operator knows what to clean up manually.
+
+    Returns ``(ok, diagnostic, audit)`` where ``audit`` is always a dict with
+    keys ``snapshot``, ``modified``, ``quarantined``, ``quarantine_dir``.
+    """
+    snapshot = snapshot_porcelain(workspace_path)
+    audit: dict = {
+        "snapshot": sorted(snapshot),
+        "modified": [],
+        "quarantined": [],
+        "quarantine_dir": None,
+    }
+    if not snapshot:
+        return True, None, audit
+
+    untracked: list[str] = []
+    modified: list[str] = []
+    for entry in snapshot:
+        # Porcelain format: XY␠path. "??" = untracked. Anything else = tracked
+        # change (modified, added, deleted, renamed, copied, unmerged).
+        status = entry[:2]
+        path = _path_of(entry)
+        if status == "??":
+            if path in _ALLOWED_ROOT_UNTRACKED:
+                continue
+            untracked.append(path)
+        else:
+            modified.append(path)
+
+    audit["modified"] = sorted(modified)
+
+    if not untracked:
+        return True, None, audit
+
+    quarantine_dir = _quarantine_root(workspace_path, run_id, iteration)
+    moved, failed = quarantine_paths(workspace_path, sorted(untracked), quarantine_dir)
+    audit["quarantined"] = moved
+    audit["quarantine_dir"] = str(quarantine_dir.relative_to(workspace_path))
+    if failed:
+        rendered = ", ".join(failed)
+        diagnostic = (
+            "Unexpected untracked files in worktree before DEV could not be "
+            f"quarantined: {rendered}. Workspace hygiene gate refuses to hand a "
+            "dirty tree to the dev agent. Resolve manually before retrying."
+        )
+        return False, diagnostic, audit
+
+    return True, None, audit

--- a/tests/test_coord_workspace_hygiene.py
+++ b/tests/test_coord_workspace_hygiene.py
@@ -1,0 +1,253 @@
+"""Tests for the workspace hygiene gate.
+
+Covers the helpers in workspace_hygiene plus the seam-level wiring that
+addresses issue #1179: stray files at repo root must not be silently handed to
+the dev agent, and non-DEV phases must not mutate the worktree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from coord_test_helpers import _make_agent_result, _make_config
+
+from theforge.coordinator.dev_phase import _run_dev_phase
+from theforge.coordinator.state import CoordinatorState
+from theforge.coordinator.workspace_hygiene import (
+    check_phase_no_mutation,
+    enforce_pre_dev_hygiene,
+    ensure_scratch_dir,
+    snapshot_porcelain,
+    unexpected_entries,
+)
+from theforge.task import TaskStory
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / ".gitignore").write_text(".forge/\n", encoding="utf-8")
+    (path / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+
+
+# ── snapshot_porcelain ────────────────────────────────────────────────
+
+
+def test_snapshot_porcelain_clean_repo_returns_empty_set(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    assert snapshot_porcelain(tmp_path) == set()
+
+
+def test_snapshot_porcelain_lists_untracked(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "test_flock.py").write_text("scratch\n", encoding="utf-8")
+    snap = snapshot_porcelain(tmp_path)
+    paths = {entry[3:] for entry in snap}
+    assert "test_flock.py" in paths
+
+
+def test_snapshot_porcelain_excludes_gitignored_forge_dir(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / ".forge").mkdir()
+    (tmp_path / ".forge" / "tmp.txt").write_text("scratch\n", encoding="utf-8")
+    snap = snapshot_porcelain(tmp_path)
+    assert all(".forge" not in entry for entry in snap)
+
+
+def test_snapshot_porcelain_returns_empty_on_non_repo(tmp_path: Path) -> None:
+    assert snapshot_porcelain(tmp_path) == set()
+
+
+# ── unexpected_entries ────────────────────────────────────────────────
+
+
+def test_unexpected_entries_returns_only_new_paths() -> None:
+    before = {"?? a.py"}
+    after = {"?? a.py", "?? b.py", " M c.py"}
+    new = unexpected_entries(before, after)
+    assert [entry[3:] for entry in new] == ["b.py", "c.py"]
+
+
+# ── check_phase_no_mutation ───────────────────────────────────────────
+
+
+def test_check_phase_no_mutation_passes_when_clean(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    ok, diag, offending = check_phase_no_mutation(tmp_path, before, "PLAN")
+    assert ok is True
+    assert diag is None
+    assert offending == []
+
+
+def test_check_phase_no_mutation_rejects_new_untracked(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / "scratch.txt").write_text("oops\n", encoding="utf-8")
+    ok, diag, offending = check_phase_no_mutation(tmp_path, before, "REVIEW")
+    assert ok is False
+    assert "REVIEW" in diag
+    assert "scratch.txt" in diag
+    assert offending == ["scratch.txt"]
+
+
+def test_check_phase_no_mutation_rejects_modified_tracked(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / "README.md").write_text("changed\n", encoding="utf-8")
+    ok, diag, offending = check_phase_no_mutation(tmp_path, before, "PLAN")
+    assert ok is False
+    assert "README.md" in diag
+
+
+# ── ensure_scratch_dir ────────────────────────────────────────────────
+
+
+def test_ensure_scratch_dir_creates_under_forge_tmp(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    scratch = ensure_scratch_dir(tmp_path, "abcd1234")
+    assert scratch == tmp_path / ".forge" / "tmp" / "abcd1234"
+    assert scratch.is_dir()
+
+
+# ── enforce_pre_dev_hygiene ───────────────────────────────────────────
+
+
+def test_enforce_pre_dev_hygiene_passes_on_clean_worktree(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    ok, diag, audit = enforce_pre_dev_hygiene(tmp_path, "run-1", iteration=1)
+    assert ok is True
+    assert diag is None
+    assert audit["modified"] == []
+    assert audit["quarantined"] == []
+
+
+def test_enforce_pre_dev_hygiene_quarantines_untracked(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "test_flock.py").write_text("scratch\n", encoding="utf-8")
+    (tmp_path / "test_flock2.py").write_text("scratch\n", encoding="utf-8")
+
+    ok, diag, audit = enforce_pre_dev_hygiene(tmp_path, "run-xyz", iteration=1)
+
+    assert ok is True
+    assert diag is None
+    # Files moved out of root.
+    assert not (tmp_path / "test_flock.py").exists()
+    assert not (tmp_path / "test_flock2.py").exists()
+    # Quarantine directory holds originals; audit mentions both.
+    quarantine_dir = tmp_path / ".forge" / "quarantine" / "run-xyz" / "iter-1"
+    assert (quarantine_dir / "test_flock.py").read_text() == "scratch\n"
+    assert (quarantine_dir / "test_flock2.py").read_text() == "scratch\n"
+    assert sorted(audit["quarantined"]) == ["test_flock.py", "test_flock2.py"]
+    assert audit["quarantine_dir"] == ".forge/quarantine/run-xyz/iter-1"
+
+
+def test_enforce_pre_dev_hygiene_records_but_does_not_quarantine_modified_tracked(
+    tmp_path: Path,
+) -> None:
+    """Modified tracked files are legitimate worktree-reuse state.
+
+    They are audited (so an operator can see them) but NOT silently moved —
+    that would qualify as "forge ate my work". Validate-phase's auto-commit
+    handles cleanup after DEV runs.
+    """
+    _init_repo(tmp_path)
+    (tmp_path / "README.md").write_text("worktree-reuse work in progress\n", encoding="utf-8")
+
+    ok, diag, audit = enforce_pre_dev_hygiene(tmp_path, "run-1", iteration=1)
+
+    assert ok is True
+    assert diag is None
+    assert audit["modified"] == ["README.md"]
+    assert audit["quarantined"] == []
+    assert (tmp_path / "README.md").exists()
+
+
+# ── seam: _run_dev_phase quarantines and proceeds ─────────────────────
+
+
+def test_run_dev_phase_quarantines_untracked_root_scratch(tmp_path: Path) -> None:
+    """The #1179 motivating case: stray test_flock*.py at root before DEV.
+
+    Coordinator must quarantine them and let DEV proceed against a clean tree.
+    """
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "test_flock.py").write_text("scratch\n", encoding="utf-8")
+    (tmp_path / "test_flock2.py").write_text("scratch\n", encoding="utf-8")
+
+    config = _make_config(tmp_path)
+    spec_path = tmp_path.parent / f"{tmp_path.name}-spec.md"
+    spec_path.write_text("# spec\n", encoding="utf-8")
+    task = TaskStory(name="t", slug="t", story_path=spec_path)
+    state = CoordinatorState()
+    state.run_id = "abcd1234"
+
+    # Successful dev result so we don't bail out on the zero-commits guard.
+    def _run_agent(**kwargs):
+        # Simulate dev agent committing real work — keeps zero-commits guard happy.
+        (tmp_path / "src.py").write_text("ok\n", encoding="utf-8")
+        subprocess.run(["git", "add", "src.py"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=tmp_path, check=True)
+        return _make_agent_result(success=True, dev_handoff={"summary": "done"})
+
+    with (
+        patch("theforge.coordinator.dev_phase.run_agent", side_effect=_run_agent),
+        patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock()),
+    ):
+        result = _run_dev_phase(
+            state, config, task, "# spec\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+
+    assert result is None  # no escalation
+    assert not (tmp_path / "test_flock.py").exists()
+    assert not (tmp_path / "test_flock2.py").exists()
+    quarantine_dir = tmp_path / ".forge" / "quarantine" / "abcd1234" / "iter-0"
+    assert (quarantine_dir / "test_flock.py").exists()
+    # Hygiene audit recorded.
+    assert state.workspace_hygiene_audit
+    pre_dev_entry = next(e for e in state.workspace_hygiene_audit if e["phase"] == "PRE_DEV")
+    assert sorted(pre_dev_entry["quarantined"]) == ["test_flock.py", "test_flock2.py"]
+
+
+def test_run_dev_phase_skips_hygiene_gate_on_retry_iterations(tmp_path: Path) -> None:
+    """Iterations 2+ are not re-gated — validate-phase auto-commit owns cleanup.
+
+    A worktree dirty mid-loop is a legitimate retry handoff; re-gating would
+    break the validate→DEV retry path.
+    """
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "src.py").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "src.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "iter1"], cwd=tmp_path, check=True)
+    # Stray scratch file — would normally be quarantined on iter 1, but iter 2+
+    # is intentionally not re-gated.
+    (tmp_path / "test_flock.py").write_text("scratch\n", encoding="utf-8")
+
+    config = _make_config(tmp_path)
+    spec_path = tmp_path.parent / f"{tmp_path.name}-spec.md"
+    spec_path.write_text("# spec\n", encoding="utf-8")
+    task = TaskStory(name="t", slug="t", story_path=spec_path)
+    state = CoordinatorState(dev_iteration=2)
+    state.run_id = "abcd1234"
+
+    with (
+        patch(
+            "theforge.coordinator.dev_phase.run_agent",
+            return_value=_make_agent_result(success=True, dev_handoff={"summary": "done"}),
+        ),
+        patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock()),
+    ):
+        result = _run_dev_phase(
+            state, config, task, "# spec\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+
+    assert result is None  # no escalation, no quarantine
+    assert (tmp_path / "test_flock.py").exists()
+    assert not any(e.get("phase") == "PRE_DEV" for e in state.workspace_hygiene_audit)


### PR DESCRIPTION
Closes #1179.

Implements the runtime workspace-hygiene gate per the issue's three ACs.
Dev work was produced and reviewed inside a forge sprint that escalated
during PR creation due to #1256 (null-byte in LLM-generated PR body);
opening this PR by hand to bypass that bug and preserve the reviewed
work.

## Review verdict

APPROVE with 3 P2 findings (none blocking):

- logger None-guard missing in plan_flow escalation path (pre-existing pattern)
- no seam tests for PLAN/REVIEW mutation detection (Convention #8 gap)
- rename porcelain entries produce garbled path diagnostics

## Branch summary

\`feat(coordinator): workspace hygiene gate for phase boundaries\`

- src/theforge/coordinator/dev_phase.py
- src/theforge/coordinator/plan_flow.py
- src/theforge/coordinator/review_phase.py
- src/theforge/coordinator/state.py
- src/theforge/coordinator/workspace_hygiene.py
- tests/test_coord_workspace_hygiene.py