### PR TITLE
Reopen context never enters the sprint contract — dev agents reason from the original issue body and ignore reopen comments

### DIFF
--- a/src/theforge/sprint/reopen_context.py
+++ b/src/theforge/sprint/reopen_context.py
@@ -1,0 +1,174 @@
+"""Helpers for reopen-aware issue contract handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class ReopenContractState:
+    """Derived reopen-contract metadata for a GitHub issue."""
+
+    reopened_at: str | None = None
+    reopened_by: str | None = None
+    reopen_comment_at: str | None = None
+    reopen_comment_author: str | None = None
+    reopen_comment_body: str | None = None
+    body_edited_after_reopen: bool = False
+
+    @property
+    def has_reopen_context(self) -> bool:
+        return self.reopen_comment_body is not None
+
+    @property
+    def has_stale_body(self) -> bool:
+        return self.has_reopen_context and not self.body_edited_after_reopen
+
+
+def analyze_reopen_contract(
+    issue: Mapping[str, Any],
+    timeline: Sequence[Mapping[str, Any]],
+) -> ReopenContractState:
+    """Return reopen-aware contract state from issue JSON plus timeline events."""
+    if str(issue.get("state", "OPEN")).upper() != "OPEN":
+        return ReopenContractState()
+
+    reopened_event = _latest_reopened_event(timeline)
+    if reopened_event is None:
+        return ReopenContractState()
+
+    reopened_at = _coerce_timestamp(reopened_event.get("created_at"))
+    if reopened_at is None:
+        return ReopenContractState()
+
+    comment = _first_reopen_comment(issue.get("comments") or [], reopened_at)
+    return ReopenContractState(
+        reopened_at=reopened_at,
+        reopened_by=_actor_login(reopened_event.get("actor")),
+        reopen_comment_at=_coerce_timestamp(comment.get("createdAt")) if comment else None,
+        reopen_comment_author=_actor_login(comment.get("author")) if comment else None,
+        reopen_comment_body=_comment_body(comment) if comment else None,
+        body_edited_after_reopen=_has_body_edit_after_reopen(timeline, reopened_at),
+    )
+
+
+def append_reopen_context(story_text: str, state: ReopenContractState) -> str:
+    """Append a structured reopen-context block when present."""
+    if not state.has_reopen_context:
+        return story_text
+
+    author = state.reopen_comment_author or state.reopened_by or "unknown"
+    when = state.reopen_comment_at or state.reopened_at or "unknown time"
+    quoted = "\n".join(
+        f"> {line}" if line else ">" for line in state.reopen_comment_body.splitlines()
+    )
+    block = (
+        "## Reopen Context\n\n"
+        f"This issue was reopened on {state.reopened_at or 'unknown time'}.\n"
+        "Operator follow-up comment from "
+        f"{author} at {when} defines the current reopen context:\n\n"
+        f"{quoted}"
+    )
+    return f"{story_text.rstrip()}\n\n{block}\n"
+
+
+def format_reopen_stale_detail(state: ReopenContractState) -> str:
+    """Render the operator-facing stale-contract refusal detail."""
+    when = state.reopen_comment_at or state.reopened_at or "unknown time"
+    author = state.reopen_comment_author or state.reopened_by or "unknown author"
+    return (
+        f"issue reopened with new context in the comment from {when} by {author}; "
+        "reconcile the body before sprinting or pass --force"
+    )
+
+
+def _latest_reopened_event(
+    timeline: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    reopened_events = [
+        event
+        for event in timeline
+        if isinstance(event, Mapping)
+        and str(event.get("event", "")).lower() == "reopened"
+        and _coerce_timestamp(event.get("created_at")) is not None
+    ]
+    if not reopened_events:
+        return None
+    return max(reopened_events, key=lambda event: _coerce_timestamp(event.get("created_at")) or "")
+
+
+def _first_reopen_comment(
+    comments: Sequence[Any],
+    reopened_at: str,
+) -> Mapping[str, Any] | None:
+    candidates: list[Mapping[str, Any]] = []
+    for comment in comments:
+        if not isinstance(comment, Mapping):
+            continue
+        created_at = _coerce_timestamp(comment.get("createdAt"))
+        if created_at is None or created_at < reopened_at:
+            continue
+        body = _comment_body(comment)
+        if body is None:
+            continue
+        candidates.append(comment)
+    if not candidates:
+        return None
+
+    non_bot = [comment for comment in candidates if not _is_bot_actor(comment.get("author"))]
+    pool = non_bot or candidates
+    return min(pool, key=lambda comment: _coerce_timestamp(comment.get("createdAt")) or "")
+
+
+def _has_body_edit_after_reopen(
+    timeline: Sequence[Mapping[str, Any]],
+    reopened_at: str,
+) -> bool:
+    for event in timeline:
+        if not isinstance(event, Mapping):
+            continue
+        if str(event.get("event", "")).lower() != "edited":
+            continue
+        created_at = _coerce_timestamp(event.get("created_at"))
+        if created_at is None or created_at < reopened_at:
+            continue
+        changes = event.get("changes")
+        if isinstance(changes, Mapping) and "body" in changes:
+            return True
+    return False
+
+
+def _comment_body(comment: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(comment, Mapping):
+        return None
+    body = str(comment.get("body", "")).strip()
+    return body or None
+
+
+def _actor_login(actor: Any) -> str | None:
+    if not isinstance(actor, Mapping):
+        return None
+    login = actor.get("login")
+    if isinstance(login, str) and login.strip():
+        return login.strip()
+    return None
+
+
+def _is_bot_actor(actor: Any) -> bool:
+    if not isinstance(actor, Mapping):
+        return False
+    login = str(actor.get("login", "")).strip().lower()
+    actor_type = str(actor.get("type", "")).strip().lower()
+    return actor_type == "bot" or login.endswith("[bot]")
+
+
+def _coerce_timestamp(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -22,8 +22,10 @@ from pathlib import Path
 
 from ..shape_check import Shape, ShapeResult, check
 from ..shape_check.types import Severity
+from .reopen_context import analyze_reopen_contract, format_reopen_stale_detail
 
 NEEDS_GROOMING_LABEL = "needs-grooming"
+REOPENED_STALE_CONTRACT_CODE = "reopened_stale_contract"
 
 # Bot comments from #806b embed machine-readable reason codes on a single
 # line so local re-runs can match the Action's verdict exactly. Accept either
@@ -61,7 +63,7 @@ class ShapeGateResult:
 
 
 def _fetch_issue_detail(number: int, project_root: Path | None) -> dict | None:
-    """Fetch ``{title, body, labels}`` for a single issue via ``gh``.
+    """Fetch issue detail for a single issue via ``gh``.
 
     Returns ``None`` on any fetch failure so callers can decide whether to
     fail-open (leave the issue runnable) or fail-closed.
@@ -74,7 +76,7 @@ def _fetch_issue_detail(number: int, project_root: Path | None) -> dict | None:
                 "view",
                 str(number),
                 "--json",
-                "title,body,labels",
+                "title,body,labels,state,closedAt,stateReason,updatedAt,comments",
             ],
             capture_output=True,
             text=True,
@@ -98,7 +100,42 @@ def _fetch_issue_detail(number: int, project_root: Path | None) -> dict | None:
         "title": data.get("title", "") or "",
         "body": data.get("body", "") or "",
         "labels": label_names,
+        "state": data.get("state", "OPEN"),
+        "closedAt": data.get("closedAt"),
+        "stateReason": data.get("stateReason"),
+        "updatedAt": data.get("updatedAt"),
+        "comments": data.get("comments") or [],
+        "timeline": _fetch_issue_timeline(number, project_root),
     }
+
+
+def _fetch_issue_timeline(number: int, project_root: Path | None) -> list[dict]:
+    """Return raw issue timeline events, or an empty list when unavailable."""
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                f"repos/{{owner}}/{{repo}}/issues/{number}/timeline?per_page=100",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root) if project_root else None,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
 
 
 def _fetch_bot_reason_codes(number: int, project_root: Path | None) -> list[str]:
@@ -243,6 +280,7 @@ def apply_shape_gate(
         labels = detail["labels"]
         title = detail["title"] or title_short
         body = detail["body"]
+        reopen_state = analyze_reopen_contract(detail, detail.get("timeline") or [])
         local = check(
             title,
             body,
@@ -263,6 +301,18 @@ def apply_shape_gate(
                         local,
                         fallback=f"issue carries '{NEEDS_GROOMING_LABEL}' label",
                     ),
+                )
+            )
+            continue
+
+        if reopen_state.has_stale_body:
+            skipped.append(
+                SkippedIssue(
+                    issue_number=number,
+                    reason_codes=(REOPENED_STALE_CONTRACT_CODE,),
+                    source="local_check",
+                    title=title_short,
+                    detail=format_reopen_stale_detail(reopen_state),
                 )
             )
             continue

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -18,6 +18,7 @@ from ..shape_check.heuristics import (
 )
 from ..task import ALLOW_MUTATE_FORGE_YAML_KEY, RECOGNIZED_STORY_TYPES, StoryTypeError, TaskStory
 from .manifest import _build_task_from_story
+from .reopen_context import analyze_reopen_contract, append_reopen_context
 
 if TYPE_CHECKING:
     from ..config import ForgeConfig
@@ -151,18 +152,8 @@ class GitHubIssueSource:
             return {}
         return metadata
 
-    def _fetch_issue_blockers(self, number: int, project_root: Path) -> list[int]:
-        """Return issue numbers that block this issue.
-
-        Best-effort: tries GitHub's timeline API first, then falls back to issue-body
-        text patterns. Native relationship payloads have varied over time, so the
-        parser accepts several candidate keys and event names.
-        """
-        blockers = self._fetch_issue_blockers_from_timeline(number, project_root)
-        return sorted(blockers)
-
-    def _fetch_issue_blockers_from_timeline(self, number: int, project_root: Path) -> set[int]:
-        """Return blocker issue numbers from the GitHub issue timeline."""
+    def _fetch_issue_timeline(self, number: int, project_root: Path) -> list[dict]:
+        """Return raw GitHub timeline events for an issue."""
         try:
             proc = subprocess.run(
                 [
@@ -178,23 +169,36 @@ class GitHubIssueSource:
                 timeout=30,
             )
         except (subprocess.TimeoutExpired, OSError):
-            return set()
+            return []
 
         if proc.returncode != 0:
-            return set()
+            return []
 
         try:
             data = json.loads(proc.stdout)
         except json.JSONDecodeError:
-            return set()
+            return []
 
         if not isinstance(data, list):
-            return set()
+            return []
+        return [item for item in data if isinstance(item, dict)]
 
+    def _fetch_issue_blockers(self, number: int, project_root: Path) -> list[int]:
+        """Return issue numbers that block this issue.
+
+        Best-effort: tries GitHub's timeline API first, then falls back to issue-body
+        text patterns. Native relationship payloads have varied over time, so the
+        parser accepts several candidate keys and event names.
+        """
+        blockers = self._fetch_issue_blockers_from_timeline(
+            self._fetch_issue_timeline(number, project_root)
+        )
+        return sorted(blockers)
+
+    def _fetch_issue_blockers_from_timeline(self, timeline: list[dict]) -> set[int]:
+        """Return blocker issue numbers from the GitHub issue timeline."""
         blockers: set[int] = set()
-        for item in data:
-            if not isinstance(item, dict):
-                continue
+        for item in timeline:
             event = str(item.get("event", "")).lower()
             if "blocked" not in event or "by" not in event or "unblock" in event:
                 continue
@@ -289,7 +293,14 @@ class GitHubIssueSource:
         number = int(ref)
         try:
             proc = subprocess.run(
-                ["gh", "issue", "view", str(number), "--json", "title,body,state,labels"],
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(number),
+                    "--json",
+                    "title,body,state,labels,closedAt,stateReason,updatedAt,comments",
+                ],
                 capture_output=True,
                 text=True,
                 cwd=str(project_root),
@@ -314,7 +325,9 @@ class GitHubIssueSource:
         title = data.get("title", f"Issue #{number}")
         body = data.get("body", "")
         metadata = self._parse_issue_metadata(body)
-        blockers = self._fetch_issue_blockers(number, project_root)
+        timeline = self._fetch_issue_timeline(number, project_root)
+        reopen_state = analyze_reopen_contract(data, timeline)
+        blockers = sorted(self._fetch_issue_blockers_from_timeline(timeline))
         if not blockers:
             blockers = self._parse_issue_blockers_from_body_metadata(body)
         blocker_slugs = [f"issue-{blocker}" for blocker in blockers]
@@ -354,7 +367,7 @@ class GitHubIssueSource:
             name=title,
             story_path=None,
             slug=slug,
-            story_text=body,
+            story_text=append_reopen_context(body, reopen_state),
             depends_on=blocker_slugs,
             inferred_dependencies=blocker_slugs,
             dependency_warnings=dependency_warnings,

--- a/tests/test_sprint_shape_gate.py
+++ b/tests/test_sprint_shape_gate.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from theforge.sprint.shape_gate import (
     NEEDS_GROOMING_LABEL,
+    REOPENED_STALE_CONTRACT_CODE,
     ShapeGateResult,
     SkippedIssue,
     _fetch_bot_reason_codes,
@@ -132,6 +133,76 @@ def test_local_check_allows_runnable_issue(tmp_path: Path) -> None:
     assert result.skipped == []
 
 
+def test_reopened_issue_with_stale_body_is_skipped(tmp_path: Path) -> None:
+    issues = [{"number": 55, "title": "Reopened"}]
+
+    def fetch(_number, _project_root):
+        return {
+            "title": "Reopened",
+            "body": _RUNNABLE_BODY,
+            "labels": ["bug"],
+            "state": "OPEN",
+            "comments": [
+                {
+                    "author": {"login": "operator"},
+                    "body": "The original close only covered half the work.",
+                    "createdAt": "2026-05-02T12:30:00Z",
+                }
+            ],
+            "timeline": [
+                {
+                    "event": "reopened",
+                    "created_at": "2026-05-02T12:00:00Z",
+                    "actor": {"login": "operator"},
+                }
+            ],
+        }
+
+    result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
+
+    assert result.runnable == []
+    assert len(result.skipped) == 1
+    entry = result.skipped[0]
+    assert entry.reason_codes == (REOPENED_STALE_CONTRACT_CODE,)
+    assert "reconcile the body before sprinting or pass --force" in entry.detail
+
+
+def test_reopened_issue_with_body_edit_after_reopen_is_runnable(tmp_path: Path) -> None:
+    issues = [{"number": 56, "title": "Reconciled"}]
+
+    def fetch(_number, _project_root):
+        return {
+            "title": "Reconciled",
+            "body": _RUNNABLE_BODY,
+            "labels": ["enhancement"],
+            "state": "OPEN",
+            "comments": [
+                {
+                    "author": {"login": "operator"},
+                    "body": "Need one more follow-up change.",
+                    "createdAt": "2026-05-02T12:30:00Z",
+                }
+            ],
+            "timeline": [
+                {
+                    "event": "reopened",
+                    "created_at": "2026-05-02T12:00:00Z",
+                    "actor": {"login": "operator"},
+                },
+                {
+                    "event": "edited",
+                    "created_at": "2026-05-02T13:00:00Z",
+                    "changes": {"body": {"from": "old body"}},
+                },
+            ],
+        }
+
+    result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
+
+    assert result.runnable == issues
+    assert result.skipped == []
+
+
 # ── Force override ─────────────────────────────────────────────────────────
 
 
@@ -146,11 +217,7 @@ def test_force_override_returns_all_issues_runnable_but_keeps_skipped_list(
     def fetch(number, _project_root):
         if number == 1:
             return {"title": "Good", "body": _RUNNABLE_BODY, "labels": ["enhancement"]}
-        return {
-            "title": "Flagged",
-            "body": _RUNNABLE_BODY,
-            "labels": [NEEDS_GROOMING_LABEL],
-        }
+        return {"title": "Flagged", "body": _RUNNABLE_BODY, "labels": [NEEDS_GROOMING_LABEL]}
 
     result = apply_shape_gate(
         issues,
@@ -165,6 +232,38 @@ def test_force_override_returns_all_issues_runnable_but_keeps_skipped_list(
     assert len(result.skipped) == 1
     assert result.skipped[0].issue_number == 2
     assert result.skipped[0].source == "label"
+
+
+def test_force_override_keeps_reopened_stale_contract_warning(tmp_path: Path) -> None:
+    issues = [{"number": 57, "title": "Reopened"}]
+
+    def fetch(_number, _project_root):
+        return {
+            "title": "Reopened",
+            "body": _RUNNABLE_BODY,
+            "labels": ["enhancement"],
+            "state": "OPEN",
+            "comments": [
+                {
+                    "author": {"login": "operator"},
+                    "body": "Still missing the reopen follow-up.",
+                    "createdAt": "2026-05-02T12:30:00Z",
+                }
+            ],
+            "timeline": [
+                {
+                    "event": "reopened",
+                    "created_at": "2026-05-02T12:00:00Z",
+                    "actor": {"login": "operator"},
+                }
+            ],
+        }
+
+    result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch, force=True)
+
+    assert result.runnable == issues
+    assert len(result.skipped) == 1
+    assert result.skipped[0].reason_codes == (REOPENED_STALE_CONTRACT_CODE,)
 
 
 # ── Mixed sprint ───────────────────────────────────────────────────────────

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -135,6 +135,45 @@ class TestGitHubIssueSource:
         assert task.inferred_dependencies == ["issue-7", "issue-12"]
         assert task.dependency_warnings == []
 
+    def test_fetch_appends_reopen_comment_to_story_text(self, tmp_path: Path) -> None:
+        issue_data = json.dumps(
+            {
+                "title": "Fix the bug",
+                "body": "## What happened\nOriginal contract",
+                "state": "OPEN",
+                "comments": [
+                    {
+                        "author": {"login": "operator"},
+                        "body": "The remaining work is to wire reopen context into sprint intake.",
+                        "createdAt": "2026-05-02T12:30:00Z",
+                    }
+                ],
+            }
+        )
+        timeline = json.dumps(
+            [
+                {
+                    "event": "reopened",
+                    "created_at": "2026-05-02T12:00:00Z",
+                    "actor": {"login": "operator"},
+                }
+            ]
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=issue_data, stderr=""),
+                MagicMock(returncode=0, stdout=timeline, stderr=""),
+            ]
+            task = GitHubIssueSource().fetch("42", tmp_path)
+
+        assert "## Reopen Context" in task.story_text
+        assert "operator" in task.story_text
+        assert (
+            "The remaining work is to wire reopen context into sprint intake." in task.story_text
+        )
+        assert "Original contract" in task.story_text
+
     @pytest.mark.parametrize(
         "body, expected",
         [


### PR DESCRIPTION
## Summary

Reopen-aware sprint intake correctly gates stale-body issues and injects reopen context into story_text; both paths verified end-to-end

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.53
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/shape_gate.py:103`** _fetch_issue_timeline in shape_gate.py duplicates the identical implementation in sources.py (GitHubIssueSource._fetch_issue_timeline). Convention 3 says extract instead of growing — this logic belongs in reopen_context.py or a shared gh-api helper, not copy-pasted across two modules.
- **[P2] `src/theforge/sprint/shape_gate.py:120`** Timeline fetch is capped at per_page=100. An issue with a long event history (>100 events) could have its reopen event paged out, causing analyze_reopen_contract to return an empty state and silently pass a stale-body issue through the gate.

## Story

Reopen context never enters the sprint contract — dev agents reason from the original issue body and ignore reopen comments (GitHub Issue #1271)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1271