### PR TITLE
Split per-story routing cost cap from sprint budget; rename to assignment.max_cost_per_story_usd, default None

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -373,12 +373,12 @@ def _check_promotion(
 def _enforce_budget(
     decision: AssignmentDecision,
     agents: list[AgentDef],
-    budget_per_story_usd: float,
+    max_cost_per_story_usd: float,
     dev_floor_tier: str = "cheap",
     planner_floor_tier: str | None = None,
     locked_roles: set[str] | None = None,
 ) -> AssignmentDecision:
-    """Downgrade highest-cost non-preflight model if over budget cap.
+    """Downgrade highest-cost non-preflight model if over the per-story routing cost cap.
 
     Candidates for downgrade: planner, plan_reviewers, dev, code_reviewers.
     Preflight is excluded to preserve classification quality.
@@ -394,24 +394,27 @@ def _enforce_budget(
 
     locked_roles = locked_roles or set()
     initial_total = _decision_total(decision)
+    preferred_snapshot = _preferred_snapshot(decision, initial_total)
     budget_steps: list[dict[str, object]] = []
     protected_roles: set[str] = set()
 
-    if initial_total <= budget_per_story_usd:
+    if initial_total <= max_cost_per_story_usd:
         rationale = dict(decision.rationale)
-        rationale["budget"] = (
-            f"within budget cap ${budget_per_story_usd:.2f} (estimated total ${initial_total:.2f})"
+        rationale["per_story_routing_cost_cap"] = (
+            f"within per-story routing cost cap ${max_cost_per_story_usd:.2f} "
+            f"(estimated total ${initial_total:.2f})"
         )
         return _dc_replace(
             decision,
             rationale=rationale,
             budget_audit={
-                "budget_cap_usd": budget_per_story_usd,
+                "cap_usd": max_cost_per_story_usd,
                 "initial_total_usd": round(initial_total, 2),
                 "final_total_usd": round(initial_total, 2),
-                "within_budget": True,
+                "within_cap": True,
                 "downgraded": False,
                 "steps": [],
+                "preferred": preferred_snapshot,
             },
         )
 
@@ -440,9 +443,9 @@ def _enforce_budget(
             cheapest = min(cheaper_options, key=lambda a: a.budget_usd)
             return cheapest.to_model_profile(allowed_tools=profile.allowed_tools)
 
-    # Iteratively downgrade until within budget (max 10 passes)
+    # Iteratively downgrade until within cap (max 10 passes)
     for _ in range(10):
-        if _decision_total(decision) <= budget_per_story_usd:
+        if _decision_total(decision) <= max_cost_per_story_usd:
             break
 
         # Find highest-cost non-preflight profile that can be downgraded.
@@ -547,63 +550,89 @@ def _enforce_budget(
                 break
 
     final_total = _decision_total(decision)
-    within_budget = final_total <= budget_per_story_usd
+    within_cap = final_total <= max_cost_per_story_usd
     rationale = dict(decision.rationale)
     impacted_roles = {
         str(step.get("role"))
         for step in budget_steps
         if isinstance(step, dict) and step.get("role")
     }
+    cap_phrase = f"per-story routing cost cap ${max_cost_per_story_usd:.2f}"
     if "planner" in impacted_roles and "planner" in rationale:
-        rationale["planner"] += f"; budget adjusted -> final model {decision.planner.model}"
+        _p = decision.planner
+        rationale["planner"] += f"; {cap_phrase} downgraded to {_p.model} @ ${_p.budget_usd:.2f}"
     if "dev" in impacted_roles and "dev" in rationale:
-        rationale["dev"] += f"; budget adjusted -> final model {decision.dev.model}"
+        _d = decision.dev
+        rationale["dev"] += f"; {cap_phrase} downgraded to {_d.model} @ ${_d.budget_usd:.2f}"
     if "plan_review" in impacted_roles and "plan_review" in rationale:
+        _pr_total = sum(p.budget_usd for p in decision.plan_reviewers)
         rationale["plan_review"] += (
-            f"; budget adjusted -> final reviewers {[p.model for p in decision.plan_reviewers]}"
+            f"; {cap_phrase} downgraded to "
+            f"{[p.model for p in decision.plan_reviewers]} @ ${_pr_total:.2f}"
         )
     if "code_review" in impacted_roles and "code_review" in rationale:
+        _cr_total = sum(p.budget_usd for p in decision.code_reviewers)
         rationale["code_review"] += (
-            f"; budget adjusted -> final reviewers {[p.model for p in decision.code_reviewers]}"
+            f"; {cap_phrase} downgraded to "
+            f"{[p.model for p in decision.code_reviewers]} @ ${_cr_total:.2f}"
         )
     if budget_steps:
-        rationale["budget"] = (
-            f"budget cap ${budget_per_story_usd:.2f}: downgraded to "
-            f"${final_total:.2f} via {len(budget_steps)} adjustment(s)"
+        rationale["per_story_routing_cost_cap"] = (
+            f"{cap_phrase}: downgraded to ${final_total:.2f} via {len(budget_steps)} adjustment(s)"
         )
-    elif within_budget:
-        rationale["budget"] = (
-            f"within budget cap ${budget_per_story_usd:.2f} (estimated total ${final_total:.2f})"
+    elif within_cap:
+        rationale["per_story_routing_cost_cap"] = (
+            f"within {cap_phrase} (estimated total ${final_total:.2f})"
         )
     else:
-        rationale["budget"] = (
-            f"budget cap ${budget_per_story_usd:.2f} could not be met; "
-            f"estimated total ${final_total:.2f}"
+        rationale["per_story_routing_cost_cap"] = (
+            f"{cap_phrase} could not be met; estimated total ${final_total:.2f}"
         )
     if protected_roles:
-        rationale["budget"] += f" (protected roles: {sorted(protected_roles)})"
+        rationale["per_story_routing_cost_cap"] += f" (protected roles: {sorted(protected_roles)})"
 
-    if not within_budget:
+    if not within_cap:
         warnings.warn(
-            f"[adaptive] Budget cap ${budget_per_story_usd:.2f} cannot be met; "
-            f"actual total ${final_total:.2f}",
+            f"[adaptive] per-story routing cost cap ${max_cost_per_story_usd:.2f} "
+            f"cannot be met; actual total ${final_total:.2f}",
             stacklevel=2,
         )
 
     audit: dict[str, object] = {
-        "budget_cap_usd": budget_per_story_usd,
+        "cap_usd": max_cost_per_story_usd,
         "initial_total_usd": round(initial_total, 2),
         "final_total_usd": round(final_total, 2),
-        "within_budget": within_budget,
+        "within_cap": within_cap,
         "downgraded": bool(budget_steps),
         "steps": budget_steps,
+        "preferred": preferred_snapshot,
     }
     if protected_roles:
         audit["protected_roles"] = sorted(protected_roles)
-    if not within_budget and locked_roles:
+    if not within_cap and locked_roles:
         audit["override_forced_overrun"] = True
         audit["locked_roles"] = sorted(locked_roles)
     return _dc_replace(decision, rationale=rationale, budget_audit=audit)
+
+
+def _preferred_snapshot(decision: AssignmentDecision, total_usd: float) -> dict[str, object]:
+    """Capture adaptive's pre-cap selection for warning emission and audit."""
+    return {
+        "dev": {"model": decision.dev.model, "budget_usd": round(decision.dev.budget_usd, 2)},
+        "planner": {
+            "model": decision.planner.model,
+            "budget_usd": round(decision.planner.budget_usd, 2),
+        },
+        "plan_reviewers": [
+            {"model": p.model, "budget_usd": round(p.budget_usd, 2)}
+            for p in decision.plan_reviewers
+        ],
+        "code_reviewers": [
+            {"model": p.model, "budget_usd": round(p.budget_usd, 2)}
+            for p in decision.code_reviewers
+        ],
+        "total_usd": round(total_usd, 2),
+    }
 
 
 def _agent_to_profile(
@@ -924,8 +953,36 @@ def assign_models(
         rationale=rationale,
     )
 
-    # Enforce budget cap — pass dev floor so the enforcer never downgrades dev
-    # below the complexity-required tier.
+    # Enforce per-story routing cost cap — pass dev floor so the enforcer never
+    # downgrades dev below the complexity-required tier.  When the cap is unset
+    # (None), adaptive's selection is preserved as-is and only the sprint-wide
+    # budget_usd guard remains.
+    cap = assignment_config.max_cost_per_story_usd
+    if cap is None:
+        for _role in ("planner", "dev", "plan_review", "code_review"):
+            if _role in rationale:
+                rationale[_role] += "; per-story routing cost cap: unset"
+        rationale["per_story_routing_cost_cap"] = (
+            "unset — adaptive routes by complexity; no per-story cap enforcement"
+        )
+        from dataclasses import replace as _dc_replace
+
+        _initial_total = _decision_total(decision)
+        decision = _dc_replace(
+            decision,
+            rationale=rationale,
+            budget_audit={
+                "cap_usd": None,
+                "initial_total_usd": round(_initial_total, 2),
+                "final_total_usd": round(_initial_total, 2),
+                "within_cap": True,
+                "downgraded": False,
+                "steps": [],
+                "preferred": _preferred_snapshot(decision, _initial_total),
+            },
+        )
+        return decision
+
     planner_floor_tier = None
     if (
         planner_target_tier == "strong"
@@ -936,7 +993,7 @@ def assign_models(
     decision = _enforce_budget(
         decision,
         agents,
-        assignment_config.budget_per_story_usd,
+        cap,
         dev_floor_tier=dev_base_tier,
         planner_floor_tier=planner_floor_tier,
         locked_roles=locked_roles,

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -265,7 +265,14 @@ def _format_config(
                     provider_labels.append(lbl)
             lines.append(f"Providers: {', '.join(provider_labels)}")
     elif config.assignment.enabled:
-        lines.append(f"Budget:  ${config.assignment.budget_per_story_usd:.2f}/story")
+        _cap = config.assignment.max_cost_per_story_usd
+        if _cap is None:
+            lines.append(
+                "Per-story routing cost cap: unset "
+                "(adaptive routes by complexity; only budget_usd enforces spend)"
+            )
+        else:
+            lines.append(f"Per-story routing cost cap: ${_cap:.2f}/story")
     lines.append("")
 
     if config.models or config.custom_models:
@@ -408,9 +415,12 @@ def _format_config(
     lines.append("SETTINGS")
     if config.assignment.enabled:
         a = config.assignment
+        if a.max_cost_per_story_usd is None:
+            cap_str = "no per-story routing cost cap configured"
+        else:
+            cap_str = f"per-story routing cost cap=${a.max_cost_per_story_usd:.2f}/story"
         lines.append(
-            f"  assignment:    enabled  (min={a.min_reviewers}, max={a.max_reviewers},"
-            f" budget=${a.budget_per_story_usd:.2f}/story)"
+            f"  assignment:    enabled  (min={a.min_reviewers}, max={a.max_reviewers}, {cap_str})"
         )
     else:
         lines.append("  assignment:    disabled")

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -586,7 +586,11 @@ def _parse_assignment(assignment_raw: dict[str, Any]) -> AssignmentConfig:
         min_reviewers=int(assignment_raw.get("min_reviewers", 1)),
         max_reviewers=int(assignment_raw.get("max_reviewers", 3)),
         prefer_cross_provider=bool(assignment_raw.get("prefer_cross_provider", True)),
-        budget_per_story_usd=float(assignment_raw.get("budget_per_story_usd", 15.0)),
+        max_cost_per_story_usd=(
+            float(assignment_raw["max_cost_per_story_usd"])
+            if assignment_raw.get("max_cost_per_story_usd") is not None
+            else None
+        ),
         escalation_memory=bool(assignment_raw.get("escalation_memory", True)),
         adaptive_enabled=bool(assignment_raw.get("adaptive_enabled", True)),
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -20,7 +20,7 @@ class AssignmentConfig:
     min_reviewers: int = 1
     max_reviewers: int = 3
     prefer_cross_provider: bool = True
-    budget_per_story_usd: float = 15.0
+    max_cost_per_story_usd: float | None = None
     escalation_memory: bool = True
     adaptive_enabled: bool = True
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -835,7 +835,7 @@ def run_task(
             state.preflight_cache_validation = cache_validation
             if cache_valid:
                 apply_cached_preflight_state(state, cached_preflight_state)
-                config = _apply_preflight_config(config, state)
+                config = _apply_preflight_config(config, state, task_slug=task.slug)
                 from .preflight_flow import _handle_preflight_verdict  # noqa: PLC0415
 
                 config, _pf_result, _pf_already_done_loop = _handle_preflight_verdict(
@@ -1139,7 +1139,7 @@ def _run_resume_coordinator(
         state.preflight_cache_validation = cache_validation
         if cache_valid:
             apply_cached_preflight_state(state, cached_preflight_state)
-            config = _apply_preflight_config(config, state)
+            config = _apply_preflight_config(config, state, task_slug=task.slug)
         else:
             # Cache invalidated mid-sprint (e.g., base branch advanced after a
             # prior batch merged): re-run preflight against the current base so

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -833,12 +833,53 @@ def _apply_complexity_adaptation(
     return new_config
 
 
+def _emit_cap_downgrade_warning(
+    log: Callable[[str], None],
+    cap_audit: dict[str, object],
+    downgraded_roles: set[str],
+    *,
+    story_slug: str | None,
+) -> None:
+    """Print a visible terminal warning when the per-story routing cost cap forced a downgrade.
+
+    The warning fires when ``_enforce_budget`` either dropped a reviewer or
+    swapped a selected role for a cheaper one — i.e. adaptive's preferred
+    selection was overridden by the cap.
+    """
+    if not cap_audit.get("downgraded"):
+        return
+    cap = cap_audit.get("cap_usd")
+    preferred = cap_audit.get("preferred") or {}
+    if not isinstance(preferred, dict):
+        return
+    final_total = cap_audit.get("final_total_usd")
+    initial_total = preferred.get("total_usd")
+    pref_dev = (preferred.get("dev") or {}).get("model")
+    pref_cr = [r.get("model") for r in preferred.get("code_reviewers", []) if isinstance(r, dict)]
+    pref_pr = [r.get("model") for r in preferred.get("plan_reviewers", []) if isinstance(r, dict)]
+    pref_planner = (preferred.get("planner") or {}).get("model")
+    story_label = f"story {story_slug}" if story_slug else "story"
+    log(
+        f"  ⚠ {story_label}: per-story routing cost cap ${cap:.2f} forces downgrade"
+        if isinstance(cap, (int, float))
+        else f"  ⚠ {story_label}: per-story routing cost cap forces downgrade"
+    )
+    pref_total_str = f" @ ~${initial_total:.2f}" if isinstance(initial_total, (int, float)) else ""
+    log(
+        f"    adaptive selected: dev={pref_dev}, planner={pref_planner}, "
+        f"plan_reviewers={pref_pr}, code_reviewers={pref_cr}{pref_total_str}"
+    )
+    final_total_str = f" @ ~${final_total:.2f}" if isinstance(final_total, (int, float)) else ""
+    log(f"    after cap:         downgraded roles={sorted(downgraded_roles)}{final_total_str}")
+
+
 def _apply_preflight_config(
     config: ForgeConfig,
     state: "CoordinatorState",
     *,
     log: Callable[[str], None] | None = None,
     log_verbose: Callable[[str], None] | None = None,
+    task_slug: str | None = None,
 ) -> ForgeConfig:
     """Apply complexity-driven config updates using values already stored on state."""
     complexity = state.preflight_complexity or "medium"
@@ -972,14 +1013,15 @@ def _apply_preflight_config(
             + _decision.dev.budget_usd
             + sum(p.budget_usd for p in _decision.code_reviewers)
         )
-        _budget_cap = config.assignment.budget_per_story_usd
-        _within = _runtime_total <= _budget_cap
+        _cap = config.assignment.max_cost_per_story_usd
         _new_audit = dict(_decision.budget_audit)
         _new_audit["final_total_usd"] = round(_runtime_total, 2)
-        _new_audit["within_budget"] = _within
-        if not _within:
-            _new_audit["override_forced_overrun"] = True
-            _new_audit["locked_roles"] = sorted(set(_explicit.keys()))
+        if _cap is not None:
+            _within = _runtime_total <= _cap
+            _new_audit["within_cap"] = _within
+            if not _within:
+                _new_audit["override_forced_overrun"] = True
+                _new_audit["locked_roles"] = sorted(set(_explicit.keys()))
         _decision = _dc_replace(_decision, budget_audit=_new_audit)
 
     _replace_kwargs: dict[str, object] = {
@@ -1010,12 +1052,13 @@ def _apply_preflight_config(
     state._explicit_roles = _explicit_roles
     _existing_routing_audit = dict(state.complexity_routing_audit or {})
     _adaptive_enabled = config.assignment.adaptive_enabled
-    _budget_audit = dict(_decision.budget_audit)
-    _budget_downgraded_roles = {
+    _cap_audit = dict(_decision.budget_audit)
+    _cap_downgraded_roles = {
         str(step.get("role"))
-        for step in _budget_audit.get("steps", [])
+        for step in _cap_audit.get("steps", [])
         if isinstance(step, dict) and step.get("role")
     }
+    _emit_cap_downgrade_warning(_log, _cap_audit, _cap_downgraded_roles, story_slug=task_slug)
 
     # Map audit roles to whichever explicit-source hint indicates an override.
     # _explicit (passed to assign_models) keys: dev/preflight/planner/code_review/plan_review
@@ -1034,8 +1077,8 @@ def _apply_preflight_config(
             return "explicit_override"
         if not _adaptive_enabled:
             return "static"
-        if role in _budget_downgraded_roles:
-            return "budget_downgrade"
+        if role in _cap_downgraded_roles:
+            return "cap_downgrade"
         return "adaptive"
 
     _per_role_sources = {
@@ -1075,7 +1118,7 @@ def _apply_preflight_config(
             "code_reviewers": [_assignment_entry(p) for p in _decision.code_reviewers],
         },
         "rationale": dict(_decision.rationale),
-        "budget": _budget_audit,
+        "per_story_routing_cost_cap": _cap_audit,
         **({"config_model_routing": _existing_routing_audit} if _existing_routing_audit else {}),
     }
 

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -631,7 +631,9 @@ def _run_preflight_phase(
             }
         )
 
-    config = _apply_preflight_config(config, state, log=_log, log_verbose=_log_verbose)
+    config = _apply_preflight_config(
+        config, state, log=_log, log_verbose=_log_verbose, task_slug=task.slug
+    )
 
     _log(f"  ✓ PREFLIGHT   {verdict}")
     _log_verbose(f"  Reason: {reason}")

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -34,7 +34,7 @@ def _make_cfg(**kwargs) -> AssignmentConfig:
         min_reviewers=1,
         max_reviewers=3,
         prefer_cross_provider=True,
-        budget_per_story_usd=100.0,  # generous default so budget tests can be explicit
+        max_cost_per_story_usd=100.0,  # generous default so budget tests can be explicit
         escalation_memory=True,
     )
     defaults.update(kwargs)
@@ -168,7 +168,7 @@ def test_tier_selection_medium():
 def test_tier_selection_high():
     """HIGH complexity: plan=strong, dev=strong; code_review excludes dev model."""
     agents = _make_agents_one_per_tier()
-    cfg = _make_cfg(min_reviewers=1, max_reviewers=3, budget_per_story_usd=1000.0)
+    cfg = _make_cfg(min_reviewers=1, max_reviewers=3, max_cost_per_story_usd=1000.0)
     decision = assign_models(agents, cfg, "large")
 
     assert decision.dev.model == "opus"  # strong
@@ -197,7 +197,7 @@ def test_cross_provider_with_three_reviewers():
     """With prefer_cross_provider and 2 providers, 3 reviewers still returns valid pool."""
     agents = _make_agents_cross_provider()
     cfg = _make_cfg(
-        min_reviewers=3, max_reviewers=3, prefer_cross_provider=True, budget_per_story_usd=1000.0
+        min_reviewers=3, max_reviewers=3, prefer_cross_provider=True, max_cost_per_story_usd=1000.0
     )
     decision = assign_models(agents, cfg, "large")
 
@@ -385,7 +385,7 @@ def test_explicit_override_survives_budget_downgrade_pressure():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=6.0,
+        max_cost_per_story_usd=6.0,
         prefer_cross_provider=False,
     )
     explicit_dev = ModelProfile(
@@ -418,7 +418,7 @@ def test_explicit_override_records_forced_overrun_when_budget_unmet():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=2.0,  # very tight cap
+        max_cost_per_story_usd=2.0,  # very tight cap
         prefer_cross_provider=False,
     )
     explicit_dev = ModelProfile(
@@ -431,7 +431,7 @@ def test_explicit_override_records_forced_overrun_when_budget_unmet():
         allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
     )
 
-    with pytest.warns(UserWarning, match="Budget cap"):
+    with pytest.warns(UserWarning, match="per-story routing cost cap"):
         decision = assign_models(
             agents,
             cfg,
@@ -440,7 +440,7 @@ def test_explicit_override_records_forced_overrun_when_budget_unmet():
         )
 
     assert decision.dev.model == "custom-model"
-    assert decision.budget_audit["within_budget"] is False
+    assert decision.budget_audit["within_cap"] is False
     assert decision.budget_audit.get("override_forced_overrun") is True
     assert "dev" in decision.budget_audit.get("locked_roles", [])
 
@@ -497,7 +497,7 @@ def test_budget_cap_enforcement():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=10.0,
+        max_cost_per_story_usd=10.0,
         prefer_cross_provider=False,
     )
 
@@ -529,7 +529,7 @@ def test_budget_cap_plan_phase_downgraded():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=12.0,
+        max_cost_per_story_usd=12.0,
         prefer_cross_provider=False,
     )
 
@@ -568,7 +568,7 @@ def test_budget_cap_downgrade_dev_respects_floor():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=5.0,
+        max_cost_per_story_usd=5.0,
         prefer_cross_provider=False,
     )
     import warnings
@@ -582,7 +582,7 @@ def test_budget_cap_downgrade_dev_respects_floor():
         f"Dev should stay strong for HIGH; got {decision.dev.name}"
     )
     # Budget cannot be met, so a warning must have been issued
-    assert any("Budget cap" in str(w.message) for w in caught), (
+    assert any("per-story routing cost cap" in str(w.message) for w in caught), (
         "Expected budget-cap warning when floor prevents the cap from being met"
     )
 
@@ -606,7 +606,7 @@ def test_budget_cap_downgrade_dev_medium_stops_at_mid():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=20.0,
+        max_cost_per_story_usd=20.0,
         prefer_cross_provider=False,
     )
     import warnings
@@ -627,7 +627,7 @@ def test_budget_cap_preserves_strong_planner_when_dev_is_also_strong():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=15.0,
+        max_cost_per_story_usd=15.0,
         prefer_cross_provider=False,
     )
     import warnings
@@ -638,10 +638,10 @@ def test_budget_cap_preserves_strong_planner_when_dev_is_also_strong():
 
     assert decision.dev.model == "opus"
     assert decision.planner.model == "opus"
-    assert decision.budget_audit["within_budget"] is False
+    assert decision.budget_audit["within_cap"] is False
     assert "planner" in decision.budget_audit.get("protected_roles", [])
-    assert "protected roles" in decision.rationale["budget"]
-    assert any("Budget cap" in str(w.message) for w in caught)
+    assert "protected roles" in decision.rationale["per_story_routing_cost_cap"]
+    assert any("per-story routing cost cap" in str(w.message) for w in caught)
 
 
 def test_budget_cap_records_downgrade_rationale():
@@ -650,13 +650,13 @@ def test_budget_cap_records_downgrade_rationale():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=10.0,
+        max_cost_per_story_usd=10.0,
         prefer_cross_provider=False,
     )
 
     decision = assign_models(agents, cfg, "medium")
 
-    assert "budget cap $10.00" in decision.rationale["budget"]
+    assert "per-story routing cost cap $10.00" in decision.rationale["per_story_routing_cost_cap"]
     assert decision.budget_audit["downgraded"] is True
     assert decision.budget_audit["final_total_usd"] <= 10.0
     assert decision.budget_audit["steps"]
@@ -668,14 +668,14 @@ def test_budget_cap_keeps_planner_rationale_aligned_with_final_model():
     cfg = _make_cfg(
         min_reviewers=1,
         max_reviewers=1,
-        budget_per_story_usd=10.0,
+        max_cost_per_story_usd=10.0,
         prefer_cross_provider=False,
     )
 
     decision = assign_models(agents, cfg, "medium", complexity_score=4)
 
     assert decision.planner.model == "haiku"
-    assert "budget adjusted -> final model haiku" in decision.rationale["planner"]
+    assert "per-story routing cost cap $10.00 downgraded to haiku" in decision.rationale["planner"]
     assert any(step["role"] == "planner" for step in decision.budget_audit["steps"])
 
 
@@ -1015,3 +1015,65 @@ def test_guardrail_mid_promoted_to_strong_for_large():
     decision = assign_models(agents, cfg, "large", escalation_history=history)
 
     assert decision.dev.name == "opus", f"Expected strong (opus) for HIGH, got {decision.dev.name}"
+
+
+# ── per-story routing cost cap (split from sprint budget) ──────────────
+
+
+def test_unset_cap_preserves_adaptive_full_pool_on_high_complexity():
+    """AC: with cap unset, a score-9 large story keeps adaptive's full reviewer pool/tier."""
+    from dataclasses import replace as _dc_replace
+
+    agents = [
+        AgentDef("opus", "anthropic", "opus", 8.0, 1200, "strong"),
+        AgentDef("gemini-pro", "google", "gemini-pro", 5.0, 900, "strong"),
+        AgentDef("deepseek-r1", "deepseek", "deepseek-reasoner", 1.0, 600, "strong"),
+        AgentDef("sonnet", "anthropic", "sonnet", 5.0, 900, "mid"),
+    ]
+    cfg = _make_cfg(min_reviewers=1, max_reviewers=3, max_cost_per_story_usd=None)
+
+    # Reference run with a generous cap captures adaptive's preferred selection.
+    ref_decision = assign_models(
+        agents,
+        _dc_replace(cfg, max_cost_per_story_usd=1000.0),
+        "large",
+        complexity_score=9,
+    )
+
+    # With cap unset, selection must match the unconstrained reference exactly.
+    decision = assign_models(agents, cfg, "large", complexity_score=9)
+
+    assert decision.budget_audit["downgraded"] is False
+    assert decision.budget_audit["steps"] == []
+    assert decision.budget_audit["cap_usd"] is None
+    assert len(decision.code_reviewers) == len(ref_decision.code_reviewers)
+    assert decision.dev.model == ref_decision.dev.model
+    assert [r.model for r in decision.code_reviewers] == [
+        r.model for r in ref_decision.code_reviewers
+    ]
+    cap_text = decision.rationale["per_story_routing_cost_cap"]
+    assert "unset" in cap_text
+    assert "budget" not in cap_text.lower()
+
+
+def test_set_cap_records_preferred_snapshot_in_audit():
+    """AC support: when cap downgrades selection, audit records adaptive's preferred selection."""
+    agents = _make_agents_one_per_tier()
+    cfg = _make_cfg(
+        min_reviewers=1,
+        max_reviewers=1,
+        max_cost_per_story_usd=10.0,
+        prefer_cross_provider=False,
+    )
+
+    decision = assign_models(agents, cfg, "medium")
+
+    audit = decision.budget_audit
+    assert audit["downgraded"] is True
+    preferred = audit["preferred"]
+    assert preferred["dev"]["model"]
+    assert preferred["planner"]["model"]
+    assert preferred["total_usd"] > audit["final_total_usd"]
+    # Audit must never carry the word "budget" in its top-level keys
+    assert "budget" not in audit
+    assert "budget_cap_usd" not in audit

--- a/tests/test_assignment_model_profiles.py
+++ b/tests/test_assignment_model_profiles.py
@@ -52,7 +52,7 @@ def _cfg() -> AssignmentConfig:
         min_reviewers=1,
         max_reviewers=1,
         prefer_cross_provider=False,
-        budget_per_story_usd=100.0,
+        max_cost_per_story_usd=100.0,
         escalation_memory=False,
     )
 

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -467,7 +467,7 @@ class TestCheckConfigAgentsSection:
             enabled=True,
             min_reviewers=1,
             max_reviewers=3,
-            budget_per_story_usd=15.0,
+            max_cost_per_story_usd=15.0,
         )
         config = _make_forge_config(tmp_path, agents=agents, assignment=assignment)
         with (
@@ -499,7 +499,7 @@ class TestCheckConfigAgentsSection:
         assert "AGENTS" not in out
 
     def test_assignment_budget_shown_in_header(self, tmp_path: Path, capsys) -> None:
-        assignment = AssignmentConfig(enabled=True, budget_per_story_usd=20.0)
+        assignment = AssignmentConfig(enabled=True, max_cost_per_story_usd=20.0)
         config = _make_forge_config(tmp_path, assignment=assignment)
         with (
             patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
@@ -511,7 +511,7 @@ class TestCheckConfigAgentsSection:
         ):
             cmd_check_config(_make_args())
         out = capsys.readouterr().out
-        assert "Budget:  $20.00/story" in out
+        assert "Per-story routing cost cap: $20.00/story" in out
 
     def test_no_budget_header_when_assignment_disabled(self, tmp_path: Path, capsys) -> None:
         config = _make_forge_config(tmp_path)  # assignment disabled
@@ -525,6 +525,7 @@ class TestCheckConfigAgentsSection:
         ):
             cmd_check_config(_make_args())
         out = capsys.readouterr().out
+        assert "Per-story routing cost cap" not in out
         assert "Budget:" not in out
 
 

--- a/tests/test_config_v08_loader.py
+++ b/tests/test_config_v08_loader.py
@@ -72,7 +72,7 @@ models:
   - google/gemini-3.1-pro-preview
 assignment:
   enabled: true
-  budget_per_story_usd: 100.0
+  max_cost_per_story_usd: 100.0
 plan:
   enabled: true
 plan_agent_review:

--- a/tests/test_coord_adaptive_plan_reviewers.py
+++ b/tests/test_coord_adaptive_plan_reviewers.py
@@ -71,7 +71,7 @@ def _make_assignment_config(**kwargs) -> AssignmentConfig:
         min_reviewers=1,
         max_reviewers=2,
         prefer_cross_provider=False,
-        budget_per_story_usd=100.0,
+        max_cost_per_story_usd=100.0,
         escalation_memory=True,
     )
     defaults.update(kwargs)

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -78,7 +78,7 @@ def test_model_profiles_written_even_when_escalation_memory_disabled(
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=False,  # deliberately off — profiles must still write
-            budget_per_story_usd=30.0,
+            max_cost_per_story_usd=30.0,
         ),
     )
     task = _make_task(tmp_path)
@@ -138,7 +138,7 @@ def test_preflight_passes_model_profiles_to_assign_models(tmp_path, monkeypatch)
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=False,
-            budget_per_story_usd=30.0,
+            max_cost_per_story_usd=30.0,
             min_reviewers=1,
             max_reviewers=1,
         ),
@@ -213,7 +213,7 @@ def test_preflight_records_assignment_rationale_in_audit_state(tmp_path, monkeyp
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=False,
-            budget_per_story_usd=30.0,
+            max_cost_per_story_usd=30.0,
             min_reviewers=1,
             max_reviewers=1,
         ),
@@ -234,7 +234,7 @@ def test_preflight_records_assignment_rationale_in_audit_state(tmp_path, monkeyp
     assert audit["assignments"]["dev"]["model"] == state._adaptive_decision.dev.model
     assert audit["assignments"]["dev"]["source"] == state._adaptive_decision.dev.registry_source
     assert "dev" in audit["rationale"]
-    assert "budget_cap_usd" in audit["budget"]
+    assert "cap_usd" in audit["per_story_routing_cost_cap"]
 
 
 def test_preflight_audit_keeps_strong_planner_when_strong_dev_forces_budget_pressure(
@@ -279,7 +279,7 @@ def test_preflight_audit_keeps_strong_planner_when_strong_dev_forces_budget_pres
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=False,
-            budget_per_story_usd=15.0,
+            max_cost_per_story_usd=15.0,
             min_reviewers=1,
             max_reviewers=1,
             prefer_cross_provider=False,
@@ -304,8 +304,8 @@ def test_preflight_audit_keeps_strong_planner_when_strong_dev_forces_budget_pres
     assert audit["assignments"]["planner"]["model"] == "opus"
     assert audit["rationale"]["planner"].startswith("complexity score 9 → tier strong")
     assert audit["role_sources"]["planner"] == "adaptive"
-    assert audit["budget"]["within_budget"] is False
-    assert "planner" in audit["budget"].get("protected_roles", [])
+    assert audit["per_story_routing_cost_cap"]["within_cap"] is False
+    assert "planner" in audit["per_story_routing_cost_cap"].get("protected_roles", [])
 
 
 def test_preflight_seam_adaptive_on_vs_off_diverges_then_converges(tmp_path, monkeypatch):
@@ -351,7 +351,7 @@ def test_preflight_seam_adaptive_on_vs_off_diverges_then_converges(tmp_path, mon
             assignment=AssignmentConfig(
                 enabled=True,
                 escalation_memory=False,
-                budget_per_story_usd=100.0,
+                max_cost_per_story_usd=100.0,
                 min_reviewers=1,
                 max_reviewers=3,
                 prefer_cross_provider=False,
@@ -445,7 +445,7 @@ def test_explicit_planner_and_review_pool_threaded_into_assignment(tmp_path, mon
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=False,
-            budget_per_story_usd=20.0,
+            max_cost_per_story_usd=20.0,
             min_reviewers=1,
             max_reviewers=2,
             prefer_cross_provider=False,
@@ -478,7 +478,7 @@ def test_explicit_planner_and_review_pool_threaded_into_assignment(tmp_path, mon
         + decision.dev.budget_usd
         + sum(p.budget_usd for p in decision.code_reviewers)
     )
-    assert audit["budget"]["final_total_usd"] == round(runtime_total, 2)
+    assert audit["per_story_routing_cost_cap"]["final_total_usd"] == round(runtime_total, 2)
 
 
 def test_explicit_review_pool_records_override_forced_overrun_when_over_cap(tmp_path, monkeypatch):
@@ -518,7 +518,7 @@ def test_explicit_review_pool_records_override_forced_overrun_when_over_cap(tmp_
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=False,
-            budget_per_story_usd=5.0,
+            max_cost_per_story_usd=5.0,
             min_reviewers=1,
             max_reviewers=2,
             prefer_cross_provider=False,
@@ -534,9 +534,9 @@ def test_explicit_review_pool_records_override_forced_overrun_when_over_cap(tmp_
     audit = state.complexity_routing_audit
     assert audit is not None
     assert audit["role_sources"]["code_review"] == "explicit_override"
-    assert audit["budget"]["within_budget"] is False
-    assert audit["budget"]["override_forced_overrun"] is True
-    assert "code_review" in audit["budget"]["locked_roles"]
+    assert audit["per_story_routing_cost_cap"]["within_cap"] is False
+    assert audit["per_story_routing_cost_cap"]["override_forced_overrun"] is True
+    assert "code_review" in audit["per_story_routing_cost_cap"]["locked_roles"]
 
 
 def test_models_path_with_explicit_plan_and_review_pool_preserved(tmp_path, monkeypatch):
@@ -604,7 +604,7 @@ def test_models_path_with_explicit_plan_and_review_pool_preserved(tmp_path, monk
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=False,
-            budget_per_story_usd=50.0,
+            max_cost_per_story_usd=50.0,
             min_reviewers=1,
             max_reviewers=2,
             prefer_cross_provider=False,
@@ -673,7 +673,7 @@ def test_record_run_memory_writes_profiles_and_history(tmp_path):
         assignment=AssignmentConfig(
             enabled=True,
             escalation_memory=True,
-            budget_per_story_usd=30.0,
+            max_cost_per_story_usd=30.0,
         ),
     )
     task = _make_task(tmp_path)
@@ -706,3 +706,94 @@ def test_record_run_memory_skips_when_preflight_complexity_missing(tmp_path, cap
 
     profiles_path = tmp_path / ".forge" / "model_profiles.yaml"
     assert not profiles_path.exists()
+
+
+def test_apply_preflight_emits_terminal_warning_on_cap_downgrade(tmp_path, monkeypatch):
+    """AC: explicit cap that downgrades selection prints a visible terminal warning.
+
+    Verifies the seam between assign_models's downgrade detection and the
+    preflight log printer. The warning must name the story, the cap, and
+    both adaptive's selection and the post-cap result.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    from theforge.coordinator import preflight as _pf
+
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef("haiku", "anthropic", "haiku", 1.0, 300, "cheap", cli="claude"),
+            AgentDef("sonnet", "anthropic", "sonnet", 5.0, 900, "mid", cli="claude"),
+            AgentDef("opus", "anthropic", "opus", 8.0, 1200, "strong", cli="claude"),
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=False,
+            max_cost_per_story_usd=10.0,
+            min_reviewers=1,
+            max_reviewers=2,
+            prefer_cross_provider=False,
+        ),
+        dev_profile_is_default=True,
+        plan_model_is_default=True,
+        review_pool_is_default=True,
+    )
+
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 9
+
+    captured: list[str] = []
+    _pf._apply_preflight_config(config, state, log=captured.append, task_slug="story-test")
+
+    blob = "\n".join(captured)
+    assert "per-story routing cost cap" in blob
+    assert "story-test" in blob
+    assert "adaptive selected:" in blob
+    assert "after cap:" in blob
+    # Wording rule: cap warning lines must never use the word "budget"
+    for line in captured:
+        if "per-story routing cost cap" in line or "after cap:" in line:
+            assert "budget" not in line.lower(), f"Cap warning must not say 'budget': {line!r}"
+
+
+def test_apply_preflight_skips_warning_when_cap_unset(tmp_path, monkeypatch):
+    """AC: with cap unset, a high-complexity story emits no cap downgrade warning."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    from theforge.coordinator import preflight as _pf
+
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef("haiku", "anthropic", "haiku", 1.0, 300, "cheap", cli="claude"),
+            AgentDef("sonnet", "anthropic", "sonnet", 5.0, 900, "mid", cli="claude"),
+            AgentDef("opus", "anthropic", "opus", 8.0, 1200, "strong", cli="claude"),
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=False,
+            max_cost_per_story_usd=None,  # unset — adaptive runs free
+            min_reviewers=1,
+            max_reviewers=2,
+            prefer_cross_provider=False,
+        ),
+        dev_profile_is_default=True,
+        plan_model_is_default=True,
+        review_pool_is_default=True,
+    )
+
+    state = CoordinatorState()
+    state.preflight_complexity = "large"
+    state.preflight_complexity_score = 9
+
+    captured: list[str] = []
+    _pf._apply_preflight_config(config, state, log=captured.append, task_slug="story-unset")
+
+    blob = "\n".join(captured)
+    assert "forces downgrade" not in blob
+    assert "after cap:" not in blob
+    # Adaptive's selection survives — strong dev tier preserved
+    assert state._adaptive_decision.dev.model == "opus"
+    assert state._adaptive_decision.budget_audit["cap_usd"] is None
+    assert state._adaptive_decision.budget_audit["downgraded"] is False

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -374,7 +374,7 @@ class TestDevModelEscalationIntegration:
             assignment=AssignmentConfig(
                 enabled=True,
                 escalation_memory=True,
-                budget_per_story_usd=30.0,
+                max_cost_per_story_usd=30.0,
             ),
         )
         task = _make_task(tmp_path)

--- a/tests/test_coord_state.py
+++ b/tests/test_coord_state.py
@@ -336,7 +336,7 @@ class TestStructuredLoggingIntegration:
             assignment=AssignmentConfig(
                 enabled=True,
                 escalation_memory=False,
-                budget_per_story_usd=100.0,
+                max_cost_per_story_usd=100.0,
                 min_reviewers=1,
                 max_reviewers=2,
                 prefer_cross_provider=False,
@@ -387,7 +387,7 @@ class TestStructuredLoggingIntegration:
         assert preflight_phase_end["complexity_routing"]["preflight"]
         assert preflight_phase_end["complexity_routing"]["plan_review"]
         assert preflight_phase_end["complexity_routing"]["code_review"]
-        assert preflight_phase_end["complexity_routing"]["budget"]
+        assert preflight_phase_end["complexity_routing"]["per_story_routing_cost_cap"]
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")

--- a/tests/test_generate_audit_log.py
+++ b/tests/test_generate_audit_log.py
@@ -164,7 +164,7 @@ class TestPreflightAudit:
                 "planner": "adaptive",
                 "plan_review": "adaptive",
                 "dev": "explicit_override",
-                "code_review": "budget_downgrade",
+                "code_review": "cap_downgrade",
             },
             "assignments": {
                 "planner": {"model": "opus", "source": "builtin"},
@@ -177,9 +177,11 @@ class TestPreflightAudit:
             },
             "rationale": {
                 "dev": "complexity score 7 (MEDIUM) -> tier strong",
-                "budget": "within budget cap $30.00 (estimated total $27.00)",
+                "per_story_routing_cost_cap": (
+                    "within per-story routing cost cap $30.00 (estimated total $27.00)"
+                ),
             },
-            "budget": {"budget_cap_usd": 30.0, "within_budget": True},
+            "per_story_routing_cost_cap": {"cap_usd": 30.0, "within_cap": True},
         }
 
         log = generate_audit_log(
@@ -192,10 +194,10 @@ class TestPreflightAudit:
         assert routing["source"] == "adaptive_assignment"
         assert routing["adaptive_enabled"] is True
         assert routing["role_sources"]["dev"] == "explicit_override"
-        assert routing["role_sources"]["code_review"] == "budget_downgrade"
+        assert routing["role_sources"]["code_review"] == "cap_downgrade"
         assert routing["assignments"]["dev"]["model"] == "opus"
         assert routing["assignments"]["dev"]["source"] == "forge.yaml"
-        assert "budget" in routing["rationale"]
+        assert "per_story_routing_cost_cap" in routing["rationale"]
 
 
 # ── Cost.agents tests ─────────────────────────────────────────────────

--- a/tests/test_profiles_migration.py
+++ b/tests/test_profiles_migration.py
@@ -446,7 +446,7 @@ def test_routing_decision_matches_pre_and_post_migration():
         min_reviewers=1,
         max_reviewers=2,
         prefer_cross_provider=True,
-        budget_per_story_usd=50.0,
+        max_cost_per_story_usd=50.0,
         escalation_memory=False,
         adaptive_enabled=True,
     )


### PR DESCRIPTION
## Summary

Clean rename of budget_per_story_usd → max_cost_per_story_usd with None default; all seven ACs are satisfied, tests cover the critical paths, and the audit/warning wording correctly avoids 'budget' throughout.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $10.07
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/assignment.py:964`** Late import 'from dataclasses import replace as _dc_replace' inside the 'if cap is None' branch is redundant — _dc_replace is already imported at module level (evidenced by its use in _enforce_budget which is defined above). The shadowing import is harmless but inconsistent with the rest of the file.
- **[P2] `tests/test_check_config.py:None`** No test exercises the 'assignment enabled + cap unset' path for the header line. test_assignment_budget_shown_in_header only tests the set-cap case; test_no_budget_header_when_assignment_disabled tests the disabled-assignment case. The 'Per-story routing cost cap: unset (adaptive routes by complexity...)' branch in check_config.py is untested.
- **[P2] `tests/test_check_config.py:None`** The SETTINGS section 'no per-story routing cost cap configured' string is also untested (the SETTINGS block changed from 'budget=...' to 'cap_str' branching). Only the header section has a set-cap assertion.

## Story

Split per-story routing cost cap from sprint budget; rename to assignment.max_cost_per_story_usd, default None (GitHub Issue #1311)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1311