### PR TITLE
feat(runners): add CLI argv contract test layer (#1014)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pythonpath = ["src", "tests"]
 addopts = "-n auto --dist worksteal"
 markers = [
     "network_integration: marks tests that make real external network calls (requires THEFORGE_RUN_INTEGRATION=1)",
+    "cli_contract: marks tests that invoke real provider CLIs to validate argv contracts (requires THEFORGE_RUN_CLI_CONTRACT=1)",
 ]
 
 [tool.ruff]

--- a/src/theforge/runners/CONVENTIONS.md
+++ b/src/theforge/runners/CONVENTIONS.md
@@ -35,3 +35,14 @@ results.
   review failures.
 - `tool_runtime.py` is the place to look when agent tool execution semantics or
   environment wiring are involved.
+
+## CLI argv contract layer
+
+Each CLI-backed runner exposes a pure `build_argv` (and any `build_resume_argv`
+or variant) function. `tests/contract/test_<name>_cli_contract.py` invokes the
+real installed CLI with that argv to catch contract drift the mocks cannot see.
+The layer is gated behind the `cli_contract` pytest marker and the
+`THEFORGE_RUN_CLI_CONTRACT=1` env var, so the default gate stays fast and
+contributors without every CLI installed are not blocked. A new CLI runner
+without a matching contract test fails `tests/test_conventions.py::test_runner_contract_coverage`.
+See `tests/contract/README.md`.

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -35,6 +35,35 @@ def _log_verbose(msg: str) -> None:
         _log_line("[forge]", msg)
 
 
+# ── Argv builder ──────────────────────────────────────────────────────
+
+
+def build_argv(
+    *,
+    profile: ModelProfile,
+    session_id: str | None = None,
+) -> list[str]:
+    """Construct argv for `claude` invocation (initial run or resume)."""
+    cmd: list[str] = [
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--input-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        profile.model,
+    ]
+    if profile.allowed_tools:
+        cmd.extend(["--allowedTools", " ".join(profile.allowed_tools)])
+    if session_id:
+        cmd.extend(["--resume", session_id])
+    if profile.sandbox_mode != "none":
+        cmd.extend(["--permission-mode", "default"])
+    return cmd
+
+
 # ── Claude-specific helpers ───────────────────────────────────────────
 
 
@@ -317,38 +346,17 @@ def _run_claude(
     stop_event: "threading.Event | None" = None,
 ) -> AgentResult:
     """Invoke `claude -p --output-format stream-json --verbose` as a subprocess."""
-    cmd: list[str] = [
-        "claude",
-        "-p",
-        "--output-format",
-        "stream-json",
-        "--input-format",
-        "stream-json",
-        "--verbose",
-        "--model",
-        profile.model,
-    ]
-
-    if profile.allowed_tools:
-        cmd.extend(["--allowedTools", " ".join(profile.allowed_tools)])
-
-    if session_id:
-        cmd.extend(["--resume", session_id])
-
-    # Engage Claude's native permission mode when sandboxing is requested.
-    # "default" prompts before writes outside cwd; in automated runs where there is
-    # no human to approve, out-of-worktree writes are effectively blocked.
     # NOTE: Claude CLI has no mechanically-enforced read-only mode. When
-    # sandbox_mode == "read-only" we apply the same --permission-mode default and
-    # log a warning so operators know the read-only constraint is not syscall-enforced.
+    # sandbox_mode == "read-only" we apply --permission-mode default (set by
+    # build_argv) and log a warning so operators know the read-only constraint
+    # is not syscall-enforced.
     if profile.sandbox_mode == "read-only":
         _log(
             "  WARNING: sandbox_mode=read-only is not mechanically enforced by Claude CLI; "
             "applying --permission-mode default (writes require permission approval). "
             "Use a provider/API profile for true read-only enforcement."
         )
-    if profile.sandbox_mode != "none":
-        cmd.extend(["--permission-mode", "default"])
+    cmd: list[str] = build_argv(profile=profile, session_id=session_id)
 
     # Unset CLAUDECODE so the subprocess isn't blocked by the nested-session check
     env = build_workspace_env(working_dir, extra=secrets)

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -46,6 +46,55 @@ def _try_parse_handoff(output: str) -> dict | None:
         return None
 
 
+# ── Argv builders ─────────────────────────────────────────────────────
+
+
+def build_argv(
+    *,
+    profile: ModelProfile,
+    working_dir: Path,
+    output_file: Path,
+    prompt: str,
+) -> list[str]:
+    """Construct argv for a fresh `codex exec` invocation."""
+    cmd: list[str] = [
+        "npx",
+        "@openai/codex",
+        "exec",
+        "--full-auto",
+        "-m",
+        profile.model,
+    ]
+    if profile.reasoning_effort:
+        cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
+    if profile.sandbox_mode != "none":
+        cmd += ["--sandbox", profile.sandbox_mode]
+    cmd += ["-C", str(working_dir), "-o", str(output_file), prompt]
+    return cmd
+
+
+def build_resume_argv(
+    *,
+    profile: ModelProfile,
+    output_file: Path,
+    session_id: str,
+) -> list[str]:
+    """Construct argv for `codex exec resume` (prompt provided via stdin)."""
+    cmd: list[str] = [
+        "npx",
+        "@openai/codex",
+        "exec",
+        "resume",
+        "--full-auto",
+        "-m",
+        profile.model,
+    ]
+    if profile.reasoning_effort:
+        cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
+    cmd += ["-o", str(output_file), session_id, "-"]
+    return cmd
+
+
 # ── Codex-specific helpers ────────────────────────────────────────────
 
 
@@ -116,33 +165,17 @@ def _run_codex(
     # Fresh runs still accept the explicit sandbox flag.
     # Fresh start: `codex exec [flags] <prompt>` (prompt as positional arg).
     if session_id:
-        cmd: list[str] = [
-            "npx",
-            "@openai/codex",
-            "exec",
-            "resume",
-            "--full-auto",
-            "-m",
-            profile.model,
-        ]
-        if profile.reasoning_effort:
-            cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
-        cmd += ["-o", str(output_file), session_id, "-"]
+        cmd: list[str] = build_resume_argv(
+            profile=profile, output_file=output_file, session_id=session_id
+        )
         stdin_prompt: str | None = prompt
     else:
-        cmd = [
-            "npx",
-            "@openai/codex",
-            "exec",
-            "--full-auto",
-            "-m",
-            profile.model,
-        ]
-        if profile.reasoning_effort:
-            cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
-        if profile.sandbox_mode != "none":
-            cmd += ["--sandbox", profile.sandbox_mode]
-        cmd += ["-C", str(working_dir), "-o", str(output_file), prompt]
+        cmd = build_argv(
+            profile=profile,
+            working_dir=working_dir,
+            output_file=output_file,
+            prompt=prompt,
+        )
         stdin_prompt = None
 
     start_wall = time.time()

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -43,6 +43,31 @@ def _try_parse_handoff(output: str) -> dict | None:
         return None
 
 
+# ── Argv builder ──────────────────────────────────────────────────────
+
+
+def build_argv(
+    *,
+    profile: ModelProfile,
+    prompt: str,
+    session_id: str | None = None,
+) -> list[str]:
+    """Construct argv for `npx @google/gemini-cli` invocation."""
+    cmd: list[str] = ["npx", "@google/gemini-cli"]
+    if session_id:
+        cmd += ["--resume", session_id]
+    cmd += [
+        "-p",
+        prompt,
+        "--yolo",
+        "-m",
+        profile.model,
+        "-o",
+        "json",
+    ]
+    return cmd
+
+
 # ── Gemini runner ─────────────────────────────────────────────────────
 
 
@@ -65,18 +90,7 @@ def _run_gemini(
     is not invocation-scoped and two concurrent gemini reviewers would trample each
     other's context.
     """
-    cmd: list[str] = ["npx", "@google/gemini-cli"]
-    if session_id:
-        cmd += ["--resume", session_id]
-    cmd += [
-        "-p",
-        prompt,
-        "--yolo",
-        "-m",
-        profile.model,
-        "-o",
-        "json",
-    ]
+    cmd: list[str] = build_argv(profile=profile, prompt=prompt, session_id=session_id)
 
     # NOTE: Gemini CLI has no --config flag for thinking config.
     # reasoning_effort is silently ignored for gemini until a CLI mechanism exists.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,6 +167,38 @@ def _enforce_network_integration_marker(request):
         _socket_module.socket = _BlockedSocket
 
 
+@pytest.fixture(autouse=True)
+def _enforce_cli_contract_marker(request, monkeypatch):
+    """Gate cli_contract tests behind THEFORGE_RUN_CLI_CONTRACT=1.
+
+    When the marker is present and the env gate is set, lift the network guard
+    and the coordinator-runner blockers and the credential scrub so the test
+    can spawn the real provider CLI to validate argv parsing.
+    """
+    marker = request.node.get_closest_marker("cli_contract")
+    if marker is None:
+        yield
+        return
+
+    if not os.environ.get("THEFORGE_RUN_CLI_CONTRACT"):
+        pytest.skip("set THEFORGE_RUN_CLI_CONTRACT=1 to run cli_contract tests")
+
+    _socket_module.socket = _REAL_SOCKET
+    monkeypatch.setattr("shutil.which", _REAL_WHICH)
+    try:
+        yield
+    finally:
+        _socket_module.socket = _BlockedSocket
+
+
+def require_cli(name: str) -> str:
+    """Return the absolute path to *name*, or skip the test if not on PATH."""
+    path = _REAL_WHICH(name)
+    if not path:
+        pytest.skip(f"{name!r} not installed on PATH")
+    return path
+
+
 @pytest.fixture
 def dev_profile() -> ModelProfile:
     return ModelProfile(

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -1,0 +1,36 @@
+# CLI contract tests
+
+This layer validates that the argv each runner constructs is actually accepted
+by the installed provider CLI. It complements (does not replace) the mocked
+unit tests in `tests/test_runner_*.py`.
+
+## Running
+
+Default test gate skips this layer. Opt in with:
+
+```
+THEFORGE_RUN_CLI_CONTRACT=1 .venv/bin/python -m pytest tests/contract -v
+```
+
+Tests auto-skip individually if the corresponding CLI is not on `PATH`, so a
+contributor with only `claude` installed will run the Claude contract tests
+and skip the others.
+
+## Scope
+
+Covered: every runner that spawns a provider CLI subprocess
+(`runner_claude.py`, `runner_codex.py`, `runner_gemini.py`).
+
+Excluded: `adapters/deepseek.py`. DeepSeek is an HTTP-API adapter — it has no
+subprocess argv surface to validate. If a CLI-backed DeepSeek runner is added
+later, contract coverage must accompany it (enforced by the
+`test_runner_contract_coverage` check in `tests/test_conventions.py`).
+
+## Adding a new runner
+
+1. Add a `build_argv` (and any resume/variant) function to the runner module.
+2. Create `tests/contract/test_<name>_cli_contract.py` with
+   `pytestmark = pytest.mark.cli_contract`, calling `require_cli(...)` and
+   `assert_cli_accepts_argv(...)` for every argv shape the runner emits.
+3. The conventions check enforces step 2 — adding a runner without a contract
+   file will fail the default gate.

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,0 +1,94 @@
+"""Shared helpers for the CLI-contract test layer.
+
+Each contract test constructs argv via the runner's real builder and invokes
+the installed CLI. The helper ``assert_cli_accepts_argv`` spawns the binary,
+gives it a short window to either exit (e.g. on parse error or --help) or
+start doing real work, then kills it and inspects stderr for argparse-style
+parse failures.
+
+This layer is gated behind the ``cli_contract`` marker and the
+``THEFORGE_RUN_CLI_CONTRACT=1`` env var (see tests/conftest.py).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+# Patterns that indicate the CLI rejected the argv before doing any model work.
+# These are conservative — false negatives (a real bug we miss) are worse than
+# false positives (a flaky-looking test we have to investigate). The patterns
+# below match argparse, clap (Rust), commander (Node), and yargs error output.
+_PARSE_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"unrecognized arguments?:\s*(\S+)", re.IGNORECASE),
+    re.compile(r"unknown option[: ]+'?(--?\S+?)'?\b", re.IGNORECASE),
+    re.compile(r"unexpected argument '?(--?\S+?)'?\b", re.IGNORECASE),
+    re.compile(r"no such (?:option|subcommand)[: ]+'?(\S+)'?", re.IGNORECASE),
+    re.compile(r"error: argument (\S+)", re.IGNORECASE),
+    re.compile(r"invalid (?:option|argument)[: ]+'?(--?\S+?)'?\b", re.IGNORECASE),
+    re.compile(r"unknown (?:flag|argument)[: ]+'?(--?\S+?)'?\b", re.IGNORECASE),
+)
+
+
+def _extract_offending_flag(text: str) -> str | None:
+    for pattern in _PARSE_ERROR_PATTERNS:
+        m = pattern.search(text)
+        if m:
+            return m.group(1)
+    return None
+
+
+def assert_cli_accepts_argv(
+    runner_name: str,
+    argv: list[str],
+    *,
+    timeout: float = 4.0,
+    stdin_input: str | None = "",
+) -> None:
+    """Spawn *argv* and assert the CLI did not reject it as malformed.
+
+    Strategy:
+    - Spawn the process with stdin/stdout/stderr piped.
+    - Wait up to *timeout* seconds for it to either exit on its own or stay
+      alive past the parse phase.
+    - If it stayed alive past the timeout, the argv was at least syntactically
+      accepted — kill it and pass.
+    - If it exited within the timeout, scan stderr (and stdout, since some
+      CLIs print parse errors there) for argparse-style failure markers.
+      If found, fail with a message naming the runner and the offending flag.
+    - A clean exit-0 (e.g. --help short-circuit) is also a pass.
+    """
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise AssertionError(f"[{runner_name}] could not spawn {argv[0]!r}: {exc}") from exc
+
+    try:
+        stdout, stderr = proc.communicate(input=stdin_input, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+        return  # alive past parse — argv accepted as well-formed
+
+    combined = (stderr or "") + "\n" + (stdout or "")
+    flag = _extract_offending_flag(combined)
+    if flag is not None:
+        raise AssertionError(
+            f"[{runner_name}] CLI rejected argv: offending flag/argument {flag!r}\n"
+            f"  argv: {argv}\n"
+            f"  stderr: {(stderr or '').strip()[:500]}"
+        )
+    if proc.returncode not in (0, None):
+        # Nonzero exit without a recognized parse-error marker is not, by itself,
+        # an argv-contract failure (could be missing API key, network, etc).
+        # Surface it for diagnostic value but do not fail.
+        return

--- a/tests/contract/test_claude_cli_contract.py
+++ b/tests/contract/test_claude_cli_contract.py
@@ -1,0 +1,54 @@
+"""Claude CLI contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import require_cli
+from tests.contract.conftest import assert_cli_accepts_argv
+from theforge.config import ModelProfile
+from theforge.runners import runner_claude
+
+pytestmark = pytest.mark.cli_contract
+
+
+def _profile(**kwargs) -> ModelProfile:
+    defaults = dict(
+        name="claude-contract",
+        cli="claude",
+        model="sonnet",
+        budget_usd=1.0,
+        timeout_seconds=60,
+        allowed_tools=("Read", "Bash"),
+        sandbox_mode="workspace-write",
+    )
+    defaults.update(kwargs)
+    return ModelProfile(**defaults)
+
+
+@pytest.mark.parametrize(
+    "shape,builder",
+    [
+        ("fresh", lambda: runner_claude.build_argv(profile=_profile())),
+        (
+            "fresh_no_sandbox",
+            lambda: runner_claude.build_argv(profile=_profile(sandbox_mode="none")),
+        ),
+        (
+            "fresh_no_tools",
+            lambda: runner_claude.build_argv(profile=_profile(allowed_tools=())),
+        ),
+        (
+            "resume",
+            lambda: runner_claude.build_argv(
+                profile=_profile(), session_id="00000000-0000-0000-0000-000000000000"
+            ),
+        ),
+    ],
+)
+def test_claude_argv_accepted(shape: str, builder) -> None:
+    require_cli("claude")
+    argv = builder()
+    # Claude blocks until stdin closes; sending an empty stdin lets it parse
+    # the argv and exit cleanly without making a model call.
+    assert_cli_accepts_argv(f"claude/{shape}", argv, stdin_input="")

--- a/tests/contract/test_codex_cli_contract.py
+++ b/tests/contract/test_codex_cli_contract.py
@@ -1,0 +1,98 @@
+"""Codex CLI contract tests.
+
+Validates that argv constructed by the runner is accepted by the installed
+`codex` CLI on both fresh-run and resume paths. The 2026-04-24 incident
+(#1011 + sibling) was exactly the resume-path argv contract drifting unnoticed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import require_cli
+from tests.contract.conftest import assert_cli_accepts_argv
+from theforge.config import ModelProfile
+from theforge.runners import runner_codex
+
+pytestmark = pytest.mark.cli_contract
+
+
+def _profile(**kwargs) -> ModelProfile:
+    defaults = dict(
+        name="codex-contract",
+        cli="codex",
+        model="o4-mini",
+        budget_usd=1.0,
+        timeout_seconds=60,
+        allowed_tools=(),
+        sandbox_mode="workspace-write",
+    )
+    defaults.update(kwargs)
+    return ModelProfile(**defaults)
+
+
+def _replace_npx_with_codex(argv: list[str]) -> list[str]:
+    """Substitute the installed `codex` binary for `npx @openai/codex`.
+
+    Avoids pulling a fresh package via npx on every CI run while still
+    exercising the same argv shape the runner produces.
+    """
+    if argv[:2] == ["npx", "@openai/codex"]:
+        return ["codex", *argv[2:]]
+    return argv
+
+
+@pytest.mark.parametrize(
+    "shape,builder",
+    [
+        (
+            "exec_fresh",
+            lambda: runner_codex.build_argv(
+                profile=_profile(),
+                working_dir=Path("/tmp"),
+                output_file=Path("/tmp/contract-out.txt"),
+                prompt="contract-check",
+            ),
+        ),
+        (
+            "exec_fresh_no_sandbox",
+            lambda: runner_codex.build_argv(
+                profile=_profile(sandbox_mode="none"),
+                working_dir=Path("/tmp"),
+                output_file=Path("/tmp/contract-out.txt"),
+                prompt="contract-check",
+            ),
+        ),
+        (
+            "exec_fresh_with_reasoning",
+            lambda: runner_codex.build_argv(
+                profile=_profile(reasoning_effort="medium"),
+                working_dir=Path("/tmp"),
+                output_file=Path("/tmp/contract-out.txt"),
+                prompt="contract-check",
+            ),
+        ),
+        (
+            "exec_resume",
+            lambda: runner_codex.build_resume_argv(
+                profile=_profile(),
+                output_file=Path("/tmp/contract-out.txt"),
+                session_id="00000000-0000-0000-0000-000000000000",
+            ),
+        ),
+        (
+            "exec_resume_with_reasoning",
+            lambda: runner_codex.build_resume_argv(
+                profile=_profile(reasoning_effort="high"),
+                output_file=Path("/tmp/contract-out.txt"),
+                session_id="00000000-0000-0000-0000-000000000000",
+            ),
+        ),
+    ],
+)
+def test_codex_argv_accepted(shape: str, builder) -> None:
+    require_cli("codex")
+    argv = _replace_npx_with_codex(builder())
+    assert_cli_accepts_argv(f"codex/{shape}", argv)

--- a/tests/contract/test_gemini_cli_contract.py
+++ b/tests/contract/test_gemini_cli_contract.py
@@ -1,0 +1,53 @@
+"""Gemini CLI contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import require_cli
+from tests.contract.conftest import assert_cli_accepts_argv
+from theforge.config import ModelProfile
+from theforge.runners import runner_gemini
+
+pytestmark = pytest.mark.cli_contract
+
+
+def _profile(**kwargs) -> ModelProfile:
+    defaults = dict(
+        name="gemini-contract",
+        cli="gemini",
+        model="gemini-2.5-pro",
+        budget_usd=1.0,
+        timeout_seconds=60,
+        allowed_tools=(),
+        sandbox_mode="none",
+    )
+    defaults.update(kwargs)
+    return ModelProfile(**defaults)
+
+
+def _replace_npx_with_gemini(argv: list[str]) -> list[str]:
+    if argv[:2] == ["npx", "@google/gemini-cli"]:
+        return ["gemini", *argv[2:]]
+    return argv
+
+
+@pytest.mark.parametrize(
+    "shape,builder",
+    [
+        (
+            "fresh",
+            lambda: runner_gemini.build_argv(profile=_profile(), prompt="contract-check"),
+        ),
+        (
+            "resume",
+            lambda: runner_gemini.build_argv(
+                profile=_profile(), prompt="contract-check", session_id="latest"
+            ),
+        ),
+    ],
+)
+def test_gemini_argv_accepted(shape: str, builder) -> None:
+    require_cli("gemini")
+    argv = _replace_npx_with_gemini(builder())
+    assert_cli_accepts_argv(f"gemini/{shape}", argv)

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -629,6 +629,31 @@ class TestNoScratchFilesCheck:
         assert any(v.rule == "no_scratch_files" for v in violations)
 
 
+def test_runner_contract_coverage() -> None:
+    """Every CLI-backed runner module must have a matching contract test file.
+
+    Catches the failure mode behind issue #1014: a runner argv is changed
+    without anyone updating the mock-based test, and the real CLI silently
+    rejects the argv at runtime. A required contract file means the author
+    has to consider real-CLI parsing.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    runners_dir = repo_root / "src" / "theforge" / "runners"
+    contract_dir = repo_root / "tests" / "contract"
+    missing: list[str] = []
+    for path in sorted(runners_dir.glob("runner_*.py")):
+        name = path.stem  # e.g. runner_codex
+        short = name[len("runner_") :]  # e.g. codex
+        expected = contract_dir / f"test_{short}_cli_contract.py"
+        if not expected.is_file():
+            missing.append(f"{path.name} → expected {expected.relative_to(repo_root)}")
+    assert not missing, (
+        "CLI runner modules without contract test coverage:\n  "
+        + "\n  ".join(missing)
+        + "\nSee tests/contract/README.md."
+    )
+
+
 def _git(repo: Path, *args: str) -> str:
     proc = subprocess.run(
         ["git", *args],


### PR DESCRIPTION
Closes #1014.

## Summary

Adds an opt-in `cli_contract` pytest layer that constructs each runner's argv via the real builders and invokes the installed CLI to validate it parses cleanly. Catches the failure mode behind the 2026-04-24 Codex resume-path drift (#1011 + sibling) where mocks happily accepted argv the real CLI rejected.

## Changes

- New `cli_contract` pytest marker gated behind `THEFORGE_RUN_CLI_CONTRACT=1`; `require_cli` auto-skips when a binary is missing.
- Each runner exposes pure `build_argv` / `build_resume_argv` functions (refactor only — call sites unchanged).
- Per-runner contract tests for codex (fresh + resume), claude (fresh + resume), gemini (fresh + resume).
- DeepSeek scoped out as API-only in `tests/contract/README.md`.
- New `test_runner_contract_coverage` convention check fails the default gate when a `runner_*.py` lacks a contract test.

## Review

Sprint produced APPROVE verdict from claude-sonnet (deepseek-reasoner timed out at 15 iterations and is excluded). The integration push initially failed with a transient `remote: fatal error in commit_refs` GitHub-side rejection; this PR is the manual recovery (work + verdict are intact, only the orchestrator's automated push step lost the race). Per the orchestrator's MERGE_FAILED classification, this was distinct from MERGE_ARMING_FAILED — exactly the distinction #1363 just shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)