### PR TITLE
Sprint summary shows DONE for deps that ended in MERGE_FAILED via queued-PR poll-failure

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2004,6 +2004,9 @@ def run_sprint(
                                 _err,
                                 dep_result.state.branch_name,
                             )
+                            _set_outcome(
+                                dep, StoryOutcome.MERGE_FAILED, phase=dep_result.phase.name
+                            )
                             del queued_prs[dep]
                             _write_story_audit(config, dep_task, dep_result, sprint_id=_sprint_id)
                             _log(


### PR DESCRIPTION
## Summary

Minimal, correct fix — adds the missing _set_outcome call in the dep-poll-failure branch to sync sprint-summary.yaml with audit.yaml on MERGE_FAILED, matching the pattern already used in the three sibling branches.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.45
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint summary shows DONE for deps that ended in MERGE_FAILED via queued-PR poll-failure (GitHub Issue #1277)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1277