### PR TITLE
ALREADY_DONE preflight verifies the diagnosis sentence, not the symptom — bugs close while the underlying defect persists

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -562,6 +562,60 @@ def _parse_preflight_criteria_checked(output: str) -> list[dict]:
         return []
 
 
+_VALID_SYMPTOM_VERIFICATION_STATUSES = frozenset(
+    {"verified_resolved", "not_reproduced", "not_feasible", "not_attempted"}
+)
+
+
+def _parse_preflight_symptom_verification(output: str) -> dict:
+    """Extract symptom_verification from preflight agent output.
+
+    Returns a normalized dict with keys:
+      - status: one of the valid status enum values, or "" when absent/invalid
+      - evidence: stripped string, "" when absent
+      - reproduces_now: bool | None — explicit signal that the symptom was
+        exercised against the current baseline (False = not reproduced =
+        symptom resolved); None when not asserted
+
+    Returns {} when the field is absent so the caller can distinguish "agent
+    did not address symptom" from "agent addressed and gave a status".
+    """
+    yaml_text = output
+    if "```yaml" in output:
+        start = output.index("```yaml") + len("```yaml")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+    elif "```" in output:
+        start = output.index("```") + len("```")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+
+    try:
+        parsed = yaml.safe_load(yaml_text)
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    raw = parsed.get("symptom_verification")
+    if not isinstance(raw, dict):
+        return {}
+
+    status = str(raw.get("status", "")).strip().lower()
+    if status not in _VALID_SYMPTOM_VERIFICATION_STATUSES:
+        status = ""
+    evidence = str(raw.get("evidence") or "").strip()
+    reproduces_raw = raw.get("reproduces_now")
+    if isinstance(reproduces_raw, bool):
+        reproduces_now: bool | None = reproduces_raw
+    else:
+        reproduces_now = None
+    return {
+        "status": status,
+        "evidence": evidence,
+        "reproduces_now": reproduces_now,
+    }
+
+
 def _find_registry_info_for_profile(
     profile: ModelProfile,
     *,

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -45,6 +45,7 @@ from .preflight import (
     _parse_preflight_criteria_checked,
     _parse_preflight_likely_files,
     _parse_preflight_sufficiency,
+    _parse_preflight_symptom_verification,
     _parse_preflight_verdict,
     _parse_preflight_warnings,
     _parse_preflight_work_type,
@@ -429,6 +430,8 @@ def _run_preflight_phase(
         # The sprint scheduler writes this field after compute_bundle_assignments.
         criteria_checked = _parse_preflight_criteria_checked(preflight_result.output)
         state.preflight_criteria_checked = criteria_checked
+        symptom_verification = _parse_preflight_symptom_verification(preflight_result.output)
+        state.preflight_symptom_verification = symptom_verification
 
         # ── Deterministic contract-change policy ───────────────────────
         # A contract change touches a shared interface field, prompt template
@@ -573,6 +576,48 @@ def _run_preflight_phase(
                             f"AC '{criterion}' evidence too thin for ALREADY_DONE "
                             f"(len={len(evidence)})"
                         )
+            # ── Symptom-verification gate for bug stories ─────────────────
+            # AC-evidence checks above prove that named acceptance criteria
+            # are observable in the live code. For bug stories the verdict
+            # ALREADY_DONE additionally requires that the originally observed
+            # symptom no longer reproduces — refuting a hypothesized cause in
+            # the body's Diagnosis section is not equivalent to confirming the
+            # defect is fixed. Require an explicit symptom_verification block
+            # asserting status=verified_resolved with non-thin evidence;
+            # otherwise demote to PROCEED so the dev cycle exercises the
+            # symptom against the current baseline.
+            if work_type == "bug":
+                sv_status = str(symptom_verification.get("status") or "").strip()
+                sv_evidence = str(symptom_verification.get("evidence") or "").strip()
+                reproduces_now = symptom_verification.get("reproduces_now")
+                if not symptom_verification or not sv_status:
+                    downgrade_reasons.append(
+                        "symptom_verification absent — bug ALREADY_DONE requires "
+                        "evidence the originally observed symptom does not "
+                        "reproduce against the current baseline; refuting a "
+                        "diagnosis hypothesis is not symptom verification"
+                    )
+                elif sv_status != "verified_resolved":
+                    downgrade_reasons.append(
+                        f"symptom_verification.status={sv_status!r} — only "
+                        "'verified_resolved' justifies bug ALREADY_DONE; "
+                        "demoting to PROCEED so the dev cycle reproduces and "
+                        "verifies symptom resolution"
+                    )
+                elif reproduces_now is True:
+                    downgrade_reasons.append(
+                        "symptom_verification.reproduces_now=true — symptom "
+                        "still reproduces against the current baseline; "
+                        "ALREADY_DONE is not justified"
+                    )
+                elif not sv_evidence or _evidence_is_too_thin(sv_evidence):
+                    downgrade_reasons.append(
+                        "symptom_verification.evidence missing or too thin "
+                        f"(len={len(sv_evidence)}) — bug ALREADY_DONE requires "
+                        "concrete evidence the symptom was exercised and did "
+                        "not reproduce"
+                    )
+
             if downgrade_reasons:
                 verdict = "PROCEED"
                 state.preflight_verdict = verdict
@@ -670,6 +715,7 @@ def _run_preflight_phase(
             workspace_path=workspace_path,
         ),
         "criteria_checked": state.preflight_criteria_checked,
+        "symptom_verification": dict(state.preflight_symptom_verification or {}),
         "degraded": state.preflight_degraded,
         "degraded_reason": state.preflight_degraded_reason,
         "risk_signals": list(state.preflight_risk_signals),

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -317,6 +317,13 @@ class CoordinatorState:
     preflight_degraded: bool = False
     preflight_degraded_reason: str | None = None
     preflight_criteria_checked: list[dict] = field(default_factory=list)
+    # Structured symptom-verification record for bug ALREADY_DONE verdicts.
+    # Keys: status ("verified_resolved" | "not_reproduced" | "not_feasible" |
+    # "not_attempted" | "" when absent), evidence (str), reproduces_now (bool|None).
+    # An empty dict means the preflight output did not contain the field — for
+    # bug-typed stories this is treated as missing symptom verification and
+    # downgrades ALREADY_DONE to PROCEED.
+    preflight_symptom_verification: dict = field(default_factory=dict)
     # Risk signals consulted when preflight agent failed and the coordinator
     # had to choose between conservative PROCEED and explicit escalation.
     # Empty list means no signals were detected (or preflight succeeded so

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -266,6 +266,13 @@ def build_preflight_prompt(
             evidence: >-
               <conclusion: how the cited runtime path turns the relevant
               input into the observable behavior/output, or what is missing>
+        symptom_verification:
+          status: verified_resolved | not_reproduced | not_feasible | not_attempted
+          reproduces_now: true | false
+          evidence: >-
+            <what concrete inspection or reproduction step was performed
+            against the current baseline to determine whether the
+            originally observed symptom still fires>
         ```
 
         Use `spec_issues: []` if the spec is clean.
@@ -285,6 +292,40 @@ def build_preflight_prompt(
         A valid ALREADY_DONE verdict also requires a non-empty `runtime_path` for every
         criterion. `runtime_path` must cite the live orchestrator/coordinator/sprint call
         path that actually exercises the behavior, not a related helper that merely exists.
+
+        ## Symptom Verification (bug stories)
+
+        For **bug** stories, ALREADY_DONE means "the originally observed symptom no
+        longer reproduces against the current baseline." Refuting a hypothesized
+        cause in the body's Diagnosis section is NOT equivalent to confirming the
+        defect is fixed — issue bodies routinely state a wrong theory of the
+        defect alongside a real symptom, and a wrong theory does not entail a
+        fixed symptom.
+
+        Whenever you classify a bug story, emit a `symptom_verification` block:
+
+        - `status: verified_resolved` — you reproduced or otherwise exercised the
+          originally reported symptom against the configured baseline branch and
+          confirmed the symptom no longer fires. Set `reproduces_now: false` and
+          provide concrete `evidence` (what you ran, inspected, or executed).
+        - `status: not_reproduced` — you attempted to verify but the originally
+          reported behavior could not be exercised from preflight context (no
+          test scenario, no reproduction harness, behavior depends on external
+          state). Set `reproduces_now: false` only if you have reason to believe
+          it does not — otherwise omit or set null.
+        - `status: not_feasible` — symptom reproduction is not feasible from
+          preflight (e.g., requires a live external service, multi-sprint state,
+          quota-exhausted CLI). Use this when the symptom is real but a
+          preflight-time verifier cannot exercise it.
+        - `status: not_attempted` — you did not attempt symptom verification.
+
+        Only `status: verified_resolved` with `reproduces_now: false` and concrete
+        `evidence` justifies a bug ALREADY_DONE verdict. The other statuses
+        will be downgraded by the coordinator to PROCEED so the dev cycle can
+        verify symptom resolution.
+
+        For non-bug stories, set `status: not_attempted` (or omit the block);
+        AC-evidence checks via `criteria_checked` are sufficient.
 
         ## Rules
 

--- a/tests/test_coord_preflight_symptom_verification.py
+++ b/tests/test_coord_preflight_symptom_verification.py
@@ -1,0 +1,546 @@
+"""Tests for the bug ALREADY_DONE symptom-verification gate.
+
+Refuting a hypothesized cause stated in an issue body — even when the
+refutation is correct — must not by itself satisfy ``ALREADY_DONE`` for a
+bug-typed story. The verdict requires an explicit ``symptom_verification``
+block attesting that the originally observed symptom no longer reproduces
+against the current baseline. Anything else (status missing, status not
+``verified_resolved``, evidence absent or thin, ``reproduces_now: true``)
+must demote the verdict to ``PROCEED`` so the dev cycle exercises the
+symptom against the current codebase.
+
+Non-bug work types are unaffected; AC-evidence checks via
+``criteria_checked`` are sufficient there.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import yaml as _yaml
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.preflight import _parse_preflight_symptom_verification
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+# Bug ALREADY_DONE with full AC evidence AND verified_resolved symptom — honored.
+PREFLIGHT_BUG_VERIFIED_RESOLVED = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Diagnosis was wrong; symptom verified resolved."
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+criteria_checked:
+  - criterion: "Codex CLI quota errors trigger provider_fallback"
+    satisfied: true
+    files_checked:
+      - "src/theforge/config/load.py"
+    runtime_path: "load_config -> _apply_provider_fallback at config/load.py:638"
+    evidence: >-
+      The configured provider_fallbacks.openai mapping is applied to every
+      review-pool reviewer profile by load.py at the cited line, exercised
+      by the live config loader path.
+symptom_verification:
+  status: verified_resolved
+  reproduces_now: false
+  evidence: >-
+    Reproduced the quota path in a fixture: a Codex CLI reviewer hitting
+    a _CLI_QUOTA_FALLBACK_PATTERNS error now switches to the API fallback
+    profile rather than entering Pending Escalate Gate.
+```
+"""
+
+# Bug ALREADY_DONE with AC evidence but no symptom_verification block — must downgrade.
+# This is the exact failure shape the spec calls out: diagnosis section is
+# refuted (criteria_checked says satisfied=true) but the symptom was never
+# reproduced before closing the issue.
+PREFLIGHT_BUG_NO_SYMPTOM_VERIFICATION = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Diagnosis section claim was refuted by code inspection."
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+criteria_checked:
+  - criterion: "Codex CLI quota errors trigger provider_fallback"
+    satisfied: true
+    files_checked:
+      - "src/theforge/config/load.py"
+    runtime_path: "load_config -> _apply_provider_fallback at config/load.py:638"
+    evidence: >-
+      The diagnosis section claimed no _apply_provider_fallback calls in any
+      module that builds reviewer profiles. That claim is refuted by the
+      call at config/load.py:638.
+```
+"""
+
+# Bug ALREADY_DONE with status=not_attempted — must downgrade.
+PREFLIGHT_BUG_NOT_ATTEMPTED = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Diagnosis section claim was refuted; symptom not exercised."
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+criteria_checked:
+  - criterion: "Codex CLI quota errors trigger provider_fallback"
+    satisfied: true
+    files_checked:
+      - "src/theforge/config/load.py"
+    runtime_path: "load_config -> _apply_provider_fallback at config/load.py:638"
+    evidence: >-
+      Refuted the diagnosis sentence by locating the call at the cited
+      runtime path; the static evidence is concrete and present.
+symptom_verification:
+  status: not_attempted
+  evidence: ""
+```
+"""
+
+# Bug ALREADY_DONE with status=not_feasible — must downgrade.
+PREFLIGHT_BUG_NOT_FEASIBLE = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Cannot reproduce the symptom from preflight context."
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+criteria_checked:
+  - criterion: "Codex CLI quota errors trigger provider_fallback"
+    satisfied: true
+    files_checked:
+      - "src/theforge/config/load.py"
+    runtime_path: "load_config -> _apply_provider_fallback at config/load.py:638"
+    evidence: >-
+      Static call site at config/load.py:638 wires the fallback into every
+      review-pool profile through the live config loader path.
+symptom_verification:
+  status: not_feasible
+  evidence: >-
+    Reproducing the original quota failure requires a live Codex CLI
+    session that exhausts quota; not reachable from preflight.
+```
+"""
+
+# Bug ALREADY_DONE with reproduces_now=true — must downgrade even with status=verified_resolved
+# (defensive: contradictory status+reproduces_now combination must not pass).
+PREFLIGHT_BUG_STILL_REPRODUCES = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Symptom still fires."
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+criteria_checked:
+  - criterion: "Codex CLI quota errors trigger provider_fallback"
+    satisfied: true
+    files_checked:
+      - "src/theforge/config/load.py"
+    runtime_path: "load_config -> _apply_provider_fallback at config/load.py:638"
+    evidence: >-
+      Static call site at config/load.py:638 wires the fallback into every
+      review-pool profile through the live config loader path.
+symptom_verification:
+  status: verified_resolved
+  reproduces_now: true
+  evidence: >-
+    Exercising the quota path still routes to Pending Escalate Gate, the
+    fallback does not fire as expected.
+```
+"""
+
+# Bug ALREADY_DONE with thin evidence — must downgrade.
+PREFLIGHT_BUG_THIN_EVIDENCE = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Symptom resolved."
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+criteria_checked:
+  - criterion: "Codex CLI quota errors trigger provider_fallback"
+    satisfied: true
+    files_checked:
+      - "src/theforge/config/load.py"
+    runtime_path: "load_config -> _apply_provider_fallback at config/load.py:638"
+    evidence: >-
+      Static call site at config/load.py:638 wires the fallback into every
+      review-pool profile through the live config loader path.
+symptom_verification:
+  status: verified_resolved
+  reproduces_now: false
+  evidence: "fine"
+```
+"""
+
+# Feature ALREADY_DONE with AC evidence and no symptom_verification — honored
+# (the symptom-verification gate applies only to bug stories).
+PREFLIGHT_FEATURE_NO_SYMPTOM_FIELD = """\
+```yaml
+verdict: ALREADY_DONE
+reason: "Feature is observable in live code."
+complexity: small
+sufficiency: implementation_ready
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X is implemented"
+    satisfied: true
+    files_checked:
+      - "src/theforge/coordinator/engine.py"
+    runtime_path: "run_task -> _run_preflight_phase -> live engine path"
+    evidence: >-
+      The configured engine path executes the new behavior end-to-end as
+      the acceptance criterion describes.
+```
+"""
+
+
+def _make_bug_task(tmp_path):
+    """Create a bug-typed task whose body has Diagnosis + Observed sections."""
+    spec = tmp_path / "spec.md"
+    spec.write_text(
+        "# Bug: provider_fallback not applied to review pool\n\n"
+        "## Observed\n\n"
+        "Codex CLI reviewer hit quota and the API fallback did not fire.\n\n"
+        "## Diagnosis\n\n"
+        "_apply_provider_fallback is missing from review pool config.\n",
+        encoding="utf-8",
+    )
+    from theforge.task import TaskStory
+
+    return TaskStory(
+        name="Bug Task",
+        story_path=spec,
+        slug="test-bug-task",
+        type="bug",
+    )
+
+
+# ── Parser tests ─────────────────────────────────────────────────────────
+
+
+class TestParseSymptomVerification:
+    def test_parses_verified_resolved(self) -> None:
+        parsed = _parse_preflight_symptom_verification(PREFLIGHT_BUG_VERIFIED_RESOLVED)
+        assert parsed["status"] == "verified_resolved"
+        assert parsed["reproduces_now"] is False
+        assert "Reproduced" in parsed["evidence"]
+
+    def test_returns_empty_dict_when_field_absent(self) -> None:
+        parsed = _parse_preflight_symptom_verification(PREFLIGHT_BUG_NO_SYMPTOM_VERIFICATION)
+        assert parsed == {}
+
+    def test_normalizes_unknown_status_to_empty(self) -> None:
+        output = """```yaml
+verdict: ALREADY_DONE
+work_type: bug
+symptom_verification:
+  status: maybe_done
+  evidence: "n/a"
+```"""
+        parsed = _parse_preflight_symptom_verification(output)
+        assert parsed["status"] == ""
+
+    def test_handles_non_bool_reproduces_now(self) -> None:
+        output = """```yaml
+verdict: ALREADY_DONE
+work_type: bug
+symptom_verification:
+  status: verified_resolved
+  reproduces_now: maybe
+  evidence: "ok"
+```"""
+        parsed = _parse_preflight_symptom_verification(output)
+        assert parsed["status"] == "verified_resolved"
+        assert parsed["reproduces_now"] is None
+
+
+# ── Integration tests through run_task ───────────────────────────────────
+
+
+class TestBugAlreadyDoneSymptomGate:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow.has_review_approve", return_value=True)
+    def test_verified_resolved_keeps_already_done(
+        self,
+        mock_approve,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_bug_task(tmp_path)
+        workspace = tmp_path / "test-bug-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BUG_VERIFIED_RESOLVED, cost_usd=0.05
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.preflight_verdict == "ALREADY_DONE"
+        sv = result.state.preflight_symptom_verification
+        assert sv["status"] == "verified_resolved"
+        assert sv["reproduces_now"] is False
+        mock_dev.assert_not_called()
+        mock_pool.assert_not_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_missing_symptom_verification_downgrades_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """The headline regression: bug ALREADY_DONE with refuted diagnosis but
+        no symptom verification must not close the issue."""
+        config = _make_config(tmp_path)
+        task = _make_bug_task(tmp_path)
+        workspace = tmp_path / "test-bug-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BUG_NO_SYMPTOM_VERIFICATION, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        warnings = result.state.preflight_warnings or []
+        assert any("symptom_verification absent" in w for w in warnings), warnings
+        mock_dev.assert_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_not_attempted_status_downgrades_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_bug_task(tmp_path)
+        workspace = tmp_path / "test-bug-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BUG_NOT_ATTEMPTED, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        warnings = result.state.preflight_warnings or []
+        assert any("'not_attempted'" in w for w in warnings), warnings
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_not_feasible_status_downgrades_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_bug_task(tmp_path)
+        workspace = tmp_path / "test-bug-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BUG_NOT_FEASIBLE, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        warnings = result.state.preflight_warnings or []
+        assert any("'not_feasible'" in w for w in warnings), warnings
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_reproduces_now_true_downgrades_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_bug_task(tmp_path)
+        workspace = tmp_path / "test-bug-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BUG_STILL_REPRODUCES, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        warnings = result.state.preflight_warnings or []
+        assert any("reproduces_now=true" in w for w in warnings), warnings
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_thin_symptom_evidence_downgrades_to_proceed(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_bug_task(tmp_path)
+        workspace = tmp_path / "test-bug-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BUG_THIN_EVIDENCE, cost_usd=0.05
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.state.preflight_verdict == "PROCEED"
+        warnings = result.state.preflight_warnings or []
+        assert any("evidence missing or too thin" in w for w in warnings), warnings
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow.has_review_approve", return_value=True)
+    def test_feature_already_done_unaffected_by_gate(
+        self,
+        mock_approve,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        """Feature stories without symptom_verification still honor ALREADY_DONE
+        when AC evidence is present — the new gate is bug-specific."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)  # default feature-typed task
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_FEATURE_NO_SYMPTOM_FIELD, cost_usd=0.05
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.preflight_verdict == "ALREADY_DONE"
+        mock_dev.assert_not_called()
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    @patch("theforge.coordinator.preflight_flow.has_review_approve", return_value=True)
+    def test_symptom_verification_persists_in_artifact(
+        self,
+        mock_approve,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        tmp_path,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_bug_task(tmp_path)
+        workspace = tmp_path / "test-bug-task"
+        workspace.mkdir()
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_BUG_VERIFIED_RESOLVED, cost_usd=0.05
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        log_dir = result.state.log_dir
+        assert log_dir is not None
+        artifact = _yaml.safe_load((log_dir / "preflight.yaml").read_text(encoding="utf-8"))
+        sv = artifact.get("symptom_verification")
+        assert isinstance(sv, dict)
+        assert sv["status"] == "verified_resolved"
+        assert sv["reproduces_now"] is False


### PR DESCRIPTION
## Summary

The preflight ALREADY_DONE path now separates static diagnosis checks from bug symptom verification and demotes unverified bug closures to PROCEED.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $3.02
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

ALREADY_DONE preflight verifies the diagnosis sentence, not the symptom — bugs close while the underlying defect persists (GitHub Issue #1446)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1446