### PR TITLE
RC release flow — cut-rc.sh, promote-rc.sh, RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,23 +17,101 @@ This document defines how TheForge releases are cut, maintained, and hotfixed.
 
 ---
 
-## Cutting a new release
+## Cutting a new release — RC flow (preferred)
 
-Use the release script — it handles all steps automatically:
+Releases ship via a release-candidate ladder so dogfood sprints exercise the
+candidate against the next milestone's stories before the final tag is cut.
+The pattern: cut an RC, install it as the dogfood `forge` binary, run a small
+sprint ladder against it, promote when the ladder passes (or cut another RC
+if it doesn't).
+
+### 1. Cut an RC
 
 ```bash
-scripts/release.sh X.Y.Z
+scripts/cut-rc.sh X.Y.Z         # first RC: cuts vX.Y.ZrcN with N=0
+scripts/cut-rc.sh X.Y.Z 1       # subsequent RCs: explicit RC_NUM
+scripts/cut-rc.sh --dry-run X.Y.Z
+scripts/cut-rc.sh --no-install X.Y.Z   # skip auto-installing the RC into the active env
 ```
 
-Use `--dry-run` to preview what it will do without making changes:
+`cut-rc.sh`:
+
+- prints the open issues remaining in milestone `vX.Y.Z` (informational only —
+  RC cuts deliberately do **not** require a clean milestone)
+- creates or fast-forwards `release/vX.Y` from `main`
+- bumps `pyproject.toml` to `X.Y.ZrcN` (PEP 440)
+- runs `make gate`
+- commits, tags `vX.Y.ZrcN`, pushes branch and tag
+- pip-installs the RC into the active Python environment (so `forge --version`
+  reports the RC and dogfood sprints exercise the candidate)
+- prints the test ladder
+
+The install step is intentional: cutting an RC and dogfooding it are the same
+muscle-memory action. Use `--no-install` if you need to install on a different
+machine or env.
+
+### 2. Run the test ladder against the RC
+
+The ladder is three sprints of ascending complexity, all run on TheForge's own
+repo against the RC binary:
+
+| Pass       | Story shape                                              |
+|------------|----------------------------------------------------------|
+| Smoke      | Small, well-scoped story (low spend, gross-breakage check) |
+| Boundary   | Medium-complexity story touching CLI/precondition surface |
+| Moneyshot  | High-complexity story (exercises adaptive routing decisions) |
 
 ```bash
-scripts/release.sh --dry-run X.Y.Z
+forge sprint --verbose --issues <small-issue>            --budget 50 --parallel 1
+forge sprint --verbose --issues <medium-issue>           --budget 50 --parallel 1
+forge sprint --verbose --issues <high-complexity-issue>  --budget 50 --parallel 1
 ```
 
-The script: verifies the milestone is closed, runs `make gate`, updates
-CHANGELOG, bumps `pyproject.toml`, tags and pushes, cuts the release branch,
-bumps main to the next dev version, and creates the GitHub release.
+Pick the candidates from the **next** milestone (so the work also makes progress
+on the next release) — exact picks are per-release, not scripted.
+
+Watch for: regressions in any behavior shipped by `vX.Y.Z`, surprising routing
+decisions, missing or wrong audit/log wording, anything that contradicts the
+release's CHANGELOG entry.
+
+### 3. Either fix or promote
+
+- **Ladder passes** → `scripts/promote-rc.sh X.Y.Z`
+- **Ladder fails** → fix on `release/vX.Y`, then `scripts/cut-rc.sh X.Y.Z N+1`
+
+### 4. Promote the RC to a final release
+
+```bash
+scripts/promote-rc.sh X.Y.Z
+scripts/promote-rc.sh --dry-run X.Y.Z
+```
+
+`promote-rc.sh`:
+
+- requires you are on `release/vX.Y` with `pyproject.toml` version = `X.Y.ZrcN`
+- requires milestone `vX.Y.Z` has zero open issues (this is where the milestone
+  block lives, not in `cut-rc.sh`)
+- runs `make gate`
+- updates `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z] — YYYY-MM-DD`, new
+  `[Unreleased]` inserted)
+- bumps `pyproject.toml` from `X.Y.ZrcN` to `X.Y.Z`
+- commits, tags `vX.Y.Z`, pushes
+- bumps `main` to the next `.dev0` version
+- creates the GitHub release from the CHANGELOG section
+- files the post-release doc-review issue against the next milestone
+
+After promotion, the script prints reminders for the manual follow-ups it
+intentionally does **not** automate:
+
+1. Update the dogfood install pin to the new release tag.
+2. Forward-port any RC fixes from `release/vX.Y` to `main` if main has diverged.
+3. Run the post-release doc review.
+
+### Direct release from main (legacy)
+
+`scripts/release.sh X.Y.Z` still exists for releasing directly from main without
+an RC ladder. Use only when an RC dogfood pass would add no signal — for
+example, a one-line patch. Default path is the RC flow above.
 
 ### Manual steps (reference)
 

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# scripts/cut-rc.sh — cut a TheForge release candidate
+#
+# Usage: scripts/cut-rc.sh [--dry-run] [--no-install] VERSION [RC_NUM]
+#   VERSION   The target final version, e.g. 0.10.0
+#   RC_NUM    The RC number, default 0 (so first RC is 0.10.0rc0)
+#
+# Cuts release/vX.Y from current main (or fast-forwards if it exists),
+# bumps pyproject.toml to X.Y.ZrcN, runs gate, tags vX.Y.ZrcN, pushes
+# branch and tag. Then installs the RC into the active Python environment
+# so dogfood sprints exercise the candidate (use --no-install to skip).
+#
+# Does NOT block on open milestone issues — that's a promote-rc requirement.
+# Prints them informationally so the operator can see what is or isn't in
+# the cut.
+#
+# See RELEASING.md for the end-to-end RC flow.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:$PATH"
+
+DRY_RUN=false
+NO_INSTALL=false
+VERSION=""
+RC_NUM=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --no-install) NO_INSTALL=true ;;
+        *)
+            if [[ -z "$VERSION" ]]; then
+                VERSION="$arg"
+            elif [[ -z "$RC_NUM" ]]; then
+                RC_NUM="$arg"
+            else
+                echo "Error: unexpected argument: $arg" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: VERSION required (e.g. 0.10.0)" >&2
+    echo "Usage: scripts/cut-rc.sh [--dry-run] [--no-install] VERSION [RC_NUM]" >&2
+    exit 2
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: VERSION must be X.Y.Z (got: $VERSION)" >&2
+    exit 2
+fi
+
+RC_NUM="${RC_NUM:-0}"
+if [[ ! "$RC_NUM" =~ ^[0-9]+$ ]]; then
+    echo "Error: RC_NUM must be a non-negative integer (got: $RC_NUM)" >&2
+    exit 2
+fi
+
+RC_VERSION="${VERSION}rc${RC_NUM}"
+RC_TAG="v${RC_VERSION}"
+RELEASE_BRANCH="release/v$(echo "$VERSION" | cut -d. -f1,2)"
+
+CURRENT_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+
+echo "Current version : $CURRENT_VERSION"
+echo "Cutting RC      : $RC_VERSION"
+echo "RC tag          : $RC_TAG"
+echo "Release branch  : $RELEASE_BRANCH"
+echo "Dry run         : $DRY_RUN"
+echo "Install RC      : $([ "$NO_INSTALL" = true ] && echo "no (--no-install)" || echo "yes")"
+echo ""
+
+run() {
+    echo "+ $*"
+    if [[ "$DRY_RUN" == false ]]; then
+        "$@"
+    fi
+}
+
+# --- 1. Print milestone state (informational, do not block) ---
+echo "==> Milestone v$VERSION state (informational)..."
+OPEN_ISSUES=$(gh issue list --repo fuzzypete/theforge --milestone "v$VERSION" --state open --json number --jq 'length')
+echo "    Open issues remaining in milestone v$VERSION: $OPEN_ISSUES"
+if [[ "$OPEN_ISSUES" != "0" ]]; then
+    echo "    (RC cuts do not require a clean milestone; promote-rc.sh does.)"
+    gh issue list --repo fuzzypete/theforge --milestone "v$VERSION" --state open
+fi
+echo ""
+
+# --- 2. Verify clean state and pull main ---
+echo "==> Verifying clean state..."
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: working tree is dirty. Commit or stash changes before cutting an RC." >&2
+    exit 1
+fi
+run git checkout main
+run git pull --ff-only
+
+# --- 3. Create or fast-forward the release branch ---
+echo "==> Preparing release branch $RELEASE_BRANCH..."
+if git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+    run git checkout "$RELEASE_BRANCH"
+    if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+        run git pull --ff-only origin "$RELEASE_BRANCH"
+    fi
+elif git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+    run git checkout -b "$RELEASE_BRANCH" "origin/$RELEASE_BRANCH"
+else
+    run git checkout -b "$RELEASE_BRANCH"
+    echo "    (created $RELEASE_BRANCH from main)"
+fi
+
+# --- 4. Refuse if the RC tag already exists ---
+if git rev-parse --verify --quiet "$RC_TAG" >/dev/null; then
+    echo "Error: tag $RC_TAG already exists locally. Delete it or bump RC_NUM." >&2
+    exit 1
+fi
+if git ls-remote --tags origin "refs/tags/$RC_TAG" | grep -q "$RC_TAG"; then
+    echo "Error: tag $RC_TAG already exists on origin. Bump RC_NUM." >&2
+    exit 1
+fi
+
+# --- 5. Bump pyproject to RC version ---
+echo "==> Bumping pyproject.toml to $RC_VERSION..."
+if [[ "$DRY_RUN" == false ]]; then
+    sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$RC_VERSION\"/" pyproject.toml
+fi
+
+# --- 6. Gate ---
+echo "==> Running gate..."
+run make gate
+
+# --- 7. Commit, tag, push ---
+echo "==> Committing, tagging, pushing..."
+run git add pyproject.toml
+run git commit -m "chore: cut $RC_TAG"
+run git tag "$RC_TAG"
+run git push -u origin "$RELEASE_BRANCH"
+run git push origin "$RC_TAG"
+
+# --- 8. Install the RC into the active env ---
+if [[ "$NO_INSTALL" == false ]]; then
+    echo "==> Installing $RC_TAG into active Python environment..."
+    run pip install --force-reinstall "git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
+    if [[ "$DRY_RUN" == false ]]; then
+        INSTALLED_VERSION=$(forge --version 2>/dev/null || echo "unknown")
+        echo "    forge --version: $INSTALLED_VERSION"
+    fi
+else
+    echo "==> Skipping install (--no-install)."
+    echo "    To install manually:"
+    echo "      pip install --force-reinstall git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
+fi
+
+# --- 9. Print test ladder ---
+echo ""
+echo "==> $RC_TAG cut on $RELEASE_BRANCH."
+echo ""
+echo "Test ladder — run on TheForge's own repo against the installed RC:"
+echo "  1. Smoke pass (small story):       forge sprint --verbose --issues <small-issue>  --budget 50 --parallel 1"
+echo "  2. Boundary pass (medium story):   forge sprint --verbose --issues <medium-issue> --budget 50 --parallel 1"
+echo "  3. Moneyshot pass (high-complexity story): forge sprint --verbose --issues <high-complexity-issue> --budget 50 --parallel 1"
+echo ""
+echo "Pick the issues from milestone v$(echo "$VERSION" | awk -F. '{print $1"."$2+1".0"}') (or the next milestone after v$VERSION)."
+echo "Watch for: 'budget' wording in audit/logs (should be 'per-story routing cost cap'), silent tier/pool downgrades without terminal warnings, regressions in any v$VERSION-shipped behavior."
+echo ""
+echo "If the ladder passes, promote with:"
+echo "  scripts/promote-rc.sh $VERSION"
+echo ""
+echo "If the ladder fails, fix on $RELEASE_BRANCH and cut another RC:"
+echo "  scripts/cut-rc.sh $VERSION $((RC_NUM + 1))"

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -63,9 +63,11 @@ RC_VERSION="${VERSION}rc${RC_NUM}"
 RC_TAG="v${RC_VERSION}"
 RELEASE_BRANCH="release/v$(echo "$VERSION" | cut -d. -f1,2)"
 
-CURRENT_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+# CURRENT_VERSION is read after the release branch is checked out (step 4)
+# to avoid bumping against a stale main version when the release branch is
+# already at a prior RC.
+CURRENT_VERSION=""
 
-echo "Current version : $CURRENT_VERSION"
 echo "Cutting RC      : $RC_VERSION"
 echo "RC tag          : $RC_TAG"
 echo "Release branch  : $RELEASE_BRANCH"
@@ -123,17 +125,30 @@ if git ls-remote --tags origin "refs/tags/$RC_TAG" | grep -q "$RC_TAG"; then
     exit 1
 fi
 
-# --- 5. Bump pyproject to RC version ---
+# --- 5. Read current pyproject version (now that release branch is up to date) ---
+CURRENT_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+echo "==> Current version on $RELEASE_BRANCH: $CURRENT_VERSION"
+if [[ "$CURRENT_VERSION" == "$RC_VERSION" ]]; then
+    echo "Error: pyproject is already at $RC_VERSION on $RELEASE_BRANCH." >&2
+    exit 1
+fi
+
+# --- 6. Bump pyproject to RC version ---
 echo "==> Bumping pyproject.toml to $RC_VERSION..."
 if [[ "$DRY_RUN" == false ]]; then
     sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$RC_VERSION\"/" pyproject.toml
+    BUMPED=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+    if [[ "$BUMPED" != "$RC_VERSION" ]]; then
+        echo "Error: pyproject bump failed — version is $BUMPED, expected $RC_VERSION." >&2
+        exit 1
+    fi
 fi
 
-# --- 6. Gate ---
+# --- 7. Gate ---
 echo "==> Running gate..."
 run make gate
 
-# --- 7. Commit, tag, push ---
+# --- 8. Commit, tag, push ---
 echo "==> Committing, tagging, pushing..."
 run git add pyproject.toml
 run git commit -m "chore: cut $RC_TAG"
@@ -141,13 +156,27 @@ run git tag "$RC_TAG"
 run git push -u origin "$RELEASE_BRANCH"
 run git push origin "$RC_TAG"
 
-# --- 8. Install the RC into the active env ---
+# --- 9. Install the RC into the active env, then assert the right binary is on PATH ---
 if [[ "$NO_INSTALL" == false ]]; then
     echo "==> Installing $RC_TAG into active Python environment..."
     run pip install --force-reinstall "git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
     if [[ "$DRY_RUN" == false ]]; then
-        INSTALLED_VERSION=$(forge --version 2>/dev/null || echo "unknown")
-        echo "    forge --version: $INSTALLED_VERSION"
+        INSTALLED_VERSION=$(forge --version 2>/dev/null || echo "")
+        FORGE_PATH=$(command -v forge 2>/dev/null || echo "<not found>")
+        PIP_PATH=$(command -v pip 2>/dev/null || echo "<not found>")
+        PYTHON_PATH=$(command -v python 2>/dev/null || echo "<not found>")
+        echo "    forge --version  : $INSTALLED_VERSION"
+        echo "    forge on PATH    : $FORGE_PATH"
+        echo "    pip on PATH      : $PIP_PATH"
+        echo "    python on PATH   : $PYTHON_PATH"
+        if [[ "$INSTALLED_VERSION" != *"$RC_VERSION"* ]]; then
+            echo "" >&2
+            echo "Error: installed forge version does not match RC ($RC_VERSION)." >&2
+            echo "       'pip install' may have targeted a different environment than the 'forge' on PATH." >&2
+            echo "       Compare the pip/python/forge paths above and reinstall into the correct env, e.g.:" >&2
+            echo "         \"\$PYTHON_PATH\" -m pip install --force-reinstall git+https://github.com/fuzzypete/theforge.git@${RC_TAG}" >&2
+            exit 1
+        fi
     fi
 else
     echo "==> Skipping install (--no-install)."
@@ -155,7 +184,7 @@ else
     echo "      pip install --force-reinstall git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
 fi
 
-# --- 9. Print test ladder ---
+# --- 10. Print test ladder ---
 echo ""
 echo "==> $RC_TAG cut on $RELEASE_BRANCH."
 echo ""

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# scripts/promote-rc.sh — promote a TheForge release candidate to a final release
+#
+# Usage: scripts/promote-rc.sh [--dry-run] VERSION
+#   VERSION  The final version to release, e.g. 0.10.0
+#
+# Promotes the current release candidate (X.Y.ZrcN, on release/vX.Y) to
+# the final X.Y.Z release: bumps pyproject, updates CHANGELOG, runs gate,
+# tags vX.Y.Z, pushes, creates the GitHub release, bumps main to next dev,
+# and files the post-release doc-review issue.
+#
+# Requires:
+#   - currently on release/vX.Y branch
+#   - pyproject.toml version is X.Y.ZrcN (an RC was previously cut)
+#   - milestone vX.Y.Z has zero open issues
+#
+# Reminds the operator at the end to merge release branch back to main and
+# update the dogfood install pin.
+#
+# See RELEASING.md for the end-to-end RC flow.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:$PATH"
+
+DRY_RUN=false
+VERSION=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        *)
+            if [[ -z "$VERSION" ]]; then
+                VERSION="$arg"
+            else
+                echo "Error: unexpected argument: $arg" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: VERSION required (e.g. 0.10.0)" >&2
+    echo "Usage: scripts/promote-rc.sh [--dry-run] VERSION" >&2
+    exit 2
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: VERSION must be X.Y.Z (got: $VERSION)" >&2
+    exit 2
+fi
+
+RELEASE_BRANCH="release/v$(echo "$VERSION" | cut -d. -f1,2)"
+NEXT_DEV="$(echo "$VERSION" | awk -F. '{print $1"."$2+1".0.dev0"}')"
+NEXT_MILESTONE="v$(echo "$VERSION" | awk -F. '{print $1"."$2+1".0"}')"
+
+CURRENT_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+
+# --- 1. Verify on release branch ---
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
+    echo "Error: must be on $RELEASE_BRANCH (currently on $CURRENT_BRANCH)." >&2
+    echo "       Run: git checkout $RELEASE_BRANCH" >&2
+    exit 1
+fi
+
+# --- 2. Verify current version is an RC of the target ---
+if [[ ! "$CURRENT_VERSION" =~ ^${VERSION}rc[0-9]+$ ]]; then
+    echo "Error: current pyproject version is $CURRENT_VERSION; expected ${VERSION}rcN." >&2
+    echo "       Cut an RC first: scripts/cut-rc.sh $VERSION" >&2
+    exit 1
+fi
+RC_NUM=$(echo "$CURRENT_VERSION" | sed "s/^${VERSION}rc//")
+RC_TAG="v$CURRENT_VERSION"
+
+echo "Current RC      : $CURRENT_VERSION (rc$RC_NUM)"
+echo "Promoting to    : $VERSION"
+echo "Release branch  : $RELEASE_BRANCH"
+echo "Next dev        : $NEXT_DEV"
+echo "Next milestone  : $NEXT_MILESTONE"
+echo "Dry run         : $DRY_RUN"
+echo ""
+
+run() {
+    echo "+ $*"
+    if [[ "$DRY_RUN" == false ]]; then
+        "$@"
+    fi
+}
+
+# --- 3. Verify milestone is empty ---
+echo "==> Checking milestone v$VERSION..."
+OPEN_ISSUES=$(gh issue list --repo fuzzypete/theforge --milestone "v$VERSION" --state open --json number --jq 'length')
+if [[ "$OPEN_ISSUES" != "0" ]]; then
+    echo "Error: $OPEN_ISSUES open issue(s) remain in milestone v$VERSION. Close them before promoting." >&2
+    gh issue list --repo fuzzypete/theforge --milestone "v$VERSION" --state open >&2
+    exit 1
+fi
+echo "    Milestone clean."
+
+# --- 4. Verify clean tree, pull release branch ---
+echo "==> Verifying clean state..."
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: working tree is dirty. Commit or stash changes before promoting." >&2
+    exit 1
+fi
+if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+    run git pull --ff-only origin "$RELEASE_BRANCH"
+fi
+
+# --- 5. Refuse if final tag already exists ---
+if git rev-parse --verify --quiet "v$VERSION" >/dev/null; then
+    echo "Error: tag v$VERSION already exists locally." >&2
+    exit 1
+fi
+if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q "v$VERSION"; then
+    echo "Error: tag v$VERSION already exists on origin." >&2
+    exit 1
+fi
+
+# --- 6. Gate ---
+echo "==> Running gate..."
+run make gate
+
+# --- 7. Update CHANGELOG ---
+echo "==> Updating CHANGELOG..."
+TODAY=$(date +%Y-%m-%d)
+if [[ "$DRY_RUN" == false ]]; then
+    sed -i '' \
+        "s/^## \[Unreleased\]/## [$VERSION] — $TODAY/" \
+        CHANGELOG.md
+    sed -i '' \
+        "/^## \[$VERSION\]/i\\
+## [Unreleased]\\
+\\
+" \
+        CHANGELOG.md
+fi
+
+# --- 8. Bump pyproject from RC to final ---
+echo "==> Bumping pyproject.toml: $CURRENT_VERSION -> $VERSION..."
+if [[ "$DRY_RUN" == false ]]; then
+    sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$VERSION\"/" pyproject.toml
+fi
+
+# --- 9. Commit, tag, push ---
+echo "==> Committing, tagging, pushing..."
+run git add CHANGELOG.md pyproject.toml
+run git commit -m "chore: release v$VERSION"
+run git tag "v$VERSION"
+run git push origin "$RELEASE_BRANCH"
+run git push origin "v$VERSION"
+
+# --- 10. Bump main to next dev ---
+echo "==> Bumping main to $NEXT_DEV..."
+run git checkout main
+run git pull --ff-only
+MAIN_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+if [[ "$DRY_RUN" == false ]]; then
+    sed -i '' "s/^version = \"$MAIN_VERSION\"/version = \"$NEXT_DEV\"/" pyproject.toml
+fi
+run git add pyproject.toml
+run git commit -m "chore: begin v$NEXT_DEV development [skip ci]"
+run git push origin main
+
+# --- 11. GitHub Release ---
+echo "==> Creating GitHub release..."
+RELEASE_NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+run gh release create "v$VERSION" --repo fuzzypete/theforge \
+    --title "v$VERSION" \
+    --notes "$RELEASE_NOTES"
+
+# --- 12. Post-release doc review issue ---
+echo "==> Creating post-release doc review issue for $NEXT_MILESTONE..."
+DOC_REVIEW_BODY="## What
+
+Review every public-facing and decision-preserving doc after v$VERSION ships. Verify each concrete claim against the current code, CLI, or schema — not against another doc. Record every mismatch as a drift entry in this issue before closing.
+
+## Why
+
+Docs drift past release reviews when reviewers check whether docs agree with each other or simply \"read neatly,\" instead of checking whether the claims match the system. Recent concrete example: \`docs/guides/inputs-reference.md\` documented a deprecated \`pytest_target\` frontmatter field through multiple releases — it survived every review because reviewers triangulated across CONVENTIONS.md, CLAUDE.md, AGENTS.md, and other guides instead of comparing against the current schema. This template forces verification against code and makes drift findings the required output.
+
+## How to verify (read before ticking anything)
+
+For every doc in the checklist below, verify claims **against the system**, not against other docs:
+
+- For every field name in a doc → grep the source, compare to the current dataclass / schema / frontmatter parser
+- For every CLI command, flag, or subcommand → run it, paste the actual output into your drift notes, compare
+- For every file or directory path referenced → confirm it exists at that path in the current working tree
+- For every example config, story, issue, or YAML snippet → run it through the relevant loader or shape-check path exercised by the tests, and confirm it passes
+- For every architectural or behavioral claim → locate the code that implements it and confirm the doc's description still matches
+
+\"It agrees with CONVENTIONS.md / CLAUDE.md / AGENTS.md / another guide\" is **not** verification — those are docs too and may themselves be stale. The only passing signal is \"I ran it / read the code and it matches.\"
+
+## Scope — docs to review
+
+- [ ] **README.md** — capabilities, install instructions, quick start
+- [ ] **CHANGELOG.md** — v$VERSION section accurately covers what shipped
+- [ ] **CONVENTIONS.md** (root and all directory-level) — conventions, architecture notes, phase descriptions, invariants
+- [ ] **CLAUDE.md / AGENTS.md** — agent-specific pointer docs and harness notes match current prompt construction and tool usage
+- [ ] **RELEASING.md** — process gaps from this release
+- [ ] **forge.yaml** — inline comments match current schema and behavior
+- [ ] **CLI help text** — \`forge --help\` and every subcommand reflect current flags
+- [ ] **GitHub release notes** — body covers what users need to know
+- [ ] **docs/guides/** — every file currently present (run \`ls docs/guides/\`); do not work from a hardcoded list in this template, since files are added and renamed between releases
+- [ ] **docs/vision.md** and anything under **docs/vision/** — reflect current direction, not abandoned paths
+- [ ] **docs/plans/** — active plans are still active; completed or abandoned plans are archived or marked
+- [ ] **docs/postmortems/** — referenced issue numbers and dates resolve; follow-ups are closed or tracked
+
+## Required output — drift report
+
+Before closing this issue, add a comment containing a drift report with one entry per mismatch found:
+
+\`\`\`
+<path/to/doc>:<line> — doc says \"<X>\" — code/CLI/schema says \"<Y>\"
+\`\`\`
+
+For each drift entry, either:
+- Patch the doc in a follow-up PR and link it, **or**
+- File a follow-up issue and link it here
+
+An empty drift report is acceptable — it means every claim was checked and confirmed. But \"empty\" must be an explicit comment (\"no drift found — verified against X, Y, Z\"), not a missing one. A missing drift report blocks closure.
+
+## Acceptance criteria
+
+- A drift-report comment exists on this issue listing every mismatch found, in the format above, or explicitly stating \"no drift found\" with a list of the verification steps that were actually executed
+- For each drifted line, either a patch PR or a follow-up issue is linked in the drift report
+- The verification method for each reviewed doc is auditable from the drift report: which command was run, which file/schema was read, not just \"I reviewed it\"
+- No checklist item is marked done on the basis of agreement with another doc
+- Every checkbox in the scope list above is ticked before the issue closes"
+run gh issue create --repo fuzzypete/theforge \
+    --title "Post-release doc review for v$VERSION" \
+    --body "$DOC_REVIEW_BODY" \
+    --label "documentation" \
+    --milestone "$NEXT_MILESTONE"
+
+# --- 13. Reminders the script intentionally does not automate ---
+echo ""
+echo "Promoted v$VERSION (from $RC_TAG)."
+echo ""
+echo "Manual follow-ups:"
+echo "  1. Update the dogfood install pin to the new release:"
+echo "       pip install --force-reinstall git+https://github.com/fuzzypete/theforge.git@v$VERSION"
+echo ""
+echo "  2. Forward-port any RC fixes from $RELEASE_BRANCH to main if main has diverged:"
+echo "       git checkout main"
+echo "       git log main..$RELEASE_BRANCH --oneline    # see what's on the branch but not on main"
+echo "       # cherry-pick or merge as appropriate"
+echo ""
+echo "  3. Run the post-release doc review (issue filed in milestone $NEXT_MILESTONE)."

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -55,7 +55,26 @@ RELEASE_BRANCH="release/v$(echo "$VERSION" | cut -d. -f1,2)"
 NEXT_DEV="$(echo "$VERSION" | awk -F. '{print $1"."$2+1".0.dev0"}')"
 NEXT_MILESTONE="v$(echo "$VERSION" | awk -F. '{print $1"."$2+1".0"}')"
 
-CURRENT_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+# CURRENT_VERSION is read after the release branch is pulled (step 3) so a
+# stale local checkout can't pass the RC precondition with one version while
+# the bump-and-tag operates on a different version.
+CURRENT_VERSION=""
+RC_NUM=""
+RC_TAG=""
+
+run() {
+    echo "+ $*"
+    if [[ "$DRY_RUN" == false ]]; then
+        "$@"
+    fi
+}
+
+echo "Promoting to    : $VERSION"
+echo "Release branch  : $RELEASE_BRANCH"
+echo "Next dev        : $NEXT_DEV"
+echo "Next milestone  : $NEXT_MILESTONE"
+echo "Dry run         : $DRY_RUN"
+echo ""
 
 # --- 1. Verify on release branch ---
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -65,31 +84,30 @@ if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
     exit 1
 fi
 
-# --- 2. Verify current version is an RC of the target ---
+# --- 2. Verify clean tree ---
+echo "==> Verifying clean state..."
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: working tree is dirty. Commit or stash changes before promoting." >&2
+    exit 1
+fi
+
+# --- 3. Pull release branch BEFORE reading version ---
+if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+    run git pull --ff-only origin "$RELEASE_BRANCH"
+fi
+
+# --- 4. Read current version from the up-to-date release branch and validate it's an RC ---
+CURRENT_VERSION=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
 if [[ ! "$CURRENT_VERSION" =~ ^${VERSION}rc[0-9]+$ ]]; then
-    echo "Error: current pyproject version is $CURRENT_VERSION; expected ${VERSION}rcN." >&2
+    echo "Error: current pyproject version on $RELEASE_BRANCH is $CURRENT_VERSION; expected ${VERSION}rcN." >&2
     echo "       Cut an RC first: scripts/cut-rc.sh $VERSION" >&2
     exit 1
 fi
 RC_NUM=$(echo "$CURRENT_VERSION" | sed "s/^${VERSION}rc//")
 RC_TAG="v$CURRENT_VERSION"
+echo "==> Current RC: $CURRENT_VERSION ($RC_TAG)"
 
-echo "Current RC      : $CURRENT_VERSION (rc$RC_NUM)"
-echo "Promoting to    : $VERSION"
-echo "Release branch  : $RELEASE_BRANCH"
-echo "Next dev        : $NEXT_DEV"
-echo "Next milestone  : $NEXT_MILESTONE"
-echo "Dry run         : $DRY_RUN"
-echo ""
-
-run() {
-    echo "+ $*"
-    if [[ "$DRY_RUN" == false ]]; then
-        "$@"
-    fi
-}
-
-# --- 3. Verify milestone is empty ---
+# --- 5. Verify milestone is empty ---
 echo "==> Checking milestone v$VERSION..."
 OPEN_ISSUES=$(gh issue list --repo fuzzypete/theforge --milestone "v$VERSION" --state open --json number --jq 'length')
 if [[ "$OPEN_ISSUES" != "0" ]]; then
@@ -99,17 +117,7 @@ if [[ "$OPEN_ISSUES" != "0" ]]; then
 fi
 echo "    Milestone clean."
 
-# --- 4. Verify clean tree, pull release branch ---
-echo "==> Verifying clean state..."
-if [[ -n "$(git status --porcelain)" ]]; then
-    echo "Error: working tree is dirty. Commit or stash changes before promoting." >&2
-    exit 1
-fi
-if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
-    run git pull --ff-only origin "$RELEASE_BRANCH"
-fi
-
-# --- 5. Refuse if final tag already exists ---
+# --- 6. Refuse if final tag already exists ---
 if git rev-parse --verify --quiet "v$VERSION" >/dev/null; then
     echo "Error: tag v$VERSION already exists locally." >&2
     exit 1
@@ -119,11 +127,11 @@ if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q "v$VERSION"; then
     exit 1
 fi
 
-# --- 6. Gate ---
+# --- 7. Gate ---
 echo "==> Running gate..."
 run make gate
 
-# --- 7. Update CHANGELOG ---
+# --- 8. Update CHANGELOG ---
 echo "==> Updating CHANGELOG..."
 TODAY=$(date +%Y-%m-%d)
 if [[ "$DRY_RUN" == false ]]; then
@@ -138,13 +146,31 @@ if [[ "$DRY_RUN" == false ]]; then
         CHANGELOG.md
 fi
 
-# --- 8. Bump pyproject from RC to final ---
+# --- 9. Bump pyproject from RC to final ---
 echo "==> Bumping pyproject.toml: $CURRENT_VERSION -> $VERSION..."
 if [[ "$DRY_RUN" == false ]]; then
     sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$VERSION\"/" pyproject.toml
+    BUMPED=$(grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+    if [[ "$BUMPED" != "$VERSION" ]]; then
+        echo "Error: pyproject bump failed — version is $BUMPED, expected $VERSION." >&2
+        exit 1
+    fi
 fi
 
-# --- 9. Commit, tag, push ---
+# --- 10. Capture release notes from the RELEASE BRANCH's CHANGELOG ---
+# Must happen before checking out main, since main may only have [Unreleased].
+echo "==> Capturing release notes from $RELEASE_BRANCH CHANGELOG..."
+if [[ "$DRY_RUN" == false ]]; then
+    RELEASE_NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+    if [[ -z "$RELEASE_NOTES" ]]; then
+        echo "Error: release notes for [$VERSION] are empty. Did the CHANGELOG bump produce a section?" >&2
+        exit 1
+    fi
+else
+    RELEASE_NOTES="(dry-run: would be extracted from CHANGELOG.md after bump)"
+fi
+
+# --- 11. Commit, tag, push release branch ---
 echo "==> Committing, tagging, pushing..."
 run git add CHANGELOG.md pyproject.toml
 run git commit -m "chore: release v$VERSION"
@@ -152,7 +178,7 @@ run git tag "v$VERSION"
 run git push origin "$RELEASE_BRANCH"
 run git push origin "v$VERSION"
 
-# --- 10. Bump main to next dev ---
+# --- 12. Bump main to next dev ---
 echo "==> Bumping main to $NEXT_DEV..."
 run git checkout main
 run git pull --ff-only
@@ -164,14 +190,13 @@ run git add pyproject.toml
 run git commit -m "chore: begin v$NEXT_DEV development [skip ci]"
 run git push origin main
 
-# --- 11. GitHub Release ---
+# --- 13. GitHub Release (using notes captured before main checkout) ---
 echo "==> Creating GitHub release..."
-RELEASE_NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
 run gh release create "v$VERSION" --repo fuzzypete/theforge \
     --title "v$VERSION" \
     --notes "$RELEASE_NOTES"
 
-# --- 12. Post-release doc review issue ---
+# --- 14. Post-release doc review issue ---
 echo "==> Creating post-release doc review issue for $NEXT_MILESTONE..."
 DOC_REVIEW_BODY="## What
 
@@ -235,7 +260,7 @@ run gh issue create --repo fuzzypete/theforge \
     --label "documentation" \
     --milestone "$NEXT_MILESTONE"
 
-# --- 13. Reminders the script intentionally does not automate ---
+# --- 15. Reminders the script intentionally does not automate ---
 echo ""
 echo "Promoted v$VERSION (from $RC_TAG)."
 echo ""


### PR DESCRIPTION
## Summary

- Adds `scripts/cut-rc.sh` and `scripts/promote-rc.sh` so the release flow becomes RC-first: cut → install → dogfood-ladder → promote (or fix and re-cut). Existing `scripts/release.sh` is preserved as the legacy direct-from-main path.
- `cut-rc.sh` creates/fast-forwards `release/vX.Y`, bumps `pyproject.toml` to `X.Y.ZrcN` (PEP 440), runs gate, tags, pushes, and pip-installs the RC into the active env so `forge --version` reports it for dogfood. Milestone state is informational only — RC cuts deliberately do not block on it.
- `promote-rc.sh` requires release branch + RC version + clean milestone, runs gate, updates CHANGELOG, bumps pyproject to final, tags, pushes, creates the GitHub release, bumps main to next dev, files the post-release doc-review issue. Prints reminders for manual follow-ups (dogfood pin update, RC fix forward-port to main).
- `RELEASING.md` documents the RC flow as the preferred path, with the legacy direct-release section retained for one-line patches.

## Design notes worth surfacing for review

**Auto-installing the RC was overruled.** Initial design suggested `cut-rc.sh` should *not* edit the dogfood install — print the install command, leave the actual `pip install` to the operator. The operator (correctly) called this out as the dumb tradeoff: "I run a script that can run bash commands, but it doesn't do it and then I'm forced to immediately do that by hand?" The "no auto-edit" caveat was over-applied — it had been about the absent dogfood-pin file, not about install side effects. Cutting an RC and dogfooding it are the same muscle-memory action; the install IS the point of the cut, not an unrelated side effect. So `cut-rc.sh` runs `pip install --force-reinstall git+https://github.com/fuzzypete/theforge.git@vX.Y.ZrcN` after pushing the tag, with `--no-install` as an escape hatch for the rare cross-machine case.

**RC happens on `release/vX.Y`, not on `main`.** Existing `release.sh` creates the release branch *after* the final tag; the new flow creates it *before* the RC tag so main stays free for next-release work and RC fixes don't pollute main with version churn. Cost: RC fixes that should also land on main need manual forward-porting after promotion. `promote-rc.sh` prints the `git log main..$RELEASE_BRANCH` command to surface what needs porting.

**Existing `release.sh` was intentionally not refactored.** Don't preemptively rewrite a working script before the RC flow has run end-to-end successfully even once. Once the RC pattern is steady-state (~2 cycles), `release.sh` either becomes a thin wrapper around `promote-rc.sh` or stays as the legacy direct-release path. Premature consolidation is the same anti-pattern we're trying to avoid in the release content itself.

**Both scripts have `--dry-run` parity** with the existing `release.sh`. Verified `cut-rc.sh --dry-run --no-install 0.10.0 0` produces the expected step trace. `promote-rc.sh --dry-run` was also exercised; it correctly errors on the precondition checks (wrong branch, wrong pyproject version) before attempting any destructive op.

## Test plan

- [ ] Code review by a second pair of eyes (this PR)
- [ ] First real use is the v0.10.0 cut: `scripts/cut-rc.sh 0.10.0` against current main
- [ ] After RC ladder runs against v0.11.0 candidate stories, `scripts/promote-rc.sh 0.10.0`
- [ ] Capture any rough edges as follow-up issues; if process gaps surface, update RELEASING.md before the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)