### PR TITLE
cut-rc.sh: configure branch protection on release/vX.Y so auto-merge works for RC ladder fixes

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -5,24 +5,14 @@ project: theforge
 # and synthesis roles automatically from this list and the story complexity.
 # See docs/guides/inputs-reference.md for the full schema reference.
 models:
-  enabled:
-    - claude/sonnet
-    - claude/opus
-    - openai/gpt-5.4
-    - openai/gpt-5.5  
-    - deepseek/deepseek-reasoner
-    - google/gemini-3.1-pro-preview
-  custom:
-    # GPT-5.5 — added via the user-declared registry overlay shipped in #1184
-    # (v0.10.0). Disabled pending #1355: AGENT_REGISTRY direct-readers in
-    # model_profiles.py bypass the overlay and crash worker dispatch with
-    # 'Unknown model'. Re-enable when #1355 ships.
-    openai/gpt-5.5:
-      provider: openai            # routes via Codex CLI; use 'openai-api' for the API adapter
-      model: gpt-5.5
-      tier: strong
-      input_cost_per_mtok: 5.00
-      output_cost_per_mtok: 30.00
+  - claude/sonnet
+  - claude/opus
+  - openai/gpt-5.4
+  - deepseek/deepseek-reasoner
+  - google/gemini-3.1-pro-preview
+
+plan_agent_review:
+  enabled: true
 
 provider_fallbacks:
   openai:
@@ -30,11 +20,6 @@ provider_fallbacks:
     timeout_seconds: 600
 
 budget_usd: 50.0
-
-intake:
-  grooming: true
-  auto_fix: true
-  auto_fix_mode: edit
 
 workspace:
   create_command: "git worktree add .forge/worktrees/{slug} -b feat/{slug} {base_branch}"
@@ -73,13 +58,6 @@ conventions:
     - "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail — diagnosing sprint failures requires tracing real data, not reconstructing it"
     - "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing."
     - "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
-  advisory:
-    artifact_path: ".forge/conventions/advisory.yaml"
-    summary_top_n: 10
-    noteworthy_threshold_percent: 10.0
-    commit_shared_artifact: false
-    issue_filing:
-      enabled: false
 
 assignment:
   enabled: true
@@ -95,20 +73,10 @@ stuck_detection:
 
 retry:
   max_dev_iterations: 3
-  max_dev_transport_retries: 2
   max_review_cycles: 3
-  adaptive_iterations: true
-  max_dev_iterations_cap: 5
-  max_review_cycles_cap: 5
 
 plan:
   enabled: true
-
-diagnose:
-  output_destination: comment
-  budget_usd: 1.50
-  timeout_seconds: 600
-  autonomous_default: true
 
 hooks:
   pre_run: .forge/hooks/pre_run.sh

--- a/forge.yaml
+++ b/forge.yaml
@@ -5,14 +5,24 @@ project: theforge
 # and synthesis roles automatically from this list and the story complexity.
 # See docs/guides/inputs-reference.md for the full schema reference.
 models:
-  - claude/sonnet
-  - claude/opus
-  - openai/gpt-5.4
-  - deepseek/deepseek-reasoner
-  - google/gemini-3.1-pro-preview
-
-plan_agent_review:
-  enabled: true
+  enabled:
+    - claude/sonnet
+    - claude/opus
+    - openai/gpt-5.4
+    - openai/gpt-5.5  
+    - deepseek/deepseek-reasoner
+    - google/gemini-3.1-pro-preview
+  custom:
+    # GPT-5.5 — added via the user-declared registry overlay shipped in #1184
+    # (v0.10.0). Disabled pending #1355: AGENT_REGISTRY direct-readers in
+    # model_profiles.py bypass the overlay and crash worker dispatch with
+    # 'Unknown model'. Re-enable when #1355 ships.
+    openai/gpt-5.5:
+      provider: openai            # routes via Codex CLI; use 'openai-api' for the API adapter
+      model: gpt-5.5
+      tier: strong
+      input_cost_per_mtok: 5.00
+      output_cost_per_mtok: 30.00
 
 provider_fallbacks:
   openai:
@@ -20,6 +30,11 @@ provider_fallbacks:
     timeout_seconds: 600
 
 budget_usd: 50.0
+
+intake:
+  grooming: true
+  auto_fix: true
+  auto_fix_mode: edit
 
 workspace:
   create_command: "git worktree add .forge/worktrees/{slug} -b feat/{slug} {base_branch}"
@@ -58,6 +73,13 @@ conventions:
     - "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail — diagnosing sprint failures requires tracing real data, not reconstructing it"
     - "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing."
     - "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+  advisory:
+    artifact_path: ".forge/conventions/advisory.yaml"
+    summary_top_n: 10
+    noteworthy_threshold_percent: 10.0
+    commit_shared_artifact: false
+    issue_filing:
+      enabled: false
 
 assignment:
   enabled: true
@@ -73,10 +95,20 @@ stuck_detection:
 
 retry:
   max_dev_iterations: 3
+  max_dev_transport_retries: 2
   max_review_cycles: 3
+  adaptive_iterations: true
+  max_dev_iterations_cap: 5
+  max_review_cycles_cap: 5
 
 plan:
   enabled: true
+
+diagnose:
+  output_destination: comment
+  budget_usd: 1.50
+  timeout_seconds: 600
+  autonomous_default: true
 
 hooks:
   pre_run: .forge/hooks/pre_run.sh

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/apply-branch-protection.sh — apply minimum branch protection to
+# a release branch so GitHub's enablePullRequestAutoMerge mutation works.
+#
+# Usage: scripts/apply-branch-protection.sh [--dry-run] <repo> <branch>
+#
+# Behavior:
+#   - If branch already has protection, preserve it (log and exit 0).
+#   - Otherwise, PUT a minimal protection ruleset.
+#   - On API failure, warn (do NOT abort with non-zero) so the caller can
+#     proceed; manual recovery command is printed to stderr.
+#   - With --dry-run, log the planned PUT and body but do not call gh.
+#
+# Extracted from cut-rc.sh so the behavior can be exercised by tests with
+# a PATH-mocked `gh`.
+
+set -uo pipefail
+
+DRY_RUN=false
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        *) ARGS+=("$arg") ;;
+    esac
+done
+
+if [[ "${#ARGS[@]}" -ne 2 ]]; then
+    echo "Usage: $0 [--dry-run] <repo> <branch>" >&2
+    exit 2
+fi
+
+REPO="${ARGS[0]}"
+BRANCH="${ARGS[1]}"
+PROTECTION_BODY='{"required_status_checks":null,"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "+ (dry-run) gh api --method PUT repos/$REPO/branches/$BRANCH/protection --input -"
+    echo "    body: $PROTECTION_BODY"
+    echo "[forge] dry-run: would apply branch protection to $BRANCH (allow_auto_merge=true)"
+    exit 0
+fi
+
+if gh api "repos/$REPO/branches/$BRANCH/protection" >/dev/null 2>&1; then
+    echo "[forge] branch protection already exists on $BRANCH; preserving it"
+    exit 0
+fi
+
+echo "[forge] applying branch protection to $BRANCH: allow_auto_merge=true"
+if echo "$PROTECTION_BODY" | gh api --method PUT "repos/$REPO/branches/$BRANCH/protection" --input - >/dev/null 2>&1; then
+    echo "[forge] ✓ branch protected; auto-merge enabled"
+    exit 0
+fi
+
+echo "[forge] ⚠ failed to apply branch protection on $BRANCH (continuing)" >&2
+echo "[forge]   apply manually: echo '$PROTECTION_BODY' | gh api --method PUT repos/$REPO/branches/$BRANCH/protection --input -" >&2
+exit 0

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -161,31 +161,16 @@ run git push origin "$RC_TAG"
 # GitHub's enablePullRequestAutoMerge mutation (which Forge calls after APPROVE
 # via `gh pr merge --auto`) requires the target branch to have a branch
 # protection rule. Without protection, every RC-ladder fix lands in
-# MERGE_FAILED and the operator click-merges by hand. We apply a minimal
-# protection ruleset (no required reviews, no required checks, no
-# restrictions) — just enough to make GitHub treat the branch as protected.
-# Specific rule selection is intentionally minimal; tightening is a follow-on.
+# MERGE_FAILED and the operator click-merges by hand. The helper applies a
+# minimal protection ruleset — just enough to make GitHub treat the branch
+# as protected. Specific rule selection is intentionally minimal; tightening
+# is a follow-on.
 echo "==> Configuring branch protection on $RELEASE_BRANCH..."
-REPO="fuzzypete/theforge"
-PROTECTION_BODY='{"required_status_checks":null,"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
-
-if [[ "$DRY_RUN" == true ]]; then
-    echo "+ (dry-run) gh api --method PUT repos/$REPO/branches/$RELEASE_BRANCH/protection --input -"
-    echo "    body: $PROTECTION_BODY"
-    echo "[forge] dry-run: would apply branch protection to $RELEASE_BRANCH (allow_auto_merge=true)"
-else
-    if gh api "repos/$REPO/branches/$RELEASE_BRANCH/protection" >/dev/null 2>&1; then
-        echo "[forge] branch protection already exists on $RELEASE_BRANCH; preserving it"
-    else
-        echo "[forge] applying branch protection to $RELEASE_BRANCH: allow_auto_merge=true"
-        if echo "$PROTECTION_BODY" | gh api --method PUT "repos/$REPO/branches/$RELEASE_BRANCH/protection" --input - >/dev/null 2>&1; then
-            echo "[forge] ✓ branch protected; auto-merge enabled"
-        else
-            echo "[forge] ⚠ failed to apply branch protection on $RELEASE_BRANCH (continuing)" >&2
-            echo "[forge]   apply manually: echo '$PROTECTION_BODY' | gh api --method PUT repos/$REPO/branches/$RELEASE_BRANCH/protection --input -" >&2
-        fi
-    fi
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROTECT_ARGS=()
+[[ "$DRY_RUN" == true ]] && PROTECT_ARGS+=("--dry-run")
+PROTECT_ARGS+=("fuzzypete/theforge" "$RELEASE_BRANCH")
+"$SCRIPT_DIR/apply-branch-protection.sh" "${PROTECT_ARGS[@]}" || true
 
 # --- 10. Install the RC into the active env, then assert the right binary is on PATH ---
 if [[ "$NO_INSTALL" == false ]]; then

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -156,7 +156,38 @@ run git tag "$RC_TAG"
 run git push -u origin "$RELEASE_BRANCH"
 run git push origin "$RC_TAG"
 
-# --- 9. Install the RC into the active env, then assert the right binary is on PATH ---
+# --- 9. Configure branch protection on release branch so auto-merge works ---
+#
+# GitHub's enablePullRequestAutoMerge mutation (which Forge calls after APPROVE
+# via `gh pr merge --auto`) requires the target branch to have a branch
+# protection rule. Without protection, every RC-ladder fix lands in
+# MERGE_FAILED and the operator click-merges by hand. We apply a minimal
+# protection ruleset (no required reviews, no required checks, no
+# restrictions) — just enough to make GitHub treat the branch as protected.
+# Specific rule selection is intentionally minimal; tightening is a follow-on.
+echo "==> Configuring branch protection on $RELEASE_BRANCH..."
+REPO="fuzzypete/theforge"
+PROTECTION_BODY='{"required_status_checks":null,"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "+ (dry-run) gh api --method PUT repos/$REPO/branches/$RELEASE_BRANCH/protection --input -"
+    echo "    body: $PROTECTION_BODY"
+    echo "[forge] dry-run: would apply branch protection to $RELEASE_BRANCH (allow_auto_merge=true)"
+else
+    if gh api "repos/$REPO/branches/$RELEASE_BRANCH/protection" >/dev/null 2>&1; then
+        echo "[forge] branch protection already exists on $RELEASE_BRANCH; preserving it"
+    else
+        echo "[forge] applying branch protection to $RELEASE_BRANCH: allow_auto_merge=true"
+        if echo "$PROTECTION_BODY" | gh api --method PUT "repos/$REPO/branches/$RELEASE_BRANCH/protection" --input - >/dev/null 2>&1; then
+            echo "[forge] ✓ branch protected; auto-merge enabled"
+        else
+            echo "[forge] ⚠ failed to apply branch protection on $RELEASE_BRANCH (continuing)" >&2
+            echo "[forge]   apply manually: echo '$PROTECTION_BODY' | gh api --method PUT repos/$REPO/branches/$RELEASE_BRANCH/protection --input -" >&2
+        fi
+    fi
+fi
+
+# --- 10. Install the RC into the active env, then assert the right binary is on PATH ---
 if [[ "$NO_INSTALL" == false ]]; then
     echo "==> Installing $RC_TAG into active Python environment..."
     run pip install --force-reinstall "git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
@@ -184,7 +215,7 @@ else
     echo "      pip install --force-reinstall git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
 fi
 
-# --- 10. Print test ladder ---
+# --- 11. Print test ladder ---
 echo ""
 echo "==> $RC_TAG cut on $RELEASE_BRANCH."
 echo ""

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -32,10 +32,10 @@ def _write_fake_gh(bin_dir: Path, *, get_exit: int, put_exit: int) -> Path:
     fake.write_text(
         "#!/usr/bin/env bash\n"
         f'echo "$@" >> "{log}"\n'
-        'is_put=false\n'
+        "is_put=false\n"
         'for a in "$@"; do\n'
         '    if [[ "$a" == "PUT" ]]; then is_put=true; fi\n'
-        'done\n'
+        "done\n"
         f'if [[ "$is_put" == true ]]; then exit {put_exit}; else exit {get_exit}; fi\n'
     )
     fake.chmod(0o755)

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -1,0 +1,137 @@
+"""Tests for scripts/apply-branch-protection.sh.
+
+The helper is the branch-protection step extracted out of cut-rc.sh so the
+critical RC merge path can be exercised under a PATH-mocked `gh`. Covers:
+  - --dry-run reports the planned PUT and does NOT call `gh`
+  - existing protection is preserved (probe GET returns 0; no PUT)
+  - new protection is applied via PUT when probe GET returns non-zero
+  - PUT failures warn-and-continue (script exits 0 so cut-rc.sh proceeds)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "apply-branch-protection.sh"
+
+
+def _write_fake_gh(bin_dir: Path, *, get_exit: int, put_exit: int) -> Path:
+    """Install a fake `gh` on PATH that records every invocation.
+
+    The fake distinguishes the protection probe (a GET, no --method flag)
+    from the protection apply (PUT via --method PUT) and exits with the
+    caller-specified codes for each.
+    """
+    log = bin_dir / "gh.log"
+    fake = bin_dir / "gh"
+    fake.write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "$@" >> "{log}"\n'
+        'is_put=false\n'
+        'for a in "$@"; do\n'
+        '    if [[ "$a" == "PUT" ]]; then is_put=true; fi\n'
+        'done\n'
+        f'if [[ "$is_put" == true ]]; then exit {put_exit}; else exit {get_exit}; fi\n'
+    )
+    fake.chmod(0o755)
+    return log
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    return bin_dir
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_dry_run_does_not_call_gh(sandbox):
+    log = _write_fake_gh(sandbox, get_exit=0, put_exit=0)
+
+    result = _run("--dry-run", "fuzzypete/theforge", "release/v0.10")
+
+    assert result.returncode == 0, result.stderr
+    assert "dry-run" in result.stdout
+    assert "would apply branch protection to release/v0.10" in result.stdout
+    assert "PUT repos/fuzzypete/theforge/branches/release/v0.10/protection" in result.stdout
+    # The log file must NOT exist — the fake `gh` was never invoked.
+    assert not log.exists(), f"gh was called in dry-run: {log.read_text()}"
+
+
+def test_existing_protection_is_preserved(sandbox):
+    # Probe GET succeeds (exit 0) → branch already protected → no PUT.
+    log = _write_fake_gh(sandbox, get_exit=0, put_exit=99)
+
+    result = _run("fuzzypete/theforge", "release/v0.10")
+
+    assert result.returncode == 0, result.stderr
+    assert "already exists on release/v0.10; preserving it" in result.stdout
+    calls = log.read_text().strip().splitlines()
+    assert len(calls) == 1, f"expected exactly one gh call (the probe), got: {calls}"
+    assert "PUT" not in calls[0], "must not call PUT when protection already exists"
+
+
+def test_protection_applied_when_missing(sandbox):
+    # Probe GET fails (exit 1) → not protected → PUT to apply.
+    log = _write_fake_gh(sandbox, get_exit=1, put_exit=0)
+
+    result = _run("fuzzypete/theforge", "release/v0.10")
+
+    assert result.returncode == 0, result.stderr
+    assert "applying branch protection to release/v0.10" in result.stdout
+    assert "branch protected; auto-merge enabled" in result.stdout
+    calls = log.read_text().strip().splitlines()
+    assert len(calls) == 2, f"expected probe + PUT, got: {calls}"
+    assert "PUT" in calls[1], "second call must be the PUT apply"
+
+
+def test_put_failure_warns_and_continues(sandbox):
+    # Probe says unprotected, PUT fails (no admin perms / fork).
+    log = _write_fake_gh(sandbox, get_exit=1, put_exit=1)
+
+    result = _run("fuzzypete/theforge", "release/v0.10")
+
+    # Critical: exit code MUST be 0 so cut-rc.sh's `|| true` is unnecessary
+    # and the cut proceeds even on permission-limited accounts.
+    assert result.returncode == 0, result.stderr
+    assert "failed to apply branch protection" in result.stderr
+    assert "apply manually" in result.stderr
+    calls = log.read_text().strip().splitlines()
+    assert len(calls) == 2, f"expected probe + PUT attempt, got: {calls}"
+
+
+def test_missing_args_exits_nonzero(sandbox):
+    _write_fake_gh(sandbox, get_exit=0, put_exit=0)
+
+    result = _run("only-one-arg")
+
+    assert result.returncode == 2
+    assert "Usage:" in result.stderr
+
+
+def test_cut_rc_invokes_helper_with_release_branch():
+    """Smoke check: cut-rc.sh references the helper with the right args.
+
+    Cheaper than spinning up the full cut-rc.sh flow under mocks — the
+    helper itself is already covered by the tests above; here we just pin
+    that cut-rc.sh actually calls it with the release branch name and
+    forwards --dry-run.
+    """
+    cut_rc = (REPO_ROOT / "scripts" / "cut-rc.sh").read_text()
+    assert "apply-branch-protection.sh" in cut_rc
+    assert '"$RELEASE_BRANCH"' in cut_rc
+    assert '[[ "$DRY_RUN" == true ]] && PROTECT_ARGS+=("--dry-run")' in cut_rc


### PR DESCRIPTION
## Summary

Prior P1 coverage gap is resolved; the current diff adds focused helper coverage and I found no blocking regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.14
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

cut-rc.sh: configure branch protection on release/vX.Y so auto-merge works for RC ladder fixes (GitHub Issue #1361)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1361