### PR TITLE
Sprint reports DONE/APPROVE but silently skips landing, losing the commit

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -720,6 +720,117 @@ def _step_cleanup(
         _pr_log.warning("remote branch cleanup failed (non-fatal): %s", exc)
 
 
+def _worktree_head_sha(worktree_path: Path) -> str | None:
+    """Return the current HEAD commit SHA in ``worktree_path``, or None if unknown.
+
+    The "already merged" guard in _merge_pr uses this to verify the merged PR
+    actually contains the work currently sitting in the worktree — branch names
+    are reused across sprint attempts, so matching by branch alone can mistake a
+    prior PR for the current one and silently discard the new commit.
+    """
+    if not worktree_path.is_dir():
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(worktree_path),
+            timeout=15,
+        )
+    except Exception as exc:
+        _pr_log.warning("HEAD lookup failed in %s: %s", worktree_path, exc)
+        return None
+    if proc.returncode != 0:
+        _pr_log.warning(
+            "HEAD lookup in %s failed (git exited %d): %s",
+            worktree_path,
+            proc.returncode,
+            (proc.stderr or proc.stdout).strip(),
+        )
+        return None
+    sha = proc.stdout.strip()
+    return sha or None
+
+
+def _pr_contains_commit(pr_number: int | str, head_sha: str, *, project_root: Path) -> bool | None:
+    """Return True/False if the PR's commits contain ``head_sha``, or None if unknown.
+
+    Works for squash- and rebase-merged PRs because ``gh pr view --json commits``
+    returns the original commits of the PR branch even after merge.
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "commits"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except Exception as exc:
+        _pr_log.warning("gh pr view #%s failed: %s", pr_number, exc)
+        return None
+    if proc.returncode != 0:
+        _pr_log.warning(
+            "gh pr view #%s failed (exit %d): %s",
+            pr_number,
+            proc.returncode,
+            (proc.stderr or proc.stdout).strip(),
+        )
+        return None
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        _pr_log.warning("gh pr view #%s returned invalid JSON: %s", pr_number, exc)
+        return None
+    commits = payload.get("commits") or []
+    return any(c.get("oid") == head_sha for c in commits)
+
+
+def _find_pr_containing_head(
+    merged_prs: list[dict],
+    *,
+    worktree_path: Path,
+    project_root: Path,
+    branch_name: str,
+) -> dict | None:
+    """Return the merged PR that contains the worktree's current HEAD, else None.
+
+    Filters ``merged_prs`` to those with a ``mergedAt`` timestamp, then verifies
+    each candidate's commit list against the worktree HEAD. If HEAD cannot be
+    determined, no candidate fires the guard — the safer default is to fall
+    through to the normal push/PR/merge sequence rather than silently skip
+    landing on a false positive.
+    """
+    candidates = [pr for pr in merged_prs if pr.get("mergedAt")]
+    if not candidates:
+        return None
+
+    head_sha = _worktree_head_sha(worktree_path)
+    if head_sha is None:
+        _pr_log.warning(
+            "cannot verify merged PR for branch %s contains current HEAD; "
+            "falling through to normal merge sequence",
+            branch_name,
+        )
+        return None
+
+    for pr in candidates:
+        pr_number = pr.get("number")
+        if pr_number is None:
+            continue
+        contains = _pr_contains_commit(pr_number, head_sha, project_root=project_root)
+        if contains is True:
+            return pr
+        if contains is None:
+            _pr_log.warning(
+                "could not confirm PR #%s contains HEAD %s; skipping guard",
+                pr_number,
+                head_sha,
+            )
+    return None
+
+
 def _merge_pr(
     config: ForgeConfig,
     task: TaskStory,
@@ -809,11 +920,17 @@ def _merge_pr(
         )
         if merged_pr_proc.returncode == 0:
             merged_prs = json.loads(merged_pr_proc.stdout or "[]")
-            merged_pr = next((pr for pr in merged_prs if pr.get("mergedAt")), None)
+            merged_pr = _find_pr_containing_head(
+                merged_prs,
+                worktree_path=worktree_path,
+                project_root=config.project_root,
+                branch_name=branch_name,
+            )
             if merged_pr is not None:
                 pr_url = merged_pr.get("url")
                 _pr_log.info(
-                    "PR already merged for branch %s; skipping PR recreation and merge retry: %s",
+                    "PR already merged for branch %s contains current HEAD; "
+                    "skipping PR recreation and merge retry: %s",
                     branch_name,
                     pr_url,
                 )

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -253,6 +253,8 @@ class TestMergePrFunction:
 
     def test_already_merged_branch_skips_push_and_pr_recreation(self, tmp_path: Path) -> None:
         config = _make_merge_pr_config(tmp_path)
+        # Create the worktree so `git rev-parse HEAD` is callable on it.
+        (tmp_path / "test-task").mkdir(parents=True, exist_ok=True)
         task = _make_task(tmp_path)
         review = _make_review_result()
         state = MagicMock()
@@ -261,6 +263,7 @@ class TestMergePrFunction:
         state.dev_iteration = 1
 
         calls: list[list[str]] = []
+        head_sha = "abc1234abc1234abc1234abc1234abc1234abc1"
 
         def _fake_run(cmd, **kwargs):
             if isinstance(cmd, list):
@@ -269,9 +272,16 @@ class TestMergePrFunction:
                     return _make_subprocess_result(
                         0,
                         stdout=(
-                            '[{"url": "https://github.com/fuzzypete/theforge/pull/42", '
+                            '[{"number": 42, '
+                            '"url": "https://github.com/fuzzypete/theforge/pull/42", '
                             '"mergedAt": "2025-01-01T00:00:00Z"}]'
                         ),
+                    )
+                if cmd[:2] == ["git", "rev-parse"]:
+                    return _make_subprocess_result(0, stdout=f"{head_sha}\n")
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return _make_subprocess_result(
+                        0, stdout=f'{{"commits": [{{"oid": "{head_sha}"}}]}}'
                     )
             return _make_subprocess_result(0)
 
@@ -292,8 +302,74 @@ class TestMergePrFunction:
         }
         mock_create_pr.assert_not_called()
         assert calls[0][:3] == ["gh", "pr", "list"]
+        assert any(cmd[:3] == ["gh", "pr", "view"] for cmd in calls)
         assert not any(cmd[:3] == ["git", "push", "-f"] for cmd in calls)
         assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd in calls)
+
+    def test_reused_branch_with_unrelated_merged_pr_proceeds_with_merge(
+        self, tmp_path: Path
+    ) -> None:
+        """A merged PR sharing the branch name but not the current HEAD must NOT
+        short-circuit landing — that's the bug from issue 1420 where a reused
+        branch caused the new commit to be silently discarded."""
+        config = _make_merge_pr_config(tmp_path)
+        (tmp_path / "test-task").mkdir(parents=True, exist_ok=True)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        current_head = "newnewnewnewnewnewnewnewnewnewnewnewnewn"
+        old_pr_commit = "oldoldoldoldoldoldoldoldoldoldoldoldoldo"
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list):
+                calls.append(cmd)
+                if cmd[:3] == ["gh", "pr", "list"] and "--state" in cmd:
+                    return _make_subprocess_result(
+                        0,
+                        stdout=(
+                            '[{"number": 42, '
+                            '"url": "https://github.com/fuzzypete/theforge/pull/42", '
+                            '"mergedAt": "2025-01-01T00:00:00Z"}]'
+                        ),
+                    )
+                if cmd[:2] == ["git", "rev-parse"]:
+                    return _make_subprocess_result(0, stdout=f"{current_head}\n")
+                if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd and "commits" in cmd:
+                    return _make_subprocess_result(
+                        0, stdout=f'{{"commits": [{{"oid": "{old_pr_commit}"}}]}}'
+                    )
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return _make_subprocess_result(0, stdout="MERGED")
+                if cmd[:3] == ["gh", "pr", "merge"]:
+                    return _make_subprocess_result(0)
+            return _make_subprocess_result(0)
+
+        new_pr_url = "https://github.com/fuzzypete/theforge/pull/99"
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": new_pr_url,
+                    "success": True,
+                    "error": None,
+                },
+            ) as mock_create_pr,
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        # Guard must NOT have fired: PR creation and merge must have run.
+        mock_create_pr.assert_called_once()
+        assert result["pr_url"] == new_pr_url
+        assert result["success"] is True
+        assert result["merged"] is True
+        assert any(cmd[:3] == ["gh", "pr", "merge"] for cmd in calls)
 
     def test_pr_creation_failure_no_merge(self, tmp_path: Path) -> None:
         failed_pr = {"action": "pr", "pr_url": None, "success": False, "error": "gh auth failed"}


### PR DESCRIPTION
## Summary

The guard now verifies the worktree HEAD is present in a merged PR before skipping landing, with a regression test for reused branches.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.10
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint reports DONE/APPROVE but silently skips landing, losing the commit (GitHub Issue #1420)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1420