### PR TITLE
forge status --watch exits immediately during preflight and DAG-build phases

### DIFF
--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -379,8 +379,10 @@ def run_watch_loop(
 ) -> int:
     """Drive the watch redraw loop.
 
-    Returns 0 on clean exit (Ctrl-C or max_frames reached) and non-zero when
-    the underlying sprint snapshot cannot be read on the first frame.
+    Returns 0 on clean exit (Ctrl-C or max_frames reached). Transient read
+    failures (e.g. during preflight or DAG-build before state files are written)
+    are tolerated: the loop shows a waiting message and continues polling rather
+    than exiting. The loop only terminates on Ctrl-C or when max_frames is reached.
 
     Redraws are in-place: after the first frame we record the line count and
     on each subsequent frame issue ``CURSOR_UP(n) + CARRIAGE_RETURN +
@@ -428,30 +430,18 @@ def run_watch_loop(
                 stale_after_seconds=stale_after_seconds,
             )
 
-            if frame == 0 and not snapshot_ok:
-                # First frame failed: forward the snapshot's diagnostic that
-                # render_frame captured. There is no in-place redraw region
-                # yet, so printing to stderr is safe. (Mid-loop captures stay
-                # discarded so they can't scroll past the CURSOR_UP region.)
-                if captured_err:
-                    sys.stderr.write(captured_err)
-                    if not captured_err.endswith("\n"):
-                        sys.stderr.write("\n")
-                    sys.stderr.flush()
-                else:
-                    print(
-                        "forge status --watch: failed to read sprint state.",
-                        file=sys.stderr,
-                    )
-                return 1
+            if not body:
+                # No content yet — sprint is in preflight or DAG-build phase
+                # and state files have not been written. Show a waiting message
+                # so the operator knows the watch is alive, then keep polling.
+                body = "Waiting for sprint to initialize...\n"
 
-            if body is not None:
-                if frame == 0:
-                    sys.stdout.write(body)
-                else:
-                    sys.stdout.write(CURSOR_UP(prev_lines) + CARRIAGE_RETURN + CLEAR_BELOW + body)
-                sys.stdout.flush()
-                prev_lines = body.count("\n")
+            if frame == 0:
+                sys.stdout.write(body)
+            else:
+                sys.stdout.write(CURSOR_UP(prev_lines) + CARRIAGE_RETURN + CLEAR_BELOW + body)
+            sys.stdout.flush()
+            prev_lines = body.count("\n")
 
             frame += 1
             if max_frames is not None and frame >= max_frames:

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -462,9 +462,10 @@ class TestRunWatchLoop:
 
         assert rc == 0
 
-    def test_first_frame_failure_returns_nonzero(
+    def test_first_frame_failure_stays_alive(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        """A render_frame exception on frame 0 shows a waiting message; the loop does not exit."""
         with (
             patch.object(
                 status_watch,
@@ -482,9 +483,9 @@ class TestRunWatchLoop:
                 max_frames=1,
             )
 
-        assert rc == 1
-        err = capsys.readouterr().err
-        assert "state unreadable" in err
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Waiting" in out
 
     def test_cursor_restored_on_tty_exit(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -670,6 +671,53 @@ class TestRunWatchLoop:
         assert rc == 0
         assert seen_costs == [{}, {}]
 
+    def test_watch_stays_alive_through_preflight_window(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Watch loop stays alive when state files do not exist yet (preflight/DAG-build).
+
+        Simulates the real startup window: frame 0 and frame 1 return no content
+        (state files not written yet), frame 2 returns normal content once the
+        sprint is past DAG-build.
+        """
+        frame_returns = [
+            ("", False, ""),  # preflight — no state files
+            ("", False, ""),  # DAG-build — still no state files
+            ("story rows\n", True, ""),  # sprint running — state populated
+        ]
+
+        def fake_render_frame(
+            _run_id: str,
+            _project_root: Path,
+            state: dict,
+            frame_idx: int,
+            *,
+            color: bool,
+            now_fn=None,
+        ) -> tuple[str, bool, str]:
+            del state, frame_idx, color, now_fn
+            return frame_returns.pop(0)
+
+        with (
+            patch.object(status_watch, "render_frame", side_effect=fake_render_frame),
+            patch.object(status_watch, "is_tty", return_value=False),
+        ):
+            rc = status_watch.run_watch_loop(
+                "run-x",
+                tmp_path,
+                interval=0.01,
+                color=False,
+                sleep_fn=lambda _s: None,
+                max_frames=3,
+            )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Waiting message shown during startup window.
+        assert "Waiting" in out
+        # Story rows shown once state is available.
+        assert "story rows" in out
+
 
 # ── cmd_status routing ───────────────────────────────────────────────────────
 
@@ -815,11 +863,16 @@ class TestCmdStatusWatchRouting:
 
 
 class TestSnapshotFailurePropagates:
-    """display_sprint_status returning non-zero on first frame must exit non-zero."""
+    """Frame-0 snapshot failures must not exit the watch loop.
 
-    def test_first_frame_snapshot_failure_exits_one(
+    The watch must stay alive through the sprint startup window (preflight and
+    DAG-build phases) before any state files are written to disk.
+    """
+
+    def test_first_frame_snapshot_failure_stays_alive(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        """snapshot_ok=False on frame 0 shows a waiting message; the loop does not exit."""
         with (
             patch.object(
                 status_watch,
@@ -837,16 +890,14 @@ class TestSnapshotFailurePropagates:
                 max_frames=1,
             )
 
-        assert rc == 1
-        # The captured diagnostic from display_sprint_status must reach stderr
-        # so the operator sees WHY the watch session refused to start.
-        err = capsys.readouterr().err
-        assert "snapshot diag" in err
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Waiting" in out
 
-    def test_first_frame_failure_falls_back_when_no_captured_diagnostic(
+    def test_first_frame_no_body_shows_waiting_message(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """If the snapshot returned non-zero but emitted nothing, we still surface a message."""
+        """When no body is produced on frame 0, a waiting message is shown instead of nothing."""
         with (
             patch.object(
                 status_watch,
@@ -864,9 +915,9 @@ class TestSnapshotFailurePropagates:
                 max_frames=1,
             )
 
-        assert rc == 1
-        err = capsys.readouterr().err
-        assert "failed to read sprint state" in err
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Waiting" in out
 
 
 class TestRenderFrameCapturesStderr:


### PR DESCRIPTION
## Summary

Frame-0 early-exit guard removed; loop now shows waiting message and keeps polling. Tests cover the startup window symptom.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.94
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status --watch exits immediately during preflight and DAG-build phases (GitHub Issue #1405)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1405