### PR TITLE
Audit redactor does not recurse into tuples, leaking secrets stored in tuple values

### DIFF
--- a/src/theforge/coordinator/redact.py
+++ b/src/theforge/coordinator/redact.py
@@ -84,6 +84,8 @@ def _redact_obj(obj: Any, secrets: set[str]) -> Any:
         return result
     if isinstance(obj, list):
         return [_redact_obj(item, secrets) for item in obj]
+    if isinstance(obj, tuple):
+        return tuple(_redact_obj(item, secrets) for item in obj)
     if isinstance(obj, str):
         return _redact_value(obj, secrets)
     return obj

--- a/tests/test_coord_redact.py
+++ b/tests/test_coord_redact.py
@@ -134,6 +134,37 @@ class TestRedactEnvironmentDict:
         assert result["runtime"]["environment"] == ["A", "B"]
 
 
+class TestRedactTuples:
+    def test_redacts_secret_string_inside_tuple(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("TUPLE_SECRET=tuplesecretvalue1\n")
+        obj = ("safe", "contains tuplesecretvalue1")
+        result = redact(obj, env)
+        assert isinstance(result, tuple)
+        assert result[0] == "safe"
+        assert result[1] == "[REDACTED]"
+
+    def test_preserves_tuple_shape(self) -> None:
+        result = redact({"data": ("a", "b", 42)}, None)
+        assert isinstance(result["data"], tuple)
+        assert result["data"] == ("a", "b", 42)
+
+    def test_redacts_secret_key_value_in_tuple(self) -> None:
+        result = redact({"items": ({"token": "tok_abc"}, "safe")}, None)
+        assert isinstance(result["items"], tuple)
+        assert result["items"][0]["token"] == "[REDACTED]"
+        assert result["items"][1] == "safe"
+
+    def test_redacts_nested_tuples(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("NESTED_SECRET=nestedsecretval1\n")
+        obj = (("inner", "nestedsecretval1"),)
+        result = redact(obj, env)
+        assert isinstance(result, tuple)
+        assert isinstance(result[0], tuple)
+        assert result[0][1] == "[REDACTED]"
+
+
 class TestRedactReturnsCopy:
     def test_original_not_mutated(self) -> None:
         original = {"password": "secret123", "name": "Alice"}

--- a/tests/test_coord_redact.py
+++ b/tests/test_coord_redact.py
@@ -142,7 +142,7 @@ class TestRedactTuples:
         result = redact(obj, env)
         assert isinstance(result, tuple)
         assert result[0] == "safe"
-        assert result[1] == "[REDACTED]"
+        assert result[1] == "contains [REDACTED]"
 
     def test_preserves_tuple_shape(self) -> None:
         result = redact({"data": ("a", "b", 42)}, None)


### PR DESCRIPTION
## Summary

Minimal, correct tuple branch added to _redact_obj; four targeted tests cover direct, nested, and mixed-container cases

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.12
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

Audit redactor does not recurse into tuples, leaking secrets stored in tuple values (GitHub Issue #800)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #800