### PR TITLE
Forge dev agents have empty project memory — propagate user memory to spawned worktree subprocesses

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -42,6 +42,53 @@ _VENV_GUARD_RE = re.compile(
 )
 
 
+def _claude_project_slug(path: Path) -> str:
+    """Encode a filesystem path the same way Claude Code names ~/.claude/projects/<slug>/.
+
+    Mirrors runner_claude._get_claude_session_id: replace separators in the resolved
+    absolute path with hyphens. Keep this in sync with that encoding.
+    """
+    return str(path.resolve()).replace("/", "-")
+
+
+def _propagate_claude_memory(project_root: Path, workspace_path: Path) -> None:
+    """Symlink the worktree's Claude project memory dir to the main project's.
+
+    Claude Code stores per-project memory under ~/.claude/projects/<encoded-cwd>/memory/.
+    A worktree's cwd encodes to a different slug than the main project, so a dev
+    subprocess spawned in the worktree starts with empty memory. Symlinking the
+    worktree's memory dir back to the main project's makes them share state, so
+    lessons accumulated by interactive sessions reach forge dev agents.
+
+    Best-effort: failures are logged but never block workspace creation.
+    """
+    try:
+        if workspace_path.resolve() == project_root.resolve():
+            return
+        claude_projects = Path.home() / ".claude" / "projects"
+        if not claude_projects.is_dir():
+            return
+        main_memory = claude_projects / _claude_project_slug(project_root) / "memory"
+        if not main_memory.is_dir():
+            return
+        worktree_proj_dir = claude_projects / _claude_project_slug(workspace_path)
+        worktree_proj_dir.mkdir(parents=True, exist_ok=True)
+        link = worktree_proj_dir / "memory"
+        if link.is_symlink():
+            try:
+                if link.resolve() == main_memory.resolve():
+                    return
+            except OSError:
+                pass
+            link.unlink()
+        elif link.exists():
+            # Real directory already present — don't clobber unknown user data.
+            return
+        link.symlink_to(main_memory, target_is_directory=True)
+    except OSError as exc:
+        _cu._log(f"⚠ WORKSPACE  failed to propagate Claude memory: {exc}")
+
+
 def _resolve_setup_command(cmd: str) -> str:
     """Replace {forge_python} with the shell-safe path to the running interpreter.
 
@@ -694,6 +741,7 @@ def _create_workspace(
                 if not ok_s:
                     return None, None, f"Workspace setup command failed: {out_s}"
             _deindex_forge_artifacts(workspace_path, purge=True)
+            _propagate_claude_memory(config.project_root, workspace_path)
             return workspace_path, branch_name, None
 
     if not no_pull:
@@ -726,6 +774,7 @@ def _create_workspace(
                     if not ok_s:
                         return None, None, f"Workspace setup command failed: {out_s}"
                 _deindex_forge_artifacts(existing_wt, purge=True)
+                _propagate_claude_memory(config.project_root, existing_wt)
                 return existing_wt, branch_name, None
             else:
                 _cu._log("⚠ WORKSPACE  linked worktree directory missing — pruning")
@@ -753,6 +802,7 @@ def _create_workspace(
                 if not ok_s:
                     return None, None, f"Workspace setup command failed: {out_s}"
             _deindex_forge_artifacts(workspace_path, purge=True)
+            _propagate_claude_memory(config.project_root, workspace_path)
             return workspace_path, branch_name, None
         else:
             _cu._log(
@@ -780,4 +830,5 @@ def _create_workspace(
             return None, None, f"Workspace setup command failed: {output}"
 
     _deindex_forge_artifacts(workspace_path, purge=True)
+    _propagate_claude_memory(config.project_root, workspace_path)
     return workspace_path, branch_name, None

--- a/tests/test_coord_workspace_claude_memory.py
+++ b/tests/test_coord_workspace_claude_memory.py
@@ -1,0 +1,185 @@
+"""Tests for propagating Claude project memory into worktree subprocesses.
+
+Claude Code stores memory under ~/.claude/projects/<encoded-cwd>/memory/.  A
+worktree's cwd encodes to a different slug than the main project, so dev
+subprocesses spawned in worktrees see no project memory unless we link the
+two directories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.coordinator.workspace import (
+    _claude_project_slug,
+    _create_workspace,
+    _propagate_claude_memory,
+)
+
+
+def _seed_main_memory(home: Path, project_root: Path, files: dict[str, str]) -> Path:
+    main_dir = home / ".claude" / "projects" / _claude_project_slug(project_root) / "memory"
+    main_dir.mkdir(parents=True)
+    for name, content in files.items():
+        (main_dir / name).write_text(content, encoding="utf-8")
+    return main_dir
+
+
+class TestPropagateClaudeMemoryHelper:
+    def test_creates_symlink_to_main_memory(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        workspace = project_root / ".forge" / "worktrees" / "issue-99"
+        workspace.mkdir(parents=True)
+
+        main_memory = _seed_main_memory(home, project_root, {"MEMORY.md": "- index\n"})
+
+        with patch("theforge.coordinator.workspace.Path.home", return_value=home):
+            _propagate_claude_memory(project_root, workspace)
+
+        link = home / ".claude" / "projects" / _claude_project_slug(workspace) / "memory"
+        assert link.is_symlink()
+        assert link.resolve() == main_memory.resolve()
+        assert (link / "MEMORY.md").read_text(encoding="utf-8") == "- index\n"
+
+    def test_idempotent_on_existing_correct_link(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        workspace = project_root / ".forge" / "worktrees" / "issue-99"
+        workspace.mkdir(parents=True)
+        main_memory = _seed_main_memory(home, project_root, {"a.md": "x"})
+
+        with patch("theforge.coordinator.workspace.Path.home", return_value=home):
+            _propagate_claude_memory(project_root, workspace)
+            _propagate_claude_memory(project_root, workspace)
+
+        link = home / ".claude" / "projects" / _claude_project_slug(workspace) / "memory"
+        assert link.is_symlink()
+        assert link.resolve() == main_memory.resolve()
+
+    def test_replaces_stale_symlink(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        workspace = project_root / ".forge" / "worktrees" / "issue-99"
+        workspace.mkdir(parents=True)
+        main_memory = _seed_main_memory(home, project_root, {})
+
+        wrong_target = tmp_path / "elsewhere"
+        wrong_target.mkdir()
+        worktree_proj = home / ".claude" / "projects" / _claude_project_slug(workspace)
+        worktree_proj.mkdir(parents=True)
+        stale_link = worktree_proj / "memory"
+        stale_link.symlink_to(wrong_target, target_is_directory=True)
+
+        with patch("theforge.coordinator.workspace.Path.home", return_value=home):
+            _propagate_claude_memory(project_root, workspace)
+
+        assert stale_link.is_symlink()
+        assert stale_link.resolve() == main_memory.resolve()
+
+    def test_does_not_clobber_real_directory(self, tmp_path):
+        """If a real (non-symlink) memory dir already exists in the worktree slot,
+        leave it alone — assume the operator has data we shouldn't trash."""
+        home = tmp_path / "home"
+        home.mkdir()
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        workspace = project_root / ".forge" / "worktrees" / "issue-99"
+        workspace.mkdir(parents=True)
+        _seed_main_memory(home, project_root, {})
+
+        worktree_proj = home / ".claude" / "projects" / _claude_project_slug(workspace)
+        worktree_proj.mkdir(parents=True)
+        existing = worktree_proj / "memory"
+        existing.mkdir()
+        (existing / "operator.md").write_text("local data", encoding="utf-8")
+
+        with patch("theforge.coordinator.workspace.Path.home", return_value=home):
+            _propagate_claude_memory(project_root, workspace)
+
+        assert not existing.is_symlink()
+        assert (existing / "operator.md").read_text(encoding="utf-8") == "local data"
+
+    def test_no_op_when_main_memory_missing(self, tmp_path):
+        home = tmp_path / "home"
+        (home / ".claude" / "projects").mkdir(parents=True)
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        workspace = project_root / ".forge" / "worktrees" / "issue-99"
+        workspace.mkdir(parents=True)
+
+        with patch("theforge.coordinator.workspace.Path.home", return_value=home):
+            _propagate_claude_memory(project_root, workspace)
+
+        worktree_proj = home / ".claude" / "projects" / _claude_project_slug(workspace)
+        # Should NOT have created a dangling memory link.
+        assert not (worktree_proj / "memory").exists()
+
+    def test_no_op_when_workspace_equals_project_root(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        _seed_main_memory(home, project_root, {"a.md": "x"})
+
+        with patch("theforge.coordinator.workspace.Path.home", return_value=home):
+            _propagate_claude_memory(project_root, project_root)
+
+        # Main memory dir is untouched, no extra slugs created.
+        slugs = list((home / ".claude" / "projects").iterdir())
+        assert len(slugs) == 1
+
+
+class TestCreateWorkspaceWiresPropagation:
+    """Seam-level: _create_workspace must invoke memory propagation on every
+    successful return path."""
+
+    @patch("theforge.coordinator.workspace._propagate_claude_memory")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_fresh_path_propagates(self, _log, mock_shell, mock_propagate, tmp_path):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, config.workspace.base_branch)
+            if "mkdir" in cmd:
+                (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        workspace_path, _branch, err = _create_workspace(config, task, no_pull=True)
+
+        assert err is None
+        mock_propagate.assert_called_once_with(config.project_root, workspace_path)
+
+    @patch("theforge.coordinator.workspace._is_stale_worktree", return_value=(False, "fresh"))
+    @patch("theforge.coordinator.workspace._propagate_claude_memory")
+    @patch("theforge.coordinator.workspace._cu._run_shell", return_value=(True, ""))
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_existing_worktree_path_propagates(
+        self, _log, _shell, mock_propagate, _is_stale, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        # Pre-create the worktree path so we hit the "existing worktree" branch.
+        existing = tmp_path / task.slug
+        existing.mkdir()
+
+        workspace_path, _branch, err = _create_workspace(config, task, no_pull=True)
+
+        assert err is None
+        assert workspace_path == existing
+        mock_propagate.assert_called_once_with(config.project_root, existing)


### PR DESCRIPTION
## Summary

Memory propagation via symlink is correctly implemented across all four _create_workspace return paths, with solid helper-level unit tests and two seam-level wiring tests; two pre-existing P2 findings (dead enum value, unused --verbose flag) already captured in the diagnose commit message; two minor new P2 findings noted below.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $2.22
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_coord_workspace_claude_memory.py:130`** Convention 8 (seam-level tests for touched boundaries): _create_workspace has four successful return paths with _propagate_claude_memory wired to each, but TestCreateWorkspaceWiresPropagation only exercises two (fresh path and existing-worktree path). The third path (around workspace.py:802 — the no-pull fresh-create branch) and the fourth (the final fallback at workspace.py:830) are not covered at the seam level.
- **[P2] `src/theforge/coordinator/diagnose_flow.py:258`** confirm_landing parameter is annotated as 'callable | None' using the lowercase builtin callable as a type, which is not valid as a type annotation in all Python versions and is inconsistent with the rest of the codebase that uses typing.Callable or omits the annotation.

## Story

Forge dev agents have empty project memory — propagate user memory to spawned worktree subprocesses (GitHub Issue #1155)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1155