### PR TITLE
Sprint exits after successful intake remediation instead of continuing to run

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -429,6 +429,7 @@ def _run_query_mode(
     _generate_run_id: object,
 ) -> int:
     """Handle --milestone / --label / --issues query mode."""
+    from theforge.intake import IntakeOutcomeKind
     from theforge.sprint.dag import resolve_satisfied_dependencies
     from theforge.sprint.entry_intake import remediate_entry_skipped_issues
     from theforge.sprint.query import (
@@ -525,6 +526,23 @@ def _run_query_mode(
                 config=config,
                 log=lambda m: print(f"[forge] {m}", file=sys.stderr),
             )
+
+        # Re-add successfully remediated issues so the sprint continues without
+        # requiring the operator to re-invoke forge sprint.
+        if entry_intake_outcomes:
+            remediated_numbers = {
+                num
+                for num, outcome in entry_intake_outcomes.items()
+                if outcome.kind is IntakeOutcomeKind.REMEDIATED
+            }
+            if remediated_numbers:
+                skip_by_number = {sk.issue_number: sk for sk in skipped_issues}
+                for num in sorted(remediated_numbers):
+                    sk = skip_by_number[num]
+                    issues.append({"number": sk.issue_number, "title": sk.title})
+                skipped_issues = [
+                    sk for sk in skipped_issues if sk.issue_number not in remediated_numbers
+                ]
 
         if not issues:
             print(

--- a/tests/test_cli_sprint_shape_gate.py
+++ b/tests/test_cli_sprint_shape_gate.py
@@ -410,3 +410,134 @@ def test_cli_query_mode_force_runs_every_issue_but_warns(tmp_path: Path, capsys)
     assert "--force in effect" in err
     assert "#2" in err
     assert "missing_ac" in err
+
+
+def test_cli_remediated_issues_continue_to_run_sprint(tmp_path: Path) -> None:
+    """When all issues are skipped at the entry gate but intake remediation
+    successfully fixes them (REMEDIATED outcome), the sprint must continue and
+    pass those issues to run_sprint — the operator must not re-invoke forge."""
+    from theforge.config.types import IntakeConfig
+    from theforge.intake import IntakeOutcome, IntakeOutcomeKind
+
+    config = _make_config(tmp_path)
+    object.__setattr__(
+        config,
+        "intake",
+        IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="edit"),
+    )
+    args = _query_args(tmp_path)
+
+    fetched = [{"number": 42, "title": "fixable"}]
+    gated = ShapeGateResult(
+        runnable=[],
+        skipped=[
+            SkippedIssue(
+                issue_number=42,
+                reason_codes=("missing_ac",),
+                source="local_check",
+                title="fixable",
+            )
+        ],
+    )
+
+    def fake_remediate(skipped, **_kw):
+        return {
+            sk.issue_number: IntakeOutcome(
+                slug=f"issue-{sk.issue_number}",
+                kind=IntakeOutcomeKind.REMEDIATED,
+                detail="edit mode: issue body updated, gate rerun passed",
+                audit={"remediation_source": "agent"},
+            )
+            for sk in skipped
+        }
+
+    run_sprint_calls: list[dict] = []
+
+    def fake_run_sprint(*_a, **kw):
+        run_sprint_calls.append(kw)
+        return _ok_result()
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=config),
+        patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+        patch("theforge.sprint.query.fetch_issues_for_milestone", return_value=fetched),
+        patch("theforge.sprint.shape_gate.apply_shape_gate", return_value=gated),
+        patch(
+            "theforge.sprint.entry_intake.remediate_entry_skipped_issues",
+            side_effect=fake_remediate,
+        ),
+        patch("theforge.sprint.query.build_resolved_sprint", return_value=_resolved([42])),
+        patch(
+            "theforge.cli.sprint._acquire_launch_locks",
+            return_value=([], None, {}),
+        ),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint.run_sprint", side_effect=fake_run_sprint),
+    ):
+        rc = cmd_sprint(args)
+
+    assert rc == 0
+    # run_sprint must have been called — remediation is not a terminal condition.
+    assert run_sprint_calls, "run_sprint was never called; sprint exited after remediation"
+
+
+def test_cli_remediated_issues_not_in_nothing_to_run_message(tmp_path: Path, capsys) -> None:
+    """The 'nothing to run' message must not appear when at least one issue was
+    successfully REMEDIATED."""
+    from theforge.config.types import IntakeConfig
+    from theforge.intake import IntakeOutcome, IntakeOutcomeKind
+
+    config = _make_config(tmp_path)
+    object.__setattr__(
+        config,
+        "intake",
+        IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="edit"),
+    )
+    args = _query_args(tmp_path)
+
+    fetched = [{"number": 99, "title": "autofix-me"}]
+    gated = ShapeGateResult(
+        runnable=[],
+        skipped=[
+            SkippedIssue(
+                issue_number=99,
+                reason_codes=("missing_ac",),
+                source="local_check",
+                title="autofix-me",
+            )
+        ],
+    )
+
+    def fake_remediate(skipped, **_kw):
+        return {
+            sk.issue_number: IntakeOutcome(
+                slug=f"issue-{sk.issue_number}",
+                kind=IntakeOutcomeKind.REMEDIATED,
+                detail="edit mode: issue body updated, gate rerun passed",
+                audit={"remediation_source": "agent"},
+            )
+            for sk in skipped
+        }
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=config),
+        patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+        patch("theforge.sprint.query.fetch_issues_for_milestone", return_value=fetched),
+        patch("theforge.sprint.shape_gate.apply_shape_gate", return_value=gated),
+        patch(
+            "theforge.sprint.entry_intake.remediate_entry_skipped_issues",
+            side_effect=fake_remediate,
+        ),
+        patch("theforge.sprint.query.build_resolved_sprint", return_value=_resolved([99])),
+        patch(
+            "theforge.cli.sprint._acquire_launch_locks",
+            return_value=([], None, {}),
+        ),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint.run_sprint", return_value=_ok_result()),
+    ):
+        rc = cmd_sprint(args)
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "nothing to run" not in err


### PR DESCRIPTION
## Summary

Fix correctly re-populates issues list with REMEDIATED outcomes before the early-exit guard; tests verify both the run_sprint call and message suppression.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.92
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint exits after successful intake remediation instead of continuing to run (GitHub Issue #1408)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1408