### PR TITLE
Collision-DAG depends_on releases dependents on auto-merge queue, not actual merge to main, causing rebase conflicts on overlapping stories

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1027,8 +1027,21 @@ def _terminal_story_model(result: CoordinatorResult) -> str | None:
     return None
 
 
-def _poll_queued_pr(pr_url: str, project_root: Path, timeout_seconds: int) -> dict[str, str]:
-    """Poll GitHub until a queued PR is merged, closed, or times out."""
+def _poll_queued_pr(
+    pr_url: str,
+    project_root: Path,
+    timeout_seconds: int,
+    base_branch: str | None = None,
+) -> dict[str, str]:
+    """Poll GitHub until a queued PR is merged, closed, or times out.
+
+    When ``base_branch`` is supplied, "merged" is only reported once GitHub
+    reports MERGED *and* the PR's merge commit is reachable on
+    ``origin/<base_branch>``. GitHub's auto-merge queue flips a PR to MERGED
+    several seconds before the merge commit propagates to the base ref;
+    releasing a collision-serialized dependent on the GitHub state alone
+    re-creates the race the collision DAG existed to prevent (issue #1402).
+    """
     deadline = time.monotonic() + timeout_seconds
     while True:
         try:
@@ -1045,13 +1058,81 @@ def _poll_queued_pr(pr_url: str, project_root: Path, timeout_seconds: int) -> di
         if proc.returncode == 0:
             state = proc.stdout.strip()
             if state == "MERGED":
-                return {"status": "merged"}
-            if state == "CLOSED":
+                if base_branch is None or _merge_visible_on_base(
+                    pr_url, project_root, base_branch
+                ):
+                    return {"status": "merged"}
+            elif state == "CLOSED":
                 return {"status": "closed"}
 
         if time.monotonic() >= deadline:
             return {"status": "timeout"}
         time.sleep(30)
+
+
+def _merge_visible_on_base(pr_url: str, project_root: Path, base_branch: str) -> bool:
+    """Return True when the PR's merge commit is reachable on origin/<base_branch>.
+
+    The collision detector serializes overlapping stories with `depends_on`
+    edges; the gating predicate that unblocks a dependent must match the
+    edge's purpose, which is to make the parent's diff visible to the
+    dependent's dev iteration. "PR auto-merge queued" or even GitHub's
+    `state == MERGED` happens before the merge commit reaches origin/<base>;
+    a dependent worktree created in that window is stale relative to the
+    parent's edits and rebases conflict on the shared file. Confirm origin
+    actually carries the merge commit before treating the parent as landed.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                pr_url,
+                "--json",
+                "mergeCommit",
+                "-q",
+                '.mergeCommit.oid? // ""',
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception:
+        return False
+    if proc.returncode != 0:
+        return False
+    merge_sha = proc.stdout.strip()
+    if not merge_sha:
+        return False
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin", base_branch],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception:
+        return False
+    try:
+        ancestor = subprocess.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                merge_sha,
+                f"origin/{base_branch}",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception:
+        return False
+    return ancestor.returncode == 0
 
 
 def _classify_and_record(
@@ -2007,6 +2088,7 @@ def run_sprint(
                             dep_pr_url,
                             config.project_root,
                             config.workspace.merge_wait_timeout_seconds,
+                            base_branch=config.workspace.base_branch,
                         )
                         if poll_result["status"] == "merged":
                             merged_slugs.add(dep)
@@ -2182,6 +2264,7 @@ def run_sprint(
                         _qp_pr_url,
                         config.project_root,
                         config.workspace.merge_wait_timeout_seconds,
+                        base_branch=config.workspace.base_branch,
                     )
                     if _qp_poll["status"] == "merged":
                         merged_slugs.add(_qp_slug)
@@ -2458,6 +2541,7 @@ def run_sprint(
                 pr_url,
                 config.project_root,
                 config.workspace.merge_wait_timeout_seconds,
+                base_branch=config.workspace.base_branch,
             )
             if poll_result["status"] == "merged":
                 merged_slugs.add(slug)

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1536,6 +1536,90 @@ class TestQueuedMergePolling:
                 "status": "timeout"
             }
 
+    def test_poll_queued_pr_waits_for_origin_main_when_base_branch_set(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #1402: GitHub MERGED alone is not enough — origin/<base> must
+        carry the merge commit before a collision-serialized dependent is
+        released. The poll keeps spinning while origin lags."""
+
+        from theforge.sprint.runner import _poll_queued_pr
+
+        # Sequence of subprocess calls per polling iteration when state==MERGED:
+        #   1. gh pr view --json state           → "MERGED"
+        #   2. gh pr view --json mergeCommit     → "abc1234"
+        #   3. git fetch origin <base>           → returncode 0
+        #   4. git merge-base --is-ancestor ...  → returncode 1 (not yet) / 0 (yes)
+        # First iteration: not-an-ancestor → keep polling.
+        # Second iteration: ancestor → return merged.
+        responses = [
+            MagicMock(returncode=0, stdout="MERGED", stderr=""),
+            MagicMock(returncode=0, stdout="abc1234", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="MERGED", stderr=""),
+            MagicMock(returncode=0, stdout="abc1234", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+
+        with (
+            patch("theforge.sprint.runner.subprocess.run", side_effect=responses),
+            patch("theforge.sprint.runner.time.sleep"),
+        ):
+            assert _poll_queued_pr(
+                "https://github.com/x/y/pull/1",
+                tmp_path,
+                90,
+                base_branch="main",
+            ) == {"status": "merged"}
+
+    def test_poll_queued_pr_no_base_branch_keeps_legacy_behavior(self, tmp_path: Path) -> None:
+        """Without base_branch (e.g. callers that don't care about origin
+        propagation), MERGED is sufficient — preserves legacy semantics."""
+
+        from theforge.sprint.runner import _poll_queued_pr
+
+        with (
+            patch(
+                "theforge.sprint.runner.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="MERGED", stderr=""),
+            ),
+            patch("theforge.sprint.runner.time.sleep"),
+        ):
+            assert _poll_queued_pr("https://github.com/x/y/pull/1", tmp_path, 90) == {
+                "status": "merged"
+            }
+
+    def test_poll_queued_pr_treats_empty_merge_sha_as_unreachable(self, tmp_path: Path) -> None:
+        """If `gh pr view --json mergeCommit` comes back empty (race window
+        between MERGED state and mergeCommit population), we must keep polling
+        rather than release the dependent."""
+
+        from theforge.sprint.runner import _poll_queued_pr
+
+        # Iteration 1: state=MERGED, mergeCommit empty → no fetch/ancestor; loop.
+        # Iteration 2: state=MERGED, mergeCommit=sha, fetch ok, ancestor ok.
+        responses = [
+            MagicMock(returncode=0, stdout="MERGED", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="MERGED", stderr=""),
+            MagicMock(returncode=0, stdout="abc1234", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+
+        with (
+            patch("theforge.sprint.runner.subprocess.run", side_effect=responses),
+            patch("theforge.sprint.runner.time.sleep"),
+        ):
+            assert _poll_queued_pr(
+                "https://github.com/x/y/pull/1",
+                tmp_path,
+                90,
+                base_branch="main",
+            ) == {"status": "merged"}
+
     def test_merge_queued_timeout_escalates_during_wrap_up(self, tmp_path: Path) -> None:
         _make_spec_file(tmp_path, "Story A", "story-a")
         manifest_path = _make_manifest_parallel(


### PR DESCRIPTION
## Summary

The scheduler now gates queued PR completion on origin base-branch reachability; only a non-blocking seam-level test gap remains.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.62
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `tests/test_sprint_parallel.py:1539`** Project convention 8 requires seam-level integration tests for coordinator phase boundary and state handoff changes, but the new coverage only exercises _poll_queued_pr directly; no test drives run_sprint queued_prs through dependent dispatch.

## Story

Collision-DAG depends_on releases dependents on auto-merge queue, not actual merge to main, causing rebase conflicts on overlapping stories (GitHub Issue #1402)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1402