### PR TITLE
Documented prose dependency syntax (Depends on: #N) is parsed only to be discarded; runtime ignores its own contract

### DIFF
--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -218,7 +218,8 @@ class GitHubIssueSource:
               - issue-123
             ---
 
-        Free-form prose is intentionally excluded from this parser.
+        Free-form prose is handled by ``_find_prose_dependency_phrases`` and
+        merged into the blockers set by ``fetch`` when no timeline edges exist.
         """
         metadata = metadata if metadata is not None else self._parse_issue_metadata(body, 0).data
         if not metadata:
@@ -252,7 +253,11 @@ class GitHubIssueSource:
         return _strip_illustrative_markdown(self._body_without_issue_metadata(body))
 
     def _find_prose_dependency_phrases(self, body: str) -> list[tuple[str, list[int]]]:
-        """Return non-authoritative dependency-shaped prose phrases and refs."""
+        """Return dependency-shaped prose phrases and the issue refs they declare.
+
+        Refs returned here are honored as scheduler blockers when no native
+        ``blocked_by`` timeline relationship is present; see ``fetch``.
+        """
         scan_body = self._body_without_illustrative_markdown(body)
         matches: list[tuple[str, list[int]]] = []
         for match in _BLOCKED_BY_BODY_RE.finditer(scan_body):
@@ -275,7 +280,14 @@ class GitHubIssueSource:
     def _dependency_authoring_warnings(
         self, body: str, structured_blockers: list[int]
     ) -> list[str]:
-        """Warn when prose looks like a dependency but is not structured metadata."""
+        """Return prose phrases whose refs are not honored as scheduler edges.
+
+        When a prose ref appears in ``structured_blockers`` (because either the
+        timeline, frontmatter, or prose itself promoted it to a blocker), the
+        phrase is silent. Phrases left over here typically indicate prose that
+        could not be promoted (e.g. a timeline-only blocker set that excludes a
+        prose-mentioned issue).
+        """
         declared = set(structured_blockers)
         warnings: list[str] = []
         for phrase, refs in self._find_prose_dependency_phrases(body):
@@ -329,7 +341,12 @@ class GitHubIssueSource:
         reopen_state = analyze_reopen_contract(data, timeline)
         blockers = sorted(self._fetch_issue_blockers_from_timeline(timeline))
         if not blockers:
-            blockers = self._parse_issue_blockers_from_body_metadata(body, metadata)
+            body_blockers: set[int] = set(
+                self._parse_issue_blockers_from_body_metadata(body, metadata)
+            )
+            for _phrase, refs in self._find_prose_dependency_phrases(body):
+                body_blockers.update(refs)
+            blockers = sorted(body_blockers)
         blocker_slugs = [f"issue-{blocker}" for blocker in blockers]
         dependency_warnings = self._dependency_authoring_warnings(body, blockers)
         if metadata_result.warning is not None:

--- a/tests/test_sprint_github_query.py
+++ b/tests/test_sprint_github_query.py
@@ -652,8 +652,12 @@ class TestClosedDependencySlugs:
         assert "issue-265" in resolved.closed_dependency_slugs
 
         tasks = [task for task, _src, _ref in resolved.stories]
-        assert tasks[0].depends_on == []
-        assert tasks[0].dependency_warnings == ["depends_on: issue-265"]
+        # Prose dependency declarations are now honored as scheduler edges,
+        # so issue-265 appears as a depends_on entry. Because the dep is
+        # already closed, the satisfied/closed_dependency_slugs path below
+        # is what unblocks issue-750.
+        assert tasks[0].depends_on == ["issue-265"]
+        assert tasks[0].dependency_warnings == []
         # resolve_satisfied_dependencies must not need a live gh call because
         # issue-265 is already in pre_satisfied from closed_dependency_slugs.
         satisfied = resolve_satisfied_dependencies(
@@ -670,7 +674,7 @@ class TestClosedDependencySlugs:
         normalized = normalize_dependency_plan(tasks, satisfied=satisfied)
         assert normalized.blocked == {}
 
-        # Prose-only references no longer create a DAG edge, so issue-750 is immediately ready.
+        # issue-265 is satisfied (closed), so issue-750 is immediately ready.
         dag = build_dag(normalized.tasks, satisfied=satisfied)
         ready_slugs = [t.slug for t in dag.ready()]
         assert "issue-750" in ready_slugs

--- a/tests/test_sprint_lifecycle.py
+++ b/tests/test_sprint_lifecycle.py
@@ -524,10 +524,10 @@ class TestRunSprint:
             "github_blockers": ["issue-9"],
         }
 
-    def test_authoring_warning_for_dependency_shaped_prose_is_visible(
+    def test_no_warning_emitted_when_prose_dependencies_are_honored(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Sprint start logs issue-body prose that looks dependency-shaped."""
+        """Prose dependencies promoted to scheduler edges suppress the legacy warning."""
         from theforge.sprint.manifest import ResolvedSprint
         from theforge.sprint.sources import GitHubIssueSource
         from theforge.task import TaskStory
@@ -543,7 +543,9 @@ class TestRunSprint:
                         name="Issue B",
                         slug="issue-2",
                         github_issue=2,
-                        dependency_warnings=["Depends on #265"],
+                        depends_on=["issue-265"],
+                        inferred_dependencies=["issue-265"],
+                        dependency_warnings=[],
                     ),
                     GitHubIssueSource(),
                     "issue:2",
@@ -556,13 +558,7 @@ class TestRunSprint:
             run_sprint(config, resolved)
 
         captured = capsys.readouterr()
-        assert "dependency-shaped prose ignored" in captured.err
-        assert "issue-2 (Issue B)" in captured.err
-        assert "Depends on #265" in captured.err
-        assert (
-            "declare dependencies with GitHub blocked-by relationships or leading issue metadata"
-            in captured.err
-        )
+        assert "dependency-shaped prose ignored" not in captured.err
 
 
 # ── Notification tests ────────────────────────────────────────────────

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -94,7 +94,7 @@ class TestGitHubIssueSource:
         assert task.depends_on == ["issue-12"]
         assert task.inferred_dependencies == ["issue-12"]
 
-    def test_fetch_ignores_body_prose_dependency_as_edge(self, tmp_path: Path) -> None:
+    def test_fetch_promotes_body_prose_dependency_to_edge(self, tmp_path: Path) -> None:
         issue_data = json.dumps(
             {
                 "title": "Fix the bug",
@@ -109,12 +109,68 @@ class TestGitHubIssueSource:
             ]
             task = GitHubIssueSource().fetch("42", tmp_path)
 
-        assert task.depends_on == []
-        assert task.inferred_dependencies == []
-        assert task.dependency_warnings == [
-            "blocked by #12",
-            "blocked by https://github.com/acme/repo/issues/7",
-        ]
+        assert task.depends_on == ["issue-7", "issue-12"]
+        assert task.inferred_dependencies == ["issue-7", "issue-12"]
+        assert task.dependency_warnings == []
+
+    def test_fetch_promotes_depends_on_prose_to_edge(self, tmp_path: Path) -> None:
+        issue_data = json.dumps(
+            {
+                "title": "Fix the bug",
+                "body": "## Background\nDepends on: #265 for the schema change.",
+                "state": "OPEN",
+            }
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=issue_data, stderr=""),
+                MagicMock(returncode=1, stdout="", stderr="preview unavailable"),
+            ]
+            task = GitHubIssueSource().fetch("42", tmp_path)
+
+        assert task.depends_on == ["issue-265"]
+        assert task.inferred_dependencies == ["issue-265"]
+        assert task.dependency_warnings == []
+
+    def test_fetch_timeline_blockers_take_precedence_over_prose(self, tmp_path: Path) -> None:
+        """Native blocked_by relationships override body-derived dependencies."""
+        issue_data = json.dumps(
+            {
+                "title": "Fix the bug",
+                "body": "Depends on #265",
+                "state": "OPEN",
+            }
+        )
+        timeline = json.dumps([{"event": "blocked_by", "blocking_issue": {"number": 12}}])
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=issue_data, stderr=""),
+                MagicMock(returncode=0, stdout=timeline, stderr=""),
+            ]
+            task = GitHubIssueSource().fetch("42", tmp_path)
+
+        assert task.depends_on == ["issue-12"]
+        assert task.inferred_dependencies == ["issue-12"]
+
+    def test_fetch_merges_frontmatter_and_prose_when_timeline_empty(self, tmp_path: Path) -> None:
+        issue_data = json.dumps(
+            {
+                "title": "Fix the bug",
+                "body": (
+                    "---\ndepends_on:\n  - issue-100\n---\n\nAlso depends on #200 for context."
+                ),
+                "state": "OPEN",
+            }
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=issue_data, stderr=""),
+                MagicMock(returncode=1, stdout="", stderr="preview unavailable"),
+            ]
+            task = GitHubIssueSource().fetch("42", tmp_path)
+
+        assert task.depends_on == ["issue-100", "issue-200"]
+        assert task.dependency_warnings == []
 
     def test_fetch_populates_depends_on_from_issue_frontmatter(self, tmp_path: Path) -> None:
         issue_data = json.dumps(
@@ -150,11 +206,13 @@ class TestGitHubIssueSource:
             ]
             task = GitHubIssueSource().fetch("42", tmp_path)
 
-        assert task.depends_on == []
-        assert task.inferred_dependencies == []
+        # Malformed frontmatter falls back to prose detection: the depends_on
+        # line is still honored as a scheduler edge, but the malformed-YAML
+        # warning remains visible to the operator.
+        assert task.depends_on == ["issue-12"]
+        assert task.inferred_dependencies == ["issue-12"]
         assert task.dependency_warnings
         assert "malformed YAML frontmatter" in task.dependency_warnings[0]
-        assert any("depends_on: issue-12" in warning for warning in task.dependency_warnings)
 
     def test_fetch_appends_reopen_comment_to_story_text(self, tmp_path: Path) -> None:
         issue_data = json.dumps(
@@ -218,9 +276,7 @@ class TestGitHubIssueSource:
             ),
         ],
     )
-    def test_prose_dependency_phrases_are_diagnostics_only(
-        self, body: str, expected: list
-    ) -> None:
+    def test_prose_dependency_phrases_extract_refs(self, body: str, expected: list) -> None:
         source = GitHubIssueSource()
         result = sorted(
             {ref for _phrase, refs in source._find_prose_dependency_phrases(body) for ref in refs}


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change honors documented prose dependencies on the GitHub issue fetch path and has focused regression coverage. | [deepseek-deepseek-reasoner] Change correctly aligns runtime behavior with documented prose dependency contract by merging prose-derived refs into scheduler blockers when no timeline relationships exist. All acceptance criteria are met with corresponding tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Documented prose dependency syntax (Depends on: #N) is parsed only to be discarded; runtime ignores its own contract (GitHub Issue #1430)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1430