### PR TITLE
Custom model registry overlay bypassed by AGENT_REGISTRY direct-readers, crashing workers on declared models

### DIFF
--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -32,6 +32,7 @@ from .models import (
     canonical_id_for_spec,
     canonical_model_id,
     is_canonical_model_id,
+    model_info_view,
     resolve_agent_spec,
 )
 from .types import (
@@ -100,6 +101,7 @@ __all__ = [
     "canonical_id_for_spec",
     "canonical_model_id",
     "is_canonical_model_id",
+    "model_info_view",
     "resolve_agent_spec",
     # defaults
     "API_PROVIDER_DEFAULT_TOOLS",

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -487,6 +487,20 @@ MODEL_REGISTRY: dict[str, ModelInfo] = {
 }
 
 
+def model_info_view(
+    registry: dict[str, AgentSpec] | None = None,
+) -> dict[str, ModelInfo]:
+    """Return a {model_key: ModelInfo} view of an AgentSpec registry.
+
+    With ``registry=None`` returns the built-in MODEL_REGISTRY. Pass
+    ``ForgeConfig.model_registry`` (the merged built-in + forge.yaml overlay)
+    so consumers see user-declared custom models as first-class entries.
+    """
+    if registry is None:
+        return MODEL_REGISTRY
+    return {k: _spec_to_model_info(k, v) for k, v in registry.items()}
+
+
 @overload
 def apply_model_info(profile: ModelProfile, info: ModelInfo) -> ModelProfile: ...
 

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import yaml
 
-from theforge.config import MODEL_REGISTRY, ForgeConfig, apply_model_info
+from theforge.config import ForgeConfig, apply_model_info
 from theforge.config.auth import sandbox_available_for_profile
 from theforge.config.types import StuckDetectionConfig
 from theforge.coordinator.context_scope import plan_file_list
@@ -835,11 +835,20 @@ def _run_dev_phase(
             if not state.dev_escalated:
                 _old_model = config.dev_profile.model
                 if config.retry.auto_model_escalation and config.models is not None:
-                    _curr_key = _find_registry_key_for_profile(config.dev_profile)
+                    _registry = config.model_registry or None
+                    _curr_key = _find_registry_key_for_profile(
+                        config.dev_profile, registry=_registry
+                    )
                     if _curr_key is not None:
-                        _next_key = _escalate_dev_model(_curr_key, config.models)
+                        _next_key = _escalate_dev_model(
+                            _curr_key, config.models, registry=_registry
+                        )
                         if _next_key is not None:
-                            _next_info = MODEL_REGISTRY[_next_key]
+                            from theforge.config.models import (  # noqa: PLC0415
+                                _resolve_model_info,
+                            )
+
+                            _next_info = _resolve_model_info(_next_key, registry=_registry)
                             _new_dev = apply_model_info(config.dev_profile, _next_info)
                             config.dev_profile = _new_dev
                             state.dev_escalated = True

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -901,11 +901,16 @@ def _run_plan_agent_review(
             state.plan_regen_count >= config.retry.plan_escalation_threshold
             and not state.plan_escalated
         ):
-            _curr_key = _find_registry_key_for_profile(plan_profile)
+            _registry = config.model_registry or None
+            _curr_key = _find_registry_key_for_profile(plan_profile, registry=_registry)
             if _curr_key is not None and config.models is not None:
-                _next_key = _escalate_dev_model(_curr_key, config.models)
+                _next_key = _escalate_dev_model(_curr_key, config.models, registry=_registry)
                 if _next_key is not None:
-                    _next_info = MODEL_REGISTRY[_next_key]
+                    from theforge.config.models import (  # noqa: PLC0415
+                        _resolve_model_info,
+                    )
+
+                    _next_info = _resolve_model_info(_next_key, registry=_registry)
                     _old_model = plan_profile.model
                     _new_model = _next_info.model
                     plan_profile = apply_model_info(plan_profile, _next_info)

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -10,7 +10,14 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from theforge.config import MODEL_REGISTRY, ForgeConfig, ModelInfo, ModelProfile, apply_model_info
+from theforge.config import (
+    AgentSpec,
+    ForgeConfig,
+    ModelInfo,
+    ModelProfile,
+    apply_model_info,
+    model_info_view,
+)
 from theforge.review import ReviewFinding
 from theforge.routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
 
@@ -216,13 +223,25 @@ def _detect_large_preflight_story_categories(story_content: str) -> list[str]:
     return list(dict.fromkeys(matched))
 
 
-def _build_pool_entries(model_keys: list[str]) -> list[tuple[int, str, ModelInfo]]:
-    """Build sorted (cost_rank, registry_key, ModelInfo) list from models."""
+def _build_pool_entries(
+    model_keys: list[str],
+    *,
+    registry: dict[str, AgentSpec] | None = None,
+) -> list[tuple[int, str, ModelInfo]]:
+    """Build sorted (cost_rank, registry_key, ModelInfo) list from models.
+
+    ``registry`` is the merged AgentSpec view (built-in + forge.yaml overlay)
+    from ``ForgeConfig.model_registry``. When None, only built-ins are visible
+    and custom-overlay model keys raise ValueError.
+    """
     from theforge.config.models import _resolve_model_info  # noqa: PLC0415
 
+    info_view = model_info_view(registry)
     entries: list[tuple[int, str, ModelInfo]] = []
     for key in model_keys:
-        info: ModelInfo = MODEL_REGISTRY.get(key) or _resolve_model_info(key)
+        info = info_view.get(key)
+        if info is None:
+            info = _resolve_model_info(key, registry=registry)
         entries.append((info.cost_rank, key, info))
     entries.sort(key=lambda x: (x[0], -x[2].capability))
     return entries
@@ -542,7 +561,11 @@ def _parse_preflight_criteria_checked(output: str) -> list[dict]:
         return []
 
 
-def _find_registry_info_for_profile(profile: ModelProfile) -> tuple[int, int]:
+def _find_registry_info_for_profile(
+    profile: ModelProfile,
+    *,
+    registry: dict[str, AgentSpec] | None = None,
+) -> tuple[int, int]:
     """Return (cost_rank, capability) for a profile using the model registry.
 
     CLI profiles match by cli+model. API profiles match by provider+model against
@@ -551,22 +574,26 @@ def _find_registry_info_for_profile(profile: ModelProfile) -> tuple[int, int]:
 
     Falls back to (2, 5) for unknown models.
     """
-    registry_key = _find_registry_key_for_profile(profile)
+    registry_key = _find_registry_key_for_profile(profile, registry=registry)
     if registry_key is None:
         return 2, 5
-    info = MODEL_REGISTRY[registry_key]
+    info = model_info_view(registry)[registry_key]
     return info.cost_rank, info.capability
 
 
-def _find_registry_key_for_profile(profile: ModelProfile) -> str | None:
-    """Return the MODEL_REGISTRY key for a profile, or None if unknown.
+def _find_registry_key_for_profile(
+    profile: ModelProfile,
+    *,
+    registry: dict[str, AgentSpec] | None = None,
+) -> str | None:
+    """Return the model registry key for a profile, or None if unknown.
 
     Matches by TransportSpec (single source of dispatch truth) plus model name.
     Falls back to cli/provider matching for profiles without an explicit
     transport.
     """
     profile_transport = profile.transport
-    for key, info in MODEL_REGISTRY.items():
+    for key, info in model_info_view(registry).items():
         if info.model != profile.model:
             continue
         if profile_transport is not None and info.transport is not None:
@@ -683,22 +710,25 @@ def _p1_findings_match(current: ReviewFinding, previous: ReviewFinding) -> bool:
 def _escalate_dev_model(
     current_model: str,
     available_models: list[str],
+    *,
+    registry: dict[str, AgentSpec] | None = None,
 ) -> str | None:
     """Return the next higher-capability dev-capable model, or None.
 
     Selects the lowest-capability model that is still higher than current
-    and has dev_capable=True in MODEL_REGISTRY.
+    and has ``dev_capable=True`` in the merged registry view.
     """
-    current_info = MODEL_REGISTRY.get(current_model)
+    info_view = model_info_view(registry)
+    current_info = info_view.get(current_model)
     if current_info is None:
         return None
 
     candidates = [
-        (key, MODEL_REGISTRY[key])
+        (key, info_view[key])
         for key in available_models
-        if key in MODEL_REGISTRY
-        and MODEL_REGISTRY[key].dev_capable
-        and MODEL_REGISTRY[key].capability > current_info.capability
+        if key in info_view
+        and info_view[key].dev_capable
+        and info_view[key].capability > current_info.capability
     ]
 
     if not candidates:
@@ -735,7 +765,8 @@ def _apply_complexity_adaptation(
     if norm is None:
         return config
 
-    pool_entries = _build_pool_entries(config.models)
+    _registry = config.model_registry or None
+    pool_entries = _build_pool_entries(config.models, registry=_registry)
     if not pool_entries:
         return config
 
@@ -775,7 +806,11 @@ def _apply_complexity_adaptation(
         non_dev_reviewers = [p for p in config.review_pool if p.model != new_dev_model]
         review_candidates = non_dev_reviewers if non_dev_reviewers else list(config.review_pool)
 
-        mid_strong = [p for p in review_candidates if _find_registry_info_for_profile(p)[0] >= 2]
+        mid_strong = [
+            p
+            for p in review_candidates
+            if _find_registry_info_for_profile(p, registry=_registry)[0] >= 2
+        ]
 
         if norm == "LOW":
             # Single mid/strong reviewer, no synthesis
@@ -788,8 +823,8 @@ def _apply_complexity_adaptation(
             single = min(
                 candidate_pool,
                 key=lambda p: (
-                    _find_registry_info_for_profile(p)[0],
-                    -_find_registry_info_for_profile(p)[1],
+                    _find_registry_info_for_profile(p, registry=_registry)[0],
+                    -_find_registry_info_for_profile(p, registry=_registry)[1],
                 ),
             )
             new_config = _dc_replace(new_config, review_pool=[single], synthesis_profile=None)
@@ -800,7 +835,8 @@ def _apply_complexity_adaptation(
             if synthesis is None:
                 synth_candidates = review_broader or [new_config.dev_profile]
                 strongest = max(
-                    synth_candidates, key=lambda p: _find_registry_info_for_profile(p)[1]
+                    synth_candidates,
+                    key=lambda p: _find_registry_info_for_profile(p, registry=_registry)[1],
                 )
                 synth_budget = max(config.dev_profile.budget_usd * 0.02, 1.0)
                 synthesis = _dc_replace(strongest, name="synthesis", budget_usd=synth_budget)

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -10,7 +10,7 @@ from dataclasses import replace as _dc_replace
 from enum import Enum, auto
 from pathlib import Path
 
-from theforge.config import MODEL_REGISTRY, ForgeConfig, apply_model_info
+from theforge.config import ForgeConfig, apply_model_info
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.review import (
     ReviewFinding,
@@ -79,13 +79,16 @@ def _perform_dev_model_escalation(
     model is available. Callers are responsible for updating state flags and emitting
     audit records appropriate to their escalation reason.
     """
-    curr_key = _find_registry_key_for_profile(config.dev_profile)
+    registry = config.model_registry or None
+    curr_key = _find_registry_key_for_profile(config.dev_profile, registry=registry)
     if curr_key is None:
         return None
-    next_key = _escalate_dev_model(curr_key, config.models)
+    next_key = _escalate_dev_model(curr_key, config.models, registry=registry)
     if next_key is None:
         return None
-    next_info = MODEL_REGISTRY[next_key]
+    from theforge.config.models import _resolve_model_info  # noqa: PLC0415
+
+    next_info = _resolve_model_info(next_key, registry=registry)
     old_model = config.dev_profile.model
     new_dev = apply_model_info(config.dev_profile, next_info)
     return old_model, next_info.model, _dc_replace(config, dev_profile=new_dev)

--- a/tests/test_preflight_custom_model.py
+++ b/tests/test_preflight_custom_model.py
@@ -1,0 +1,173 @@
+"""Regression: custom forge.yaml model overlays must work in coordinator paths.
+
+The bug (issue #1355): preflight `_apply_complexity_adaptation` and the
+escalation helpers consulted built-in MODEL_REGISTRY/AGENT_REGISTRY directly,
+so a model declared under `models.custom` (which `forge check-config` accepts)
+crashed sprint workers with `ValueError: Unknown model 'openai/gpt-5.5': not in
+AGENT_REGISTRY` before any productive work was done.
+
+These tests assert that, given a ForgeConfig whose `model_registry` is the
+merged built-in + forge.yaml view, complexity adaptation and escalation
+succeed for a custom model and the merged registry's source attribution is
+preserved through the seam.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.config import (
+    AGENT_REGISTRY,
+    DEFAULT_VALIDATION,
+    AgentSpec,
+    ForgeConfig,
+    ModelProfile,
+    RetryPolicy,
+    TransportSpec,
+    WorkspaceConfig,
+)
+from theforge.config.types import PlanConfig
+from theforge.coordinator.preflight import (
+    _apply_complexity_adaptation,
+    _build_pool_entries,
+    _escalate_dev_model,
+    _find_registry_key_for_profile,
+)
+
+_CUSTOM_KEY = "openai/gpt-5.5"
+
+
+def _custom_spec() -> AgentSpec:
+    return AgentSpec(
+        provider="openai",
+        model="gpt-5.5",
+        transport=TransportSpec(kind="api", runner="openai"),
+        tier="strong",
+        capability=9,
+        cost_rank=3,
+        dev_capable=True,
+        registry_source="forge.yaml",
+        input_cost_per_mtok=5.0,
+        output_cost_per_mtok=30.0,
+    )
+
+
+def _merged_registry() -> dict[str, AgentSpec]:
+    merged = dict(AGENT_REGISTRY)
+    merged[_CUSTOM_KEY] = _custom_spec()
+    return merged
+
+
+def _registry_sources() -> dict[str, str]:
+    sources = {key: "builtin" for key in AGENT_REGISTRY}
+    sources[_CUSTOM_KEY] = "forge.yaml"
+    return sources
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    """A simple-mode ForgeConfig whose pool includes a custom forge.yaml model."""
+    dev = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=6.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    custom = ModelProfile(
+        name="openai-gpt-5.5",
+        cli=None,
+        provider="openai",
+        model="gpt-5.5",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    plan = PlanConfig(cli="claude", model="sonnet", budget_usd=0.5, timeout=600)
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev,
+        preflight_profile=dev,
+        review_pool=[custom],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        models=["claude/sonnet", _CUSTOM_KEY],
+        plan=plan,
+        plan_model_is_default=True,
+        dev_profile_is_default=True,
+        review_pool_is_default=True,
+        model_registry=_merged_registry(),
+        model_registry_sources=_registry_sources(),
+        custom_models=(_CUSTOM_KEY,),
+    )
+
+
+# ── _build_pool_entries: registry overlay observed ─────────────────────
+
+
+def test_build_pool_entries_accepts_custom_model_with_merged_registry():
+    """Without registry= the custom model raises; with merged registry it resolves."""
+    merged = _merged_registry()
+    entries = _build_pool_entries(["claude/sonnet", _CUSTOM_KEY], registry=merged)
+    keys = {key for _, key, _ in entries}
+    assert _CUSTOM_KEY in keys
+
+
+def test_build_pool_entries_without_registry_raises_for_custom_key():
+    """Sanity: the bug's failure mode persists when no registry is supplied."""
+    import pytest
+
+    with pytest.raises(ValueError, match="Unknown model"):
+        _build_pool_entries(["claude/sonnet", _CUSTOM_KEY])
+
+
+# ── _apply_complexity_adaptation: full preflight seam, custom in pool ─
+
+
+def test_complexity_adaptation_custom_model_does_not_raise(tmp_path):
+    config = _make_config(tmp_path)
+    adapted = _apply_complexity_adaptation(config, "medium", complexity_score=7)
+    # Score 7 routes dev to 'strong'; custom model is the only strong entry.
+    assert adapted.dev_profile.model == "gpt-5.5"
+
+
+def test_complexity_adaptation_preserves_registry_attribution(tmp_path):
+    """Audit attribution survives the fix (per spec fix-success criterion)."""
+    config = _make_config(tmp_path)
+    adapted = _apply_complexity_adaptation(config, "medium", complexity_score=7)
+    assert adapted.model_registry_sources[_CUSTOM_KEY] == "forge.yaml"
+    assert adapted.model_registry_sources["claude/sonnet"] == "builtin"
+
+
+# ── escalation paths use merged registry ──────────────────────────────
+
+
+def test_escalate_dev_model_includes_custom_model(tmp_path):
+    """A custom 'strong' model is a valid escalation target for a built-in mid model."""
+    merged = _merged_registry()
+    next_key = _escalate_dev_model(
+        "claude/sonnet", ["claude/sonnet", _CUSTOM_KEY], registry=merged
+    )
+    assert next_key == _CUSTOM_KEY
+
+
+def test_find_registry_key_for_profile_resolves_custom_model(tmp_path):
+    custom_profile = ModelProfile(
+        name="openai-gpt-5.5",
+        cli=None,
+        provider="openai",
+        model="gpt-5.5",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    merged = _merged_registry()
+    key = _find_registry_key_for_profile(custom_profile, registry=merged)
+    assert key == _CUSTOM_KEY


### PR DESCRIPTION
## Summary

[claude-sonnet] Clean targeted fix — threaded ForgeConfig.model_registry through all coordinator consumers, zero remaining AGENT_REGISTRY references in coordinator paths, tests cover the exact failure modes from the spec. | [deepseek-deepseek-reasoner] Threads merged model registry through all coordinator preflight/escalation consumers, eliminating the custom-model crash; all 6 regression tests pass and audit attribution is preserved.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $5.67
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/dev_phase.py:836`** config.model_registry or None uses falsy-dict evaluation on a field typed dict[str, AgentSpec] with default_factory=dict. An empty dict would silently fall back to AGENT_REGISTRY. Functionally harmless (model_registry is always populated by load.py), but the idiom is fragile for directly-constructed ForgeConfig objects.
- **[P2] `tests/test_preflight_custom_model.py:106`** test_build_pool_entries_without_registry_raises_for_custom_key imports pytest inline rather than at the top of the module — project convention for test files typically uses top-level imports.

## Story

Custom model registry overlay bypassed by AGENT_REGISTRY direct-readers, crashing workers on declared models (GitHub Issue #1355)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1355