### PR TITLE
fix(release): install working copy before gate in cut-rc.sh (#1379)

### DIFF
--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -6,9 +6,11 @@
 #   RC_NUM    The RC number, default 0 (so first RC is 0.10.0rc0)
 #
 # Cuts release/vX.Y from current main (or fast-forwards if it exists),
-# bumps pyproject.toml to X.Y.ZrcN, runs gate, tags vX.Y.ZrcN, pushes
-# branch and tag. Then installs the RC into the active Python environment
-# so dogfood sprints exercise the candidate (use --no-install to skip).
+# bumps pyproject.toml to X.Y.ZrcN, installs the working copy (`pip install -e .`),
+# runs gate (which now exercises the candidate source, not the previously-installed
+# binary), tags vX.Y.ZrcN, pushes branch and tag. Then installs the tagged RC
+# into the active Python environment so dogfood sprints exercise the candidate
+# (use --no-install to skip the post-tag install).
 #
 # Does NOT block on open milestone issues — that's a promote-rc requirement.
 # Prints them informationally so the operator can see what is or isn't in
@@ -144,11 +146,15 @@ if [[ "$DRY_RUN" == false ]]; then
     fi
 fi
 
-# --- 7. Gate ---
+# --- 7. Install working copy so gate exercises candidate source ---
+echo "==> Installing working copy into active environment (gate must exercise candidate source, not previously-installed binary)..."
+run pip install -e .
+
+# --- 8. Gate ---
 echo "==> Running gate..."
 run make gate
 
-# --- 8. Commit, tag, push ---
+# --- 9. Commit, tag, push ---
 echo "==> Committing, tagging, pushing..."
 run git add pyproject.toml
 run git commit -m "chore: cut $RC_TAG"


### PR DESCRIPTION
Closes #1379.

## Summary

`cut-rc.sh` ran `make gate` against the **previously-installed** forge binary before tagging and installing the RC. Gate logic changes on a release branch were being validated against stale installed code rather than the candidate source — gate regressions could ship silently, and gate improvements would fail their own RC cut. This PR adds an in-place `pip install -e .` of the working copy immediately before the gate, so the gate exercises the candidate source.

## Recovery context

Sprint `f3d9d03da246` produced this work APPROVE'd, but integration failed with a deterministic rebase conflict against #1361 (which had landed earlier in the same sprint, also editing `scripts/cut-rc.sh`). Both stories were collision-DAG-serialized via `depends_on`, but the dependent was released to start its dev iteration when #1361 hit the auto-merge queue rather than when #1361's commit was actually on `origin/main`. Captured as #1402.

This PR is the manual recovery: rebase onto current `main` (which has #1361's branch-protection block), resolve the cut-rc.sh conflict so both edits coexist, push. The acceptance_criteria commit from the sprint was dropped during rebase as its content was already upstream.

## Review

- Verdict: APPROVE (0 P1, 2 P2) — cost $0.50, 2m 31s
- Reviewer P2 notes are advisory and do not block: (a) lack of automated test coverage on cut-rc.sh's symptom, reasonable for a release shell script; (b) suggestion to factor the install path. Both follow-on candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)