### PR TITLE
Shape gate must flag issue bodies with implementation-plan content (Design sections, file paths, function names, line numbers) as needs-grooming

### DIFF
--- a/src/theforge/shape_check/check.py
+++ b/src/theforge/shape_check/check.py
@@ -12,6 +12,7 @@ from theforge.shape_check.heuristics import (
     check_bug_missing_diagnosis,
     check_epic_or_tracking,
     check_implementation_design_dump,
+    check_implementation_plan_in_body,
     check_missing_acceptance_criteria,
     check_missing_example,
     check_missing_type,
@@ -60,6 +61,7 @@ def check(
         check_missing_example,
         check_no_observable_done_state,
         check_implementation_design_dump,
+        check_implementation_plan_in_body,
     ):
         r = fn(title, body, labels)
         if r is not None:

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -512,6 +512,141 @@ def check_implementation_design_dump(
     return None
 
 
+_PLAN_HEADING_RE = re.compile(
+    r"^\s{0,3}#{1,6}\s+"
+    r"(?P<title>"
+    r"design"
+    r"|implementation(?:\s+(?:plan|notes|details|strategy|approach))?"
+    r"|technical\s+design"
+    r"|proposed\s+(?:implementation|design|approach)"
+    r")\b[^\n]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_FILE_LINE_RE = re.compile(
+    r"(?<![\w/])"
+    r"(?P<path>(?:[\w][\w./-]*/)?[\w][\w.-]*\.(?:py|pyi|js|jsx|ts|tsx|yaml|yml|json|sh|toml|rs|go|java|rb))"
+    r":(?P<line>\d+)\b"
+)
+
+_FILE_PATH_RE = re.compile(
+    r"(?<![\w/])"
+    r"(?:[\w][\w.-]*/)+[\w][\w.-]*\.(?:py|pyi|js|jsx|ts|tsx|yaml|yml|json|sh|toml|rs|go|java|rb|md)"
+    r"(?![\w./])"
+)
+
+_PLAN_EXCEPTION_RE = re.compile(
+    r"^\s*(?:implementation\s+target|refactor\s+target)\s*:\s*\S",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_FENCE_RE = re.compile(r"^\s*```")
+
+
+def _strip_fenced_blocks(body: str) -> str:
+    out: list[str] = []
+    in_fence = False
+    for line in body.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+_EXAMPLE_HEADING_RE = re.compile(
+    r"^\s{0,3}(?P<hashes>#{1,6})\s+"
+    r"(?:examples?|target(?:\s+(?:sketch|output|state))?|"
+    r"what\s+it\s+should\s+look\s+like)"
+    r"\s*:?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _strip_example_section(body: str) -> str:
+    out: list[str] = []
+    skip_level: int | None = None
+    for line in body.splitlines():
+        if skip_level is not None:
+            heading_m = re.match(r"^\s{0,3}(#{1,6})\s+", line)
+            if heading_m and len(heading_m.group(1)) <= skip_level:
+                skip_level = None
+                out.append(line)
+            continue
+        m = _EXAMPLE_HEADING_RE.match(line)
+        if m:
+            skip_level = len(m.group("hashes"))
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def check_implementation_plan_in_body(
+    title: str, body: str, labels: Iterable[str]
+) -> Reason | None:
+    """Flag issue bodies that contain implementation-plan content (HOW, not WHAT).
+
+    A story body is meant to describe observable behavior. When it instead
+    pre-names file paths, function signatures, line numbers, or carries a
+    ``## Design`` section, the body becomes a structural plan that dev agents
+    can verify against existing code while missing the actually-undelivered
+    behavior — the failure mode documented in superseded issue #1110.
+
+    Bug-format issues are exempt because their Diagnosis section is required
+    to name the affected code path. Stories that legitimately describe a
+    refactor of one named module can opt out by adding a body line of the form
+    ``Implementation target: <path>``.
+    """
+    if is_bug_format_issue(body, labels):
+        return None
+    if _PLAN_EXCEPTION_RE.search(body):
+        return None
+
+    pruned = _strip_example_section(_strip_fenced_blocks(body))
+
+    signals: list[str] = []
+
+    heading_match = _PLAN_HEADING_RE.search(pruned)
+    if heading_match is not None:
+        heading_text = heading_match.group(0).strip()
+        signals.append(f"plan-style heading {heading_text!r}")
+
+    file_line_hits = [m.group(0) for m in _FILE_LINE_RE.finditer(pruned)]
+    if file_line_hits:
+        sample = sorted(set(file_line_hits))[:3]
+        signals.append(f"{len(file_line_hits)} file:line reference(s) (e.g. {', '.join(sample)})")
+
+    pruned_no_fileline = _FILE_LINE_RE.sub("", pruned)
+    path_hits = _FILE_PATH_RE.findall(pruned_no_fileline)
+    distinct_paths = sorted(set(path_hits))
+    if distinct_paths:
+        sample = distinct_paths[:3]
+        signals.append(
+            f"{len(path_hits)} file path reference(s) "
+            f"({len(distinct_paths)} distinct, e.g. {', '.join(sample)})"
+        )
+
+    fires = heading_match is not None or bool(file_line_hits) or len(distinct_paths) >= 2
+    if not fires:
+        return None
+
+    return Reason(
+        code="implementation_plan_in_body",
+        severity=Severity.BLOCKING,
+        detail=(
+            "Body contains implementation-plan content (HOW belongs in the plan "
+            "phase, not the issue body): "
+            + "; ".join(signals)
+            + ". Rewrite acceptance criteria as observable behavior and remove "
+            "any ## Design / ## Implementation section. To opt out for a "
+            "legitimate single-file refactor, add a body line "
+            "'Implementation target: <path>'."
+        ),
+    )
+
+
 def check_no_observable_done_state(title: str, body: str, labels: Iterable[str]) -> Reason | None:
     if is_bug_format_issue(body, labels):
         return None

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -416,6 +416,15 @@ def build_review_prompt(
           that may be stale or wrong. Notes are NOT acceptance criteria — do not
           flag a spec mismatch because reality diverges from a Note. Only evaluate
           compliance against explicit acceptance criteria and requirements.
+        - **WHAT-not-HOW body rule**: An issue body must describe observable
+          behavior, not implementation. If the spec body contains a `## Design`
+          (or equivalent) section, file paths, function names, or line numbers
+          in its acceptance criteria, treat those as informational only —
+          verify the implementation against the *behavior* the criterion
+          describes, not against the named code locations. The shape gate
+          flags such bodies as `implementation_plan_in_body`; if you see a
+          body that should have been flagged but slipped through, note it
+          in `summary` so the operator can re-shape the issue.
         - **Spec-to-runtime traceability**: For each AC in the spec, verify
           BOTH layers: (a) the logic exists in the codebase, AND (b) it is
           actually invoked at runtime by the calling code. Code that produces

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -19,6 +19,7 @@ from theforge.shape_check.classifier import classify
 from theforge.shape_check.heuristics import (
     check_epic_or_tracking,
     check_implementation_design_dump,
+    check_implementation_plan_in_body,
     check_missing_acceptance_criteria,
     check_missing_example,
     check_no_observable_done_state,
@@ -271,6 +272,168 @@ class TestImplementationDesignDump:
         assert check_implementation_design_dump("T", WELL_FORMED_AC, []) is None
 
 
+class TestImplementationPlanInBody:
+    def test_clean_what_only_body_passes(self):
+        body = textwrap.dedent(
+            """\
+            ## What
+            The command must succeed for valid inputs.
+
+            ## Acceptance Criteria
+            - The command returns 0 on success.
+            - Failure writes a diagnostic to stderr.
+            """
+        )
+        assert check_implementation_plan_in_body("T", body, []) is None
+
+    def test_design_section_is_flagged(self):
+        body = textwrap.dedent(
+            """\
+            ## What
+            We need a hygiene gate before DEV.
+
+            ## Acceptance Criteria
+            - Phase boundaries are enforced before DEV iterations begin.
+
+            ## Design
+            The hygiene gate uses a snapshot of git status taken at phase entry,
+            compared against a snapshot at phase exit. Mutations are flagged.
+            """
+        )
+        r = check_implementation_plan_in_body("T", body, [])
+        assert r is not None
+        assert r.code == "implementation_plan_in_body"
+        assert r.severity is Severity.BLOCKING
+        assert "Design" in r.detail
+
+    def test_file_paths_and_function_names_flagged(self):
+        body = textwrap.dedent(
+            """\
+            ## What
+            Add a hygiene gate.
+
+            ## Acceptance Criteria
+            - The gate fires after `normalize_dependency_plan` and before
+              `run_batch_preflight` in `src/theforge/coordinator/runner.py`.
+            - `src/theforge/coordinator/workspace_hygiene.py` is called for
+              each phase transition.
+            - Tests added at `tests/test_coord_workspace_hygiene.py` cover
+              the three boundaries.
+            """
+        )
+        r = check_implementation_plan_in_body("T", body, [])
+        assert r is not None
+        assert r.code == "implementation_plan_in_body"
+        assert "file path reference" in r.detail
+
+    def test_file_line_reference_flagged(self):
+        body = textwrap.dedent(
+            """\
+            ## What
+            Refactor.
+
+            ## Acceptance Criteria
+            - The fix is applied at src/theforge/runner.py:109.
+            """
+        )
+        r = check_implementation_plan_in_body("T", body, [])
+        assert r is not None
+        assert "file:line" in r.detail
+
+    def test_refactor_exception_path_permits_file_paths(self):
+        body = textwrap.dedent(
+            """\
+            ## What
+            Split the monolithic runner.py into per-phase modules.
+
+            Implementation target: src/theforge/coordinator/runner.py
+
+            ## Acceptance Criteria
+            - The src/theforge/coordinator/runner.py module is split into
+              dev_phase.py, review_phase.py, and validate_phase.py.
+            - Public entry points remain importable from runner.py.
+            """
+        )
+        assert check_implementation_plan_in_body("T", body, []) is None
+
+    def test_single_file_path_does_not_fire(self):
+        # A single config-file mention in prose is not an implementation plan.
+        body = textwrap.dedent(
+            """\
+            ## What
+            Honor the threshold value declared in forge.yaml.
+
+            ## Acceptance Criteria
+            - The runtime reads the configured threshold and applies it.
+            """
+        )
+        assert check_implementation_plan_in_body("T", body, []) is None
+
+    def test_bug_format_issue_is_exempt(self):
+        # Bugs legitimately name affected code paths in their Diagnosis section
+        # — the WHAT-not-HOW rule applies to features, not symptom reports.
+        body = textwrap.dedent(
+            """\
+            ## What happened
+            Command exits 1 instead of 0.
+
+            ## What was expected
+            Command exits 0 on success.
+
+            ## Diagnosis
+            - Observed symptom: wrong exit code.
+            - Evidence: reproduction in run abc123.
+            - Ruled out: config drift.
+            - Confirmed cause: off-by-one at src/theforge/runner.py:42.
+            - Affected code path: runner.exit_code.
+            - Fix-success criterion: command returns 0.
+            """
+        )
+        assert check_implementation_plan_in_body("T", body, ["bug"]) is None
+
+    def test_fenced_code_blocks_do_not_trip_check(self):
+        # Diagnostic samples inside fenced blocks shouldn't count — they're
+        # often illustrative output, not implementation guidance.
+        body = textwrap.dedent(
+            """\
+            ## What
+            Improve diagnostics.
+
+            ## Acceptance Criteria
+            - The diagnostic emits the offending file path.
+
+            ```
+            error in src/foo/bar.py:42
+            error in src/foo/baz.py:10
+            ```
+            """
+        )
+        assert check_implementation_plan_in_body("T", body, []) is None
+
+    def test_example_section_is_excluded(self):
+        # An Example section may legitimately illustrate a "bad" body shape
+        # (typically wrapped in a fenced markdown block); the check itself
+        # should not flag the host issue for that demonstration content.
+        body = textwrap.dedent(
+            """\
+            ## What
+            The shape gate must flag bodies with implementation-plan content.
+
+            ## Acceptance Criteria
+            - Bodies containing structural plan signals are flagged.
+
+            ## Example
+            Bad body that should be flagged:
+
+            ```markdown
+            ## Design
+            See src/theforge/runner.py:42 and src/theforge/cli.py:10.
+            ```
+            """
+        )
+        assert check_implementation_plan_in_body("T", body, []) is None
+
+
 class TestNoObservableDoneState:
     def test_no_ac(self):
         r = check_no_observable_done_state("T", "## What\nprose", [])
@@ -423,6 +586,25 @@ class TestCheckAggregation:
         result = check("Shape gate blocks bugs", body, ["bug"])
         assert result.shape is Shape.NEEDS_GROOMING
         assert any(r.code == "bug_missing_diagnosis" for r in result.reasons)
+
+    def test_implementation_plan_in_body_flags_as_needs_grooming(self):
+        body = textwrap.dedent(
+            """\
+            ## What
+            Add a hygiene gate.
+
+            ## Acceptance Criteria
+            - The gate runs in `src/theforge/coordinator/runner.py`.
+            - Tests are added at `tests/test_coord_workspace_hygiene.py`.
+
+            ## Design
+            Snapshot git status at phase entry and exit; diff to detect mutations.
+            """
+        )
+        result = check("Add hygiene gate", body, ["enhancement"])
+        assert result.shape is Shape.NEEDS_GROOMING
+        assert result.suggested_action is SuggestedAction.CLARIFY
+        assert any(r.code == "implementation_plan_in_body" for r in result.reasons)
 
     def test_bug_with_complete_diagnosis_is_runnable(self):
         result = check("Bug: command exits incorrectly", DIAGNOSED_BUG_BODY, ["bug"])


### PR DESCRIPTION
## Summary

Clean, well-scoped implementation that satisfies all five ACs with solid test coverage and no correctness defects.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $2.59
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/shape_check/heuristics.py:None`** The exception check (_PLAN_EXCEPTION_RE.search) is applied before any signal detection and suppresses the entire heuristic — including ## Design sections — when any 'Implementation target:' line appears. A story could carry both an exception line and a genuine ## Design section and slip through. The spec's intent was narrowly to permit single-file refactors, not to broadly bypass all signals.
- **[P2] `src/theforge/shape_check/heuristics.py:None`** Standalone function names in prose (e.g. 'normalize_dependency_plan' without a file path or file:line reference) are not detected unless accompanied by another signal. The spec lists 'function names' as a detection signal but also grants implementation discretion on the heuristic mix — flagging this for awareness, not as a defect.

## Story

Shape gate must flag issue bodies with implementation-plan content (Design sections, file paths, function names, line numbers) as needs-grooming (GitHub Issue #1273)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1273