### PR TITLE
Auto-scale gate_timeout with --parallel to prevent contention-driven escalations

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -518,6 +518,8 @@ def load_config(config_path: Path) -> ForgeConfig:
         gate_debug_timeout=val_data.get("gate_debug_timeout"),
         test_command=val_data.get("test_command"),
         pre_validate_command=val_data.get("pre_validate_command"),
+        gate_cpu_cores=val_data.get("gate_cpu_cores"),
+        gate_timeout_scale=str(val_data.get("gate_timeout_scale", "adaptive")),
     )
 
     # ── v0.8 models: key ──────────────────────────────────────────────

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -236,6 +236,13 @@ class ValidationConfig:
     gate_debug_timeout: int | None = None  # seconds; None = same resolved value as gate_timeout
     test_command: str | None = None  # canonical command for intermediate test runs in dev loop
     pre_validate_command: str | None = None  # optional command run before dirty check
+    # Adaptive gate-timeout scaling under sprint --parallel N. The baseline
+    # gate_timeout above is the alone-time budget. When mode == "adaptive"
+    # (default), sprint start scales the effective gate_timeout by host CPU
+    # contention. "fixed" disables scaling so gate_timeout is a hard ceiling
+    # regardless of parallelism.
+    gate_cpu_cores: int | None = None  # operator hint for gate CPU demand; None => host_cores
+    gate_timeout_scale: str = "adaptive"  # "adaptive" | "fixed"
 
 
 @dataclass(frozen=True)

--- a/src/theforge/sprint/gate_timeout_resolver.py
+++ b/src/theforge/sprint/gate_timeout_resolver.py
@@ -1,0 +1,71 @@
+"""Adaptive gate-timeout resolver.
+
+Computes an effective per-gate timeout from the static baseline and runtime
+contention conditions (host CPU count, gate CPU demand, sprint --parallel N).
+Pure function, stdlib-only — easy to unit-test in isolation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GateTimeoutResolution:
+    """Result of resolving the effective gate timeout for a sprint run."""
+
+    effective_timeout: int
+    baseline: int
+    factor: float
+    overcommit: bool
+    mode: str
+    host_cores: int
+    gate_cpu_cores: int
+    max_parallel: int
+    reason: str
+
+
+def resolve_effective_gate_timeout(
+    baseline: int,
+    max_parallel: int,
+    host_cores: int,
+    gate_cpu_cores: int | None,
+    mode: str,
+) -> GateTimeoutResolution:
+    """Resolve the effective gate timeout given contention conditions.
+
+    Formula:
+        gate_demand_cores = gate_cpu_cores or host_cores
+        demand            = gate_demand_cores * max_parallel
+        factor            = max(1.0, demand / host_cores)
+        effective         = baseline if mode == "fixed" else ceil(baseline * factor)
+        overcommit        = demand > host_cores * 1.5
+    """
+    safe_host = max(1, host_cores)
+    safe_parallel = max(1, max_parallel)
+    gate_demand_cores = gate_cpu_cores if gate_cpu_cores and gate_cpu_cores > 0 else safe_host
+    demand = gate_demand_cores * safe_parallel
+    factor = max(1.0, demand / safe_host)
+    normalized_mode = mode if mode in ("adaptive", "fixed") else "adaptive"
+    if normalized_mode == "fixed":
+        effective = int(baseline)
+    else:
+        effective = int(math.ceil(baseline * factor))
+    overcommit = demand > safe_host * 1.5
+    reason = (
+        f"baseline={baseline}s mode={normalized_mode} parallel={safe_parallel} "
+        f"gate_cpu_cores={gate_demand_cores} host_cores={safe_host} "
+        f"demand={demand} factor={factor:.2f} effective={effective}s"
+    )
+    return GateTimeoutResolution(
+        effective_timeout=effective,
+        baseline=int(baseline),
+        factor=factor,
+        overcommit=overcommit,
+        mode=normalized_mode,
+        host_cores=safe_host,
+        gate_cpu_cores=gate_demand_cores,
+        max_parallel=safe_parallel,
+        reason=reason,
+    )

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -65,6 +65,7 @@ from .dag import (
     resolve_satisfied_dependencies,
 )
 from .display import _print_worker_status, _story_header
+from .gate_timeout_resolver import resolve_effective_gate_timeout
 from .lock import integration_lock
 from .manifest import (
     ResolvedSprint,
@@ -1213,6 +1214,57 @@ def run_sprint(
         file=sys.stderr,
         flush=True,
     )
+
+    # Resolve adaptive per-gate timeout once, propagate via dataclasses.replace
+    # so each per-story coordinator invocation reads the scaled value through
+    # the existing config.validation.gate_timeout path.
+    _gate_timeout_resolution = None
+    _baseline_gate_timeout = 600
+    try:
+        _baseline_gate_timeout = int(config.validation.gate_timeout or 600)
+        _host_cores = os.cpu_count() or 1
+        _gate_cpu_raw = config.validation.gate_cpu_cores
+        _gate_cpu_cores = int(_gate_cpu_raw) if _gate_cpu_raw else None
+        _mode = str(config.validation.gate_timeout_scale or "adaptive")
+        _gate_timeout_resolution = resolve_effective_gate_timeout(
+            baseline=_baseline_gate_timeout,
+            max_parallel=max_parallel,
+            host_cores=_host_cores,
+            gate_cpu_cores=_gate_cpu_cores,
+            mode=_mode,
+        )
+    except (TypeError, ValueError):
+        # Mock or partial config in tests; skip adaptive scaling silently.
+        _gate_timeout_resolution = None
+    if _gate_timeout_resolution is not None:
+        print(
+            f"[sprint] gate_timeout: {_gate_timeout_resolution.reason}",
+            file=sys.stderr,
+            flush=True,
+        )
+    if _gate_timeout_resolution is not None and _gate_timeout_resolution.overcommit:
+        _gpc = _gate_timeout_resolution.gate_cpu_cores
+        _mp = _gate_timeout_resolution.max_parallel
+        _hc = _gate_timeout_resolution.host_cores
+        print(
+            f"[sprint] WARNING: gate CPU demand ({_gpc} cores × parallel {_mp} = "
+            f"{_gpc * _mp} cores) exceeds host capacity ({_hc} cores) by >50%; "
+            "consider lowering --parallel to avoid contention-driven gate timeouts",
+            file=sys.stderr,
+            flush=True,
+        )
+    if (
+        _gate_timeout_resolution is not None
+        and _gate_timeout_resolution.effective_timeout != _baseline_gate_timeout
+    ):
+        config = replace(
+            config,
+            validation=replace(
+                config.validation,
+                gate_timeout=_gate_timeout_resolution.effective_timeout,
+            ),
+        )
+
     for warning in _agent_cost_tracking_warnings(config):
         _log(warning)
     for task, _src, _ref in task_entries:

--- a/tests/test_sprint_gate_timeout_scaling.py
+++ b/tests/test_sprint_gate_timeout_scaling.py
@@ -1,0 +1,213 @@
+"""Adaptive gate-timeout scaling under sprint --parallel N.
+
+Covers:
+  - Pure resolver math (factor, mode, overcommit).
+  - Seam-level integration: run_sprint resolves the effective timeout once at
+    sprint start and propagates it through worker_config so the per-story
+    coordinator invocation reads the scaled value via config.validation.gate_timeout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    SprintConfig,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.sprint import run_sprint
+from theforge.sprint.gate_timeout_resolver import resolve_effective_gate_timeout
+
+# ── Pure resolver tests ───────────────────────────────────────────────────────
+
+
+class TestResolveEffectiveGateTimeout:
+    def test_parallel_one_factor_is_baseline(self) -> None:
+        r = resolve_effective_gate_timeout(
+            baseline=45, max_parallel=1, host_cores=10, gate_cpu_cores=7, mode="adaptive"
+        )
+        assert r.factor == 1.0
+        assert r.effective_timeout == 45
+        assert r.overcommit is False
+
+    def test_parallel_n_scales_up(self) -> None:
+        r = resolve_effective_gate_timeout(
+            baseline=45, max_parallel=3, host_cores=10, gate_cpu_cores=7, mode="adaptive"
+        )
+        # demand = 21, factor = 2.1, effective = ceil(45*2.1) = 95
+        assert r.factor == 2.1
+        assert r.effective_timeout == 95
+        assert r.overcommit is True
+
+    def test_fixed_mode_preserves_baseline(self) -> None:
+        r = resolve_effective_gate_timeout(
+            baseline=45, max_parallel=3, host_cores=10, gate_cpu_cores=7, mode="fixed"
+        )
+        assert r.effective_timeout == 45
+        assert r.mode == "fixed"
+
+    def test_overcommit_threshold_is_1_5x_host(self) -> None:
+        # demand = 12, host = 10, ratio = 1.2 → not overcommit
+        r = resolve_effective_gate_timeout(
+            baseline=60, max_parallel=2, host_cores=10, gate_cpu_cores=6, mode="adaptive"
+        )
+        assert r.overcommit is False
+
+        # demand = 16, host = 10, ratio = 1.6 → overcommit
+        r2 = resolve_effective_gate_timeout(
+            baseline=60, max_parallel=2, host_cores=10, gate_cpu_cores=8, mode="adaptive"
+        )
+        assert r2.overcommit is True
+
+    def test_gate_cpu_cores_none_defaults_to_host_cores(self) -> None:
+        r = resolve_effective_gate_timeout(
+            baseline=30, max_parallel=2, host_cores=8, gate_cpu_cores=None, mode="adaptive"
+        )
+        # demand = 8 * 2 = 16, factor = 2.0
+        assert r.gate_cpu_cores == 8
+        assert r.factor == 2.0
+        assert r.effective_timeout == 60
+
+    def test_unknown_mode_defaults_to_adaptive(self) -> None:
+        r = resolve_effective_gate_timeout(
+            baseline=10, max_parallel=2, host_cores=2, gate_cpu_cores=2, mode="bogus"
+        )
+        assert r.mode == "adaptive"
+        assert r.effective_timeout == 20
+
+
+# ── Seam-level integration: runner → coordinator config propagation ──────────
+
+
+def _make_config(
+    tmp_path: Path, *, gate_timeout: int, gate_cpu_cores: int | None, mode: str = "adaptive"
+) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=replace(
+            DEFAULT_VALIDATION,
+            gate_timeout=gate_timeout,
+            gate_cpu_cores=gate_cpu_cores,
+            gate_timeout_scale=mode,
+        ),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=1, max_review_cycles=1),
+        sprint=SprintConfig(max_parallel=1),
+    )
+
+
+def _make_spec_file(tmp_path: Path, slug: str) -> None:
+    (tmp_path / f"{slug}.md").write_text(
+        f"---\nname: {slug}\nslug: {slug}\n---\n# {slug}\n",
+        encoding="utf-8",
+    )
+
+
+def _make_manifest(tmp_path: Path, slugs: list[str], max_parallel: int) -> Path:
+    path = tmp_path / "sprint.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "name": "Scale Sprint",
+                "budget_usd": 10.0,
+                "stories": [f"{s}.md" for s in slugs],
+                "max_parallel": max_parallel,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _ok_result() -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    pf = MagicMock()
+    pf.cost_usd = 0.0
+    state.preflight_result = pf
+    return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok")
+
+
+def test_sprint_propagates_scaled_gate_timeout_to_run_task(tmp_path: Path) -> None:
+    """worker_config seen by run_task must carry the scaled gate_timeout."""
+    _make_spec_file(tmp_path, "story-a")
+    manifest_path = _make_manifest(tmp_path, ["story-a"], max_parallel=3)
+    config = _make_config(tmp_path, gate_timeout=45, gate_cpu_cores=7)
+
+    captured: dict = {}
+
+    def fake_run_task(cfg, task, **kwargs):  # type: ignore[no-untyped-def]
+        captured["gate_timeout"] = cfg.validation.gate_timeout
+        captured["mode"] = cfg.validation.gate_timeout_scale
+        return _ok_result()
+
+    with (
+        patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+        patch("os.cpu_count", return_value=10),
+    ):
+        run_sprint(config, manifest_path)
+
+    # Resolver math at parallel=3, gate_cpu=7, host=10 → factor=2.1 → 45*2.1 = 94.5 → ceil=95
+    assert captured["gate_timeout"] == 95
+    # The replace() must not corrupt other fields.
+    assert captured["mode"] == "adaptive"
+
+
+def test_sprint_fixed_mode_keeps_baseline(tmp_path: Path) -> None:
+    """gate_timeout_scale=fixed pins the timeout regardless of --parallel."""
+    _make_spec_file(tmp_path, "story-a")
+    manifest_path = _make_manifest(tmp_path, ["story-a"], max_parallel=3)
+    config = _make_config(tmp_path, gate_timeout=45, gate_cpu_cores=7, mode="fixed")
+
+    captured: dict = {}
+
+    def fake_run_task(cfg, task, **kwargs):  # type: ignore[no-untyped-def]
+        captured["gate_timeout"] = cfg.validation.gate_timeout
+        return _ok_result()
+
+    with (
+        patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+        patch("os.cpu_count", return_value=10),
+    ):
+        run_sprint(config, manifest_path)
+
+    assert captured["gate_timeout"] == 45
+
+
+def test_sprint_emits_overcommit_warning(tmp_path: Path, capsys) -> None:
+    """When demand exceeds 1.5× host cores, an overcommit WARNING is logged."""
+    _make_spec_file(tmp_path, "story-a")
+    manifest_path = _make_manifest(tmp_path, ["story-a"], max_parallel=3)
+    config = _make_config(tmp_path, gate_timeout=45, gate_cpu_cores=7)
+
+    with (
+        patch("theforge.sprint.runner.run_task", return_value=_ok_result()),
+        patch("os.cpu_count", return_value=10),
+    ):
+        run_sprint(config, manifest_path)
+
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "overcommit" in err.lower() or "consider lowering --parallel" in err
+    # And the resolution reasoning line:
+    assert "gate_timeout: baseline=45s" in err


### PR DESCRIPTION
## Summary

[claude-sonnet] Adaptive gate-timeout scaling is correctly implemented and all ACs are met; one P2 for silent normalization of unknown gate_timeout_scale values contrary to config integrity invariant. | [deepseek-deepseek-reasoner] Correctly implements adaptive gate-timeout scaling for sprint --parallel N. Pure resolver computes effective timeout, logging and overcommit warning are emitted, scaled value propagates via dataclasses.replace through existing config path. All acceptance criteria are met, tests pass. | [google-gemini-3.1-pro-preview] Safely implements adaptive gate timeout scaling based on parallelism and host cores.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $8.49
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/gate_timeout_resolver.py:50`** Unknown mode strings (e.g. gate_timeout_scale: typo) are silently normalized to 'adaptive' by the resolver instead of raising a validation error. The config invariant says 'prefer explicit validation errors over permissive fallback behavior that hides bad config.' A typo in forge.yaml will be swallowed without any operator-visible signal, violating the integrity-boundary convention.
- **[P2] `src/theforge/sprint/runner.py:1236`** Catching ValueError and silently skipping adaptive scaling hides invalid user configuration (e.g., if `gate_cpu_cores` is set to a non-integer string). This violates the invariant to prefer explicit validation errors over permissive fallback behavior.

## Story

Auto-scale gate_timeout with --parallel to prevent contention-driven escalations (GitHub Issue #1341)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1341