### PR TITLE
Shape gate's reopened_stale_contract claims semantic enforcement but verifies only timestamp ceremony, blocking sprint entry on a check the gate cannot actually perform

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -439,7 +439,11 @@ def _run_query_mode(
         fetch_issues_for_label,
         fetch_issues_for_milestone,
     )
-    from theforge.sprint.shape_gate import apply_shape_gate, format_skipped_warning
+    from theforge.sprint.shape_gate import (
+        apply_shape_gate,
+        format_advisory_warning,
+        format_skipped_warning,
+    )
 
     try:
         budget_usd = float(budget_str)
@@ -512,6 +516,8 @@ def _run_query_mode(
                 )
             else:
                 print(warning, file=sys.stderr)
+        if gate_result.advisories:
+            print(format_advisory_warning(gate_result.advisories), file=sys.stderr)
         issues = gate_result.runnable
         skipped_issues = gate_result.skipped
 

--- a/src/theforge/sprint/reopen_context.py
+++ b/src/theforge/sprint/reopen_context.py
@@ -75,12 +75,20 @@ def append_reopen_context(story_text: str, state: ReopenContractState) -> str:
 
 
 def format_reopen_stale_detail(state: ReopenContractState) -> str:
-    """Render the operator-facing stale-contract refusal detail."""
+    """Render the operator-facing reopen-context advisory detail.
+
+    The check this string accompanies verifies only timestamp ordering of
+    GitHub timeline events — it cannot determine whether the body's content
+    has incorporated the reopen comment. The message must therefore frame
+    this as advisory information for operator/reviewer awareness, not a
+    semantic claim about body content.
+    """
     when = state.reopen_comment_at or state.reopened_at or "unknown time"
     author = state.reopen_comment_author or state.reopened_by or "unknown author"
     return (
-        f"issue reopened with new context in the comment from {when} by {author}; "
-        "reconcile the body before sprinting or pass --force"
+        f"reopen comment from {when} by {author} postdates the last body edit; "
+        "the reopen context is included in the story for dev/review — "
+        "verify the body reflects it if needed"
     )
 
 

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -60,6 +60,7 @@ class SkippedIssue:
 class ShapeGateResult:
     runnable: list[dict] = field(default_factory=list)
     skipped: list[SkippedIssue] = field(default_factory=list)
+    advisories: list[SkippedIssue] = field(default_factory=list)
 
 
 def _fetch_issue_detail(number: int, project_root: Path | None) -> dict | None:
@@ -267,6 +268,7 @@ def apply_shape_gate(
     effective_mode = _resolve_classifier(classifier_mode, llm_caller=llm_caller)
     runnable: list[dict] = []
     skipped: list[SkippedIssue] = []
+    advisories: list[SkippedIssue] = []
 
     for issue in issues:
         number = int(issue["number"])
@@ -306,7 +308,12 @@ def apply_shape_gate(
             continue
 
         if reopen_state.has_stale_body:
-            skipped.append(
+            # Advisory only: the underlying check verifies timeline-event
+            # ordering, not body content, so blocking sprint entry on it
+            # would demand ceremonial work the gate cannot validate. The
+            # reopen comment itself flows to dev/review via
+            # ``append_reopen_context`` in ``sources.py`` regardless.
+            advisories.append(
                 SkippedIssue(
                     issue_number=number,
                     reason_codes=(REOPENED_STALE_CONTRACT_CODE,),
@@ -315,7 +322,6 @@ def apply_shape_gate(
                     detail=format_reopen_stale_detail(reopen_state),
                 )
             )
-            continue
 
         if local.shape is not Shape.RUNNABLE:
             codes = _blocking_codes(local) or [r.code for r in local.reasons]
@@ -339,9 +345,9 @@ def apply_shape_gate(
     if force:
         # Escape hatch: caller wants to run every input issue. Skip list is
         # preserved so CLI can render a prominent warning.
-        return ShapeGateResult(runnable=list(issues), skipped=skipped)
+        return ShapeGateResult(runnable=list(issues), skipped=skipped, advisories=advisories)
 
-    return ShapeGateResult(runnable=runnable, skipped=skipped)
+    return ShapeGateResult(runnable=runnable, skipped=skipped, advisories=advisories)
 
 
 def format_skipped_warning(skipped: list[SkippedIssue]) -> str:
@@ -350,6 +356,19 @@ def format_skipped_warning(skipped: list[SkippedIssue]) -> str:
         return ""
     lines = [f"[forge] {len(skipped)} issue(s) flagged by shape gate:"]
     for entry in skipped:
+        codes = ", ".join(entry.reason_codes) or "<no codes>"
+        title = f" — {entry.title}" if entry.title else ""
+        detail = f" [{entry.detail}]" if entry.detail else ""
+        lines.append(f"  - #{entry.issue_number} ({entry.source}): {codes}{title}{detail}")
+    return "\n".join(lines)
+
+
+def format_advisory_warning(advisories: list[SkippedIssue]) -> str:
+    """Render a human-readable advisory note for non-blocking findings."""
+    if not advisories:
+        return ""
+    lines = [f"[forge] {len(advisories)} issue(s) carry shape-gate advisories (not blocking):"]
+    for entry in advisories:
         codes = ", ".join(entry.reason_codes) or "<no codes>"
         title = f" — {entry.title}" if entry.title else ""
         detail = f" [{entry.detail}]" if entry.detail else ""

--- a/tests/test_sprint_shape_gate.py
+++ b/tests/test_sprint_shape_gate.py
@@ -133,14 +133,18 @@ def test_local_check_allows_runnable_issue(tmp_path: Path) -> None:
     assert result.skipped == []
 
 
-def test_reopened_issue_with_stale_body_is_skipped(tmp_path: Path) -> None:
+def test_reopened_issue_with_stale_body_is_advisory_not_blocking(tmp_path: Path) -> None:
+    """A reopened bug whose body predates the reopen event is no longer
+    refused at sprint entry; the rule is downgraded to a non-blocking
+    advisory because the underlying check verifies only timeline-event
+    ordering, not body content."""
     issues = [{"number": 55, "title": "Reopened"}]
 
     def fetch(_number, _project_root):
         return {
             "title": "Reopened",
             "body": _RUNNABLE_BODY,
-            "labels": ["bug"],
+            "labels": ["enhancement"],
             "state": "OPEN",
             "comments": [
                 {
@@ -160,11 +164,14 @@ def test_reopened_issue_with_stale_body_is_skipped(tmp_path: Path) -> None:
 
     result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
 
-    assert result.runnable == []
-    assert len(result.skipped) == 1
-    entry = result.skipped[0]
+    assert result.runnable == issues
+    assert result.skipped == []
+    assert len(result.advisories) == 1
+    entry = result.advisories[0]
     assert entry.reason_codes == (REOPENED_STALE_CONTRACT_CODE,)
-    assert "reconcile the body before sprinting or pass --force" in entry.detail
+    # Honest framing: no instruction to "reconcile the body before sprinting".
+    assert "reconcile the body before sprinting" not in entry.detail
+    assert "postdates the last body edit" in entry.detail
 
 
 def test_reopened_issue_with_body_edit_after_reopen_is_runnable(tmp_path: Path) -> None:
@@ -234,7 +241,10 @@ def test_force_override_returns_all_issues_runnable_but_keeps_skipped_list(
     assert result.skipped[0].source == "label"
 
 
-def test_force_override_keeps_reopened_stale_contract_warning(tmp_path: Path) -> None:
+def test_force_override_preserves_reopened_stale_contract_advisory(tmp_path: Path) -> None:
+    """Under --force the reopen advisory remains visible (advisory channel),
+    matching the prior force-mode behavior of preserving the warning while
+    still running every issue."""
     issues = [{"number": 57, "title": "Reopened"}]
 
     def fetch(_number, _project_root):
@@ -262,8 +272,8 @@ def test_force_override_keeps_reopened_stale_contract_warning(tmp_path: Path) ->
     result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch, force=True)
 
     assert result.runnable == issues
-    assert len(result.skipped) == 1
-    assert result.skipped[0].reason_codes == (REOPENED_STALE_CONTRACT_CODE,)
+    assert len(result.advisories) == 1
+    assert result.advisories[0].reason_codes == (REOPENED_STALE_CONTRACT_CODE,)
 
 
 # ── Mixed sprint ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The change downgrades reopened_stale_contract to an advisory, keeps stale reopened issues runnable, and preserves visible advisory output without introducing blocking defects.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.73
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Shape gate's reopened_stale_contract claims semantic enforcement but verifies only timestamp ceremony, blocking sprint entry on a check the gate cannot actually perform (GitHub Issue #1452)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1452