### PR TITLE
Advisory convention violations are recorded in per-run audit only — never aggregated, never surfaced, accumulating silently in a black hole

### DIFF
--- a/src/theforge/advisory_conventions.py
+++ b/src/theforge/advisory_conventions.py
@@ -1,0 +1,247 @@
+"""Rolling aggregation and surfacing for advisory convention violations."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .config import ForgeConfig
+
+_LINE_COUNT_RULES = frozenset({"max_module_lines", "max_test_file_lines"})
+_DETAIL_RE = re.compile(r"^(?P<file>.+) has (?P<line_count>\d+) lines \(limit (?P<limit>\d+)\)$")
+
+
+def advisory_artifact_path(config: ForgeConfig) -> Path:
+    """Return the local rolling advisory artifact path."""
+    return config.project_root / config.conventions_advisory.artifact_path
+
+
+def load_advisory_summary(config: ForgeConfig) -> dict[str, Any]:
+    """Load the local rolling advisory artifact, returning an empty structure on failure."""
+    artifact_path = advisory_artifact_path(config)
+    if not artifact_path.exists():
+        return {"entries": {}}
+    try:
+        with open(artifact_path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except (OSError, yaml.YAMLError):
+        return {"entries": {}}
+    if not isinstance(data, dict):
+        return {"entries": {}}
+    entries = data.get("entries")
+    if not isinstance(entries, dict):
+        data["entries"] = {}
+    return data
+
+
+def noteworthy_advisory_entries(config: ForgeConfig) -> list[dict[str, Any]]:
+    """Return current notable advisory entries sorted by largest absolute gap."""
+    entries = list(load_advisory_summary(config).get("entries", {}).values())
+    threshold = config.conventions_advisory.noteworthy_threshold_percent
+    notable = [
+        entry
+        for entry in entries
+        if isinstance(entry, dict)
+        and _entry_percent_over(entry) is not None
+        and _entry_percent_over(entry) >= threshold
+    ]
+    notable.sort(
+        key=lambda entry: (
+            int(entry.get("gap") or 0),
+            float(_entry_percent_over(entry) or 0.0),
+            str(entry.get("file") or ""),
+        ),
+        reverse=True,
+    )
+    return notable[: config.conventions_advisory.summary_top_n]
+
+
+def update_advisory_violations(
+    config: ForgeConfig,
+    violations: list[dict[str, Any]],
+    *,
+    observed_at: dt.datetime,
+    run_id: str | None,
+    story_slug: str | None,
+) -> dict[str, Any]:
+    """Update the rolling artifact from the current advisory convention scan."""
+    advisory_cfg = config.conventions_advisory
+    observed_entries: dict[str, dict[str, Any]] = {}
+    existing = load_advisory_summary(config)
+    existing_entries = existing.get("entries", {})
+    if not isinstance(existing_entries, dict):
+        existing_entries = {}
+
+    observed_at_str = observed_at.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    newly_filed: list[dict[str, Any]] = []
+
+    for violation in violations:
+        normalized = _normalize_advisory_violation(violation)
+        if normalized is None:
+            continue
+        key = _entry_key(normalized["rule"], normalized["file"])
+        prior = existing_entries.get(key) if isinstance(existing_entries.get(key), dict) else None
+        entry = {
+            "rule": normalized["rule"],
+            "file": normalized["file"],
+            "detail": normalized["detail"],
+            "line_count": normalized["line_count"],
+            "limit": normalized["limit"],
+            "gap": normalized["gap"],
+            "first_seen": prior.get("first_seen") if prior else observed_at_str,
+            "last_seen": observed_at_str,
+            "last_run_id": run_id,
+            "last_story_slug": story_slug,
+        }
+        issue_block = (
+            dict(prior.get("issue", {})) if prior and isinstance(prior.get("issue"), dict) else {}
+        )
+        if issue_block:
+            entry["issue"] = issue_block
+        observed_entries[key] = entry
+
+    for key, entry in observed_entries.items():
+        maybe_issue = _maybe_file_issue(config, entry)
+        if maybe_issue is not None:
+            entry["issue"] = maybe_issue
+            newly_filed.append({"key": key, **maybe_issue})
+
+    artifact_data = {
+        "updated_at": observed_at_str,
+        "entries": observed_entries,
+    }
+    _write_yaml_atomic(advisory_artifact_path(config), artifact_data)
+    if advisory_cfg.commit_shared_artifact:
+        _write_yaml_atomic(config.project_root / advisory_cfg.shared_artifact_path, artifact_data)
+
+    return {
+        "path": str(advisory_artifact_path(config)),
+        "entry_count": len(observed_entries),
+        "newly_filed_issues": newly_filed,
+        "entries": observed_entries,
+    }
+
+
+def _normalize_advisory_violation(violation: dict[str, Any]) -> dict[str, Any] | None:
+    rule = violation.get("rule")
+    file = violation.get("file")
+    detail = violation.get("detail")
+    blocking = violation.get("blocking", True)
+    if blocking or rule not in _LINE_COUNT_RULES:
+        return None
+    if not isinstance(rule, str) or not isinstance(file, str) or not isinstance(detail, str):
+        return None
+    parsed = _DETAIL_RE.match(detail.strip())
+    if parsed is None:
+        return None
+    line_count = int(parsed.group("line_count"))
+    limit = int(parsed.group("limit"))
+    return {
+        "rule": rule,
+        "file": file,
+        "detail": detail,
+        "line_count": line_count,
+        "limit": limit,
+        "gap": max(0, line_count - limit),
+    }
+
+
+def _entry_key(rule: str, file: str) -> str:
+    return json.dumps([rule, file], separators=(",", ":"))
+
+
+def _entry_percent_over(entry: dict[str, Any]) -> float | None:
+    try:
+        gap = float(entry["gap"])
+        limit = float(entry["limit"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if limit <= 0:
+        return None
+    return (gap / limit) * 100.0
+
+
+def _maybe_file_issue(config: ForgeConfig, entry: dict[str, Any]) -> dict[str, Any] | None:
+    issue_cfg = config.conventions_advisory.issue_filing
+    if not issue_cfg.enabled:
+        return entry.get("issue") if isinstance(entry.get("issue"), dict) else None
+    if isinstance(entry.get("issue"), dict):
+        return entry["issue"]
+    percent_over = _entry_percent_over(entry)
+    if percent_over is None or percent_over < issue_cfg.threshold_percent:
+        return None
+
+    title = f"Advisory convention debt: {entry['rule']} in {entry['file']}"
+    body_lines = [
+        "## Advisory convention violation",
+        "",
+        f"- Rule: `{entry['rule']}`",
+        f"- File: `{entry['file']}`",
+        f"- Detail: {entry['detail']}",
+        f"- Last observed run: `{entry.get('last_run_id') or 'unknown'}`",
+    ]
+    if entry.get("last_story_slug"):
+        body_lines.append(f"- Observed while running: `{entry['last_story_slug']}`")
+    body_lines.extend(
+        [
+            "",
+            "## Audit excerpt",
+            "",
+            "```yaml",
+            yaml.safe_dump(
+                {
+                    "rule": entry["rule"],
+                    "file": entry["file"],
+                    "detail": entry["detail"],
+                    "blocking": False,
+                },
+                sort_keys=False,
+            ).strip(),
+            "```",
+        ]
+    )
+    command = [
+        "gh",
+        "issue",
+        "create",
+        "--title",
+        title,
+        "--body",
+        "\n".join(body_lines),
+        "--label",
+        issue_cfg.label,
+    ]
+    if issue_cfg.milestone:
+        command.extend(["--milestone", issue_cfg.milestone])
+    proc = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        cwd=str(config.project_root),
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    issue_url = proc.stdout.strip() or None
+    return {
+        "title": title,
+        "url": issue_url,
+        "label": issue_cfg.label,
+        "milestone": issue_cfg.milestone,
+        "filed_at": entry["last_seen"],
+    }
+
+
+def _write_yaml_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, default_flow_style=False, sort_keys=False)
+    tmp_path.replace(path)

--- a/src/theforge/advisory_conventions.py
+++ b/src/theforge/advisory_conventions.py
@@ -117,7 +117,7 @@ def update_advisory_violations(
         "entries": observed_entries,
     }
     _write_yaml_atomic(advisory_artifact_path(config), artifact_data)
-    if advisory_cfg.commit_shared_artifact:
+    if advisory_cfg.commit_shared_artifact and advisory_cfg.shared_artifact_path:
         _write_yaml_atomic(config.project_root / advisory_cfg.shared_artifact_path, artifact_data)
 
     return {

--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -33,6 +33,8 @@ from .models import (
 )
 from .types import (
     SUPPORTED_PROVIDERS,
+    AdvisoryConventionsConfig,
+    AdvisoryIssueFilingConfig,
     ApiFallbackConfig,
     AssignmentConfig,
     BackendConfig,
@@ -59,6 +61,8 @@ from .types import (
 __all__ = [
     # types
     "AgentDef",
+    "AdvisoryConventionsConfig",
+    "AdvisoryIssueFilingConfig",
     "ApiFallbackConfig",
     "AssignmentConfig",
     "BackendConfig",

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -35,6 +35,8 @@ from .role_derivation import derive_roles
 from .secrets import _parse_notifications
 from .types import (
     SUPPORTED_PROVIDERS,
+    AdvisoryConventionsConfig,
+    AdvisoryIssueFilingConfig,
     ApiFallbackConfig,
     ContextConfig,
     FindingClassifierConfig,
@@ -698,8 +700,10 @@ def load_config(config_path: Path) -> ForgeConfig:
         review_budget=int(context_data.get("review_budget", ContextConfig.review_budget)),
     )
 
+    conventions_raw = raw.get("conventions", {})
+
     # Conventions config — soft
-    conventions_soft_raw = raw.get("conventions", {}).get("soft", [])
+    conventions_soft_raw = conventions_raw.get("soft", [])
     if not isinstance(conventions_soft_raw, list):
         raise ValueError(
             "forge.yaml 'conventions.soft' must be a list of strings,"
@@ -711,7 +715,7 @@ def load_config(config_path: Path) -> ForgeConfig:
     conventions_soft_list: list[str] = conventions_soft_raw
 
     # Conventions config — hard
-    conventions_hard_raw = raw.get("conventions", {}).get("hard", None)
+    conventions_hard_raw = conventions_raw.get("hard", None)
     if conventions_hard_raw is None:
         conventions_hard_cfg: HardConventionsConfig | None = None
     else:
@@ -762,6 +766,105 @@ def load_config(config_path: Path) -> ForgeConfig:
             allowed_root_files=tuple(_allowed_root_files),
         )
 
+    conventions_advisory_raw = conventions_raw.get("advisory", {})
+    if not isinstance(conventions_advisory_raw, dict):
+        raise ValueError(
+            "forge.yaml 'conventions.advisory' must be a mapping,"
+            f" got {conventions_advisory_raw!r}"
+        )
+
+    _artifact_path = conventions_advisory_raw.get(
+        "artifact_path", AdvisoryConventionsConfig.artifact_path
+    )
+    _summary_top_n = conventions_advisory_raw.get(
+        "summary_top_n", AdvisoryConventionsConfig.summary_top_n
+    )
+    _noteworthy_threshold = conventions_advisory_raw.get(
+        "noteworthy_threshold_percent", AdvisoryConventionsConfig.noteworthy_threshold_percent
+    )
+    _commit_shared = conventions_advisory_raw.get(
+        "commit_shared_artifact", AdvisoryConventionsConfig.commit_shared_artifact
+    )
+    _shared_artifact_path = conventions_advisory_raw.get(
+        "shared_artifact_path", AdvisoryConventionsConfig.shared_artifact_path
+    )
+    _issue_filing_raw = conventions_advisory_raw.get("issue_filing", {})
+
+    if not isinstance(_artifact_path, str) or not _artifact_path.strip():
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.artifact_path' must be a non-empty string,"
+            f" got {_artifact_path!r}"
+        )
+    if not isinstance(_summary_top_n, int) or _summary_top_n < 1:
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.summary_top_n' must be an int >= 1,"
+            f" got {_summary_top_n!r}"
+        )
+    if not isinstance(_noteworthy_threshold, (int, float)) or _noteworthy_threshold < 0:
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.noteworthy_threshold_percent' must be a number >= 0,"
+            f" got {_noteworthy_threshold!r}"
+        )
+    if not isinstance(_commit_shared, bool):
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.commit_shared_artifact' must be a bool,"
+            f" got {_commit_shared!r}"
+        )
+    if not isinstance(_shared_artifact_path, str) or not _shared_artifact_path.strip():
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.shared_artifact_path' must be a non-empty string,"
+            f" got {_shared_artifact_path!r}"
+        )
+    if not isinstance(_issue_filing_raw, dict):
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.issue_filing' must be a mapping,"
+            f" got {_issue_filing_raw!r}"
+        )
+
+    _issue_filing_enabled = _issue_filing_raw.get("enabled", AdvisoryIssueFilingConfig.enabled)
+    _issue_filing_threshold = _issue_filing_raw.get(
+        "threshold_percent", AdvisoryIssueFilingConfig.threshold_percent
+    )
+    _issue_filing_label = _issue_filing_raw.get("label", AdvisoryIssueFilingConfig.label)
+    _issue_filing_milestone = _issue_filing_raw.get(
+        "milestone", AdvisoryIssueFilingConfig.milestone
+    )
+
+    if not isinstance(_issue_filing_enabled, bool):
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.issue_filing.enabled' must be a bool,"
+            f" got {_issue_filing_enabled!r}"
+        )
+    if not isinstance(_issue_filing_threshold, (int, float)) or _issue_filing_threshold < 0:
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.issue_filing.threshold_percent'"
+            f" must be a number >= 0, got {_issue_filing_threshold!r}"
+        )
+    if not isinstance(_issue_filing_label, str) or not _issue_filing_label.strip():
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.issue_filing.label' must be a non-empty string,"
+            f" got {_issue_filing_label!r}"
+        )
+    if _issue_filing_milestone is not None and not isinstance(_issue_filing_milestone, str):
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.issue_filing.milestone' must be a string or null,"
+            f" got {_issue_filing_milestone!r}"
+        )
+
+    conventions_advisory_cfg = AdvisoryConventionsConfig(
+        artifact_path=_artifact_path,
+        summary_top_n=_summary_top_n,
+        noteworthy_threshold_percent=float(_noteworthy_threshold),
+        commit_shared_artifact=_commit_shared,
+        shared_artifact_path=_shared_artifact_path,
+        issue_filing=AdvisoryIssueFilingConfig(
+            enabled=_issue_filing_enabled,
+            threshold_percent=float(_issue_filing_threshold),
+            label=_issue_filing_label,
+            milestone=_issue_filing_milestone,
+        ),
+    )
+
     _fc_raw = raw.get("finding_classifier", {})
     _allow_bypass = _fc_raw.get("allow_net_new_bypass", False)
     if not isinstance(_allow_bypass, bool):
@@ -806,6 +909,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         dev_profile_is_default=_dev_profile_is_default,
         conventions_hard=conventions_hard_cfg,
         conventions_soft=conventions_soft_list,
+        conventions_advisory=conventions_advisory_cfg,
         finding_classifier=finding_classifier_cfg,
         stuck_detection=stuck_detection_cfg,
         models_budget_usd=budget_usd_val,

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -810,10 +810,18 @@ def load_config(config_path: Path) -> ForgeConfig:
             "forge.yaml 'conventions.advisory.commit_shared_artifact' must be a bool,"
             f" got {_commit_shared!r}"
         )
-    if not isinstance(_shared_artifact_path, str) or not _shared_artifact_path.strip():
+    if _shared_artifact_path is not None and (
+        not isinstance(_shared_artifact_path, str) or not _shared_artifact_path.strip()
+    ):
         raise ValueError(
-            "forge.yaml 'conventions.advisory.shared_artifact_path' must be a non-empty string,"
+            "forge.yaml 'conventions.advisory.shared_artifact_path' must be "
+            "a non-empty string or null,"
             f" got {_shared_artifact_path!r}"
+        )
+    if _commit_shared and _shared_artifact_path is None:
+        raise ValueError(
+            "forge.yaml 'conventions.advisory.shared_artifact_path' must be set when "
+            "'commit_shared_artifact' is true"
         )
     if not isinstance(_issue_filing_raw, dict):
         raise ValueError(
@@ -856,7 +864,9 @@ def load_config(config_path: Path) -> ForgeConfig:
         summary_top_n=_summary_top_n,
         noteworthy_threshold_percent=float(_noteworthy_threshold),
         commit_shared_artifact=_commit_shared,
-        shared_artifact_path=_shared_artifact_path,
+        shared_artifact_path=(
+            _shared_artifact_path.strip() if isinstance(_shared_artifact_path, str) else None
+        ),
         issue_filing=AdvisoryIssueFilingConfig(
             enabled=_issue_filing_enabled,
             threshold_percent=float(_issue_filing_threshold),

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -462,7 +462,7 @@ class AdvisoryConventionsConfig:
     summary_top_n: int = 10
     noteworthy_threshold_percent: float = 10.0
     commit_shared_artifact: bool = False
-    shared_artifact_path: str = "docs/advisory-conventions.yaml"
+    shared_artifact_path: str | None = None
     issue_filing: AdvisoryIssueFilingConfig = field(default_factory=AdvisoryIssueFilingConfig)
 
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -445,6 +445,28 @@ class HardConventionsConfig:
 
 
 @dataclass(frozen=True)
+class AdvisoryIssueFilingConfig:
+    """Opt-in GitHub issue filing for advisory convention debt."""
+
+    enabled: bool = False
+    threshold_percent: float = 25.0
+    label: str = "refactor-debt"
+    milestone: str | None = None
+
+
+@dataclass(frozen=True)
+class AdvisoryConventionsConfig:
+    """Aggregation and surfacing settings for non-blocking convention debt."""
+
+    artifact_path: str = ".forge/conventions/advisory.yaml"
+    summary_top_n: int = 10
+    noteworthy_threshold_percent: float = 10.0
+    commit_shared_artifact: bool = False
+    shared_artifact_path: str = "docs/advisory-conventions.yaml"
+    issue_filing: AdvisoryIssueFilingConfig = field(default_factory=AdvisoryIssueFilingConfig)
+
+
+@dataclass(frozen=True)
 class ForgeConfig:
     """Top-level orchestrator configuration loaded from forge.yaml."""
 
@@ -482,6 +504,9 @@ class ForgeConfig:
     )
     conventions_hard: HardConventionsConfig | None = None  # None = no section = no checks
     conventions_soft: list[str] = field(default_factory=list)  # [] = no soft conventions
+    conventions_advisory: AdvisoryConventionsConfig = field(
+        default_factory=AdvisoryConventionsConfig
+    )
     finding_classifier: FindingClassifierConfig = field(default_factory=FindingClassifierConfig)
     stuck_detection: StuckDetectionConfig = field(default_factory=StuckDetectionConfig)
     models_budget_usd: float | None = None  # set when models: key is used (v0.8 path)

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import dataclasses
+import datetime as dt
 import subprocess
 import time
 import types
@@ -11,6 +12,7 @@ from collections.abc import Callable
 from enum import Enum, auto
 from pathlib import Path
 
+from theforge.advisory_conventions import update_advisory_violations
 from theforge.config import ForgeConfig
 from theforge.task import TaskStory
 
@@ -120,6 +122,30 @@ def _check_conventions_parallel(
         all_v = [types.SimpleNamespace(**d) for d in result["violations"]]
         net_v = all_v
     return all_v, net_v
+
+
+def _record_advisory_convention_state(
+    config: ForgeConfig,
+    task: TaskStory,
+    state: CoordinatorState,
+    violations: list[dict],
+    logger: StructuredLogger | None,
+) -> None:
+    """Persist rolling advisory convention state for the current scan."""
+    advisory_result = update_advisory_violations(
+        config,
+        violations,
+        observed_at=dt.datetime.now(dt.timezone.utc),
+        run_id=state.run_id,
+        story_slug=task.slug,
+    )
+    if logger:
+        logger._safe_emit(
+            "convention_advisory_state",
+            artifact_path=advisory_result["path"],
+            entry_count=advisory_result["entry_count"],
+            newly_filed_issues=advisory_result["newly_filed_issues"],
+        )
 
 
 def _build_timeout_rca_packet(
@@ -274,6 +300,17 @@ def _run_validate_phase(
         {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
         for v in _cv_violations
     ]
+    if _cv_result_raw is not None:
+        _record_advisory_convention_state(
+            config,
+            task,
+            state,
+            [
+                {"rule": v.rule, "file": v.file, "detail": v.detail, "blocking": v.blocking}
+                for v in _cv_all
+            ],
+            logger,
+        )
 
     if gate_err:
         is_timeout = "timed out" in (gate_err or "").lower()

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from ..advisory_conventions import noteworthy_advisory_entries
 from ..log_util import _log_line
 from .manifest import ResolvedSprint, SprintManifest, SprintResult
 
@@ -32,6 +33,37 @@ if TYPE_CHECKING:
 
 def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
+
+
+def _build_advisory_summary(config: ForgeConfig | None) -> dict | None:
+    """Return a sprint-summary section for current advisory convention debt."""
+    if config is None:
+        return None
+    entries = noteworthy_advisory_entries(config)
+    if not entries:
+        return {
+            "noteworthy_threshold_percent": (
+                config.conventions_advisory.noteworthy_threshold_percent
+            ),
+            "top_n": config.conventions_advisory.summary_top_n,
+            "entries": [],
+        }
+    return {
+        "noteworthy_threshold_percent": config.conventions_advisory.noteworthy_threshold_percent,
+        "top_n": config.conventions_advisory.summary_top_n,
+        "entries": [
+            {
+                "rule": entry["rule"],
+                "file": entry["file"],
+                "line_count": entry["line_count"],
+                "limit": entry["limit"],
+                "gap": entry["gap"],
+                "last_seen": entry["last_seen"],
+                "first_seen": entry.get("first_seen"),
+            }
+            for entry in entries
+        ],
+    }
 
 
 # ── Sprint-level stable identity ──────────────────────────────────────────────
@@ -540,6 +572,7 @@ def _write_sprint_summary(
     triage_actions_by_ref: "dict[str, str] | None" = None,
     current_story_entries_by_ref: "dict[str, dict] | None" = None,
     story_state: "object | None" = None,
+    config: "ForgeConfig | None" = None,
 ) -> None:
     """Write sprint-summary.yaml to <project_root>/.forge/logs/<sprint-name>/.
 
@@ -848,6 +881,7 @@ def _write_sprint_summary(
             "stopped_reason": result.stopped_reason,
             "ci_break_slug": ci_break_slug,
         },
+        "advisory_convention_violations": _build_advisory_summary(config),
         "stories": spec_entries,
         "skipped": [s.as_dict() if hasattr(s, "as_dict") else dict(s) for s in skipped_issues],
         "iteration_usage_distribution": usage_distribution,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2493,6 +2493,7 @@ def run_sprint(
             },
             current_story_entries_by_ref=current_story_entries_by_ref,
             story_state=_story_state,
+            config=config,
         )
 
     if _state_writer is not None:

--- a/tests/test_advisory_conventions.py
+++ b/tests/test_advisory_conventions.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import subprocess
+from unittest.mock import patch
+
+import yaml
+from coord_test_helpers import _make_config
+
+from theforge.advisory_conventions import load_advisory_summary, update_advisory_violations
+from theforge.config import AdvisoryConventionsConfig, AdvisoryIssueFilingConfig
+
+
+def _violation(
+    *,
+    file: str = "src/theforge/assignment.py",
+    rule: str = "max_module_lines",
+    line_count: int = 965,
+    limit: int = 600,
+) -> dict[str, object]:
+    return {
+        "rule": rule,
+        "file": file,
+        "detail": f"{file} has {line_count} lines (limit {limit})",
+        "blocking": False,
+    }
+
+
+def test_update_advisory_violations_aggregates_and_prunes(tmp_path):
+    config = _make_config(tmp_path)
+    observed_at = dt.datetime(2026, 5, 2, 18, 45, tzinfo=dt.timezone.utc)
+
+    result = update_advisory_violations(
+        config,
+        [_violation()],
+        observed_at=observed_at,
+        run_id="run-1",
+        story_slug="story-1",
+    )
+
+    assert result["entry_count"] == 1
+    artifact = yaml.safe_load(
+        (tmp_path / ".forge" / "conventions" / "advisory.yaml").read_text(encoding="utf-8")
+    )
+    entry = next(iter(artifact["entries"].values()))
+    assert entry["line_count"] == 965
+    assert entry["limit"] == 600
+    assert entry["gap"] == 365
+    assert entry["first_seen"] == "2026-05-02T18:45:00Z"
+    assert entry["last_seen"] == "2026-05-02T18:45:00Z"
+
+    update_advisory_violations(
+        config,
+        [],
+        observed_at=observed_at + dt.timedelta(hours=1),
+        run_id="run-2",
+        story_slug="story-2",
+    )
+    pruned = load_advisory_summary(config)
+    assert pruned["entries"] == {}
+
+
+def test_update_advisory_violations_writes_shared_mirror_when_enabled(tmp_path):
+    config = dataclasses.replace(
+        _make_config(tmp_path),
+        conventions_advisory=AdvisoryConventionsConfig(
+            commit_shared_artifact=True,
+            shared_artifact_path="docs/advisory-conventions.yaml",
+        ),
+    )
+    observed_at = dt.datetime(2026, 5, 2, 18, 45, tzinfo=dt.timezone.utc)
+
+    update_advisory_violations(
+        config,
+        [_violation(file="src/theforge/cli/status.py", line_count=832)],
+        observed_at=observed_at,
+        run_id="run-3",
+        story_slug="story-3",
+    )
+
+    shared_path = tmp_path / "docs" / "advisory-conventions.yaml"
+    assert shared_path.exists()
+    shared = yaml.safe_load(shared_path.read_text(encoding="utf-8"))
+    assert len(shared["entries"]) == 1
+
+
+def test_update_advisory_violations_files_issue_once_when_enabled(tmp_path):
+    config = dataclasses.replace(
+        _make_config(tmp_path),
+        conventions_advisory=AdvisoryConventionsConfig(
+            issue_filing=AdvisoryIssueFilingConfig(
+                enabled=True,
+                threshold_percent=25.0,
+                label="refactor-debt",
+                milestone="v0.12.0",
+            )
+        ),
+    )
+    observed_at = dt.datetime(2026, 5, 2, 18, 45, tzinfo=dt.timezone.utc)
+    gh_result = subprocess.CompletedProcess(
+        args=["gh"],
+        returncode=0,
+        stdout="https://github.com/example/repo/issues/123\n",
+        stderr="",
+    )
+
+    with patch("theforge.advisory_conventions.subprocess.run", return_value=gh_result) as mock_run:
+        update_advisory_violations(
+            config,
+            [_violation()],
+            observed_at=observed_at,
+            run_id="run-4",
+            story_slug="story-4",
+        )
+        update_advisory_violations(
+            config,
+            [_violation(line_count=970)],
+            observed_at=observed_at + dt.timedelta(hours=1),
+            run_id="run-5",
+            story_slug="story-5",
+        )
+
+    assert mock_run.call_count == 1
+    artifact = load_advisory_summary(config)
+    entry = next(iter(artifact["entries"].values()))
+    assert entry["issue"]["url"] == "https://github.com/example/repo/issues/123"
+    assert entry["issue"]["label"] == "refactor-debt"
+    assert entry["issue"]["milestone"] == "v0.12.0"

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -701,6 +701,61 @@ class TestConventionsConfig:
         with pytest.raises(ValueError, match="max_module_lines"):
             load_config(config_path)
 
+    def test_conventions_advisory_defaults(self, tmp_path):
+        """Advisory convention surfacing is enabled with default local-state settings."""
+        config_path = _write_config({"conventions": {"hard": {}}}, tmp_path)
+        config = load_config(config_path)
+        assert config.conventions_advisory.artifact_path == ".forge/conventions/advisory.yaml"
+        assert config.conventions_advisory.summary_top_n == 10
+        assert config.conventions_advisory.noteworthy_threshold_percent == 10.0
+        assert config.conventions_advisory.commit_shared_artifact is False
+        assert config.conventions_advisory.shared_artifact_path == "docs/advisory-conventions.yaml"
+        assert config.conventions_advisory.issue_filing.enabled is False
+        assert config.conventions_advisory.issue_filing.threshold_percent == 25.0
+        assert config.conventions_advisory.issue_filing.label == "refactor-debt"
+
+    def test_conventions_advisory_custom_values(self, tmp_path):
+        """Advisory convention config parses nested summary and issue-filing settings."""
+        config_path = _write_config(
+            {
+                "conventions": {
+                    "advisory": {
+                        "artifact_path": ".forge/custom/advisory.yaml",
+                        "summary_top_n": 3,
+                        "noteworthy_threshold_percent": 12.5,
+                        "commit_shared_artifact": True,
+                        "shared_artifact_path": "docs/custom-advisory.yaml",
+                        "issue_filing": {
+                            "enabled": True,
+                            "threshold_percent": 30,
+                            "label": "debt",
+                            "milestone": "v0.12.0",
+                        },
+                    }
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.conventions_advisory.artifact_path == ".forge/custom/advisory.yaml"
+        assert config.conventions_advisory.summary_top_n == 3
+        assert config.conventions_advisory.noteworthy_threshold_percent == 12.5
+        assert config.conventions_advisory.commit_shared_artifact is True
+        assert config.conventions_advisory.shared_artifact_path == "docs/custom-advisory.yaml"
+        assert config.conventions_advisory.issue_filing.enabled is True
+        assert config.conventions_advisory.issue_filing.threshold_percent == 30.0
+        assert config.conventions_advisory.issue_filing.label == "debt"
+        assert config.conventions_advisory.issue_filing.milestone == "v0.12.0"
+
+    def test_conventions_advisory_invalid_summary_top_n_raises(self, tmp_path):
+        """Invalid advisory summary limits fail closed at config load."""
+        config_path = _write_config(
+            {"conventions": {"advisory": {"summary_top_n": 0}}},
+            tmp_path,
+        )
+        with pytest.raises(ValueError, match="summary_top_n"):
+            load_config(config_path)
+
 
 class TestValidationTestCommand:
     """Tests for validation.test_command config field."""

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -709,7 +709,7 @@ class TestConventionsConfig:
         assert config.conventions_advisory.summary_top_n == 10
         assert config.conventions_advisory.noteworthy_threshold_percent == 10.0
         assert config.conventions_advisory.commit_shared_artifact is False
-        assert config.conventions_advisory.shared_artifact_path == "docs/advisory-conventions.yaml"
+        assert config.conventions_advisory.shared_artifact_path is None
         assert config.conventions_advisory.issue_filing.enabled is False
         assert config.conventions_advisory.issue_filing.threshold_percent == 25.0
         assert config.conventions_advisory.issue_filing.label == "refactor-debt"
@@ -754,6 +754,15 @@ class TestConventionsConfig:
             tmp_path,
         )
         with pytest.raises(ValueError, match="summary_top_n"):
+            load_config(config_path)
+
+    def test_conventions_advisory_commit_shared_requires_explicit_path(self, tmp_path):
+        """Shared advisory mirroring stays opt-in and must not assume a repo layout."""
+        config_path = _write_config(
+            {"conventions": {"advisory": {"commit_shared_artifact": True}}},
+            tmp_path,
+        )
+        with pytest.raises(ValueError, match="shared_artifact_path"):
             load_config(config_path)
 
 

--- a/tests/test_coord_convention_parallel.py
+++ b/tests/test_coord_convention_parallel.py
@@ -129,6 +129,7 @@ class TestConventionParallelCheck:
         assert state.last_review_findings is None
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
+    @patch("theforge.coordinator.validate_phase.update_advisory_violations")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
     @patch("theforge.coordinator.validate_phase._run_gate_full")
     @patch("theforge.coordinator.validate_phase._cu._run_shell")
@@ -139,6 +140,7 @@ class TestConventionParallelCheck:
         mock_shell,
         mock_gate,
         mock_cv,
+        mock_update_advisory,
         mock_telemetry,
         tmp_path,
     ):
@@ -158,6 +160,12 @@ class TestConventionParallelCheck:
         mock_gate.return_value = ("PASS", None, "", "make gate")
         mock_cv.return_value = ([viol], [viol])
         mock_shell.return_value = (True, "")  # clean worktree
+        mock_update_advisory.return_value = {
+            "path": str(tmp_path / ".forge" / "conventions" / "advisory.yaml"),
+            "entry_count": 1,
+            "newly_filed_issues": [],
+            "entries": {},
+        }
 
         outcome, result = _run_validate_phase(
             state,
@@ -179,6 +187,16 @@ class TestConventionParallelCheck:
         assert not state.human_feedback or "convention" not in state.human_feedback.lower()
         # retry_reason is not set to CONVENTION_VIOLATIONS
         assert state.retry_reason != RetryReason.CONVENTION_VIOLATIONS
+        mock_update_advisory.assert_called_once()
+        advisory_payload = mock_update_advisory.call_args.args[1]
+        assert advisory_payload == [
+            {
+                "rule": "max_module_lines",
+                "file": "src/foo.py",
+                "detail": "Module exceeds 500 lines (600 found)",
+                "blocking": False,
+            }
+        ]
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")

--- a/tests/test_sprint_shape_gate_audit.py
+++ b/tests/test_sprint_shape_gate_audit.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 from pathlib import Path
 
 import yaml
+from coord_test_helpers import _make_config
 
+from theforge.config import AdvisoryConventionsConfig
 from theforge.sprint.audit import _write_sprint_audit, _write_sprint_summary
 from theforge.sprint.manifest import ResolvedSprint, SprintResult
 from theforge.sprint.shape_gate import SkippedIssue
@@ -99,6 +102,83 @@ def test_sprint_summary_writes_skipped_issues(tmp_path: Path) -> None:
     assert entry["source"] == "label"
     assert entry["reason_codes"] == ["needs-grooming-label"]
     assert entry["detail"] == "issue carries 'needs-grooming' label"
+
+
+def test_sprint_summary_surfaces_noteworthy_advisory_violations(tmp_path: Path) -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    log_dir = tmp_path / "logs"
+    config = dataclasses.replace(
+        _make_config(tmp_path),
+        conventions_advisory=AdvisoryConventionsConfig(
+            summary_top_n=2,
+            noteworthy_threshold_percent=10.0,
+        ),
+    )
+    advisory_dir = tmp_path / ".forge" / "conventions"
+    advisory_dir.mkdir(parents=True, exist_ok=True)
+    (advisory_dir / "advisory.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "updated_at": "2026-05-02T18:45:00Z",
+                "entries": {
+                    '["max_module_lines","src/theforge/assignment.py"]': {
+                        "rule": "max_module_lines",
+                        "file": "src/theforge/assignment.py",
+                        "detail": "src/theforge/assignment.py has 965 lines (limit 600)",
+                        "line_count": 965,
+                        "limit": 600,
+                        "gap": 365,
+                        "first_seen": "2026-05-02T18:45:00Z",
+                        "last_seen": "2026-05-02T18:45:00Z",
+                    },
+                    '["max_module_lines","src/theforge/cli/sprint.py"]': {
+                        "rule": "max_module_lines",
+                        "file": "src/theforge/cli/sprint.py",
+                        "detail": "src/theforge/cli/sprint.py has 689 lines (limit 600)",
+                        "line_count": 689,
+                        "limit": 600,
+                        "gap": 89,
+                        "first_seen": "2026-05-02T18:45:00Z",
+                        "last_seen": "2026-05-02T19:10:00Z",
+                    },
+                    '["max_module_lines","src/theforge/small.py"]': {
+                        "rule": "max_module_lines",
+                        "file": "src/theforge/small.py",
+                        "detail": "src/theforge/small.py has 605 lines (limit 600)",
+                        "line_count": 605,
+                        "limit": 600,
+                        "gap": 5,
+                        "first_seen": "2026-05-02T18:45:00Z",
+                        "last_seen": "2026-05-02T19:20:00Z",
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _write_sprint_summary(
+        manifest=_make_manifest(),
+        result=_make_result(),
+        canonical_refs=[],
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        sprint_log_dir=log_dir,
+        config=config,
+    )
+
+    summary = yaml.safe_load((log_dir / "sprint-summary.yaml").read_text())
+    advisory = summary["advisory_convention_violations"]
+    assert advisory["noteworthy_threshold_percent"] == 10.0
+    assert advisory["top_n"] == 2
+    assert [entry["file"] for entry in advisory["entries"]] == [
+        "src/theforge/assignment.py",
+        "src/theforge/cli/sprint.py",
+    ]
+    assert advisory["entries"][0]["line_count"] == 965
+    assert advisory["entries"][0]["gap"] == 365
 
 
 def test_sprint_audit_skipped_empty_when_not_supplied(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

All ACs satisfied. Rolling artifact aggregates correctly, sprint summary surfaces advisory debt, issue filing is opt-in and defaults off, .forge/ is gitignored covering AC4. One P2 cosmetic bug in newly_filed reporting when filing is disabled.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.53
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/advisory_conventions.py:109`** When issue_cfg.enabled is False and a prior issue block exists in the entry, _maybe_file_issue returns the existing issue dict (non-None), which causes the caller to append it to newly_filed on every run. Previously-filed issues are reported as 'newly filed' in the log emission and return value even though no new issue was created.

## Story

Advisory convention violations are recorded in per-run audit only — never aggregated, never surfaced, accumulating silently in a black hole (GitHub Issue #1260)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1260