### PR TITLE
Sprint intake remediation uses a deferred placeholder agent caller instead of the configured agent-backed grooming path

### DIFF
--- a/src/theforge/intake/__init__.py
+++ b/src/theforge/intake/__init__.py
@@ -11,6 +11,11 @@ injectable callables so the module remains testable without network.
 
 from __future__ import annotations
 
+from .agent_rewrite import (
+    AgentRewriteResult,
+    build_agent_rewrite_prompt,
+    parse_agent_rewrite_output,
+)
 from .findings import (
     FixType,
     IntakeFinding,
@@ -27,12 +32,15 @@ from .remediation import (
 
 __all__ = [
     "FixType",
+    "AgentRewriteResult",
     "IntakeFinding",
     "IntakeOutcome",
     "IntakeOutcomeKind",
     "IntakeSeverity",
     "apply_mechanical_fixes",
+    "build_agent_rewrite_prompt",
     "findings_from_shape_result",
     "groom_check",
+    "parse_agent_rewrite_output",
     "run_intake_remediation",
 ]

--- a/src/theforge/intake/agent_rewrite.py
+++ b/src/theforge/intake/agent_rewrite.py
@@ -1,0 +1,91 @@
+"""Prompt + parser helpers for intake agent remediation.
+
+This module intentionally owns only the textual contract for intake rewrite
+agents: how we ask for a remediation and how we interpret the response. The
+runner remains responsible for transport/config wiring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .findings import IntakeFinding
+
+_NO_REMEDIATION_PREFIX = "NO_REMEDIATION:"
+
+
+@dataclass(frozen=True)
+class AgentRewriteResult:
+    """Structured result from an intake remediation agent call."""
+
+    replacement: str | None
+    detail: str = ""
+    attempted: bool = False
+    profile_name: str | None = None
+    model_used: str | None = None
+    cost_usd: float | None = None
+    transport_used: str | None = None
+
+
+def build_agent_rewrite_prompt(body: str, findings: list[IntakeFinding]) -> str:
+    """Build the one-shot intake remediation prompt."""
+    lines = [
+        "You are remediating a GitHub issue body for TheForge sprint intake.",
+        "Rewrite the issue body so it resolves the blocking findings below.",
+        "Preserve the issue's intent. Do not add implementation steps, file paths, or test plans.",
+        "",
+        "Output rules:",
+        "1. If you can fix the issue, return only the full replacement Markdown body.",
+        "2. If you cannot produce a compliant replacement, return exactly one line starting with",
+        f"   {_NO_REMEDIATION_PREFIX}",
+        "3. Do not include explanations, bullets outside the issue body, or surrounding prose.",
+        "",
+        "Blocking findings:",
+    ]
+    for finding in findings:
+        lines.append(f"- `{finding.code}` at `{finding.location}`: {finding.problem}")
+    lines.extend(
+        [
+            "",
+            "Current issue body:",
+            "```markdown",
+            body,
+            "```",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_agent_rewrite_output(output: str) -> AgentRewriteResult:
+    """Parse the intake rewrite agent output into a structured result."""
+    text = output.strip()
+    if not text:
+        return AgentRewriteResult(
+            replacement=None,
+            detail="agent returned empty output",
+            attempted=True,
+        )
+
+    if text.startswith(_NO_REMEDIATION_PREFIX):
+        reason = text[len(_NO_REMEDIATION_PREFIX) :].strip() or "agent declined remediation"
+        return AgentRewriteResult(replacement=None, detail=reason, attempted=True)
+
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline != -1:
+            text = text[first_newline + 1 :]
+    if text.endswith("```"):
+        text = text[: text.rfind("```")].rstrip()
+
+    text = text.strip()
+    if not text:
+        return AgentRewriteResult(
+            replacement=None,
+            detail="agent returned an empty fenced body",
+            attempted=True,
+        )
+    return AgentRewriteResult(
+        replacement=text,
+        detail="agent produced replacement",
+        attempted=True,
+    )

--- a/src/theforge/intake/remediation.py
+++ b/src/theforge/intake/remediation.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from ..shape_check import check as shape_check
 from ..task import TaskStory
+from .agent_rewrite import AgentRewriteResult
 from .findings import FixType, IntakeFinding, IntakeSeverity, findings_from_shape_result
 from .groom import groom_check
 from .mechanical import apply_mechanical_fixes
@@ -47,6 +48,7 @@ class IntakeOutcome:
     findings: tuple[IntakeFinding, ...] = field(default_factory=tuple)
     proposed_replacement: str | None = None
     detail: str = ""
+    audit: dict[str, object] = field(default_factory=dict)
 
     def as_dict(self) -> dict:
         return {
@@ -55,6 +57,7 @@ class IntakeOutcome:
             "findings": [f.as_dict() for f in self.findings],
             "proposed_replacement": self.proposed_replacement,
             "detail": self.detail,
+            "audit": dict(self.audit),
         }
 
 
@@ -62,7 +65,7 @@ class IntakeOutcome:
 FetchIssueDetail = Callable[[int, Path | None], dict | None]
 PostIssueComment = Callable[[int, str, Path | None], bool]
 EditIssueBody = Callable[[int, str, Path | None], bool]
-AgentRewriteCaller = Callable[[str, list[IntakeFinding]], str | None]
+AgentRewriteCaller = Callable[[str, list[IntakeFinding]], AgentRewriteResult]
 
 
 def _default_fetch_detail(number: int, project_root: Path | None) -> dict | None:
@@ -178,6 +181,32 @@ def _gather_findings(
     return findings
 
 
+def _build_audit(
+    *,
+    consumed: list[IntakeFinding],
+    semantic_remaining: list[IntakeFinding],
+    agent: AgentRewriteResult | None = None,
+    remediation_source: str = "none",
+    issue_updated: bool = False,
+    comment_posted: bool = False,
+) -> dict[str, object]:
+    return {
+        "remediation_source": remediation_source,
+        "mechanical_findings": [f.as_dict() for f in consumed],
+        "semantic_findings": [f.as_dict() for f in semantic_remaining],
+        "agent": {
+            "attempted": bool(agent.attempted) if agent is not None else False,
+            "detail": agent.detail if agent is not None else "",
+            "profile_name": agent.profile_name if agent is not None else None,
+            "model_used": agent.model_used if agent is not None else None,
+            "cost_usd": agent.cost_usd if agent is not None else None,
+            "transport_used": agent.transport_used if agent is not None else None,
+        },
+        "issue_updated": issue_updated,
+        "comment_posted": comment_posted,
+    }
+
+
 def _remediate_one(
     *,
     slug: str,
@@ -189,6 +218,7 @@ def _remediate_one(
     auto_fix_enabled: bool,
     auto_fix_mode: str,
     agent_caller: AgentRewriteCaller | None,
+    missing_agent_detail: str,
     post_comment: PostIssueComment,
     edit_body: EditIssueBody,
     project_root: Path | None,
@@ -197,7 +227,12 @@ def _remediate_one(
     findings = _gather_findings(title, body, labels, grooming_enabled=grooming_enabled)
     blocking = _blocking(findings)
     if not blocking:
-        return IntakeOutcome(slug=slug, kind=IntakeOutcomeKind.PASSED, findings=tuple(findings))
+        return IntakeOutcome(
+            slug=slug,
+            kind=IntakeOutcomeKind.PASSED,
+            findings=tuple(findings),
+            audit=_build_audit(consumed=[], semantic_remaining=[]),
+        )
 
     # Apply mechanical patches first; they need no LLM and never fail.
     patched_body, patched_labels, _consumed, remaining = apply_mechanical_fixes(
@@ -212,29 +247,42 @@ def _remediate_one(
             kind=IntakeOutcomeKind.DROPPED_SHAPE,
             findings=tuple(blocking),
             detail="auto-fix disabled",
+            audit=_build_audit(consumed=[], semantic_remaining=blocking),
         )
 
     # Even if mechanical patches resolved everything, the gate must rerun once
     # to verify. If no semantic findings remain, skip the agent call.
     proposed_body = patched_body
+    agent_result: AgentRewriteResult | None = None
     if semantic_remaining:
         if agent_caller is None:
             return IntakeOutcome(
                 slug=slug,
                 kind=IntakeOutcomeKind.DROPPED_SHAPE,
                 findings=tuple(blocking),
-                detail="auto-fix enabled but no agent caller wired",
+                detail=missing_agent_detail,
+                audit=_build_audit(
+                    consumed=_consumed,
+                    semantic_remaining=semantic_remaining,
+                    remediation_source="missing_agent",
+                ),
             )
-        agent_output = agent_caller(patched_body, semantic_remaining)
-        if not agent_output:
+        agent_result = agent_caller(patched_body, semantic_remaining)
+        if not agent_result.replacement:
             return IntakeOutcome(
                 slug=slug,
                 kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
                 findings=tuple(blocking),
                 proposed_replacement=None,
-                detail="agent remediation produced no output",
+                detail=agent_result.detail or "agent remediation produced no output",
+                audit=_build_audit(
+                    consumed=_consumed,
+                    semantic_remaining=semantic_remaining,
+                    agent=agent_result,
+                    remediation_source="agent_no_output",
+                ),
             )
-        proposed_body = agent_output
+        proposed_body = agent_result.replacement
 
     # Re-run shape + grooming once on the proposed body to verify resolution.
     rerun_findings = _gather_findings(
@@ -251,6 +299,12 @@ def _remediate_one(
                 findings=tuple(rerun_blocking),
                 proposed_replacement=proposed_body,
                 detail="rerun gate still failing; did not edit issue",
+                audit=_build_audit(
+                    consumed=_consumed,
+                    semantic_remaining=semantic_remaining,
+                    agent=agent_result,
+                    remediation_source=("agent" if agent_result is not None else "mechanical"),
+                ),
             )
         if not edit_body(issue_number, proposed_body, project_root):
             return IntakeOutcome(
@@ -259,6 +313,12 @@ def _remediate_one(
                 findings=tuple(blocking),
                 proposed_replacement=proposed_body,
                 detail="gh issue edit failed",
+                audit=_build_audit(
+                    consumed=_consumed,
+                    semantic_remaining=semantic_remaining,
+                    agent=agent_result,
+                    remediation_source=("agent" if agent_result is not None else "mechanical"),
+                ),
             )
         return IntakeOutcome(
             slug=slug,
@@ -266,13 +326,20 @@ def _remediate_one(
             findings=tuple(blocking),
             proposed_replacement=proposed_body,
             detail="edit mode: issue body updated, gate rerun passed",
+            audit=_build_audit(
+                consumed=_consumed,
+                semantic_remaining=semantic_remaining,
+                agent=agent_result,
+                remediation_source=("agent" if agent_result is not None else "mechanical"),
+                issue_updated=True,
+            ),
         )
 
     # Default: comment mode. Post the proposed replacement and drop the story
     # from this sprint. The contract is unchanged on disk; the operator
     # decides whether to accept the rewrite.
     comment = _format_remediation_comment(blocking, proposed_body)
-    post_comment(issue_number, comment, project_root)
+    posted = post_comment(issue_number, comment, project_root)
     if rerun_blocking:
         return IntakeOutcome(
             slug=slug,
@@ -280,6 +347,13 @@ def _remediate_one(
             findings=tuple(rerun_blocking),
             proposed_replacement=proposed_body,
             detail="comment mode: posted replacement; rerun gate still failing",
+            audit=_build_audit(
+                consumed=_consumed,
+                semantic_remaining=semantic_remaining,
+                agent=agent_result,
+                remediation_source=("agent" if agent_result is not None else "mechanical"),
+                comment_posted=posted,
+            ),
         )
     return IntakeOutcome(
         slug=slug,
@@ -287,6 +361,13 @@ def _remediate_one(
         findings=tuple(blocking),
         proposed_replacement=proposed_body,
         detail="comment mode: proposed replacement posted; story dropped",
+        audit=_build_audit(
+            consumed=_consumed,
+            semantic_remaining=semantic_remaining,
+            agent=agent_result,
+            remediation_source=("agent" if agent_result is not None else "mechanical"),
+            comment_posted=posted,
+        ),
     )
 
 
@@ -298,6 +379,7 @@ def run_intake_remediation(
     auto_fix_enabled: bool = False,
     auto_fix_mode: str = "comment",
     agent_caller: AgentRewriteCaller | None = None,
+    missing_agent_detail: str = "auto-fix enabled but no agent caller wired",
     fetch_detail: FetchIssueDetail = _default_fetch_detail,
     post_comment: PostIssueComment = _default_post_comment,
     edit_body: EditIssueBody = _default_edit_body,
@@ -348,6 +430,7 @@ def run_intake_remediation(
             auto_fix_enabled=auto_fix_enabled,
             auto_fix_mode=auto_fix_mode,
             agent_caller=agent_caller,
+            missing_agent_detail=missing_agent_detail,
             post_comment=post_comment,
             edit_body=edit_body,
             project_root=project_root,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -12,11 +12,13 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import replace
 from pathlib import Path
 
 import yaml
 
 from ..config import ForgeConfig
+from ..config.auth import check_agent_auth
 from ..coordinator import workspace as coordinator_workspace
 from ..coordinator.engine import run_from_dev, run_from_review, run_task
 from ..coordinator.gate import run_gate_full
@@ -32,8 +34,11 @@ from ..coordinator.util import (
 )
 from ..coordinator.workspace import sweep_orphan_worktrees
 from ..intake import (
+    AgentRewriteResult,
     IntakeOutcome,
     IntakeOutcomeKind,
+    build_agent_rewrite_prompt,
+    parse_agent_rewrite_output,
     run_intake_remediation,
 )
 from ..log_util import _log_line
@@ -73,6 +78,8 @@ from .state_writer import SprintStateWriter
 from .story_state import SprintStoryState, StoryOutcome, coerce_outcome
 
 _UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"codex", "gemini"})
+run_agent = None
+log_agent_result = None
 
 
 def _log(msg: str) -> None:
@@ -88,23 +95,75 @@ def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:
     _deindex_forge_artifacts(config.project_root)
 
 
-def _intake_agent_caller_stub(_body: str, findings: list) -> str | None:
-    """Minimal default agent caller for the intake remediation gate.
+def _ensure_intake_runner() -> None:
+    global run_agent, log_agent_result
+    if run_agent is not None and log_agent_result is not None:
+        return
+    import theforge.runners as _r  # noqa: PLC0415
 
-    A real LLM-backed rewrite is a deferred follow-up; until that lands,
-    this stub records the deferral explicitly in the sprint log and returns
-    None so the orchestrator routes the story to DROPPED_AFTER_FIX (with
-    findings preserved) instead of silently masquerading as DROPPED_SHAPE.
-    The intent: an operator who sets ``intake.auto_fix: true`` and sees a
-    drop should be able to tell from the audit trail that the agent path
-    fired but produced no rewrite, not that auto-fix was never attempted.
-    """
-    codes = ", ".join(getattr(f, "code", "?") for f in findings)
-    _log(
-        "Intake auto-fix agent caller is a stub (no LLM wired). "
-        f"Returning no rewrite for {len(findings)} semantic finding(s): {codes}"
-    )
-    return None
+    if run_agent is None:
+        run_agent = _r.run_agent
+    if log_agent_result is None:
+        log_agent_result = _r.log_agent_result
+
+
+def _build_intake_agent_caller(
+    *,
+    config: ForgeConfig,
+    log: Callable[[str], None],
+) -> tuple[Callable[[str, list], AgentRewriteResult] | None, str]:
+    """Build the configured intake remediation caller or return an explicit reason."""
+    _ensure_intake_runner()
+    try:
+        profile = replace(
+            config.dev_profile,
+            name="intake-remediation",
+            phase="preflight",
+            allowed_tools=(),
+        )
+    except TypeError:
+        detail = "auto-fix enabled but no intake agent caller is available: invalid dev profile"
+        log(detail)
+        return None, detail
+    ready, reason = check_agent_auth(profile, config.secrets)
+    if not ready:
+        detail = f"auto-fix enabled but no intake agent caller is available: {reason}"
+        log(f"Intake remediation agent unavailable: {reason}")
+        return None, detail
+
+    def _call(body: str, findings: list) -> AgentRewriteResult:
+        prompt = build_agent_rewrite_prompt(body, findings)
+        result = run_agent(
+            prompt=prompt,
+            profile=profile,
+            working_dir=config.project_root,
+            quiet=True,
+            secrets=config.secrets,
+            plain_text=True,
+        )
+        log_agent_result(result, "INTAKE_REMEDIATION")
+        if not result.success:
+            output_snippet = (result.output or "").strip()[:200] or "unknown error"
+            detail = f"agent invocation failed: {output_snippet}"
+            return AgentRewriteResult(
+                replacement=None,
+                detail=detail,
+                attempted=True,
+                profile_name=profile.name,
+                model_used=result.model_used or profile.model,
+                cost_usd=result.cost_usd,
+                transport_used=result.transport_used,
+            )
+        parsed = parse_agent_rewrite_output(result.output)
+        return replace(
+            parsed,
+            profile_name=profile.name,
+            model_used=result.model_used or profile.model,
+            cost_usd=result.cost_usd,
+            transport_used=result.transport_used,
+        )
+
+    return _call, ""
 
 
 def _run_intake_remediation_pass(
@@ -120,22 +179,34 @@ def _run_intake_remediation_pass(
     that case, preserving today's behavior exactly.
     """
     intake_cfg = getattr(config, "intake", None)
-    grooming_enabled = bool(getattr(intake_cfg, "grooming", False))
-    auto_fix_enabled = bool(getattr(intake_cfg, "auto_fix", False))
-    auto_fix_mode = getattr(intake_cfg, "auto_fix_mode", "comment") or "comment"
+    grooming_raw = getattr(intake_cfg, "grooming", False)
+    auto_fix_raw = getattr(intake_cfg, "auto_fix", False)
+    auto_fix_mode_raw = getattr(intake_cfg, "auto_fix_mode", "comment")
+    grooming_enabled = grooming_raw if isinstance(grooming_raw, bool) else False
+    auto_fix_enabled = auto_fix_raw if isinstance(auto_fix_raw, bool) else False
+    auto_fix_mode = auto_fix_mode_raw if isinstance(auto_fix_mode_raw, str) else "comment"
+    auto_fix_mode = auto_fix_mode or "comment"
     if not grooming_enabled and not auto_fix_enabled:
         return {}
     log(
         "Intake remediation gate: grooming="
         f"{grooming_enabled} auto_fix={auto_fix_enabled} mode={auto_fix_mode}"
     )
+    agent_caller = None
+    missing_agent_detail = "auto-fix enabled but no agent caller wired"
+    if auto_fix_enabled:
+        agent_caller, missing_agent_detail = _build_intake_agent_caller(
+            config=config,
+            log=log,
+        )
     return run_intake_remediation(
         tasks,
         config.project_root,
         grooming_enabled=grooming_enabled,
         auto_fix_enabled=auto_fix_enabled,
         auto_fix_mode=auto_fix_mode,
-        agent_caller=_intake_agent_caller_stub if auto_fix_enabled else None,
+        agent_caller=agent_caller,
+        missing_agent_detail=missing_agent_detail,
     )
 
 
@@ -1397,6 +1468,7 @@ def run_sprint(
                     "intake_kind": outcome.kind.value,
                     "intake_findings": [f.as_dict() for f in outcome.findings],
                     "intake_detail": outcome.detail,
+                    "intake_audit": dict(outcome.audit),
                 },
                 reason=outcome.detail or outcome.kind.value,
             )

--- a/tests/test_intake/test_remediation.py
+++ b/tests/test_intake/test_remediation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from theforge.intake import (
+    AgentRewriteResult,
     IntakeOutcomeKind,
     run_intake_remediation,
 )
@@ -97,7 +98,7 @@ def test_auto_fix_comment_mode_posts_replacement_and_drops():
     edit_body, edit_calls = _record_calls()
 
     def agent(body, findings):
-        return _PASSING_BODY
+        return AgentRewriteResult(replacement=_PASSING_BODY, detail="agent produced replacement")
 
     outcomes = run_intake_remediation(
         [task],
@@ -124,7 +125,7 @@ def test_auto_fix_edit_mode_updates_body_and_remediates():
     edit_body, edit_calls = _record_calls()
 
     def agent(body, findings):
-        return _PASSING_BODY
+        return AgentRewriteResult(replacement=_PASSING_BODY, detail="agent produced replacement")
 
     outcomes = run_intake_remediation(
         [task],
@@ -140,6 +141,7 @@ def test_auto_fix_edit_mode_updates_body_and_remediates():
     out = outcomes[task.slug]
     assert out.kind is IntakeOutcomeKind.REMEDIATED
     assert out.proposed_replacement == _PASSING_BODY
+    assert out.audit["remediation_source"] == "agent"
     assert len(edit_calls) == 1
     assert post_calls == []
 
@@ -150,7 +152,7 @@ def test_auto_fix_edit_mode_keeps_failing_body_off_issue():
     edit_body, edit_calls = _record_calls()
 
     def agent(body, findings):
-        return _FAILING_BODY  # still failing
+        return AgentRewriteResult(replacement=_FAILING_BODY, detail="agent produced replacement")
 
     outcomes = run_intake_remediation(
         [task],
@@ -174,7 +176,7 @@ def test_agent_called_at_most_once_per_story():
 
     def agent(body, findings):
         calls.append(1)
-        return _PASSING_BODY
+        return AgentRewriteResult(replacement=_PASSING_BODY, detail="agent produced replacement")
 
     run_intake_remediation(
         [task],
@@ -212,3 +214,67 @@ def test_failed_fetch_falls_open():
         fetch_detail=lambda *_: None,
     )
     assert outcomes[task.slug].kind is IntakeOutcomeKind.PASSED
+
+
+def test_missing_agent_caller_fails_explicitly():
+    task = _make_task()
+    outcomes = run_intake_remediation(
+        [task],
+        None,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        agent_caller=None,
+        missing_agent_detail=(
+            "auto-fix enabled but no intake agent caller is available: auth missing"
+        ),
+        fetch_detail=_make_fetch({"title": "T", "body": _FAILING_BODY, "labels": ["enhancement"]}),
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_SHAPE
+    assert out.detail == "auto-fix enabled but no intake agent caller is available: auth missing"
+    assert out.audit["remediation_source"] == "missing_agent"
+    assert out.audit["agent"]["attempted"] is False
+
+
+def test_mechanical_only_remediation_is_distinguished_from_agent_flow():
+    task = _make_task()
+    post_comment, post_calls = _record_calls()
+    outcomes = run_intake_remediation(
+        [task],
+        None,
+        grooming_enabled=False,
+        auto_fix_enabled=True,
+        auto_fix_mode="comment",
+        fetch_detail=_make_fetch({"title": "T", "body": _PASSING_BODY, "labels": []}),
+        post_comment=post_comment,
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_SHAPE
+    assert out.audit["remediation_source"] == "mechanical"
+    assert out.audit["agent"]["attempted"] is False
+    assert len(out.audit["mechanical_findings"]) == 1
+    assert post_calls
+
+
+def test_agent_no_output_is_distinguished_in_audit():
+    task = _make_task()
+
+    def agent(body, findings):
+        return AgentRewriteResult(replacement=None, detail="model refused rewrite", attempted=True)
+
+    outcomes = run_intake_remediation(
+        [task],
+        None,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="edit",
+        agent_caller=agent,
+        fetch_detail=_make_fetch({"title": "T", "body": _FAILING_BODY, "labels": ["enhancement"]}),
+        post_comment=lambda *_: True,
+        edit_body=lambda *_: True,
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
+    assert out.detail == "model refused rewrite"
+    assert out.audit["remediation_source"] == "agent_no_output"
+    assert out.audit["agent"]["attempted"] is True

--- a/tests/test_intake/test_runner_seam.py
+++ b/tests/test_intake/test_runner_seam.py
@@ -9,9 +9,19 @@ must have a seam-level test that doesn't rely on the full sprint pipeline.
 
 from __future__ import annotations
 
-from theforge.intake import IntakeFinding, IntakeSeverity
+from unittest.mock import patch
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
 from theforge.sprint.query import NormalizedDependencyPlan
-from theforge.sprint.runner import _filter_normalized_for_intake, _intake_agent_caller_stub
+from theforge.sprint.runner import _build_intake_agent_caller, _filter_normalized_for_intake
 from theforge.task import TaskStory
 
 
@@ -43,13 +53,24 @@ def test_filter_preserves_existing_blocked_entries():
     assert "a" in new.blocked["b"]
 
 
-def test_intake_agent_caller_stub_returns_none():
-    findings = [
-        IntakeFinding(
-            code="missing_acceptance_criteria",
-            severity=IntakeSeverity.BLOCK,
-            location="acceptance_criteria",
-            problem="no AC",
-        )
-    ]
-    assert _intake_agent_caller_stub("body", findings) is None
+def test_build_intake_agent_caller_returns_none_when_profile_unavailable(tmp_path):
+    config = ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+    with patch("theforge.sprint.runner.check_agent_auth", return_value=(False, "auth missing")):
+        caller, detail = _build_intake_agent_caller(config=config, log=lambda *_: None)
+
+    assert caller is None
+    assert "auth missing" in detail

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -23,6 +23,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.config.types import IntakeConfig
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint.dag import (
     StoryDAG,
@@ -32,9 +33,11 @@ from theforge.sprint.dag import (
 )
 from theforge.sprint.manifest import ResolvedSprint
 from theforge.sprint.runner import (
+    _build_intake_agent_caller,
     _make_worker_phase_fn,
     _refresh_external_satisfied,
     _run_baseline_gate,
+    _run_intake_remediation_pass,
     _terminal_story_model,
     run_sprint,
 )
@@ -82,6 +85,57 @@ def _make_result_with_dev_runs(*dev_results: AgentResult) -> CoordinatorResult:
         state=state,
         message="done",
     )
+
+
+def test_build_intake_agent_caller_uses_configured_runner(tmp_path: Path) -> None:
+    config = _make_runner_config(tmp_path)
+    with (
+        patch("theforge.sprint.runner.check_agent_auth", return_value=(True, "")),
+        patch("theforge.sprint.runner.run_agent") as mock_run_agent,
+        patch("theforge.sprint.runner.log_agent_result"),
+    ):
+        mock_run_agent.return_value = AgentResult(
+            success=True,
+            output="```markdown\n## What\n\nRewritten.\n```",
+            session_id=None,
+            cost_usd=0.12,
+            exit_code=0,
+            raw={},
+            profile_name="intake-remediation",
+            model_used="sonnet",
+            transport_used="cli",
+        )
+        caller, detail = _build_intake_agent_caller(config=config, log=lambda *_: None)
+        assert detail == ""
+        assert caller is not None
+        result = caller("old body", [])
+
+    assert result.replacement == "## What\n\nRewritten."
+    assert result.model_used == "sonnet"
+    assert result.cost_usd == 0.12
+    assert result.transport_used == "cli"
+
+
+def test_run_intake_remediation_pass_records_missing_caller_reason(tmp_path: Path) -> None:
+    config = _make_runner_config(tmp_path)
+    config = replace(
+        config,
+        intake=IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="edit"),
+    )
+    task = TaskStory(name="Issue 7", slug="issue-7", github_issue=7)
+
+    with (
+        patch(
+            "theforge.sprint.runner._build_intake_agent_caller",
+            return_value=(None, "auth missing"),
+        ),
+        patch("theforge.sprint.runner.run_intake_remediation") as mock_run,
+    ):
+        mock_run.return_value = {"issue-7": MagicMock()}
+        _run_intake_remediation_pass(config=config, tasks=[task], log=lambda *_: None)
+
+    assert mock_run.call_args.kwargs["agent_caller"] is None
+    assert mock_run.call_args.kwargs["missing_agent_detail"] == "auth missing"
 
 
 # ── build_dag: unknown slug handling ──────────────────────────────────


### PR DESCRIPTION
## Summary

Correctly replaces the placeholder stub with a real LLM-backed intake remediation caller; audit trail, explicit failure on missing auth, and seam tests all satisfy the spec.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.52
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:98`** _ensure_intake_runner uses an unsynchronized check-then-set pattern on module-level globals. In current usage this is safe because intake runs before the ThreadPoolExecutor starts, but the pattern is fragile — a future caller from a worker thread would produce a TOCTOU race.

## Story

Sprint intake remediation uses a deferred placeholder agent caller instead of the configured agent-backed grooming path (GitHub Issue #1270)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1270