### PR TITLE
Cross-sprint conflict detection trusts stale lock files without PID verification, aborts entire sprint on single-story conflict, ignores --force

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -135,7 +135,7 @@ def cmd_sprint(args: object) -> int:
     slugs = parse_manifest_slugs(config, manifest_path)
     reexec = _is_reexec()
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
-        slugs=slugs, config=config, resume=resume, allow_drop=reexec
+        slugs=slugs, config=config, resume=resume, allow_drop=reexec, force=force
     )
     if launch_error is not None:
         return launch_error
@@ -214,12 +214,14 @@ def _acquire_launch_locks(
     resume: bool,
     *,
     allow_drop: bool = False,
+    force: bool = False,
 ) -> tuple[list, int | None, dict[str, str]]:
     return acquire_launch_story_locks(
         slugs=slugs,
         config=config,
         resume=resume,
         allow_drop=allow_drop,
+        force=force,
     )
 
 
@@ -506,7 +508,7 @@ def _run_query_mode(
     slugs = [task.slug for task, _src, _ref in resolved.stories]
     reexec = _is_reexec()
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
-        slugs=slugs, config=config, resume=resume, allow_drop=reexec
+        slugs=slugs, config=config, resume=resume, allow_drop=reexec, force=force
     )
     if launch_error is not None:
         return launch_error

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -6,14 +6,16 @@ import sys
 from typing import Any
 
 from theforge.sprint.lock import (
-    acquire_story_locks,
+    acquire_story_locks_detailed,
     check_active_worktrees,
     check_escalated_worktrees,
+    sweep_story_locks,
 )
 from theforge.sprint.preflight import (
     abort_for_active_worktrees,
-    abort_for_running_stories,
     check_active_worktrees_or_continue,
+    drop_conflicting_running_stories,
+    warn_for_running_stories,
 )
 
 # Reason codes used as the value in the ``dropped_slugs`` mapping.  These are
@@ -29,6 +31,7 @@ def acquire_launch_story_locks(
     config: Any,
     resume: bool,
     allow_drop: bool = False,
+    force: bool = False,
 ) -> tuple[list, int | None, dict[str, str]]:
     """Acquire launch-time story locks after checking for active worktrees.
 
@@ -40,12 +43,11 @@ def acquire_launch_story_locks(
     a distinct outcome (``dropped`` / ``preserved``) rather than silently
     vanishing or falling back to a generic SKIPPED entry.
 
-    When ``allow_drop`` is False (default, initial launch), any active worktree
-    or locked-by-another-process conflict aborts the whole sprint — the caller
-    returns ``exit_code`` to the shell.  Escalated worktrees are still treated
-    as preserved (never collisions) and are removed from scheduling even on
-    the initial-launch path; otherwise a sprint resumed over an already-
-    escalated worktree would re-run it.
+    When ``allow_drop`` is False (default, initial launch), active-worktree
+    collisions still abort the whole sprint. Story-lock conflicts are resolved
+    per story: conflicting stories are dropped and the rest continue, unless
+    ``force`` is True, in which case the conflict is warned about and the story
+    proceeds without a launch lock.
 
     When ``allow_drop`` is True (re-exec path), conflicting stories are
     individually recorded in ``dropped_slugs`` and the remaining, unconflicted
@@ -82,9 +84,18 @@ def acquire_launch_story_locks(
             flush=True,
         )
 
+    reaped_lock_paths = sweep_story_locks(config.project_root)
+    if reaped_lock_paths:
+        print(
+            f"[forge] Reaped {len(reaped_lock_paths)} stale story lock file(s) at sprint launch.",
+            file=sys.stderr,
+            flush=True,
+        )
+
     if not allow_drop:
         # Initial-launch path: escalated stories are silently excluded from
-        # scheduling, but any other collision still aborts the whole sprint.
+        # scheduling, active worktree collisions still abort, and story-lock
+        # collisions are resolved per story.
         active_worktree_error = check_active_worktrees_or_continue(
             slugs=schedulable,
             config=config,
@@ -92,9 +103,21 @@ def acquire_launch_story_locks(
         )
         if active_worktree_error is not None:
             return [], active_worktree_error, dropped
-        locked_fds, conflicted = acquire_story_locks(schedulable, config.project_root)
-        if conflicted:
-            return [], abort_for_running_stories(conflicted), dropped
+        remaining = list(schedulable)
+        locked_fds: list = []
+        while remaining:
+            attempt_fds, conflicted = acquire_story_locks_detailed(remaining, config.project_root)
+            if not conflicted:
+                locked_fds = attempt_fds
+                break
+            conflicted_slugs = {conflict.slug for conflict in conflicted}
+            if force:
+                warn_for_running_stories(conflicted)
+            else:
+                for slug in conflicted_slugs:
+                    dropped[slug] = REASON_LOCK_HELD
+                drop_conflicting_running_stories(conflicted)
+            remaining = [slug for slug in remaining if slug not in conflicted_slugs]
         return locked_fds, None, dropped
 
     # ── Re-exec path: convert every collision into a per-story drop ─────
@@ -124,19 +147,14 @@ def acquire_launch_story_locks(
     live_slugs: list[str] = list(remaining)
     locked_fds: list = []
     while live_slugs:
-        attempt_fds, conflicted = acquire_story_locks(live_slugs, config.project_root)
+        attempt_fds, conflicted = acquire_story_locks_detailed(live_slugs, config.project_root)
         if not conflicted:
             locked_fds = attempt_fds
             break
-        for slug in conflicted:
+        for conflict in conflicted:
+            slug = conflict.slug
             dropped[slug] = REASON_LOCK_HELD
-        print(
-            f"[forge] DROPPED {', '.join(conflicted)}: story lock held by "
-            "another process after re-exec; continuing with remaining stories.",
-            file=sys.stderr,
-            flush=True,
-        )
-        abort_for_running_stories(conflicted)
+        drop_conflicting_running_stories(conflicted)
         live_slugs = [s for s in live_slugs if s not in dropped]
         # attempt_fds is already empty/released by acquire_story_locks on
         # conflict — loop around and reacquire for the surviving subset.

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -8,11 +8,12 @@ import shutil
 import subprocess
 import time
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from theforge import detach as _detach_mod
 from theforge.artifacts import ESCALATED_MARKER_PATH
-from theforge.pid import _current_process_fingerprint, _pid_matches_fingerprint
+from theforge.pid import _current_process_fingerprint, _is_pid_alive, _pid_matches_fingerprint
 
 _LOCK_METADATA_SEPARATOR = "|"
 _UNAVAILABLE_FINGERPRINT = "unavailable"
@@ -105,32 +106,95 @@ class SprintConflictError(Exception):
         super().__init__(f"Stories already running: {', '.join(conflicting_slugs)}")
 
 
-def _read_lock_metadata(fd) -> tuple[int | None, str | None]:
-    """Return ``(pid, fingerprint)`` from a lock file, if present and valid."""
+@dataclass(frozen=True)
+class StoryLockRecord:
+    """Parsed lock-file metadata."""
+
+    pid: int | None
+    timestamp: str | None
+    fingerprint: str | None
+
+
+@dataclass(frozen=True)
+class StoryLockConflict:
+    """Operator-facing description of a conflicting story lock."""
+
+    slug: str
+    lock_path: Path
+    pid: int | None
+    pid_alive: bool
+    timestamp: str | None
+
+
+def _read_lock_record(fd) -> StoryLockRecord:
+    """Return parsed lock metadata from *fd*.
+
+    Supported formats:
+
+    - ``<pid>|<timestamp>|<fingerprint>`` (current)
+    - ``<pid>|<fingerprint>`` (legacy)
+    - ``<pid>`` (legacy/corrupt)
+    """
     fd.seek(0)
     raw = fd.read().strip()
     if not raw:
-        return None, None
+        return StoryLockRecord(pid=None, timestamp=None, fingerprint=None)
 
-    pid_text, separator, fingerprint = raw.partition(_LOCK_METADATA_SEPARATOR)
+    parts = [part.strip() for part in raw.split(_LOCK_METADATA_SEPARATOR)]
     try:
-        pid = int(pid_text)
+        pid = int(parts[0])
     except ValueError:
-        return None, None
+        return StoryLockRecord(pid=None, timestamp=None, fingerprint=None)
 
-    normalized_fingerprint = fingerprint.strip() if separator else None
-    return pid, normalized_fingerprint or None
+    if len(parts) >= 3:
+        timestamp = parts[1] or None
+        fingerprint = _LOCK_METADATA_SEPARATOR.join(parts[2:]).strip() or None
+        return StoryLockRecord(pid=pid, timestamp=timestamp, fingerprint=fingerprint)
+
+    if len(parts) == 2:
+        legacy_field = parts[1] or None
+        return StoryLockRecord(pid=pid, timestamp=legacy_field, fingerprint=legacy_field)
+
+    return StoryLockRecord(pid=pid, timestamp=None, fingerprint=None)
+
+
+def _read_lock_metadata(fd) -> tuple[int | None, str | None]:
+    """Return ``(pid, fingerprint)`` from a lock file, if present and valid."""
+    record = _read_lock_record(fd)
+    return record.pid, record.fingerprint
 
 
 def _write_lock_metadata(fd) -> None:
     """Persist the current process PID plus a stable process fingerprint."""
     pid = os.getpid()
     fingerprint = _current_process_fingerprint(pid) or _UNAVAILABLE_FINGERPRINT
-    payload = f"{pid}{_LOCK_METADATA_SEPARATOR}{fingerprint}"
+    timestamp = time.ctime()
+    payload = f"{pid}{_LOCK_METADATA_SEPARATOR}{timestamp}{_LOCK_METADATA_SEPARATOR}{fingerprint}"
     fd.truncate(0)
     fd.seek(0)
     fd.write(payload)
     fd.flush()
+
+
+def _record_claims_live_holder(record: StoryLockRecord) -> bool:
+    """Return True when *record* still points at a live owning process instance."""
+    if record.pid is None:
+        return False
+    return _pid_matches_fingerprint(record.pid, record.fingerprint)
+
+
+def _conflict_from_record(
+    slug: str, lock_path: Path, record: StoryLockRecord
+) -> StoryLockConflict:
+    """Build a stable conflict description from lock metadata."""
+    pid_alive = False if record.pid is None else _is_pid_alive(record.pid)
+    return StoryLockConflict(
+        slug=slug,
+        lock_path=lock_path,
+        pid=record.pid,
+        pid_alive=pid_alive,
+        timestamp=record.timestamp,
+    )
 
 
 def check_escalated_worktrees(
@@ -204,14 +268,16 @@ def check_active_worktrees(
     return active
 
 
-def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, list[str]]:
+def acquire_story_locks_detailed(
+    slugs: list[str], project_root: Path
+) -> tuple[list, list[StoryLockConflict]]:
     """Try to acquire exclusive non-blocking flocks for each slug.
 
     Creates `.forge/locks/<slug>.lock` files under *project_root*.
 
     Returns:
         ``(locked_fds, [])`` when all locks are successfully acquired.
-        ``([], conflicting_slugs)`` if any slug is already locked by another
+        ``([], conflicting_locks)`` if any slug is already locked by another
         process. All successfully acquired locks are released before returning
         in the conflict case.
     """
@@ -222,7 +288,7 @@ def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, lis
     lock_dir.mkdir(parents=True, exist_ok=True)
 
     locked_fds: list = []
-    conflicted: list[str] = []
+    conflicted: list[StoryLockConflict] = []
 
     for slug in slugs:
         lock_path = lock_dir / f"{slug}.lock"
@@ -236,10 +302,10 @@ def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, lis
                 acquired_fd = fd
                 break
             except BlockingIOError:
-                owner_pid, owner_fingerprint = _read_lock_metadata(fd)
+                record = _read_lock_record(fd)
                 fd.close()
-                if owner_pid is None or _pid_matches_fingerprint(owner_pid, owner_fingerprint):
-                    conflicted.append(slug)
+                if record.pid is None or _record_claims_live_holder(record):
+                    conflicted.append(_conflict_from_record(slug, lock_path, record))
                     break
                 # TOCTOU: a live process could acquire this lock and write its
                 # metadata between the ownership check above and unlink() below.
@@ -253,13 +319,21 @@ def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, lis
                 except FileNotFoundError:
                     continue
                 except OSError:
-                    conflicted.append(slug)
+                    conflicted.append(_conflict_from_record(slug, lock_path, record))
                     break
 
         if acquired_fd is not None:
             locked_fds.append(acquired_fd)
-        elif slug not in conflicted:
-            conflicted.append(slug)
+        elif all(conflict.slug != slug for conflict in conflicted):
+            conflicted.append(
+                StoryLockConflict(
+                    slug=slug,
+                    lock_path=lock_path,
+                    pid=None,
+                    pid_alive=False,
+                    timestamp=None,
+                )
+            )
 
     if conflicted:
         # Release all successfully acquired locks before returning
@@ -272,6 +346,12 @@ def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, lis
         return [], conflicted
 
     return locked_fds, []
+
+
+def acquire_story_locks(slugs: list[str], project_root: Path) -> tuple[list, list[str]]:
+    """Backwards-compatible wrapper around :func:`acquire_story_locks_detailed`."""
+    locked_fds, conflicts = acquire_story_locks_detailed(slugs, project_root)
+    return locked_fds, [conflict.slug for conflict in conflicts]
 
 
 def release_story_locks(fds: list) -> None:
@@ -330,6 +410,51 @@ def cleanup_story_locks(
             continue
 
     return cleaned
+
+
+def sweep_story_locks(
+    project_root: Path,
+    *,
+    slugs: list[str] | None = None,
+) -> list[Path]:
+    """Remove unlocked story lock files at sprint launch.
+
+    Policy: any lock file in ``.forge/locks`` whose flock is not currently held
+    at sprint launch is stale and is removed, regardless of whether its recorded
+    PID is dead, recycled, or still alive. Live holders keep their flock and are
+    left in place for the conflict gate to inspect precisely.
+    """
+    lock_dir = project_root / ".forge" / "locks"
+    if not lock_dir.exists():
+        return []
+
+    if slugs is None:
+        lock_paths = sorted(lock_dir.glob("*.lock"))
+    else:
+        lock_paths = [lock_dir / f"{slug}.lock" for slug in slugs]
+
+    removed: list[Path] = []
+    for lock_path in lock_paths:
+        if not lock_path.exists():
+            continue
+        try:
+            fd = open(lock_path, "a+")  # noqa: WPS515,SIM115
+        except OSError:
+            continue
+        try:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                continue
+        finally:
+            fd.close()
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            continue
+        removed.append(lock_path)
+
+    return removed
 
 
 @contextmanager

--- a/src/theforge/sprint/preflight.py
+++ b/src/theforge/sprint/preflight.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from theforge.sprint.lock import _write_lock_metadata, check_active_worktrees
+from theforge.sprint.lock import StoryLockConflict, _write_lock_metadata, check_active_worktrees
 
 _ACTIVE_WORKTREE_ABORT_PREFIX = "[forge] Stories already have active worktrees"
 _RUNNING_STORIES_ABORT_PREFIX = "[forge] Stories already running"
@@ -21,14 +21,64 @@ def _abort_with_message(prefix: str, slugs: list[str]) -> int:
     return 1
 
 
+def _format_issue_label(slug: str) -> str:
+    if slug.startswith("issue-") and slug[6:].isdigit():
+        return f"#{slug[6:]} ({slug})"
+    return slug
+
+
+def _format_running_story_conflict(conflict: StoryLockConflict) -> str:
+    pid_text = str(conflict.pid) if conflict.pid is not None else "unknown"
+    alive_text = "yes" if conflict.pid_alive else "no"
+    timestamp = conflict.timestamp or "unknown"
+    return (
+        f"  - {_format_issue_label(conflict.slug)}: lock={conflict.lock_path} "
+        f"pid={pid_text} alive={alive_text} timestamp={timestamp}"
+    )
+
+
+def _emit_running_story_conflicts(
+    prefix: str,
+    conflicts: list[StoryLockConflict],
+    suffix: str,
+) -> None:
+    print(prefix, file=sys.stderr)
+    for conflict in conflicts:
+        print(_format_running_story_conflict(conflict), file=sys.stderr)
+    print(suffix, file=sys.stderr)
+
+
 def abort_for_active_worktrees(slugs: list[str]) -> int:
     """Print the active-worktree refusal message and return the CLI exit code."""
     return _abort_with_message(_ACTIVE_WORKTREE_ABORT_PREFIX, slugs)
 
 
-def abort_for_running_stories(slugs: list[str]) -> int:
+def abort_for_running_stories(conflicts: list[StoryLockConflict]) -> int:
     """Print the running-stories refusal message and return the CLI exit code."""
-    return _abort_with_message(_RUNNING_STORIES_ABORT_PREFIX, slugs)
+    _emit_running_story_conflicts(
+        _RUNNING_STORIES_ABORT_PREFIX + ":",
+        conflicts,
+        "[forge] Aborting.",
+    )
+    return 1
+
+
+def warn_for_running_stories(conflicts: list[StoryLockConflict]) -> None:
+    """Emit a loud warning that --force is overriding lock conflicts."""
+    _emit_running_story_conflicts(
+        "[forge] WARNING: --force overrides apparent story lock conflicts:",
+        conflicts,
+        "[forge] Proceeding without launch locks for the conflicting stories.",
+    )
+
+
+def drop_conflicting_running_stories(conflicts: list[StoryLockConflict]) -> None:
+    """Emit a per-story drop diagnostic for lock conflicts."""
+    _emit_running_story_conflicts(
+        "[forge] DROPPED conflicting stories with apparent live launch locks:",
+        conflicts,
+        "[forge] Continuing with the remaining stories.",
+    )
 
 
 def check_active_worktrees_or_continue(

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -18,6 +18,7 @@ from theforge.sprint.lock import (
     cleanup_story_locks,
     integration_lock,
     release_story_locks,
+    sweep_story_locks,
 )
 
 # Use 'fork' so local functions can be passed to child processes without pickling.
@@ -40,8 +41,11 @@ class TestAcquireStoryLocks:
             assert conflicted == []
             assert len(fds) == 1
             lock_path = tmp_path / ".forge" / "locks" / "my-story.lock"
-            pid_text, fingerprint = lock_path.read_text(encoding="utf-8").strip().split("|", 1)
+            pid_text, timestamp, fingerprint = (
+                lock_path.read_text(encoding="utf-8").strip().split("|", 2)
+            )
             assert pid_text.isdigit()
+            assert timestamp
             assert fingerprint
         finally:
             release_story_locks(fds)
@@ -287,6 +291,45 @@ class TestCleanupStoryLocks:
         assert lock_path.exists()
 
 
+class TestSweepStoryLocks:
+    def test_removes_unlocked_stale_lock_files(self, tmp_path: Path) -> None:
+        lock_dir = tmp_path / ".forge" / "locks"
+        lock_dir.mkdir(parents=True)
+        stale_lock = lock_dir / "issue-1110.lock"
+        stale_lock.write_text("40858|Sat May  2 15:49:34 2026|old-start\n", encoding="utf-8")
+
+        removed = sweep_story_locks(tmp_path)
+
+        assert removed == [stale_lock]
+        assert not stale_lock.exists()
+
+    def test_keeps_live_locked_files(self, tmp_path: Path) -> None:
+        ready_event = _mp.Event()
+        release_event = _mp.Event()
+
+        def hold_lock(path: str, slug: str, ready: object, release: object) -> None:
+            fds, conflicted = acquire_story_locks([slug], Path(path))
+            if conflicted:
+                sys.exit(1)
+            ready.set()
+            release.wait(timeout=10)
+            release_story_locks(fds)
+
+        proc = _mp.Process(
+            target=hold_lock,
+            args=(str(tmp_path), "issue-1111", ready_event, release_event),
+        )
+        proc.start()
+        try:
+            assert ready_event.wait(timeout=5)
+            removed = sweep_story_locks(tmp_path)
+            assert removed == []
+            assert (tmp_path / ".forge" / "locks" / "issue-1111.lock").exists()
+        finally:
+            release_event.set()
+            proc.join(timeout=5)
+
+
 class TestCheckActiveWorktrees:
     def test_missing_worktree_is_not_active(self, tmp_path: Path) -> None:
         active = check_active_worktrees(["story-a"], ".forge/worktrees/{slug}", "main", tmp_path)
@@ -412,7 +455,7 @@ class TestIntegrationLock:
 
 
 class TestCmdSprintConflictGuard:
-    """cmd_sprint returns exit code 1 and prints conflicting slugs when locked."""
+    """cmd_sprint respects the launch lock conflict contract."""
 
     def _make_story(self, tmp_path: Path, slug: str) -> Path:
         story = tmp_path / f"{slug}.md"
@@ -441,20 +484,26 @@ class TestCmdSprintConflictGuard:
             interactive=False,
             verbose=False,
             no_notify=True,
+            force=False,
         )
 
-    def test_conflict_returns_exit_1(self, tmp_path: Path, capsys) -> None:
-        """cmd_sprint returns 1 when a story lock is already held."""
+    def test_conflict_drops_locked_story_and_runs_remaining(self, tmp_path: Path, capsys) -> None:
+        """Initial launch drops only the conflicted story and runs the rest."""
         from theforge import cli
 
-        story = self._make_story(tmp_path, "my-feature")
-        manifest = self._make_manifest(tmp_path, story)
+        story_a = self._make_story(tmp_path, "my-feature")
+        story_b = self._make_story(tmp_path, "other-feature")
+        manifest = self._make_manifest(tmp_path, story_a, story_b)
         args = self._make_args(tmp_path, manifest)
 
         mock_config = MagicMock()
         mock_config.project_root = tmp_path
         mock_config.workspace.path_pattern = ".forge/worktrees/{slug}"
         mock_config.workspace.base_branch = "main"
+        mock_config.workspace.branch_pattern = "forge/{slug}"
+
+        mock_result = MagicMock()
+        mock_result.specs_failed = 0
 
         ready_event = _mp.Event()
         release_event = _mp.Event()
@@ -474,16 +523,110 @@ class TestCmdSprintConflictGuard:
             assert ready_event.wait(timeout=5)
 
             with patch("theforge.cli.sprint.load_config", return_value=mock_config):
-                with patch("theforge.cli.sprint.run_sprint") as mock_run:
-                    rc = cli.cmd_sprint(args)
+                with patch("theforge.cli.sprint.run_sprint", return_value=mock_result) as mock_run:
+                    with patch("theforge.detach.remove_pid"):
+                        rc = cli.cmd_sprint(args)
 
-            assert rc == 1
-            mock_run.assert_not_called()
+            assert rc == 0
+            mock_run.assert_called_once()
+            assert mock_run.call_args.kwargs["dropped_slugs"] == {
+                "my-feature": "story-lock-held-by-other-process"
+            }
             captured = capsys.readouterr()
+            assert "DROPPED" in captured.err
             assert "my-feature" in captured.err
+            assert "alive=yes" in captured.err
         finally:
             release_event.set()
             proc.join(timeout=5)
+
+    def test_force_overrides_live_lock_and_runs_every_story(self, tmp_path: Path, capsys) -> None:
+        """--force warns and proceeds even when a live process holds a story lock."""
+        from theforge import cli
+
+        story = self._make_story(tmp_path, "my-feature")
+        manifest = self._make_manifest(tmp_path, story)
+        args = self._make_args(tmp_path, manifest)
+        args.force = True
+
+        mock_config = MagicMock()
+        mock_config.project_root = tmp_path
+        mock_config.workspace.path_pattern = ".forge/worktrees/{slug}"
+        mock_config.workspace.base_branch = "main"
+        mock_config.workspace.branch_pattern = "forge/{slug}"
+
+        mock_result = MagicMock()
+        mock_result.specs_failed = 0
+
+        ready_event = _mp.Event()
+        release_event = _mp.Event()
+
+        def hold_lock(path: str, slug: str, ready: object, release: object) -> None:
+            fds, _ = acquire_story_locks([slug], Path(path))
+            ready.set()
+            release.wait(timeout=10)
+            release_story_locks(fds)
+
+        proc = _mp.Process(
+            target=hold_lock,
+            args=(str(tmp_path), "my-feature", ready_event, release_event),
+        )
+        proc.start()
+        try:
+            assert ready_event.wait(timeout=5)
+            with patch("theforge.cli.sprint.load_config", return_value=mock_config):
+                with patch("theforge.cli.sprint.run_sprint", return_value=mock_result) as mock_run:
+                    with patch("theforge.detach.remove_pid"):
+                        rc = cli.cmd_sprint(args)
+
+            assert rc == 0
+            mock_run.assert_called_once()
+            assert mock_run.call_args.kwargs["dropped_slugs"] == {}
+            captured = capsys.readouterr()
+            assert "--force overrides apparent story lock conflicts" in captured.err
+            assert "Proceeding without launch locks" in captured.err
+        finally:
+            release_event.set()
+            proc.join(timeout=5)
+
+    def test_stale_lock_is_reaped_and_story_runs(self, tmp_path: Path, capsys) -> None:
+        """A dead-PID launch lock is removed during the pre-sprint sweep."""
+        from theforge import cli
+
+        story = self._make_story(tmp_path, "issue-1110")
+        manifest = self._make_manifest(tmp_path, story)
+        args = self._make_args(tmp_path, manifest)
+
+        lock_dir = tmp_path / ".forge" / "locks"
+        lock_dir.mkdir(parents=True)
+        lock_path = lock_dir / "issue-1110.lock"
+        lock_path.write_text(
+            "40858|Sat May  2 15:49:34 2026|Sat May  2 15:49:34 2026\n",
+            encoding="utf-8",
+        )
+
+        mock_config = MagicMock()
+        mock_config.project_root = tmp_path
+        mock_config.workspace.path_pattern = ".forge/worktrees/{slug}"
+        mock_config.workspace.base_branch = "main"
+        mock_config.workspace.branch_pattern = "forge/{slug}"
+
+        mock_result = MagicMock()
+        mock_result.specs_failed = 0
+
+        with patch("theforge.cli.sprint.load_config", return_value=mock_config):
+            with patch("theforge.cli.sprint.run_sprint", return_value=mock_result) as mock_run:
+                with patch("theforge.detach.remove_pid"):
+                    rc = cli.cmd_sprint(args)
+
+        assert rc == 0
+        mock_run.assert_called_once()
+        lock_parts = lock_path.read_text(encoding="utf-8").strip().split("|", 2)
+        assert len(lock_parts) == 3
+        assert lock_parts[0].isdigit()
+        assert lock_parts[1] != "Sat May  2 15:49:34 2026"
+        captured = capsys.readouterr()
+        assert "Reaped 1 stale story lock file" in captured.err
 
     def test_no_conflict_calls_run_sprint(self, tmp_path: Path) -> None:
         """cmd_sprint proceeds to run_sprint when no conflicts exist."""
@@ -526,7 +669,7 @@ class TestCmdSprintConflictGuard:
         worktree.mkdir(parents=True)
 
         with patch("theforge.cli.sprint.load_config", return_value=mock_config):
-            with patch("theforge.sprint.launch_guard.acquire_story_locks") as mock_locks:
+            with patch("theforge.sprint.launch_guard.acquire_story_locks_detailed") as mock_locks:
                 with patch(
                     "theforge.sprint.lock.subprocess.run",
                     return_value=MagicMock(returncode=0, stdout="1\n"),
@@ -548,6 +691,7 @@ class TestCmdSprintConflictGuard:
         mock_config.project_root = tmp_path
         mock_config.workspace.path_pattern = ".forge/worktrees/{slug}"
         mock_config.workspace.base_branch = "main"
+        mock_config.workspace.branch_pattern = "forge/{slug}"
 
         worktree = tmp_path / ".forge" / "worktrees" / "my-feature"
         worktree.mkdir(parents=True)

--- a/tests/test_sprint_preflight.py
+++ b/tests/test_sprint_preflight.py
@@ -4,12 +4,14 @@ import io
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from theforge.sprint.lock import _read_lock_metadata
+from theforge.sprint.lock import StoryLockConflict, _read_lock_metadata
 from theforge.sprint.preflight import (
     abort_for_active_worktrees,
     abort_for_running_stories,
     check_active_worktrees_or_continue,
+    drop_conflicting_running_stories,
     reacquire_story_locks_in_daemon,
+    warn_for_running_stories,
 )
 
 
@@ -23,12 +25,70 @@ def test_abort_for_active_worktrees_lists_slugs(capsys) -> None:
 
 
 def test_abort_for_running_stories_lists_slugs(capsys) -> None:
-    rc = abort_for_running_stories(["story-a", "story-b"])
+    rc = abort_for_running_stories(
+        [
+            StoryLockConflict(
+                slug="issue-1110",
+                lock_path=Path("/tmp/.forge/locks/issue-1110.lock"),
+                pid=40858,
+                pid_alive=False,
+                timestamp="Sat May  2 15:49:34 2026",
+            ),
+            StoryLockConflict(
+                slug="story-b",
+                lock_path=Path("/tmp/.forge/locks/story-b.lock"),
+                pid=5150,
+                pid_alive=True,
+                timestamp="Sat May  2 16:00:00 2026",
+            ),
+        ]
+    )
 
     assert rc == 1
     captured = capsys.readouterr()
     assert "Stories already running" in captured.err
-    assert "story-a, story-b" in captured.err
+    assert "#1110 (issue-1110)" in captured.err
+    assert "story-b" in captured.err
+    assert "pid=40858" in captured.err
+    assert "alive=no" in captured.err
+    assert "timestamp=Sat May  2 15:49:34 2026" in captured.err
+    assert "/tmp/.forge/locks/issue-1110.lock" in captured.err
+
+
+def test_warn_for_running_stories_mentions_force_override(capsys) -> None:
+    warn_for_running_stories(
+        [
+            StoryLockConflict(
+                slug="story-a",
+                lock_path=Path("/tmp/.forge/locks/story-a.lock"),
+                pid=1234,
+                pid_alive=True,
+                timestamp="Sat May  2 16:00:00 2026",
+            )
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert "--force overrides" in captured.err
+    assert "Proceeding without launch locks" in captured.err
+
+
+def test_drop_conflicting_running_stories_mentions_continuation(capsys) -> None:
+    drop_conflicting_running_stories(
+        [
+            StoryLockConflict(
+                slug="story-a",
+                lock_path=Path("/tmp/.forge/locks/story-a.lock"),
+                pid=1234,
+                pid_alive=True,
+                timestamp="Sat May  2 16:00:00 2026",
+            )
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert "DROPPED" in captured.err
+    assert "Continuing with the remaining stories." in captured.err
 
 
 def test_check_active_worktrees_returns_abort_when_active(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

All four failure modes addressed correctly; PID verification, sweep, per-story drops, and --force wiring all check out against the ACs.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.81
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/lock.py:449`** sweep_story_locks releases the flock (via fd.close() in the finally block) before calling lock_path.unlink(). A concurrent sprint launch could open the same file, acquire the flock, and write its metadata in the window between fd.close() and unlink(), causing a legitimately held lock to be deleted. Convention: changes to lock-lifecycle code should be robust to concurrent callers.
- **[P2] `tests/test_sprint_lock.py:None`** AC6 requires '--force overrides on dead and live PID with appropriate warnings'. The dead-PID + --force combination is only implicitly covered (sweep removes the dead lock before the conflict gate, so force never sees it). There is no test that injects a stale lock, enables --force, and verifies the sweep-then-run path specifically under force.

## Story

Cross-sprint conflict detection trusts stale lock files without PID verification, aborts entire sprint on single-story conflict, ignores --force (GitHub Issue #1264)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1264