### PR TITLE
Shape gate forces operators to assert a 'confirmed cause' before one is known, manufacturing the false-confidence loop the rule was designed to prevent

### DIFF
--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -219,12 +219,101 @@ REQUIRED_DIAGNOSIS_TOKENS: tuple[str, ...] = (
     "fix-success criterion",
 )
 
+# Non-assertion vocabulary admissible as the value of the "confirmed cause" field.
+# A bug whose Diagnosis section has every other component but states the cause is
+# unknown is investigation-ready (admissible) — not implementation-ready. The dev
+# cycle's first job on such bugs is cause discovery, not hypothesized-cause
+# implementation. The gate must distinguish these states rather than coercing
+# operators into asserting causes they have not confirmed (which produced the
+# silent-contract-swap failure mode of #1435/#1446/#1447).
+_NON_ASSERTION_CAUSE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*(?:cause\s+(?:is|remains)\s+)?unknown\b", re.IGNORECASE),
+    re.compile(
+        r"^\s*(?:still\s+|currently\s+)?not\s+yet\s+"
+        r"(?:identified|known|determined|confirmed|isolated|established)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*not\s+(?:identified|known|determined|confirmed|established)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"^\s*(?:still\s+|currently\s+)?pending\s+investigation\b", re.IGNORECASE),
+    re.compile(r"^\s*under\s+investigation\b", re.IGNORECASE),
+    re.compile(r"^\s*tbd\b", re.IGNORECASE),
+    re.compile(r"^\s*to\s+be\s+(?:determined|identified|investigated|confirmed)\b", re.IGNORECASE),
+    re.compile(r"^\s*undetermined\b", re.IGNORECASE),
+    re.compile(r"^\s*unconfirmed\b", re.IGNORECASE),
+    re.compile(r"^\s*unidentified\b", re.IGNORECASE),
+    re.compile(r"^\s*investigation\s+(?:ongoing|in\s+progress)\b", re.IGNORECASE),
+    re.compile(r"^\s*\?+\s*$"),
+)
+
 # Status labels operators can apply to a bug to communicate fix-readiness intent.
 # These are advisory — the body's Diagnosis section is the authoritative signal.
 RECOGNIZED_STATUS_LABELS: frozenset[str] = frozenset(
     {"status:triage", "status:investigating", "status:diagnosed"}
 )
 FIX_READY_STATUS_LABELS: frozenset[str] = frozenset({"status:diagnosed"})
+
+
+def _extract_confirmed_cause_value(section: str) -> str | None:
+    """Return the prose value following the 'confirmed cause' label, if present.
+
+    Operators write the field in several common shapes::
+
+        - **Confirmed cause.** the cause is X
+        - **Confirmed cause:** unknown
+        - Confirmed cause: not yet identified
+        - Confirmed cause — pending investigation
+
+    Returns the trimmed text after the label up to the end of that logical
+    line, or ``None`` when no labelled occurrence exists. The match is
+    case-insensitive on the label only.
+    """
+    for line in section.splitlines():
+        # Strip leading whitespace, bullet markers, and opening bold markers.
+        cleaned = re.sub(r"^\s*(?:[-*+]\s+)?", "", line)
+        cleaned = re.sub(r"^\*+\s*", "", cleaned)
+        m = re.match(r"confirmed\s+cause\b", cleaned, re.IGNORECASE)
+        if m is None:
+            continue
+        rest = cleaned[m.end() :]
+        # Strip any combination of label punctuation, closing bold markers, and
+        # whitespace separating the label from its value.
+        rest = re.sub(r"^[\s*:.\-—]+", "", rest)
+        value = re.sub(r"\*+\s*$", "", rest).strip()
+        return value
+    return None
+
+
+def _is_non_assertion_cause(value: str) -> bool:
+    if not value:
+        return False
+    return any(pattern.match(value) for pattern in _NON_ASSERTION_CAUSE_PATTERNS)
+
+
+def cause_assertion_state(body: str) -> str:
+    """Classify the confirmed-cause field of the Diagnosis section.
+
+    Returns one of:
+
+    - ``"asserted"``: a confirmed-cause line exists and its value is a
+      specific cause claim (i.e. not non-assertion vocabulary).
+    - ``"non_asserted"``: the field exists but its value is non-assertion
+      vocabulary (``unknown``, ``not yet identified``, ``pending
+      investigation``, ``TBD``, etc.). Bug is investigation-ready.
+    - ``"missing"``: no confirmed-cause line present (or no Diagnosis
+      section at all).
+    """
+    section = extract_section(body, DIAGNOSIS_HEADING_PATTERN)
+    if section is None:
+        return "missing"
+    value = _extract_confirmed_cause_value(section)
+    if value is None:
+        return "missing"
+    if _is_non_assertion_cause(value):
+        return "non_asserted"
+    return "asserted"
 
 
 def diagnosis_completeness(body: str) -> tuple[bool, list[str]]:
@@ -234,6 +323,12 @@ def diagnosis_completeness(body: str) -> tuple[bool, list[str]]:
     absent. Returns ``(False, [...])`` when the section is present but lacks
     one or more required tokens. Returns ``(True, [])`` only when every
     required token appears within the section text (case-insensitive).
+
+    The ``confirmed cause`` token requires presence of the field label; the
+    field's *value* may be either a specific cause or a non-assertion phrase
+    such as ``unknown`` or ``not yet identified``. Distinguishing those two
+    states is the job of :func:`cause_assertion_state` — the gate's only
+    responsibility here is verifying the operator filled the slot at all.
     """
     section = extract_section(body, DIAGNOSIS_HEADING_PATTERN)
     if section is None:
@@ -247,35 +342,59 @@ def diagnosis_completeness(body: str) -> tuple[bool, list[str]]:
 
 def derive_fix_ready(
     story_type: str | None, body: str, labels: Iterable[str] | None = None
-) -> tuple[bool | None, list[str]]:
-    """Compute the binary fix-readiness signal from structured type and body.
+) -> tuple[bool | None, bool, list[str]]:
+    """Compute the (fix_ready, investigation_ready, warnings) signals.
 
     Rules:
-    - ``type=None`` → ``(None, [warning])`` (cannot determine).
-    - ``type='bug'`` → ``True`` iff the body contains a complete Diagnosis section
-      with every required component; otherwise ``False`` with explanatory warnings.
-    - Any other recognized type (enhancement, task, epic) → always fix-ready
-      since features/tasks are described by acceptance criteria, not diagnosis.
+    - ``type=None`` → ``(None, False, [warning])`` (cannot determine).
+    - ``type='bug'`` with a complete Diagnosis section whose confirmed-cause
+      value is a specific claim → ``(True, False, [])`` (implementation-ready).
+    - ``type='bug'`` with a complete Diagnosis section whose confirmed-cause
+      value is non-assertion vocabulary (``unknown``, ``not yet identified``,
+      ``pending investigation``, ``TBD``, etc.) → ``(True, True, [warning])``
+      (investigation-ready). The bug passes the shape gate; the dev cycle's
+      first job is cause discovery, not hypothesized-cause implementation.
+    - ``type='bug'`` with a missing or incomplete Diagnosis section →
+      ``(False, False, [warnings])``.
+    - Any other recognized type (enhancement, task, epic) →
+      ``(True, False, [])``.
 
     Status labels (e.g. ``status:diagnosed``) are operator intent and do not
     override body content per AC: absence of the Diagnosis section flips a
     bug to not-fix-ready regardless of label.
     """
     if story_type is None:
-        return None, ["fix-readiness undetermined: story type unknown"]
+        return None, False, ["fix-readiness undetermined: story type unknown"]
     if story_type == "bug":
         ok, missing = diagnosis_completeness(body)
         if ok:
-            return True, []
+            state = cause_assertion_state(body)
+            if state == "non_asserted":
+                return (
+                    True,
+                    True,
+                    [
+                        "bug is investigation-ready: Diagnosis section is complete but the "
+                        "confirmed-cause field is a non-assertion (e.g. 'unknown', 'not yet "
+                        "identified'). Dev cycle's first job is cause discovery."
+                    ],
+                )
+            return True, False, []
         if missing == ["missing Diagnosis section"]:
-            return False, [
-                "bug missing Diagnosis section — not fix-ready (run "
-                "`forge diagnose` or add diagnosis manually)"
-            ]
-        return False, [
-            f"bug Diagnosis section missing required component: {tok}" for tok in missing
-        ]
-    return True, []
+            return (
+                False,
+                False,
+                [
+                    "bug missing Diagnosis section — not fix-ready (run "
+                    "`forge diagnose` or add diagnosis manually)"
+                ],
+            )
+        return (
+            False,
+            False,
+            [f"bug Diagnosis section missing required component: {tok}" for tok in missing],
+        )
+    return True, False, []
 
 
 def is_bug_format_issue(body: str, labels: Iterable[str]) -> bool:
@@ -338,7 +457,11 @@ def check_bug_missing_diagnosis(title: str, body: str, labels: Iterable[str]) ->
                 "Bug has no Diagnosis section — not fix-ready. Add a '## Diagnosis' "
                 "section containing observed symptom, evidence, ruled-out hypotheses, "
                 "confirmed cause, affected code path, and fix-success criterion before "
-                "sprinting (or run `forge diagnose` when available)."
+                "sprinting (or run `forge diagnose` when available). The confirmed-cause "
+                "value may be a specific claim or a non-assertion phrase such as "
+                "'unknown', 'not yet identified', 'pending investigation', or 'TBD' — "
+                "investigation-ready bugs are admissible; only symptom-only bodies are "
+                "refused."
             ),
         )
     return Reason(

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -213,7 +213,7 @@ def _build_task_from_story(story_path: Path) -> TaskStory:
         _logging.getLogger(__name__).warning(warning)
 
     body = story_path.read_text(encoding="utf-8")
-    fix_ready, readiness_warnings = derive_fix_ready(story_type, body)
+    fix_ready, investigation_ready, readiness_warnings = derive_fix_ready(story_type, body)
     fm_override = fm.get("fix_ready")
     if isinstance(fm_override, bool):
         if fm_override is True and fix_ready is False:
@@ -242,6 +242,7 @@ def _build_task_from_story(story_path: Path) -> TaskStory:
         type=story_type,
         type_warnings=type_warnings,
         fix_ready=fix_ready,
+        investigation_ready=investigation_ready,
         readiness_warnings=readiness_warnings,
     )
 

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -358,7 +358,7 @@ class GitHubIssueSource:
             if isinstance(lbl, dict) and lbl.get("name")
         ]
         story_type, type_warnings = _derive_type_from_labels(label_names, number)
-        fix_ready, readiness_warnings = derive_fix_ready(story_type, body)
+        fix_ready, investigation_ready, readiness_warnings = derive_fix_ready(story_type, body)
         status_labels = sorted(set(label_names) & RECOGNIZED_STATUS_LABELS)
         # Surface label/body disagreement for operator awareness — body is authoritative.
         if (
@@ -395,6 +395,7 @@ class GitHubIssueSource:
             type=story_type,
             type_warnings=type_warnings,
             fix_ready=fix_ready,
+            investigation_ready=investigation_ready,
             readiness_warnings=readiness_warnings,
         )
 

--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -45,6 +45,35 @@ def build_dev_prompt(
     The orchestrator fills ALL placeholders. The agent makes zero process decisions.
     """
     feedback_section = ""
+    if getattr(task, "investigation_ready", False):
+        feedback_section += dedent("""\
+
+            ## ⚠ Investigation-Ready Bug — Cause Not Yet Confirmed
+
+            This bug's Diagnosis section explicitly states the cause is not yet
+            identified (e.g. "unknown", "not yet identified", "pending
+            investigation", "TBD"). It passed the shape gate as
+            *investigation-ready*, **not** implementation-ready.
+
+            Your first job is **cause discovery**, not hypothesized-cause
+            implementation:
+
+            1. Reproduce the observed symptom from the Diagnosis section before
+               making any code change.
+            2. Investigate the affected code path and verify the actual cause
+               with evidence (logs, failing test, instrumentation). Do **not**
+               treat the confirmed-cause field as an implementation target — it
+               is a non-assertion placeholder.
+            3. Only after you have a verified cause, write the fix. The fix
+               must demonstrably resolve the originally observed symptom (per
+               the fix-success criterion), not merely the cause you guessed.
+            4. Record the confirmed cause in your handoff so reviewers can
+               verify the symptom resolution against a real diagnosis.
+
+            Hypothesizing a cause and refuting it is the silent-contract-swap
+            failure mode this gate is designed to prevent — closing the bug as
+            ALREADY_DONE while the symptom remains live in the codebase.
+        """)
     if escalation_note:
         feedback_section += dedent(f"""\
 

--- a/src/theforge/task/story.py
+++ b/src/theforge/task/story.py
@@ -43,6 +43,7 @@ class TaskStory:
     type: str | None = None  # structured story type from frontmatter or GH label
     type_warnings: list[str] = field(default_factory=list)  # missing-type migration warnings
     fix_ready: bool | None = None  # True iff bug has full Diagnosis section or non-bug type
+    investigation_ready: bool = False  # True when bug passes gate but cause is not yet asserted
     readiness_warnings: list[str] = field(default_factory=list)  # why fix_ready is False/None
 
 

--- a/tests/test_dev_prompts.py
+++ b/tests/test_dev_prompts.py
@@ -130,6 +130,74 @@ class TestPlanObedienceFraming:
         assert "Follow it closely" in prompt
 
 
+class TestInvestigationReadyDevPromptRouting:
+    """Seam test: TaskStory.investigation_ready must change downstream dev-cycle
+    behavior. The dev prompt is the runtime consumer of the typed signal —
+    investigation-ready bugs are routed to cause discovery rather than
+    hypothesized-cause implementation.
+    """
+
+    def test_investigation_ready_inserts_cause_discovery_section(self, tmp_path):
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Spec\n\nDo the thing.", encoding="utf-8")
+        task = TaskStory(
+            name="Bug: symptom only",
+            story_path=spec,
+            slug="bug",
+            type="bug",
+            fix_ready=True,
+            investigation_ready=True,
+        )
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+        )
+        assert "Investigation-Ready Bug" in prompt
+        assert "cause discovery" in prompt.lower()
+        assert "not yet" in prompt.lower()
+        # Must explicitly tell the dev agent NOT to treat the confirmed-cause
+        # field as an implementation target.
+        assert "implementation target" in prompt
+        # Must reference the symptom-resolution gate the reviewer applies.
+        assert "fix-success criterion" in prompt
+
+    def test_implementation_ready_bug_omits_cause_discovery_section(self, tmp_path):
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Spec\n\nDo the thing.", encoding="utf-8")
+        task = TaskStory(
+            name="Bug: known cause",
+            story_path=spec,
+            slug="bug",
+            type="bug",
+            fix_ready=True,
+            investigation_ready=False,
+        )
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+        )
+        assert "Investigation-Ready Bug" not in prompt
+
+    def test_default_task_omits_cause_discovery_section(self, tmp_path):
+        # Backwards-compat: tasks with default investigation_ready=False (e.g.
+        # features, tasks) must not see the bug-cycle scaffolding.
+        task = _make_task(tmp_path)
+        prompt = build_dev_prompt(
+            task,
+            workspace_path=tmp_path / "ws",
+            branch_name="feat/test",
+            story_content="# Spec",
+            gate_command="make gate",
+        )
+        assert "Investigation-Ready Bug" not in prompt
+
+
 def test_dev_prompt_includes_repository_context_pack(tmp_path):
     task = _make_task(tmp_path)
     from theforge.task.context_assembler import ContextManifestEntry, ContextPack

--- a/tests/test_fix_readiness.py
+++ b/tests/test_fix_readiness.py
@@ -17,6 +17,7 @@ import pytest
 from theforge.shape_check import Shape, check
 from theforge.shape_check.heuristics import (
     REQUIRED_DIAGNOSIS_TOKENS,
+    cause_assertion_state,
     check_bug_missing_diagnosis,
     derive_fix_ready,
     diagnosis_completeness,
@@ -107,36 +108,193 @@ class TestCheckBugMissingDiagnosis:
 
 class TestDeriveFixReady:
     def test_unknown_type_returns_none(self) -> None:
-        signal, warnings = derive_fix_ready(None, DIAGNOSIS_BODY)
+        signal, investigation_ready, warnings = derive_fix_ready(None, DIAGNOSIS_BODY)
         assert signal is None
+        assert investigation_ready is False
         assert warnings and "type unknown" in warnings[0]
 
     def test_feature_always_fix_ready(self) -> None:
         # No diagnosis section needed for non-bug types per AC: "Features are
         # always fix-ready (no diagnosis required for new functionality)."
-        signal, warnings = derive_fix_ready("enhancement", "## What\nDo a thing.")
+        signal, investigation_ready, warnings = derive_fix_ready(
+            "enhancement", "## What\nDo a thing."
+        )
         assert signal is True
+        assert investigation_ready is False
         assert warnings == []
 
     def test_task_type_always_fix_ready(self) -> None:
-        signal, warnings = derive_fix_ready("task", "## What\nDo it.")
+        signal, investigation_ready, warnings = derive_fix_ready("task", "## What\nDo it.")
         assert signal is True
+        assert investigation_ready is False
         assert warnings == []
 
     def test_bug_with_diagnosis_is_fix_ready(self) -> None:
-        signal, warnings = derive_fix_ready("bug", DIAGNOSIS_BODY)
+        signal, investigation_ready, warnings = derive_fix_ready("bug", DIAGNOSIS_BODY)
         assert signal is True
+        assert investigation_ready is False
         assert warnings == []
 
     def test_bug_without_diagnosis_is_not_fix_ready(self) -> None:
-        signal, warnings = derive_fix_ready("bug", "## What\nprose only")
+        signal, investigation_ready, warnings = derive_fix_ready("bug", "## What\nprose only")
         assert signal is False
+        assert investigation_ready is False
         assert warnings and "not fix-ready" in warnings[0]
 
     def test_required_tokens_documented(self) -> None:
         # Guard against drift between docstring and implementation.
         assert "observed symptom" in REQUIRED_DIAGNOSIS_TOKENS
         assert "fix-success criterion" in REQUIRED_DIAGNOSIS_TOKENS
+
+
+# Diagnosis body that's complete except confirmed-cause is a non-assertion phrase.
+# This is the v0.10 admissible "investigation-ready" intake state — the operator
+# documented every other slot honestly, including that the cause is not yet known.
+def _investigation_ready_body(cause_value: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        ## Diagnosis
+
+        - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
+        - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
+        - **Ruled out.** Workspace creation actually succeeds (verified in logs).
+        - **Confirmed cause.** {cause_value}
+        - **Affected code path.** sprint.runner._is_already_merged.
+        - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.
+        """
+    )
+
+
+class TestCauseAssertionState:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "unknown",
+            "Unknown",
+            "not yet identified",
+            "not yet known",
+            "not yet determined",
+            "pending investigation",
+            "still pending investigation",
+            "under investigation",
+            "TBD",
+            "tbd",
+            "to be determined",
+            "to be investigated",
+            "undetermined",
+            "unconfirmed",
+            "unidentified",
+            "investigation ongoing",
+            "investigation in progress",
+            "?",
+            "???",
+            "cause is unknown",
+            "cause remains unknown",
+        ],
+    )
+    def test_non_assertion_values_recognized(self, value: str) -> None:
+        body = _investigation_ready_body(value)
+        assert cause_assertion_state(body) == "non_asserted"
+
+    def test_specific_cause_is_asserted(self) -> None:
+        assert cause_assertion_state(DIAGNOSIS_BODY) == "asserted"
+
+    def test_no_diagnosis_section_is_missing(self) -> None:
+        assert cause_assertion_state("## What\nprose only") == "missing"
+
+    def test_section_without_cause_field_is_missing(self) -> None:
+        body = "## Diagnosis\n- Observed symptom: x.\n- Evidence: y.\n"
+        assert cause_assertion_state(body) == "missing"
+
+    def test_non_assertion_prefix_with_trailing_prose(self) -> None:
+        # Operators may add tailing context after the non-assertion phrase.
+        body = _investigation_ready_body("unknown — first cycle's job is to find it")
+        assert cause_assertion_state(body) == "non_asserted"
+
+
+class TestInvestigationReadyDerivation:
+    def test_non_assertion_cause_passes_gate_as_investigation_ready(self) -> None:
+        body = _investigation_ready_body("not yet identified")
+        signal, investigation_ready, warnings = derive_fix_ready("bug", body)
+        assert signal is True
+        assert investigation_ready is True
+        assert warnings and "investigation-ready" in warnings[0]
+
+    def test_specific_cause_remains_implementation_ready(self) -> None:
+        signal, investigation_ready, warnings = derive_fix_ready("bug", DIAGNOSIS_BODY)
+        assert signal is True
+        assert investigation_ready is False
+        assert warnings == []
+
+    def test_check_pipeline_admits_investigation_ready_bug(self) -> None:
+        # The discipline's spirit — refuse symptom-only bugs — must hold while
+        # the new admissibility — accept honest non-assertion — also holds.
+        body = _investigation_ready_body("unknown")
+        result = check("Bug: foo", body, ["bug"])
+        assert result.shape is Shape.RUNNABLE
+        assert result.reasons == ()
+
+    def test_shape_gate_admits_investigation_ready_bug(self, tmp_path: Path) -> None:
+        body = _investigation_ready_body("pending investigation")
+        issues = [{"number": 101, "title": "Investigation-ready bug"}]
+
+        def fetch(_number, _root):
+            return {
+                "title": "Investigation-ready bug",
+                "body": body,
+                "labels": ["bug"],
+            }
+
+        result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
+        assert result.runnable == issues
+        assert result.skipped == []
+
+    def test_github_source_propagates_investigation_ready(self, tmp_path: Path) -> None:
+        body = _investigation_ready_body("unknown")
+        issue_data = json.dumps(
+            {
+                "title": "Investigation-ready bug",
+                "body": body,
+                "state": "OPEN",
+                "labels": [{"name": "bug"}],
+            }
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=issue_data, stderr=""),
+                MagicMock(returncode=0, stdout="[]", stderr=""),
+            ]
+            task = GitHubIssueSource().fetch("123", tmp_path)
+        assert task.fix_ready is True
+        assert task.investigation_ready is True
+        assert task.readiness_warnings and any(
+            "investigation-ready" in w for w in task.readiness_warnings
+        )
+
+    def test_file_source_propagates_investigation_ready(self, tmp_path: Path) -> None:
+        body = _investigation_ready_body("not yet identified")
+        story = tmp_path / "bug.md"
+        story.write_text(
+            "---\nname: B\nslug: b\ntype: bug\n---\n" + body,
+            encoding="utf-8",
+        )
+        task = _build_task_from_story(story)
+        assert task.fix_ready is True
+        assert task.investigation_ready is True
+
+    def test_implementation_ready_bug_does_not_set_investigation_ready(
+        self, tmp_path: Path
+    ) -> None:
+        # Symmetric fix: a bug asserting a specific cause must continue to pass
+        # the gate and route to implementation, with investigation_ready=False.
+        story = tmp_path / "bug.md"
+        story.write_text(
+            "---\nname: B\nslug: b\ntype: bug\n---\n" + DIAGNOSIS_BODY,
+            encoding="utf-8",
+        )
+        task = _build_task_from_story(story)
+        assert task.fix_ready is True
+        assert task.investigation_ready is False
 
 
 class TestGitHubFixReadyPropagation:


### PR DESCRIPTION
## Summary

The prior P1 is resolved: investigation_ready is now propagated from sources and consumed by the dev prompt routing path; no blocking regressions found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $3.82
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Shape gate forces operators to assert a 'confirmed cause' before one is known, manufacturing the false-confidence loop the rule was designed to prevent (GitHub Issue #1451)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1451