### PR TITLE
forge status --watch admits pid-only sprints via marker (#1405)

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -129,7 +129,9 @@ def cmd_sprint(args: object) -> int:
 
         if _detach_mod.is_detached_child():
             launch_run_id = _os.environ.get("FORGE_DETACHED_RUN_ID") or _generate_run_id()
-            _detach_mod.setup_detached_child(launch_run_id, launch_slug, config.project_root)
+            _detach_mod.setup_detached_child(
+                launch_run_id, launch_slug, config.project_root, is_sprint=True
+            )
             _detach_mod.install_cleanup_handler(launch_run_id, config.project_root)
             print("[forge] Detached sprint starting", file=sys.stderr, flush=True)
             args.__dict__["_detached_run_id"] = launch_run_id
@@ -150,7 +152,9 @@ def cmd_sprint(args: object) -> int:
             _atexit.register(_detach_mod.remove_pid, launch_run_id, config.project_root)
         else:
             launch_run_id = _generate_run_id()
-            _detach_mod.daemonize_run(launch_run_id, launch_slug, config.project_root)
+            _detach_mod.daemonize_run(
+                launch_run_id, launch_slug, config.project_root, is_sprint=True
+            )
             # daemonize_run never returns in the parent.
 
     if getattr(args, "verbose", False):

--- a/src/theforge/cli/status_run_helpers.py
+++ b/src/theforge/cli/status_run_helpers.py
@@ -27,6 +27,11 @@ def is_sprint_run(run_id: str, project_root: Path) -> bool:
         return True
 
     runs_dir = project_root / ".forge" / "runs"
+    # Sprint marker is written at detach time, before any sprint state exists.
+    # Without this check, watch mode falls back to a one-shot snapshot during
+    # the preflight/DAG-build window when only the PID file is present.
+    if (runs_dir / f"{run_id}.sprint").exists():
+        return True
     for redirect_file in runs_dir.glob("*.redirect"):
         try:
             data = json.loads(redirect_file.read_text(encoding="utf-8"))

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -48,12 +48,41 @@ def write_pid(run_id: str, slug: str, project_root: Path) -> Path:
 
 
 def remove_pid(run_id: str, project_root: Path) -> None:
-    """Remove .forge/runs/<run-id>.pid, ignoring missing files."""
+    """Remove .forge/runs/<run-id>.pid (and the sprint marker), ignoring missing files."""
     pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
     try:
         pid_file.unlink()
     except FileNotFoundError:
         pass
+    remove_sprint_marker(run_id, project_root)
+
+
+def write_sprint_marker(run_id: str, project_root: Path) -> Path:
+    """Mark <run_id> as a sprint run before any sprint state is written.
+
+    Without this marker, ``forge status --watch`` cannot recognise a freshly
+    detached sprint as watchable during preflight/DAG-build (only a PID file
+    exists at that point), and silently falls back to a one-shot snapshot.
+    """
+    runs_dir = project_root / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    marker = runs_dir / f"{run_id}.sprint"
+    marker.write_text("sprint\n", encoding="utf-8")
+    return marker
+
+
+def remove_sprint_marker(run_id: str, project_root: Path) -> None:
+    """Remove .forge/runs/<run_id>.sprint, ignoring missing files."""
+    marker = project_root / ".forge" / "runs" / f"{run_id}.sprint"
+    try:
+        marker.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def has_sprint_marker(run_id: str, project_root: Path) -> bool:
+    """Return True when <run_id>.sprint marker exists."""
+    return (project_root / ".forge" / "runs" / f"{run_id}.sprint").exists()
 
 
 def write_run_ended(
@@ -335,7 +364,9 @@ def is_detached_child() -> bool:
     return os.environ.get(_DETACHED_ENV) == "1"
 
 
-def setup_detached_child(run_id: str, slug: str, project_root: Path) -> None:
+def setup_detached_child(
+    run_id: str, slug: str, project_root: Path, *, is_sprint: bool = False
+) -> None:
     """Initialize a re-exec'd detached child: write PID file and redirect file.
 
     The parent already redirected stdin/stdout/stderr via ``subprocess.Popen``
@@ -347,6 +378,8 @@ def setup_detached_child(run_id: str, slug: str, project_root: Path) -> None:
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
     write_pid(run_id, slug, project_root)
+    if is_sprint:
+        write_sprint_marker(run_id, project_root)
 
     # Coordinator post-pull execv inherits FORGE_DETACHED + FORGE_PREV_RUN_ID
     # in env. Write the redirect sidecar so the log follower can switch.
@@ -355,7 +388,7 @@ def setup_detached_child(run_id: str, slug: str, project_root: Path) -> None:
         write_reexec_redirect(prev_run_id, run_id, log_file, project_root)
 
 
-def daemonize_run(run_id: str, slug: str, project_root: Path) -> None:
+def daemonize_run(run_id: str, slug: str, project_root: Path, *, is_sprint: bool = False) -> None:
     """Spawn a fresh interpreter as a detached child and exit the parent.
 
     Replaces the previous ``os.fork()``-based double-fork daemonization to
@@ -400,6 +433,8 @@ def daemonize_run(run_id: str, slug: str, project_root: Path) -> None:
     runs_dir.mkdir(parents=True, exist_ok=True)
     pid_file = runs_dir / f"{run_id}.pid"
     pid_file.write_text(f"{proc.pid}\n{slug}\n", encoding="utf-8")
+    if is_sprint:
+        write_sprint_marker(run_id, project_root)
 
     print("[forge] Run started in background")
     print(f"[forge] Run ID:  {run_id}")

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -806,6 +806,42 @@ class TestCmdStatusWatchRouting:
         assert rc == 0
         loop.assert_called_once()
 
+    def test_tty_watch_enters_loop_for_pid_only_sprint_marker(self, tmp_path: Path) -> None:
+        """Regression for #1405: a sprint with only PID + sprint marker (no .state, no
+        summary, no redirect) must still enter watch mode.
+
+        Exercises the real ``_resolve_watch_run_ids`` path — does NOT patch the
+        resolver — so the gate logic that previously returned [] for PID-only sprint
+        runs is genuinely covered.
+        """
+        from theforge.cli import cmd_status
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = self._config(tmp_path)
+        args = argparse.Namespace(run_id=None, recent=False, last=False, watch=3, no_color=True)
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "run-1.pid").write_text("99999\nissues-1430,1435,1438\n")
+        (runs_dir / "run-1.sprint").write_text("sprint\n")
+        # No .state, no sprint-summary.yaml, no .redirect — early-lifecycle window.
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status._list_active_run_ids", return_value=["run-1"]),
+            patch("theforge.cli.status_watch.is_tty", return_value=True),
+            patch("theforge.cli.status_watch.run_watch_loop", return_value=0) as loop,
+            patch("theforge.pending.cleanup_stale"),
+            patch("theforge.pending.list_pending", return_value=[]),
+        ):
+            rc = cmd_status(args)
+
+        assert rc == 0
+        loop.assert_called_once()
+        assert loop.call_args.kwargs["follow_active_runs"] is True
+
     def test_tty_single_run_falls_back(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
Reopens fix for #1405 after PR #1419 (rc6) merged a fix that did not actually address the user-visible symptom (\`forge status --watch\` exiting during pid-only startup window before \`.state\` / \`.summary\` / \`.redirect\` exist).

## Recovery context

Dev cycle in sprint \`774a42e9cc11\` (2026-05-09 06:46-07:11 PT) produced commit \`b3c404c "fix(status): admit pid-only sprints to watch mode via sprint marker"\`. Review pool returned APPROVE 0 P1 1 P2 (the P2 is a dead-code complaint about a defined-but-unused \`has_sprint_marker()\` helper — non-blocking).

The sprint integration step emitted \`MERGE_FAILED: PR already merged for branch feat/issue-1405\` because the branch name \`feat/issue-1405\` was reused by the dev cycle and GitHub returned PR #1419 (already merged) for that branch. New commits were preserved on the branch but no fresh PR was opened. This PR is opened from a renamed branch (\`feat/issue-1405-marker\`) to recover the work.

## What changed

The fix writes a \`.sprint\` marker sidecar alongside the PID file at sprint detach time, so \`is_sprint_run()\` returns True immediately and \`_resolve_watch_run_ids()\` admits the run into the watch loop before any of \`.state\` / \`.summary\` / \`.redirect\` are written. Closes the gap PR #1419 missed.

Files: \`cli/sprint.py\`, \`cli/status_run_helpers.py\`, \`coordinator/engine.py\`, \`coordinator/state.py\`, \`coordinator/validate_phase.py\`, \`detach.py\`, \`sprint/runner.py\`, plus regression tests in \`tests/test_cli_status_watch.py\`, \`tests/test_sprint_parallel.py\`, \`tests/test_validate_phase.py\`.

Closes #1405.