### PR TITLE
Profile maintenance command for resetting or excluding contaminated model history

### DIFF
--- a/src/theforge/cli/main.py
+++ b/src/theforge/cli/main.py
@@ -16,6 +16,7 @@ from theforge.cli import (
     ideate,
     index,
     migrate_profiles,
+    profiles,
     providers,
     review,
     run,
@@ -63,6 +64,7 @@ def build_parser() -> argparse.ArgumentParser:
     todo.register_parser(subparsers)
     diagnose.register_parser(subparsers)
     migrate_profiles.register_parser(subparsers)
+    profiles.register_parser(subparsers)
     status.register_parsers(subparsers)
 
     return parser
@@ -99,6 +101,7 @@ def main() -> None:
         "todo": todo.cmd_todo,
         "diagnose": diagnose.cmd_diagnose,
         "migrate-profiles": migrate_profiles.cmd_migrate_profiles,
+        "profiles": profiles.cmd_profiles,
         "status": status.cmd_status,
         "logs": status.cmd_logs,
         "stop": status.cmd_stop,

--- a/src/theforge/cli/profiles.py
+++ b/src/theforge/cli/profiles.py
@@ -1,0 +1,291 @@
+"""``forge profiles`` — inspect and reset model capability profile history."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+from typing import Any
+
+from theforge.config import is_canonical_model_id
+from theforge.model_profiles import (
+    COMPLEXITY_BANDS,
+    ROLES,
+    canonical_id_for_legacy_key,
+    load_profiles,
+    record_profile_reset,
+)
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser(
+        "profiles",
+        help="Inspect and maintain model capability profiles",
+    )
+    profile_subparsers = parser.add_subparsers(dest="profiles_command", required=True)
+
+    list_parser = profile_subparsers.add_parser("list", help="List current profile counters")
+    list_parser.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing the .forge directory (default: cwd)",
+    )
+    list_parser.add_argument(
+        "--model",
+        "--filter",
+        dest="model",
+        default=None,
+        help="Show only one canonical model ID",
+    )
+    list_parser.add_argument(
+        "--role",
+        choices=ROLES,
+        default=None,
+        help="Show only one role",
+    )
+
+    reset_parser = profile_subparsers.add_parser(
+        "reset",
+        help="Reset cumulative profile counters for one canonical model ID",
+    )
+    reset_parser.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing the .forge directory (default: cwd)",
+    )
+    reset_parser.add_argument(
+        "--model",
+        required=True,
+        help="Canonical model ID to reset (for example anthropic/sonnet/cli)",
+    )
+    reset_parser.add_argument(
+        "--role",
+        choices=ROLES,
+        default=None,
+        help="Reset only one role's history",
+    )
+    reset_parser.add_argument(
+        "--complexity",
+        choices=COMPLEXITY_BANDS,
+        default=None,
+        help="Reset only one dev complexity bucket",
+    )
+    reset_parser.add_argument(
+        "--reason",
+        default=None,
+        help="Optional operator-supplied reason to record in the reset audit log",
+    )
+
+
+def cmd_profiles(args: argparse.Namespace) -> int:
+    if args.profiles_command == "list":
+        return cmd_profiles_list(args)
+    if args.profiles_command == "reset":
+        return cmd_profiles_reset(args)
+    print(f"[forge] Unknown profiles subcommand: {args.profiles_command}", file=sys.stderr)
+    return 1
+
+
+def cmd_profiles_list(args: argparse.Namespace) -> int:
+    project_root = Path(args.project_root).resolve()
+    profiles_path = project_root / ".forge" / "model_profiles.yaml"
+    data = load_profiles(profiles_path)
+    rows = _profile_rows(data, model=args.model, role=args.role)
+
+    if not rows:
+        print("canonical_id              role       complexity  runs  successes  rate")
+        return 0
+
+    widths = {
+        "canonical_id": max(len("canonical_id"), *(len(str(row["canonical_id"])) for row in rows)),
+        "role": max(len("role"), *(len(str(row["role"])) for row in rows)),
+        "complexity": max(len("complexity"), *(len(str(row["complexity"])) for row in rows)),
+        "runs": max(len("runs"), *(len(str(row["runs"])) for row in rows)),
+        "successes": max(len("successes"), *(len(str(row["successes"])) for row in rows)),
+        "rate": max(len("rate"), *(len(str(row["rate"])) for row in rows)),
+    }
+    print(
+        f"{'canonical_id':<{widths['canonical_id']}}  "
+        f"{'role':<{widths['role']}}  "
+        f"{'complexity':<{widths['complexity']}}  "
+        f"{'runs':>{widths['runs']}}  "
+        f"{'successes':>{widths['successes']}}  "
+        f"{'rate':>{widths['rate']}}"
+    )
+    for row in rows:
+        print(
+            f"{row['canonical_id']:<{widths['canonical_id']}}  "
+            f"{row['role']:<{widths['role']}}  "
+            f"{row['complexity']:<{widths['complexity']}}  "
+            f"{row['runs']:>{widths['runs']}}  "
+            f"{row['successes']:>{widths['successes']}}  "
+            f"{row['rate']:>{widths['rate']}}"
+        )
+    return 0
+
+
+def cmd_profiles_reset(args: argparse.Namespace) -> int:
+    canonical_id = str(args.model).strip()
+    if not is_canonical_model_id(canonical_id):
+        resolved = canonical_id_for_legacy_key(canonical_id)
+        if resolved:
+            print(
+                f"[forge] {canonical_id!r} is a legacy alias. Reset by canonical ID instead: "
+                f"{resolved}",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"[forge] {canonical_id!r} is not a canonical model ID. Use "
+                f"<provider>/<model>/<cli|api>, for example anthropic/sonnet/cli.",
+                file=sys.stderr,
+            )
+        return 2
+
+    if args.role not in (None, "dev") and args.complexity is not None:
+        print(
+            "[forge] --complexity only applies to dev history; omit --role or use --role dev.",
+            file=sys.stderr,
+        )
+        return 2
+
+    project_root = Path(args.project_root).resolve()
+    profiles_path = project_root / ".forge" / "model_profiles.yaml"
+    reset_history_path = project_root / ".forge" / "profiles" / "reset-history.yaml"
+    audit_entry = record_profile_reset(
+        profiles_path=profiles_path,
+        reset_history_path=reset_history_path,
+        canonical_id=canonical_id,
+        operator=getpass.getuser(),
+        role=args.role,
+        complexity=args.complexity,
+        reason=args.reason,
+    )
+
+    scope = _scope_label(canonical_id, args.role, args.complexity)
+    print(f"[forge] Reset {scope} history.")
+    if audit_entry["pre_reset"]:
+        for summary in audit_entry["pre_reset"]:
+            print(f"        Pre-reset: {_format_summary(summary)}.")
+    else:
+        print("        Pre-reset: no matching history.")
+    print(f"        Post-reset: {_post_reset_label(args.role, args.complexity)}")
+    if args.reason:
+        print(f"        Reason given: {args.reason}")
+    print(f"        Audit record: {reset_history_path} entry at {audit_entry['timestamp']}")
+    return 0
+
+
+def _profile_rows(
+    data: dict[str, Any],
+    *,
+    model: str | None = None,
+    role: str | None = None,
+) -> list[dict[str, Any]]:
+    models = (data or {}).get("models") or {}
+    if not isinstance(models, dict):
+        return []
+    rows: list[dict[str, Any]] = []
+    model_items = sorted(models.items())
+    for canonical_id, entry in model_items:
+        if model is not None and canonical_id != model:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        rows.extend(_entry_rows(canonical_id, entry, role=role))
+    return rows
+
+
+def _entry_rows(
+    canonical_id: str,
+    entry: dict[str, Any],
+    *,
+    role: str | None = None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    roles = (role,) if role else ROLES
+    for current_role in roles:
+        section = entry.get(current_role) or {}
+        if current_role == "dev":
+            by = section.get("by_complexity") if isinstance(section, dict) else {}
+            by = by if isinstance(by, dict) else {}
+            for band in COMPLEXITY_BANDS:
+                bucket = by.get(band) or {}
+                if not isinstance(bucket, dict):
+                    bucket = {}
+                rows.append(
+                    {
+                        "canonical_id": canonical_id,
+                        "role": "dev",
+                        "complexity": band,
+                        "runs": int(bucket.get("runs", 0)),
+                        "successes": int(bucket.get("_successes", 0)),
+                        "rate": _format_rate(
+                            bucket.get("runs", 0),
+                            bucket.get("success_rate", 0.0),
+                        ),
+                    }
+                )
+            continue
+        if role is None and not isinstance(section, dict):
+            continue
+        runs = int(section.get("runs", 0)) if isinstance(section, dict) else 0
+        rows.append(
+            {
+                "canonical_id": canonical_id,
+                "role": current_role,
+                "complexity": "—",
+                "runs": runs,
+                "successes": "—",
+                "rate": "—",
+            }
+        )
+    return rows
+
+
+def _format_rate(runs: int | float, rate: float | int) -> str:
+    if int(runs) <= 0:
+        return "—"
+    return f"{float(rate):.2f}"
+
+
+def _scope_label(canonical_id: str, role: str | None, complexity: str | None) -> str:
+    parts = [canonical_id]
+    if role:
+        parts.append(role)
+    elif complexity:
+        parts.append("dev")
+    if complexity:
+        parts.append(complexity)
+    return " ".join(parts)
+
+
+def _format_summary(summary: dict[str, Any]) -> str:
+    role = summary["role"]
+    complexity = summary.get("complexity")
+    prefix = role if complexity is None else f"{role}/{complexity}"
+    if role == "dev":
+        return (
+            f"{prefix}: {summary.get('runs', 0)} runs, {summary.get('successes', 0)} successes, "
+            f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost, "
+            f"{float(summary.get('avg_iterations', 0.0)):.1f} avg iterations"
+        )
+    if role == "review":
+        return (
+            f"{prefix}: {summary.get('runs', 0)} runs, "
+            f"{float(summary.get('avg_findings', 0.0)):.1f} avg findings, "
+            f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost"
+        )
+    return (
+        f"{prefix}: {summary.get('runs', 0)} runs, "
+        f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost"
+    )
+
+
+def _post_reset_label(role: str | None, complexity: str | None) -> str:
+    if complexity is not None:
+        return f"0 runs in dev/{complexity}."
+    if role is not None:
+        return f"0 runs in {role}."
+    return "0 runs in every reset scope."

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -29,7 +29,9 @@ fields in place. They are part of the persisted schema.
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -100,6 +102,34 @@ def save_profiles(path: Path, data: dict[str, Any]) -> None:
             yaml.safe_dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=True)
     except Exception as exc:  # noqa: BLE001
         log.warning("[model_profiles] Failed to write %s: %s", path, exc)
+
+
+def load_reset_history(path: Path) -> dict[str, list[dict[str, Any]]]:
+    """Read the profile reset audit log; return an empty skeleton if absent/bad."""
+    if not path.exists():
+        return {"resets": []}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[model_profiles] Failed to load reset history %s: %s", path, exc)
+        return {"resets": []}
+    if not isinstance(data, dict):
+        return {"resets": []}
+    resets = data.get("resets")
+    if not isinstance(resets, list):
+        data["resets"] = []
+    return data
+
+
+def save_reset_history(path: Path, data: dict[str, list[dict[str, Any]]]) -> None:
+    """Write the reset audit log to disk; best-effort (warns but doesn't raise)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[model_profiles] Failed to write reset history %s: %s", path, exc)
 
 
 # ── Pure aggregation ──────────────────────────────────────────────────────
@@ -247,6 +277,51 @@ def _update_preflight(entry: dict, cost_usd: float) -> None:
     pf["runs"] = runs
     pf["_cost_sum"] = cost_sum
     pf["avg_cost_usd"] = round(cost_sum / runs, 6)
+
+
+def _zero_dev_bucket(bucket: dict) -> None:
+    bucket["runs"] = 0
+    bucket["_successes"] = 0
+    bucket["_iterations_sum"] = 0.0
+    bucket["_cost_sum"] = 0.0
+    bucket["success_rate"] = 0.0
+    bucket["avg_iterations"] = 0.0
+    bucket["avg_cost_usd"] = 0.0
+
+
+def _zero_review_section(section: dict) -> None:
+    section["runs"] = 0
+    section["_findings_sum"] = 0.0
+    section["_cost_sum"] = 0.0
+    section["avg_findings"] = 0.0
+    section["avg_cost_usd"] = 0.0
+
+
+def _zero_preflight_section(section: dict) -> None:
+    section["runs"] = 0
+    section["_cost_sum"] = 0.0
+    section["avg_cost_usd"] = 0.0
+
+
+def _recompute_dev_section(section: dict) -> None:
+    by = section.setdefault("by_complexity", {})
+    runs = 0
+    successes = 0
+    iterations = 0.0
+    cost = 0.0
+    for band in COMPLEXITY_BANDS:
+        bucket = by.setdefault(band, {})
+        runs += int(bucket.get("runs", 0))
+        successes += int(bucket.get("_successes", 0))
+        iterations += float(bucket.get("_iterations_sum", 0.0))
+        cost += float(bucket.get("_cost_sum", 0.0))
+    section["runs"] = runs
+    section["_successes"] = successes
+    section["_iterations_sum"] = iterations
+    section["_cost_sum"] = cost
+    section["success_rate"] = round(successes / runs, 4) if runs > 0 else 0.0
+    section["avg_iterations"] = round(iterations / runs, 4) if runs > 0 else 0.0
+    section["avg_cost_usd"] = round(cost / runs, 6) if runs > 0 else 0.0
 
 
 def apply_run(data: dict, outcome: RunOutcome) -> dict:
@@ -497,6 +572,187 @@ def _resolve_identity(
     if explicit_provider and model_key:
         return (explicit_provider, model_key)
     return None
+
+
+def summarize_profile_scope(
+    data: dict | None,
+    canonical_id: str,
+    *,
+    role: str | None = None,
+    complexity: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return the exact slices a reset would affect, with pre-reset counts."""
+    models = (data or {}).get("models") or {}
+    if not isinstance(models, dict):
+        return []
+    entry = models.get(canonical_id)
+    if not isinstance(entry, dict):
+        return []
+
+    normalized_complexity = _normalize_band(complexity) if complexity is not None else None
+    summaries: list[dict[str, Any]] = []
+    if normalized_complexity is not None:
+        roles = ("dev",)
+    else:
+        roles = (role,) if role else ROLES
+
+    for current_role in roles:
+        section = entry.get(current_role)
+        if not isinstance(section, dict):
+            if current_role == "dev" and normalized_complexity is not None:
+                summaries.append(
+                    {
+                        "role": "dev",
+                        "complexity": normalized_complexity,
+                        "runs": 0,
+                        "successes": 0,
+                        "avg_iterations": 0.0,
+                        "avg_cost_usd": 0.0,
+                    }
+                )
+            continue
+
+        if current_role == "dev":
+            if normalized_complexity is not None:
+                bucket = (section.get("by_complexity") or {}).get(normalized_complexity) or {}
+                if not isinstance(bucket, dict):
+                    bucket = {}
+                summaries.append(
+                    {
+                        "role": "dev",
+                        "complexity": normalized_complexity,
+                        "runs": int(bucket.get("runs", 0)),
+                        "successes": int(bucket.get("_successes", 0)),
+                        "avg_iterations": float(bucket.get("avg_iterations", 0.0)),
+                        "avg_cost_usd": float(bucket.get("avg_cost_usd", 0.0)),
+                    }
+                )
+                continue
+            summaries.append(
+                {
+                    "role": "dev",
+                    "complexity": None,
+                    "runs": int(section.get("runs", 0)),
+                    "successes": int(section.get("_successes", 0)),
+                    "avg_iterations": float(section.get("avg_iterations", 0.0)),
+                    "avg_cost_usd": float(section.get("avg_cost_usd", 0.0)),
+                    "by_complexity": deepcopy(section.get("by_complexity") or {}),
+                }
+            )
+            continue
+
+        summary = {
+            "role": current_role,
+            "complexity": None,
+            "runs": int(section.get("runs", 0)),
+            "avg_cost_usd": float(section.get("avg_cost_usd", 0.0)),
+        }
+        if current_role == "review":
+            summary["avg_findings"] = float(section.get("avg_findings", 0.0))
+        summaries.append(summary)
+
+    return summaries
+
+
+def reset_profile_data(
+    data: dict | None,
+    canonical_id: str,
+    *,
+    role: str | None = None,
+    complexity: str | None = None,
+) -> tuple[dict, list[dict[str, Any]]]:
+    """Pure: reset one canonical model's profile data, optionally scoped."""
+    updated = deepcopy(data if isinstance(data, dict) else {"models": {}})
+    models = updated.setdefault("models", {})
+    if not isinstance(models, dict):
+        updated["models"] = {}
+        models = updated["models"]
+
+    pre_reset = summarize_profile_scope(
+        updated,
+        canonical_id,
+        role=role,
+        complexity=complexity,
+    )
+    if canonical_id not in models or not isinstance(models.get(canonical_id), dict):
+        return updated, pre_reset
+
+    entry = models[canonical_id]
+    normalized_complexity = _normalize_band(complexity) if complexity is not None else None
+
+    if role == "dev" and normalized_complexity is not None:
+        dev = entry.setdefault("dev", {})
+        by = dev.setdefault("by_complexity", {})
+        bucket = by.setdefault(normalized_complexity, {})
+        _zero_dev_bucket(bucket)
+        _recompute_dev_section(dev)
+        return updated, pre_reset
+
+    if normalized_complexity is not None:
+        dev = entry.setdefault("dev", {})
+        by = dev.setdefault("by_complexity", {})
+        bucket = by.setdefault(normalized_complexity, {})
+        _zero_dev_bucket(bucket)
+        _recompute_dev_section(dev)
+        return updated, pre_reset
+
+    roles = (role,) if role else ROLES
+    for current_role in roles:
+        if current_role == "dev":
+            dev = entry.setdefault("dev", {})
+            by = dev.setdefault("by_complexity", {})
+            for band in COMPLEXITY_BANDS:
+                _zero_dev_bucket(by.setdefault(band, {}))
+            _recompute_dev_section(dev)
+        elif current_role == "review":
+            _zero_review_section(entry.setdefault("review", {}))
+        elif current_role == "preflight":
+            _zero_preflight_section(entry.setdefault("preflight", {}))
+
+    return updated, pre_reset
+
+
+def record_profile_reset(
+    *,
+    profiles_path: Path,
+    reset_history_path: Path,
+    canonical_id: str,
+    operator: str,
+    role: str | None = None,
+    complexity: str | None = None,
+    reason: str | None = None,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Reset one canonical model profile slice and append an audit log entry."""
+    data = load_profiles(profiles_path)
+    updated, pre_reset = reset_profile_data(
+        data,
+        canonical_id,
+        role=role,
+        complexity=complexity,
+    )
+    save_profiles(profiles_path, updated)
+
+    changed = any(int(summary.get("runs", 0)) > 0 for summary in pre_reset)
+    entry = {
+        "timestamp": timestamp
+        or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "operator": operator,
+        "scope": {
+            "canonical_id": canonical_id,
+            "role": role,
+            "complexity": _normalize_band(complexity) if complexity is not None else None,
+        },
+        "changed": changed,
+        "pre_reset": pre_reset,
+    }
+    if reason:
+        entry["reason"] = reason
+
+    history = load_reset_history(reset_history_path)
+    history.setdefault("resets", []).append(entry)
+    save_reset_history(reset_history_path, history)
+    return entry
 
 
 def _infer_identity_from_key(model_key: str) -> tuple[str, str] | None:

--- a/tests/test_profiles_reset.py
+++ b/tests/test_profiles_reset.py
@@ -1,0 +1,294 @@
+"""Tests for ``forge profiles reset`` and related profile-maintenance helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from theforge.cli.main import build_parser
+from theforge.cli.profiles import cmd_profiles
+from theforge.model_profiles import (
+    get_dev_success_rate,
+    load_profiles,
+    reset_profile_data,
+    save_profiles,
+)
+
+CANONICAL_ID = "anthropic/sonnet/cli"
+
+
+def _profiles_fixture() -> dict:
+    return {
+        "models": {
+            CANONICAL_ID: {
+                "_identity": {
+                    "provider": "anthropic",
+                    "model": "sonnet",
+                    "transport": "cli",
+                    "cli": "claude",
+                },
+                "dev": {
+                    "runs": 12,
+                    "_successes": 7,
+                    "_iterations_sum": 16.0,
+                    "_cost_sum": 1.2,
+                    "success_rate": round(7 / 12, 4),
+                    "avg_iterations": round(16.0 / 12, 4),
+                    "avg_cost_usd": round(1.2 / 12, 6),
+                    "by_complexity": {
+                        "small": {
+                            "runs": 5,
+                            "_successes": 2,
+                            "_iterations_sum": 5.0,
+                            "_cost_sum": 0.5,
+                            "success_rate": 0.4,
+                            "avg_iterations": 1.0,
+                            "avg_cost_usd": 0.1,
+                        },
+                        "medium": {
+                            "runs": 4,
+                            "_successes": 3,
+                            "_iterations_sum": 5.0,
+                            "_cost_sum": 0.4,
+                            "success_rate": 0.75,
+                            "avg_iterations": 1.25,
+                            "avg_cost_usd": 0.1,
+                        },
+                        "large": {
+                            "runs": 3,
+                            "_successes": 2,
+                            "_iterations_sum": 6.0,
+                            "_cost_sum": 0.3,
+                            "success_rate": round(2 / 3, 4),
+                            "avg_iterations": 2.0,
+                            "avg_cost_usd": 0.1,
+                        },
+                    },
+                },
+                "review": {
+                    "runs": 6,
+                    "_findings_sum": 15.0,
+                    "_cost_sum": 0.9,
+                    "avg_findings": 2.5,
+                    "avg_cost_usd": 0.15,
+                },
+                "preflight": {
+                    "runs": 3,
+                    "_cost_sum": 0.21,
+                    "avg_cost_usd": 0.07,
+                },
+            }
+        }
+    }
+
+
+def _write_profiles(tmp_path: Path, data: dict | None = None) -> Path:
+    project_root = tmp_path
+    profiles_path = project_root / ".forge" / "model_profiles.yaml"
+    save_profiles(profiles_path, data or _profiles_fixture())
+    return project_root
+
+
+def _read_reset_history(project_root: Path) -> dict:
+    history_path = project_root / ".forge" / "profiles" / "reset-history.yaml"
+    return yaml.safe_load(history_path.read_text(encoding="utf-8"))
+
+
+def test_reset_profile_data_full_reset_clears_model_history():
+    updated, _pre_reset = reset_profile_data(_profiles_fixture(), CANONICAL_ID)
+
+    dev = updated["models"][CANONICAL_ID]["dev"]
+    assert dev["runs"] == 0
+    assert dev["_successes"] == 0
+    assert all(dev["by_complexity"][band]["runs"] == 0 for band in ("small", "medium", "large"))
+    assert updated["models"][CANONICAL_ID]["review"]["runs"] == 0
+    assert updated["models"][CANONICAL_ID]["preflight"]["runs"] == 0
+    assert get_dev_success_rate(updated, CANONICAL_ID, "small") is None
+
+
+def test_reset_profile_data_role_scoped_reset_preserves_other_roles():
+    updated, pre_reset = reset_profile_data(_profiles_fixture(), CANONICAL_ID, role="review")
+
+    assert pre_reset == [
+        {
+            "role": "review",
+            "complexity": None,
+            "runs": 6,
+            "avg_cost_usd": 0.15,
+            "avg_findings": 2.5,
+        }
+    ]
+    assert updated["models"][CANONICAL_ID]["review"]["runs"] == 0
+    assert updated["models"][CANONICAL_ID]["dev"]["runs"] == 12
+    assert updated["models"][CANONICAL_ID]["preflight"]["runs"] == 3
+
+
+def test_reset_profile_data_complexity_scoped_reset_preserves_other_buckets():
+    updated, pre_reset = reset_profile_data(_profiles_fixture(), CANONICAL_ID, complexity="medium")
+
+    assert pre_reset == [
+        {
+            "role": "dev",
+            "complexity": "medium",
+            "runs": 4,
+            "successes": 3,
+            "avg_iterations": 1.25,
+            "avg_cost_usd": 0.1,
+        }
+    ]
+    dev = updated["models"][CANONICAL_ID]["dev"]
+    assert dev["by_complexity"]["medium"]["runs"] == 0
+    assert dev["by_complexity"]["small"]["runs"] == 5
+    assert dev["by_complexity"]["large"]["runs"] == 3
+    assert dev["runs"] == 8
+    assert dev["_successes"] == 4
+
+
+def test_reset_profile_data_combined_scope_resets_one_role_bucket():
+    updated, _pre_reset = reset_profile_data(
+        _profiles_fixture(),
+        CANONICAL_ID,
+        role="dev",
+        complexity="small",
+    )
+
+    dev = updated["models"][CANONICAL_ID]["dev"]
+    assert dev["by_complexity"]["small"]["runs"] == 0
+    assert dev["by_complexity"]["medium"]["runs"] == 4
+    assert dev["by_complexity"]["large"]["runs"] == 3
+    assert dev["runs"] == 7
+    assert dev["_successes"] == 5
+
+
+def test_profiles_reset_command_audits_pre_reset_counts_and_prints_reason(capsys, tmp_path):
+    project_root = _write_profiles(tmp_path)
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "profiles",
+            "reset",
+            "--project-root",
+            str(project_root),
+            "--model",
+            CANONICAL_ID,
+            "--role",
+            "dev",
+            "--complexity",
+            "small",
+            "--reason",
+            "stuck detection false positive",
+        ]
+    )
+
+    assert cmd_profiles(args) == 0
+
+    stdout = capsys.readouterr().out
+    assert "Reset anthropic/sonnet/cli dev small history." in stdout
+    assert "Reason given: stuck detection false positive" in stdout
+
+    reloaded = load_profiles(project_root / ".forge" / "model_profiles.yaml")
+    assert reloaded["models"][CANONICAL_ID]["dev"]["by_complexity"]["small"]["runs"] == 0
+
+    history = _read_reset_history(project_root)
+    [entry] = history["resets"]
+    assert entry["scope"] == {
+        "canonical_id": CANONICAL_ID,
+        "role": "dev",
+        "complexity": "small",
+    }
+    assert entry["reason"] == "stuck detection false positive"
+    assert entry["pre_reset"] == [
+        {
+            "role": "dev",
+            "complexity": "small",
+            "runs": 5,
+            "successes": 2,
+            "avg_iterations": 1.0,
+            "avg_cost_usd": 0.1,
+        }
+    ]
+
+
+def test_profiles_reset_command_on_missing_history_is_noop_not_error(tmp_path):
+    project_root = tmp_path
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "profiles",
+            "reset",
+            "--project-root",
+            str(project_root),
+            "--model",
+            "openai/gpt-5.4/cli",
+        ]
+    )
+
+    assert cmd_profiles(args) == 0
+
+    history = _read_reset_history(project_root)
+    [entry] = history["resets"]
+    assert entry["scope"]["canonical_id"] == "openai/gpt-5.4/cli"
+    assert entry["pre_reset"] == []
+    assert entry["changed"] is False
+
+
+def test_profiles_reset_command_rejects_legacy_alias_input(capsys, tmp_path):
+    project_root = _write_profiles(tmp_path)
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "profiles",
+            "reset",
+            "--project-root",
+            str(project_root),
+            "--model",
+            "claude-sonnet",
+        ]
+    )
+
+    assert cmd_profiles(args) == 2
+    stderr = capsys.readouterr().err
+    assert "legacy alias" in stderr
+    assert CANONICAL_ID in stderr
+
+
+def test_profiles_list_shows_zeroed_bucket_after_reset(capsys, tmp_path):
+    project_root = _write_profiles(tmp_path)
+    parser = build_parser()
+    reset_args = parser.parse_args(
+        [
+            "profiles",
+            "reset",
+            "--project-root",
+            str(project_root),
+            "--model",
+            CANONICAL_ID,
+            "--role",
+            "dev",
+            "--complexity",
+            "small",
+        ]
+    )
+    assert cmd_profiles(reset_args) == 0
+
+    list_args = parser.parse_args(
+        [
+            "profiles",
+            "list",
+            "--project-root",
+            str(project_root),
+            "--model",
+            CANONICAL_ID,
+            "--role",
+            "dev",
+        ]
+    )
+    assert cmd_profiles(list_args) == 0
+
+    stdout = capsys.readouterr().out
+    assert "anthropic/sonnet/cli" in stdout
+    assert "dev" in stdout
+    assert "small" in stdout
+    assert "anthropic/sonnet/cli  dev   small" in stdout
+    assert "0          0     —" in stdout


### PR DESCRIPTION
## Summary

All 7 ACs met; reset logic is correct, audit trail is complete, alias rejection works, and tests cover all required cases.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.46
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/model_profiles.py:658`** The first branch 'if role == 'dev' and normalized_complexity is not None' is dead code — its condition is a strict subset of the immediately following 'if normalized_complexity is not None' branch, which performs the identical operation. Both branches do the same thing; the first is never uniquely reachable.

## Story

Profile maintenance command for resetting or excluding contaminated model history (GitHub Issue #1292)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1292