### PR TITLE
forge logs re-tails from the top on every sprint re-exec, blasting the terminal

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -19,16 +19,24 @@ _WATCH_SPRINT_STARTUP_POLL_SECONDS = 0.1
 
 
 def _follow_log_with_redirect(
-    log_path: Path, current_run_id: str, *, runs_dir: Path | None = None
-) -> tuple[str, Path] | None:
+    log_path: Path,
+    current_run_id: str,
+    *,
+    runs_dir: Path | None = None,
+    start_offset: int = 0,
+) -> tuple[str, Path, int] | None:
     """Stream log_path to stdout; poll ``runs_dir/<current_run_id>.redirect`` on EOF.
 
-    Returns (new_run_id, new_log_path) on redirect, None on sentinel EOF.
+    Returns (new_run_id, new_log_path, byte_offset) on redirect, None on sentinel EOF.
+    start_offset allows callers to continue reading from a known position, avoiding
+    duplicate output when a re-exec redirect resolves to the same log file.
     Runs indefinitely on real EOF (tail-f style); caller catches KeyboardInterrupt.
     """
     redirect_file = (runs_dir / f"{current_run_id}.redirect") if runs_dir else None
 
     with open(log_path) as fh:
+        if start_offset > 0:
+            fh.seek(start_offset)
         while True:
             pos = fh.tell()
             line = fh.readline()
@@ -36,7 +44,7 @@ def _follow_log_with_redirect(
                 if redirect_file is not None and redirect_file.exists():
                     try:
                         d = json.loads(redirect_file.read_text(encoding="utf-8"))
-                        return d["new_run_id"], Path(d["new_log"])
+                        return d["new_run_id"], Path(d["new_log"]), fh.tell()
                     except (OSError, KeyError, ValueError, json.JSONDecodeError):
                         pass
                 time.sleep(0.1)
@@ -492,14 +500,17 @@ def cmd_logs(args: object) -> int:
 
     current_run_id = run_id
     current_log = log_path
+    current_offset = 0
     runs_dir = project_root / ".forge" / "runs"
     try:
         while True:
             print(f"[forge] Tailing {current_log} — Ctrl+C to stop", file=sys.stderr)
-            result = _follow_log_with_redirect(current_log, current_run_id, runs_dir=runs_dir)
+            result = _follow_log_with_redirect(
+                current_log, current_run_id, runs_dir=runs_dir, start_offset=current_offset
+            )
             if result is None:
                 break
-            new_run_id, new_log = result
+            new_run_id, new_log, redirect_offset = result
             print(
                 f"[forge] Run re-exec'd — following new run {new_run_id}",
                 file=sys.stderr,
@@ -516,6 +527,9 @@ def cmd_logs(args: object) -> int:
                 )
                 return 1
             current_run_id = new_run_id
+            # If re-exec reuses the same log file, continue from the current read
+            # position to avoid replaying already-printed lines from offset 0.
+            current_offset = redirect_offset if new_log == current_log else 0
             current_log = new_log
     except KeyboardInterrupt:
         pass

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -224,6 +224,52 @@ class TestCmdLogs:
         captured = capsys.readouterr()
         assert "Timed out waiting for new log" in captured.err
 
+    def test_same_log_reexec_no_duplicate_lines(self, tmp_path, capsys):
+        """Re-exec that redirects to the same log file must not replay prior lines."""
+        import json
+
+        from theforge.cli import cmd_logs
+        from theforge.cli.status import _SENTINEL_EOF
+
+        old_run_id = "aabbccddee11"
+        new_run_id = "ff99887766aa"
+        slug = "my-slug"
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{old_run_id}.pid").write_text(f"12345\n{slug}\n")
+
+        log_dir = tmp_path / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True)
+
+        # Single log file used by both the old and new run (same path, new run ID).
+        log_file = log_dir / f"run-{old_run_id}.log"
+        log_file.write_text(f"before reexec\nafter reexec\n{_SENTINEL_EOF}\n")
+
+        # Redirect sidecar points back to the SAME log file.
+        (runs_dir / f"{old_run_id}.redirect").write_text(
+            json.dumps({"new_run_id": new_run_id, "new_log": str(log_file)}),
+            encoding="utf-8",
+        )
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=old_run_id)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+        # Each log line must appear exactly once — no replay on re-exec.
+        assert lines.count("before reexec") == 1, f"duplicated 'before reexec': {lines}"
+        assert lines.count("after reexec") == 1, f"duplicated 'after reexec': {lines}"
+
     def test_spoof_log_lines_do_not_trigger_redirect(self, tmp_path, capsys):
         """Log lines that look like re-exec trailers must NOT trigger a redirect.
 


### PR DESCRIPTION
## Summary

Fix correctly carries read offset across same-file re-exec redirect; test reproduces the symptom.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.61
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge logs re-tails from the top on every sprint re-exec, blasting the terminal (GitHub Issue #1411)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1411