### PR TITLE
Canonical model identity scheme and historical profile alias migration

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -28,6 +28,17 @@ from .routing import score_to_dev_tier
 log = logging.getLogger(__name__)
 
 
+def _agent_canonical_id(agent: AgentDef) -> str | None:
+    """Derive the canonical model ID (provider/model/transport) for an agent."""
+    from theforge.model_profiles import canonical_id_from_identity  # noqa: PLC0415
+
+    return canonical_id_from_identity(
+        actual_model=agent.model,
+        provider=agent.provider,
+        cli=agent.cli,
+    )
+
+
 def _has_auth(agent: AgentDef, secrets: dict[str, str] | None = None) -> bool:
     """Return True if the agent's provider has usable auth.
 
@@ -325,20 +336,30 @@ def _check_promotion(
     dev_agent_name: str,
     history: list[EscalationRecord],
     sprint_promotions: dict[str, str] | None,
+    *,
+    dev_canonical_id: str | None = None,
 ) -> str | None:
     """Return promoted tier string if promotion is warranted, else None.
 
     Checks sprint_promotions cache first (sticky within sprint).
-    Looks at last 10 records matching complexity+dev_model.
+    Looks at last 10 records matching complexity and dev model identity.
+    Records are matched against ``dev_canonical_id`` when provided (so
+    canonicalized history records still match the agent), and against the
+    legacy ``dev_agent_name`` as a fallback for unmigrated history.
     Promotes if 2+ have outcome=ESCALATE.
     """
     if sprint_promotions and complexity in sprint_promotions:
         return sprint_promotions[complexity]
 
+    def _matches(r: EscalationRecord) -> bool:
+        if r.complexity != complexity:
+            return False
+        if dev_canonical_id and r.dev_model == dev_canonical_id:
+            return True
+        return r.dev_model == dev_agent_name
+
     # Filter to last 10 matching records
-    matching = [
-        r for r in history if r.complexity == complexity and r.dev_model == dev_agent_name
-    ][-10:]
+    matching = [r for r in history if _matches(r)][-10:]
 
     if not matching:
         return None
@@ -673,8 +694,13 @@ def assign_models(
             complexity=norm_complexity,
         )
         dev_model_name = dev_agent_for_check.name if dev_agent_for_check else ""
+        dev_canonical = _agent_canonical_id(dev_agent_for_check) if dev_agent_for_check else None
         promoted = _check_promotion(
-            norm_complexity, dev_model_name, effective_history, effective_promotions
+            norm_complexity,
+            dev_model_name,
+            effective_history,
+            effective_promotions,
+            dev_canonical_id=dev_canonical,
         )
         effective_dev_tier = dev_base_tier
         if promoted is not None:
@@ -683,7 +709,11 @@ def assign_models(
             _matching = [
                 r
                 for r in effective_history
-                if r.complexity == norm_complexity and r.dev_model == dev_model_name
+                if r.complexity == norm_complexity
+                and (
+                    r.dev_model == dev_model_name
+                    or (dev_canonical and r.dev_model == dev_canonical)
+                )
             ][-10:]
             escalation_cnt = sum(1 for r in _matching if r.outcome == "ESCALATE")
             rationale["dev"] = (

--- a/src/theforge/cli/main.py
+++ b/src/theforge/cli/main.py
@@ -15,6 +15,7 @@ from theforge.cli import (
     hooks,
     ideate,
     index,
+    migrate_profiles,
     providers,
     review,
     run,
@@ -61,6 +62,7 @@ def build_parser() -> argparse.ArgumentParser:
     eval_cmd.register_parser(subparsers)
     todo.register_parser(subparsers)
     diagnose.register_parser(subparsers)
+    migrate_profiles.register_parser(subparsers)
     status.register_parsers(subparsers)
 
     return parser
@@ -96,6 +98,7 @@ def main() -> None:
         "eval-preflight": eval_cmd.cmd_eval_preflight,
         "todo": todo.cmd_todo,
         "diagnose": diagnose.cmd_diagnose,
+        "migrate-profiles": migrate_profiles.cmd_migrate_profiles,
         "status": status.cmd_status,
         "logs": status.cmd_logs,
         "stop": status.cmd_stop,

--- a/src/theforge/cli/migrate_profiles.py
+++ b/src/theforge/cli/migrate_profiles.py
@@ -1,0 +1,119 @@
+"""``forge migrate-profiles`` — canonicalize legacy model_profiles + history.
+
+Operator-invoked, idempotent. Resolves every legacy storage key in
+``.forge/model_profiles.yaml`` and ``.forge/assignment_history.yaml`` to its
+canonical model ID (``<provider>/<model>/<transport.kind>``) and rewrites the
+files in place. Prints a per-canonical merge report. Ambiguous keys are kept
+under their legacy names with an explicit warning rather than guessed at.
+
+This is the documented one-time release migration trigger; running it again
+on already-migrated data is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from theforge.model_profiles import (
+    load_profiles,
+    migrate_history_data,
+    migrate_profiles_data,
+    save_profiles,
+)
+
+
+def register_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "migrate-profiles",
+        help="Canonicalize legacy model_profiles.yaml and assignment_history.yaml keys",
+    )
+    parser.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing the .forge directory (default: cwd)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the migration report without writing back to disk",
+    )
+
+
+def cmd_migrate_profiles(args: argparse.Namespace) -> int:
+    project_root = Path(args.project_root).resolve()
+    profiles_path = project_root / ".forge" / "model_profiles.yaml"
+    history_path = project_root / ".forge" / "assignment_history.yaml"
+
+    print(f"[migrate-profiles] project_root={project_root}")
+
+    profiles_data = load_profiles(profiles_path)
+    new_profiles, profile_report = migrate_profiles_data(profiles_data)
+    _print_profile_report(profile_report)
+
+    if not args.dry_run and profiles_path.exists():
+        save_profiles(profiles_path, new_profiles)
+        print(f"[migrate-profiles] wrote {profiles_path}")
+    elif args.dry_run:
+        print("[migrate-profiles] dry-run — profiles file not written")
+
+    history_data: dict | None = None
+    if history_path.exists():
+        try:
+            with open(history_path, encoding="utf-8") as f:
+                history_data = yaml.safe_load(f)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[migrate-profiles] failed to read {history_path}: {exc}")
+            history_data = None
+
+    if isinstance(history_data, dict):
+        new_history, history_report = migrate_history_data(history_data)
+        _print_history_report(history_report)
+        if not args.dry_run and history_report:
+            history_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(history_path, "w", encoding="utf-8") as f:
+                yaml.safe_dump(new_history, f, default_flow_style=False, allow_unicode=True)
+            print(f"[migrate-profiles] wrote {history_path}")
+    else:
+        print("[migrate-profiles] no assignment_history.yaml — skipping")
+
+    return 0
+
+
+def _print_profile_report(report: list[dict]) -> None:
+    if not report:
+        print("[migrate-profiles] no legacy alias entries found — already canonical")
+        return
+    for entry in report:
+        if "canonical_id" in entry:
+            combined = entry["combined"]
+            print(f"[migration] {entry['canonical_id']} (canonical)")
+            for src in entry["merged_from"]:
+                print(
+                    f"  ← {src['key']} ({src['runs']} runs, "
+                    f"{src['successes']:.0f} successes, "
+                    f"${src['cost_usd']:.2f})"
+                )
+            print(
+                f"  combined: {combined['runs']} runs, "
+                f"{combined['successes']:.0f} successes, "
+                f"${combined['cost_usd']:.2f}"
+            )
+        elif "ambiguous_key" in entry:
+            print(f"[migration] AMBIGUOUS: {entry['ambiguous_key']} — {entry['reason']}")
+
+
+def _print_history_report(report: list[dict]) -> None:
+    if not report:
+        print("[migrate-profiles] assignment_history.yaml — already canonical")
+        return
+    for entry in report:
+        if "to" in entry:
+            print(f"[history] {entry['from']!r} -> {entry['to']!r} (story={entry.get('story')})")
+        elif "ambiguous_key" in entry:
+            print(
+                f"[history] AMBIGUOUS dev_model={entry['ambiguous_key']!r} "
+                f"(story={entry.get('story')})"
+            )

--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -29,6 +29,9 @@ from .models import (
     ModelInfo,
     TransportSpec,
     apply_model_info,
+    canonical_id_for_spec,
+    canonical_model_id,
+    is_canonical_model_id,
     resolve_agent_spec,
 )
 from .types import (
@@ -94,6 +97,9 @@ __all__ = [
     "MODEL_REGISTRY",
     "TransportSpec",
     "apply_model_info",
+    "canonical_id_for_spec",
+    "canonical_model_id",
+    "is_canonical_model_id",
     "resolve_agent_spec",
     # defaults
     "API_PROVIDER_DEFAULT_TOOLS",

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -367,6 +367,33 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
 }
 
 
+# ── Canonical model identity ─────────────────────────────────────────
+#
+# The canonical model ID is the single key under which all profile data,
+# assignment history and audit records accumulate. Two registrations resolve
+# to the same canonical ID iff they refer to the same actual provider, model
+# and transport.kind. Format: ``<provider>/<model>/<transport.kind>``
+# (e.g. ``anthropic/sonnet/cli``, ``openai/gpt-5.4/api``).
+
+
+def canonical_model_id(provider: str, model: str, transport_kind: str) -> str:
+    """Build the canonical ID from its three constituent parts."""
+    return f"{provider}/{model}/{transport_kind}"
+
+
+def canonical_id_for_spec(spec: AgentSpec) -> str:
+    """Return the canonical ID for an :class:`AgentSpec`."""
+    return canonical_model_id(spec.provider, spec.model, spec.transport.kind)
+
+
+def is_canonical_model_id(value: str | None) -> bool:
+    """Return True if ``value`` already follows the canonical format."""
+    if not value or not isinstance(value, str):
+        return False
+    parts = value.split("/")
+    return len(parts) == 3 and bool(parts[0]) and bool(parts[1]) and parts[2] in ("cli", "api")
+
+
 def known_model_overlay_providers() -> tuple[str, ...]:
     """Return accepted provider/adaptor tokens for forge.yaml model overlays."""
     return tuple(sorted(_MODEL_OVERLAY_PROVIDER_MAP))

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1034,14 +1034,21 @@ def _record_run_memory(
             append_escalation_record as _append_esc,
         )
 
+        from theforge.model_profiles import canonical_id_from_identity  # noqa: PLC0415
+
         _esc_path = config.project_root / ".forge" / "assignment_history.yaml"
         _esc_outcome = "DONE" if result.success else "ESCALATE"
+        _esc_canonical = canonical_id_from_identity(
+            actual_model=getattr(config.dev_profile, "model", None),
+            provider=getattr(config.dev_profile, "provider", None),
+            cli=getattr(config.dev_profile, "cli", None),
+        )
         _esc_record = _EscRec(
             story=task.slug,
             complexity=state.preflight_complexity.upper()
             if state.preflight_complexity in ("small", "medium", "large")
             else state.preflight_complexity,
-            dev_model=config.dev_profile.name,
+            dev_model=_esc_canonical or config.dev_profile.name,
             outcome=_esc_outcome,
             reason=state.escalation_note or "",
             timestamp=datetime.datetime.utcnow().isoformat() + "Z",

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -1047,9 +1047,17 @@ def _apply_preflight_config(
     }
 
     def _assignment_entry(profile):  # type: ignore[no-untyped-def]
+        from theforge.model_profiles import canonical_id_from_identity  # noqa: PLC0415
+
+        canonical = canonical_id_from_identity(
+            actual_model=getattr(profile, "model", None),
+            provider=getattr(profile, "provider", None),
+            cli=getattr(profile, "cli", None),
+        )
         return {
             "model": profile.model,
             "source": getattr(profile, "registry_source", "builtin"),
+            "canonical_id": canonical or "",
         }
 
     state.complexity_routing_audit = {

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -153,6 +153,26 @@ def _identity_metadata(
     return out
 
 
+def canonical_id_from_identity(
+    *,
+    actual_model: str | None,
+    provider: str | None,
+    cli: str | None,
+) -> str | None:
+    """Derive a canonical model ID from runtime identity fields.
+
+    Returns None when the input is too thin to identify a canonical
+    (provider+model+transport) — e.g. role-shaped names like ``"dev"`` that
+    carry no provider hint.
+    """
+    inferred_provider = (provider or _provider_from_cli(cli) or "").strip()
+    transport = _transport_from_identity(inferred_provider or None, cli)
+    model = (actual_model or "").strip()
+    if not (model and inferred_provider and transport):
+        return None
+    return f"{inferred_provider}/{model}/{transport}"
+
+
 def _ensure_model(
     data: dict,
     name: str,
@@ -162,7 +182,9 @@ def _ensure_model(
     cli: str | None = None,
 ) -> dict:
     models = data.setdefault("models", {})
-    entry = models.setdefault(name, {})
+    canonical = canonical_id_from_identity(actual_model=actual_model, provider=provider, cli=cli)
+    storage_key = canonical or name
+    entry = models.setdefault(storage_key, {})
     metadata = _identity_metadata(actual_model=actual_model, provider=provider, cli=cli)
     if metadata and not isinstance(entry.get("_identity"), dict):
         entry["_identity"] = metadata
@@ -528,6 +550,362 @@ def _identity_from_unique_spec(
     if len(unique) == 1:
         return next(iter(unique))
     return None
+
+
+# ── Canonical-ID migration ────────────────────────────────────────────────
+
+
+def canonical_id_for_legacy_key(model_key: str, entry: dict | None = None) -> str | None:
+    """Return canonical ID (`provider/model/transport`) for a legacy storage key.
+
+    Resolution order:
+      1. ``_identity`` metadata stamped on the entry (richest, most reliable).
+      2. Already-canonical key (idempotency: ``anthropic/sonnet/cli`` → itself).
+      3. Direct AGENT_REGISTRY match (e.g. ``claude/sonnet`` registry slot).
+      4. ``-cli``/``-api`` suffix-aware unique-spec lookup
+         (e.g. ``sonnet-cli`` → unique anthropic/sonnet CLI spec).
+      5. Bare-name unique-spec lookup with constructable transport
+         (e.g. ``deepseek-deepseek-reasoner`` → unique deepseek/deepseek-reasoner
+         API spec).
+
+    Returns ``None`` when the key cannot be resolved unambiguously — those keys
+    are reported as ambiguous by the migration tool and left under their legacy
+    storage names rather than guessed at.
+    """
+    key = (model_key or "").strip()
+    if not key:
+        return None
+
+    if isinstance(entry, dict):
+        metadata = entry.get("_identity")
+        if isinstance(metadata, dict):
+            provider = str(metadata.get("provider") or "").strip()
+            model = str(metadata.get("model") or "").strip()
+            transport = str(metadata.get("transport") or "").strip()
+            if not transport and metadata.get("cli"):
+                transport = "cli"
+            if provider and model and transport in ("cli", "api"):
+                return f"{provider}/{model}/{transport}"
+
+    # Already canonical?
+    parts = key.split("/")
+    if len(parts) == 3 and parts[2] in ("cli", "api"):
+        return key
+
+    spec = _resolve_agent_spec_for_profile_key(key)
+    if spec is not None:
+        return f"{spec.provider}/{spec.model}/{spec.transport.kind}"
+
+    transport_hint: str | None = None
+    base = key
+    if key.endswith("-cli"):
+        transport_hint = "cli"
+        base = key[: -len("-cli")]
+    elif key.endswith("-api"):
+        transport_hint = "api"
+        base = key[: -len("-api")]
+
+    spec = _unique_registry_spec(base, transport_hint)
+    if spec is not None:
+        return f"{spec.provider}/{spec.model}/{spec.transport.kind}"
+
+    if transport_hint is None:
+        # Try `<provider>-<model>` style: split at the first dash where the
+        # prefix matches a known provider, e.g. ``deepseek-deepseek-reasoner``
+        # → provider=deepseek, model=deepseek-reasoner.
+        try:
+            from theforge.config.models import AGENT_REGISTRY  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            AGENT_REGISTRY = {}  # type: ignore[assignment]
+        for spec_obj in AGENT_REGISTRY.values():
+            prefix = f"{spec_obj.provider}-"
+            if key.startswith(prefix):
+                model_part = key[len(prefix) :]
+                if model_part == spec_obj.model:
+                    same_model = [
+                        s
+                        for s in AGENT_REGISTRY.values()
+                        if s.provider == spec_obj.provider and s.model == spec_obj.model
+                    ]
+                    transports = {s.transport.kind for s in same_model}
+                    if len(transports) == 1:
+                        return f"{spec_obj.provider}/{spec_obj.model}/{spec_obj.transport.kind}"
+
+    return None
+
+
+def _unique_registry_spec(model_name: str, transport: str | None) -> Any | None:
+    try:
+        from theforge.config.models import AGENT_REGISTRY  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    matches = [
+        spec
+        for spec in AGENT_REGISTRY.values()
+        if spec.model == model_name and (transport is None or spec.transport.kind == transport)
+    ]
+    # Unique by (provider, model, transport) — keep all distinct triples to
+    # detect ambiguity (e.g. CLI + API for same model with no transport hint).
+    triples = {(s.provider, s.model, s.transport.kind) for s in matches}
+    if len(triples) == 1:
+        return matches[0]
+    return None
+
+
+def _bucket_summary(entry: dict) -> dict[str, float | int]:
+    """Headline numbers for an entry, used in the migration report."""
+    runs = 0
+    successes = 0.0
+    cost = 0.0
+    iterations = 0.0
+    for role in ("dev", "review", "preflight"):
+        sec = entry.get(role)
+        if not isinstance(sec, dict):
+            continue
+        sec_runs = int(sec.get("runs", 0))
+        runs += sec_runs
+        if role == "dev":
+            successes += _success_count(sec, sec_runs)
+            cost += float(sec.get("_cost_sum", float(sec.get("avg_cost_usd", 0.0)) * sec_runs))
+            iterations += float(
+                sec.get("_iterations_sum", float(sec.get("avg_iterations", 0.0)) * sec_runs)
+            )
+        elif role == "review":
+            cost += float(sec.get("_cost_sum", float(sec.get("avg_cost_usd", 0.0)) * sec_runs))
+        elif role == "preflight":
+            cost += float(sec.get("_cost_sum", float(sec.get("avg_cost_usd", 0.0)) * sec_runs))
+    return {
+        "runs": runs,
+        "successes": successes,
+        "cost_usd": round(cost, 6),
+        "iterations": round(iterations, 4),
+    }
+
+
+def _merge_dev(target: dict, src: dict) -> None:
+    runs = int(target.get("runs", 0)) + int(src.get("runs", 0))
+    successes = int(target.get("_successes", 0)) + int(src.get("_successes", 0))
+    iter_sum = float(target.get("_iterations_sum", 0.0)) + float(src.get("_iterations_sum", 0.0))
+    cost_sum = float(target.get("_cost_sum", 0.0)) + float(src.get("_cost_sum", 0.0))
+    # If accumulators absent on src, derive from runs * avg fields.
+    if "_successes" not in src and "runs" in src:
+        successes = int(target.get("_successes", 0)) + int(
+            round(float(src.get("success_rate", 0.0)) * int(src.get("runs", 0)))
+        )
+    if "_iterations_sum" not in src and "runs" in src:
+        iter_sum = float(target.get("_iterations_sum", 0.0)) + float(
+            src.get("avg_iterations", 0.0)
+        ) * int(src.get("runs", 0))
+    if "_cost_sum" not in src and "runs" in src:
+        cost_sum = float(target.get("_cost_sum", 0.0)) + float(src.get("avg_cost_usd", 0.0)) * int(
+            src.get("runs", 0)
+        )
+
+    target["runs"] = runs
+    target["_successes"] = successes
+    target["_iterations_sum"] = iter_sum
+    target["_cost_sum"] = cost_sum
+    if runs > 0:
+        target["success_rate"] = round(successes / runs, 4)
+        target["avg_iterations"] = round(iter_sum / runs, 4)
+        target["avg_cost_usd"] = round(cost_sum / runs, 6)
+
+    src_by = src.get("by_complexity") or {}
+    if src_by:
+        target_by = target.setdefault("by_complexity", {})
+        for band, bc_src in src_by.items():
+            if not isinstance(bc_src, dict):
+                continue
+            bc_target = target_by.setdefault(band, {})
+            bc_runs = int(bc_target.get("runs", 0)) + int(bc_src.get("runs", 0))
+            bc_succ = int(bc_target.get("_successes", 0)) + int(
+                bc_src.get(
+                    "_successes",
+                    round(float(bc_src.get("success_rate", 0.0)) * int(bc_src.get("runs", 0))),
+                )
+            )
+            bc_iter = float(bc_target.get("_iterations_sum", 0.0)) + float(
+                bc_src.get(
+                    "_iterations_sum",
+                    float(bc_src.get("avg_iterations", 0.0)) * int(bc_src.get("runs", 0)),
+                )
+            )
+            bc_cost = float(bc_target.get("_cost_sum", 0.0)) + float(
+                bc_src.get(
+                    "_cost_sum",
+                    float(bc_src.get("avg_cost_usd", 0.0)) * int(bc_src.get("runs", 0)),
+                )
+            )
+            bc_target["runs"] = bc_runs
+            bc_target["_successes"] = bc_succ
+            bc_target["_iterations_sum"] = bc_iter
+            bc_target["_cost_sum"] = bc_cost
+            if bc_runs > 0:
+                bc_target["success_rate"] = round(bc_succ / bc_runs, 4)
+                bc_target["avg_iterations"] = round(bc_iter / bc_runs, 4)
+                bc_target["avg_cost_usd"] = round(bc_cost / bc_runs, 6)
+
+
+def _merge_review(target: dict, src: dict) -> None:
+    runs = int(target.get("runs", 0)) + int(src.get("runs", 0))
+    find_sum = float(target.get("_findings_sum", 0.0)) + float(
+        src.get("_findings_sum", float(src.get("avg_findings", 0.0)) * int(src.get("runs", 0)))
+    )
+    cost_sum = float(target.get("_cost_sum", 0.0)) + float(
+        src.get("_cost_sum", float(src.get("avg_cost_usd", 0.0)) * int(src.get("runs", 0)))
+    )
+    target["runs"] = runs
+    target["_findings_sum"] = find_sum
+    target["_cost_sum"] = cost_sum
+    if runs > 0:
+        target["avg_findings"] = round(find_sum / runs, 4)
+        target["avg_cost_usd"] = round(cost_sum / runs, 6)
+
+
+def _merge_preflight(target: dict, src: dict) -> None:
+    runs = int(target.get("runs", 0)) + int(src.get("runs", 0))
+    cost_sum = float(target.get("_cost_sum", 0.0)) + float(
+        src.get("_cost_sum", float(src.get("avg_cost_usd", 0.0)) * int(src.get("runs", 0)))
+    )
+    target["runs"] = runs
+    target["_cost_sum"] = cost_sum
+    if runs > 0:
+        target["avg_cost_usd"] = round(cost_sum / runs, 6)
+
+
+def _merge_entry(target: dict, src: dict) -> None:
+    if not isinstance(src, dict):
+        return
+    for role, merger in (
+        ("dev", _merge_dev),
+        ("review", _merge_review),
+        ("preflight", _merge_preflight),
+    ):
+        sec = src.get(role)
+        if not isinstance(sec, dict):
+            continue
+        target_sec = target.setdefault(role, {})
+        merger(target_sec, sec)
+    src_id = src.get("_identity")
+    if isinstance(src_id, dict) and not isinstance(target.get("_identity"), dict):
+        target["_identity"] = dict(src_id)
+
+
+def migrate_profiles_data(
+    data: dict | None,
+) -> tuple[dict, list[dict]]:
+    """Pure: rewrite ``data`` so legacy alias entries merge under canonical IDs.
+
+    Idempotent. Re-running on already-migrated data returns the same dict.
+    Ambiguous keys (those with no unambiguous resolution) are left in place and
+    flagged in the report. The report is a list of dicts — each entry is either
+    a merge record (``canonical_id``, ``merged_from``, ``combined``) or an
+    ambiguous-skip record (``ambiguous_key``, ``reason``).
+    """
+    models = (data or {}).get("models") or {}
+    if not isinstance(models, dict):
+        models = {}
+
+    groups: dict[str, list[tuple[str, dict]]] = {}
+    ambiguous: list[tuple[str, dict]] = []
+
+    for key, entry in models.items():
+        if not isinstance(entry, dict):
+            continue
+        canonical = canonical_id_for_legacy_key(key, entry)
+        if canonical is None:
+            ambiguous.append((key, entry))
+        else:
+            groups.setdefault(canonical, []).append((key, entry))
+
+    new_models: dict[str, dict] = {}
+    report: list[dict] = []
+
+    for canonical, members in groups.items():
+        if len(members) == 1 and members[0][0] == canonical:
+            # Already canonical with no aliases to merge.
+            new_models[canonical] = members[0][1]
+            continue
+        merged: dict = {}
+        # Stamp identity early so later metadata wins are skipped.
+        provider, model, transport = canonical.split("/", 2)
+        merged["_identity"] = {
+            "provider": provider,
+            "model": model,
+            "transport": transport,
+        }
+        if transport == "cli":
+            cli_runner = _provider_to_cli_runner(provider)
+            if cli_runner:
+                merged["_identity"]["cli"] = cli_runner
+        for _, entry in members:
+            _merge_entry(merged, entry)
+        new_models[canonical] = merged
+        report.append(
+            {
+                "canonical_id": canonical,
+                "merged_from": [{"key": k, **_bucket_summary(e)} for k, e in members],
+                "combined": _bucket_summary(merged),
+            }
+        )
+
+    for key, entry in ambiguous:
+        new_models[key] = entry
+        report.append(
+            {
+                "ambiguous_key": key,
+                "reason": "could not resolve to a unique canonical identity",
+            }
+        )
+
+    out = dict(data or {})
+    out["models"] = new_models
+    return out, report
+
+
+def _provider_to_cli_runner(provider: str) -> str | None:
+    return {"anthropic": "claude", "openai": "codex", "google": "gemini"}.get(provider)
+
+
+def migrate_history_data(
+    data: dict | None,
+) -> tuple[dict, list[dict]]:
+    """Pure: canonicalize ``dev_model`` field on each escalation record.
+
+    For records whose ``dev_model`` resolves to a canonical ID, the field is
+    overwritten in place. Records that cannot be resolved are left unchanged
+    and reported. Idempotent.
+    """
+    if not isinstance(data, dict):
+        return {"escalations": []}, []
+    records = data.get("escalations") or []
+    if not isinstance(records, list):
+        return {"escalations": []}, []
+
+    new_records: list[dict] = []
+    report: list[dict] = []
+    for r in records:
+        if not isinstance(r, dict):
+            continue
+        new_r = dict(r)
+        legacy = str(r.get("dev_model") or "").strip()
+        canonical = canonical_id_for_legacy_key(legacy) if legacy else None
+        if canonical and canonical != legacy:
+            new_r["dev_model"] = canonical
+            report.append(
+                {
+                    "from": legacy,
+                    "to": canonical,
+                    "story": r.get("story"),
+                }
+            )
+        elif legacy and canonical is None:
+            report.append({"ambiguous_key": legacy, "story": r.get("story")})
+        new_records.append(new_r)
+
+    out = dict(data)
+    out["escalations"] = new_records
+    return out, report
 
 
 def _success_count(stats: dict[str, Any], runs: int) -> float:

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -133,17 +133,22 @@ def test_apply_run_stamps_identity_metadata():
     )
     apply_run(data, outcome)
 
-    assert data["models"]["claude-sonnet"]["_identity"] == {
+    # Storage now keys by canonical ID (provider/model/transport.kind), not by
+    # the legacy profile name. The legacy `dev_model` and `preflight_model`
+    # arguments are display labels only.
+    assert data["models"]["anthropic/sonnet/cli"]["_identity"] == {
         "provider": "anthropic",
         "model": "sonnet",
         "transport": "cli",
         "cli": "claude",
     }
-    assert data["models"]["openai-gpt-5.4"]["_identity"] == {
+    assert data["models"]["openai/gpt-5.4/api"]["_identity"] == {
         "provider": "openai",
         "model": "gpt-5.4",
         "transport": "api",
     }
+    assert "claude-sonnet" not in data["models"]
+    assert "openai-gpt-5.4" not in data["models"]
 
 
 def test_complexity_normalization_handles_legacy_enums():

--- a/tests/test_profiles_migration.py
+++ b/tests/test_profiles_migration.py
@@ -1,0 +1,469 @@
+"""Canonical-ID migration for model_profiles.yaml + assignment_history.yaml.
+
+Covers the contract on issue #1291:
+
+* Fragmented sonnet aliases (``claude-sonnet`` + ``sonnet-cli``) merge into
+  one canonical entry (``anthropic/sonnet/cli``) with combined accumulators.
+* Fragmented gpt-5.4 CLI aliases merge into one canonical entry with combined
+  accumulators (CLI + API legacy keys remain distinct because transport is
+  part of the canonical identity per AC 1).
+* Ambiguous storage keys (role-shaped names like ``dev``, ``preflight``,
+  ``gemini-reviewer``, ``codex-cli``) are flagged in the report and left in
+  place rather than guessed at.
+* Migration is idempotent — re-running converges to the same state.
+* Behaviour-equivalence: the routing decision computed from a fragmented
+  pre-migration profile fixture matches the decision computed from its
+  post-migration canonical equivalent.
+"""
+
+from __future__ import annotations
+
+from theforge.assignment import (
+    AssignmentConfig,
+    assign_models,
+)
+from theforge.config import AgentDef
+from theforge.model_profiles import (
+    canonical_id_for_legacy_key,
+    canonical_id_from_identity,
+    get_dev_success_rate,
+    migrate_history_data,
+    migrate_profiles_data,
+)
+
+# ── canonical_id_from_identity ──────────────────────────────────────────
+
+
+def test_canonical_id_from_identity_cli():
+    assert (
+        canonical_id_from_identity(actual_model="sonnet", provider=None, cli="claude")
+        == "anthropic/sonnet/cli"
+    )
+
+
+def test_canonical_id_from_identity_api():
+    assert (
+        canonical_id_from_identity(actual_model="gpt-5.4", provider="openai", cli=None)
+        == "openai/gpt-5.4/api"
+    )
+
+
+def test_canonical_id_from_identity_returns_none_when_thin():
+    assert canonical_id_from_identity(actual_model=None, provider=None, cli=None) is None
+    assert canonical_id_from_identity(actual_model="dev", provider=None, cli=None) is None
+
+
+# ── canonical_id_for_legacy_key ────────────────────────────────────────
+
+
+def test_legacy_key_resolves_via_registry():
+    # `claude/sonnet` is already a registry slot; canonical adds transport.
+    assert canonical_id_for_legacy_key("claude/sonnet") == "anthropic/sonnet/cli"
+
+
+def test_legacy_key_resolves_via_dash_prefix():
+    assert canonical_id_for_legacy_key("claude-sonnet") == "anthropic/sonnet/cli"
+    assert canonical_id_for_legacy_key("claude-opus") == "anthropic/opus/cli"
+
+
+def test_legacy_key_resolves_via_cli_suffix():
+    # `sonnet-cli` is unique once we constrain transport to cli.
+    assert canonical_id_for_legacy_key("sonnet-cli") == "anthropic/sonnet/cli"
+
+
+def test_legacy_key_resolves_via_provider_model_concatenation():
+    assert (
+        canonical_id_for_legacy_key("deepseek-deepseek-reasoner")
+        == "deepseek/deepseek-reasoner/api"
+    )
+
+
+def test_already_canonical_passes_through():
+    assert canonical_id_for_legacy_key("anthropic/sonnet/cli") == "anthropic/sonnet/cli"
+
+
+def test_role_shaped_keys_are_ambiguous():
+    assert canonical_id_for_legacy_key("dev") is None
+    assert canonical_id_for_legacy_key("preflight") is None
+    assert canonical_id_for_legacy_key("gemini-reviewer") is None
+    # `codex-cli` is the codex binary name with no model attached.
+    assert canonical_id_for_legacy_key("codex-cli") is None
+
+
+def test_identity_metadata_takes_precedence():
+    entry = {"_identity": {"provider": "anthropic", "model": "sonnet", "cli": "claude"}}
+    assert canonical_id_for_legacy_key("legacy-name", entry) == "anthropic/sonnet/cli"
+
+
+# ── migrate_profiles_data ──────────────────────────────────────────────
+
+
+def _fragmented_sonnet_fixture() -> dict:
+    return {
+        "models": {
+            "claude-sonnet": {
+                "dev": {
+                    "runs": 5,
+                    "_successes": 2,
+                    "_iterations_sum": 5.0,
+                    "_cost_sum": 0.74,
+                    "success_rate": 0.4,
+                    "avg_iterations": 1.0,
+                    "avg_cost_usd": 0.148,
+                    "by_complexity": {
+                        "small": {
+                            "runs": 5,
+                            "_successes": 2,
+                            "_iterations_sum": 5.0,
+                            "_cost_sum": 0.74,
+                            "success_rate": 0.4,
+                            "avg_iterations": 1.0,
+                            "avg_cost_usd": 0.148,
+                        }
+                    },
+                }
+            },
+            "sonnet-cli": {
+                "dev": {
+                    "runs": 7,
+                    "_successes": 8,
+                    "_iterations_sum": 9.0,
+                    "_cost_sum": 0.0,
+                    "success_rate": round(8 / 7, 4),
+                    "avg_iterations": round(9 / 7, 4),
+                    "avg_cost_usd": 0.0,
+                    "by_complexity": {
+                        "medium": {
+                            "runs": 4,
+                            "_successes": 3,
+                            "_iterations_sum": 5.0,
+                            "_cost_sum": 0.0,
+                            "success_rate": 0.75,
+                            "avg_iterations": 1.25,
+                            "avg_cost_usd": 0.0,
+                        },
+                        "large": {
+                            "runs": 3,
+                            "_successes": 2,
+                            "_iterations_sum": 4.0,
+                            "_cost_sum": 0.0,
+                            "success_rate": 0.6667,
+                            "avg_iterations": 1.3333,
+                            "avg_cost_usd": 0.0,
+                        },
+                    },
+                }
+            },
+        }
+    }
+
+
+def test_migrate_merges_fragmented_sonnet_aliases():
+    data = _fragmented_sonnet_fixture()
+    migrated, report = migrate_profiles_data(data)
+
+    assert "claude-sonnet" not in migrated["models"]
+    assert "sonnet-cli" not in migrated["models"]
+    canonical = migrated["models"]["anthropic/sonnet/cli"]
+    dev = canonical["dev"]
+    assert dev["runs"] == 12
+    assert dev["_successes"] == 10
+    assert dev["_iterations_sum"] == 14.0
+    assert round(dev["_cost_sum"], 4) == 0.74
+    by = dev["by_complexity"]
+    assert by["small"]["runs"] == 5
+    assert by["small"]["_successes"] == 2
+    assert by["medium"]["runs"] == 4
+    assert by["medium"]["_successes"] == 3
+    assert by["large"]["runs"] == 3
+    assert by["large"]["_successes"] == 2
+
+    # Report is auditable.
+    [merge] = [r for r in report if r.get("canonical_id") == "anthropic/sonnet/cli"]
+    keys = {src["key"] for src in merge["merged_from"]}
+    assert keys == {"claude-sonnet", "sonnet-cli"}
+    assert merge["combined"]["runs"] == 12
+
+
+def test_migrate_merges_fragmented_gpt54_cli_aliases():
+    # Two legacy storage names that both resolve to the same CLI canonical.
+    data = {
+        "models": {
+            "openai-gpt-5.4": {
+                "dev": {
+                    "runs": 4,
+                    "_successes": 2,
+                    "_iterations_sum": 4.0,
+                    "_cost_sum": 1.0,
+                    "by_complexity": {
+                        "medium": {
+                            "runs": 4,
+                            "_successes": 2,
+                            "_iterations_sum": 4.0,
+                            "_cost_sum": 1.0,
+                        }
+                    },
+                }
+            },
+            "gpt-5.4-cli": {
+                "dev": {
+                    "runs": 6,
+                    "_successes": 5,
+                    "_iterations_sum": 6.0,
+                    "_cost_sum": 2.5,
+                    "by_complexity": {
+                        "large": {
+                            "runs": 6,
+                            "_successes": 5,
+                            "_iterations_sum": 6.0,
+                            "_cost_sum": 2.5,
+                        }
+                    },
+                }
+            },
+        }
+    }
+    migrated, _report = migrate_profiles_data(data)
+    canonical = migrated["models"]["openai/gpt-5.4/cli"]
+    dev = canonical["dev"]
+    assert dev["runs"] == 10
+    assert dev["_successes"] == 7
+    assert dev["by_complexity"]["medium"]["runs"] == 4
+    assert dev["by_complexity"]["large"]["runs"] == 6
+
+
+def test_migrate_keeps_cli_and_api_canonicals_distinct():
+    # Per AC 1, transport is part of canonical identity; CLI and API of the
+    # same provider+model resolve to different canonicals and must NOT merge.
+    data = {
+        "models": {
+            "openai-gpt-5.4": {  # codex CLI canonical
+                "dev": {"runs": 3, "_successes": 1, "_iterations_sum": 3.0, "_cost_sum": 0.5}
+            },
+            "openai-api-gpt-5.4": {  # openai API canonical
+                "dev": {"runs": 5, "_successes": 4, "_iterations_sum": 5.0, "_cost_sum": 2.0}
+            },
+        }
+    }
+    migrated, _ = migrate_profiles_data(data)
+    assert migrated["models"]["openai/gpt-5.4/cli"]["dev"]["runs"] == 3
+    assert migrated["models"]["openai/gpt-5.4/api"]["dev"]["runs"] == 5
+
+
+def test_migrate_reports_ambiguous_keys_and_leaves_them_in_place():
+    data = {
+        "models": {
+            "dev": {"dev": {"runs": 10, "_successes": 5}},
+            "preflight": {"preflight": {"runs": 3, "_cost_sum": 0.5}},
+            "gemini-reviewer": {"review": {"runs": 4, "_findings_sum": 8.0, "_cost_sum": 1.0}},
+            "codex-cli": {"dev": {"runs": 2, "_successes": 0}},
+        }
+    }
+    migrated, report = migrate_profiles_data(data)
+    # Ambiguous keys remain unchanged.
+    for k in ("dev", "preflight", "gemini-reviewer", "codex-cli"):
+        assert k in migrated["models"]
+    ambiguous_keys = {r["ambiguous_key"] for r in report if "ambiguous_key" in r}
+    assert ambiguous_keys == {"dev", "preflight", "gemini-reviewer", "codex-cli"}
+
+
+def test_migrate_is_idempotent():
+    data = _fragmented_sonnet_fixture()
+    once, _ = migrate_profiles_data(data)
+    twice, report_twice = migrate_profiles_data(once)
+    # Second pass produces no merges (already canonical).
+    assert all("canonical_id" not in r for r in report_twice)
+    assert once == twice
+
+
+def test_migrate_partial_data_converges():
+    # One alias already merged, one still legacy — second pass merges the rest.
+    data = {
+        "models": {
+            "anthropic/sonnet/cli": {
+                "_identity": {"provider": "anthropic", "model": "sonnet", "transport": "cli"},
+                "dev": {
+                    "runs": 5,
+                    "_successes": 2,
+                    "_iterations_sum": 5.0,
+                    "_cost_sum": 0.74,
+                    "by_complexity": {
+                        "small": {
+                            "runs": 5,
+                            "_successes": 2,
+                            "_iterations_sum": 5.0,
+                            "_cost_sum": 0.74,
+                        }
+                    },
+                },
+            },
+            "sonnet-cli": {
+                "dev": {
+                    "runs": 7,
+                    "_successes": 8,
+                    "_iterations_sum": 9.0,
+                    "_cost_sum": 0.0,
+                    "by_complexity": {
+                        "medium": {
+                            "runs": 4,
+                            "_successes": 3,
+                            "_iterations_sum": 5.0,
+                            "_cost_sum": 0.0,
+                        }
+                    },
+                },
+            },
+        }
+    }
+    migrated, _ = migrate_profiles_data(data)
+    dev = migrated["models"]["anthropic/sonnet/cli"]["dev"]
+    assert dev["runs"] == 12
+    assert dev["_successes"] == 10
+
+
+# ── migrate_history_data ───────────────────────────────────────────────
+
+
+def test_migrate_history_canonicalizes_dev_model_field():
+    data = {
+        "escalations": [
+            {
+                "story": "a",
+                "complexity": "MEDIUM",
+                "dev_model": "claude-sonnet",
+                "outcome": "DONE",
+            },  # noqa: E501
+            {
+                "story": "b",
+                "complexity": "LARGE",
+                "dev_model": "sonnet-cli",
+                "outcome": "ESCALATE",
+            },  # noqa: E501
+            {"story": "c", "complexity": "LARGE", "dev_model": "dev", "outcome": "DONE"},
+        ]
+    }
+    migrated, report = migrate_history_data(data)
+    records = migrated["escalations"]
+    assert records[0]["dev_model"] == "anthropic/sonnet/cli"
+    assert records[1]["dev_model"] == "anthropic/sonnet/cli"
+    # ``dev`` is ambiguous and is preserved.
+    assert records[2]["dev_model"] == "dev"
+    canonicalized = [r for r in report if "to" in r]
+    assert len(canonicalized) == 2
+    [ambiguous] = [r for r in report if "ambiguous_key" in r]
+    assert ambiguous["ambiguous_key"] == "dev"
+
+
+def test_migrate_history_is_idempotent():
+    data = {
+        "escalations": [
+            {
+                "story": "a",
+                "complexity": "MEDIUM",
+                "dev_model": "claude-sonnet",
+                "outcome": "DONE",
+            },  # noqa: E501
+        ]
+    }
+    once, _ = migrate_history_data(data)
+    twice, report = migrate_history_data(once)
+    assert once == twice
+    assert report == []
+
+
+# ── Behaviour equivalence: routing decision is preserved across migration ──
+
+
+def _agent_pool() -> list[AgentDef]:
+    return [
+        AgentDef(
+            name="sonnet",
+            provider="anthropic",
+            model="sonnet",
+            cli="claude",
+            budget_usd=2.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="opus",
+            provider="anthropic",
+            model="opus",
+            cli="claude",
+            budget_usd=10.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+        AgentDef(
+            name="gpt-5.4-mini",
+            provider="openai",
+            model="gpt-5.4-mini",
+            cli="codex",
+            budget_usd=1.0,
+            timeout_seconds=600,
+            tier="cheap",
+        ),
+    ]
+
+
+def test_routing_decision_matches_pre_and_post_migration():
+    """Pre- and post-migration profile fixtures must produce the same dev pick.
+
+    This is the load-bearing regression: without it a migration could pass
+    syntactic checks while producing different routing decisions than the
+    pre-migration data warranted.
+    """
+    fragmented = _fragmented_sonnet_fixture()
+    canonical, _ = migrate_profiles_data(fragmented)
+
+    # With ``claude`` CLI metadata both fixtures should report the same
+    # success rate for sonnet at small complexity (combined: 2/5 == 0.4 wait
+    # no, 2 + (small not present in sonnet-cli) = 2/5). Actually the small
+    # bucket only exists in claude-sonnet, but the function reads across all
+    # entries that resolve to the same canonical identity, so the pre and
+    # post-migration fixtures must agree.
+    pre = get_dev_success_rate(
+        fragmented,
+        "claude-sonnet",
+        "small",
+        actual_model="sonnet",
+        cli="claude",
+    )
+    post = get_dev_success_rate(
+        canonical,
+        "claude-sonnet",
+        "small",
+        actual_model="sonnet",
+        cli="claude",
+    )
+    assert pre == post
+
+    # Routing decision check: dev model selection at the small band should be
+    # identical against both fixtures (rerank-by-profile is the only thing
+    # that can drift, and it must read the same combined data either way).
+    cfg = AssignmentConfig(
+        enabled=True,
+        min_reviewers=1,
+        max_reviewers=2,
+        prefer_cross_provider=True,
+        budget_per_story_usd=50.0,
+        escalation_memory=False,
+        adaptive_enabled=True,
+    )
+    agents = _agent_pool()
+    decision_pre = assign_models(
+        agents,
+        cfg,
+        complexity="small",
+        complexity_score=3,
+        model_profiles=fragmented,
+    )
+    decision_post = assign_models(
+        agents,
+        cfg,
+        complexity="small",
+        complexity_score=3,
+        model_profiles=canonical,
+    )
+    assert decision_pre.dev.model == decision_post.dev.model
+    assert decision_pre.dev.provider == decision_post.dev.provider


### PR DESCRIPTION
## Summary

All 8 acceptance criteria met. Canonical ID defined, legacy alias resolution implemented, runtime writes canonicalized, migration is auditable and idempotent, forge migrate-profiles documented, audit includes canonical_id. Spec deviation on gpt-5.4 CLI+API test is correctly resolved per AC 1 (transport is part of canonical identity). Three P2 findings, zero P1.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $6.05
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/config/load.py:297`** _validate_auto_api_fallback_schema uses AGENT_REGISTRY directly (not the merged model_registry) when cross-checking plan_agent_review CLI settings against the models list. Custom CLI models in models.enabled skip the PAR consistency check because the key-in-AGENT_REGISTRY guard returns false for them. This was flagged as P2 in the #1315 merge review and is not a regression from the current commit, but is still unresolved.
- **[P2] `tests/test_coord_model_profiles_seam.py:231`** Seam tests updated for the new assignments dict shape check model and source, but no test asserts the new canonical_id field emitted by _assignment_entry in preflight.py. Convention 8 asks for seam-level coverage of touched phase-boundary state.
- **[P2] `src/theforge/config/models.py:412`** The single-argument fallback path in _spec_to_model_info sets registry_id = spec.model (e.g. 'sonnet') rather than the full registry key (e.g. 'claude/sonnet'). No caller in this PR exercises that path — all callers now pass both arguments — but if external code calls _spec_to_model_info(spec) directly it silently gets a truncated registry_id.

## Story

Canonical model identity scheme and historical profile alias migration (GitHub Issue #1291)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1291