### PR TITLE
fix(cli): skip mutation guard on any non-story branch context (#1377)

### DIFF
--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -70,10 +70,28 @@ def _current_branch(repo_root: Path) -> str:
 
 
 def _issue_number_from_branch(branch: str) -> int | None:
-    """Extract an issue number from a story branch name like feat/issue-283."""
+    """Extract an issue number from a story branch name.
+
+    Accepts both bare `issue-N` components (as Forge sprint worktrees emit)
+    and descriptive `issue-N-summary` / `issue-N_summary` components (as
+    manual story branches typically use, e.g. `fix/issue-1377-guard-...`).
+    Returns the integer issue number from the first matching component, or
+    None if no component encodes one.
+    """
     for part in branch.split("/"):
-        if part.startswith("issue-") and part[6:].isdigit():
-            return int(part[6:])
+        if not part.startswith("issue-"):
+            continue
+        rest = part[6:]
+        digits = ""
+        for char in rest:
+            if char.isdigit():
+                digits += char
+                continue
+            break
+        if not digits:
+            continue
+        if len(digits) == len(rest) or rest[len(digits)] in ("-", "_"):
+            return int(digits)
     return None
 
 

--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -102,6 +102,29 @@ def _matches_story_issue(frontmatter: dict[str, Any], issue_number: int) -> bool
         return False
 
 
+def _branch_has_story_context(repo_root: Path, branch: str) -> bool:
+    """Return whether the current branch represents a per-story context.
+
+    A story context exists when the branch encodes an issue number
+    (feat/issue-N, fix/issue-N, etc.) or when a local story file under the
+    repo root matches the branch by issue number or slug. The mutation guard
+    only applies in story contexts; non-story branches (main, release/*,
+    detached HEAD, ad-hoc maintenance branches) have no story to attribute
+    a mutation to and the guard must short-circuit.
+    """
+    if _issue_number_from_branch(branch) is not None:
+        return True
+    slug = _branch_slug(branch)
+    for story_path in _iter_local_story_paths(repo_root):
+        frontmatter = parse_story_frontmatter(story_path)
+        if not frontmatter:
+            continue
+        story_slug = frontmatter.get("slug")
+        if story_slug == slug or story_path.stem == slug:
+            return True
+    return False
+
+
 def _local_story_override_active(repo_root: Path, branch: str) -> bool:
     """Return whether a matching local story file opts into forge.yaml mutations."""
     issue_number = _issue_number_from_branch(branch)
@@ -174,17 +197,19 @@ def evaluate_forge_yaml_guard(repo_root: Path, *, base_branch: str) -> ForgeYaml
     if not current_path.exists():
         return ForgeYamlGuardResult(ok=True)
 
-    # The mutation guard is per-story. If there is no story-branch context —
-    # detached HEAD (e.g. the sprint baseline gate's temporary worktree) or the
-    # current branch is the configured base itself (e.g. running `make gate`
-    # directly on a release branch) — there is no story mutation to attribute
-    # and the guard must short-circuit. Without this check, legitimate
-    # cross-branch divergence (release branch vs main) is misread as a
-    # forbidden story edit and blocks every sprint that runs the baseline gate.
-    # Branch-detection failures must propagate so the caller surfaces them
-    # explicitly rather than fail-open through the guard.
+    # The mutation guard is per-story. If the current branch has no story
+    # context — no issue-N token in the name and no matching local story
+    # file — there is no story to attribute a mutation to and the guard
+    # must short-circuit. This covers detached HEAD (sprint baseline gate
+    # worktrees), the configured base branch itself, release branches,
+    # main, and any ad-hoc maintenance branch. Without this check,
+    # legitimate cross-branch divergence (release branch vs main) is
+    # misread as a forbidden story edit and blocks `make gate` runs on
+    # release branches and `cut-rc.sh`. Branch-detection failures must
+    # propagate so the caller surfaces them explicitly rather than
+    # fail-open through the guard.
     current_branch = _current_branch(repo_root)
-    if current_branch in ("HEAD", base_branch):
+    if not _branch_has_story_context(repo_root, current_branch):
         return ForgeYamlGuardResult(ok=True)
 
     diff_proc = subprocess.run(

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from theforge.cli.forge_yaml_guard import (
     ForgeYamlGuardResult,
     _changed_top_level_keys,
+    _issue_number_from_branch,
     cmd_check_story_config,
     evaluate_forge_yaml_guard,
 )
@@ -268,6 +269,51 @@ def test_evaluate_forge_yaml_guard_skips_on_release_branch_with_main_as_base(
     assert result.violating_keys == ()
     # No diff attempted; the short-circuit fired on the absence of story context.
     assert mock_run.call_count == 1
+
+
+def test_issue_number_from_branch_recognizes_descriptive_suffix() -> None:
+    """Manual story branches commonly use `issue-N-summary` or `issue-N_summary`
+    (e.g. `fix/issue-1377-guard-non-story-branches`). Both must resolve to the
+    issue number so the mutation guard treats them as story context."""
+    assert _issue_number_from_branch("feat/issue-283") == 283
+    assert _issue_number_from_branch("fix/issue-1377-guard-non-story-branches") == 1377
+    assert _issue_number_from_branch("fix/issue-42_describe_thing") == 42
+    assert _issue_number_from_branch("issue-7") == 7
+    # Non-story branches still return None.
+    assert _issue_number_from_branch("release/v0.10") is None
+    assert _issue_number_from_branch("main") is None
+    assert _issue_number_from_branch("HEAD") is None
+    # `issue-` followed by non-digit is not a story branch.
+    assert _issue_number_from_branch("feat/issue-abc") is None
+    # Digits must be followed by a separator or end-of-component.
+    assert _issue_number_from_branch("feat/issue-12foo") is None
+
+
+def test_evaluate_forge_yaml_guard_applies_on_descriptive_issue_branch(
+    tmp_path: Path,
+) -> None:
+    """A manual story branch like `fix/issue-1377-guard-non-story-branches`
+    encodes story context and the guard must apply (not silently skip).
+    Regression test for the descriptive-suffix gap caught in PR #1378 review."""
+    (tmp_path / "forge.yaml").write_text(
+        "validation:\n  gate_command: make gate\n", encoding="utf-8"
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="fix/issue-1377-guard-non-story-branches\n", stderr=""),
+            MagicMock(returncode=0, stdout="forge.yaml\n", stderr=""),
+            MagicMock(returncode=0, stdout="models:\n  - claude/sonnet\n", stderr=""),
+            MagicMock(returncode=0, stdout="fix/issue-1377-guard-non-story-branches\n", stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps({"body": ""}), stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    # Branch encodes story context, so the guard runs and rejects the
+    # non-allowlisted `validation` change.
+    assert result.ok is False
+    assert result.violating_keys == ("validation",)
 
 
 def test_evaluate_forge_yaml_guard_skips_on_adhoc_non_story_branch(tmp_path: Path) -> None:

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -245,6 +245,49 @@ def test_evaluate_forge_yaml_guard_skips_when_current_branch_is_base(tmp_path: P
     assert mock_run.call_count == 1
 
 
+def test_evaluate_forge_yaml_guard_skips_on_release_branch_with_main_as_base(
+    tmp_path: Path,
+) -> None:
+    """cut-rc.sh runs `make gate` on `release/v0.10` while `forge.yaml`
+    configures `main` as base. Without story context (no issue-N branch,
+    no matching local story file), the guard must short-circuit even
+    when current_branch != base_branch. Regression test for #1377."""
+    (tmp_path / "forge.yaml").write_text(
+        "conventions:\n  one: a\nretry:\n  attempts: 2\n", encoding="utf-8"
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="release/v0.10\n", stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is True
+    assert result.changed_keys == ()
+    assert result.violating_keys == ()
+    # No diff attempted; the short-circuit fired on the absence of story context.
+    assert mock_run.call_count == 1
+
+
+def test_evaluate_forge_yaml_guard_skips_on_adhoc_non_story_branch(tmp_path: Path) -> None:
+    """Ad-hoc maintenance branches (no issue-N token, no matching local
+    story file) are not story-mutation contexts. Regression test for #1377."""
+    (tmp_path / "forge.yaml").write_text(
+        "validation:\n  gate_command: make gate\n", encoding="utf-8"
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="chore/cleanup\n", stderr=""),
+        ]
+
+        result = evaluate_forge_yaml_guard(tmp_path, base_branch="main")
+
+    assert result.ok is True
+    assert mock_run.call_count == 1
+
+
 def test_cmd_check_story_config_prints_violating_keys(capsys, tmp_path: Path) -> None:
     config_path = tmp_path / "forge.yaml"
     config_path.write_text("project: test\n", encoding="utf-8")


### PR DESCRIPTION
Fixes #1377.

## Summary

Generalizes the short-circuit added in PR #1376 to cover the case `cut-rc.sh` actually hits: running `make gate` directly on `release/v0.10` while `forge.yaml` configures `main` as base. The prior predicate (`current_branch in ("HEAD", base_branch)`) was too narrow and missed this scenario.

The new predicate uses the right semantic check: the mutation guard applies only when the current branch represents a per-story context (encodes an issue number, or matches a local story file by slug or issue). All non-story contexts — detached HEAD, the configured base, release branches, main, ad-hoc maintenance branches — are skipped uniformly.

## Why this is a v0.10 RC blocker

`scripts/cut-rc.sh 0.10.0 2` aborted on `make gate` against `release/v0.10`. The release-floor-dogfood discipline cannot complete if the RC cannot be cut. Same blocker class as #1375.

## Verification

- 15/15 tests pass in `tests/test_forge_yaml_guard.py` (13 prior + 2 new):
  - `test_evaluate_forge_yaml_guard_skips_on_release_branch_with_main_as_base` — the exact `cut-rc.sh` scenario
  - `test_evaluate_forge_yaml_guard_skips_on_adhoc_non_story_branch` — generalizes to any non-story branch
- End-to-end on the actual `release/v0.10` checkout: with the patched source on `PYTHONPATH`, `evaluate_forge_yaml_guard(Path('.'), base_branch='main')` returns `ok=True changed=() violating=()`. Pre-fix: same `conventions, plan_agent_review, retry` failure that blocked `cut-rc.sh`.

## Scope

- Touches only `cli/forge_yaml_guard.py` and its tests.
- New helper `_branch_has_story_context` reuses the existing `_issue_number_from_branch`, `_iter_local_story_paths`, `_branch_slug`, and `parse_story_frontmatter` helpers — no new gh subprocess calls, no new failure modes.
- The narrow `("HEAD", base_branch)` predicate from PR #1376 is removed in favor of the general check; both prior cases fall out as instances of "no story context" so the regression tests for #1375 still pass.

## Out of scope

- The `OPENAI_API_KEY not set` warning from `openai-api-fallback` is informational and orthogonal.
- The `pyproject.toml` version bump that `cut-rc.sh` left uncommitted on `release/v0.10` is reverted manually; not a code change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)