### PR TITLE
VALIDATE phase classifies 'dev cycle determined no work needed' as missing-work failure when handoff explicitly reports work already complete

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -459,6 +459,12 @@ def _coordinator_loop(
             )
             if _val_outcome == _ValidateOutcome.ESCALATE:
                 return _val_result  # type: ignore[return-value]
+            if _val_outcome == _ValidateOutcome.ALREADY_COMPLETE:
+                # Dev cycle determined no work was needed and the handoff
+                # documents this with verifiable cited commits. Short-circuit
+                # to DONE (skip REVIEW and merge) — the cited commits are
+                # already on the base branch.
+                return _val_result  # type: ignore[return-value]
             if _val_outcome == _ValidateOutcome.REVIEW_CONVENTION_BLOCK:
                 state.review_cycle += 1
                 state.review_results.append(_build_convention_blocking_review(state))

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -442,6 +442,13 @@ class CoordinatorState:
     # Per-phase hygiene gate audit entries. Each dict carries a "phase" key
     # ("PRE_DEV" / "PLAN" / "PLAN_REVIEW" / "REVIEW") plus phase-specific fields
     # (snapshot, modified, quarantined, quarantine_dir, offending_paths).
+    # Set by VALIDATE when the dev cycle determined no commits were needed and the
+    # handoff YAML documents this with all acceptance criteria MET and at least one
+    # cited commit present in base-branch history. Distinguishes the deliberate
+    # "work already complete" outcome from genuine missing-work failures.
+    validate_already_complete: bool = False
+    validate_already_complete_commits: list[dict] = field(default_factory=list)
+    validate_already_complete_reason: str | None = None
 
     def __post_init__(self, dev_iteration: int) -> None:
         # Sync the budget's per-cycle counter with the constructor kwarg.

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -22,7 +22,12 @@ from .dev_phase import _extract_failed_tests, record_dev_iteration_telemetry
 from .gate import _is_gate_skip, _parse_dirty_files, _run_gate_debug_command, _run_gate_full
 from .logging import StructuredLogger
 from .notify import _escalate_notify
-from .review_context import _get_handoff_content, _get_raw_dev_notes, _latest_forge_handoff_path
+from .review_context import (
+    _get_handoff_content,
+    _get_raw_dev_notes,
+    _latest_forge_handoff_path,
+    _parse_dev_handoff,
+)
 from .state import CoordinatorResult, CoordinatorState, DevIterationTelemetry, Phase, RetryReason
 from .util import _log, _log_phase, _log_verbose
 from .workspace import _deindex_forge_artifacts
@@ -33,6 +38,72 @@ class _ValidateOutcome(Enum):
     RETRY_DEV = auto()
     REVIEW_CONVENTION_BLOCK = auto()
     ESCALATE = auto()
+    ALREADY_COMPLETE = auto()
+
+
+def _verified_handoff_commit_shas(workspace_path: Path, shas: list[str]) -> list[str]:
+    """Return the subset of ``shas`` that exist in this worktree's git history.
+
+    A commit SHA is "verified" when ``git cat-file -e <sha>`` resolves it in the
+    worktree. Without this check, a handoff could cite an arbitrary string and
+    the empty-worktree-as-success path would accept it.
+    """
+    verified: list[str] = []
+    for sha in shas:
+        sha = sha.strip()
+        if not sha:
+            continue
+        try:
+            proc = subprocess.run(
+                ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+                cwd=str(workspace_path),
+                capture_output=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception:  # noqa: BLE001
+            continue
+        if proc.returncode == 0:
+            verified.append(sha)
+    return verified
+
+
+def _handoff_documents_already_complete(
+    workspace_path: Path,
+    forge_handoff_path: Path | None,
+) -> tuple[bool, list[dict], str | None]:
+    """Decide whether the dev handoff explicitly documents 'work already complete'.
+
+    Returns ``(is_already_complete, verified_commits, reason)``. The first
+    element is True only when:
+    - the handoff parsed cleanly (no schema or parse errors),
+    - it lists at least one acceptance criterion,
+    - every acceptance criterion has status normalized to ``MET``,
+    - at least one commit SHA cited in the handoff resolves in the worktree's
+      git history (citation verification — protects against fabricated SHAs).
+    """
+    handoff = _parse_dev_handoff(forge_handoff_path=forge_handoff_path)
+    if handoff is None:
+        return False, [], "no handoff artifact"
+    if handoff.parse_errors:
+        return False, [], f"handoff parse errors: {handoff.parse_errors[0]}"
+    if not handoff.acceptance_criteria:
+        return False, [], "handoff has no acceptance_criteria"
+    for ac in handoff.acceptance_criteria:
+        status = (ac.get("status") or "").strip().upper()
+        if status != "MET":
+            return False, [], f"acceptance criterion status is {status!r}, not MET"
+    cited_shas = [c.get("sha", "") for c in handoff.commits]
+    verified = _verified_handoff_commit_shas(workspace_path, cited_shas)
+    if not verified:
+        return False, [], "handoff cites no commit SHA verifiable on this branch"
+    verified_set = set(verified)
+    verified_commits = [
+        {"sha": c.get("sha", "").strip(), "message": c.get("message", "")}
+        for c in handoff.commits
+        if c.get("sha", "").strip() in verified_set
+    ]
+    return True, verified_commits, None
 
 
 def _is_identical_failure(telemetry: list[DevIterationTelemetry]) -> bool:
@@ -462,13 +533,50 @@ def _run_validate_phase(
                     )
 
         # ── Zero-commits guard ──────────────────────────────────────
-        # A trivially passing gate over an empty worktree is not a real PASS;
-        # treat it as a missing-work failure rather than letting it advance to
-        # REVIEW where the empty diff would silently approve.
+        # A trivially passing gate over an empty worktree is *usually* not a real
+        # PASS; the default routing treats it as a missing-work failure rather
+        # than letting it advance to REVIEW where the empty diff would silently
+        # approve. The exception is the deliberate "work already complete"
+        # outcome: when the dev cycle inspected the issue and produced a handoff
+        # YAML where every acceptance criterion is MET and at least one cited
+        # commit SHA resolves in the worktree's git history, the empty diff is
+        # the dev cycle's documented contract output and must be classified as a
+        # successful ALREADY_DONE-shaped result, not a failure.
         if not _has_commits_ahead_of_base(workspace_path, config.workspace.base_branch):
+            handoff_path = _latest_forge_handoff_path(state)
+            already_complete, verified_commits, reject_reason = (
+                _handoff_documents_already_complete(workspace_path, handoff_path)
+            )
+            if already_complete:
+                state.validate_already_complete = True
+                state.validate_already_complete_commits = verified_commits
+                state.validate_already_complete_reason = (
+                    "Dev cycle determined no work needed; handoff cites commit"
+                    f"(s) {', '.join(c['sha'][:7] for c in verified_commits)}"
+                    " already on this branch satisfying all acceptance criteria."
+                )
+                state.phase = Phase.DONE
+                _log(f"  ✓ ALREADY_COMPLETE   {state.validate_already_complete_reason}")
+                if logger:
+                    logger._safe_emit(
+                        "phase_end",
+                        phase="VALIDATE",
+                        outcome="already_complete",
+                        commits=[c["sha"] for c in verified_commits],
+                    )
+                return _ValidateOutcome.ALREADY_COMPLETE, CoordinatorResult(
+                    success=True,
+                    phase=state.phase,
+                    state=state,
+                    message=state.validate_already_complete_reason,
+                )
             state.phase = Phase.ESCALATE
             state.error = (
                 "Gate exited PASS but branch has no commits ahead of base — "
+                "treating empty worktree as missing-work failure"
+                f" ({reject_reason})"
+                if reject_reason
+                else "Gate exited PASS but branch has no commits ahead of base — "
                 "treating empty worktree as missing-work failure"
             )
             _log(f"✗ ESCALATE   {state.error}")

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -41,29 +41,41 @@ class _ValidateOutcome(Enum):
     ALREADY_COMPLETE = auto()
 
 
-def _verified_handoff_commit_shas(workspace_path: Path, shas: list[str]) -> list[str]:
-    """Return the subset of ``shas`` that exist in this worktree's git history.
+def _verified_handoff_commit_shas(
+    workspace_path: Path, shas: list[str], base_branch: str
+) -> list[str]:
+    """Return the subset of ``shas`` reachable from HEAD or the base branch.
 
-    A commit SHA is "verified" when ``git cat-file -e <sha>`` resolves it in the
-    worktree. Without this check, a handoff could cite an arbitrary string and
-    the empty-worktree-as-success path would accept it.
+    A commit SHA is "verified" only when ``git merge-base --is-ancestor`` shows
+    it is reachable from this worktree's HEAD or from the configured base
+    branch (preferring ``origin/<base>``, falling back to the local ref). This
+    is a stronger check than object existence: a handoff that cites a SHA from
+    another local branch or a fetched-but-unreachable ref must not unlock the
+    ALREADY_COMPLETE success path, because the cited work is not actually on
+    the target branch.
     """
+    refs_to_check = ["HEAD", f"origin/{base_branch}", base_branch]
     verified: list[str] = []
     for sha in shas:
         sha = sha.strip()
         if not sha:
             continue
-        try:
-            proc = subprocess.run(
-                ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
-                cwd=str(workspace_path),
-                capture_output=True,
-                timeout=10,
-                check=False,
-            )
-        except Exception:  # noqa: BLE001
-            continue
-        if proc.returncode == 0:
+        reachable = False
+        for ref in refs_to_check:
+            try:
+                proc = subprocess.run(
+                    ["git", "merge-base", "--is-ancestor", sha, ref],
+                    cwd=str(workspace_path),
+                    capture_output=True,
+                    timeout=10,
+                    check=False,
+                )
+            except Exception:  # noqa: BLE001
+                continue
+            if proc.returncode == 0:
+                reachable = True
+                break
+        if reachable:
             verified.append(sha)
     return verified
 
@@ -71,6 +83,7 @@ def _verified_handoff_commit_shas(workspace_path: Path, shas: list[str]) -> list
 def _handoff_documents_already_complete(
     workspace_path: Path,
     forge_handoff_path: Path | None,
+    base_branch: str,
 ) -> tuple[bool, list[dict], str | None]:
     """Decide whether the dev handoff explicitly documents 'work already complete'.
 
@@ -79,8 +92,10 @@ def _handoff_documents_already_complete(
     - the handoff parsed cleanly (no schema or parse errors),
     - it lists at least one acceptance criterion,
     - every acceptance criterion has status normalized to ``MET``,
-    - at least one commit SHA cited in the handoff resolves in the worktree's
-      git history (citation verification — protects against fabricated SHAs).
+    - at least one commit SHA cited in the handoff is reachable from HEAD or
+      the base branch (citation verification — protects against fabricated
+      SHAs and against SHAs on unrelated branches that are not actually part
+      of this branch's history).
     """
     handoff = _parse_dev_handoff(forge_handoff_path=forge_handoff_path)
     if handoff is None:
@@ -94,9 +109,9 @@ def _handoff_documents_already_complete(
         if status != "MET":
             return False, [], f"acceptance criterion status is {status!r}, not MET"
     cited_shas = [c.get("sha", "") for c in handoff.commits]
-    verified = _verified_handoff_commit_shas(workspace_path, cited_shas)
+    verified = _verified_handoff_commit_shas(workspace_path, cited_shas, base_branch)
     if not verified:
-        return False, [], "handoff cites no commit SHA verifiable on this branch"
+        return False, [], "handoff cites no commit SHA reachable from HEAD or base branch"
     verified_set = set(verified)
     verified_commits = [
         {"sha": c.get("sha", "").strip(), "message": c.get("message", "")}
@@ -545,7 +560,9 @@ def _run_validate_phase(
         if not _has_commits_ahead_of_base(workspace_path, config.workspace.base_branch):
             handoff_path = _latest_forge_handoff_path(state)
             already_complete, verified_commits, reject_reason = (
-                _handoff_documents_already_complete(workspace_path, handoff_path)
+                _handoff_documents_already_complete(
+                    workspace_path, handoff_path, config.workspace.base_branch
+                )
             )
             if already_complete:
                 state.validate_already_complete = True

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1189,8 +1189,16 @@ def _classify_and_record(
     """
     preflight_verdict = result.state.preflight_verdict
     landing_status = getattr(result, "landing_status", None)
+    validate_already_complete = getattr(result.state, "validate_already_complete", False)
 
     if preflight_verdict == "ALREADY_DONE" and result.success:
+        outcome = StoryOutcome.ALREADY_DONE
+        merged_slugs.add(task.slug)
+        dag.mark_complete(task.slug)
+    elif validate_already_complete and result.success:
+        # VALIDATE determined the dev cycle correctly produced no commits
+        # because the work was already on the base branch. Treat this as a
+        # successful ALREADY_DONE-shaped outcome rather than FAILED.
         outcome = StoryOutcome.ALREADY_DONE
         merged_slugs.add(task.slug)
         dag.mark_complete(task.slug)

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -609,6 +609,35 @@ class TestClassifyAndRecord:
         assert "a" in merged_slugs
         assert {t.slug for t in dag.ready()} == {"b"}
 
+    def test_validate_already_complete_classifies_as_already_done(self) -> None:
+        """state.validate_already_complete=True with success → ALREADY_DONE outcome.
+
+        Regression test: when VALIDATE recognizes that the dev cycle correctly
+        determined no work was needed (handoff documents existing commits as
+        satisfying all ACs), sprint must classify the story as a successful
+        ALREADY_DONE rather than FAILED, even though preflight returned PROCEED.
+        """
+        from theforge.sprint.story_state import StoryOutcome
+
+        a = _make_task("a")
+        b = _make_task("b", depends_on=["a"])
+        dag = StoryDAG([a, b])
+        merged_slugs: set[str] = set()
+
+        result = _make_coordinator_result(
+            success=True, cost=0.5, preflight_verdict="PROCEED", phase=Phase.DONE
+        )
+        result.state.validate_already_complete = True
+        result.state.validate_already_complete_commits = [
+            {"sha": "a0a1319" + "0" * 33, "message": "fix: already-landed"}
+        ]
+        outcome = _classify_and_record(a, result, dag, merged_slugs)
+
+        assert outcome is StoryOutcome.ALREADY_DONE
+        assert outcome.is_succeeded
+        assert "a" in merged_slugs
+        assert {t.slug for t in dag.ready()} == {"b"}
+
     def test_failed_result_does_not_get_promoted_to_already_done(self) -> None:
         """An ALREADY_DONE preflight verdict must not mask a later failed result."""
         from theforge.sprint.story_state import StoryOutcome

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -412,6 +412,283 @@ def test_run_validate_phase_timeout_with_commits_but_budget_exhausted_escalates(
     assert outcome is _ValidateOutcome.ESCALATE
 
 
+def test_run_validate_phase_already_complete_when_handoff_documents_work_done(
+    tmp_path: Path,
+) -> None:
+    """Empty worktree + handoff with all ACs MET + cited commit on branch → ALREADY_COMPLETE.
+
+    Regression test for the failure mode where a dev cycle correctly determined
+    no work was needed (because the fix is already on the base branch) and
+    documented this in the handoff YAML, but VALIDATE classified the empty
+    worktree as a missing-work failure.
+    """
+    # Build a real git repo so _has_commits_ahead_of_base returns False
+    # (HEAD == base) and _verified_handoff_commit_shas can resolve a real SHA.
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _write(tmp_path / "README.md", "base\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "fix: already-landed work")
+    landed_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    # Write a handoff YAML at the path the coordinator records under
+    # state.dev_handoff_snapshots so _latest_forge_handoff_path resolves it.
+    handoff_dir = tmp_path / ".forge" / "handoffs" / "issue-1447"
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    handoff_path = handoff_dir / "iter_1.yaml"
+    handoff_path.write_text(
+        "summary: 'The fix for this issue was already implemented and committed'\n"
+        "commits:\n"
+        f"  - sha: '{landed_sha}'\n"
+        "    message: 'fix: already-landed work'\n"
+        "acceptance_criteria:\n"
+        "  - criterion: 'AC1 text from spec'\n"
+        "    status: MET\n"
+        "    notes: 'satisfied by existing commit'\n"
+        "  - criterion: 'AC2 text from spec'\n"
+        "    status: MET\n"
+        "    notes: 'satisfied by existing commit'\n"
+        "story_deviations: []\n"
+        "deferred_items: []\n",
+        encoding="utf-8",
+    )
+
+    config = _make_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        workspace=dataclasses.replace(config.workspace, base_branch="main"),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.0)
+    state.last_dev_start_commit = landed_sha
+    state.dev_handoff_snapshots.append(
+        {"source": "structured_output", "path": str(handoff_path), "handoff": {}}
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/"),
+        ),
+        patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
+        # _check_conventions_parallel runs in a thread; stub it out so the test
+        # doesn't depend on convention configuration.
+        patch(
+            "theforge.coordinator.validate_phase._check_conventions_parallel",
+            return_value=None,
+        ),
+        # Clean worktree → git status --porcelain returns empty.
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ALREADY_COMPLETE
+    assert result is not None
+    assert result.success is True
+    assert state.validate_already_complete is True
+    assert any(c["sha"] == landed_sha for c in state.validate_already_complete_commits)
+    assert state.validate_already_complete_reason is not None
+
+
+def test_run_validate_phase_empty_worktree_without_handoff_still_escalates(
+    tmp_path: Path,
+) -> None:
+    """Empty worktree with no handoff signal still routes to missing-work failure."""
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _write(tmp_path / "README.md", "base\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "base")
+
+    config = _make_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        workspace=dataclasses.replace(config.workspace, base_branch="main"),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.0)
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/"),
+        ),
+        patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
+        patch(
+            "theforge.coordinator.validate_phase._check_conventions_parallel",
+            return_value=None,
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert state.validate_already_complete is False
+    assert "missing-work failure" in (result.message or "")
+
+
+def test_run_validate_phase_empty_worktree_handoff_partial_ac_escalates(
+    tmp_path: Path,
+) -> None:
+    """Handoff with NOT_MET acceptance criterion does not unlock ALREADY_COMPLETE."""
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _write(tmp_path / "README.md", "base\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "base")
+    landed_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    handoff_dir = tmp_path / ".forge" / "handoffs" / "story"
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    handoff_path = handoff_dir / "iter_1.yaml"
+    handoff_path.write_text(
+        "summary: 'Partial'\n"
+        "commits:\n"
+        f"  - sha: '{landed_sha}'\n"
+        "    message: 'base'\n"
+        "acceptance_criteria:\n"
+        "  - criterion: 'AC1'\n"
+        "    status: MET\n"
+        "    notes: 'ok'\n"
+        "  - criterion: 'AC2'\n"
+        "    status: NOT_MET\n"
+        "    notes: 'still pending'\n"
+        "story_deviations: []\n"
+        "deferred_items: []\n",
+        encoding="utf-8",
+    )
+
+    config = _make_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        workspace=dataclasses.replace(config.workspace, base_branch="main"),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.0)
+    state.dev_handoff_snapshots.append(
+        {"source": "structured_output", "path": str(handoff_path), "handoff": {}}
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/"),
+        ),
+        patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
+        patch(
+            "theforge.coordinator.validate_phase._check_conventions_parallel",
+            return_value=None,
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, _result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert state.validate_already_complete is False
+
+
+def test_run_validate_phase_empty_worktree_handoff_unverifiable_sha_escalates(
+    tmp_path: Path,
+) -> None:
+    """A handoff that cites a SHA not present on the branch must not unlock success."""
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _write(tmp_path / "README.md", "base\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "base")
+
+    handoff_dir = tmp_path / ".forge" / "handoffs" / "story"
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    handoff_path = handoff_dir / "iter_1.yaml"
+    handoff_path.write_text(
+        "summary: 'fabricated'\n"
+        "commits:\n"
+        "  - sha: 'deadbeefcafebabefeedfacedeadbeefcafebabe'\n"
+        "    message: 'fake'\n"
+        "acceptance_criteria:\n"
+        "  - criterion: 'AC1'\n"
+        "    status: MET\n"
+        "    notes: 'fabricated'\n"
+        "story_deviations: []\n"
+        "deferred_items: []\n",
+        encoding="utf-8",
+    )
+
+    config = _make_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        workspace=dataclasses.replace(config.workspace, base_branch="main"),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.0)
+    state.dev_handoff_snapshots.append(
+        {"source": "structured_output", "path": str(handoff_path), "handoff": {}}
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/"),
+        ),
+        patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
+        patch(
+            "theforge.coordinator.validate_phase._check_conventions_parallel",
+            return_value=None,
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, _result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert state.validate_already_complete is False
+
+
 def _git(repo: Path, *args: str) -> str:
     proc = subprocess.run(
         ["git", *args],

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -689,6 +689,85 @@ def test_run_validate_phase_empty_worktree_handoff_unverifiable_sha_escalates(
     assert state.validate_already_complete is False
 
 
+def test_run_validate_phase_empty_worktree_handoff_off_branch_sha_escalates(
+    tmp_path: Path,
+) -> None:
+    """A handoff citing a real SHA from another branch (not reachable from HEAD or
+    base) must not unlock ALREADY_COMPLETE — object existence is insufficient,
+    reachability is required."""
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _write(tmp_path / "README.md", "base\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "base on main")
+
+    # Create a sibling branch with its own commit, then return to main. The
+    # sibling commit is a real object in the repo but is not reachable from
+    # HEAD or from main, so it must not satisfy the citation check.
+    _git(tmp_path, "checkout", "-b", "other")
+    _write(tmp_path / "other.txt", "off-branch\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "off-branch work")
+    off_branch_sha = _git(tmp_path, "rev-parse", "HEAD")
+    _git(tmp_path, "checkout", "main")
+
+    handoff_dir = tmp_path / ".forge" / "handoffs" / "story"
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    handoff_path = handoff_dir / "iter_1.yaml"
+    handoff_path.write_text(
+        "summary: 'cites off-branch sha'\n"
+        "commits:\n"
+        f"  - sha: '{off_branch_sha}'\n"
+        "    message: 'off-branch work'\n"
+        "acceptance_criteria:\n"
+        "  - criterion: 'AC1'\n"
+        "    status: MET\n"
+        "    notes: 'claimed'\n"
+        "story_deviations: []\n"
+        "deferred_items: []\n",
+        encoding="utf-8",
+    )
+
+    config = _make_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        workspace=dataclasses.replace(config.workspace, base_branch="main"),
+    )
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1)
+    state.budget.max_iterations = config.retry.max_dev_iterations
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.0)
+    state.dev_handoff_snapshots.append(
+        {"source": "structured_output", "path": str(handoff_path), "handoff": {}}
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase._run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/"),
+        ),
+        patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
+        patch(
+            "theforge.coordinator.validate_phase._check_conventions_parallel",
+            return_value=None,
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, _result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert state.validate_already_complete is False
+
+
 def _git(repo: Path, *args: str) -> str:
     proc = subprocess.run(
         ["git", *args],


### PR DESCRIPTION
## Summary

Prior P1 is resolved; VALIDATE now recognizes documented already-complete handoffs and sprint classification surfaces them as ALREADY_DONE.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $5.46
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

VALIDATE phase classifies 'dev cycle determined no work needed' as missing-work failure when handoff explicitly reports work already complete (GitHub Issue #1457)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1457