### PR TITLE
forge.yaml story-mutation guard allowlist excludes v0.10.0's own opt-in feature blocks

### DIFF
--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -20,7 +20,9 @@ from theforge.task import (
     parse_story_frontmatter,
 )
 
-_ALLOWED_TOP_LEVEL_KEYS = frozenset({"assignment", "models"})
+_ALLOWED_TOP_LEVEL_KEYS = frozenset(
+    {"assignment", "models", "intake", "conventions_advisory", "diagnose"}
+)
 
 
 @dataclass(frozen=True)

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -171,6 +171,30 @@ def test_evaluate_forge_yaml_guard_honors_slug_matched_local_story_override(
     assert result.violating_keys == ("workspace",)
 
 
+def test_evaluate_forge_yaml_guard_passes_for_v010_optin_keys(tmp_path: Path) -> None:
+    """All v0.10.0 opt-in feature blocks must be operator-mutable without override."""
+    current_yaml = (
+        "intake:\n  grooming: true\n"
+        "conventions_advisory:\n  enabled: true\n"
+        "diagnose:\n  enabled: true\n"
+    )
+    (tmp_path / "forge.yaml").write_text(current_yaml, encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),  # base has no forge.yaml content
+            MagicMock(returncode=0, stdout="feat/issue-1001\n", stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps({"body": ""}), stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is True
+    assert result.violating_keys == ()
+    assert set(result.changed_keys) == {"intake", "conventions_advisory", "diagnose"}
+
+
 def test_cmd_check_story_config_prints_violating_keys(capsys, tmp_path: Path) -> None:
     config_path = tmp_path / "forge.yaml"
     config_path.write_text("project: test\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Allowlist extended with intake/conventions_advisory/diagnose; regression test covers all three opt-in keys.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $0.46
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge.yaml story-mutation guard allowlist excludes v0.10.0's own opt-in feature blocks (GitHub Issue #1356)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1356