### PR TITLE
Sprint integration cannot publish new work when a reopened issue's prior fix PR is already merged on the same branch name, requiring manual operator recovery

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -299,6 +299,9 @@ def _create_pr(
 
     pr_title = f"{task.name}"
 
+    worktree_dir = config.workspace.path_pattern.format(slug=task.slug)
+    worktree_path = config.project_root / worktree_dir
+
     try:
         merged_pr_proc = subprocess.run(
             [
@@ -319,12 +322,31 @@ def _create_pr(
         )
         if merged_pr_proc.returncode == 0:
             merged_prs = json.loads(merged_pr_proc.stdout or "[]")
-            merged_pr = next((pr for pr in merged_prs if pr.get("mergedAt")), None)
+            merged_pr = _find_pr_containing_head(
+                merged_prs,
+                worktree_path=worktree_path,
+                project_root=config.project_root,
+                branch_name=branch_name,
+            )
             if merged_pr is not None:
                 pr_url = merged_pr.get("url")
-                message = f"PR already merged for branch {branch_name}: {pr_url}"
-                _pr_log.warning(message)
-                return {"action": "pr", "pr_url": pr_url, "success": False, "error": message}
+                _pr_log.info(
+                    "PR already merged for branch %s contains current HEAD; "
+                    "skipping PR recreation: %s",
+                    branch_name,
+                    pr_url,
+                )
+                return {
+                    "action": "pr",
+                    "pr_url": pr_url,
+                    "success": True,
+                    "error": None,
+                    "skipped": True,
+                    "skip_reason": "prior PR already contains current HEAD",
+                }
+            # No matching merged PR for current HEAD: fall through and open a fresh
+            # PR for the new commits — even if a prior PR for this branch name was
+            # merged with different commits (reopened-issue-with-prior-merged-fix).
         else:
             err = merged_pr_proc.stderr.strip() or merged_pr_proc.stdout.strip()
             _pr_log.warning(
@@ -356,8 +378,6 @@ def _create_pr(
 
     # Archive spec from backlog/ to done/ in the feature branch so the
     # merge carries the move into main.
-    worktree_dir = config.workspace.path_pattern.format(slug=task.slug)
-    worktree_path = config.project_root / worktree_dir
     push_cwd = worktree_path if worktree_path.is_dir() else config.project_root
     if task.story_path:
         _archive_story_to_done(task.story_path, push_cwd, commit=True)

--- a/tests/test_coord_gate_fix.py
+++ b/tests/test_coord_gate_fix.py
@@ -649,39 +649,109 @@ class TestCreatePR:
         assert "Closes" not in body
 
     @patch("theforge.coordinator.validate_phase.subprocess.run")
-    def test_merged_pr_lookup_skips_duplicate_pr_creation(self, mock_run, tmp_path):
-        """If a merged PR already exists for the branch, _create_pr returns early."""
+    def test_prior_merged_pr_containing_head_short_circuits_with_success(self, mock_run, tmp_path):
+        """When prior merged PR contains current HEAD, skip PR creation as success.
+
+        This is the already-landed case: the work is already in the merged PR, so
+        recreating a PR would be a no-op. Returning success-skipped lets the merge
+        machinery treat the branch as landed.
+        """
         from theforge.coordinator.completion import _create_pr
 
         config = self._make_pr_config(tmp_path)
+        worktree = tmp_path / "test-task"
+        worktree.mkdir(parents=True, exist_ok=True)
         spec = tmp_path / "spec.md"
         spec.write_text("# Test\n", encoding="utf-8")
         task = TaskStory(name="Test Task", slug="test-task", story_path=spec)
         state = CoordinatorState()
 
-        mock_run.return_value = type(
-            "Proc",
-            (),
-            {
-                "returncode": 0,
-                "stdout": (
-                    '[{"number": 222, "url": "https://github.com/test/pr/222", '
-                    '"mergedAt": "2024-01-02T03:04:05Z"}]'
-                ),
-                "stderr": "",
-            },
-        )()
+        head_sha = "abc1234abc1234abc1234abc1234abc1234abc1"
+
+        def _proc(stdout: str = "", returncode: int = 0):
+            return type(
+                "Proc",
+                (),
+                {"returncode": returncode, "stdout": stdout, "stderr": ""},
+            )()
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list):
+                if cmd[:3] == ["gh", "pr", "list"]:
+                    return _proc(
+                        '[{"number": 222, "url": "https://github.com/test/pr/222", '
+                        '"mergedAt": "2024-01-02T03:04:05Z"}]'
+                    )
+                if cmd[:2] == ["git", "rev-parse"]:
+                    return _proc(f"{head_sha}\n")
+                if cmd[:3] == ["gh", "pr", "view"] and "commits" in cmd:
+                    return _proc(f'{{"commits": [{{"oid": "{head_sha}"}}]}}')
+            return _proc()
+
+        mock_run.side_effect = _fake_run
 
         result = _create_pr(config, task, "feat/test-task", self._make_review(), state)
 
-        assert result["success"] is False
+        assert result["success"] is True
         assert result["pr_url"] == "https://github.com/test/pr/222"
-        assert "already merged" in result["error"]
-        assert mock_run.call_count == 1
-        lookup_call = mock_run.call_args_list[0]
-        assert lookup_call[0][0][:3] == ["gh", "pr", "list"]
-        json_idx = lookup_call[0][0].index("--json") + 1
-        assert lookup_call[0][0][json_idx] == "number,url,mergedAt"
+        assert result.get("skipped") is True
+        # Must not have attempted push or create.
+        all_cmds = [c[0][0] for c in mock_run.call_args_list]
+        assert not any(c[:2] == ["git", "push"] for c in all_cmds)
+        assert not any(c[:3] == ["gh", "pr", "create"] for c in all_cmds)
+
+    @patch("theforge.coordinator.validate_phase.subprocess.run")
+    def test_prior_merged_pr_without_head_falls_through_to_create(self, mock_run, tmp_path):
+        """A reopened-issue case: prior merged PR exists for the branch name but
+        its commits don't contain current HEAD. _create_pr must publish a fresh
+        PR rather than fail with 'already merged' (issue #1461)."""
+        from theforge.coordinator.completion import _create_pr
+
+        config = self._make_pr_config(tmp_path)
+        worktree = tmp_path / "test-task"
+        worktree.mkdir(parents=True, exist_ok=True)
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Test\n", encoding="utf-8")
+        task = TaskStory(name="Test Task", slug="test-task", story_path=spec)
+        state = CoordinatorState()
+
+        current_head = "newnewnewnewnewnewnewnewnewnewnewnewnewn"
+        old_pr_commit = "oldoldoldoldoldoldoldoldoldoldoldoldoldo"
+        new_pr_url = "https://github.com/test/pr/999"
+
+        def _proc(stdout: str = "", returncode: int = 0):
+            return type(
+                "Proc",
+                (),
+                {"returncode": returncode, "stdout": stdout, "stderr": ""},
+            )()
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list):
+                if cmd[:3] == ["gh", "pr", "list"]:
+                    return _proc(
+                        '[{"number": 222, "url": "https://github.com/test/pr/222", '
+                        '"mergedAt": "2024-01-02T03:04:05Z"}]'
+                    )
+                if cmd[:2] == ["git", "rev-parse"]:
+                    return _proc(f"{current_head}\n")
+                if cmd[:3] == ["gh", "pr", "view"] and "commits" in cmd:
+                    return _proc(f'{{"commits": [{{"oid": "{old_pr_commit}"}}]}}')
+                if cmd[:3] == ["git", "rev-list", "--count"]:
+                    return _proc("3\n")
+                if cmd[:3] == ["gh", "pr", "create"]:
+                    return _proc(f"{new_pr_url}\n")
+            return _proc()
+
+        mock_run.side_effect = _fake_run
+
+        result = _create_pr(config, task, "feat/test-task", self._make_review(), state)
+
+        assert result["success"] is True
+        assert result["pr_url"] == new_pr_url
+        assert result.get("error") is None
+        all_cmds = [c[0][0] for c in mock_run.call_args_list]
+        assert any(c[:3] == ["gh", "pr", "create"] for c in all_cmds)
 
     @patch("theforge.coordinator.validate_phase.subprocess.run")
     def test_push_failure_aborts_pr(self, mock_run, tmp_path):

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -1399,6 +1399,116 @@ class TestPrBodyContent:
         }
 
 
+# ── Reopened-issue with prior merged PR on same branch name ──────
+
+
+class TestCreatePrReopenedBranch:
+    """_create_pr opens a fresh PR when prior merged PR's commits don't contain HEAD.
+
+    Exercises the failure mode from issue #1461: a reopened issue whose prior fix
+    PR is already merged on the same deterministic branch name. The dev cycle has
+    produced new commits distinct from the prior PR; integration must publish a
+    fresh PR rather than fail with MERGE_FAILED.
+    """
+
+    def test_prior_merged_pr_without_head_falls_through_to_create(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        (tmp_path / "test-task").mkdir(parents=True, exist_ok=True)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        current_head = "newnewnewnewnewnewnewnewnewnewnewnewnewn"
+        old_pr_commit = "oldoldoldoldoldoldoldoldoldoldoldoldoldo"
+        new_pr_url = "https://github.com/fuzzypete/theforge/pull/99"
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list):
+                calls.append(cmd)
+                if cmd[:3] == ["gh", "pr", "list"] and "--state" in cmd and "closed" in cmd:
+                    return _make_subprocess_result(
+                        0,
+                        stdout=(
+                            '[{"number": 1419, '
+                            '"url": "https://github.com/fuzzypete/theforge/pull/1419", '
+                            '"mergedAt": "2026-05-06T00:00:00Z"}]'
+                        ),
+                    )
+                if cmd[:2] == ["git", "rev-parse"]:
+                    return _make_subprocess_result(0, stdout=f"{current_head}\n")
+                if cmd[:3] == ["gh", "pr", "view"] and "commits" in cmd:
+                    return _make_subprocess_result(
+                        0, stdout=f'{{"commits": [{{"oid": "{old_pr_commit}"}}]}}'
+                    )
+                if cmd[:3] == ["git", "rev-list", "--count"]:
+                    return _make_subprocess_result(0, stdout="3\n")
+                if cmd[:3] == ["gh", "pr", "create"]:
+                    return _make_subprocess_result(0, stdout=new_pr_url)
+                if cmd[:2] == ["git", "push"]:
+                    return _make_subprocess_result(0)
+            return _make_subprocess_result(0)
+
+        with patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run):
+            result = _create_pr(config, task, "feat/issue-1405", review, state)
+
+        assert result["success"] is True, result
+        assert result["pr_url"] == new_pr_url
+        assert result.get("error") is None
+        assert any(cmd[:3] == ["gh", "pr", "create"] for cmd in calls), (
+            "Expected gh pr create to be invoked when prior merged PR doesn't contain HEAD"
+        )
+
+    def test_prior_merged_pr_containing_head_short_circuits_with_success(
+        self, tmp_path: Path
+    ) -> None:
+        """When the prior merged PR already contains current HEAD, skip with success.
+
+        Avoids a redundant push/PR-create when the work has already landed.
+        """
+        config = _make_merge_pr_config(tmp_path)
+        (tmp_path / "test-task").mkdir(parents=True, exist_ok=True)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        head_sha = "abc1234abc1234abc1234abc1234abc1234abc1"
+        prior_pr_url = "https://github.com/fuzzypete/theforge/pull/1419"
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list):
+                calls.append(cmd)
+                if cmd[:3] == ["gh", "pr", "list"]:
+                    return _make_subprocess_result(
+                        0,
+                        stdout=(
+                            f'[{{"number": 1419, "url": "{prior_pr_url}", '
+                            '"mergedAt": "2026-05-06T00:00:00Z"}]'
+                        ),
+                    )
+                if cmd[:2] == ["git", "rev-parse"]:
+                    return _make_subprocess_result(0, stdout=f"{head_sha}\n")
+                if cmd[:3] == ["gh", "pr", "view"] and "commits" in cmd:
+                    return _make_subprocess_result(
+                        0, stdout=f'{{"commits": [{{"oid": "{head_sha}"}}]}}'
+                    )
+            return _make_subprocess_result(0)
+
+        with patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run):
+            result = _create_pr(config, task, "feat/issue-1405", review, state)
+
+        assert result["success"] is True
+        assert result["pr_url"] == prior_pr_url
+        assert result.get("skipped") is True
+        assert not any(cmd[:3] == ["gh", "pr", "create"] for cmd in calls)
+        assert not any(cmd[:2] == ["git", "push"] for cmd in calls)
+
+
 # ── Escalate on merge-pr failure ─────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

The change satisfies the reopened-issue branch reuse bug path and the targeted regressions pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.42
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint integration cannot publish new work when a reopened issue's prior fix PR is already merged on the same branch name, requiring manual operator recovery (GitHub Issue #1461)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1461