### PR TITLE
complexity_score (1-10) never reaches sprint status or logs — display still shows band string

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -212,11 +212,17 @@ def _print_story_line(entry: object, status_icons: dict, indent: int) -> None:
     elapsed_s = getattr(entry, "elapsed_seconds", None)
     detail = getattr(entry, "detail", "")
     complexity = getattr(entry, "complexity", None)
+    complexity_score = getattr(entry, "complexity_score", None)
     model = getattr(entry, "model", None)
 
     phase_str = phase if phase else "—"
     stage_str = stage if stage else "—"
-    complexity_str = complexity if complexity else "—"
+    if isinstance(complexity_score, int):
+        complexity_str = str(complexity_score)
+    elif complexity:
+        complexity_str = complexity
+    else:
+        complexity_str = "—"
     model_str = model if model else "—"
     if len(model_str) > 24:
         model_str = model_str[:24]

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -384,6 +384,7 @@ def _coordinator_loop(
                         "iteration": state.dev_iteration,
                         "cost_usd": state.total_cost,
                         "complexity": state.preflight_complexity,
+                        "complexity_score": state.preflight_complexity_score,
                         "current_model": config.dev_profile.model,
                         "detail": {
                             "review_cycle": state.review_cycle,
@@ -414,6 +415,7 @@ def _coordinator_loop(
                         "iteration": state.dev_iteration,
                         "cost_usd": state.total_cost,
                         "complexity": state.preflight_complexity,
+                        "complexity_score": state.preflight_complexity_score,
                         "current_model": config.dev_profile.model,
                         "detail": {
                             "review_cycle": state.review_cycle,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -986,6 +986,8 @@ def _make_worker_phase_fn(
                     update_kwargs["phase"] = phase
                 if "complexity" in updates:
                     update_kwargs["complexity"] = updates["complexity"]
+                if "complexity_score" in updates:
+                    update_kwargs["complexity_score"] = updates["complexity_score"]
                 if "cost_usd" in updates:
                     update_kwargs["cost_usd"] = updates["cost_usd"]
                 if "current_model" in updates:

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -26,6 +26,7 @@ class StoryStatusEntry:
     stage: str = ""
     detail: str = ""
     complexity: str | None = None
+    complexity_score: int | None = None
     model: str | None = None
 
 
@@ -142,6 +143,14 @@ def _outcome_to_status(outcome: str) -> str:
     if outcome in ("ESCALATE", "MERGE_FAILED"):
         return "failed"
     return "failed"
+
+
+def _normalize_complexity_score(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
 
 
 def _normalize_complexity(value: object) -> str | None:
@@ -501,6 +510,7 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
 
         bundle_candidate = False
         complexity = None
+        complexity_score: int | None = None
         audit_data: dict | None = None
         if slug:
             audit_path = sprint_log_dir / slug / "audit.yaml"
@@ -513,6 +523,9 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
                         if isinstance(preflight, dict):
                             bundle_candidate = bool(preflight.get("bundle_candidate", False))
                             complexity = _normalize_complexity(preflight.get("complexity"))
+                            complexity_score = _normalize_complexity_score(
+                                preflight.get("complexity_score")
+                            )
                 except Exception:
                     pass
 
@@ -543,6 +556,7 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
                 stage=stage,
                 detail=detail,
                 complexity=complexity,
+                complexity_score=complexity_score,
                 model=model_val,
             )
         )
@@ -586,6 +600,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
         if status_val in {"waiting", "blocked"} and blocked_by_val:
             phase_display = "waiting"
         stage, detail, complexity = _stage_and_detail_from_live_story(story)
+        complexity_score = _normalize_complexity_score(story.get("complexity_score"))
 
         if status_val in {"skipped", "blocked"}:
             model_val: str | None = None
@@ -606,6 +621,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                 stage=stage,
                 detail=detail,
                 complexity=complexity,
+                complexity_score=complexity_score,
                 model=model_val,
             )
         )

--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -159,6 +159,7 @@ class StoryStateEntry:
     bundle_candidate: bool = False
     blocked_by: list[str] = field(default_factory=list)
     complexity: str | None = None
+    complexity_score: int | None = None
     detail: dict = field(default_factory=dict)
     reason: str | None = None
     canonical_ref: str | None = None
@@ -209,6 +210,7 @@ class StoryStateEntry:
             "bundle_candidate": self.bundle_candidate,
             "blocked_by": list(self.blocked_by),
             "complexity": self.complexity,
+            "complexity_score": self.complexity_score,
             "detail": deepcopy(merged_detail),
             "reason": self.reason,
             "canonical_ref": self.canonical_ref,
@@ -246,6 +248,7 @@ class SprintStoryState:
         bundle_candidate: bool = False,
         blocked_by: list[str] | None = None,
         complexity: str | None = None,
+        complexity_score: int | None = None,
         detail: dict | None = None,
         reason: str | None = None,
         canonical_ref: str | None = None,
@@ -273,6 +276,8 @@ class SprintStoryState:
                 entry.blocked_by = list(blocked_by)
             if complexity is not None:
                 entry.complexity = complexity
+            if complexity_score is not None:
+                entry.complexity_score = complexity_score
             if detail is not None:
                 entry.detail = dict(detail)
             if reason is not None:
@@ -317,6 +322,11 @@ class SprintStoryState:
                     entry.blocked_by = list(v)
                 elif k == "complexity":
                     entry.complexity = v  # type: ignore[assignment]
+                elif k == "complexity_score":
+                    if isinstance(v, int):
+                        entry.complexity_score = v
+                    elif v is None:
+                        entry.complexity_score = None
                 elif k == "detail" and isinstance(v, dict):
                     entry.detail = dict(v)
                 elif k == "reason":
@@ -385,6 +395,11 @@ class SprintStoryState:
                 bundle_candidate=bool(d.get("bundle_candidate", False)),
                 blocked_by=list(d.get("blocked_by") or []),
                 complexity=d.get("complexity"),
+                complexity_score=(
+                    d.get("complexity_score")
+                    if isinstance(d.get("complexity_score"), int)
+                    else None
+                ),
                 detail=dict(d.get("detail") or {}),
                 reason=d.get("reason"),
                 canonical_ref=d.get("canonical_ref"),
@@ -402,6 +417,7 @@ class SprintStoryState:
                     "bundle_candidate",
                     "blocked_by",
                     "complexity",
+                    "complexity_score",
                     "detail",
                     "reason",
                     "canonical_ref",

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -80,6 +80,7 @@ def test_read_live_status_parses_state_file(tmp_path: Path) -> None:
                 "bundle_candidate": False,
                 "blocked_by": [],
                 "complexity": "medium",
+                "complexity_score": 7,
                 "detail": {"dev_iteration": 2, "dev_max_iterations": 3},
             },
             {
@@ -106,6 +107,7 @@ def test_read_live_status_parses_state_file(tmp_path: Path) -> None:
     assert e1.cost_usd == pytest.approx(0.12)
     assert e1.bundle_candidate is False
     assert e1.complexity == "medium"
+    assert e1.complexity_score == 7
     assert e1.stage == "iter=2/3"
     assert e1.detail == "running"
 
@@ -366,7 +368,7 @@ def test_read_completed_status_uses_audit_for_terminal_stage_and_detail(tmp_path
     audit_dir = tmp_path / ".forge" / "logs" / "audit-sprint" / "issue-8"
     audit_dir.mkdir(parents=True, exist_ok=True)
     audit_data = {
-        "preflight": {"complexity": "medium"},
+        "preflight": {"complexity": "medium", "complexity_score": 4},
         "reviews": [
             {
                 "verdict": "APPROVE",
@@ -384,6 +386,7 @@ def test_read_completed_status_uses_audit_for_terminal_stage_and_detail(tmp_path
     assert entries[0].stage == "2 cyc / 1 iter"
     assert entries[0].detail == "APPROVE 0P1 0P2 — No findings remain."
     assert entries[0].complexity == "medium"
+    assert entries[0].complexity_score == 4
 
 
 def test_read_completed_status_already_done_prefers_preflight_reason(tmp_path: Path) -> None:
@@ -772,6 +775,74 @@ def test_display_sprint_status_column_header_present(tmp_path: Path) -> None:
     assert "DETAIL" in output
 
 
+def test_display_sprint_status_prefers_numeric_complexity_score(tmp_path: Path) -> None:
+    """When a numeric complexity_score is available, the COMPLEXITY column shows it
+    instead of the band string."""
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "score-run.pid").write_text("12345\nscore-sprint\n")
+
+    _make_state_file(
+        tmp_path,
+        "score-run",
+        "score-sprint",
+        [
+            {
+                "slug": "issue-77",
+                "path": "Issue #77",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 0.05,
+                "bundle_candidate": False,
+                "blocked_by": [],
+                "complexity": "medium",
+                "complexity_score": 7,
+                "detail": {"dev_iteration": 1, "dev_max_iterations": 3},
+            },
+        ],
+    )
+
+    code, output = _run_sprint_status(tmp_path, "score-run")
+    assert code == 0
+    assert " 7 " in output or output.rstrip().endswith(" 7")
+    # Header still says COMPLEXITY but the row value should not be the band.
+    row_lines = [line for line in output.splitlines() if "Issue #77" in line]
+    assert row_lines, output
+    assert "medium" not in row_lines[0]
+
+
+def test_display_sprint_status_falls_back_to_band_when_score_absent(tmp_path: Path) -> None:
+    """Without a complexity_score, the COMPLEXITY column still shows the band."""
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "band-run.pid").write_text("12345\nband-sprint\n")
+
+    _make_state_file(
+        tmp_path,
+        "band-run",
+        "band-sprint",
+        [
+            {
+                "slug": "issue-78",
+                "path": "Issue #78",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 0.05,
+                "bundle_candidate": False,
+                "blocked_by": [],
+                "complexity": "large",
+                "detail": {"dev_iteration": 1, "dev_max_iterations": 3},
+            },
+        ],
+    )
+
+    code, output = _run_sprint_status(tmp_path, "band-run")
+    assert code == 0
+    row_lines = [line for line in output.splitlines() if "Issue #78" in line]
+    assert row_lines, output
+    assert "large" in row_lines[0]
+
+
 def test_display_sprint_status_wraps_long_detail_without_truncation(tmp_path: Path) -> None:
     runs_dir = tmp_path / ".forge" / "runs"
     runs_dir.mkdir(parents=True, exist_ok=True)
@@ -949,6 +1020,7 @@ def test_worker_phase_fn_forwards_coordinator_detail(tmp_path: Path) -> None:
             "iteration": 0,
             "cost_usd": 0.01,
             "complexity": "medium",
+            "complexity_score": 6,
             "detail": {
                 "preflight_verdict": "PROCEED",
                 "preflight_sufficiency": "implementation_ready",
@@ -959,6 +1031,7 @@ def test_worker_phase_fn_forwards_coordinator_detail(tmp_path: Path) -> None:
     story = data["stories"][0]
     assert story["phase"] == "PREFLIGHT"
     assert story["complexity"] == "medium"
+    assert story["complexity_score"] == 6
     assert story["detail"]["preflight_verdict"] == "PROCEED"
     assert story["detail"]["preflight_sufficiency"] == "implementation_ready"
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.4] Numeric complexity_score is threaded through the live and completed sprint-status paths and the observed band-only display symptom is covered by targeted tests. | [deepseek-deepseek-reasoner] Change correctly threads numeric complexity_score through the entire display pipeline from coordinator state to sprint-status output. Implementation is clean, well-tested, and satisfies all acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $4.97
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/status_reader.py:526`** read_completed_status reads complexity_score from audit preflight, but the corresponding _stage_and_detail_from_completed_story helper at line 390 still only reads preflight.get('complexity') for its own internal complexity variable. This is not a bug because complexity_score is passed separately into StoryStatusEntry, but the asymmetry could confuse future maintainers.

## Story

complexity_score (1-10) never reaches sprint status or logs — display still shows band string (GitHub Issue #1364)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1364