### PR TITLE
Preflight SIGKILL fallback to 'conservative PROCEED' is too permissive — reopened or contract-changed stories sprint without preflight verification

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -547,6 +547,14 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "cache_validation": state.preflight_cache_validation or None,
                 "degraded": state.preflight_degraded,
                 "degraded_reason": state.preflight_degraded_reason,
+                "risk_signals": list(state.preflight_risk_signals),
+                "failure_action": state.preflight_failure_action,
+                "attempts": (
+                    list(state.preflight_result.raw.get("attempts", []))
+                    if state.preflight_result is not None
+                    and isinstance(state.preflight_result.raw, dict)
+                    else []
+                ),
                 **(
                     {"complexity_routing": state.complexity_routing_audit}
                     if state.complexity_routing_audit is not None

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -76,6 +76,38 @@ def _evidence_is_too_thin(evidence: str) -> bool:
     return len(evidence.strip()) < 20
 
 
+def _detect_preflight_risk_signals(
+    story_content: str,
+    project_root: Path,
+    branch_name: str,
+    base_branch: str,
+) -> list[str]:
+    """Return risk signals indicating preflight verification is load-bearing.
+
+    These are the signals that distinguish a story where preflight is a
+    confidence boost (safe to fall through on agent failure) from a story
+    where preflight is the only check that would catch contract drift
+    (must escalate on agent failure rather than silently PROCEED).
+
+    Signals returned as short identifier strings so they can be logged,
+    audited, and matched on without parsing free-form prose.
+    """
+    signals: list[str] = []
+    # Reopened-with-new-context stories carry a "## Reopen Context" block
+    # appended by sprint/reopen_context.py. Its presence means an operator
+    # left a follow-up comment after the issue was reopened — the body and
+    # the operator's intent may have diverged.
+    if story_content and "## Reopen Context" in story_content:
+        signals.append("reopen_context_in_body")
+    # A branch with commits ahead of base means a previous run already
+    # produced work for this story — the story is in-progress, not fresh.
+    # Re-sprinting without preflight verification risks re-doing or
+    # contradicting prior commits.
+    if _has_prior_execution_evidence(project_root, branch_name, base_branch):
+        signals.append("prior_execution_on_branch")
+    return signals
+
+
 def _has_prior_execution_evidence(
     project_root: "Path", branch_name: str, base_branch: str
 ) -> bool:
@@ -296,14 +328,45 @@ def _run_preflight_phase(
             state.preflight_degraded_reason = "parse_error"
             _log("  ⚠ PREFLIGHT output malformed — fallback PROCEED (degraded)")
     else:
-        verdict, reason = (
-            "PROCEED",
-            f"Preflight agent failed (exit={preflight_result.exit_code}); "
-            "falling back to conservative PROCEED.",
+        # Preflight agent failed (timeout, SIGKILL, non-zero exit). Whether
+        # it is safe to fall through to a conservative PROCEED depends on
+        # whether preflight was a confidence boost or the load-bearing check
+        # that catches contract drift. Detect risk signals deterministically
+        # from local state — no extra agent calls — and escalate when any
+        # signal indicates the story may be stale relative to the codebase.
+        risk_signals = _detect_preflight_risk_signals(
+            story_content,
+            config.project_root,
+            branch_name,
+            config.workspace.base_branch,
         )
+        state.preflight_risk_signals = risk_signals
         state.preflight_degraded = True
-        state.preflight_degraded_reason = "timeout_no_verdict"
-        _log("  ⚠ PREFLIGHT failed — fallback PROCEED (degraded)")
+        if risk_signals:
+            verdict = "BLOCKED"
+            reason = (
+                f"Preflight agent failed (exit={preflight_result.exit_code}); "
+                f"risk signals present ({', '.join(risk_signals)}) — escalating "
+                "rather than silently sprinting on an unverified contract."
+            )
+            state.preflight_degraded_reason = "agent_failed_with_risk_signals"
+            state.preflight_failure_action = "escalate"
+            _log(
+                f"  ✗ PREFLIGHT failed (exit={preflight_result.exit_code}) with "
+                f"risk signals [{', '.join(risk_signals)}] — escalating"
+            )
+        else:
+            verdict, reason = (
+                "PROCEED",
+                f"Preflight agent failed (exit={preflight_result.exit_code}); "
+                "no risk signals detected — falling back to conservative PROCEED.",
+            )
+            state.preflight_degraded_reason = "timeout_no_verdict"
+            state.preflight_failure_action = "proceed"
+            _log(
+                f"  ⚠ PREFLIGHT failed (exit={preflight_result.exit_code}) — "
+                "no risk signals; fallback PROCEED (degraded)"
+            )
 
     state.preflight_verdict = verdict
     state.preflight_reason = reason
@@ -607,6 +670,11 @@ def _run_preflight_phase(
             workspace_path=workspace_path,
         ),
         "criteria_checked": state.preflight_criteria_checked,
+        "degraded": state.preflight_degraded,
+        "degraded_reason": state.preflight_degraded_reason,
+        "risk_signals": list(state.preflight_risk_signals),
+        "failure_action": state.preflight_failure_action,
+        "attempts": attempts,
     }
     state.preflight_cache_snapshot = dict(_preflight_artifact["cache_snapshot"])
     _write_log_artifact(state.log_dir, "preflight-raw.log", preflight_result.output or "")

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -317,6 +317,15 @@ class CoordinatorState:
     preflight_degraded: bool = False
     preflight_degraded_reason: str | None = None
     preflight_criteria_checked: list[dict] = field(default_factory=list)
+    # Risk signals consulted when preflight agent failed and the coordinator
+    # had to choose between conservative PROCEED and explicit escalation.
+    # Empty list means no signals were detected (or preflight succeeded so
+    # the question never arose).
+    preflight_risk_signals: list[str] = field(default_factory=list)
+    # Outcome of the failure-fallback policy: "proceed" (no risk signals →
+    # conservative PROCEED) or "escalate" (risk signals present → BLOCKED).
+    # None when preflight did not fail.
+    preflight_failure_action: str | None = None
     plan_results: list[AgentResult] = field(default_factory=list)
     plan_output: str | None = (
         None  # contents of the worktree plan file, passed to dev (raw string for audit)

--- a/tests/test_coord_preflight_fallback.py
+++ b/tests/test_coord_preflight_fallback.py
@@ -18,6 +18,7 @@ from coord_test_helpers import (
 from theforge.config.types import ModelProfile
 from theforge.coordinator.engine import run_task
 from theforge.coordinator.state import Phase
+from theforge.runners import AgentResult
 
 # ── BLOCKED output with an ambiguous/verifiability reason ────────────────────
 
@@ -282,6 +283,152 @@ class TestPreflightConservativeFallback:
         assert result.state.preflight_sufficiency == "needs_planning"
         # small→medium upgrade should have fired
         assert result.state.preflight_complexity in ("medium", "large")
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow._has_prior_execution_evidence", return_value=True)
+    def test_sigkill_with_prior_commits_escalates(
+        self,
+        mock_evidence,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """SIGKILL on a story with prior-execution evidence escalates, not PROCEED."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(success=False, output="", cost_usd=0.0)
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "BLOCKED"
+        assert result.state.preflight_failure_action == "escalate"
+        assert "prior_execution_on_branch" in result.state.preflight_risk_signals
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "agent_failed_with_risk_signals"
+        assert result.phase == Phase.ESCALATE
+        assert result.success is False
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow._has_prior_execution_evidence", return_value=False)
+    def test_sigkill_with_reopen_context_escalates(
+        self,
+        mock_evidence,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """SIGKILL on a reopened story (## Reopen Context block in body) escalates."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        # Append a reopen-context block to the spec — simulates what
+        # sprint/reopen_context.py adds for a reopened issue.
+        spec_text = task.story_path.read_text(encoding="utf-8")
+        task.story_path.write_text(
+            spec_text + "\n\n## Reopen Context\n\nThis issue was reopened on 2026-05-01.\n"
+            "Operator follow-up:\n\n> the previous attempt missed the audit fields\n",
+            encoding="utf-8",
+        )
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        # exit_code=-9 simulates SIGKILL
+        mock_preflight.return_value = AgentResult(
+            success=False,
+            output="",
+            session_id=None,
+            cost_usd=0.04,
+            exit_code=-9,
+            raw={},
+            profile_name="preflight",
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "BLOCKED"
+        assert result.state.preflight_failure_action == "escalate"
+        assert "reopen_context_in_body" in result.state.preflight_risk_signals
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "agent_failed_with_risk_signals"
+        assert "exit=-9" in (result.state.preflight_reason or "")
+        assert result.phase == Phase.ESCALATE
+        assert result.success is False
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow._has_prior_execution_evidence", return_value=False)
+    def test_sigkill_without_risk_signals_still_proceeds(
+        self,
+        mock_evidence,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """Fresh story (no reopen, no prior commits) preserves conservative PROCEED on SIGKILL."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = AgentResult(
+            success=False,
+            output="",
+            session_id=None,
+            cost_usd=0.0,
+            exit_code=-9,
+            raw={},
+            profile_name="preflight",
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_failure_action == "proceed"
+        assert result.state.preflight_risk_signals == []
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "timeout_no_verdict"
         assert result.phase == Phase.DONE
         assert result.success is True
 


### PR DESCRIPTION
## Summary

Risk-signal-aware preflight fallback correctly escalates on reopen/prior-commits signals, falls through on clean stories, and fully instruments the audit trail.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $2.67
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight SIGKILL fallback to 'conservative PROCEED' is too permissive — reopened or contract-changed stories sprint without preflight verification (GitHub Issue #1272)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1272