### PR TITLE
Detached sprint crashes on macOS fork safety after prelaunch/gate work

### DIFF
--- a/src/theforge/__init__.py
+++ b/src/theforge/__init__.py
@@ -1,5 +1,17 @@
 """TheForge — Deterministic multi-LLM development orchestrator."""
 
+# Force multiprocessing to use the spawn start method process-wide. Defense
+# in depth against macOS Objective-C fork-safety crashes (the Obj-C runtime
+# aborts when a child of fork() finds Foundation initialization in flight on
+# another thread). subprocess.Popen has its own posix_spawn fast path; this
+# guard covers any future code that introduces multiprocessing.Pool/Process.
+try:
+    import multiprocessing as _multiprocessing
+
+    _multiprocessing.set_start_method("spawn", force=True)
+except (RuntimeError, ValueError):
+    pass
+
 try:
     from importlib.metadata import version as _version
 

--- a/src/theforge/cli/run.py
+++ b/src/theforge/cli/run.py
@@ -104,14 +104,21 @@ def cmd_run(args: "argparse.Namespace") -> int:
 
     task = _build_task(story_path, slug=args.slug)
 
-    # ── Daemonization (default) ────────────────────────────────────────
+    # ── Detach (Popen re-exec) ─────────────────────────────────────────
+    # Replaces the previous os.fork-based double-fork to avoid macOS
+    # Objective-C fork-safety crashes once Foundation has been touched
+    # (e.g., by `gh` subprocess calls earlier in the pipeline).
     if not getattr(args, "dry_run", False) and not getattr(args, "fg", False):
-        run_id = _generate_run_id()
-        _detach.daemonize_run(run_id, task.slug, config.project_root)
-        # Grandchild continues here; parent has already exited above
-        # NOTE: suppress_app_nap() intentionally skipped — PyObjC crashes
-        # in forked processes. setsid() provides sufficient protection.
-        _detach.install_cleanup_handler(run_id, config.project_root)
+        if _detach.is_detached_child():
+            import os as _os
+
+            run_id = _os.environ.get("FORGE_DETACHED_RUN_ID") or _generate_run_id()
+            _detach.setup_detached_child(run_id, task.slug, config.project_root)
+            _detach.install_cleanup_handler(run_id, config.project_root)
+        else:
+            run_id = _generate_run_id()
+            _detach.daemonize_run(run_id, task.slug, config.project_root)
+            # daemonize_run never returns in the parent.
     else:
         run_id = _generate_run_id()
 

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -92,6 +92,67 @@ def cmd_sprint(args: object) -> int:
         load_config(config_path), getattr(args, "base_branch", None)
     )
 
+    # ── Detach BEFORE any subprocess/gh work ─────────────────────────────
+    # macOS aborts the child of a fork() when Foundation has been initialized
+    # in the parent (e.g., by `gh` subprocess calls during shape-gate /
+    # intake remediation). The new daemonize_run is a clean Popen re-exec
+    # rather than a fork, but we still hoist it above the subprocess work so
+    # neither the parent nor the child lands in a tainted-then-fork state.
+    # The detached child re-executes the full CLI; this branch detects that
+    # re-entry and skips daemonize while still installing the PID/cleanup.
+    import os as _os
+
+    fg = bool(getattr(args, "fg", False))
+    submit_to_daemon = bool(getattr(args, "detach", False))
+    dry_run = bool(getattr(args, "dry_run", False))
+    detach_to_background = not fg and not submit_to_daemon and not dry_run
+
+    if detach_to_background:
+        from theforge import detach as _detach_mod
+
+        # Compute slug from args alone — no subprocess work in the parent.
+        manifest_arg_local: str | None = getattr(args, "manifest", None)
+        milestone_local: str | None = getattr(args, "milestone", None)
+        label_local: str | None = getattr(args, "label", None)
+        issues_arg_local: str | None = getattr(args, "issues", None)
+        query_mode_local = bool(milestone_local or label_local or issues_arg_local)
+        if query_mode_local:
+            sprint_name_local = (
+                getattr(args, "name", None)
+                or milestone_local
+                or label_local
+                or f"issues-{issues_arg_local}"
+            )
+            launch_slug = sprint_name_local.replace(" ", "-").replace("/", "-").lower()[:50]
+        else:
+            launch_slug = Path(manifest_arg_local).stem if manifest_arg_local else "sprint"
+
+        if _detach_mod.is_detached_child():
+            launch_run_id = _os.environ.get("FORGE_DETACHED_RUN_ID") or _generate_run_id()
+            _detach_mod.setup_detached_child(launch_run_id, launch_slug, config.project_root)
+            _detach_mod.install_cleanup_handler(launch_run_id, config.project_root)
+            print("[forge] Detached sprint starting", file=sys.stderr, flush=True)
+            args.__dict__["_detached_run_id"] = launch_run_id
+            args.__dict__["_detached_slug"] = launch_slug
+
+            # Backstop cleanup for early-return paths (all-skipped, no
+            # stories, --detach-not-supported guard) that bypass the
+            # try/finally in run_sprint blocks. Idempotent — write_run_ended
+            # is a no-op if the .ended marker already exists.
+            import atexit as _atexit
+
+            _atexit.register(
+                _detach_mod.write_run_ended,
+                launch_run_id,
+                config.project_root,
+                "completed",
+            )
+            _atexit.register(_detach_mod.remove_pid, launch_run_id, config.project_root)
+        else:
+            launch_run_id = _generate_run_id()
+            _detach_mod.daemonize_run(launch_run_id, launch_slug, config.project_root)
+            # daemonize_run never returns in the parent.
+
     if getattr(args, "verbose", False):
         coordinator_set_log_level(LogLevel.VERBOSE)
         runner_set_log_level(LogLevel.VERBOSE)
@@ -141,17 +202,21 @@ def cmd_sprint(args: object) -> int:
         return launch_error
 
     live_slugs = [s for s in slugs if s not in dropped_slugs]
-    if not getattr(args, "fg", False) and not getattr(args, "detach", False):
-        run_id = _generate_run_id()
-        slug = manifest_path.stem
-        _detach.daemonize_run(run_id, slug, config.project_root)
+    # Detach already happened at top of cmd_sprint (Popen re-exec model). If
+    # we are in the detached child, the run_id/slug were resolved there and
+    # cached on args; otherwise (--fg / --detach daemon submit) generate now.
+    cached_run_id = args.__dict__.get("_detached_run_id")
+    cached_slug = args.__dict__.get("_detached_slug")
+    if cached_run_id is not None:
+        run_id = cached_run_id
+        slug = cached_slug or manifest_path.stem
+        # Locks were acquired in this same process; metadata rewrite is a
+        # no-op idempotent call but we keep it for parity with prior behavior.
         locked_fds = reacquire_story_locks_in_daemon(
             live_slugs,
             config.project_root,
             locked_fds,
         )
-        _detach.install_cleanup_handler(run_id, config.project_root)
-        print("[forge] Detached sprint starting", file=sys.stderr, flush=True)
     else:
         run_id = _generate_run_id()
         slug = manifest_path.stem
@@ -539,19 +604,20 @@ def _run_query_mode(
 
     live_slugs = [s for s in slugs if s not in dropped_slugs]
 
-    # ── Daemonization: slug from sprint name, not manifest filename ───────
-    run_id = _generate_run_id()
-    sprint_slug = sprint_name.replace(" ", "-").replace("/", "-").lower()[:50]
-
-    if not getattr(args, "fg", False) and not getattr(args, "detach", False):
-        _detach.daemonize_run(run_id, sprint_slug, config.project_root)
+    # ── run_id / slug ─────────────────────────────────────────────────────
+    # Detach (Popen re-exec) already happened at top of cmd_sprint. If we
+    # are in the detached child, run_id/slug were resolved there and cached
+    # on args. Otherwise (--fg) generate fresh.
+    cached_run_id = args.__dict__.get("_detached_run_id")
+    if cached_run_id is not None:
+        run_id = cached_run_id
         locked_fds = reacquire_story_locks_in_daemon(
             live_slugs,
             config.project_root,
             locked_fds,
         )
-        _detach.install_cleanup_handler(run_id, config.project_root)
-        print("[forge] Detached sprint starting", file=sys.stderr, flush=True)
+    else:
+        run_id = _generate_run_id()
 
     # Query mode does not support daemon submission (no manifest file to pass)
     if getattr(args, "detach", False) and _daemon.is_daemon_running(config.project_root):

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -1,7 +1,9 @@
 """Process detachment primitives for forge run/sprint.
 
-Provides double-fork daemonization, App Nap suppression (macOS),
-PID file management, and run status queries.
+Provides spawn-based daemonization (re-exec via subprocess.Popen so the
+detached process is a fresh interpreter — required for macOS Objective-C
+fork-safety), App Nap suppression (macOS), PID file management, and run
+status queries.
 """
 
 from __future__ import annotations
@@ -10,10 +12,18 @@ import json
 import os
 import re
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
 from typing import Any
+
+# Env sentinel used to mark a re-exec'd detached child. Read by
+# ``is_detached_child()`` so cli/sprint.py and cli/run.py can skip the
+# daemonize step in the child while still running the workload.
+_DETACHED_ENV = "FORGE_DETACHED"
+_DETACHED_RUN_ID_ENV = "FORGE_DETACHED_RUN_ID"
+_DETACHED_SLUG_ENV = "FORGE_DETACHED_SLUG"
 
 # Module-level list to prevent GC of App Nap activity tokens
 _APP_NAP_ACTIVITIES: list[Any] = []
@@ -315,76 +325,89 @@ def write_reexec_redirect(
 # ── Daemonization ────────────────────────────────────────────────────
 
 
-def daemonize_run(run_id: str, slug: str, project_root: Path) -> None:
-    """Double-fork daemonize, redirect stdio, write PID file.
+def is_detached_child() -> bool:
+    """Return True when this process is a re-exec'd detached child.
 
-    On return from this function in the parent, we have already exited 0
-    after printing run_id and log path. The grandchild (daemon) continues.
+    Set by ``daemonize_run`` in the parent before spawning. cli/sprint.py
+    and cli/run.py read this to skip the daemonize step in the child while
+    still running the workload.
+    """
+    return os.environ.get(_DETACHED_ENV) == "1"
 
-    Raises RuntimeError if os.fork() is unavailable (Windows).
+
+def setup_detached_child(run_id: str, slug: str, project_root: Path) -> None:
+    """Initialize a re-exec'd detached child: write PID file and redirect file.
+
+    The parent already redirected stdin/stdout/stderr via ``subprocess.Popen``
+    kwargs, so no fd manipulation is needed here. We just write the PID file
+    so ``forge status`` can find this run, and write the re-exec redirect
+    sidecar if this child was launched by a coordinator post-pull execv.
     """
     log_file = project_root / ".forge" / "logs" / slug / f"run-{run_id}.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
-    # Save original stdout for the pre-fork print
-    orig_stdout = sys.stdout
-
-    # First fork
-    try:
-        pid = os.fork()
-    except AttributeError:
-        raise RuntimeError("os.fork() not available on this platform")
-
-    if pid > 0:
-        # Parent: wait for intermediate child then exit
-        os.waitpid(pid, 0)
-        # Print run info to original terminal before exiting
-        print("[forge] Run started in background", file=orig_stdout)
-        print(f"[forge] Run ID:  {run_id}", file=orig_stdout)
-        print(f"[forge] Log:     {log_file}", file=orig_stdout)
-        print("[forge] Status:  forge status", file=orig_stdout)
-        print(f"[forge] Logs:    forge logs {run_id}", file=orig_stdout)
-        orig_stdout.flush()
-        sys.exit(0)
-
-    # Intermediate child: become session leader
-    os.setsid()
-
-    # Second fork — prevents re-acquiring a controlling terminal
-    try:
-        pid = os.fork()
-    except AttributeError:
-        pass
-    else:
-        if pid > 0:
-            sys.exit(0)
-
-    # Grandchild: write PID file, redirect stdio
     write_pid(run_id, slug, project_root)
 
-    # If this is a re-exec (source changed after git pull), write a sidecar
-    # redirect file so the log follower can switch to this new run without
-    # relying on log-line parsing (which LLM output could spoof).
+    # Coordinator post-pull execv inherits FORGE_DETACHED + FORGE_PREV_RUN_ID
+    # in env. Write the redirect sidecar so the log follower can switch.
     prev_run_id = os.environ.pop("FORGE_PREV_RUN_ID", None)
     if prev_run_id:
         write_reexec_redirect(prev_run_id, run_id, log_file, project_root)
 
-    # Redirect stdin to /dev/null — use raw fd ops to avoid issues with
-    # Python file objects in forked processes
-    null_fd = os.open(os.devnull, os.O_RDONLY)
-    os.dup2(null_fd, 0)  # fd 0 = stdin
-    os.close(null_fd)
 
-    # Redirect stdout/stderr to log file
+def daemonize_run(run_id: str, slug: str, project_root: Path) -> None:
+    """Spawn a fresh interpreter as a detached child and exit the parent.
+
+    Replaces the previous ``os.fork()``-based double-fork daemonization to
+    avoid macOS Objective-C fork-safety crashes when the parent has already
+    initialized Foundation/CoreFoundation (e.g., via subprocess work).
+
+    The child re-executes the forge CLI with ``FORGE_DETACHED=1`` set in the
+    environment; the entry point detects the sentinel via
+    ``is_detached_child()`` and skips this function, calling
+    ``setup_detached_child`` instead.
+
+    This function never returns in the parent — it always calls ``sys.exit(0)``.
+    """
+    log_file = project_root / ".forge" / "logs" / slug / f"run-{run_id}.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Re-exec env: orthogonal to FORGE_PREV_RUN_ID (coordinator-reexec sentinel).
+    env = dict(os.environ)
+    env[_DETACHED_ENV] = "1"
+    env[_DETACHED_RUN_ID_ENV] = run_id
+    env[_DETACHED_SLUG_ENV] = slug
+
     log_fd = os.open(str(log_file), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
-    os.dup2(log_fd, 1)  # fd 1 = stdout
-    os.dup2(log_fd, 2)  # fd 2 = stderr
-    os.close(log_fd)
+    try:
+        proc = subprocess.Popen(  # noqa: S603
+            [sys.executable, "-m", "theforge.cli", *sys.argv[1:]],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fd,
+            stderr=log_fd,
+            start_new_session=True,
+            close_fds=True,
+            env=env,
+            cwd=os.getcwd(),
+        )
+    finally:
+        os.close(log_fd)
 
-    # Re-open Python-level file objects pointing at the new fds
-    sys.stdin = open(os.devnull, encoding="utf-8")  # noqa: WPS515
-    sys.stdout = open(log_file, "a", encoding="utf-8", buffering=1)  # noqa: WPS515
-    sys.stderr = open(log_file, "a", encoding="utf-8", buffering=1)  # noqa: WPS515
+    # Write PID file pre-emptively so a `forge status` invoked immediately
+    # after launch has something to read. The child also writes it on entry
+    # via setup_detached_child (idempotent — same pid, same slug).
+    runs_dir = project_root / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = runs_dir / f"{run_id}.pid"
+    pid_file.write_text(f"{proc.pid}\n{slug}\n", encoding="utf-8")
+
+    print("[forge] Run started in background")
+    print(f"[forge] Run ID:  {run_id}")
+    print(f"[forge] Log:     {log_file}")
+    print("[forge] Status:  forge status")
+    print(f"[forge] Logs:    forge logs {run_id}")
+    sys.stdout.flush()
+    sys.exit(0)
 
 
 # ── Signal / cleanup helpers ─────────────────────────────────────────

--- a/tests/test_detach.py
+++ b/tests/test_detach.py
@@ -6,8 +6,6 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from theforge import detach
 
 # ── PID file helpers ──────────────────────────────────────────────────
@@ -141,54 +139,101 @@ class TestSuppressAppNap:
             detach.suppress_app_nap()
 
 
-# ── Daemonize run (no actual fork in tests) ───────────────────────────
+# ── Daemonize run (Popen re-exec model — no fork) ─────────────────────
 
 
 class TestDaemonizeRun:
-    def test_grandchild_writes_pid_and_redirects(self, tmp_path):
-        """Simulate grandchild path (both forks return 0 = child) without actually forking."""
-        mock_fd = MagicMock()
-        mock_fd.fileno.return_value = 99
+    """daemonize_run spawns a fresh interpreter via subprocess.Popen and
+    exits the parent. We patch Popen and sys.exit so the test doesn't
+    actually fork or terminate the test runner.
+    """
 
-        # fork() returning 0 means "we are the child"
+    def _run_and_capture(self, tmp_path, *, popen_pid: int = 4242):
+        proc = MagicMock()
+        proc.pid = popen_pid
         with (
-            patch("theforge.detach.os.fork", return_value=0),
-            patch("theforge.detach.os.setsid"),
-            patch("theforge.detach.os.dup2"),
-            patch("theforge.detach.os.waitpid"),
-            patch("theforge.detach.os.devnull", "/dev/null"),
-            patch("theforge.detach.os.open", side_effect=[10, 11]) as mock_os_open,
-            patch("theforge.detach.os.close"),
-            patch("theforge.detach.write_pid") as mock_write_pid,
+            patch("theforge.detach.subprocess.Popen", return_value=proc) as mock_popen,
+            patch("theforge.detach.sys.exit") as mock_exit,
+        ):
+            detach.daemonize_run("run123", "my-slug", tmp_path)
+        return mock_popen, mock_exit
+
+    def test_spawns_python_via_theforge_cli(self, tmp_path):
+        mock_popen, _ = self._run_and_capture(tmp_path)
+        args, kwargs = mock_popen.call_args
+        cmd = args[0]
+        assert cmd[0] == sys.executable
+        assert cmd[1:3] == ["-m", "theforge.cli"]
+
+    def test_sets_detached_env_sentinel(self, tmp_path):
+        mock_popen, _ = self._run_and_capture(tmp_path)
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["FORGE_DETACHED"] == "1"
+        assert env["FORGE_DETACHED_RUN_ID"] == "run123"
+        assert env["FORGE_DETACHED_SLUG"] == "my-slug"
+
+    def test_uses_start_new_session_and_close_fds(self, tmp_path):
+        mock_popen, _ = self._run_and_capture(tmp_path)
+        kw = mock_popen.call_args.kwargs
+        assert kw["start_new_session"] is True
+        assert kw["close_fds"] is True
+
+    def test_writes_pid_file_with_child_pid(self, tmp_path):
+        self._run_and_capture(tmp_path, popen_pid=9876)
+        pid_file = tmp_path / ".forge" / "runs" / "run123.pid"
+        assert pid_file.exists()
+        lines = pid_file.read_text().splitlines()
+        assert int(lines[0]) == 9876
+        assert lines[1] == "my-slug"
+
+    def test_parent_exits_zero(self, tmp_path):
+        _, mock_exit = self._run_and_capture(tmp_path)
+        mock_exit.assert_called_once_with(0)
+
+    def test_does_not_call_os_fork(self, tmp_path):
+        """Regression: fork must not be invoked — that was the macOS crash."""
+        with (
+            patch("theforge.detach.subprocess.Popen", return_value=MagicMock(pid=1)),
+            patch("theforge.detach.sys.exit"),
             patch(
-                "builtins.open",
-                return_value=MagicMock(
-                    __enter__=lambda s: mock_fd,
-                    __exit__=MagicMock(return_value=False),
-                    fileno=lambda: 99,
-                    write=MagicMock(),
-                    flush=MagicMock(),
-                ),
-            ),
-            patch.object(sys, "stdin", MagicMock(fileno=MagicMock(return_value=0))),
-            patch.object(
-                sys, "stdout", MagicMock(fileno=MagicMock(return_value=1), flush=MagicMock())
-            ),
-            patch.object(
-                sys, "stderr", MagicMock(fileno=MagicMock(return_value=2), flush=MagicMock())
+                "theforge.detach.os.fork",
+                side_effect=AssertionError("os.fork must not be called"),
             ),
         ):
-            # The second fork also returns 0 — grandchild path
             detach.daemonize_run("run123", "my-slug", tmp_path)
 
-        mock_write_pid.assert_called_once_with("run123", "my-slug", tmp_path)
-        log_path = tmp_path / ".forge" / "logs" / "my-slug" / "run-run123.log"
-        assert mock_os_open.call_args_list[1].args[0] == str(log_path)
 
-    def test_raises_on_no_fork(self, tmp_path):
-        with patch("theforge.detach.os.fork", side_effect=AttributeError):
-            with pytest.raises(RuntimeError, match="os.fork"):
-                detach.daemonize_run("run123", "slug", tmp_path)
+class TestIsDetachedChild:
+    def test_false_when_unset(self, monkeypatch):
+        monkeypatch.delenv("FORGE_DETACHED", raising=False)
+        assert detach.is_detached_child() is False
+
+    def test_true_when_one(self, monkeypatch):
+        monkeypatch.setenv("FORGE_DETACHED", "1")
+        assert detach.is_detached_child() is True
+
+    def test_false_for_other_values(self, monkeypatch):
+        monkeypatch.setenv("FORGE_DETACHED", "0")
+        assert detach.is_detached_child() is False
+
+
+class TestSetupDetachedChild:
+    def test_writes_pid_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("FORGE_PREV_RUN_ID", raising=False)
+        detach.setup_detached_child("run123", "my-slug", tmp_path)
+        pid_file = tmp_path / ".forge" / "runs" / "run123.pid"
+        assert pid_file.exists()
+        lines = pid_file.read_text().splitlines()
+        assert int(lines[0]) == os.getpid()
+        assert lines[1] == "my-slug"
+
+    def test_writes_redirect_when_prev_run_id_set(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("FORGE_PREV_RUN_ID", "old-run-1")
+        detach.setup_detached_child("run123", "my-slug", tmp_path)
+        redirect = tmp_path / ".forge" / "runs" / "old-run-1.redirect"
+        assert redirect.exists()
+        # Env var consumed.
+        assert "FORGE_PREV_RUN_ID" not in os.environ
 
 
 # ── Terminal marker (.ended) ──────────────────────────────────────────

--- a/tests/test_detach_reexec_seam.py
+++ b/tests/test_detach_reexec_seam.py
@@ -1,0 +1,167 @@
+"""Seam-level integration test for the detach Popen re-exec model.
+
+Spans CLI (cmd_sprint / cmd_run) → detach (daemonize_run /
+is_detached_child / setup_detached_child) boundary. Covers the cross-phase
+state flow introduced by replacing os.fork()-based daemonization with a
+subprocess.Popen re-exec on macOS fork-safety grounds (issue #1374).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from unittest.mock import MagicMock, patch
+
+from theforge import detach
+
+# ── daemonize_run uses Popen, not fork ─────────────────────────────────
+
+
+def test_daemonize_run_uses_popen_with_detached_env(tmp_path):
+    """daemonize_run must spawn via subprocess.Popen with FORGE_DETACHED=1
+    and never invoke os.fork — that was the macOS crash trigger.
+    """
+    with (
+        patch("theforge.detach.subprocess.Popen") as mock_popen,
+        patch("theforge.detach.sys.exit") as mock_exit,
+        patch(
+            "theforge.detach.os.fork",
+            side_effect=AssertionError("os.fork must not be called by daemonize_run"),
+        ),
+    ):
+        mock_popen.return_value = MagicMock(pid=12345)
+        detach.daemonize_run("run-seam", "slug-seam", tmp_path)
+
+    mock_popen.assert_called_once()
+    args, kwargs = mock_popen.call_args
+    cmd = args[0]
+    assert cmd[0] == sys.executable
+    assert cmd[1:3] == ["-m", "theforge.cli"]
+    assert kwargs["start_new_session"] is True
+    assert kwargs["env"]["FORGE_DETACHED"] == "1"
+    assert kwargs["env"]["FORGE_DETACHED_RUN_ID"] == "run-seam"
+    mock_exit.assert_called_once_with(0)
+
+    # Parent wrote PID file with child's pid so `forge status` works
+    # immediately after launch.
+    pid_file = tmp_path / ".forge" / "runs" / "run-seam.pid"
+    assert pid_file.exists()
+    assert pid_file.read_text().splitlines()[0] == "12345"
+
+
+# ── cli/run.py: detached child skips daemonize and runs the workload ──
+
+
+def test_cmd_run_detached_child_skips_daemonize(tmp_path, monkeypatch):
+    """When FORGE_DETACHED=1 is set, cmd_run must NOT call daemonize_run;
+    it should call setup_detached_child and proceed into run_task.
+    """
+    from theforge.cli import run as run_cli
+
+    # Minimal config + story
+    story = tmp_path / "story.md"
+    story.write_text("# story\n")
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n")
+
+    args = argparse.Namespace(
+        story=str(story),
+        slug="seam-slug",
+        config=str(config_path),
+        base_branch=None,
+        dry_run=False,
+        interactive=False,
+        auto_merge=False,
+        dev_model=None,
+        plan_model=None,
+        verbose=False,
+        no_notify=True,
+        plan=None,
+        resume=False,
+        until=None,
+        from_phase=None,
+        reviewers=None,
+        max_cycles=None,
+        fg=False,
+        no_pull=False,
+    )
+
+    monkeypatch.setenv("FORGE_DETACHED", "1")
+    monkeypatch.setenv("FORGE_DETACHED_RUN_ID", "child-run-id")
+
+    fake_config = MagicMock()
+    fake_config.project_root = tmp_path
+    fake_config.project = "test"
+    fake_config.dev_profile.model = "x"
+    fake_config.review_pool = [MagicMock(name="r", model="m")]
+    fake_config.synthesis_profile = None
+    fake_config.retry.max_review_cycles = 1
+    fake_config.retry.max_dev_iterations = 1
+    fake_config.workspace.path_pattern = ".forge/worktrees/{slug}"
+
+    fake_result = MagicMock()
+    fake_result.success = True
+    fake_result.message = "ok"
+    fake_result.state.total_cost = 0.0
+
+    with (
+        patch("theforge.cli.run.load_config", return_value=fake_config),
+        patch("theforge.cli.run.apply_base_branch_override", return_value=fake_config),
+        patch("theforge.cli.run._build_task", return_value=MagicMock(slug="seam-slug")),
+        patch("theforge.cli.run._find_config", return_value=config_path),
+        patch("theforge.cli.run.run_task", return_value=fake_result) as mock_run_task,
+        patch("theforge.cli.run._write_audit", return_value=tmp_path / "audit.yaml"),
+        patch("theforge.detach.daemonize_run") as mock_daemonize,
+        patch("theforge.detach.setup_detached_child") as mock_setup,
+        patch("theforge.detach.install_cleanup_handler"),
+        patch("theforge.detach.write_run_ended"),
+        patch("theforge.detach.remove_pid"),
+        patch("theforge.cli.run.subprocess.run", return_value=MagicMock(returncode=1)),
+    ):
+        rc = run_cli.cmd_run(args)
+
+    assert rc == 0
+    mock_daemonize.assert_not_called()
+    mock_setup.assert_called_once()
+    setup_args = mock_setup.call_args.args
+    assert setup_args[0] == "child-run-id"
+    assert setup_args[1] == "seam-slug"
+    mock_run_task.assert_called_once()
+
+
+# ── FORGE_DETACHED is orthogonal to FORGE_PREV_RUN_ID ──────────────────
+
+
+def test_forge_detached_is_distinct_from_forge_prev_run_id(monkeypatch):
+    """Re-exec sentinel must not collide with the coordinator's
+    FORGE_PREV_RUN_ID re-exec sentinel — they signal different things.
+    """
+    monkeypatch.setenv("FORGE_DETACHED", "1")
+    monkeypatch.delenv("FORGE_PREV_RUN_ID", raising=False)
+    assert detach.is_detached_child() is True
+
+    # In cli/sprint.py _is_reexec() must remain False for a plain detached
+    # child — only true when coordinator did an os.execv after a git pull.
+    from theforge.cli import sprint as sprint_cli
+
+    assert sprint_cli._is_reexec() is False
+
+    monkeypatch.setenv("FORGE_PREV_RUN_ID", "prev-run")
+    assert sprint_cli._is_reexec() is True
+    # Both can coexist (coordinator-reexec inside an already-detached child).
+    assert detach.is_detached_child() is True
+
+
+# ── Multiprocessing spawn is the start method process-wide ─────────────
+
+
+def test_multiprocessing_start_method_is_spawn():
+    """theforge package import sets multiprocessing to 'spawn' as defense in
+    depth against macOS fork-safety crashes from any future Pool/Process use.
+    """
+    import multiprocessing
+
+    # Force re-import to make sure our package init has applied.
+    import theforge  # noqa: F401
+
+    assert multiprocessing.get_start_method(allow_none=False) == "spawn"


### PR DESCRIPTION
## Summary

[claude-sonnet] Correct fix: os.fork daemonization replaced with subprocess.Popen re-exec; detach hoisted above all subprocess work in cmd_sprint; regression test pins no-fork invariant; all AC verified. | [deepseek-deepseek-reasoner] Fix replaces os.fork-based double-fork daemonization with subprocess.Popen re-exec, eliminating the macOS Objective-C fork-safety crash. Detach is hoisted above subprocess work in both cmd_sprint and cmd_run. Tests are comprehensive (44/44 pass), including regression tests that assert os.fork is never called. All acceptance criteria are met.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus
- **Cost:** $12.52
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/detach.py:None`** FORGE_DETACHED_SLUG env var is set in daemonize_run but never consumed — setup_detached_child takes slug as a parameter, and cmd_sprint recomputes slug from args. The env var is dead letter.
- **[P2] `src/theforge/cli/sprint.py:297`** Stale comment in _is_reexec() says FORGE_PREV_RUN_ID 'is only popped inside daemonize_run', but the new Popen-based daemonize_run does not pop it - setup_detached_child does. Comment is misleading.
- **[P2] `src/theforge/sprint/preflight.py:111`** Stale comment in reacquire_story_locks_in_daemon still refers to 'before double-fork daemonizing', but the daemonization no longer uses double-fork.

## Story

Detached sprint crashes on macOS fork safety after prelaunch/gate work (GitHub Issue #1374)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1374