### PR TITLE
Merge automation crashes with bare 'embedded null byte' when LLM-produced PR body contains NUL — strands dev work without traceback or offending-input capture

### DIFF
--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -110,6 +110,7 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                 {
                     "verdict": r.verdict,
                     "summary": r.summary,
+                    "sanitization_audit": r.sanitization_audit or None,
                     "p1_count": sum(1 for f in r.findings if f.severity == "P1"),
                     "p2_count": sum(1 for f in r.findings if f.severity == "P2"),
                     "findings": findings_list,

--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -7,6 +7,7 @@ import logging
 import shlex
 import subprocess
 import time
+import traceback
 from pathlib import Path
 
 from theforge.config import ForgeConfig
@@ -109,6 +110,114 @@ def _branch_has_unique_commits(
         return False, f"git rev-list returned non-integer count: {output!r}"
 
 
+def _render_command_for_audit(cmd: list[str]) -> str:
+    """Render a subprocess command line while redacting bulky free-text args."""
+    rendered: list[str] = []
+    skip_next = False
+    for index, arg in enumerate(cmd):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--body" and index + 1 < len(cmd):
+            rendered.append(shlex.quote(arg))
+            rendered.append(shlex.quote(f"<redacted body len={len(cmd[index + 1])}>"))
+            skip_next = True
+            continue
+        rendered.append(shlex.quote(arg))
+    return " ".join(rendered)
+
+
+def _escape_control_preview(text: str) -> str:
+    """Render a preview string with control characters made explicit."""
+    out: list[str] = []
+    for char in text:
+        codepoint = ord(char)
+        if char == "\n":
+            out.append("\\n")
+        elif char == "\r":
+            out.append("\\r")
+        elif char == "\t":
+            out.append("\\t")
+        elif codepoint < 32 or codepoint == 127:
+            out.append(f"\\x{codepoint:02x}")
+        else:
+            out.append(char)
+    return "".join(out)
+
+
+def _preview_window(text: str, position: int, *, radius: int = 24) -> str:
+    """Return an escaped preview around a string position."""
+    start = max(0, position - radius)
+    end = min(len(text), position + radius + 1)
+    return _escape_control_preview(text[start:end])
+
+
+def _hex_window(text: str, position: int, *, radius: int = 8) -> str:
+    """Return a compact hex dump window around a string position."""
+    start = max(0, position - radius)
+    end = min(len(text), position + radius + 1)
+    return text[start:end].encode("utf-8", errors="replace").hex(" ")
+
+
+def _identify_embedded_null_source(
+    cmd: list[str],
+    input_sources: list[dict[str, str]] | None,
+) -> dict[str, object] | None:
+    """Locate the first embedded NUL in the command and source fields."""
+    for arg_index, arg in enumerate(cmd):
+        nul_position = arg.find("\x00")
+        if nul_position < 0:
+            continue
+
+        detail: dict[str, object] = {
+            "argument_index": arg_index,
+            "argument_flag": (
+                cmd[arg_index - 1]
+                if arg_index > 0 and cmd[arg_index - 1].startswith("--")
+                else None
+            ),
+            "position": nul_position,
+            "preview": _preview_window(arg, nul_position),
+            "hex_window": _hex_window(arg, nul_position),
+        }
+        for source in input_sources or []:
+            source_text = source.get("text", "")
+            source_nul_position = source_text.find("\x00")
+            if source_nul_position >= 0:
+                detail["source"] = source.get("source")
+                detail["source_position"] = source_nul_position
+                detail["source_preview"] = _preview_window(source_text, source_nul_position)
+                detail["source_hex_window"] = _hex_window(source_text, source_nul_position)
+                break
+        return detail
+    return None
+
+
+def _build_exception_context(
+    exc: Exception,
+    *,
+    cmd: list[str] | None = None,
+    input_sources: list[dict[str, str]] | None = None,
+) -> dict[str, object]:
+    """Serialize rich exception context for audit/debugging."""
+    context: dict[str, object] = {
+        "exception_class": type(exc).__name__,
+        "exception_args": [repr(arg) for arg in exc.args],
+        "traceback": traceback.format_exc(),
+    }
+    if cmd is not None:
+        context["command"] = _render_command_for_audit(cmd)
+    if (
+        isinstance(exc, ValueError)
+        and "embedded null byte" in str(exc).lower()
+        and cmd is not None
+    ):
+        offending_input = _identify_embedded_null_source(cmd, input_sources)
+        if offending_input is not None:
+            context["offending_input"] = offending_input
+    return context
+
+
 def _create_pr(
     config: ForgeConfig,
     task: TaskStory,
@@ -139,6 +248,14 @@ def _create_pr(
         story_line = f"{task.name} (GitHub Issue #{task.github_issue})"
     else:
         story_line = f"{task.name} (`{task.story_path}`)"
+    pr_body_sources = [{"source": "parsed_review.summary", "text": parsed_review.summary}]
+    for index, finding in enumerate(p2_findings):
+        pr_body_sources.append(
+            {
+                "source": f"finding[{index}].description",
+                "text": finding.description,
+            }
+        )
     pr_body = (
         f"## Summary\n\n"
         f"{parsed_review.summary}\n\n"
@@ -307,7 +424,18 @@ def _create_pr(
             return {"action": "pr", "pr_url": None, "success": False, "error": err}
     except Exception as exc:
         _pr_log.warning("PR creation failed: %s", exc)
-        return {"action": "pr", "pr_url": None, "success": False, "error": str(exc)}
+        return {
+            "action": "pr",
+            "pr_url": None,
+            "success": False,
+            "error": str(exc),
+            "error_context": _build_exception_context(
+                exc,
+                cmd=cmd,
+                input_sources=pr_body_sources,
+            ),
+            "sanitization_audit": parsed_review.sanitization_audit or None,
+        }
 
 
 def _step_fetch_rebase(push_cwd: Path, base_branch: str) -> dict:
@@ -351,7 +479,14 @@ def _step_fetch_rebase(push_cwd: Path, base_branch: str) -> dict:
             }
     except Exception as exc:
         _pr_log.warning("rebase step failed: %s", exc)
-        return {"success": False, "error": f"rebase step failed: {exc}"}
+        return {
+            "success": False,
+            "error": f"rebase step failed: {exc}",
+            "error_context": _build_exception_context(
+                exc,
+                cmd=["git", "rebase", f"origin/{base_branch}"],
+            ),
+        }
 
     return {"success": True}
 
@@ -383,7 +518,14 @@ def _step_force_push(push_cwd: Path, branch_name: str) -> dict:
             return {"success": False, "error": f"force-push after rebase failed: {err}"}
     except Exception as exc:
         _pr_log.warning("force-push failed: %s", exc)
-        return {"success": False, "error": f"force-push after rebase failed: {exc}"}
+        return {
+            "success": False,
+            "error": f"force-push after rebase failed: {exc}",
+            "error_context": _build_exception_context(
+                exc,
+                cmd=["git", "push", "-f", "origin", branch_name],
+            ),
+        }
 
     return {"success": True}
 
@@ -402,11 +544,7 @@ def _step_create_pr(
     """
     pr_result = _create_pr(config, task, branch_name, parsed_review, state)
     if not pr_result.get("success"):
-        return {
-            "success": False,
-            "error": pr_result.get("error") or "PR creation failed",
-            "pr_url": pr_result.get("pr_url"),
-        }
+        return {"success": False, **pr_result}
     return {"success": True, "pr_url": pr_result["pr_url"]}
 
 
@@ -427,7 +565,15 @@ def _step_merge(project_root: Path, pr_url: str, merge_strategy: str) -> dict:
         )
     except Exception as exc:
         _pr_log.warning("gh pr merge --auto failed: %s", exc)
-        return {"success": False, "error": f"gh pr merge failed: {exc}", "retryable": False}
+        return {
+            "success": False,
+            "error": f"gh pr merge failed: {exc}",
+            "retryable": False,
+            "error_context": _build_exception_context(
+                exc,
+                cmd=["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
+            ),
+        }
 
     if merge_proc.returncode != 0:
         err = "\n".join(
@@ -461,7 +607,14 @@ def _step_await_merge_state(project_root: Path, pr_url: str) -> dict:
         )
     except Exception as exc:
         _pr_log.warning("gh pr view failed after auto-merge queue: %s", exc)
-        return {"success": False, "error": f"gh pr view failed after auto-merge queue: {exc}"}
+        return {
+            "success": False,
+            "error": f"gh pr view failed after auto-merge queue: {exc}",
+            "error_context": _build_exception_context(
+                exc,
+                cmd=["gh", "pr", "view", pr_url, "--json", "state", "-q", ".state"],
+            ),
+        }
 
     if state_proc.returncode != 0:
         state_err = state_proc.stderr.strip() or state_proc.stdout.strip()
@@ -575,9 +728,17 @@ def _merge_pr(
     worktree_path = config.project_root / worktree_dir
     push_cwd = worktree_path if worktree_path.is_dir() else config.project_root
 
-    def _fail(error: str, *, merge_state: MergeStepState) -> dict:
+    def _fail(error: str, *, merge_state: MergeStepState, detail: dict | None = None) -> dict:
         merge_state.error = error
         save_merge_state(worktree_path, merge_state)
+        next_action = (
+            "Inspect the existing PR and retry merge automation."
+            if merge_state.pr_url
+            else (
+                "Retry PR creation after sanitizing review text, or run "
+                "`gh pr create` manually from the feature branch."
+            )
+        )
         return {
             "action": "merge-pr",
             "pr_url": merge_state.pr_url,
@@ -586,6 +747,14 @@ def _merge_pr(
             "auto_merge_queued": False,
             "success": False,
             "error": error,
+            "branch": branch_name,
+            "strand_state": {
+                "branch": branch_name,
+                "worktree_path": str(worktree_path),
+                "pr_url": merge_state.pr_url,
+                "next_action": next_action,
+            },
+            **(detail or {}),
         }
 
     def _complete_step(merge_state: MergeStepState, step: str, **log_kwargs: object) -> None:
@@ -669,7 +838,13 @@ def _merge_pr(
                 fetch_rebase_result.get("error"),
             )
             if not fetch_rebase_result["success"]:
-                return _fail(fetch_rebase_result["error"], merge_state=merge_state)
+                return _fail(
+                    fetch_rebase_result["error"],
+                    merge_state=merge_state,
+                    detail={
+                        "error_context": fetch_rebase_result.get("error_context"),
+                    },
+                )
 
             force_push_result = _step_force_push(push_cwd, branch_name)
             _pr_log.info(
@@ -679,13 +854,27 @@ def _merge_pr(
                 force_push_result.get("error"),
             )
             if not force_push_result["success"]:
-                return _fail(force_push_result["error"], merge_state=merge_state)
+                return _fail(
+                    force_push_result["error"],
+                    merge_state=merge_state,
+                    detail={
+                        "error_context": force_push_result.get("error_context"),
+                    },
+                )
 
         # create PR — only once; skip on resume if already completed.
         if "create_pr" not in merge_state.completed_steps:
             create_result = _step_create_pr(config, task, branch_name, parsed_review, state)
             if not create_result["success"]:
-                return _fail(create_result["error"], merge_state=merge_state)
+                return _fail(
+                    create_result["error"],
+                    merge_state=merge_state,
+                    detail={
+                        key: create_result.get(key)
+                        for key in ("error_context", "sanitization_audit")
+                        if create_result.get(key) is not None
+                    },
+                )
             if create_result["pr_url"] is None:
                 # Zero-delta branch: no commits ahead of base, nothing to merge.
                 _log(
@@ -727,14 +916,26 @@ def _merge_pr(
                         MAX_MERGE_RETRIES,
                     )
                     continue
-                return _fail(merge_result["error"], merge_state=merge_state)
+                return _fail(
+                    merge_result["error"],
+                    merge_state=merge_state,
+                    detail={
+                        "error_context": merge_result.get("error_context"),
+                    },
+                )
             _complete_step(merge_state, "merge")
 
         # Determine whether GitHub merged immediately or queued for checks.
         if "await_merge_state" not in merge_state.completed_steps:
             await_result = _step_await_merge_state(config.project_root, merge_state.pr_url)
             if not await_result["success"]:
-                return _fail(await_result["error"], merge_state=merge_state)
+                return _fail(
+                    await_result["error"],
+                    merge_state=merge_state,
+                    detail={
+                        "error_context": await_result.get("error_context"),
+                    },
+                )
             merge_state.merge_queued = await_result["merge_queued"]
             merge_state.auto_merge_queued = await_result["auto_merge_queued"]
             _complete_step(

--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -8,7 +8,7 @@ structures the coordinator can act on mechanically.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import yaml
 
@@ -74,6 +74,7 @@ class ReviewResult:
     parse_errors: list[str]  # non-empty if parsing/validation failed
     raw_yaml: dict  # the parsed YAML data
     ac_verification: tuple[ACVerification, ...] = ()  # per-AC verification table
+    sanitization_audit: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
 def _sanitize_yaml_text(yaml_text: str) -> str:
@@ -91,6 +92,72 @@ def _sanitize_yaml_text(yaml_text: str) -> str:
     # This prevents `foo: bar` from being parsed as a YAML mapping key.
     text = re.sub(r"`([^`\n]+)`", r"\1", text)
     return text
+
+
+def sanitize_llm_text(text: object, *, field_name: str) -> tuple[str, dict[str, dict[str, int]]]:
+    """Strip unsafe control characters from LLM-produced text fields.
+
+    Removes all ASCII control characters except tab/newline/carriage return.
+    This prevents subprocess argument construction from failing on embedded NUL
+    bytes while keeping normal markdown formatting intact.
+    """
+    if not isinstance(text, str):
+        text = "" if text is None else str(text)
+
+    removed = 0
+    parts: list[str] = []
+    for char in text:
+        codepoint = ord(char)
+        if (0 <= codepoint < 32 and char not in "\t\n\r") or codepoint == 127:
+            removed += 1
+            continue
+        parts.append(char)
+
+    sanitized = "".join(parts)
+    if removed == 0:
+        return sanitized, {}
+    return sanitized, {field_name: {"sanitized_chars": removed}}
+
+
+def _merge_sanitization_audits(*audits: dict[str, dict[str, int]]) -> dict[str, dict[str, int]]:
+    """Merge field-name keyed sanitization audits by summing replacement counts."""
+    merged: dict[str, dict[str, int]] = {}
+    for audit in audits:
+        for field_name, detail in audit.items():
+            entry = merged.setdefault(field_name, {"sanitized_chars": 0})
+            entry["sanitized_chars"] += int(detail.get("sanitized_chars", 0))
+    return merged
+
+
+def _extract_review_payload(
+    data: dict,
+) -> tuple[str, list[ReviewFinding], dict[str, dict[str, int]]]:
+    """Extract sanitized summary/findings payload from parsed review data."""
+    summary, summary_audit = sanitize_llm_text(
+        data.get("summary", "(no summary)"),
+        field_name="summary",
+    )
+
+    findings: list[ReviewFinding] = []
+    sanitization_audit = dict(summary_audit)
+    for index, finding_data in enumerate(data.get("findings", [])):
+        if not isinstance(finding_data, dict):
+            continue
+        description, description_audit = sanitize_llm_text(
+            finding_data.get("description", ""),
+            field_name=f"findings[{index}].description",
+        )
+        findings.append(
+            ReviewFinding(
+                severity=finding_data.get("severity", "P2"),
+                file=finding_data.get("file", "unknown"),
+                line=_coerce_line(finding_data.get("line")),
+                description=description,
+                suggestion=finding_data.get("suggestion"),
+            )
+        )
+        sanitization_audit = _merge_sanitization_audits(sanitization_audit, description_audit)
+    return summary, findings, sanitization_audit
 
 
 def _extract_ac_verification(data: dict) -> tuple[ACVerification, ...]:
@@ -128,18 +195,7 @@ def parse_review_json(data: dict) -> ReviewResult:
     schema_errors = validate_review_yaml(data)
 
     # Extract findings
-    findings: list[ReviewFinding] = []
-    for f in data.get("findings", []):
-        if isinstance(f, dict):
-            findings.append(
-                ReviewFinding(
-                    severity=f.get("severity", "P2"),
-                    file=f.get("file", "unknown"),
-                    line=_coerce_line(f.get("line")),
-                    description=f.get("description", ""),
-                    suggestion=f.get("suggestion"),
-                )
-            )
+    summary, findings, sanitization_audit = _extract_review_payload(data)
 
     # Extract story compliance (accept both story_compliance and spec_compliance for compat)
     spec = data.get("story_compliance") or data.get("spec_compliance") or {}
@@ -153,7 +209,7 @@ def parse_review_json(data: dict) -> ReviewResult:
 
     return ReviewResult(
         verdict=data.get("verdict", "REQUEST_CHANGES"),
-        summary=data.get("summary", "(no summary)"),
+        summary=summary,
         findings=findings,
         story_matches=story_matches,
         story_mismatches=story_mismatches if isinstance(story_mismatches, list) else [],
@@ -162,6 +218,7 @@ def parse_review_json(data: dict) -> ReviewResult:
         parse_errors=schema_errors,
         raw_yaml=data,
         ac_verification=_extract_ac_verification(data),
+        sanitization_audit=sanitization_audit,
     )
 
 
@@ -217,18 +274,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
     schema_errors = validate_review_yaml(data)
 
     # Extract findings
-    findings: list[ReviewFinding] = []
-    for f in data.get("findings", []):
-        if isinstance(f, dict):
-            findings.append(
-                ReviewFinding(
-                    severity=f.get("severity", "P2"),
-                    file=f.get("file", "unknown"),
-                    line=_coerce_line(f.get("line")),
-                    description=f.get("description", ""),
-                    suggestion=f.get("suggestion"),
-                )
-            )
+    summary, findings, sanitization_audit = _extract_review_payload(data)
 
     # Extract story compliance (accept both story_compliance and spec_compliance for compat)
     spec = data.get("story_compliance") or data.get("spec_compliance") or {}
@@ -242,7 +288,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
 
     return ReviewResult(
         verdict=data.get("verdict", "REQUEST_CHANGES"),
-        summary=data.get("summary", "(no summary)"),
+        summary=summary,
         findings=findings,
         story_matches=story_matches,
         story_mismatches=story_mismatches if isinstance(story_mismatches, list) else [],
@@ -251,6 +297,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
         parse_errors=schema_errors,
         raw_yaml=data,
         ac_verification=_extract_ac_verification(data),
+        sanitization_audit=sanitization_audit,
     )
 
 
@@ -792,6 +839,9 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
             test_gaps.append(f"[{name}] {g}")
 
     merged_ac = _merge_ac_verification([r.ac_verification for _, r in valid])
+    merged_sanitization_audit = _merge_sanitization_audits(
+        *(r.sanitization_audit for _, r in valid)
+    )
 
     return ReviewResult(
         verdict=verdict,
@@ -804,6 +854,7 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
         parse_errors=[],  # valid reviewers had no errors
         raw_yaml={},
         ac_verification=merged_ac,
+        sanitization_audit=merged_sanitization_audit,
     )
 
 

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -21,8 +21,8 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
-from theforge.coordinator.completion import MAX_MERGE_RETRIES, _merge_pr
-from theforge.review import ReviewResult
+from theforge.coordinator.completion import MAX_MERGE_RETRIES, _create_pr, _merge_pr
+from theforge.review import ReviewResult, parse_review_json
 
 # ── Helpers ───────────────────────────────────────────────────────
 
@@ -1235,8 +1235,6 @@ class TestPrBodyContent:
     """Verify _create_pr includes story name, dev cost, and review summary."""
 
     def test_pr_body_includes_required_fields(self, tmp_path: Path) -> None:
-        from theforge.coordinator.completion import _create_pr
-
         config = _make_merge_pr_config(tmp_path)
         task = _make_task(tmp_path)
         review = ReviewResult(
@@ -1276,6 +1274,53 @@ class TestPrBodyContent:
         assert "Test Task" in body  # story name
         assert "2.75" in body  # dev cost
         assert "Feature implemented correctly" in body  # review summary
+
+    def test_pr_body_uses_sanitized_review_text(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = parse_review_json(
+            {
+                "verdict": "APPROVE",
+                "summary": "Feature\x00 implemented",
+                "findings": [
+                    {
+                        "severity": "P2",
+                        "file": "src/test.py",
+                        "line": 9,
+                        "description": "Fix\x00 this edge case",
+                    }
+                ],
+                "story_compliance": {"matches_spec": True, "mismatches": []},
+                "test_coverage": {"adequate": True, "gaps": []},
+            }
+        )
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        pr_bodies: list[str] = []
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:3] == ["git", "rev-list", "--count"]:
+                return _make_subprocess_result(0, stdout="1\n")
+            result = _make_subprocess_result(0, stdout="https://github.com/x/y/pull/11")
+            if isinstance(cmd, list):
+                for i, arg in enumerate(cmd):
+                    if arg == "--body" and i + 1 < len(cmd):
+                        pr_bodies.append(cmd[i + 1])
+            return result
+
+        with patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run):
+            result = _create_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        assert "\x00" not in pr_bodies[0]
+        assert "Feature implemented" in pr_bodies[0]
+        assert "Fix this edge case" in pr_bodies[0]
+        assert review.sanitization_audit == {
+            "summary": {"sanitized_chars": 1},
+            "findings[0].description": {"sanitized_chars": 1},
+        }
 
 
 # ── Escalate on merge-pr failure ─────────────────────────────────

--- a/tests/test_coord_merge_step_state.py
+++ b/tests/test_coord_merge_step_state.py
@@ -511,6 +511,42 @@ class TestMergePrStepStateResume:
         assert loaded.error is not None
         assert "fetch" in loaded.error.lower() or "network" in loaded.error.lower()
 
+    def test_create_pr_failure_records_strand_state(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        with (
+            patch(
+                "theforge.coordinator.completion._step_fetch_rebase",
+                return_value={"success": True},
+            ),
+            patch(
+                "theforge.coordinator.completion._step_force_push",
+                return_value={"success": True},
+            ),
+            patch(
+                "theforge.coordinator.completion._step_create_pr",
+                return_value={
+                    "success": False,
+                    "error": "embedded null byte",
+                    "pr_url": None,
+                    "error_context": {"exception_class": "ValueError"},
+                },
+            ),
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is False
+        assert result["branch"] == "forge/test-task"
+        assert result["strand_state"]["branch"] == "forge/test-task"
+        assert "gh pr create" in result["strand_state"]["next_action"]
+        assert result["error_context"]["exception_class"] == "ValueError"
+
     def test_step_outcomes_logged_via_pr_log(self, tmp_path: Path) -> None:
         """Each step should log its outcome via _pr_log.info for independent auditability."""
         config = _make_config(tmp_path)

--- a/tests/test_http_timeout.py
+++ b/tests/test_http_timeout.py
@@ -260,6 +260,48 @@ class TestGhSubprocessTimeout:
             result = _create_pr(config, task, "feat/test-branch", parsed_review, state)
 
         assert result["success"] is False
+        assert result["error_context"]["exception_class"] == "TimeoutExpired"
+        assert "gh pr create" in result["error_context"]["command"]
+        assert "Traceback" in result["error_context"]["traceback"]
+
+    def test_gh_non_nul_exception_captures_traceback_and_context(self, tmp_path):
+        """Non-NUL PR creation exceptions include traceback and command context."""
+        from coord_test_helpers import _make_config, _make_task
+
+        from theforge.coordinator.completion import _create_pr
+        from theforge.coordinator.state import CoordinatorState
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = CoordinatorState()
+        parsed_review = _make_parsed_review()
+
+        worktree = tmp_path / task.slug
+        worktree.mkdir(parents=True)
+
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            if cmd[0] == "git" and "rev-list" in cmd:
+                result.stdout = "1\n"
+                return result
+            if cmd[0] == "gh" and "list" in cmd:
+                result.stdout = "[]"
+                return result
+            if cmd[0] == "gh" and "create" in cmd:
+                raise RuntimeError("boom")
+            result.stdout = ""
+            return result
+
+        with patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run):
+            result = _create_pr(config, task, "feat/test-branch", parsed_review, state)
+
+        assert result["success"] is False
+        assert result["error_context"]["exception_class"] == "RuntimeError"
+        assert result["error_context"]["exception_args"] == ["'boom'"]
+        assert "gh pr create" in result["error_context"]["command"]
+        assert "RuntimeError: boom" in result["error_context"]["traceback"]
 
 
 class TestNotifyBackendsTimeout:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -12,6 +12,7 @@ from theforge.review import (
     findings_to_markdown,
     merge_review_results,
     parse_plan_review_output,
+    parse_review_json,
     parse_review_output,
 )
 
@@ -116,6 +117,31 @@ class TestParseReviewOutput:
         )
         result = parse_review_output(text)
         assert result.verdict == "APPROVE"
+
+    def test_parse_review_json_sanitizes_summary_and_findings(self):
+        result = parse_review_json(
+            {
+                "verdict": "APPROVE",
+                "summary": "Safe\x00 summary\x07",
+                "findings": [
+                    {
+                        "severity": "P2",
+                        "file": "src/batch.py",
+                        "line": 5,
+                        "description": "Bad\x00 finding\x1f text",
+                    }
+                ],
+                "story_compliance": {"matches_spec": True, "mismatches": []},
+                "test_coverage": {"adequate": True, "gaps": []},
+            }
+        )
+
+        assert result.summary == "Safe summary"
+        assert result.findings[0].description == "Bad finding text"
+        assert result.sanitization_audit == {
+            "summary": {"sanitized_chars": 2},
+            "findings[0].description": {"sanitized_chars": 2},
+        }
 
 
 class TestFindingsToMarkdown:


### PR DESCRIPTION
## Summary

Sanitizer lands at the parse boundary, exception context flows through all merge steps, strand state is recorded — all six ACs met cleanly.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.43
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/review.py:139`** ReviewFinding.suggestion is not passed through sanitize_llm_text. findings_to_markdown likely includes suggestion in the PR body, leaving a residual path for control characters to reach subprocess args. The spec ACs name only summary and description, so this is not a blocking violation, but it is the same class of risk.

## Story

Merge automation crashes with bare 'embedded null byte' when LLM-produced PR body contains NUL — strands dev work without traceback or offending-input capture (GitHub Issue #1256)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1256