### PR TITLE
User-declared model registry overlay in forge.yaml — adding a model on an existing adapter must not require a TheForge release

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -607,6 +607,8 @@ def _agent_to_profile(
         allowed_tools=allowed_tools,
         api_fallback=agent.api_fallback,
         phase=role,
+        registry_id=agent.registry_id,
+        registry_source=agent.registry_source,
     )
 
 

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -111,10 +111,14 @@ def _thinking_budget_label(profile: ModelProfile) -> str:
     return f"  thinking_budget={profile.thinking_budget}"
 
 
-def _provider_label(model_key: str, warnings_list: list[str] | None = None) -> str:
+def _provider_label(
+    model_key: str,
+    warnings_list: list[str] | None = None,
+    registry: dict | None = None,
+) -> str:
     """Return a short human-readable label for a model key like 'claude/sonnet'."""
     try:
-        spec = resolve_agent_spec(model_key)
+        spec = resolve_agent_spec(model_key, registry=registry)
     except ValueError as exc:
         if warnings_list is not None:
             warnings_list.append(str(exc))
@@ -142,6 +146,7 @@ def _format_complexity_aware_section(
     models: list[str],
     budget_usd: float,
     overrides: dict | None,
+    registry: dict | None = None,
 ) -> list[str]:
     """Build the DERIVED ROLES section for v0.8 simple-mode configs.
 
@@ -149,9 +154,21 @@ def _format_complexity_aware_section(
     routing table so the operator can verify complexity-aware routing at a glance.
     """
     _ov = overrides or {}
-    ra_low = derive_roles(models, _ov, budget_usd=budget_usd, complexity="LOW")
-    ra_mid = derive_roles(models, _ov, budget_usd=budget_usd, complexity="MEDIUM")
-    ra_high = derive_roles(models, _ov, budget_usd=budget_usd, complexity="HIGH")
+    ra_low = derive_roles(models, _ov, budget_usd=budget_usd, complexity="LOW", registry=registry)
+    ra_mid = derive_roles(
+        models,
+        _ov,
+        budget_usd=budget_usd,
+        complexity="MEDIUM",
+        registry=registry,
+    )
+    ra_high = derive_roles(
+        models,
+        _ov,
+        budget_usd=budget_usd,
+        complexity="HIGH",
+        registry=registry,
+    )
 
     lines: list[str] = []
     lines.append("DERIVED ROLES (complexity-aware)")
@@ -242,7 +259,7 @@ def _format_config(
             seen: set[str] = set()
             provider_labels: list[str] = []
             for mk in config.models:
-                lbl = _provider_label(mk, warnings_list)
+                lbl = _provider_label(mk, warnings_list, registry=config.model_registry)
                 if lbl not in seen:
                     seen.add(lbl)
                     provider_labels.append(lbl)
@@ -251,12 +268,48 @@ def _format_config(
         lines.append(f"Budget:  ${config.assignment.budget_per_story_usd:.2f}/story")
     lines.append("")
 
+    if config.models or config.custom_models:
+        lines.append("MODEL REGISTRY")
+        if config.models:
+            builtin_models = [
+                model_id
+                for model_id in config.models
+                if config.model_registry_sources.get(model_id, "builtin") == "builtin"
+            ]
+            forge_yaml_models = [
+                model_id
+                for model_id in config.models
+                if config.model_registry_sources.get(model_id) == "forge.yaml"
+            ]
+            if builtin_models:
+                lines.append(f"  {'selected builtin:':<18}{', '.join(builtin_models)}")
+            if forge_yaml_models:
+                lines.append(f"  {'selected forge.yaml:':<18}{', '.join(forge_yaml_models)}")
+        if config.custom_models:
+            custom_details = []
+            for model_id in config.custom_models:
+                spec = config.model_registry.get(model_id)
+                if spec is None:
+                    continue
+                provider_label, transport_label = _split_provider_transport(
+                    spec.transport.executable if spec.transport.kind == "cli" else None,
+                    spec.provider,
+                    spec.transport,
+                )
+                custom_details.append(
+                    f"{model_id} [{provider_label} {transport_label} -> {spec.model}]"
+                )
+            if custom_details:
+                lines.append(f"  {'declared forge.yaml:':<18}{', '.join(custom_details)}")
+        lines.append("")
+
     # ── DERIVED ROLES (v0.8 simple mode) ─────────────────────────────────
     if config.models and config.models_budget_usd is not None:
         derived_lines = _format_complexity_aware_section(
             config.models,
             config.models_budget_usd,
             overrides=config.models_overrides,
+            registry=config.model_registry,
         )
         lines.extend(derived_lines)
         lines.append("")

--- a/src/theforge/config/bridge.py
+++ b/src/theforge/config/bridge.py
@@ -57,6 +57,8 @@ def _role_config_to_profile(
         max_iterations=ref.max_iterations,
         max_tool_output_bytes=ref.max_tool_output_bytes,
         api_fallback=ref.api_fallback,
+        registry_id=ref.registry_id,
+        registry_source=ref.registry_source,
         review_role=review_role,
         phase=phase,
         sandbox_mode=sandbox_mode,

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -25,7 +25,17 @@ from .defaults import (
     PROVIDER_SDK_MAP,
     SUPPORTED_CLIS,
 )
-from .models import AGENT_REGISTRY, _parse_assignment, resolve_agent_spec
+from .models import (
+    AGENT_REGISTRY,
+    AgentSpec,
+    _parse_assignment,
+    custom_model_capability,
+    custom_model_cost_rank,
+    custom_model_dev_capable,
+    known_model_overlay_providers,
+    overlay_transport,
+    resolve_agent_spec,
+)
 from .profiles import (
     CLI_PROVIDER_MAP,
     _agents_from_models,
@@ -63,7 +73,166 @@ from .types import (
 log = logging.getLogger("theforge.config")
 
 
-def _derive_auto_provider_fallbacks(models: list[str]) -> dict[str, ApiFallbackConfig]:
+def _parse_models_section(
+    raw_models: Any,
+) -> tuple[list[str] | None, dict[str, Any], bool]:
+    """Normalize the top-level models section.
+
+    Returns ``(enabled_models, custom_raw, simple_mode_enabled)`` where:
+    - ``enabled_models`` is the selected model list for v0.8 simple mode
+    - ``custom_raw`` is the raw ``models.custom`` mapping (possibly empty)
+    - ``simple_mode_enabled`` indicates whether the config opted into simple mode
+    """
+    if isinstance(raw_models, list):
+        return [str(m) for m in raw_models], {}, True
+    if raw_models is None:
+        raise ValueError("'models' must be a non-empty list")
+    if not isinstance(raw_models, dict):
+        raise ValueError(
+            "forge.yaml 'models' must be either a non-empty list or a mapping with "
+            "'enabled' and/or 'custom'"
+        )
+
+    unknown = set(raw_models) - {"enabled", "custom"}
+    if unknown:
+        raise ValueError(
+            "forge.yaml 'models' mapping only supports 'enabled' and 'custom'; "
+            f"unknown key(s): {sorted(unknown)}"
+        )
+
+    enabled_raw = raw_models.get("enabled")
+    custom_raw = raw_models.get("custom", {})
+    if enabled_raw is not None and (not isinstance(enabled_raw, list) or len(enabled_raw) == 0):
+        raise ValueError("forge.yaml 'models.enabled' must be a non-empty list")
+    if not isinstance(custom_raw, dict):
+        raise ValueError("forge.yaml 'models.custom' must be a mapping")
+
+    return (
+        [str(m) for m in enabled_raw] if enabled_raw is not None else None,
+        custom_raw,
+        enabled_raw is not None,
+    )
+
+
+def _parse_custom_model_registry(custom_raw: dict[str, Any]) -> dict[str, AgentSpec]:
+    """Parse and validate user-declared model overlays from forge.yaml."""
+    registry: dict[str, AgentSpec] = {}
+    for canonical_id, decl in custom_raw.items():
+        if not isinstance(canonical_id, str) or not canonical_id:
+            raise ValueError("forge.yaml 'models.custom' keys must be non-empty strings")
+        if not isinstance(decl, dict):
+            raise ValueError(f"forge.yaml 'models.custom.{canonical_id}' must be a mapping")
+
+        missing = [
+            key
+            for key in (
+                "provider",
+                "model",
+                "tier",
+                "input_cost_per_mtok",
+                "output_cost_per_mtok",
+            )
+            if key not in decl
+        ]
+        if missing:
+            raise ValueError(
+                "forge.yaml "
+                f"'models.custom.{canonical_id}' is missing required field(s): {missing}"
+            )
+
+        provider = decl["provider"]
+        model = decl["model"]
+        tier = decl["tier"]
+        if not isinstance(provider, str) or not provider:
+            raise ValueError(
+                f"forge.yaml 'models.custom.{canonical_id}.provider' must be a non-empty string"
+            )
+        if not isinstance(model, str) or not model:
+            raise ValueError(
+                f"forge.yaml 'models.custom.{canonical_id}.model' must be a non-empty string"
+            )
+        if not isinstance(tier, str) or not tier:
+            raise ValueError(
+                f"forge.yaml 'models.custom.{canonical_id}.tier' must be a non-empty string"
+            )
+
+        if provider not in known_model_overlay_providers():
+            known = ", ".join(known_model_overlay_providers())
+            raise ValueError(
+                f"Unknown provider {provider!r} in models.custom.{canonical_id}. "
+                f"Known providers/adapters: {known}"
+            )
+
+        input_cost = decl["input_cost_per_mtok"]
+        output_cost = decl["output_cost_per_mtok"]
+        if (
+            isinstance(input_cost, bool)
+            or not isinstance(input_cost, (int, float))
+            or float(input_cost) < 0
+        ):
+            raise ValueError(
+                f"forge.yaml 'models.custom.{canonical_id}.input_cost_per_mtok' must be a "
+                f"non-negative number, got {input_cost!r}"
+            )
+        if (
+            isinstance(output_cost, bool)
+            or not isinstance(output_cost, (int, float))
+            or float(output_cost) < 0
+        ):
+            raise ValueError(
+                f"forge.yaml 'models.custom.{canonical_id}.output_cost_per_mtok' must be a "
+                f"non-negative number, got {output_cost!r}"
+            )
+
+        normalized_provider, transport = overlay_transport(provider)
+        registry[canonical_id] = AgentSpec(
+            provider=normalized_provider,
+            model=model,
+            transport=transport,
+            tier=tier,
+            capability=custom_model_capability(tier),
+            cost_rank=custom_model_cost_rank(float(input_cost), float(output_cost)),
+            dev_capable=custom_model_dev_capable(transport),
+            registry_source="forge.yaml",
+            input_cost_per_mtok=float(input_cost),
+            output_cost_per_mtok=float(output_cost),
+        )
+    return registry
+
+
+def _merge_model_registry(
+    custom_registry: dict[str, AgentSpec],
+    custom_raw: dict[str, Any],
+) -> dict[str, AgentSpec]:
+    """Merge built-in and forge.yaml model registries."""
+    merged = dict(AGENT_REGISTRY)
+    for canonical_id, spec in custom_registry.items():
+        override = bool(custom_raw.get(canonical_id, {}).get("override", False))
+        if canonical_id in AGENT_REGISTRY and not override:
+            raise ValueError(
+                f"forge.yaml 'models.custom.{canonical_id}' duplicates a built-in model id. "
+                "Set override: true to replace the built-in entry explicitly."
+            )
+        merged[canonical_id] = spec
+    return merged
+
+
+def _validate_selected_models(models: list[str], registry: dict[str, AgentSpec]) -> None:
+    """Validate the selected simple-mode model ids against the merged registry."""
+    for model_key in models:
+        if model_key not in registry and "/" not in model_key:
+            raise ValueError(
+                f"Model entry {model_key!r} must be in 'provider/model' format (contains '/') "
+                "or be declared under models.custom"
+            )
+        resolve_agent_spec(model_key, registry=registry)
+
+
+def _derive_auto_provider_fallbacks(
+    models: list[str],
+    *,
+    registry: dict[str, AgentSpec],
+) -> dict[str, ApiFallbackConfig]:
     """Auto-wire same-provider API fallbacks for CLI transport models.
 
     Returns only unambiguous per-provider fallbacks. If multiple CLI models from the
@@ -73,12 +242,12 @@ def _derive_auto_provider_fallbacks(models: list[str]) -> dict[str, ApiFallbackC
     cli_models_by_provider: dict[str, set[str]] = {}
     api_models_by_provider: dict[str, set[str]] = {}
 
-    for spec in AGENT_REGISTRY.values():
+    for spec in registry.values():
         if spec.transport.kind == "api":
             api_models_by_provider.setdefault(spec.provider, set()).add(spec.model)
 
     for model_key in models:
-        spec = resolve_agent_spec(model_key)
+        spec = resolve_agent_spec(model_key, registry=registry)
         if spec.transport.kind != "cli":
             continue
         cli_models_by_provider.setdefault(spec.provider, set()).add(spec.model)
@@ -104,7 +273,10 @@ def _validate_auto_api_fallback_schema(raw: dict[str, Any]) -> None:
     """
     if "models" not in raw:
         return
-    if not isinstance(raw.get("models"), list):
+    models_raw = raw.get("models")
+    if isinstance(models_raw, dict):
+        models_raw = models_raw.get("enabled")
+    if not isinstance(models_raw, list):
         return
 
     par_raw = raw.get("plan_agent_review")
@@ -125,7 +297,7 @@ def _validate_auto_api_fallback_schema(raw: dict[str, Any]) -> None:
     model_key = next(
         (
             key
-            for key in (raw.get("models") or [])
+            for key in models_raw
             if key in AGENT_REGISTRY
             and (spec := resolve_agent_spec(str(key))).transport.kind == "cli"
             and spec.provider == CLI_PROVIDER_MAP.get(cli)
@@ -357,23 +529,22 @@ def load_config(config_path: Path) -> ForgeConfig:
     _derived_par_profile: ModelProfile | None = None
     budget_usd_val: float | None = None
     _raw_overrides: dict[str, Any] | None = None
-
+    model_registry = dict(AGENT_REGISTRY)
+    model_registry_sources = {key: "builtin" for key in AGENT_REGISTRY}
+    custom_models: tuple[str, ...] = ()
     if "models" in raw:
-        models_list = raw["models"]
-        if not isinstance(models_list, list) or len(models_list) == 0:
-            raise ValueError("'models' must be a non-empty list")
-        for m in models_list:
-            if "/" not in str(m):
-                raise ValueError(
-                    f"Model entry {m!r} must be in 'provider/model' format (contains '/')"
-                )
-            if str(m) not in AGENT_REGISTRY:
-                known_providers = sorted({k.split("/", 1)[0] for k in AGENT_REGISTRY})
-                raise ValueError(
-                    f"Unknown model {m!r}: not in AGENT_REGISTRY. "
-                    f"Known providers: {known_providers}. "
-                    "Add an explicit registry entry to support a new model."
-                )
+        models_list, custom_raw, simple_mode_enabled = _parse_models_section(raw["models"])
+    else:
+        models_list, custom_raw, simple_mode_enabled = (None, {}, False)
+    custom_registry = _parse_custom_model_registry(custom_raw)
+    if custom_registry:
+        model_registry = _merge_model_registry(custom_registry, custom_raw)
+        custom_models = tuple(sorted(custom_registry))
+        model_registry_sources.update({key: "forge.yaml" for key in custom_registry})
+
+    if simple_mode_enabled:
+        assert models_list is not None
+        _validate_selected_models(models_list, model_registry)
         budget_usd_raw = raw.get("budget_usd", 50.0)
         budget_usd_val = float(budget_usd_raw)
         if budget_usd_val <= 0:
@@ -390,9 +561,10 @@ def load_config(config_path: Path) -> ForgeConfig:
             else None
         )
         _ra = derive_roles(
-            [str(m) for m in models_list],
+            models_list,
             overrides=_par_derive_overrides,
             budget_usd=budget_usd_val,
+            registry=model_registry,
         )
         _bridge = role_assignment_to_profiles(_ra)
         dev_profile = _bridge["dev_profile"]
@@ -435,9 +607,12 @@ def load_config(config_path: Path) -> ForgeConfig:
                     for p in review_pool
                 ]
 
-        models = [str(m) for m in models_list]
+        models = list(models_list)
         if auto_api_fallback:
-            auto_provider_fallbacks = _derive_auto_provider_fallbacks(models)
+            auto_provider_fallbacks = _derive_auto_provider_fallbacks(
+                models,
+                registry=model_registry,
+            )
             provider_fallbacks = {**auto_provider_fallbacks, **provider_fallbacks}
         # Track which roles were auto-derived vs explicitly overridden. Complexity-aware
         # adaptation (preflight._apply_complexity_adaptation) only rewrites auto-derived
@@ -583,7 +758,9 @@ def load_config(config_path: Path) -> ForgeConfig:
     # assignment (assign_models) has candidates to pick from. When no models:
     # key is configured, the pool is empty and assignment falls back to the
     # static dev/review profiles above.
-    agents_list = _agents_from_models(models, budget_usd_val) if models else []
+    agents_list = (
+        _agents_from_models(models, budget_usd_val, registry=model_registry) if models else []
+    )
     assignment_cfg = _parse_assignment(raw.get("assignment", {}))
 
     _raw_par = raw.get("plan_agent_review", {})
@@ -983,5 +1160,8 @@ def load_config(config_path: Path) -> ForgeConfig:
         stuck_detection=stuck_detection_cfg,
         models_budget_usd=budget_usd_val,
         models_overrides=_raw_overrides,
+        model_registry=model_registry,
+        model_registry_sources=model_registry_sources,
+        custom_models=custom_models,
         diagnose=diagnose_cfg,
     )

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -61,6 +61,9 @@ class AgentSpec:
     dev_capable: bool = True  # whether this agent is allowed to own the dev role
     phase_eligibility: frozenset[str] = frozenset({"preflight", "dev", "plan", "review"})
     tool_mode: str = "auto"  # "auto" = follow transport default; reserved for future use
+    registry_source: str = "builtin"  # "builtin" | "forge.yaml"
+    input_cost_per_mtok: float | None = None
+    output_cost_per_mtok: float | None = None
 
 
 # Canonical transport objects — referenced by AGENT_REGISTRY entries.
@@ -83,6 +86,17 @@ _PROVIDER_API_TRANSPORT_MAP: dict[str, TransportSpec] = {
     "openai": _TRANSPORT_OPENAI_API,
     "google": _TRANSPORT_GOOGLE_API,
     "deepseek": _TRANSPORT_DEEPSEEK_API,
+}
+
+_MODEL_OVERLAY_PROVIDER_MAP: dict[str, tuple[str, TransportSpec]] = {
+    "anthropic": ("anthropic", _TRANSPORT_CLAUDE_CLI),
+    "claude": ("anthropic", _TRANSPORT_CLAUDE_CLI),
+    "openai": ("openai", _TRANSPORT_CODEX_CLI),
+    "openai-api": ("openai", _TRANSPORT_OPENAI_API),
+    "deepseek": ("deepseek", _TRANSPORT_DEEPSEEK_API),
+    "google": ("google", _TRANSPORT_GOOGLE_API),
+    "gemini": ("google", _TRANSPORT_GOOGLE_API),
+    "gemini-cli": ("google", _TRANSPORT_GEMINI_CLI),
 }
 
 
@@ -132,6 +146,10 @@ class ModelInfo:
     dev_capable: bool = True  # False for models whose CLI doesn't support dev tools
     provider: str | None = None  # API transport, mutually exclusive with cli
     phase_eligibility: frozenset[str] = _DEFAULT_PHASE_ELIGIBILITY
+    registry_id: str | None = None  # canonical model registry key
+    registry_source: str = "builtin"  # "builtin" | "forge.yaml"
+    input_cost_per_mtok: float | None = None
+    output_cost_per_mtok: float | None = None
     transport: TransportSpec | None = None  # the canonical TransportSpec this view was built from
 
 
@@ -148,6 +166,8 @@ class AgentDef:
     cli: str | None = None  # "claude", "codex", etc. — set for CLI agents
     api_fallback: ApiFallbackConfig | None = None
     strengths: tuple[str, ...] = ()
+    registry_id: str | None = None
+    registry_source: str = "builtin"
 
     def to_model_profile(self, *, allowed_tools: tuple[str, ...] = ()) -> ModelProfile:
         """Convert to a ModelProfile for use in coordinator config."""
@@ -160,6 +180,8 @@ class AgentDef:
             timeout_seconds=self.timeout_seconds,
             allowed_tools=allowed_tools,
             api_fallback=self.api_fallback,
+            registry_id=self.registry_id,
+            registry_source=self.registry_source,
         )
 
 
@@ -345,13 +367,60 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
 }
 
 
-def _spec_to_model_info(spec: AgentSpec) -> ModelInfo:
+def known_model_overlay_providers() -> tuple[str, ...]:
+    """Return accepted provider/adaptor tokens for forge.yaml model overlays."""
+    return tuple(sorted(_MODEL_OVERLAY_PROVIDER_MAP))
+
+
+def overlay_transport(provider: str) -> tuple[str, TransportSpec]:
+    """Resolve a forge.yaml provider token to its provider family and transport."""
+    if provider not in _MODEL_OVERLAY_PROVIDER_MAP:
+        known = ", ".join(sorted(_MODEL_OVERLAY_PROVIDER_MAP))
+        raise ValueError(
+            f"Unknown provider {provider!r} in models.custom. Known providers/adapters: {known}"
+        )
+    return _MODEL_OVERLAY_PROVIDER_MAP[provider]
+
+
+def custom_model_capability(tier: str) -> int:
+    """Return the default capability score for a custom model tier."""
+    by_tier = {"cheap": 6, "fast": 7, "strong": 9}
+    if tier not in by_tier:
+        raise ValueError(f"models.custom tier must be one of {sorted(by_tier)}, got {tier!r}")
+    return by_tier[tier]
+
+
+def custom_model_cost_rank(input_cost_per_mtok: float, output_cost_per_mtok: float) -> int:
+    """Map per-MTok pricing to the routing cost bands used by the registry."""
+    price_signal = max(float(input_cost_per_mtok), float(output_cost_per_mtok))
+    if price_signal <= 5.0:
+        return 1
+    if price_signal <= 25.0:
+        return 2
+    return 3
+
+
+def custom_model_dev_capable(transport: TransportSpec) -> bool:
+    """Return whether a custom model transport can own the dev role."""
+    return not (transport.kind == "cli" and transport.runner == "gemini")
+
+
+def _spec_to_model_info(
+    model_key: str | AgentSpec,
+    spec: AgentSpec | None = None,
+) -> ModelInfo:
     """Project an AgentSpec down to the legacy ModelInfo view.
 
     Carries `phase_eligibility` and the underlying `TransportSpec` through the
     projection so role derivation can filter by phase and runtime dispatch can
     read the explicit transport rather than re-inferring it from cli/provider.
     """
+    if spec is None:
+        spec = model_key
+        assert isinstance(spec, AgentSpec)
+        model_key = spec.model
+
+    assert isinstance(model_key, str)
     if spec.transport.kind == "cli":
         return ModelInfo(
             cli=spec.transport.runner,
@@ -362,6 +431,10 @@ def _spec_to_model_info(spec: AgentSpec) -> ModelInfo:
             dev_capable=spec.dev_capable,
             provider=None,
             phase_eligibility=spec.phase_eligibility,
+            registry_id=model_key,
+            registry_source=spec.registry_source,
+            input_cost_per_mtok=spec.input_cost_per_mtok,
+            output_cost_per_mtok=spec.output_cost_per_mtok,
             transport=spec.transport,
         )
     return ModelInfo(
@@ -373,13 +446,17 @@ def _spec_to_model_info(spec: AgentSpec) -> ModelInfo:
         dev_capable=spec.dev_capable,
         provider=spec.provider,
         phase_eligibility=spec.phase_eligibility,
+        registry_id=model_key,
+        registry_source=spec.registry_source,
+        input_cost_per_mtok=spec.input_cost_per_mtok,
+        output_cost_per_mtok=spec.output_cost_per_mtok,
         transport=spec.transport,
     )
 
 
 # Derived legacy view — exactly mirrors AGENT_REGISTRY.
 MODEL_REGISTRY: dict[str, ModelInfo] = {
-    k: _spec_to_model_info(v) for k, v in AGENT_REGISTRY.items()
+    k: _spec_to_model_info(k, v) for k, v in AGENT_REGISTRY.items()
 }
 
 
@@ -404,34 +481,46 @@ def apply_model_info(profile: _ProfileT, info: ModelInfo) -> _ProfileT:
         "model": info.model,
         "provider": info.provider,
     }
+    if "registry_id" in profile_fields:
+        updates["registry_id"] = info.registry_id
+    if "registry_source" in profile_fields:
+        updates["registry_source"] = info.registry_source
     if "transport" in profile_fields:
         updates["transport"] = info.transport
     return replace(profile, **updates)
 
 
-def resolve_agent_spec(model_key: str) -> AgentSpec:
+def resolve_agent_spec(
+    model_key: str,
+    registry: dict[str, AgentSpec] | None = None,
+) -> AgentSpec:
     """Resolve a `provider/model` key to its AgentSpec.
 
     Raises ValueError for any key not present in AGENT_REGISTRY — there is no
     provider-prefix-to-CLI guessing. To support a new model, add an explicit
     registry entry.
     """
-    if model_key not in AGENT_REGISTRY:
-        known = sorted(AGENT_REGISTRY)
+    effective_registry = registry or AGENT_REGISTRY
+    if model_key not in effective_registry:
+        known = sorted(effective_registry)
         raise ValueError(
             f"Unknown model {model_key!r}: not in AGENT_REGISTRY. "
             f"Add an explicit registry entry. Known models: {known}"
         )
-    return AGENT_REGISTRY[model_key]
+    return effective_registry[model_key]
 
 
-def _resolve_model_info(model_key: str) -> ModelInfo:
+def _resolve_model_info(
+    model_key: str,
+    registry: dict[str, AgentSpec] | None = None,
+) -> ModelInfo:
     """Resolve a model key to its legacy ModelInfo view.
 
     Delegates to resolve_agent_spec(): unknown keys raise ValueError rather than
     falling back to a prefix-derived CLI.
     """
-    return _spec_to_model_info(resolve_agent_spec(model_key))
+    spec = resolve_agent_spec(model_key, registry=registry)
+    return _spec_to_model_info(model_key, spec)
 
 
 def _planner_candidate_models(agents: list[AgentDef]) -> set[str]:

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -15,13 +15,18 @@ from .defaults import (
     PROVIDER_SDK_MAP,
     SUPPORTED_CLIS,
 )
-from .models import AgentDef, _resolve_model_info
+from .models import AgentDef, AgentSpec, _resolve_model_info
 from .types import SUPPORTED_PROVIDERS, ApiFallbackConfig, ModelProfile
 
 _COST_RANK_TO_TIER = {1: "cheap", 2: "mid", 3: "strong"}
 
 
-def _agents_from_models(models: list[str], budget_usd: float) -> list[AgentDef]:
+def _agents_from_models(
+    models: list[str],
+    budget_usd: float,
+    *,
+    registry: dict[str, AgentSpec] | None = None,
+) -> list[AgentDef]:
     """Derive AgentDef pool from the v0.8 models: list.
 
     Each entry becomes one agent keyed by the slash-replaced model key so names
@@ -35,7 +40,7 @@ def _agents_from_models(models: list[str], budget_usd: float) -> list[AgentDef]:
     per_agent_budget = budget_usd / len(models)
     agents: list[AgentDef] = []
     for key in models:
-        info = _resolve_model_info(key)
+        info = _resolve_model_info(key, registry=registry)
         tier = _COST_RANK_TO_TIER.get(info.cost_rank, "mid")
         agents.append(
             AgentDef(
@@ -46,6 +51,8 @@ def _agents_from_models(models: list[str], budget_usd: float) -> list[AgentDef]:
                 timeout_seconds=DEFAULT_DEV_PROFILE.timeout_seconds,
                 tier=tier,
                 cli=info.cli,
+                registry_id=info.registry_id,
+                registry_source=info.registry_source,
             )
         )
     return agents
@@ -190,6 +197,8 @@ def _apply_profile_overrides(base: ModelProfile, data: dict[str, Any]) -> ModelP
 def _auto_assign_models(
     models: list[str],
     budget_usd: float,
+    *,
+    registry: dict[str, AgentSpec] | None = None,
 ) -> tuple[ModelProfile, ModelProfile, list[ModelProfile], ModelProfile | None]:
     """Auto-assign models to stages from a declarative pool.
 
@@ -206,7 +215,7 @@ def _auto_assign_models(
     - synthesis: max(2%, $1) when pool > 1
     - each reviewer: remaining / pool_size
     """
-    infos = [(m, _resolve_model_info(m)) for m in models]
+    infos = [(m, _resolve_model_info(m, registry=registry)) for m in models]
     sorted_models = sorted(infos, key=lambda x: (x[1].cost_rank, -x[1].capability))
 
     dev_key, dev_info = sorted_models[0]
@@ -235,6 +244,8 @@ def _auto_assign_models(
         timeout_seconds=DEFAULT_DEV_PROFILE.timeout_seconds,
         allowed_tools=DEFAULT_DEV_PROFILE.allowed_tools,
         phase="dev",
+        registry_id=dev_info.registry_id,
+        registry_source=dev_info.registry_source,
     )
     preflight_profile = ModelProfile(
         name="preflight",
@@ -245,6 +256,8 @@ def _auto_assign_models(
         timeout_seconds=DEFAULT_PREFLIGHT_PROFILE.timeout_seconds,
         allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
         phase="preflight",
+        registry_id=preflight_info.registry_id,
+        registry_source=preflight_info.registry_source,
     )
     review_pool = [
         ModelProfile(
@@ -255,6 +268,8 @@ def _auto_assign_models(
             budget_usd=reviewer_budget,
             timeout_seconds=DEFAULT_REVIEW_PROFILE.timeout_seconds,
             allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+            registry_id=i.registry_id,
+            registry_source=i.registry_source,
         )
         for k, i in review_pairs
     ]
@@ -270,6 +285,8 @@ def _auto_assign_models(
             budget_usd=synthesis_budget,
             timeout_seconds=DEFAULT_REVIEW_PROFILE.timeout_seconds,
             allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+            registry_id=synth_info.registry_id,
+            registry_source=synth_info.registry_source,
         )
 
     return dev_profile, preflight_profile, review_pool, synthesis_profile

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from ..routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
 from .defaults import DEFAULT_DEV_PROFILE, DEFAULT_PREFLIGHT_PROFILE, DEFAULT_REVIEW_PROFILE
-from .models import ModelInfo, _resolve_model_info
+from .models import AgentSpec, ModelInfo, _resolve_model_info
 from .schema import (
     DevRoleConfig,
     ModelRef,
@@ -91,6 +91,8 @@ def _make_model_ref(
         provider=info.provider,
         budget_usd=budget_usd,
         timeout_seconds=timeout_seconds,
+        registry_id=info.registry_id,
+        registry_source=info.registry_source,
         transport=info.transport,
     )
 
@@ -158,6 +160,7 @@ def derive_roles(
     budget_usd: float = 10.0,
     complexity: str | None = None,
     complexity_score: int | None = None,
+    registry: dict[str, AgentSpec] | None = None,
 ) -> RoleAssignment:
     """Map a simple model list to a RoleAssignment.
 
@@ -213,7 +216,7 @@ def derive_roles(
     )
 
     # Build (model_key, ModelInfo) pairs and sort: cheapest first, then by capability desc
-    infos = [(m, _resolve_model_info(m)) for m in models]
+    infos = [(m, _resolve_model_info(m, registry=registry)) for m in models]
     sorted_models = sorted(infos, key=lambda x: (x[1].cost_rank, -x[1].capability))
 
     # Phase-eligibility-aware candidate pools — a model's AgentSpec may exclude it

--- a/src/theforge/config/schema.py
+++ b/src/theforge/config/schema.py
@@ -52,6 +52,8 @@ class ModelRef:
     max_iterations: int | None = None  # override default agent loop iterations
     max_tool_output_bytes: int = 51200  # cap for tool output (50 KB default)
     api_fallback: ApiFallbackConfig | None = None  # CLI-only same-provider API fallback
+    registry_id: str | None = None  # canonical model registry key, when sourced from a registry
+    registry_source: str = "builtin"  # "builtin" | "forge.yaml"
     # Explicit TransportSpec — carried through derive_roles → bridge → ModelProfile
     # so runtime dispatch reads TransportSpec.kind rather than inferring from cli/provider.
     transport: TransportSpec | None = None

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from .models import AgentDef, TransportSpec
+    from .models import AgentDef, AgentSpec, TransportSpec
 
 SUPPORTED_PROVIDERS = {"anthropic", "openai", "google", "deepseek"}
 
@@ -149,6 +149,8 @@ class ModelProfile:
     github_handle: str | None = None  # optional GitHub username for reviewer assignment
     fallback_models: tuple[str, ...] = ()  # additional models to try on quota/not-found failure
     sandbox_mode: str = "workspace-write"  # CLI sandbox: "workspace-write" | "read-only" | "none"
+    registry_id: str | None = None  # canonical model registry key, when sourced from a registry
+    registry_source: str = "builtin"  # "builtin" | "forge.yaml"
     # Explicit TransportSpec — when set, it is the runtime dispatch source of
     # truth. None preserves the legacy inference from cli/provider for the
     # small number of paths (e.g. raw dataclass constructions in tests) that
@@ -534,6 +536,9 @@ class ForgeConfig:
     stuck_detection: StuckDetectionConfig = field(default_factory=StuckDetectionConfig)
     models_budget_usd: float | None = None  # set when models: key is used (v0.8 path)
     models_overrides: dict[str, Any] | None = None  # raw overrides: dict from v0.8 YAML
+    model_registry: dict[str, AgentSpec] = field(default_factory=dict)
+    model_registry_sources: dict[str, str] = field(default_factory=dict)
+    custom_models: tuple[str, ...] = ()
     diagnose: DiagnoseConfig = field(default_factory=DiagnoseConfig)
 
     @property

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -1045,6 +1045,13 @@ def _apply_preflight_config(
         "dev": _role_source("dev"),
         "code_review": _role_source("code_review"),
     }
+
+    def _assignment_entry(profile):  # type: ignore[no-untyped-def]
+        return {
+            "model": profile.model,
+            "source": getattr(profile, "registry_source", "builtin"),
+        }
+
     state.complexity_routing_audit = {
         "complexity": complexity,
         "complexity_score": complexity_score,
@@ -1053,11 +1060,11 @@ def _apply_preflight_config(
         "explicit_overrides": sorted(_explicit_roles),
         "role_sources": _per_role_sources,
         "assignments": {
-            "preflight": _decision.preflight.model,
-            "planner": _decision.planner.model,
-            "plan_reviewers": [p.model for p in _decision.plan_reviewers],
-            "dev": _decision.dev.model,
-            "code_reviewers": [p.model for p in _decision.code_reviewers],
+            "preflight": _assignment_entry(_decision.preflight),
+            "planner": _assignment_entry(_decision.planner),
+            "plan_reviewers": [_assignment_entry(p) for p in _decision.plan_reviewers],
+            "dev": _assignment_entry(_decision.dev),
+            "code_reviewers": [_assignment_entry(p) for p in _decision.code_reviewers],
         },
         "rationale": dict(_decision.rationale),
         "budget": _budget_audit,

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -21,7 +21,8 @@ from theforge.config import (
     TransportSpec,
     WorkspaceConfig,
 )
-from theforge.config.models import AgentDef
+from theforge.config.models import AGENT_REGISTRY, AgentDef, AgentSpec
+from theforge.config.models import TransportSpec as ModelTransportSpec
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -66,6 +67,9 @@ def _make_forge_config(
     models: list[str] | None = None,
     models_budget_usd: float | None = None,
     models_overrides: dict | None = None,
+    model_registry: dict[str, AgentSpec] | None = None,
+    model_registry_sources: dict[str, str] | None = None,
+    custom_models: tuple[str, ...] = (),
 ) -> ForgeConfig:
     if review_pool is None:
         review_pool = [_api_profile("claude-reviewer")]
@@ -107,6 +111,9 @@ def _make_forge_config(
         models=models,
         models_budget_usd=models_budget_usd,
         models_overrides=models_overrides,
+        model_registry=model_registry or dict(AGENT_REGISTRY),
+        model_registry_sources=model_registry_sources or {k: "builtin" for k in AGENT_REGISTRY},
+        custom_models=custom_models,
     )
 
 
@@ -287,6 +294,46 @@ class TestCheckConfigHappyPath:
         assert "deepseek" in deepseek_review_line
         assert "api" in deepseek_review_line
         assert "cli:deepseek" not in deepseek_review_line
+
+    def test_model_registry_section_distinguishes_builtin_and_forge_yaml_models(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        custom_registry = dict(AGENT_REGISTRY)
+        custom_registry["gpt-5.5"] = AgentSpec(
+            provider="openai",
+            model="gpt-5.5",
+            transport=ModelTransportSpec(kind="cli", runner="codex", executable="codex"),
+            tier="strong",
+            capability=9,
+            cost_rank=3,
+            registry_source="forge.yaml",
+            input_cost_per_mtok=5.0,
+            output_cost_per_mtok=30.0,
+        )
+        config = _make_forge_config(
+            tmp_path,
+            models=["claude/sonnet", "gpt-5.5"],
+            models_budget_usd=10.0,
+            model_registry=custom_registry,
+            model_registry_sources={
+                **{k: "builtin" for k in AGENT_REGISTRY},
+                "gpt-5.5": "forge.yaml",
+            },
+            custom_models=("gpt-5.5",),
+        )
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        assert "MODEL REGISTRY" in out
+        assert "selected builtin:" in out
+        assert "claude/sonnet" in out
+        assert "selected forge.yaml:" in out
+        assert "gpt-5.5" in out
+        assert "declared forge.yaml:" in out
 
     def test_provider_label_unknown_model_warns_without_prefix_fallback(self) -> None:
         warnings: list[str] = []

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -648,6 +648,96 @@ class TestDefaultFlags:
         config = load_config(config_path)
         assert config.review_pool_is_default is False
 
+    def test_models_custom_declares_and_selects_forge_yaml_model(self, tmp_path):
+        config_path = _write_config(
+            {
+                "models": {
+                    "enabled": ["claude/sonnet", "gpt-5.5"],
+                    "custom": {
+                        "gpt-5.5": {
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 5,
+                            "output_cost_per_mtok": 30,
+                        }
+                    },
+                },
+                "budget_usd": 50.0,
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.models == ["claude/sonnet", "gpt-5.5"]
+        assert config.custom_models == ("gpt-5.5",)
+        assert config.model_registry_sources["gpt-5.5"] == "forge.yaml"
+        assert config.model_registry["gpt-5.5"].model == "gpt-5.5"
+        assert config.dev_profile.registry_source in {"builtin", "forge.yaml"}
+
+    def test_models_custom_unknown_provider_rejected(self, tmp_path):
+        config_path = _write_config(
+            {
+                "models": {
+                    "custom": {
+                        "future-model": {
+                            "provider": "future-provider",
+                            "model": "future-model",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 1,
+                            "output_cost_per_mtok": 1,
+                        }
+                    }
+                }
+            },
+            tmp_path,
+        )
+        with pytest.raises(ValueError, match="Unknown provider 'future-provider'"):
+            load_config(config_path)
+
+    def test_models_custom_builtin_conflict_requires_override(self, tmp_path):
+        config_path = _write_config(
+            {
+                "models": {
+                    "custom": {
+                        "openai/gpt-5.4": {
+                            "provider": "openai",
+                            "model": "gpt-5.4",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 5,
+                            "output_cost_per_mtok": 30,
+                        }
+                    }
+                }
+            },
+            tmp_path,
+        )
+        with pytest.raises(ValueError, match="duplicates a built-in model id"):
+            load_config(config_path)
+
+    def test_models_custom_builtin_conflict_allowed_with_override(self, tmp_path):
+        config_path = _write_config(
+            {
+                "models": {
+                    "enabled": ["openai/gpt-5.4"],
+                    "custom": {
+                        "openai/gpt-5.4": {
+                            "provider": "openai",
+                            "model": "gpt-5.4",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 5,
+                            "output_cost_per_mtok": 30,
+                            "override": True,
+                        }
+                    },
+                },
+                "budget_usd": 50.0,
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.model_registry_sources["openai/gpt-5.4"] == "forge.yaml"
+        assert config.custom_models == ("openai/gpt-5.4",)
+
 
 class TestConventionsConfig:
     def test_conventions_hard_parsed(self, tmp_path):

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -231,7 +231,8 @@ def test_preflight_records_assignment_rationale_in_audit_state(tmp_path, monkeyp
     assert audit["source"] == "adaptive_assignment"
     assert audit["adaptive_enabled"] is True
     assert audit["role_sources"]["dev"] == "adaptive"
-    assert audit["assignments"]["dev"] == state._adaptive_decision.dev.model
+    assert audit["assignments"]["dev"]["model"] == state._adaptive_decision.dev.model
+    assert audit["assignments"]["dev"]["source"] == state._adaptive_decision.dev.registry_source
     assert "dev" in audit["rationale"]
     assert "budget_cap_usd" in audit["budget"]
 
@@ -300,7 +301,7 @@ def test_preflight_audit_keeps_strong_planner_when_strong_dev_forces_budget_pres
 
     audit = state.complexity_routing_audit
     assert audit is not None
-    assert audit["assignments"]["planner"] == "opus"
+    assert audit["assignments"]["planner"]["model"] == "opus"
     assert audit["rationale"]["planner"].startswith("complexity score 9 → tier strong")
     assert audit["role_sources"]["planner"] == "adaptive"
     assert audit["budget"]["within_budget"] is False
@@ -463,8 +464,8 @@ def test_explicit_planner_and_review_pool_threaded_into_assignment(tmp_path, mon
     assert audit["role_sources"]["planner"] == "explicit_override"
     assert audit["role_sources"]["code_review"] == "explicit_override"
     # The audit's recorded planner/code_reviewers must match what runtime uses.
-    assert audit["assignments"]["planner"] == explicit_planner_model
-    assert audit["assignments"]["code_reviewers"] == [
+    assert audit["assignments"]["planner"]["model"] == explicit_planner_model
+    assert [entry["model"] for entry in audit["assignments"]["code_reviewers"]] == [
         explicit_reviewer.model,
         explicit_reviewer.model,
     ]
@@ -619,10 +620,12 @@ def test_models_path_with_explicit_plan_and_review_pool_preserved(tmp_path, monk
     audit = state.complexity_routing_audit
     assert audit is not None
     # Planner must show the explicit model, not an adaptive selection.
-    assert audit["assignments"]["planner"] == explicit_plan_model
+    assert audit["assignments"]["planner"]["model"] == explicit_plan_model
     assert audit["role_sources"]["planner"] == "explicit_override"
     # Code reviewer must show the explicit pool, not an adaptive selection.
-    assert audit["assignments"]["code_reviewers"] == [explicit_reviewer.model]
+    assert [entry["model"] for entry in audit["assignments"]["code_reviewers"]] == [
+        explicit_reviewer.model
+    ]
     assert audit["role_sources"]["code_review"] == "explicit_override"
     # The adaptive decision must also have the explicit planner so plan_flow
     # will see it when "planner" is in _explicit_roles.

--- a/tests/test_generate_audit_log.py
+++ b/tests/test_generate_audit_log.py
@@ -167,10 +167,13 @@ class TestPreflightAudit:
                 "code_review": "budget_downgrade",
             },
             "assignments": {
-                "planner": "opus",
-                "dev": "opus",
-                "plan_reviewers": ["sonnet"],
-                "code_reviewers": ["sonnet", "haiku"],
+                "planner": {"model": "opus", "source": "builtin"},
+                "dev": {"model": "opus", "source": "forge.yaml"},
+                "plan_reviewers": [{"model": "sonnet", "source": "builtin"}],
+                "code_reviewers": [
+                    {"model": "sonnet", "source": "builtin"},
+                    {"model": "haiku", "source": "builtin"},
+                ],
             },
             "rationale": {
                 "dev": "complexity score 7 (MEDIUM) -> tier strong",
@@ -190,7 +193,8 @@ class TestPreflightAudit:
         assert routing["adaptive_enabled"] is True
         assert routing["role_sources"]["dev"] == "explicit_override"
         assert routing["role_sources"]["code_review"] == "budget_downgrade"
-        assert routing["assignments"]["dev"] == "opus"
+        assert routing["assignments"]["dev"]["model"] == "opus"
+        assert routing["assignments"]["dev"]["source"] == "forge.yaml"
         assert "budget" in routing["rationale"]
 
 


### PR DESCRIPTION
## Summary

Registry overlay is correctly implemented end-to-end; all ACs met; no P1 issues found.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.86
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/config/load.py:301`** _validate_auto_api_fallback_schema uses AGENT_REGISTRY directly instead of the merged registry when cross-checking plan_agent_review CLI settings against the models list. Custom CLI models in models.enabled will be skipped by this pre-validation (the key-in-AGENT_REGISTRY check returns false), so the PAR consistency check is a no-op for custom models. The broader _validate_selected_models catches actual bad model keys, so this is not a runtime failure — just a validation gap for custom CLI models in PAR config.
- **[P2] `tests/test_config_load.py:685`** The assertion 'config.dev_profile.registry_source in {'builtin', 'forge.yaml'}' is too permissive. With gpt-5.5 declared as strong/expensive (cost_rank=3) and claude/sonnet as the cheaper option, the dev role should go to claude/sonnet (builtin). The test does not pin which model becomes dev, so a routing regression that assigns the wrong model would not be caught.
- **[P2] `src/theforge/config/load.py:None`** Convention 8 (seam-level integration tests for touched config-propagation boundaries): no seam test exercises a custom forge.yaml model through the full preflight/complexity-routing path to verify registry_source appears correctly in complexity_routing_audit.assignments. Existing seam tests (test_coord_model_profiles_seam.py) were updated for the new audit shape but use only built-in models.

## Story

User-declared model registry overlay in forge.yaml — adding a model on an existing adapter must not require a TheForge release (GitHub Issue #1184)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1184