### PR TITLE
Fix stale post_run hook + surface stale-hook gap via check-config and init-hooks

### DIFF
--- a/.forge/hooks/post_run.sh
+++ b/.forge/hooks/post_run.sh
@@ -26,6 +26,13 @@ branch=$(echo "$payload" | jq -r '.branch')
 summary=$(echo "$payload" | jq -r '.summary')
 findings_count=$(echo "$payload" | jq '.findings | length')
 
+# Ensure the intake label exists before filing findings. --force keeps the
+# description aligned without failing when the label already exists.
+gh label create "needs-triage" \
+  --description "Forge finding awaiting explicit triage decision" \
+  --color "D4C5F9" \
+  --force >/dev/null 2>&1 || true
+
 # Only act on ESCALATE or APPROVE outcomes (REQUEST_CHANGES = still in review)
 if [ "$verdict" != "ESCALATE" ] && [ "$verdict" != "APPROVE" ]; then
   exit 0
@@ -67,6 +74,7 @@ if [ "$findings_count" -gt 0 ]; then
       --title "$title" \
       --body "$body" \
       --label "forge-finding" \
+      --label "needs-triage" \
       --label "$(echo "$sev" | tr 'A-Z' 'a-z')" || true
   done
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale generated post-run hooks:** `forge check-config` now warns and exits
+  non-zero when the configured generated findings hook is missing static labels
+  or label setup required by the current template. The warning names the stale
+  hook and describes how to refresh it.
 
 ## [0.9.0] — 2026-05-01
 

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -6,6 +6,7 @@ import logging
 import sys
 from pathlib import Path
 
+from theforge.cli.hooks import post_run_hook_upgrade_warnings
 from theforge.cli.shared import _find_config
 from theforge.config import (
     ForgeConfig,
@@ -506,6 +507,13 @@ def cmd_check_config(args: object) -> int:
 
     for agent in config.agents:
         _run_auth(agent.to_model_profile(allowed_tools=()), "agent", auth_results, config.secrets)
+
+    captured_warnings.extend(
+        post_run_hook_upgrade_warnings(
+            config.project_root,
+            config.hooks.post_run if config.hooks else None,
+        )
+    )
 
     output, exit_code = _format_config(config, auth_results)
 

--- a/src/theforge/cli/hooks.py
+++ b/src/theforge/cli/hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shlex
 import sys
 from pathlib import Path
@@ -246,6 +247,45 @@ def resolve_hook_path(project_root: Path, hook_command: str | None) -> Path | No
     return path
 
 
+_STATIC_LABEL_RE = re.compile(r"--label\s+(?:\"([^\"$`\\]+)\"|'([^'$`\\]+)'|([A-Za-z0-9_.:-]+))")
+_LABEL_CREATE_RE = re.compile(
+    r"gh\s+label\s+create\s+(?:\"([^\"$`\\]+)\"|'([^'$`\\]+)'|([A-Za-z0-9_.:-]+))"
+)
+
+
+def _capture_label(match: re.Match[str]) -> str | None:
+    label = next((group for group in match.groups() if group), None)
+    if label is None or "$" in label:
+        return None
+    return label
+
+
+def static_issue_labels(script: str) -> set[str]:
+    """Return literal labels applied by gh issue create calls in a shell hook."""
+    labels: set[str] = set()
+    for match in _STATIC_LABEL_RE.finditer(script):
+        label = _capture_label(match)
+        if label:
+            labels.add(label)
+    return labels
+
+
+def created_labels(script: str) -> set[str]:
+    """Return literal labels created or refreshed by gh label create commands."""
+    labels: set[str] = set()
+    for match in _LABEL_CREATE_RE.finditer(script):
+        label = _capture_label(match)
+        if label:
+            labels.add(label)
+    return labels
+
+
+def _looks_like_generated_finding_hook(content: str) -> bool:
+    normalized = content.lower()
+    has_generated_marker = "theforge" in normalized and "post_run hook" in normalized
+    return has_generated_marker and "gh issue create" in normalized and "forge-finding" in content
+
+
 def post_run_hook_upgrade_warnings(project_root: Path, hook_command: str | None) -> list[str]:
     """Return operator-facing warnings for stale generated post_run hooks."""
     path = resolve_hook_path(project_root, hook_command)
@@ -257,22 +297,30 @@ def post_run_hook_upgrade_warnings(project_root: Path, hook_command: str | None)
     except OSError:
         return []
 
-    generated_finding_hook = (
-        "Filed by theforge post_run hook" in content and '--label "forge-finding"' in content
-    )
-    if not generated_finding_hook:
+    if not _looks_like_generated_finding_hook(content):
         return []
 
     warnings: list[str] = []
-    if '--label "needs-triage"' not in content:
+    expected_issue_labels = static_issue_labels(_POST_RUN_SH)
+    actual_issue_labels = static_issue_labels(content)
+    missing_issue_labels = sorted(expected_issue_labels - actual_issue_labels)
+    if missing_issue_labels:
         warnings.append(
-            f"{path}: generated finding hook is stale; newly filed forge findings will "
-            "miss needs-triage until the hook is updated."
+            f"{path}: generated finding hook is stale; newly filed forge findings will miss "
+            f"{', '.join(missing_issue_labels)} until the hook is updated. Update the hook "
+            "from the current template by moving the existing file aside and running "
+            "`forge init-hooks`, or copy the missing label lines from src/theforge/cli/hooks.py."
         )
-    if 'gh label create "needs-triage"' not in content:
+
+    expected_created_labels = created_labels(_POST_RUN_SH)
+    actual_created_labels = created_labels(content)
+    missing_created_labels = sorted(expected_created_labels - actual_created_labels)
+    if missing_created_labels:
         warnings.append(
-            f"{path}: generated finding hook does not ensure the needs-triage label "
-            "exists before filing findings."
+            f"{path}: generated finding hook does not ensure "
+            f"{', '.join(missing_created_labels)} exists before filing findings. Update the "
+            "hook from the current template by moving the existing file aside and running "
+            "`forge init-hooks`, or copy the missing label setup from src/theforge/cli/hooks.py."
         )
     return warnings
 

--- a/src/theforge/cli/hooks.py
+++ b/src/theforge/cli/hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import sys
 from pathlib import Path
 
@@ -229,6 +230,53 @@ hooks:
 """
 
 
+def resolve_hook_path(project_root: Path, hook_command: str | None) -> Path | None:
+    """Return the script path for a configured hook command, if it is path-like."""
+    if not hook_command:
+        return None
+    try:
+        parts = shlex.split(hook_command)
+    except ValueError:
+        return None
+    if not parts:
+        return None
+    path = Path(parts[0])
+    if not path.is_absolute():
+        path = project_root / path
+    return path
+
+
+def post_run_hook_upgrade_warnings(project_root: Path, hook_command: str | None) -> list[str]:
+    """Return operator-facing warnings for stale generated post_run hooks."""
+    path = resolve_hook_path(project_root, hook_command)
+    if path is None or not path.exists():
+        return []
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    generated_finding_hook = (
+        "Filed by theforge post_run hook" in content and '--label "forge-finding"' in content
+    )
+    if not generated_finding_hook:
+        return []
+
+    warnings: list[str] = []
+    if '--label "needs-triage"' not in content:
+        warnings.append(
+            f"{path}: generated finding hook is stale; newly filed forge findings will "
+            "miss needs-triage until the hook is updated."
+        )
+    if 'gh label create "needs-triage"' not in content:
+        warnings.append(
+            f"{path}: generated finding hook does not ensure the needs-triage label "
+            "exists before filing findings."
+        )
+    return warnings
+
+
 def cmd_init_hooks(args: object) -> int:
     """Scaffold .forge/hooks/post_run.sh and .forge/hooks/README.md."""
     project_root = Path.cwd()
@@ -242,6 +290,9 @@ def cmd_init_hooks(args: object) -> int:
 
     if sh_path.exists():
         skipped.append(str(sh_path))
+        warnings = post_run_hook_upgrade_warnings(project_root, str(sh_path))
+        for warning in warnings:
+            print(f"WARNING: {warning}", file=sys.stderr)
     else:
         sh_path.write_text(_POST_RUN_SH, encoding="utf-8")
         sh_path.chmod(0o755)

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -175,6 +175,8 @@ class TestCheckConfigHappyPath:
         out = capsys.readouterr().out
         assert "generated finding hook is stale" in out
         assert "needs-triage" in out
+        assert "forge init-hooks" in out
+        assert "--update" not in out
 
     def test_sections_present(self, tmp_path: Path, capsys) -> None:
         config = _make_forge_config(tmp_path)

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -12,6 +12,7 @@ from theforge.config import (
     DEFAULT_VALIDATION,
     AssignmentConfig,
     ForgeConfig,
+    HooksConfig,
     LogConfig,
     ModelProfile,
     PlanAgentReviewConfig,
@@ -145,6 +146,35 @@ class TestCheckConfigHappyPath:
         assert "REVIEW POOL" in out
         assert "SETTINGS" in out
         assert "WARNINGS" not in out
+
+    def test_warns_for_stale_generated_post_run_hook(self, tmp_path: Path, capsys) -> None:
+        hooks_dir = tmp_path / ".forge" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        hook = hooks_dir / "post_run.sh"
+        hook.write_text(
+            "#!/usr/bin/env bash\n"
+            "*Filed by theforge post_run hook.*\n"
+            'gh issue create --label "forge-finding"\n',
+            encoding="utf-8",
+        )
+        config = replace(
+            _make_forge_config(tmp_path),
+            hooks=HooksConfig(post_run=".forge/hooks/post_run.sh"),
+        )
+        with (
+            patch(
+                "theforge.cli.check_config._find_config",
+                return_value=tmp_path / "forge.yaml",
+            ),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            exit_code = cmd_check_config(_make_args())
+
+        assert exit_code == 1
+        out = capsys.readouterr().out
+        assert "generated finding hook is stale" in out
+        assert "needs-triage" in out
 
     def test_sections_present(self, tmp_path: Path, capsys) -> None:
         config = _make_forge_config(tmp_path)

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import stat
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -20,6 +24,8 @@ from theforge.cli import (
     cmd_init_hooks,
     cmd_secrets_init,
 )
+from theforge.cli import hooks as hooks_module
+from theforge.cli.hooks import created_labels, static_issue_labels
 from theforge.config import (
     DEFAULT_VALIDATION,
     ForgeConfig,
@@ -570,6 +576,122 @@ class TestCmdInitHooks:
         captured = capsys.readouterr()
         assert "stale" in captured.err
         assert "needs-triage" in captured.err
+        assert "forge init-hooks" in captured.err
+        assert "--update" not in captured.err
+
+    def test_existing_hook_warning_tracks_future_template_labels(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Stale-hook detection compares against the template, not one hard-coded label."""
+        monkeypatch.chdir(tmp_path)
+        future_template = hooks_module._POST_RUN_SH.replace(
+            '--label "needs-triage" \\',
+            '--label "needs-triage" \\\n      --label "release-intake" \\',
+            1,
+        )
+        monkeypatch.setattr(hooks_module, "_POST_RUN_SH", future_template)
+        hooks_dir = tmp_path / ".forge" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        sh_path = hooks_dir / "post_run.sh"
+        sh_path.write_text(
+            "#!/usr/bin/env bash\n"
+            "*Filed by theforge post_run hook.*\n"
+            'gh issue create --label "forge-finding" --label "needs-triage"\n',
+            encoding="utf-8",
+        )
+
+        rc = cmd_init_hooks(self._make_args())
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "release-intake" in captured.err
+
+    def test_repo_configured_hook_matches_generated_required_labels(self):
+        """The checked-in active hook carries the generated template's static labels."""
+        repo_root = Path(__file__).resolve().parents[1]
+        live_hook = repo_root / ".forge" / "hooks" / "post_run.sh"
+        live_content = live_hook.read_text(encoding="utf-8")
+
+        assert static_issue_labels(live_content) >= static_issue_labels(hooks_module._POST_RUN_SH)
+        assert created_labels(live_content) >= created_labels(hooks_module._POST_RUN_SH)
+
+    def test_repo_configured_hook_files_findings_with_needs_triage(self, tmp_path):
+        """Execute the checked-in active hook with fake gh/jq and inspect gh calls."""
+        repo_root = Path(__file__).resolve().parents[1]
+        live_hook = repo_root / ".forge" / "hooks" / "post_run.sh"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        gh_log = tmp_path / "gh.log"
+
+        gh = bin_dir / "gh"
+        gh.write_text(
+            '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$GH_LOG"\nexit 0\n',
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+        jq = bin_dir / "jq"
+        jq.write_text(
+            f"#!{sys.executable}\n"
+            "import json, sys\n"
+            "query = sys.argv[-1]\n"
+            "data = json.loads(sys.stdin.read())\n"
+            "if query == '.verdict': print(data['verdict'])\n"
+            "elif query == '.slug': print(data['slug'])\n"
+            "elif query == '.branch': print(data['branch'])\n"
+            "elif query == '.summary': print(data['summary'])\n"
+            "elif query == '.findings | length': print(len(data['findings']))\n"
+            "elif query == '.findings[]':\n"
+            "    print('\\n'.join(json.dumps(item) for item in data['findings']))\n"
+            "elif query == '.severity': print(data['severity'])\n"
+            "elif query == '.file': print(data['file'])\n"
+            "elif query == '.line // empty': print(data.get('line') or '')\n"
+            "elif query == '.description': print(data['description'])\n"
+            "elif query == '.suggestion // empty': print(data.get('suggestion') or '')\n"
+            "elif query == '(.reviewers // []) | length':\n"
+            "    print(len(data.get('reviewers') or []))\n"
+            "else: raise SystemExit(f'unhandled jq query: {query}')\n",
+            encoding="utf-8",
+        )
+        jq.chmod(0o755)
+
+        payload = {
+            "verdict": "APPROVE",
+            "slug": "issue-test",
+            "branch": "fix/test",
+            "summary": "approved with finding",
+            "findings": [
+                {
+                    "severity": "P2",
+                    "file": "src/example.py",
+                    "line": 12,
+                    "description": "example finding",
+                    "suggestion": "",
+                }
+            ],
+        }
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "GH_LOG": str(gh_log),
+        }
+        env.pop("FORGE_GH_PR_REVIEWS", None)
+
+        result = subprocess.run(
+            [str(live_hook)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+            cwd=repo_root,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        calls = gh_log.read_text(encoding="utf-8")
+        assert "label create needs-triage" in calls
+        assert "issue create" in calls
+        assert "--label needs-triage" in calls
 
     def test_idempotent_skips_existing_readme(self, tmp_path, monkeypatch, capsys):
         """forge init-hooks does not overwrite existing README.md."""

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -552,6 +552,25 @@ class TestCmdInitHooks:
         captured = capsys.readouterr()
         assert "post_run.sh" in captured.err
 
+    def test_existing_stale_generated_hook_warns(self, tmp_path, monkeypatch, capsys):
+        """forge init-hooks warns when the installed generated hook needs operator action."""
+        monkeypatch.chdir(tmp_path)
+        hooks_dir = tmp_path / ".forge" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        sh_path = hooks_dir / "post_run.sh"
+        sh_path.write_text(
+            "#!/usr/bin/env bash\n"
+            "*Filed by theforge post_run hook.*\n"
+            'gh issue create --label "forge-finding"\n',
+            encoding="utf-8",
+        )
+
+        rc = cmd_init_hooks(self._make_args())
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "stale" in captured.err
+        assert "needs-triage" in captured.err
+
     def test_idempotent_skips_existing_readme(self, tmp_path, monkeypatch, capsys):
         """forge init-hooks does not overwrite existing README.md."""
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

- The deployed `.forge/hooks/post_run.sh` was last regenerated at cdcab94 (March 21) and never picked up the `--label "needs-triage"` addition that landed in the src template (`_POST_RUN_SH` in `cli/hooks.py`). Result: 142 forge findings filed since the template change shipped without `needs-triage`, and the shape-check action auto-promoted them all to `needs-grooming`, breaking the intended triage-then-groom flow.
- Adds `post_run_hook_upgrade_warnings()` — a detector that fingerprints stale generated finding hooks and surfaces the gap via both `forge check-config` and `forge init-hooks`.
- Regenerates this repo's own `.forge/hooks/post_run.sh` to match the current src template (fixes the immediate symptom).

## Why this exists

Recurring operator-handoff failure mode: source template changes ship, deployed local state goes stale, operator finds out by failure mode (in this case, by manually inspecting the backlog and noticing 142 issues mis-labeled). `forge init-hooks` is idempotent and silently skips existing files — so the operator never gets a "your local hook is out of date" signal at any natural inspection point.

This is the same shape as the broader pattern flagged by [memory `project_operator_handoff_gap.md`](https://github.com/fuzzypete/theforge/issues/1009) — config/template/scaffold changes consistently lack a visible operator rollout path.

## What changed

| File | Change |
|------|--------|
| `.forge/hooks/post_run.sh` | Regenerated to match current src template (adds `--label "needs-triage"` and `gh label create needs-triage --force`) |
| `src/theforge/cli/hooks.py` | New `resolve_hook_path()` and `post_run_hook_upgrade_warnings()`; `cmd_init_hooks` warns when skipping a stale generated hook |
| `src/theforge/cli/check_config.py` | Folds stale-hook warnings into `forge check-config` output |
| `tests/test_check_config.py` | Test for the new check-config warning |
| `tests/test_cli_setup.py` | Test for `init-hooks` warning on stale existing file |

The detector only fires on hooks that fingerprint as the generated template (must contain both `"Filed by theforge post_run hook"` and `--label "forge-finding"`), so users with custom hooks see no warnings.

## Provenance note

These edits originated from codex during an interactive RCA session where the operator did not authorize code changes. The patches (minus an unrelated CONVENTIONS.md edit codex itself called tone-deaf) were extracted from the main worktree, applied cleanly to this branch, gate-verified, and brought to a proper PR. Main has been restored to clean.

## Follow-up worth filing separately

- `forge init-hooks --update` (or equivalent) so operators have a one-command way to apply the warning's remediation, rather than having to manually copy from the template. This PR ships the *warning*; the rollout-action command is a v0.12.0 candidate (autonomy theme — autonomy without operator-handoff signal is the same anti-pattern as failure-evidence-without-substrate).
- Generalize the stale-template detection: the same gap pattern recurs for any generated artifact (forge.yaml schema, `.forge/hooks/*`, future scaffolds). A single `forge doctor` (or extension to `check-config`) that audits all such artifacts is the right long-term shape.

## Test plan

- [x] `make gate` passes (4079 tests, 1 skipped)
- [x] New tests cover both warning paths: `test_warns_for_stale_generated_post_run_hook` (check-config), `test_existing_stale_generated_hook_warns` (init-hooks)
- [x] CONVENTIONS.md edit from the original codex patch explicitly excluded
- [ ] Codex review of the fix-branch contents (separate from the original patches it produced)
- [ ] Verify on a fresh checkout of TheForge that `forge check-config` warns about the stale hook before this PR merges, and stops warning after

🤖 Generated with [Claude Code](https://claude.com/claude-code)