### PR TITLE
forge diagnose default output lands in comment but shape gate reads issue body

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -105,7 +105,7 @@ plan:
   enabled: true
 
 diagnose:
-  output_destination: comment
+  output_destination: body_section
   budget_usd: 1.50
   timeout_seconds: 600
   autonomous_default: true

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -481,13 +481,16 @@ class DiagnoseConfig:
     cannot consume sprint budget — and a sprint cannot starve diagnosis.
 
     ``output_destination`` controls where the diagnosis artifact lands:
-      - ``comment``      — post the artifact as a new GitHub issue comment
       - ``body_section`` — upsert a ``## Diagnosis`` section in the issue body
+                           (default: the sprint shape gate reads the issue body
+                           for the diagnosis artifact, so this is the destination
+                           that leaves the issue fix-ready after diagnose)
+      - ``comment``      — post the artifact as a new GitHub issue comment
       - ``pr_to_body``   — write the artifact to ``.forge/diagnoses/issue-N.md``
                            so the operator can open a body-edit PR manually
     """
 
-    output_destination: str = "comment"
+    output_destination: str = "body_section"
     budget_usd: float = 1.50
     timeout_seconds: int = 600
     autonomous_default: bool = True  # default mode when --interactive is not passed

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -145,7 +145,10 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
     )
     if artifact.hypotheses:
         for h in artifact.hypotheses:
-            lines.append(f"- **[{h.status}]** {h.statement.strip()}")
+            # Underscore→space so the rendered section contains the literal
+            # tokens the sprint shape gate scans for ("ruled out" etc.).
+            display_status = h.status.replace("_", " ")
+            lines.append(f"- **[{display_status}]** {h.statement.strip()}")
             if h.evidence.strip():
                 lines.append(f"  - Evidence: {h.evidence.strip()}")
     else:

--- a/tests/test_diagnose_config.py
+++ b/tests/test_diagnose_config.py
@@ -21,7 +21,7 @@ def test_default_diagnose_config_when_block_absent(tmp_path: Path):
     cfg_path = _write_config(tmp_path, {"project": "test"})
     config = load_config(cfg_path)
     assert isinstance(config.diagnose, DiagnoseConfig)
-    assert config.diagnose.output_destination == "comment"
+    assert config.diagnose.output_destination == "body_section"
     assert config.diagnose.budget_usd > 0
     assert config.diagnose.timeout_seconds > 0
 

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -351,6 +351,50 @@ class TestDiagnoseFlow:
         assert "## Diagnosis" in new_body
         assert "Original" in new_body  # original body preserved
 
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_default_destination_lands_in_body_and_satisfies_shape_gate(
+        self, mock_agent, mock_fetch, mock_edit, tmp_path
+    ):
+        """Seam test: a default-config diagnose run must produce an issue body
+        the sprint shape gate accepts as fix-ready. Diagnose and sprint share
+        a contract on where the artifact lives — the default destination must
+        match what the gate reads."""
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+        from theforge.shape_check.heuristics import diagnosis_completeness
+
+        config = self._setup_config(tmp_path)
+        # Sanity: the configured default is the body-section destination so a
+        # plain `forge diagnose` run lands where the shape gate looks.
+        assert config.diagnose.output_destination == "body_section"
+        original_body = "Bug report: sprint drops the third story.\n"
+        mock_fetch.return_value = {
+            "number": 42,
+            "title": "broken sprint",
+            "body": original_body,
+            "state": "OPEN",
+        }
+        mock_agent.return_value = _fake_agent_result(_agent_yaml_output())
+
+        # No explicit output_destination — exercise the default contract.
+        result = run_diagnose_flow(
+            issue_number=42,
+            config=config,
+            project_root=tmp_path,
+        )
+
+        assert result.success
+        assert result.state.landing_destination == "body_section"
+        assert mock_edit.called, "default destination must edit issue body, not post a comment"
+        new_body = mock_edit.call_args[0][1]
+        assert "## Diagnosis" in new_body
+        # The body produced by diagnose must satisfy the same heuristic the
+        # sprint shape gate uses to decide bug_missing_diagnosis. If this
+        # assertion fails, diagnose and sprint disagree on what fix-ready means.
+        is_complete, missing = diagnosis_completeness(new_body)
+        assert is_complete, f"diagnose output does not satisfy shape gate; missing: {missing}"
+
     @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
     @patch("theforge.coordinator.diagnose_flow.run_agent")
     def test_pr_to_body_writes_markdown_file(self, mock_agent, mock_fetch, tmp_path):


### PR DESCRIPTION
## Summary

The change makes the default diagnose artifact land in the issue body and the added seam test verifies it satisfies the sprint diagnosis heuristic.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.17
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose default output lands in comment but shape gate reads issue body (GitHub Issue #1410)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1410