### PR TITLE
MERGE_FAILED outcome conflates auto-merge arming failures with PR rejections, masking the real fix

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -32,6 +32,8 @@ def mark_merge_failed(
     result: CoordinatorResult,
     error: str | None,
     branch_name: str | None,
+    *,
+    arming_failed: bool = False,
 ) -> None:
     """Mutate state and result coherently when the merge step fails.
 
@@ -39,6 +41,10 @@ def mark_merge_failed(
     audit ``final_phase`` cannot disagree with ``landing_status``. Replaces
     ``result.message`` with a failure-cause string so downstream surfaces do not
     inherit a "completed" message that contradicts the failed landing.
+
+    When ``arming_failed`` is True, the failure is the auto-merge *arming* RPC
+    (the PR itself is fine); the message names the distinction so operators
+    pursue branch-protection configuration instead of investigating the PR.
     """
     state.phase = Phase.MERGE_FAILED
     result.phase = Phase.MERGE_FAILED
@@ -47,7 +53,15 @@ def mark_merge_failed(
     cause = error or "unknown"
     state.error = cause
     branch_part = f" Branch '{branch_name}' carries reviewed work." if branch_name else ""
-    result.message = f"Merge failed: {cause}.{branch_part} Story is recoverable but unmerged."
+    if arming_failed:
+        result.message = (
+            f"Auto-merge arming failed: {cause}.{branch_part} "
+            "The PR itself is not rejected — configure branch protection on the "
+            "target branch or merge manually with `gh pr merge <PR> --squash` "
+            "(without `--auto`)."
+        )
+    else:
+        result.message = f"Merge failed: {cause}.{branch_part} Story is recoverable but unmerged."
 
 
 def _archive_story_to_done(
@@ -571,11 +585,41 @@ def _step_create_pr(
     return {"success": True, "pr_url": pr_result["pr_url"]}
 
 
+_AUTO_MERGE_ARMING_MARKERS = (
+    "enablepullrequestautomerge",
+    "protected branch rules not configured",
+    "auto-merge is not allowed",
+    "auto merge is not allowed",
+    "allow_auto_merge",
+    "allowautomerge",
+)
+
+_AUTO_MERGE_ARMING_HINT = (
+    "Auto-merge arming was refused by GitHub; the PR itself was not rejected. "
+    "Configure branch protection on the target branch (enable required status "
+    "checks / allow auto-merge) or merge the PR manually with "
+    "`gh pr merge <PR> --squash --delete-branch` (without `--auto`)."
+)
+
+
+def _is_auto_merge_arming_error(stderr_text: str) -> bool:
+    """Return True if ``gh pr merge --auto`` stderr indicates the *arming*
+    step failed (rather than the PR being rejected on its merits)."""
+    if not stderr_text:
+        return False
+    lowered = stderr_text.lower()
+    return any(marker in lowered for marker in _AUTO_MERGE_ARMING_MARKERS)
+
+
 def _step_merge(project_root: Path, pr_url: str, merge_strategy: str) -> dict:
     """Execute ``gh pr merge --auto --{strategy}``.
 
     Returns ``{"success": True}`` or
-    ``{"success": False, "error": ..., "retryable": bool}``.
+    ``{"success": False, "error": ..., "retryable": bool, "arming_failed": bool}``.
+
+    ``arming_failed`` is True when GitHub refused to *arm* auto-merge (e.g.
+    target branch lacks the protection rules ``enablePullRequestAutoMerge``
+    requires) — distinct from a genuine PR rejection.
     """
     merge_retry_error = "base branch was modified"
     try:
@@ -592,6 +636,7 @@ def _step_merge(project_root: Path, pr_url: str, merge_strategy: str) -> dict:
             "success": False,
             "error": f"gh pr merge failed: {exc}",
             "retryable": False,
+            "arming_failed": False,
             "error_context": _build_exception_context(
                 exc,
                 cmd=["gh", "pr", "merge", pr_url, "--auto", f"--{merge_strategy}"],
@@ -605,10 +650,16 @@ def _step_merge(project_root: Path, pr_url: str, merge_strategy: str) -> dict:
             if part and part.strip()
         )
         _pr_log.warning("gh pr merge --auto failed (exit %d): %s", merge_proc.returncode, err)
+        arming_failed = _is_auto_merge_arming_error(err)
+        if arming_failed:
+            error_msg = f"{_AUTO_MERGE_ARMING_HINT} Underlying error: {err}"
+        else:
+            error_msg = f"gh pr merge failed: {err}"
         return {
             "success": False,
-            "error": f"gh pr merge failed: {err}",
+            "error": error_msg,
             "retryable": merge_retry_error in err.lower(),
+            "arming_failed": arming_failed,
         }
 
     return {"success": True}
@@ -944,6 +995,7 @@ def _merge_pr(
                     merge_state=merge_state,
                     detail={
                         "error_context": merge_result.get("error_context"),
+                        "arming_failed": bool(merge_result.get("arming_failed")),
                     },
                 )
             _complete_step(merge_state, "merge")

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1006,7 +1006,13 @@ def run_task(
             elif _merge_info.get("merge_queued"):
                 result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
             elif _landing_status == "failed":
-                mark_merge_failed(state, result, _merge_info.get("error"), branch_name)
+                mark_merge_failed(
+                    state,
+                    result,
+                    _merge_info.get("error"),
+                    branch_name,
+                    arming_failed=bool(_merge_info.get("arming_failed")),
+                )
 
         _total_elapsed = time.monotonic() - _task_start
         _fire_post_run_hook(config, state, task, result, _run_id, _total_elapsed, logger)
@@ -1245,7 +1251,13 @@ def _run_resume_coordinator(
             elif _merge_info.get("merge_queued"):
                 result.message += f" PR queued: {_merge_info.get('pr_url', '')}"
             elif _landing_status == "failed":
-                mark_merge_failed(state, result, _merge_info.get("error"), branch_name)
+                mark_merge_failed(
+                    state,
+                    result,
+                    _merge_info.get("error"),
+                    branch_name,
+                    arming_failed=bool(_merge_info.get("arming_failed")),
+                )
 
         _total_elapsed = time.monotonic() - _task_start
         _fire_post_run_hook(config, state, task, result, logger._run_id, _total_elapsed, logger)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1082,7 +1082,11 @@ def _classify_and_record(
         merged_slugs.add(task.slug)
         dag.mark_complete(task.slug)
     elif landing_status == "failed":
-        outcome = StoryOutcome.MERGE_FAILED
+        merge_info = getattr(result, "merge", None) or {}
+        if isinstance(merge_info, dict) and merge_info.get("arming_failed"):
+            outcome = StoryOutcome.MERGE_ARMING_FAILED
+        else:
+            outcome = StoryOutcome.MERGE_FAILED
         dag.mark_skipped(task.slug)
     elif landing_status == "pending_integration":
         # Approved but merge deferred or queued — counts as succeeded, not yet in DAG
@@ -1391,6 +1395,7 @@ def run_sprint(
                 "ESCALATE": StoryOutcome.ESCALATED,
                 "FAILED": StoryOutcome.FAILED,
                 "MERGE_FAILED": StoryOutcome.MERGE_FAILED,
+                "MERGE_ARMING_FAILED": StoryOutcome.MERGE_ARMING_FAILED,
             }
             _mapped_outcome = _outcome_map.get(_prior_outcome)
             if _mapped_outcome is None:
@@ -2446,7 +2451,13 @@ def run_sprint(
                         # Optimistic classify recorded this as DONE; landing
                         # failed — correct the canonical outcome (terminal-to-
                         # terminal correction is permitted).
-                        _set_outcome(slug, StoryOutcome.MERGE_FAILED, phase=result.phase.name)
+                        _merge_info = result.merge if isinstance(result.merge, dict) else {}
+                        _failed_outcome = (
+                            StoryOutcome.MERGE_ARMING_FAILED
+                            if _merge_info.get("arming_failed")
+                            else StoryOutcome.MERGE_FAILED
+                        )
+                        _set_outcome(slug, _failed_outcome, phase=result.phase.name)
                     changed = True
                     while changed:
                         changed = False
@@ -2456,9 +2467,19 @@ def run_sprint(
                             if _attempt_integration(pending_slug, pending_task, pending_result):
                                 del pending_integration[pending_slug]
                                 if pending_result.landing_status == "failed":
+                                    _pending_merge_info = (
+                                        pending_result.merge
+                                        if isinstance(pending_result.merge, dict)
+                                        else {}
+                                    )
+                                    _pending_failed_outcome = (
+                                        StoryOutcome.MERGE_ARMING_FAILED
+                                        if _pending_merge_info.get("arming_failed")
+                                        else StoryOutcome.MERGE_FAILED
+                                    )
                                     _set_outcome(
                                         pending_slug,
-                                        StoryOutcome.MERGE_FAILED,
+                                        _pending_failed_outcome,
                                         phase=pending_result.phase.name,
                                     )
                                 changed = True

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -140,7 +140,7 @@ def _outcome_to_status(outcome: str) -> str:
         return "done"
     if outcome == "SKIPPED":
         return "skipped"
-    if outcome in ("ESCALATE", "MERGE_FAILED"):
+    if outcome in ("ESCALATE", "MERGE_FAILED", "MERGE_ARMING_FAILED"):
         return "failed"
     return "failed"
 
@@ -394,6 +394,7 @@ def _stage_and_detail_from_completed_story(
     is_failure_outcome = outcome in {
         "FAILED",
         "MERGE_FAILED",
+        "MERGE_ARMING_FAILED",
         "ESCALATE",
         "ESCALATED",
         "DROPPED",

--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -29,12 +29,19 @@ class StoryOutcome(str, Enum):
     """Sprint story lifecycle outcome.
 
     Non-terminal: WAITING, RUNNING, BLOCKED.
-    Terminal: DONE, ALREADY_DONE, FAILED, MERGE_FAILED, ESCALATED, SKIPPED,
-    PRESERVED, DROPPED.
+    Terminal: DONE, ALREADY_DONE, FAILED, MERGE_FAILED, MERGE_ARMING_FAILED,
+    ESCALATED, SKIPPED, PRESERVED, DROPPED.
 
     MERGE_FAILED is the post-approval merge-step failure (dev + review succeeded
     but the integration step crashed/refused). It is distinct from FAILED (a
     generic non-success terminal state) and from DROPPED (story did not run).
+
+    MERGE_ARMING_FAILED is the narrower case where ``gh pr merge --auto``
+    failed at the auto-merge *arming* RPC (e.g. target branch lacks the
+    protection rules ``enablePullRequestAutoMerge`` requires) — the PR itself
+    is fine; only the arming step failed. Operator remediation differs from
+    MERGE_FAILED (configure branch protection or merge manually) so it gets
+    its own outcome.
     """
 
     WAITING = "waiting"
@@ -44,6 +51,7 @@ class StoryOutcome(str, Enum):
     ALREADY_DONE = "already_done"
     FAILED = "failed"
     MERGE_FAILED = "merge_failed"
+    MERGE_ARMING_FAILED = "merge_arming_failed"
     ESCALATED = "escalated"
     SKIPPED = "skipped"
     PRESERVED = "preserved"
@@ -72,6 +80,7 @@ class StoryOutcome(str, Enum):
         return self in {
             StoryOutcome.FAILED,
             StoryOutcome.MERGE_FAILED,
+            StoryOutcome.MERGE_ARMING_FAILED,
             StoryOutcome.ESCALATED,
             StoryOutcome.DROPPED,
             StoryOutcome.DROPPED_SHAPE,
@@ -88,6 +97,7 @@ _TERMINAL_OUTCOMES = {
     StoryOutcome.ALREADY_DONE,
     StoryOutcome.FAILED,
     StoryOutcome.MERGE_FAILED,
+    StoryOutcome.MERGE_ARMING_FAILED,
     StoryOutcome.ESCALATED,
     StoryOutcome.SKIPPED,
     StoryOutcome.PRESERVED,
@@ -105,6 +115,7 @@ _CANONICAL_TO_LEGACY_STATUS = {
     StoryOutcome.ALREADY_DONE: "done",
     StoryOutcome.FAILED: "failed",
     StoryOutcome.MERGE_FAILED: "failed",
+    StoryOutcome.MERGE_ARMING_FAILED: "failed",
     StoryOutcome.ESCALATED: "failed",
     StoryOutcome.SKIPPED: "skipped",
     StoryOutcome.PRESERVED: "preserved",
@@ -125,6 +136,7 @@ _STATUS_TO_OUTCOME: dict[str, StoryOutcome] = {
     "already_done": StoryOutcome.ALREADY_DONE,
     "failed": StoryOutcome.FAILED,
     "merge_failed": StoryOutcome.MERGE_FAILED,
+    "merge_arming_failed": StoryOutcome.MERGE_ARMING_FAILED,
     "escalated": StoryOutcome.ESCALATED,
     "escalate": StoryOutcome.ESCALATED,  # phase-style alias seeded by runner
     "skipped": StoryOutcome.SKIPPED,

--- a/tests/test_coord_merge_failed_phase.py
+++ b/tests/test_coord_merge_failed_phase.py
@@ -195,3 +195,197 @@ def test_dropped_remains_distinct_from_merge_failed() -> None:
     distinct state for stories that ran but failed at the merge step."""
     assert StoryOutcome.DROPPED is not StoryOutcome.MERGE_FAILED
     assert StoryOutcome.DROPPED.value != StoryOutcome.MERGE_FAILED.value
+
+
+# ── MERGE_ARMING_FAILED: distinct from MERGE_FAILED ─────────────────────
+
+
+def test_merge_arming_failed_is_distinct_terminal_failed_outcome() -> None:
+    """MERGE_ARMING_FAILED is its own terminal failed outcome — separate enum
+    value, separate name, but same failure-bucket semantics."""
+    assert StoryOutcome.MERGE_ARMING_FAILED is not StoryOutcome.MERGE_FAILED
+    assert StoryOutcome.MERGE_ARMING_FAILED.value != StoryOutcome.MERGE_FAILED.value
+    assert StoryOutcome.MERGE_ARMING_FAILED.is_terminal
+    assert StoryOutcome.MERGE_ARMING_FAILED.is_failed
+    assert not StoryOutcome.MERGE_ARMING_FAILED.is_succeeded
+
+
+def test_mark_merge_failed_arming_message_names_arming_distinction() -> None:
+    """When arming_failed=True, the result message must name the arming
+    distinction and point at branch-protection remediation, not at the PR."""
+    result = _approved_pending_result()
+    mark_merge_failed(
+        result.state,
+        result,
+        "enablePullRequestAutoMerge: Protected branch rules not configured",
+        "forge/story-x",
+        arming_failed=True,
+    )
+
+    assert result.phase is Phase.MERGE_FAILED
+    assert result.success is False
+    assert result.landing_status == "failed"
+    assert "Auto-merge arming failed" in result.message
+    assert "branch protection" in result.message.lower()
+    # Must NOT use the generic "story is recoverable" phrasing reserved for
+    # genuine rejections — operators should pursue config, not PR investigation.
+    assert "Story is recoverable but unmerged" not in result.message
+
+
+def test_outcome_to_status_maps_merge_arming_failed_to_failed() -> None:
+    assert _outcome_to_status("MERGE_ARMING_FAILED") == "failed"
+
+
+def test_terminal_phase_returns_merge_arming_failed() -> None:
+    """STAGE column must surface MERGE_ARMING_FAILED distinctly from
+    MERGE_FAILED so operators can choose the right next action."""
+    assert _terminal_phase("MERGE_ARMING_FAILED", []) == "MERGE_ARMING_FAILED"
+    assert _terminal_phase("MERGE_FAILED", []) == "MERGE_FAILED"
+
+
+def test_status_renderer_distinguishes_arming_from_rejection(tmp_path: Path) -> None:
+    """sprint-summary outcome=MERGE_ARMING_FAILED renders as STATUS=failed,
+    PHASE=MERGE_ARMING_FAILED with a detail naming the arming distinction —
+    distinct from a MERGE_FAILED row whose detail describes a real PR rejection."""
+    sprint_dir = tmp_path / ".forge" / "logs" / "sprint-test"
+    sprint_dir.mkdir(parents=True)
+    summary = {
+        "sprint": {"run_id": "abc"},
+        "stories": [
+            {
+                "slug": "story-arming",
+                "path": "Issue #1357",
+                "outcome": "MERGE_ARMING_FAILED",
+                "cost_usd": 4.27,
+                "verdict": "APPROVE",
+            },
+            {
+                "slug": "story-rejected",
+                "path": "Issue #1358",
+                "outcome": "MERGE_FAILED",
+                "cost_usd": 4.27,
+                "verdict": "APPROVE",
+            },
+        ],
+    }
+    summary_path = sprint_dir / "sprint-summary.yaml"
+    summary_path.write_text(yaml.safe_dump(summary), encoding="utf-8")
+
+    arming_dir = sprint_dir / "story-arming"
+    arming_dir.mkdir()
+    (arming_dir / "audit.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "outcome": {
+                    "final_phase": "MERGE_FAILED",
+                    "success": False,
+                    "message": (
+                        "Auto-merge arming failed: enablePullRequestAutoMerge. "
+                        "Configure branch protection on the target branch or merge "
+                        "manually with `gh pr merge <PR> --squash`."
+                    ),
+                },
+                "landing_status": "failed",
+                "error": "enablePullRequestAutoMerge: Protected branch rules not configured",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rejected_dir = sprint_dir / "story-rejected"
+    rejected_dir.mkdir()
+    (rejected_dir / "audit.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "outcome": {
+                    "final_phase": "MERGE_FAILED",
+                    "success": False,
+                    "message": "Merge failed: required CI check failed.",
+                },
+                "landing_status": "failed",
+                "error": "required CI check failed",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    entries = read_completed_status(summary_path)
+    assert len(entries) == 2
+    by_slug = {row.slug: row for row in entries}
+
+    arming_row = by_slug["story-arming"]
+    rejected_row = by_slug["story-rejected"]
+
+    assert arming_row.status == "failed"
+    assert rejected_row.status == "failed"
+
+    # PHASE column must distinguish the two failure modes.
+    assert arming_row.phase == "MERGE_ARMING_FAILED"
+    assert rejected_row.phase == "MERGE_FAILED"
+
+    # DETAIL column must surface the operator-actionable distinction.
+    assert "arming" in arming_row.detail.lower()
+    assert "branch protection" in arming_row.detail.lower()
+    assert "arming" not in rejected_row.detail.lower()
+
+
+# ── runner-level seam: outcome assignment from merge_info.arming_failed ──
+
+
+def test_runner_classify_records_merge_arming_failed_when_flag_set() -> None:
+    """runner._classify_and_record reads merge_info.arming_failed from the
+    coordinator result and assigns MERGE_ARMING_FAILED instead of MERGE_FAILED.
+    This is the seam test that covers the path from coordinator merge_info →
+    sprint outcome → sprint-summary serialization."""
+    from theforge.sprint.dag import StoryDAG
+    from theforge.sprint.runner import _classify_and_record
+    from theforge.sprint.story_state import SprintStoryState
+    from theforge.task import TaskStory as _TaskStory
+
+    task = _TaskStory(name="story-arming", slug="story-arming", story_path="specs/x.md")
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    state.phase = Phase.MERGE_FAILED
+
+    arming_result = CoordinatorResult(
+        success=False,
+        phase=Phase.MERGE_FAILED,
+        state=state,
+        message="Auto-merge arming failed.",
+        merge={"action": "merge-pr", "merged": False, "arming_failed": True},
+        landing_status="failed",
+    )
+
+    rejected_state = CoordinatorState()
+    rejected_state.preflight_verdict = "PROCEED"
+    rejected_state.phase = Phase.MERGE_FAILED
+    rejected_result = CoordinatorResult(
+        success=False,
+        phase=Phase.MERGE_FAILED,
+        state=rejected_state,
+        message="Merge failed: required CI check failed.",
+        merge={"action": "merge-pr", "merged": False, "arming_failed": False},
+        landing_status="failed",
+    )
+
+    story_state = SprintStoryState()
+    story_state.register("story-arming", "specs/x.md")
+    story_state.register("story-rejected", "specs/y.md")
+
+    dag = StoryDAG([task, _TaskStory(name="story-rejected", slug="story-rejected")])
+
+    arming_outcome = _classify_and_record(task, arming_result, dag, set(), story_state=story_state)
+    rejected_outcome = _classify_and_record(
+        _TaskStory(name="story-rejected", slug="story-rejected"),
+        rejected_result,
+        dag,
+        set(),
+        story_state=story_state,
+    )
+
+    assert arming_outcome == StoryOutcome.MERGE_ARMING_FAILED
+    assert rejected_outcome == StoryOutcome.MERGE_FAILED
+    # The sprint-summary serialization derives from .name on the canonical
+    # outcome (audit.py:816), so the two failure modes produce distinct strings.
+    assert arming_outcome.name == "MERGE_ARMING_FAILED"
+    assert rejected_outcome.name == "MERGE_FAILED"

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -425,6 +425,83 @@ class TestMergePrFunction:
             "merge": MAX_MERGE_RETRIES,
         }
 
+    def test_arming_failure_marked_distinctly(self, tmp_path: Path) -> None:
+        """When gh pr merge --auto fails because GitHub refused to ARM auto-merge
+        (e.g. enablePullRequestAutoMerge / Protected branch rules not configured),
+        _merge_pr returns merge_info with arming_failed=True and a remediation
+        hint pointing at branch-protection configuration in the error string."""
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        arming_stderr = (
+            "GraphQL: Pull request Protected branch rules not configured for this "
+            "branch (enablePullRequestAutoMerge)"
+        )
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                return _make_subprocess_result(1, stderr=arming_stderr)
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/1357",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is False
+        assert result["merged"] is False
+        assert result.get("arming_failed") is True
+        assert "branch protection" in result["error"].lower()
+        assert "enablePullRequestAutoMerge" in result["error"]
+
+    def test_genuine_rejection_not_marked_as_arming_failure(self, tmp_path: Path) -> None:
+        """Generic merge rejections (CI failed, conflicts, branch-protection
+        review-required) must NOT be flagged as arming failures."""
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "merge"]:
+                return _make_subprocess_result(1, stderr="merge conflict with base branch")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/fuzzypete/theforge/pull/42",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is False
+        assert result.get("arming_failed") is False
+        assert "branch protection" not in result["error"].lower()
+
     def test_non_retryable_merge_failure_does_not_retry(self, tmp_path: Path) -> None:
         config = _make_merge_pr_config(tmp_path)
         task = _make_task(tmp_path)


### PR DESCRIPTION
## Summary

No blocking issues found; the change adds a distinct MERGE_ARMING_FAILED outcome and wires it through merge classification, sprint summaries, and status rendering.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.27
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

MERGE_FAILED outcome conflates auto-merge arming failures with PR rejections, masking the real fix (GitHub Issue #1363)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1363