### PR TITLE
forge logs follow loop emits 'Run re-exec'd' continuously when redirect target equals current run

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -44,7 +44,9 @@ def _follow_log_with_redirect(
                 if redirect_file is not None and redirect_file.exists():
                     try:
                         d = json.loads(redirect_file.read_text(encoding="utf-8"))
-                        return d["new_run_id"], Path(d["new_log"]), fh.tell()
+                        new_run_id = d["new_run_id"]
+                        if new_run_id != current_run_id:
+                            return new_run_id, Path(d["new_log"]), fh.tell()
                     except (OSError, KeyError, ValueError, json.JSONDecodeError):
                         pass
                 time.sleep(0.1)

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -321,3 +321,34 @@ class TestCmdLogs:
         captured = capsys.readouterr()
         assert "legitimate output" in captured.out
         assert "Run re-exec'd" not in captured.err
+
+    def test_reflexive_redirect_does_not_emit_reexec_notice(self, tmp_path, capsys):
+        """A redirect file pointing to the current run id must not trigger a re-exec notice.
+
+        This is the bug from issue #1447: when the redirect file's new_run_id equals
+        the currently-followed run id, _follow_log_with_redirect must ignore it and
+        continue tailing rather than returning a tuple that causes the outer loop to
+        emit the notice repeatedly.
+        """
+        import json
+
+        from theforge.cli.status import _SENTINEL_EOF, _follow_log_with_redirect
+
+        run_id = "fea6776bee4a"
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+
+        log_file = tmp_path / f"run-{run_id}.log"
+        log_file.write_text(f"sprint output line\n{_SENTINEL_EOF}\n")
+
+        # Redirect file points reflexively back to the same run id.
+        (runs_dir / f"{run_id}.redirect").write_text(
+            json.dumps({"new_run_id": run_id, "new_log": str(log_file)}),
+            encoding="utf-8",
+        )
+
+        result = _follow_log_with_redirect(log_file, run_id, runs_dir=runs_dir)
+
+        assert result is None, "reflexive redirect must not be treated as a re-exec"
+        captured = capsys.readouterr()
+        assert "sprint output line" in captured.out


### PR DESCRIPTION
## Summary

Equality guard in _follow_log_with_redirect cleanly fixes reflexive-redirect spam; test reproduces the symptom.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.90
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge logs follow loop emits 'Run re-exec'd' continuously when redirect target equals current run (GitHub Issue #1447)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1447