### PR TITLE
forge status --watch live overlay ΔCOST column shows '—' for every row in every sprint — delta-computation appears never to fire

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -885,7 +885,7 @@ def _make_worker_phase_fn(
     plan_done: "dict[str, str] | None" = None,
     state_writer: "SprintStateWriter | None" = None,
 ) -> "Callable[[dict], None]":
-    """Return a thread-safe state_update_fn wrapper that tracks per-worker phase.
+    """Return a thread-safe state_update_fn wrapper for worker live state.
 
     Updates worker_phases[slug] from updates["phase"] and (under lock) forwards
     updates to the outer daemon state_update_fn if provided.
@@ -893,8 +893,9 @@ def _make_worker_phase_fn(
     When *plan_done* is provided and a PLAN_DONE phase update arrives, stores
     the workspace_path in plan_done[slug] for the scheduler to read.
 
-    When *state_writer* is provided, phase transitions are also written to the
-    live sprint state file so ``forge sprint-status`` reflects the current phase.
+    When *state_writer* is provided, live-facing fields are also written to the
+    sprint state file so ``forge sprint-status`` reflects both the current phase
+    and the latest per-story cost.
     """
 
     def _update(updates: dict) -> None:
@@ -902,22 +903,25 @@ def _make_worker_phase_fn(
         with phase_lock:
             if phase:
                 worker_phases[slug] = phase
-                if state_writer is not None:
-                    incoming_detail = updates.get("detail")
-                    _detail_updates: dict[str, object] = (
-                        dict(incoming_detail) if isinstance(incoming_detail, dict) else {}
-                    )
-                    if phase == "VALIDATE" and not _detail_updates:
-                        _detail_updates = {"gate_status": "running"}
-                    update_kwargs: dict[str, object] = {"phase": phase}
-                    if "complexity" in updates:
-                        update_kwargs["complexity"] = updates["complexity"]
-                    if "cost_usd" in updates:
-                        update_kwargs["cost_usd"] = updates["cost_usd"]
-                    if "current_model" in updates:
-                        update_kwargs["current_model"] = updates["current_model"]
-                    if _detail_updates:
-                        update_kwargs["detail"] = _detail_updates
+            if state_writer is not None:
+                incoming_detail = updates.get("detail")
+                detail_updates: dict[str, object] = (
+                    dict(incoming_detail) if isinstance(incoming_detail, dict) else {}
+                )
+                if phase == "VALIDATE" and not detail_updates:
+                    detail_updates = {"gate_status": "running"}
+                update_kwargs: dict[str, object] = {}
+                if phase:
+                    update_kwargs["phase"] = phase
+                if "complexity" in updates:
+                    update_kwargs["complexity"] = updates["complexity"]
+                if "cost_usd" in updates:
+                    update_kwargs["cost_usd"] = updates["cost_usd"]
+                if "current_model" in updates:
+                    update_kwargs["current_model"] = updates["current_model"]
+                if detail_updates:
+                    update_kwargs["detail"] = detail_updates
+                if update_kwargs:
                     state_writer.update(slug, **update_kwargs)
             if phase == "PLAN_DONE" and plan_done is not None:
                 ws = updates.get("workspace_path", "")

--- a/tests/test_cli_status_integration.py
+++ b/tests/test_cli_status_integration.py
@@ -464,6 +464,42 @@ def test_watch_loop_renders_all_live_sprints_in_one_frame(tmp_path: Path, capsys
     assert "Issue #1186" in out
 
 
+def test_watch_loop_surfaces_cost_delta_after_live_state_cost_update(
+    tmp_path: Path, capsys: object
+) -> None:
+    from theforge.cli import status_watch
+
+    _write_pid_file(tmp_path, "run-a", "issues-1240")
+    _write_state_file(
+        tmp_path,
+        "run-a",
+        "issues-1240",
+        [_live_story(1240, status="running", phase="PLAN", cost_usd=0.38)],
+    )
+
+    def bump_cost(_seconds: float) -> None:
+        _write_state_file(
+            tmp_path,
+            "run-a",
+            "issues-1240",
+            [_live_story(1240, status="running", phase="PLAN", cost_usd=0.42)],
+        )
+
+    with patch.object(status_watch, "is_tty", return_value=False):
+        rc = status_watch.run_watch_loop(
+            "run-a",
+            tmp_path,
+            interval=0.01,
+            color=False,
+            sleep_fn=bump_cost,
+            max_frames=2,
+        )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "+$0.04" in out
+
+
 def test_watch_loop_drops_finished_sprint_on_next_frame(tmp_path: Path, capsys: object) -> None:
     from theforge.cli import status_watch
 

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -32,6 +32,7 @@ from theforge.sprint.dag import (
 )
 from theforge.sprint.manifest import ResolvedSprint
 from theforge.sprint.runner import (
+    _make_worker_phase_fn,
     _refresh_external_satisfied,
     _run_baseline_gate,
     _terminal_story_model,
@@ -403,6 +404,44 @@ def test_terminal_story_model_falls_back_to_model_usage_when_model_used_missing(
     result = _make_result_with_dev_runs(legacy)
 
     assert _terminal_story_model(result) == "gpt-5.4"
+
+
+def test_worker_phase_fn_flushes_cost_updates_without_phase_transition() -> None:
+    worker_phases: dict[str, str] = {}
+    state_writer = MagicMock()
+    outer_fn = MagicMock()
+
+    class _Lock:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    update = _make_worker_phase_fn(
+        "story-a",
+        worker_phases,
+        _Lock(),  # type: ignore[arg-type]
+        outer_fn,
+        state_writer=state_writer,
+    )
+
+    update(
+        {
+            "cost_usd": 0.42,
+            "current_model": "opus",
+            "detail": {"heartbeat": "tick"},
+        }
+    )
+
+    assert worker_phases == {}
+    state_writer.update.assert_called_once_with(
+        "story-a",
+        cost_usd=0.42,
+        current_model="opus",
+        detail={"heartbeat": "tick"},
+    )
+    outer_fn.assert_called_once()
 
 
 def test_run_baseline_gate_reports_local_origin_sha_gap(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Minimal, correct fix: moves state_writer.update() outside the phase-gated branch so cost/model/detail updates persist to the live state file even without a phase transition; both the callback seam and the watch-overlay rendering are covered by new tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.51
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status --watch live overlay ΔCOST column shows '—' for every row in every sprint — delta-computation appears never to fire (GitHub Issue #1240)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1240