### PR TITLE
Stack presets for root file conventions — Python/Node/Go/Rust/Java repos should not have to hand-enumerate language-standard root files

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -48,9 +48,7 @@ conventions:
     no_circular_imports: true
     test_mirrors_source: true
     no_scratch_files: true
-    allowed_root_files:
-      - pyproject.toml
-      - poetry.lock
+    stack: python
   soft:
     - "Coordinator is pure Python — no LLM calls for routing or process decisions"
     - "Schema validation is the integrity boundary — do not relax cross-validation rules"

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -12,6 +12,8 @@ from typing import Any
 import yaml
 from dotenv import dotenv_values
 
+from theforge.root_file_conventions import normalize_root_file_stacks
+
 from ._loaders import _parse_plan_agent_review, _parse_workspace, _validate_v0_8_schema
 from .auth import check_agent_auth
 from .bridge import role_assignment_to_profiles
@@ -724,6 +726,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         _no_circular = conventions_hard_raw.get("no_circular_imports", True)
         _test_mirrors = conventions_hard_raw.get("test_mirrors_source", True)
         _no_scratch = conventions_hard_raw.get("no_scratch_files", True)
+        _stack = conventions_hard_raw.get("stack", [])
         _allowed_root_files = conventions_hard_raw.get("allowed_root_files", [])
         if not isinstance(_max_module, int):
             raise ValueError(
@@ -750,6 +753,15 @@ def load_config(config_path: Path) -> ForgeConfig:
                 "forge.yaml 'conventions.hard.no_scratch_files' must be a bool,"
                 f" got {_no_scratch!r}"
             )
+        if isinstance(_stack, str):
+            _stack_items = [_stack]
+        elif isinstance(_stack, list) and all(isinstance(item, str) for item in _stack):
+            _stack_items = _stack
+        else:
+            raise ValueError(
+                "forge.yaml 'conventions.hard.stack' must be a string or list of strings,"
+                f" got {_stack!r}"
+            )
         if not isinstance(_allowed_root_files, list) or not all(
             isinstance(item, str) for item in _allowed_root_files
         ):
@@ -763,6 +775,7 @@ def load_config(config_path: Path) -> ForgeConfig:
             no_circular_imports=_no_circular,
             test_mirrors_source=_test_mirrors,
             no_scratch_files=_no_scratch,
+            stack=normalize_root_file_stacks(_stack_items),
             allowed_root_files=tuple(_allowed_root_files),
         )
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -441,6 +441,7 @@ class HardConventionsConfig:
     no_circular_imports: bool = True
     test_mirrors_source: bool = True
     no_scratch_files: bool = True
+    stack: tuple[str, ...] = ()
     allowed_root_files: tuple[str, ...] = ()
 
 

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -12,6 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from theforge.config.types import HardConventionsConfig
+from theforge.root_file_conventions import (
+    DEFAULT_ALLOWED_ROOT_FILES,
+    resolve_root_file_allowances,
+)
 
 
 @dataclass
@@ -33,7 +37,13 @@ def check_hard_conventions(
     if config.test_mirrors_source:
         violations.extend(_check_test_mirrors(project_root))
     if config.no_scratch_files:
-        violations.extend(_check_no_scratch_files(project_root, config.allowed_root_files))
+        violations.extend(
+            _check_no_scratch_files(
+                project_root,
+                stack=config.stack,
+                allowed_root_files=config.allowed_root_files,
+            )
+        )
     violations.extend(_check_stack_neutrality(project_root))
     return violations
 
@@ -279,40 +289,14 @@ def _best_match(name: str, adjacency: dict[str, list[str]]) -> str | None:
 
 # ── Scratch file check ────────────────────────────────────────────────
 
-# Files that legitimately live in the project root (non-hidden only).
-# Hidden files (dotfiles) are always skipped — they're almost always tooling config.
-_ALLOWED_ROOT_FILES: frozenset[str] = frozenset(
-    {
-        # Build / tooling
-        "Makefile",
-        "makefile",
-        "Dockerfile",
-        "dockerignore",
-        # Documentation / metadata
-        "README.md",
-        "README.rst",
-        "README.txt",
-        "CHANGELOG.md",
-        "CHANGELOG.rst",
-        "CHANGELOG.txt",
-        "LICENSE",
-        "LICENSE.md",
-        "LICENSE.txt",
-        "LICENSE.rst",
-        "RELEASING.md",
-        "CONTRIBUTING.md",
-        "SECURITY.md",
-        "CLAUDE.md",
-        "AGENTS.md",
-        "CONVENTIONS.md",
-        # Orchestrator config
-        "forge.yaml",
-    }
-)
+_ALLOWED_ROOT_FILES: frozenset[str] = frozenset(DEFAULT_ALLOWED_ROOT_FILES)
 
 
 def _check_no_scratch_files(
-    project_root: Path, allowed_root_files: tuple[str, ...] = ()
+    project_root: Path,
+    *,
+    stack: tuple[str, ...] | list[str] = (),
+    allowed_root_files: tuple[str, ...] = (),
 ) -> list[ConventionViolation]:
     """Check that no unrecognised files exist directly in the project root.
 
@@ -326,7 +310,10 @@ def _check_no_scratch_files(
     configuration and pose no risk of accidental source-code pollution.
     """
     violations: list[ConventionViolation] = []
-    allowed_files = _ALLOWED_ROOT_FILES | frozenset(allowed_root_files)
+    allowed_files = resolve_root_file_allowances(
+        stack=stack,
+        allowed_root_files=allowed_root_files,
+    ).effective
     for f in sorted(project_root.iterdir()):
         if not f.is_file():
             continue

--- a/src/theforge/coordinator/review_context.py
+++ b/src/theforge/coordinator/review_context.py
@@ -24,15 +24,16 @@ if TYPE_CHECKING:
 def hard_convention_review_kwargs(config: ForgeConfig) -> dict[str, object]:
     """Extract the hard-convention kwargs that build_review_prompt expects.
 
-    Centralizes the propagation of ``config.conventions_hard`` (allowed_root_files,
-    no_scratch_files) into the reviewer prompt so the reviewer can proactively
-    reject diffs that introduce repo-root scratch files instead of relying on
-    the runtime hygiene gate as the sole backstop.
+    Centralizes the propagation of ``config.conventions_hard`` (stack,
+    allowed_root_files, no_scratch_files) into the reviewer prompt so the
+    reviewer can proactively reject diffs that introduce repo-root scratch
+    files instead of relying on the runtime hygiene gate as the sole backstop.
     """
     hard = config.conventions_hard
     if hard is None:
-        return {"allowed_root_files": None, "no_scratch_files": None}
+        return {"stack": None, "allowed_root_files": None, "no_scratch_files": None}
     return {
+        "stack": hard.stack,
         "allowed_root_files": hard.allowed_root_files,
         "no_scratch_files": hard.no_scratch_files,
     }

--- a/src/theforge/root_file_conventions.py
+++ b/src/theforge/root_file_conventions.py
@@ -1,0 +1,178 @@
+"""Shared root-file allowlists for the no_scratch_files convention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AppliedRootFilePreset:
+    """A named root-file preset applied to a project."""
+
+    name: str
+    files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RootFileAllowances:
+    """Resolved root-file allowances grouped by source."""
+
+    defaults: tuple[str, ...]
+    presets: tuple[AppliedRootFilePreset, ...]
+    project_additions: tuple[str, ...]
+    effective: frozenset[str]
+
+
+# Files that legitimately live in the project root across public repos.
+# Hidden files (dotfiles) are always allowed separately by the check itself.
+DEFAULT_ALLOWED_ROOT_FILES: tuple[str, ...] = (
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "CHANGELOG.rst",
+    "CHANGELOG.txt",
+    "CLAUDE.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "CONVENTIONS.md",
+    "Dockerfile",
+    "LICENSE",
+    "LICENSE.md",
+    "LICENSE.rst",
+    "LICENSE.txt",
+    "Makefile",
+    "README.md",
+    "README.rst",
+    "README.txt",
+    "RELEASING.md",
+    "SECURITY.md",
+    "dockerignore",
+    "forge.yaml",
+    "makefile",
+)
+
+
+# Stack-specific presets intentionally cover conventional root files only.
+ROOT_FILE_STACK_PRESETS: dict[str, tuple[str, ...]] = {
+    "go": (
+        "go.mod",
+        "go.sum",
+        "go.work",
+        "go.work.sum",
+    ),
+    "java": (
+        "build.gradle",
+        "build.gradle.kts",
+        "gradle.properties",
+        "gradlew",
+        "gradlew.bat",
+        "mvnw",
+        "mvnw.cmd",
+        "pom.xml",
+        "settings.gradle",
+        "settings.gradle.kts",
+    ),
+    "javascript": (
+        "bun.lock",
+        "bun.lockb",
+        "jsconfig.json",
+        "npm-shrinkwrap.json",
+        "package-lock.json",
+        "package.json",
+        "pnpm-lock.yaml",
+        "tsconfig.base.json",
+        "tsconfig.json",
+        "yarn.lock",
+    ),
+    "python": (
+        "Pipfile",
+        "Pipfile.lock",
+        "conftest.py",
+        "poetry.lock",
+        "pyproject.toml",
+        "pytest.ini",
+        "requirements-dev.txt",
+        "requirements-test.txt",
+        "requirements.txt",
+        "setup.cfg",
+        "setup.py",
+        "tox.ini",
+        "uv.lock",
+    ),
+    "rust": (
+        "Cargo.lock",
+        "Cargo.toml",
+        "build.rs",
+        "clippy.toml",
+        "rust-toolchain.toml",
+        "rustfmt.toml",
+    ),
+}
+
+ROOT_FILE_STACK_ALIASES: dict[str, str] = {
+    "go": "go",
+    "golang": "go",
+    "java": "java",
+    "javascript": "javascript",
+    "js": "javascript",
+    "node": "javascript",
+    "nodejs": "javascript",
+    "python": "python",
+    "py": "python",
+    "rust": "rust",
+}
+
+
+def normalize_root_file_stacks(stacks: tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
+    """Normalize configured stack names into canonical preset ids."""
+    if not stacks:
+        return ()
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for stack in stacks:
+        canonical = ROOT_FILE_STACK_ALIASES.get(stack.strip().lower())
+        if canonical is None:
+            valid = ", ".join(sorted(ROOT_FILE_STACK_PRESETS))
+            raise ValueError(
+                "forge.yaml 'conventions.hard.stack' contains unknown preset "
+                f"{stack!r}; expected one of: {valid}"
+            )
+        if canonical not in seen:
+            normalized.append(canonical)
+            seen.add(canonical)
+    return tuple(normalized)
+
+
+def resolve_root_file_allowances(
+    *,
+    stack: tuple[str, ...] | list[str] | None = None,
+    allowed_root_files: tuple[str, ...] | list[str] | None = None,
+) -> RootFileAllowances:
+    """Resolve the effective allowlist for repo-root files."""
+    defaults = tuple(DEFAULT_ALLOWED_ROOT_FILES)
+    stack_names = normalize_root_file_stacks(stack)
+    presets = tuple(
+        AppliedRootFilePreset(
+            name=name,
+            files=ROOT_FILE_STACK_PRESETS[name],
+        )
+        for name in stack_names
+    )
+
+    preset_allowed: set[str] = set()
+    for preset in presets:
+        preset_allowed.update(preset.files)
+
+    project_items = tuple(allowed_root_files or ())
+    project_additions = tuple(
+        item
+        for item in project_items
+        if item not in DEFAULT_ALLOWED_ROOT_FILES and item not in preset_allowed
+    )
+
+    effective = frozenset(defaults) | preset_allowed | frozenset(project_items)
+    return RootFileAllowances(
+        defaults=defaults,
+        presets=presets,
+        project_additions=project_additions,
+        effective=effective,
+    )

--- a/src/theforge/task/conventions.py
+++ b/src/theforge/task/conventions.py
@@ -1,3 +1,6 @@
+from theforge.root_file_conventions import resolve_root_file_allowances
+
+
 def render_conventions_block(conventions: list[str] | None) -> str:
     """Render the soft conventions prompt block.
 
@@ -16,6 +19,7 @@ def render_conventions_block(conventions: list[str] | None) -> str:
 
 def render_hard_conventions_block(
     *,
+    stack: tuple[str, ...] | list[str] | None = None,
     allowed_root_files: tuple[str, ...] | list[str] | None = None,
     no_scratch_files: bool | None = None,
 ) -> str:
@@ -29,23 +33,34 @@ def render_hard_conventions_block(
     """
     sections: list[str] = []
     if no_scratch_files:
-        if allowed_root_files:
-            allowed = ", ".join(f"`{p}`" for p in allowed_root_files)
-            allowed_note = f"The project additionally permits these repo-root files: {allowed}."
+        allowances = resolve_root_file_allowances(
+            stack=stack,
+            allowed_root_files=allowed_root_files,
+        )
+        defaults = ", ".join(f"`{item}`" for item in allowances.defaults)
+        if allowances.presets:
+            preset_lines = "\n".join(
+                f"  - `{preset.name}`: {', '.join(f'`{item}`' for item in preset.files)}"
+                for preset in allowances.presets
+            )
         else:
-            allowed_note = "The project has not declared any additional permitted repo-root files."
+            preset_lines = "  - none"
+        if allowances.project_additions:
+            additions = ", ".join(f"`{item}`" for item in allowances.project_additions)
+        else:
+            additions = "`none`"
         sections.append(
             "### No scratch files at the repo root\n\n"
-            "Files at the repository root are restricted to a canonical allowlist "
-            "(README, LICENSE, CHANGELOG, pyproject.toml, etc.) plus any files the "
-            "project explicitly declares as allowed. "
-            f"{allowed_note}\n\n"
+            "Allowed root files (current effective set):\n"
+            f"Defaults (community standards): {defaults}\n"
+            f"Stack presets:\n{preset_lines}\n"
+            f"Project additions: {additions}\n\n"
             "Any commit in this change that introduces a new repo-root file outside "
-            "this allowlist (for example: `test_*.py`, `*.lock` scratch files, "
-            "ad-hoc audit YAML, rename leftovers) is a **P1 finding**. Cite the "
+            "this effective set (not allowed by the defaults, an applied preset, "
+            "or a project-specific addition) is a **P1 finding**. Cite the "
             "specific file path and the convention by name (`no_scratch_files`). "
-            "The runtime workspace hygiene gate will also reject these — your job "
-            "as reviewer is to catch them before they land."
+            "The runtime workspace hygiene gate will also reject these, so use the "
+            "breakdown above to audit whether a repo-root file is actually legitimate."
         )
     if not sections:
         return ""

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -158,6 +158,7 @@ def build_review_prompt(
     dev_notes: str | None = None,
     cycle_history: list[CycleHistory] | None = None,
     conventions: list[str] | None = None,
+    stack: tuple[str, ...] | list[str] | None = None,
     allowed_root_files: tuple[str, ...] | list[str] | None = None,
     no_scratch_files: bool | None = None,
     assembled_context: ContextPack | None = None,
@@ -307,6 +308,7 @@ def build_review_prompt(
 
     sandbox_label = "enabled" if sandboxed else "DISABLED (unsandboxed — effects ran unconfined)"
     _hard_block = render_hard_conventions_block(
+        stack=stack,
         allowed_root_files=allowed_root_files,
         no_scratch_files=no_scratch_files,
     )

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -662,6 +662,8 @@ class TestConventionsConfig:
                         "max_test_file_lines": 800,
                         "no_circular_imports": True,
                         "test_mirrors_source": False,
+                        "stack": ["python", "js"],
+                        "allowed_root_files": ["my-project-config.yaml"],
                     }
                 }
             },
@@ -673,6 +675,8 @@ class TestConventionsConfig:
         assert config.conventions_hard.max_test_file_lines == 800
         assert config.conventions_hard.no_circular_imports is True
         assert config.conventions_hard.test_mirrors_source is False
+        assert config.conventions_hard.stack == ("python", "javascript")
+        assert config.conventions_hard.allowed_root_files == ("my-project-config.yaml",)
 
     def test_conventions_absent_is_none(self, tmp_path):
         """forge.yaml without conventions section yields conventions_hard=None."""
@@ -691,6 +695,7 @@ class TestConventionsConfig:
         assert config.conventions_hard.max_test_file_lines == 1000
         assert config.conventions_hard.no_circular_imports is True
         assert config.conventions_hard.test_mirrors_source is True
+        assert config.conventions_hard.stack == ()
 
     def test_conventions_hard_invalid_type_raises(self, tmp_path):
         """conventions.hard with wrong type raises ValueError."""
@@ -699,6 +704,23 @@ class TestConventionsConfig:
             tmp_path,
         )
         with pytest.raises(ValueError, match="max_module_lines"):
+            load_config(config_path)
+
+    def test_conventions_hard_stack_accepts_single_string(self, tmp_path):
+        config_path = _write_config(
+            {"conventions": {"hard": {"stack": "node"}}},
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.conventions_hard is not None
+        assert config.conventions_hard.stack == ("javascript",)
+
+    def test_conventions_hard_unknown_stack_raises(self, tmp_path):
+        config_path = _write_config(
+            {"conventions": {"hard": {"stack": ["python", "elixir"]}}},
+            tmp_path,
+        )
+        with pytest.raises(ValueError, match="unknown preset"):
             load_config(config_path)
 
     def test_conventions_advisory_defaults(self, tmp_path):

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -18,6 +18,7 @@ from theforge.conventions import (
     check_hard_conventions,
     new_hard_convention_violations_since_ref,
 )
+from theforge.root_file_conventions import ROOT_FILE_STACK_PRESETS
 
 
 def _make_config(**kwargs) -> HardConventionsConfig:
@@ -230,6 +231,7 @@ class TestTestMirrorCheck:
 
 
 def test_allowed_root_files_whitelist_is_stack_neutral() -> None:
+    assert "CODE_OF_CONDUCT.md" in _ALLOWED_ROOT_FILES
     assert "CONVENTIONS.md" in _ALLOWED_ROOT_FILES
     assert "conftest.py" not in _ALLOWED_ROOT_FILES
     assert "tox.ini" not in _ALLOWED_ROOT_FILES
@@ -507,6 +509,7 @@ class TestNoScratchFilesCheck:
         (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
         (tmp_path / "Makefile").write_text("all:\n\techo hi\n", encoding="utf-8")
         (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+        (tmp_path / "CODE_OF_CONDUCT.md").write_text("Be kind.\n", encoding="utf-8")
         violations = _check_no_scratch_files(tmp_path)
         assert violations == []
 
@@ -524,9 +527,45 @@ class TestNoScratchFilesCheck:
         assert "package-lock.json" in files
         assert "yarn.lock" in files
 
+    def test_project_without_stack_presets_keeps_existing_behavior(self, tmp_path):
+        _write(tmp_path / "pyproject.toml", "[project]\n")
+        violations = _check_no_scratch_files(tmp_path)
+        assert any(v.rule == "no_scratch_files" and v.file == "pyproject.toml" for v in violations)
+
     def test_project_local_allowed_root_files_extend_whitelist(self, tmp_path):
         _write(tmp_path / "pyproject.toml", "[project]\n")
-        violations = _check_no_scratch_files(tmp_path, ("pyproject.toml",))
+        violations = _check_no_scratch_files(tmp_path, allowed_root_files=("pyproject.toml",))
+        assert violations == []
+
+    def test_each_stack_preset_allows_its_known_files(self, tmp_path):
+        for stack_name, files in ROOT_FILE_STACK_PRESETS.items():
+            for file_name in files:
+                _write(tmp_path / file_name, "ok\n")
+            violations = _check_no_scratch_files(tmp_path, stack=(stack_name,))
+            assert violations == [], stack_name
+            for file_name in files:
+                (tmp_path / file_name).unlink()
+
+    def test_multiple_stack_presets_compose(self, tmp_path):
+        _write(tmp_path / "pyproject.toml", "[project]\n")
+        _write(tmp_path / "package.json", "{}\n")
+        violations = _check_no_scratch_files(tmp_path, stack=("python", "javascript"))
+        assert violations == []
+
+    def test_unknown_files_still_violate_with_stack_preset(self, tmp_path):
+        _write(tmp_path / "pyproject.toml", "[project]\n")
+        _write(tmp_path / "scratch.txt", "oops\n")
+        violations = _check_no_scratch_files(tmp_path, stack=("python",))
+        assert any(v.rule == "no_scratch_files" and v.file == "scratch.txt" for v in violations)
+
+    def test_stack_preset_and_project_addition_compose(self, tmp_path):
+        _write(tmp_path / "pyproject.toml", "[project]\n")
+        _write(tmp_path / "my-project-config.yaml", "custom: true\n")
+        violations = _check_no_scratch_files(
+            tmp_path,
+            stack=("python",),
+            allowed_root_files=("my-project-config.yaml",),
+        )
         assert violations == []
 
     def test_dotfiles_not_flagged(self, tmp_path):

--- a/tests/test_soft_conventions.py
+++ b/tests/test_soft_conventions.py
@@ -282,7 +282,10 @@ class TestRenderHardConventionsBlock:
         # Only render when no_scratch_files is enforced.
         assert render_hard_conventions_block(no_scratch_files=False) == ""
         assert (
-            render_hard_conventions_block(no_scratch_files=False, allowed_root_files=("foo.txt",))
+            render_hard_conventions_block(
+                no_scratch_files=False,
+                allowed_root_files=("foo.txt",),
+            )
             == ""
         )
 
@@ -300,11 +303,23 @@ class TestRenderHardConventionsBlock:
         )
         assert "pyproject.toml" in result
         assert "poetry.lock" in result
+        assert "Project additions" in result
 
     def test_no_allowed_files_still_renders_when_no_scratch_files(self):
         result = render_hard_conventions_block(no_scratch_files=True, allowed_root_files=())
         assert "Hard" in result
-        assert "not declared any additional permitted repo-root files" in result
+        assert "Project additions: `none`" in result
+
+    def test_stack_presets_render_separately_from_defaults_and_additions(self):
+        result = render_hard_conventions_block(
+            no_scratch_files=True,
+            stack=("python", "javascript"),
+            allowed_root_files=("my-project-config.yaml",),
+        )
+        assert "Defaults (community standards)" in result
+        assert "`python`" in result
+        assert "`javascript`" in result
+        assert "my-project-config.yaml" in result
 
 
 class TestBuildReviewPromptHardConventions:
@@ -319,10 +334,12 @@ class TestBuildReviewPromptHardConventions:
             branch="feat/test",
             handoff_content="gate_result: PASS",
             no_scratch_files=True,
+            stack=("python",),
             allowed_root_files=("pyproject.toml",),
         )
         assert "Hard — Mechanically Enforced" in prompt
         assert "pyproject.toml" in prompt
+        assert "`python`" in prompt
         assert "no_scratch_files" in prompt
 
     def test_no_hard_conventions_no_block(self, tmp_path):
@@ -350,6 +367,7 @@ class TestBuildReviewPromptHardConventions:
             handoff_content="gate_result: PASS",
             conventions=["Single concern per module"],
             no_scratch_files=True,
+            stack=("python",),
             allowed_root_files=("pyproject.toml",),
         )
         assert "Hard — Mechanically Enforced" in prompt
@@ -372,11 +390,13 @@ class TestHardConventionConfigPropagation:
             cfg,
             conventions_hard=HardConventionsConfig(
                 no_scratch_files=True,
+                stack=("python",),
                 allowed_root_files=("pyproject.toml", "poetry.lock"),
             ),
         )
         kwargs = hard_convention_review_kwargs(cfg)
         assert kwargs == {
+            "stack": ("python",),
             "allowed_root_files": ("pyproject.toml", "poetry.lock"),
             "no_scratch_files": True,
         }
@@ -385,7 +405,7 @@ class TestHardConventionConfigPropagation:
         cfg = _make_config(tmp_path)  # conventions_hard defaults to None
         assert cfg.conventions_hard is None
         kwargs = hard_convention_review_kwargs(cfg)
-        assert kwargs == {"allowed_root_files": None, "no_scratch_files": None}
+        assert kwargs == {"stack": None, "allowed_root_files": None, "no_scratch_files": None}
 
     def test_helper_kwargs_round_trip_into_review_prompt(self, tmp_path):
         """The kwargs returned by the helper are accepted by build_review_prompt
@@ -397,6 +417,7 @@ class TestHardConventionConfigPropagation:
             cfg,
             conventions_hard=HardConventionsConfig(
                 no_scratch_files=True,
+                stack=("python",),
                 allowed_root_files=("pyproject.toml",),
             ),
         )
@@ -413,6 +434,7 @@ class TestHardConventionConfigPropagation:
         )
         assert "Hard — Mechanically Enforced" in prompt
         assert "pyproject.toml" in prompt
+        assert "`python`" in prompt
 
     def test_helper_kwargs_no_block_when_conventions_hard_none(self, tmp_path):
         cfg = _make_config(tmp_path)


### PR DESCRIPTION
## Summary

Stack preset feature satisfies all ACs — CODE_OF_CONDUCT.md added to defaults, five stack presets ship, composition works, reviewer prompt renders all three tiers; uncommitted forge.yaml revert in worktree is the only notable artifact.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.49
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

- **[P2] `forge.yaml:None`** The worktree has an uncommitted change that reverts forge.yaml from the committed 'stack: python' back to the old 'allowed_root_files: [pyproject.toml, poetry.lock]'. The committed state is correct, but this stale working-tree diff creates confusion and would undo the self-dogfooding fix if accidentally committed.
- **[P2] `src/theforge/root_file_conventions.py:111`** ROOT_FILE_STACK_ALIASES has no 'typescript' or 'ts' entry for the JavaScript preset. Operators of TypeScript-only repos would naturally try 'stack: typescript' and hit an 'unknown preset' error. The 'node'/'nodejs' aliases cover one common mental model but 'typescript' is a distinct, very common one.

## Story

Stack presets for root file conventions — Python/Node/Go/Rust/Java repos should not have to hand-enumerate language-standard root files (GitHub Issue #1265)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1265