### PR TITLE
Remove hardcoded plan_agent_review.pool — let adaptive size the reviewer pool by complexity (#1268)

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -13,18 +13,7 @@ models:
 
 plan_agent_review:
   enabled: true
-  pool:
-    - name: plan-reviewer-deepseek
-      provider: deepseek
-      model: deepseek-reasoner
-      budget_usd: 1.00
-      timeout_seconds: 600
-    - name: plan-reviewer-gemini
-      provider: google
-      model: gemini-3.1-pro-preview
-      budget_usd: 1.00
-      timeout_seconds: 600
-      
+
 provider_fallbacks:
   openai:
     model: gpt-5.4


### PR DESCRIPTION
Closes #1268.

Removes the hardcoded `plan_agent_review.pool` block from `forge.yaml`. Keeps `plan_agent_review.enabled: true`. Lets adaptive routing pick plan-review reviewers per complexity tier instead of pinning deepseek-reasoner + gemini-3.1-pro-preview on every story regardless of size.

Config-only change. No code or test impact.