### PR TITLE
Intake auto-edit drops salvageable shape remediation without surfacing the failed rewrite

### DIFF
--- a/src/theforge/intake/agent_rewrite.py
+++ b/src/theforge/intake/agent_rewrite.py
@@ -27,12 +27,24 @@ class AgentRewriteResult:
     transport_used: str | None = None
 
 
-def build_agent_rewrite_prompt(body: str, findings: list[IntakeFinding]) -> str:
-    """Build the one-shot intake remediation prompt."""
+def build_agent_rewrite_prompt(
+    body: str,
+    findings: list[IntakeFinding],
+    comments: list[str] | None = None,
+) -> str:
+    """Build the one-shot intake remediation prompt.
+
+    ``comments`` is the issue's existing comment thread in chronological
+    order. When the body lacks a structural section (e.g. ``## Diagnosis``)
+    that is present in raw form in a comment, the agent should synthesize
+    the section into the replacement body from that comment material.
+    """
     lines = [
         "You are remediating a GitHub issue body for TheForge sprint intake.",
         "Rewrite the issue body so it resolves the blocking findings below.",
         "Preserve the issue's intent. Do not add implementation steps, file paths, or test plans.",
+        "If a required structural section is missing from the body but the material exists",
+        "in the comment thread below, synthesize that section into the replacement body.",
         "",
         "Output rules:",
         "1. If you can fix the issue, return only the full replacement Markdown body.",
@@ -53,6 +65,18 @@ def build_agent_rewrite_prompt(body: str, findings: list[IntakeFinding]) -> str:
             "```",
         ]
     )
+    if comments:
+        lines.extend(["", "Existing issue comments (chronological):"])
+        for idx, comment in enumerate(comments, start=1):
+            lines.extend(
+                [
+                    "",
+                    f"Comment {idx}:",
+                    "```markdown",
+                    comment,
+                    "```",
+                ]
+            )
     return "\n".join(lines)
 
 

--- a/src/theforge/intake/remediation.py
+++ b/src/theforge/intake/remediation.py
@@ -65,7 +65,7 @@ class IntakeOutcome:
 FetchIssueDetail = Callable[[int, Path | None], dict | None]
 PostIssueComment = Callable[[int, str, Path | None], bool]
 EditIssueBody = Callable[[int, str, Path | None], bool]
-AgentRewriteCaller = Callable[[str, list[IntakeFinding]], AgentRewriteResult]
+AgentRewriteCaller = Callable[[str, list[IntakeFinding], list[str]], AgentRewriteResult]
 
 
 def _default_fetch_detail(number: int, project_root: Path | None) -> dict | None:
@@ -75,7 +75,7 @@ def _default_fetch_detail(number: int, project_root: Path | None) -> dict | None
     """
     try:
         proc = subprocess.run(
-            ["gh", "issue", "view", str(number), "--json", "title,body,labels"],
+            ["gh", "issue", "view", str(number), "--json", "title,body,labels,comments"],
             capture_output=True,
             text=True,
             cwd=str(project_root) if project_root else None,
@@ -94,10 +94,16 @@ def _default_fetch_detail(number: int, project_root: Path | None) -> dict | None
         for lbl in (data.get("labels") or [])
         if isinstance(lbl, dict) and lbl.get("name")
     ]
+    comment_bodies = [
+        (c.get("body") or "")
+        for c in (data.get("comments") or [])
+        if isinstance(c, dict) and (c.get("body") or "").strip()
+    ]
     return {
         "title": data.get("title", "") or "",
         "body": data.get("body", "") or "",
         "labels": label_names,
+        "comments": comment_bodies,
     }
 
 
@@ -151,14 +157,21 @@ def _blocking(findings: list[IntakeFinding]) -> list[IntakeFinding]:
     return [f for f in findings if f.severity is IntakeSeverity.BLOCK]
 
 
-def _format_remediation_comment(findings: list[IntakeFinding], replacement: str | None) -> str:
-    lines = ["**TheForge intake remediation — proposed replacement**", ""]
-    lines.append("Findings:")
+def _format_remediation_comment(
+    findings: list[IntakeFinding],
+    replacement: str | None,
+    *,
+    header: str = "**TheForge intake remediation — proposed replacement**",
+    findings_label: str = "Findings:",
+    replacement_label: str = "Proposed replacement issue body:",
+) -> str:
+    lines = [header, ""]
+    lines.append(findings_label)
     for f in findings:
         lines.append(f"- `{f.code}` ({f.location}): {f.problem}")
     if replacement:
         lines.append("")
-        lines.append("Proposed replacement issue body:")
+        lines.append(replacement_label)
         lines.append("")
         lines.append("```markdown")
         lines.append(replacement)
@@ -214,6 +227,7 @@ def _remediate_one(
     title: str,
     body: str,
     labels: list[str],
+    comments: list[str],
     grooming_enabled: bool,
     auto_fix_enabled: bool,
     auto_fix_mode: str,
@@ -267,7 +281,7 @@ def _remediate_one(
                     remediation_source="missing_agent",
                 ),
             )
-        agent_result = agent_caller(patched_body, semantic_remaining)
+        agent_result = agent_caller(patched_body, semantic_remaining, comments)
         if not agent_result.replacement:
             return IntakeOutcome(
                 slug=slug,
@@ -292,18 +306,38 @@ def _remediate_one(
 
     if auto_fix_mode == "edit":
         if rerun_blocking:
-            # Don't edit a body that still fails — surface for human triage.
+            # Don't edit a body that still fails — but do not silently discard
+            # the candidate either. Post the proposed replacement plus the
+            # remaining blocking findings as a comment so the operator can
+            # continue from the candidate instead of redoing the rewrite.
+            salvage_comment = _format_remediation_comment(
+                rerun_blocking,
+                proposed_body,
+                header=("**TheForge intake remediation — candidate failed rerun gate**"),
+                findings_label=("Remaining blocking findings against the candidate body:"),
+                replacement_label=(
+                    "Candidate replacement body "
+                    "(rerun gate still failing — operator review required):"
+                ),
+            )
+            posted = post_comment(issue_number, salvage_comment, project_root)
+            detail = (
+                "rerun gate still failing; candidate posted as issue comment for operator review"
+                if posted
+                else "rerun gate still failing; failed to post candidate comment"
+            )
             return IntakeOutcome(
                 slug=slug,
                 kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
                 findings=tuple(rerun_blocking),
                 proposed_replacement=proposed_body,
-                detail="rerun gate still failing; did not edit issue",
+                detail=detail,
                 audit=_build_audit(
                     consumed=_consumed,
                     semantic_remaining=semantic_remaining,
                     agent=agent_result,
                     remediation_source=("agent" if agent_result is not None else "mechanical"),
+                    comment_posted=posted,
                 ),
             )
         if not edit_body(issue_number, proposed_body, project_root):
@@ -426,6 +460,7 @@ def run_intake_remediation(
             title=detail.get("title", "") or "",
             body=detail.get("body", "") or "",
             labels=list(detail.get("labels", []) or []),
+            comments=list(detail.get("comments", []) or []),
             grooming_enabled=grooming_enabled,
             auto_fix_enabled=auto_fix_enabled,
             auto_fix_mode=auto_fix_mode,

--- a/src/theforge/intake/remediation.py
+++ b/src/theforge/intake/remediation.py
@@ -12,6 +12,7 @@ remains testable without network. Production wires real ``gh`` invocations.
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import subprocess
@@ -202,6 +203,7 @@ def _build_audit(
     remediation_source: str = "none",
     issue_updated: bool = False,
     comment_posted: bool = False,
+    candidate_artifact_path: str | None = None,
 ) -> dict[str, object]:
     return {
         "remediation_source": remediation_source,
@@ -217,7 +219,49 @@ def _build_audit(
         },
         "issue_updated": issue_updated,
         "comment_posted": comment_posted,
+        "candidate_artifact_path": candidate_artifact_path,
     }
+
+
+def _write_candidate_artifact(
+    *,
+    issue_number: int,
+    candidate_body: str,
+    findings: list[IntakeFinding],
+    project_root: Path | None,
+) -> str | None:
+    """Persist the failed-rerun candidate to a durable artifact file.
+
+    Used as a fallback when the issue-comment post fails. Returns the
+    written path (as a string) on success, or ``None`` if the artifact
+    could not be written. The artifact lives under
+    ``.forge/intake/candidates/`` so the operator can discover it without
+    grepping logs.
+    """
+    root = project_root if project_root is not None else Path.cwd()
+    artifact_dir = root / ".forge" / "intake" / "candidates"
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_path = artifact_dir / f"issue-{issue_number}-{timestamp}.md"
+    rendered = _format_remediation_comment(
+        findings,
+        candidate_body,
+        header="**TheForge intake remediation — candidate failed rerun gate**",
+        findings_label="Remaining blocking findings against the candidate body:",
+        replacement_label=(
+            "Candidate replacement body (rerun gate still failing — operator review required):"
+        ),
+    )
+    try:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(rendered, encoding="utf-8")
+    except OSError as exc:
+        _log.warning(
+            "failed to write intake candidate artifact for issue #%s: %s",
+            issue_number,
+            exc,
+        )
+        return None
+    return str(artifact_path)
 
 
 def _remediate_one(
@@ -321,11 +365,33 @@ def _remediate_one(
                 ),
             )
             posted = post_comment(issue_number, salvage_comment, project_root)
-            detail = (
-                "rerun gate still failing; candidate posted as issue comment for operator review"
-                if posted
-                else "rerun gate still failing; failed to post candidate comment"
-            )
+            artifact_path: str | None = None
+            if not posted:
+                # Fallback persistence: comment post failed, so the operator
+                # cannot find the candidate on the issue thread. Write a
+                # durable artifact instead so proposed_replacement is never
+                # silently lost.
+                artifact_path = _write_candidate_artifact(
+                    issue_number=issue_number,
+                    candidate_body=proposed_body,
+                    findings=rerun_blocking,
+                    project_root=project_root,
+                )
+            if posted:
+                detail = (
+                    "rerun gate still failing; candidate posted as issue comment "
+                    "for operator review"
+                )
+            elif artifact_path is not None:
+                detail = (
+                    "rerun gate still failing; comment post failed — candidate "
+                    f"persisted to {artifact_path}"
+                )
+            else:
+                detail = (
+                    "rerun gate still failing; comment post failed and candidate "
+                    "artifact write failed"
+                )
             return IntakeOutcome(
                 slug=slug,
                 kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
@@ -338,6 +404,7 @@ def _remediate_one(
                     agent=agent_result,
                     remediation_source=("agent" if agent_result is not None else "mechanical"),
                     comment_posted=posted,
+                    candidate_artifact_path=artifact_path,
                 ),
             )
         if not edit_body(issue_number, proposed_body, project_root):

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1516,12 +1516,18 @@ def run_sprint(
             if (
                 outcome.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
                 and outcome.proposed_replacement
-                and outcome.audit.get("comment_posted")
             ):
-                _log(
-                    f"  Intake candidate for {slug} posted as issue comment "
-                    "(rerun gate still failing — operator review required)"
-                )
+                if outcome.audit.get("comment_posted"):
+                    _log(
+                        f"  Intake candidate for {slug} posted as issue comment "
+                        "(rerun gate still failing — operator review required)"
+                    )
+                elif outcome.audit.get("candidate_artifact_path"):
+                    _log(
+                        f"  Intake candidate for {slug} persisted to "
+                        f"{outcome.audit['candidate_artifact_path']} "
+                        "(comment post failed — rerun gate still failing)"
+                    )
             outcome_value = (
                 StoryOutcome.REMEDIATED
                 if outcome.kind is IntakeOutcomeKind.REMEDIATED

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -112,7 +112,7 @@ def _build_intake_agent_caller(
     *,
     config: ForgeConfig,
     log: Callable[[str], None],
-) -> tuple[Callable[[str, list], AgentRewriteResult] | None, str]:
+) -> tuple[Callable[[str, list, list[str]], AgentRewriteResult] | None, str]:
     """Build the configured intake remediation caller or return an explicit reason."""
     _ensure_intake_runner()
     try:
@@ -132,8 +132,8 @@ def _build_intake_agent_caller(
         log(f"Intake remediation agent unavailable: {reason}")
         return None, detail
 
-    def _call(body: str, findings: list) -> AgentRewriteResult:
-        prompt = build_agent_rewrite_prompt(body, findings)
+    def _call(body: str, findings: list, comments: list[str]) -> AgentRewriteResult:
+        prompt = build_agent_rewrite_prompt(body, findings, comments)
         result = run_agent(
             prompt=prompt,
             profile=profile,
@@ -1513,6 +1513,15 @@ def run_sprint(
         for slug, outcome in intake_outcomes.items():
             if outcome.kind is IntakeOutcomeKind.PASSED:
                 continue
+            if (
+                outcome.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
+                and outcome.proposed_replacement
+                and outcome.audit.get("comment_posted")
+            ):
+                _log(
+                    f"  Intake candidate for {slug} posted as issue comment "
+                    "(rerun gate still failing — operator review required)"
+                )
             outcome_value = (
                 StoryOutcome.REMEDIATED
                 if outcome.kind is IntakeOutcomeKind.REMEDIATED

--- a/tests/test_intake/test_remediation.py
+++ b/tests/test_intake/test_remediation.py
@@ -97,7 +97,7 @@ def test_auto_fix_comment_mode_posts_replacement_and_drops():
     post_comment, post_calls = _record_calls()
     edit_body, edit_calls = _record_calls()
 
-    def agent(body, findings):
+    def agent(body, findings, comments=()):
         return AgentRewriteResult(replacement=_PASSING_BODY, detail="agent produced replacement")
 
     outcomes = run_intake_remediation(
@@ -124,7 +124,7 @@ def test_auto_fix_edit_mode_updates_body_and_remediates():
     post_comment, post_calls = _record_calls()
     edit_body, edit_calls = _record_calls()
 
-    def agent(body, findings):
+    def agent(body, findings, comments=()):
         return AgentRewriteResult(replacement=_PASSING_BODY, detail="agent produced replacement")
 
     outcomes = run_intake_remediation(
@@ -151,7 +151,7 @@ def test_auto_fix_edit_mode_keeps_failing_body_off_issue():
     post_comment, _ = _record_calls()
     edit_body, edit_calls = _record_calls()
 
-    def agent(body, findings):
+    def agent(body, findings, comments=()):
         return AgentRewriteResult(replacement=_FAILING_BODY, detail="agent produced replacement")
 
     outcomes = run_intake_remediation(
@@ -174,7 +174,7 @@ def test_agent_called_at_most_once_per_story():
     task = _make_task()
     calls: list[int] = []
 
-    def agent(body, findings):
+    def agent(body, findings, comments=()):
         calls.append(1)
         return AgentRewriteResult(replacement=_PASSING_BODY, detail="agent produced replacement")
 
@@ -256,10 +256,86 @@ def test_mechanical_only_remediation_is_distinguished_from_agent_flow():
     assert post_calls
 
 
+def test_edit_mode_rerun_failure_persists_candidate_as_comment():
+    """When the edit-mode rerun gate still fails, the candidate body must not
+    be silently discarded — it must be posted as an issue comment with the
+    remaining blocking findings so the operator can act on it.
+    """
+    task = _make_task()
+    post_comment, post_calls = _record_calls()
+    edit_body, edit_calls = _record_calls()
+
+    candidate = "## What\n\nstill not enough\n"
+
+    def agent(body, findings, comments=()):
+        return AgentRewriteResult(replacement=candidate, detail="agent produced replacement")
+
+    outcomes = run_intake_remediation(
+        [task],
+        None,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="edit",
+        agent_caller=agent,
+        fetch_detail=_make_fetch({"title": "T", "body": _FAILING_BODY, "labels": ["enhancement"]}),
+        post_comment=post_comment,
+        edit_body=edit_body,
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
+    assert out.proposed_replacement == candidate
+    assert edit_calls == []  # still must not write a failing body
+    # Candidate must be posted as a comment so the operator can find it.
+    assert len(post_calls) == 1
+    posted_body = post_calls[0][1]
+    assert candidate in posted_body
+    assert "Remaining blocking findings" in posted_body
+    assert out.audit["comment_posted"] is True
+    assert "candidate posted" in out.detail
+
+
+def test_agent_receives_issue_comments_as_input():
+    """The remediator must receive the issue's comment thread as agent input
+    so it can synthesize required structural sections (e.g. ``## Diagnosis``)
+    that exist in raw form in a comment but are missing from the body.
+    """
+    task = _make_task()
+    captured: dict = {}
+
+    def agent(body, findings, comments=()):
+        captured["body"] = body
+        captured["comments"] = list(comments)
+        return AgentRewriteResult(replacement=_PASSING_BODY, detail="agent produced replacement")
+
+    diag_comment = (
+        "## Diagnosis\n\nObserved symptom: foo. Confirmed cause: bar. "
+        "Fix-success criterion: baz.\n"
+    )
+    run_intake_remediation(
+        [task],
+        None,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="edit",
+        agent_caller=agent,
+        fetch_detail=_make_fetch(
+            {
+                "title": "T",
+                "body": _FAILING_BODY,
+                "labels": ["enhancement"],
+                "comments": [diag_comment, "another comment"],
+            }
+        ),
+        post_comment=lambda *_: True,
+        edit_body=lambda *_: True,
+    )
+    assert captured["comments"] == [diag_comment, "another comment"]
+
+
 def test_agent_no_output_is_distinguished_in_audit():
     task = _make_task()
 
-    def agent(body, findings):
+    def agent(body, findings, comments=()):
         return AgentRewriteResult(replacement=None, detail="model refused rewrite", attempted=True)
 
     outcomes = run_intake_remediation(

--- a/tests/test_intake/test_remediation.py
+++ b/tests/test_intake/test_remediation.py
@@ -294,6 +294,51 @@ def test_edit_mode_rerun_failure_persists_candidate_as_comment():
     assert "candidate posted" in out.detail
 
 
+def test_edit_mode_rerun_failure_falls_back_to_artifact_when_post_fails(tmp_path):
+    """If post_comment returns False on edit-mode rerun-gate failure, the
+    candidate body and remaining findings must still be persisted somewhere
+    operator-visible — written to a durable artifact under
+    ``.forge/intake/candidates/`` and surfaced in the outcome detail/audit.
+    """
+    task = _make_task()
+    edit_body, edit_calls = _record_calls()
+
+    def failing_post(_n, _body, _root):
+        return False
+
+    candidate = "## What\n\nstill not enough\n"
+
+    def agent(body, findings, comments=()):
+        return AgentRewriteResult(replacement=candidate, detail="agent produced replacement")
+
+    outcomes = run_intake_remediation(
+        [task],
+        tmp_path,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="edit",
+        agent_caller=agent,
+        fetch_detail=_make_fetch({"title": "T", "body": _FAILING_BODY, "labels": ["enhancement"]}),
+        post_comment=failing_post,
+        edit_body=edit_body,
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
+    assert out.proposed_replacement == candidate
+    assert edit_calls == []
+    assert out.audit["comment_posted"] is False
+    artifact_path = out.audit["candidate_artifact_path"]
+    assert artifact_path is not None
+    artifact = __import__("pathlib").Path(artifact_path)
+    assert artifact.exists()
+    contents = artifact.read_text(encoding="utf-8")
+    assert candidate in contents
+    assert "Remaining blocking findings" in contents
+    # Detail must surface the artifact path so the operator can find it
+    # without grepping logs.
+    assert artifact_path in out.detail
+
+
 def test_agent_receives_issue_comments_as_input():
     """The remediator must receive the issue's comment thread as agent input
     so it can synthesize required structural sections (e.g. ``## Diagnosis``)

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -108,7 +108,7 @@ def test_build_intake_agent_caller_uses_configured_runner(tmp_path: Path) -> Non
         caller, detail = _build_intake_agent_caller(config=config, log=lambda *_: None)
         assert detail == ""
         assert caller is not None
-        result = caller("old body", [])
+        result = caller("old body", [], [])
 
     assert result.replacement == "## What\n\nRewritten."
     assert result.model_used == "sonnet"


### PR DESCRIPTION
## Summary

Prior P1 is resolved; failed edit-mode rerun candidates are posted or persisted to an artifact, comments are fed into remediation, and focused tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $4.25
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Intake auto-edit drops salvageable shape remediation without surfacing the failed rewrite (GitHub Issue #1373)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1373