### PR TITLE
Intake remediation gate produces no output on shape-gate skips when auto_fix_mode=comment is enabled

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -244,6 +244,7 @@ def _emit_all_skipped_audit(
     sprint_name: str,
     budget_usd: float,
     skipped_issues: list,
+    intake_outcomes: "dict | None" = None,
 ) -> None:
     """Write sprint-audit.yaml and sprint-summary.yaml when every issue was
     gated out. Without this, an all-skipped sprint leaves no machine-readable
@@ -259,6 +260,7 @@ def _emit_all_skipped_audit(
     # issue so the all-skipped audit/summary projects from the same SoT
     # structure run_sprint() uses. Counts and the per-story list both flow
     # from this single source.
+    intake_outcomes = intake_outcomes or {}
     story_state = SprintStoryState()
     for sk in skipped_issues or []:
         sk_dict = sk.as_dict() if hasattr(sk, "as_dict") else dict(sk)
@@ -272,17 +274,25 @@ def _emit_all_skipped_audit(
             if sk_codes
             else (sk_dict.get("detail") or sk_dict.get("source") or "shape-gate")
         )
+        sk_detail: dict = {
+            "shape_gate_source": sk_dict.get("source"),
+            "shape_gate_codes": list(sk_codes),
+            "final_outcome": "SKIPPED",
+        }
+        outcome = intake_outcomes.get(sk_num)
+        if outcome is not None:
+            sk_detail["intake_kind"] = outcome.kind.value
+            sk_detail["intake_detail"] = outcome.detail
+            sk_detail["intake_findings"] = [f.as_dict() for f in outcome.findings]
+            sk_detail["intake_audit"] = dict(outcome.audit)
+            sk_detail["intake_proposed_replacement"] = outcome.proposed_replacement
         story_state.register(
             sk_slug,
             f"Issue #{sk_num}",
             outcome=StoryOutcome.SKIPPED,
             reason=sk_reason,
             canonical_ref=f"issue:{sk_num}",
-            detail={
-                "shape_gate_source": sk_dict.get("source"),
-                "shape_gate_codes": list(sk_codes),
-                "final_outcome": "SKIPPED",
-            },
+            detail=sk_detail,
         )
     canonical_counts = story_state.counts()
     manifest = ResolvedSprint(
@@ -355,6 +365,7 @@ def _run_query_mode(
 ) -> int:
     """Handle --milestone / --label / --issues query mode."""
     from theforge.sprint.dag import resolve_satisfied_dependencies
+    from theforge.sprint.entry_intake import remediate_entry_skipped_issues
     from theforge.sprint.query import (
         assign_dependency_batches_with_satisfied,
         build_resolved_sprint,
@@ -438,6 +449,18 @@ def _run_query_mode(
         issues = gate_result.runnable
         skipped_issues = gate_result.skipped
 
+        # Bridge to intake remediation: entry-skipped issues bypass the
+        # in-runner remediation pass, so route them through here. Suppress
+        # remediation under --force, which is the operator's explicit
+        # escape hatch.
+        entry_intake_outcomes: dict[int, object] = {}
+        if skipped_issues and not force:
+            entry_intake_outcomes = remediate_entry_skipped_issues(
+                skipped_issues,
+                config=config,
+                log=lambda m: print(f"[forge] {m}", file=sys.stderr),
+            )
+
         if not issues:
             print(
                 f"[forge] All {len(skipped_issues)} issue(s) skipped by shape gate "
@@ -452,6 +475,7 @@ def _run_query_mode(
                 or f"issues-{issues_arg}",
                 budget_usd=budget_usd,
                 skipped_issues=skipped_issues,
+                intake_outcomes=entry_intake_outcomes,
             )
             return 0
 
@@ -551,6 +575,7 @@ def _run_query_mode(
             run_id=run_id,
             dropped_slugs=dropped_slugs,
             skipped_issues=skipped_issues,
+            entry_intake_outcomes=entry_intake_outcomes,
         )
     except Exception as exc:
         import traceback

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -845,6 +845,7 @@ def _write_sprint_summary(
                     "batch": 0,
                     "depends_on": list(entry.depends_on),
                     "drop_reason": entry.reason,
+                    "detail": dict(entry.detail) if entry.detail else None,
                 }
             )
     else:

--- a/src/theforge/sprint/entry_intake.py
+++ b/src/theforge/sprint/entry_intake.py
@@ -1,0 +1,102 @@
+"""Bridge: run intake remediation on issues skipped by the sprint-entry shape gate.
+
+The entry shape gate at ``cli/sprint.py`` filters issues before ``run_sprint``
+is invoked. Without this bridge, those skipped issues bypass the intake
+remediation pass that lives inside ``run_sprint``, defeating the operator-
+visible contract that remediation must run in response to every shape-gate
+rejection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from ..intake import IntakeOutcome, IntakeOutcomeKind
+from ..task import TaskStory
+from .shape_gate import SkippedIssue
+
+if TYPE_CHECKING:
+    from ..config import ForgeConfig
+
+
+def remediate_entry_skipped_issues(
+    skipped_issues: list[SkippedIssue],
+    *,
+    config: "ForgeConfig",
+    log: Callable[[str], None],
+) -> dict[int, IntakeOutcome]:
+    """Run the intake remediation gate over entry-skipped issues.
+
+    Returns a mapping of ``issue_number`` → :class:`IntakeOutcome`. When intake
+    is fully disabled (both ``grooming`` and ``auto_fix`` False), returns an
+    empty dict so callers behave exactly as before.
+
+    Outcomes whose ``kind`` is ``PASSED`` despite a non-empty entry-skip
+    reason set are converted into ``DROPPED_SHAPE`` with an explicit
+    ``intake remediation declined`` detail. The body-only intake checks
+    can't see entry-skip categories like ``reopened_stale_contract`` that
+    depend on the issue timeline; recording the decline gives the operator
+    a written reason rather than silence.
+    """
+    if not skipped_issues:
+        return {}
+
+    intake_cfg = getattr(config, "intake", None)
+    grooming_enabled = bool(getattr(intake_cfg, "grooming", False))
+    auto_fix_enabled = bool(getattr(intake_cfg, "auto_fix", False))
+    if not grooming_enabled and not auto_fix_enabled:
+        return {}
+
+    # Lazy import: runner.py is heavy and pulls in coordinator-side code.
+    from .runner import _run_intake_remediation_pass
+
+    tasks: list[TaskStory] = []
+    slug_to_number: dict[str, int] = {}
+    for sk in skipped_issues:
+        slug = f"issue-{sk.issue_number}"
+        tasks.append(
+            TaskStory(
+                name=f"Issue #{sk.issue_number}",
+                slug=slug,
+                github_issue=sk.issue_number,
+            )
+        )
+        slug_to_number[slug] = sk.issue_number
+
+    slug_outcomes = _run_intake_remediation_pass(
+        config=config,
+        tasks=tasks,
+        log=log,
+    )
+
+    outcomes: dict[int, IntakeOutcome] = {}
+    skip_by_number = {sk.issue_number: sk for sk in skipped_issues}
+    for slug, outcome in slug_outcomes.items():
+        issue_num = slug_to_number.get(slug)
+        if issue_num is None:
+            continue
+        sk = skip_by_number.get(issue_num)
+        if outcome.kind is IntakeOutcomeKind.PASSED and sk is not None and sk.reason_codes:
+            codes = ", ".join(sk.reason_codes)
+            outcome = IntakeOutcome(
+                slug=slug,
+                kind=IntakeOutcomeKind.DROPPED_SHAPE,
+                findings=outcome.findings,
+                detail=(
+                    f"intake remediation declined: shape-gate skip reason "
+                    f"'{codes}' is not covered by body-only intake checks"
+                ),
+                audit={
+                    "remediation_source": "declined",
+                    "shape_gate_codes": list(sk.reason_codes),
+                    "shape_gate_source": sk.source,
+                    "shape_gate_detail": sk.detail,
+                },
+            )
+        outcomes[issue_num] = outcome
+        log(
+            f"Entry shape-gate skip remediation: issue #{issue_num} "
+            f"-> {outcome.kind.value}" + (f" ({outcome.detail})" if outcome.detail else "")
+        )
+    return outcomes

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1154,6 +1154,7 @@ def run_sprint(
     run_id: str | None = None,
     dropped_slugs: "dict[str, str] | None" = None,
     skipped_issues: "list | None" = None,
+    entry_intake_outcomes: "dict[int, IntakeOutcome] | None" = None,
 ) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -1820,16 +1821,24 @@ def run_sprint(
                 if _sk_codes
                 else (_sk_dict.get("detail") or _sk_dict.get("source") or "shape-gate")
             )
+            _sk_detail: dict = {
+                "shape_gate_source": _sk_dict.get("source"),
+                "shape_gate_codes": list(_sk_codes),
+                "final_outcome": "SKIPPED",
+            }
+            _sk_intake = (entry_intake_outcomes or {}).get(_sk_num)
+            if _sk_intake is not None:
+                _sk_detail["intake_kind"] = _sk_intake.kind.value
+                _sk_detail["intake_detail"] = _sk_intake.detail
+                _sk_detail["intake_findings"] = [f.as_dict() for f in _sk_intake.findings]
+                _sk_detail["intake_audit"] = dict(_sk_intake.audit)
+                _sk_detail["intake_proposed_replacement"] = _sk_intake.proposed_replacement
             _state_writer.register(
                 _sk_slug,
                 f"Issue #{_sk_num}",
                 outcome=StoryOutcome.SKIPPED,
                 reason=_sk_reason,
-                detail={
-                    "shape_gate_source": _sk_dict.get("source"),
-                    "shape_gate_codes": list(_sk_codes),
-                    "final_outcome": "SKIPPED",
-                },
+                detail=_sk_detail,
             )
     elif skipped_issues or []:
         # Headless invocation (no run_id) — still register skipped issues in
@@ -1842,11 +1851,22 @@ def run_sprint(
             _sk_slug = f"issue-{_sk_num}"
             _sk_codes = _sk_dict.get("reason_codes") or []
             _sk_reason = ", ".join(_sk_codes) if _sk_codes else "shape-gate"
+            _sk_intake = (entry_intake_outcomes or {}).get(_sk_num)
+            _sk_detail = None
+            if _sk_intake is not None:
+                _sk_detail = {
+                    "intake_kind": _sk_intake.kind.value,
+                    "intake_detail": _sk_intake.detail,
+                    "intake_findings": [f.as_dict() for f in _sk_intake.findings],
+                    "intake_audit": dict(_sk_intake.audit),
+                    "intake_proposed_replacement": _sk_intake.proposed_replacement,
+                }
             _story_state.register(
                 _sk_slug,
                 f"Issue #{_sk_num}",
                 outcome=StoryOutcome.SKIPPED,
                 reason=_sk_reason,
+                detail=_sk_detail,
             )
 
     # Parallel scheduling state

--- a/tests/test_cli_sprint_shape_gate.py
+++ b/tests/test_cli_sprint_shape_gate.py
@@ -249,6 +249,128 @@ def test_cli_passes_configured_classifier_to_shape_gate(tmp_path: Path) -> None:
     assert captured["kwargs"]["classifier_mode"] == "llm"
 
 
+def test_cli_all_skipped_runs_intake_remediation_bridge(tmp_path: Path) -> None:
+    """When every issue is skipped at the entry gate and intake remediation
+    is enabled, the bridge fires, posts the outcome into the audit/summary
+    YAML, and the sprint exits with the shape-gate-skipped issue marked
+    with an intake outcome — not silently dropped."""
+    import yaml
+
+    from theforge.config.types import IntakeConfig
+    from theforge.intake import IntakeOutcome, IntakeOutcomeKind
+
+    config = _make_config(tmp_path)
+    object.__setattr__(
+        config,
+        "intake",
+        IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="comment"),
+    )
+    args = _query_args(tmp_path)
+
+    fetched = [{"number": 1014, "title": "bad"}]
+    gated = ShapeGateResult(
+        runnable=[],
+        skipped=[
+            SkippedIssue(
+                issue_number=1014,
+                reason_codes=("implementation_plan_in_body",),
+                source="local_check",
+                title="bad",
+                detail="HOW belongs in plan, not body",
+            )
+        ],
+    )
+
+    def fake_remediate(skipped, **_kw):
+        # Emulate the bridge having run remediation in comment mode.
+        return {
+            sk.issue_number: IntakeOutcome(
+                slug=f"issue-{sk.issue_number}",
+                kind=IntakeOutcomeKind.DROPPED_SHAPE,
+                detail="comment mode: proposed replacement posted; story dropped",
+                audit={
+                    "remediation_source": "agent",
+                    "comment_posted": True,
+                },
+            )
+            for sk in skipped
+        }
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=config),
+        patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+        patch("theforge.sprint.query.fetch_issues_for_milestone", return_value=fetched),
+        patch("theforge.sprint.shape_gate.apply_shape_gate", return_value=gated),
+        patch(
+            "theforge.sprint.entry_intake.remediate_entry_skipped_issues",
+            side_effect=fake_remediate,
+        ),
+    ):
+        rc = cmd_sprint(args)
+
+    assert rc == 0
+
+    summary_path = tmp_path / ".forge" / "logs" / "v0.5.0" / "sprint-summary.yaml"
+    assert summary_path.exists()
+    summary = yaml.safe_load(summary_path.read_text())
+
+    # Bridge outcome must appear in the per-story detail so the operator
+    # can see remediation activity rather than silence.
+    stories = summary.get("stories") or []
+    target = next((s for s in stories if s.get("slug") == "issue-1014"), None)
+    assert target is not None, summary
+    detail = target.get("detail") or {}
+    assert detail.get("intake_kind") == "dropped_shape"
+    assert detail.get("intake_audit", {}).get("comment_posted") is True
+
+
+def test_cli_all_skipped_skips_remediation_under_force(tmp_path: Path) -> None:
+    """--force is the operator's explicit escape hatch; the bridge must not
+    fire and must not post comments behind the operator's back."""
+    config = _make_config(tmp_path)
+    args = _query_args(tmp_path, force=True)
+
+    fetched = [{"number": 2, "title": "bad"}]
+    gated = ShapeGateResult(
+        runnable=fetched,  # force=True returns all as runnable
+        skipped=[
+            SkippedIssue(
+                issue_number=2,
+                reason_codes=("missing_ac",),
+                source="local_check",
+                title="bad",
+            )
+        ],
+    )
+
+    bridge_calls: list = []
+
+    def spy(skipped, **_kw):
+        bridge_calls.append(list(skipped))
+        return {}
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=config),
+        patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+        patch("theforge.sprint.query.fetch_issues_for_milestone", return_value=fetched),
+        patch("theforge.sprint.query.build_resolved_sprint", return_value=_resolved([2])),
+        patch("theforge.sprint.shape_gate.apply_shape_gate", return_value=gated),
+        patch(
+            "theforge.sprint.entry_intake.remediate_entry_skipped_issues",
+            side_effect=spy,
+        ),
+        patch(
+            "theforge.cli.sprint._acquire_launch_locks",
+            return_value=([], None, {}),
+        ),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint.run_sprint", return_value=_ok_result()),
+    ):
+        cmd_sprint(args)
+
+    assert bridge_calls == []
+
+
 def test_cli_query_mode_force_runs_every_issue_but_warns(tmp_path: Path, capsys) -> None:
     config = _make_config(tmp_path)
     args = _query_args(tmp_path, force=True)

--- a/tests/test_sprint_entry_intake.py
+++ b/tests/test_sprint_entry_intake.py
@@ -1,0 +1,143 @@
+"""Tests for the entry shape-gate -> intake remediation bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from theforge.config import (
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.config.types import IntakeConfig
+from theforge.intake import IntakeOutcome, IntakeOutcomeKind
+from theforge.sprint.entry_intake import remediate_entry_skipped_issues
+from theforge.sprint.shape_gate import SkippedIssue
+
+
+def _make_config(tmp_path: Path, *, intake: IntakeConfig | None = None) -> ForgeConfig:
+    cfg = ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        ),
+        preflight_profile=ModelProfile(
+            name="preflight",
+            cli="claude",
+            model="sonnet",
+            budget_usd=0.5,
+            timeout_seconds=120,
+            allowed_tools=("Read",),
+        ),
+        review_pool=[],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        plan_agent_review=PlanAgentReviewConfig(enabled=False),
+        log=LogConfig(enabled=False),
+    )
+    if intake is not None:
+        object.__setattr__(cfg, "intake", intake)
+    return cfg
+
+
+def _skipped(num: int, *codes: str, source: str = "local_check") -> SkippedIssue:
+    return SkippedIssue(
+        issue_number=num,
+        reason_codes=tuple(codes),
+        source=source,
+        title=f"#{num}",
+        detail="; ".join(codes),
+    )
+
+
+def test_returns_empty_when_intake_disabled(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)  # default intake: both disabled
+    outcomes = remediate_entry_skipped_issues(
+        [_skipped(1, "implementation_plan_in_body")],
+        config=config,
+        log=lambda _m: None,
+    )
+    assert outcomes == {}
+
+
+def test_returns_empty_when_no_skipped(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        intake=IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="comment"),
+    )
+    assert remediate_entry_skipped_issues([], config=config, log=lambda _m: None) == {}
+
+
+def test_passing_body_with_entry_skip_records_declined(tmp_path: Path) -> None:
+    """Entry skip whose category isn't covered by body-only checks lands as
+    DROPPED_SHAPE with a written 'declined' detail rather than silence."""
+    config = _make_config(
+        tmp_path,
+        intake=IntakeConfig(grooming=True, auto_fix=False, auto_fix_mode="comment"),
+    )
+
+    def fake_pass(*, config, tasks, log):  # noqa: ARG001
+        return {t.slug: IntakeOutcome(slug=t.slug, kind=IntakeOutcomeKind.PASSED) for t in tasks}
+
+    logs: list[str] = []
+    with patch("theforge.sprint.runner._run_intake_remediation_pass", side_effect=fake_pass):
+        outcomes = remediate_entry_skipped_issues(
+            [_skipped(1135, "reopened_stale_contract")],
+            config=config,
+            log=logs.append,
+        )
+
+    assert 1135 in outcomes
+    outcome = outcomes[1135]
+    assert outcome.kind is IntakeOutcomeKind.DROPPED_SHAPE
+    assert "declined" in outcome.detail
+    assert "reopened_stale_contract" in outcome.detail
+    assert outcome.audit["remediation_source"] == "declined"
+    assert outcome.audit["shape_gate_codes"] == ["reopened_stale_contract"]
+    # Operator-visible log line ensures non-silence.
+    assert any("issue #1135" in line for line in logs)
+
+
+def test_remediation_outcome_passes_through(tmp_path: Path) -> None:
+    """Non-PASSED remediation outcomes flow back unchanged, keyed by issue#."""
+    config = _make_config(
+        tmp_path,
+        intake=IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="comment"),
+    )
+
+    def fake_pass(*, config, tasks, log):  # noqa: ARG001
+        return {
+            tasks[0].slug: IntakeOutcome(
+                slug=tasks[0].slug,
+                kind=IntakeOutcomeKind.DROPPED_SHAPE,
+                detail="comment mode: proposed replacement posted; story dropped",
+                audit={"remediation_source": "agent", "comment_posted": True},
+            )
+        }
+
+    with patch("theforge.sprint.runner._run_intake_remediation_pass", side_effect=fake_pass):
+        outcomes = remediate_entry_skipped_issues(
+            [_skipped(1014, "implementation_plan_in_body")],
+            config=config,
+            log=lambda _m: None,
+        )
+
+    assert outcomes[1014].kind is IntakeOutcomeKind.DROPPED_SHAPE
+    assert outcomes[1014].audit.get("comment_posted") is True


### PR DESCRIPTION
## Summary

[openai-gpt-5.4] The entry-shape-gate remediation bridge is wired onto the real early-exit path, persists operator-visible remediation detail, and is covered by targeted regression tests for the reported silent-drop cases. | [deepseek-deepseek-reasoner] The bridge correctly routes entry shape-gate skips through the intake remediation pass before the all-skipped early-exit, posting outcomes into audit/summary YAML and logging. All acceptance criteria are met, all tests pass, and project conventions are followed.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $5.08
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Intake remediation gate produces no output on shape-gate skips when auto_fix_mode=comment is enabled (GitHub Issue #1354)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1354