### PR TITLE
Assignment history becomes a derived view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Assignment history is now a derived view (#793):** completed stories no
+  longer rewrite `.forge/assignment_history.yaml`. Adaptive routing reads
+  escalation history straight from the SQLite audit substrate, so unrelated
+  parallel branches no longer collide on that snapshot. Any checked-in
+  `.forge/assignment_history.yaml` can be deleted post-upgrade — the audit
+  substrate already contains the same facts. Run
+  `forge audits export-assignment-history` to rebuild a local human-readable
+  snapshot on demand. `forge init`/`forge secrets-init` now ignore the file
+  in fresh repositories by default.
+
 ### Fixed
 
 - **Stale generated post-run hooks:** `forge check-config` now warns and exits

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -1006,6 +1006,41 @@ def assign_models(
 # ── I/O helpers (used only by coordinator) ────────────────────────────
 
 
+def escalation_records_from_dicts(dicts: list[dict]) -> list[EscalationRecord]:
+    """Coerce derived assignment-history dicts into :class:`EscalationRecord`s.
+
+    The dicts follow the same shape produced by
+    :func:`theforge.coordinator.audit_substrate.derive_assignment_history`:
+    a chronologically-ordered list with story, complexity, dev_model,
+    outcome, reason, timestamp, and complexity_score fields.
+    """
+    result: list[EscalationRecord] = []
+    for r in dicts:
+        if not isinstance(r, dict):
+            continue
+        raw_score = r.get("complexity_score")
+        if isinstance(raw_score, bool):
+            score: int | None = None
+        elif isinstance(raw_score, int):
+            score = raw_score
+        elif isinstance(raw_score, float):
+            score = int(raw_score)
+        else:
+            score = None
+        result.append(
+            EscalationRecord(
+                story=str(r.get("story", "")),
+                complexity=str(r.get("complexity", "")),
+                dev_model=str(r.get("dev_model", "")),
+                outcome=str(r.get("outcome", "")),
+                reason=str(r.get("reason", "")),
+                timestamp=str(r.get("timestamp", "")),
+                complexity_score=score,
+            )
+        )
+    return result
+
+
 def load_escalation_history(path: Path) -> list[EscalationRecord]:
     """Read .forge/assignment_history.yaml; return [] if missing or malformed."""
     if not path.exists():

--- a/src/theforge/cli/audits.py
+++ b/src/theforge/cli/audits.py
@@ -14,8 +14,65 @@ def cmd_audits(args: object) -> int:
     sub = getattr(args, "audits_command", None)
     if sub == "rebuild":
         return _cmd_audits_rebuild(args)
+    if sub == "export-assignment-history":
+        return _cmd_audits_export_assignment_history(args)
     print(f"forge audits: unknown subcommand {sub!r}", file=sys.stderr)
     return 2
+
+
+def _cmd_audits_export_assignment_history(args: object) -> int:
+    """Write a human-readable assignment_history.yaml from the audit substrate.
+
+    The on-disk snapshot is purely an inspection convenience; the
+    coordinator reads adaptive history straight from the substrate, so
+    operators may delete the file at any time.
+    """
+    config_path = _find_config(Path(args.config).resolve() if args.config else None)
+    if config_path is None:
+        print(
+            "[forge] forge.yaml not found. Run from a forge project root.",
+            file=sys.stderr,
+        )
+        return 1
+    project_root = config_path.parent
+    if not audit_substrate.has_audit_inputs(project_root):
+        print(
+            "[forge] no audit records found — nothing to export.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        conn = audit_substrate.require_substrate(project_root)
+    except audit_substrate.SubstrateError as exc:
+        print(f"[forge] {exc}", file=sys.stderr)
+        return 1
+    try:
+        dicts = audit_substrate.derive_assignment_history(conn)
+    finally:
+        conn.close()
+
+    output = (
+        Path(args.output).resolve()
+        if getattr(args, "output", None)
+        else (project_root / ".forge" / "assignment_history.yaml")
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    import yaml as _yaml
+
+    payload = {"escalations": [_strip_none_score(d) for d in dicts]}
+    with open(output, "w", encoding="utf-8") as fh:
+        _yaml.dump(payload, fh, default_flow_style=False, allow_unicode=True, sort_keys=True)
+    print(f"[forge] wrote {len(dicts)} records to {output}")
+    return 0
+
+
+def _strip_none_score(record: dict) -> dict:
+    """Drop ``complexity_score`` when null so the YAML matches legacy shape."""
+    out = dict(record)
+    if out.get("complexity_score") is None:
+        out.pop("complexity_score", None)
+    return out
 
 
 def _cmd_audits_rebuild(args: object) -> int:
@@ -182,6 +239,19 @@ def register_parser(subparsers: object) -> None:
         help="Also backfill from .forge/audits/history.jsonl",
     )
     rebuild_parser.add_argument(
+        "--config",
+        help="Path to forge.yaml (default: auto-detect)",
+    )
+
+    export_parser = audits_sub.add_parser(
+        "export-assignment-history",
+        help="Write a human-readable assignment_history.yaml from the substrate",
+    )
+    export_parser.add_argument(
+        "--output",
+        help="Output path (default: .forge/assignment_history.yaml)",
+    )
+    export_parser.add_argument(
         "--config",
         help="Path to forge.yaml (default: auto-detect)",
     )

--- a/src/theforge/cli/init_commands.py
+++ b/src/theforge/cli/init_commands.py
@@ -12,6 +12,13 @@ from pathlib import Path
 from theforge.config import PROVIDER_API_KEY_MAP, generate_default_config
 
 _GITIGNORE_ENTRY = ".forge/.env"
+_GITIGNORE_ENTRIES: tuple[str, ...] = (
+    ".forge/.env",
+    # Derived assignment-history snapshot — reconstructable from the audit
+    # substrate via `forge audits export-assignment-history`. Tracking it
+    # creates spurious cross-branch merge conflicts (#793).
+    ".forge/assignment_history.yaml",
+)
 
 _STORY_TEMPLATE = """\
 ---
@@ -48,16 +55,19 @@ read this as context, not as requirements.
 
 
 def _ensure_gitignored(project_root: Path) -> None:
-    """Append .forge/.env to .gitignore if not already present."""
+    """Append the TheForge gitignore entries that aren't already present."""
     gitignore = project_root / ".gitignore"
     if gitignore.exists():
         content = gitignore.read_text(encoding="utf-8")
-        if _GITIGNORE_ENTRY in content.splitlines():
+        existing = set(content.splitlines())
+        missing = [entry for entry in _GITIGNORE_ENTRIES if entry not in existing]
+        if not missing:
             return
         separator = "" if content.endswith("\n") else "\n"
-        gitignore.write_text(content + separator + _GITIGNORE_ENTRY + "\n", encoding="utf-8")
+        appended = separator + "\n".join(missing) + "\n"
+        gitignore.write_text(content + appended, encoding="utf-8")
     else:
-        gitignore.write_text(_GITIGNORE_ENTRY + "\n", encoding="utf-8")
+        gitignore.write_text("\n".join(_GITIGNORE_ENTRIES) + "\n", encoding="utf-8")
 
 
 def _generate_secrets_skeleton() -> str:
@@ -100,7 +110,7 @@ def cmd_secrets_init(args: "argparse.Namespace") -> int:
     print(f"Created {env_path}")
 
     _ensure_gitignored(project_root)
-    print(f"Updated .gitignore to exclude {_GITIGNORE_ENTRY}")
+    print(f"Updated .gitignore to exclude {', '.join(_GITIGNORE_ENTRIES)}")
     return 0
 
 

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -763,3 +763,73 @@ def count_records(conn: sqlite3.Connection) -> int:
     if row is None:
         return 0
     return int(row[0])
+
+
+# ── Derived assignment-history view ──────────────────────────────────────
+
+
+_COMPLEXITY_TO_BAND = {"small": "LOW", "medium": "MEDIUM", "large": "HIGH"}
+
+
+def _coerce_complexity_score(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def derive_assignment_history(conn: sqlite3.Connection) -> list[dict]:
+    """Return assignment-history records derived from per-run audit records.
+
+    Replaces the YAML snapshot at ``.forge/assignment_history.yaml`` as the
+    source of truth: each emitted dict has the same shape consumed by
+    :func:`theforge.assignment.load_escalation_history` (story, complexity,
+    dev_model, outcome, reason, timestamp, complexity_score). Records are
+    ordered chronologically by ``timing.started_at``.
+
+    Audit records that lack the routing/complexity fields needed to
+    reconstruct an :class:`EscalationRecord` are skipped — they predate
+    adaptive routing and were never represented in the legacy YAML either.
+    """
+    out: list[dict] = []
+    for record in iter_records(conn, order_by_started=True):
+        slug = (record.get("task") or {}).get("slug")
+        if not slug:
+            continue
+        outcome_block = record.get("outcome") or {}
+        success = outcome_block.get("success")
+        if not isinstance(success, bool):
+            continue
+        pre = record.get("preflight") if isinstance(record.get("preflight"), dict) else {}
+        complexity_raw = pre.get("complexity")
+        if not isinstance(complexity_raw, str) or not complexity_raw:
+            continue
+        complexity = _COMPLEXITY_TO_BAND.get(complexity_raw.lower(), complexity_raw.upper())
+        routing_raw = pre.get("complexity_routing")
+        routing = routing_raw if isinstance(routing_raw, dict) else {}
+        assignments_raw = routing.get("assignments")
+        assignments = assignments_raw if isinstance(assignments_raw, dict) else {}
+        dev_raw = assignments.get("dev")
+        dev = dev_raw if isinstance(dev_raw, dict) else {}
+        dev_model = dev.get("canonical_id") or dev.get("model")
+        if not isinstance(dev_model, str) or not dev_model:
+            continue
+        timing = record.get("timing") or {}
+        timestamp = timing.get("started_at") or timing.get("finished_at") or ""
+        escalation = record.get("escalation") if isinstance(record.get("escalation"), dict) else {}
+        reason = escalation.get("reason") if isinstance(escalation.get("reason"), str) else ""
+        out.append(
+            {
+                "story": str(slug),
+                "complexity": complexity,
+                "dev_model": str(dev_model),
+                "outcome": "DONE" if success else "ESCALATE",
+                "reason": reason or "",
+                "timestamp": str(timestamp),
+                "complexity_score": _coerce_complexity_score(pre.get("complexity_score")),
+            }
+        )
+    return out

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1052,37 +1052,11 @@ def _record_run_memory(
         return
 
     # ── Adaptive escalation memory ─────────────────────────────────────
-    if config.assignment.escalation_memory and config.agents:
-        from theforge.assignment import (  # noqa: I001, PLC0415
-            EscalationRecord as _EscRec,
-            append_escalation_record as _append_esc,
-        )
-
-        from theforge.model_profiles import canonical_id_from_identity  # noqa: PLC0415
-
-        _esc_path = config.project_root / ".forge" / "assignment_history.yaml"
-        _esc_outcome = "DONE" if result.success else "ESCALATE"
-        _esc_canonical = canonical_id_from_identity(
-            actual_model=getattr(config.dev_profile, "model", None),
-            provider=getattr(config.dev_profile, "provider", None),
-            cli=getattr(config.dev_profile, "cli", None),
-        )
-        _esc_record = _EscRec(
-            story=task.slug,
-            complexity=state.preflight_complexity.upper()
-            if state.preflight_complexity in ("small", "medium", "large")
-            else state.preflight_complexity,
-            dev_model=_esc_canonical or config.dev_profile.name,
-            outcome=_esc_outcome,
-            reason=state.escalation_note or "",
-            timestamp=datetime.datetime.utcnow().isoformat() + "Z",
-            complexity_score=state.preflight_complexity_score,
-        )
-        _append_esc(_esc_path, _esc_record)
-        _log_verbose(
-            f"[adaptive] Wrote escalation record: story={task.slug} "
-            f"complexity={_esc_record.complexity} outcome={_esc_outcome}"
-        )
+    # Assignment history is now a derived view over the audit substrate
+    # (#793). The per-run audit record written elsewhere already captures
+    # every fact the legacy .forge/assignment_history.yaml snapshot stored,
+    # so completed stories no longer rewrite that shared snapshot. Inspect
+    # the derived view via ``forge audits export-assignment-history``.
 
     # ── Model capability profiles (independent of escalation_memory) ───
     try:

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -133,6 +133,32 @@ COMPLEXITY_SCORE_MIN = 1
 COMPLEXITY_SCORE_MAX = 10
 
 
+def _load_esc_history_from_substrate(project_root):  # type: ignore[no-untyped-def]
+    """Derive escalation history from the audit substrate.
+
+    Replaces the legacy ``.forge/assignment_history.yaml`` read with a
+    read-on-demand projection over per-run audit records (#793). Returns
+    ``[]`` for fresh repos with no audit inputs at all, or when the
+    substrate cannot be opened — adaptive routing degrades to the same
+    "no prior history" behavior as a missing YAML.
+    """
+    from theforge.assignment import escalation_records_from_dicts  # noqa: PLC0415
+    from theforge.coordinator import audit_substrate  # noqa: PLC0415
+
+    if not audit_substrate.has_audit_inputs(project_root):
+        return []
+    try:
+        conn = audit_substrate.require_substrate(project_root)
+    except audit_substrate.SubstrateError as exc:
+        _log.warning("[adaptive] Could not open audit substrate: %s", exc)
+        return []
+    try:
+        dicts = audit_substrate.derive_assignment_history(conn)
+    finally:
+        conn.close()
+    return escalation_records_from_dicts(dicts)
+
+
 def score_to_band(score: int) -> str:
     """Map a 1-10 complexity score to the legacy small/medium/large enum.
 
@@ -898,15 +924,13 @@ def _apply_preflight_config(
         _pick_agent as _pick_agt,
         _promote_tier as _prom_tier,
         assign_models as _assign_models,
-        load_escalation_history as _load_esc_history,
     )
     from theforge.config import (  # noqa: I001, PLC0415
         DEFAULT_DEV_PROFILE as _DEF_DEV,
         DEFAULT_PREFLIGHT_PROFILE as _DEF_PRE,
     )
 
-    _history_path = config.project_root / ".forge" / "assignment_history.yaml"
-    _esc_history = _load_esc_history(_history_path)
+    _esc_history = _load_esc_history_from_substrate(config.project_root)
 
     from theforge.model_profiles import load_profiles as _load_profiles  # noqa: PLC0415
 

--- a/tests/test_assignment_history_derived.py
+++ b/tests/test_assignment_history_derived.py
@@ -1,0 +1,417 @@
+"""Tests for the audit-substrate-derived assignment-history view (#793).
+
+Covers three boundaries the YAML-snapshot replacement crosses:
+
+1. ``audit_substrate.derive_assignment_history`` reconstructs the legacy
+   ``EscalationRecord`` shape from real substrate rows.
+2. ``_apply_preflight_config`` sources its escalation history from the
+   substrate (not ``.forge/assignment_history.yaml``) and feeds those
+   records into ``assign_models``.
+3. ``forge audits export-assignment-history`` writes a YAML snapshot in
+   the legacy human-readable shape from the substrate.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+from coord_test_helpers import _make_config
+
+from theforge.config import AgentDef, AssignmentConfig
+from theforge.coordinator import audit_substrate as sub
+from theforge.coordinator.state import CoordinatorState
+
+
+def _audit_record(
+    *,
+    run_id: str,
+    slug: str,
+    success: bool,
+    complexity: str = "medium",
+    complexity_score: int = 5,
+    dev_canonical: str = "anthropic/sonnet/cli",
+    dev_model: str = "sonnet",
+    started_at: str = "2026-05-08T10:00:00+00:00",
+    reason: str = "",
+) -> dict:
+    record: dict = {
+        "run_id": run_id,
+        "task": {"slug": slug, "name": slug},
+        "outcome": {"success": success, "final_phase": "DONE" if success else "ESCALATE"},
+        "timing": {"started_at": started_at},
+        "totals": {"cost_usd": 1.0},
+        "preflight": {
+            "verdict": "PROCEED",
+            "complexity": complexity,
+            "complexity_score": complexity_score,
+            "complexity_routing": {
+                "complexity": complexity,
+                "complexity_score": complexity_score,
+                "assignments": {
+                    "dev": {
+                        "model": dev_model,
+                        "source": "builtin",
+                        "canonical_id": dev_canonical,
+                    }
+                },
+            },
+        },
+    }
+    if reason:
+        record["escalation"] = {"reason": reason}
+    return record
+
+
+def _seed_substrate(project_root: Path, records: list[dict]) -> None:
+    runs = sub.runs_dir(project_root)
+    runs.mkdir(parents=True, exist_ok=True)
+    for rec in records:
+        (runs / f"{rec['run_id']}.json").write_text(json.dumps(rec), encoding="utf-8")
+    sub.rebuild_from_runs(project_root)
+
+
+# ── derive_assignment_history ────────────────────────────────────────────
+
+
+def test_derive_assignment_history_orders_chronologically(tmp_path: Path) -> None:
+    _seed_substrate(
+        tmp_path,
+        [
+            _audit_record(
+                run_id="r-late",
+                slug="story-b",
+                success=False,
+                started_at="2026-05-08T11:00:00+00:00",
+                reason="persistent P1",
+            ),
+            _audit_record(
+                run_id="r-early",
+                slug="story-a",
+                success=True,
+                started_at="2026-05-08T09:00:00+00:00",
+            ),
+        ],
+    )
+    conn = sub.require_substrate(tmp_path)
+    try:
+        derived = sub.derive_assignment_history(conn)
+    finally:
+        conn.close()
+
+    assert [d["story"] for d in derived] == ["story-a", "story-b"]
+    assert [d["outcome"] for d in derived] == ["DONE", "ESCALATE"]
+    assert [d["complexity"] for d in derived] == ["MEDIUM", "MEDIUM"]
+    assert [d["dev_model"] for d in derived] == [
+        "anthropic/sonnet/cli",
+        "anthropic/sonnet/cli",
+    ]
+    assert derived[1]["reason"] == "persistent P1"
+    assert derived[0]["complexity_score"] == 5
+
+
+def test_derive_assignment_history_skips_records_without_routing(tmp_path: Path) -> None:
+    rec_no_routing = {
+        "run_id": "r-old",
+        "task": {"slug": "ancient"},
+        "outcome": {"success": True, "final_phase": "DONE"},
+        "timing": {"started_at": "2026-01-01T00:00:00+00:00"},
+        "preflight": {"verdict": "PROCEED"},  # no complexity / routing
+    }
+    _seed_substrate(
+        tmp_path,
+        [
+            rec_no_routing,
+            _audit_record(run_id="r-new", slug="modern", success=True),
+        ],
+    )
+    conn = sub.require_substrate(tmp_path)
+    try:
+        derived = sub.derive_assignment_history(conn)
+    finally:
+        conn.close()
+
+    assert [d["story"] for d in derived] == ["modern"]
+
+
+# ── preflight seam: substrate → assign_models ────────────────────────────
+
+
+def test_preflight_loads_escalation_history_from_substrate(tmp_path, monkeypatch) -> None:
+    """The new read path must hand substrate-derived records to assign_models."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    from theforge.coordinator import preflight as _pf
+
+    _seed_substrate(
+        tmp_path,
+        [
+            _audit_record(
+                run_id="esc-1",
+                slug="prior-1",
+                success=False,
+                started_at="2026-05-08T09:00:00+00:00",
+                reason="persistent P1 cycle 1",
+            ),
+            _audit_record(
+                run_id="esc-2",
+                slug="prior-2",
+                success=False,
+                started_at="2026-05-08T10:00:00+00:00",
+                reason="persistent P1 cycle 2",
+            ),
+        ],
+    )
+
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="claude-sonnet",
+                provider="anthropic",
+                model="sonnet",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="cheap",
+                cli="claude",
+            ),
+            AgentDef(
+                name="claude-opus",
+                provider="anthropic",
+                model="opus",
+                budget_usd=20.0,
+                timeout_seconds=900,
+                tier="strong",
+                cli="claude",
+            ),
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=True,
+            max_cost_per_story_usd=50.0,
+            min_reviewers=1,
+            max_reviewers=1,
+        ),
+    )
+
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 5
+
+    captured: dict = {}
+
+    def _fake_assign_models(*args, **kwargs):
+        captured["escalation_history"] = kwargs.get("escalation_history")
+        from theforge.assignment import AssignmentDecision
+
+        return AssignmentDecision(
+            preflight=config.preflight_profile,
+            planner=config.dev_profile,
+            plan_reviewers=[],
+            dev=config.dev_profile,
+            code_reviewers=[],
+            rationale={},
+        )
+
+    monkeypatch.setattr("theforge.assignment.assign_models", _fake_assign_models)
+
+    _pf._apply_preflight_config(config, state)
+
+    history = captured.get("escalation_history")
+    assert history is not None and len(history) == 2, (
+        "preflight must source escalation history from the audit substrate "
+        "and pass it to assign_models when escalation_memory is enabled"
+    )
+    assert all(r.outcome == "ESCALATE" for r in history)
+    assert all(r.dev_model == "anthropic/sonnet/cli" for r in history)
+    assert all(r.complexity == "MEDIUM" for r in history)
+    # Ordered chronologically by started_at — the YAML snapshot was append-ordered.
+    assert [r.story for r in history] == ["prior-1", "prior-2"]
+    assert [r.reason for r in history] == [
+        "persistent P1 cycle 1",
+        "persistent P1 cycle 2",
+    ]
+    # The legacy YAML at .forge/assignment_history.yaml is no longer the
+    # source of truth — it doesn't even need to exist.
+    assert not (tmp_path / ".forge" / "assignment_history.yaml").exists()
+
+
+def test_preflight_with_no_audit_inputs_returns_empty_history(tmp_path, monkeypatch) -> None:
+    """Fresh repos with no audit records degrade gracefully to empty history."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    from theforge.coordinator import preflight as _pf
+
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="claude-sonnet",
+                provider="anthropic",
+                model="sonnet",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="cheap",
+                cli="claude",
+            ),
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=True,
+            max_cost_per_story_usd=30.0,
+            min_reviewers=1,
+            max_reviewers=1,
+        ),
+    )
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 5
+
+    captured: dict = {}
+
+    def _fake_assign_models(*args, **kwargs):
+        captured["escalation_history"] = kwargs.get("escalation_history")
+        from theforge.assignment import AssignmentDecision
+
+        return AssignmentDecision(
+            preflight=config.preflight_profile,
+            planner=config.dev_profile,
+            plan_reviewers=[],
+            dev=config.dev_profile,
+            code_reviewers=[],
+            rationale={},
+        )
+
+    monkeypatch.setattr("theforge.assignment.assign_models", _fake_assign_models)
+
+    _pf._apply_preflight_config(config, state)
+
+    # Empty list (not None) — the assign_models contract is preserved.
+    assert captured["escalation_history"] == []
+
+
+# ── CLI: forge audits export-assignment-history ──────────────────────────
+
+
+def _setup_project(tmp_path: Path) -> Path:
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    return forge_yaml
+
+
+def test_export_assignment_history_writes_yaml_in_legacy_shape(tmp_path: Path, capsys) -> None:
+    from theforge.cli import audits as audits_cli
+
+    forge_yaml = _setup_project(tmp_path)
+    _seed_substrate(
+        tmp_path,
+        [
+            _audit_record(
+                run_id="r-done",
+                slug="story-done",
+                success=True,
+                started_at="2026-05-08T09:00:00+00:00",
+            ),
+            _audit_record(
+                run_id="r-esc",
+                slug="story-esc",
+                success=False,
+                started_at="2026-05-08T10:00:00+00:00",
+                reason="persistent P1",
+            ),
+        ],
+    )
+
+    rc = audits_cli.cmd_audits(
+        SimpleNamespace(
+            config=str(forge_yaml),
+            audits_command="export-assignment-history",
+            output=None,
+        )
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "wrote 2 records" in out
+
+    out_path = tmp_path / ".forge" / "assignment_history.yaml"
+    assert out_path.exists()
+    payload = yaml.safe_load(out_path.read_text(encoding="utf-8"))
+    assert "escalations" in payload
+    entries = payload["escalations"]
+    assert len(entries) == 2
+    by_story = {e["story"]: e for e in entries}
+    assert by_story["story-done"]["outcome"] == "DONE"
+    assert by_story["story-done"]["complexity"] == "MEDIUM"
+    assert by_story["story-done"]["dev_model"] == "anthropic/sonnet/cli"
+    assert by_story["story-done"]["complexity_score"] == 5
+    assert by_story["story-esc"]["outcome"] == "ESCALATE"
+    assert by_story["story-esc"]["reason"] == "persistent P1"
+
+
+def test_export_assignment_history_respects_explicit_output(tmp_path: Path) -> None:
+    from theforge.cli import audits as audits_cli
+
+    forge_yaml = _setup_project(tmp_path)
+    _seed_substrate(tmp_path, [_audit_record(run_id="r1", slug="s1", success=True)])
+
+    explicit = tmp_path / "out" / "history.yaml"
+    rc = audits_cli.cmd_audits(
+        SimpleNamespace(
+            config=str(forge_yaml),
+            audits_command="export-assignment-history",
+            output=str(explicit),
+        )
+    )
+    assert rc == 0
+    assert explicit.exists()
+    payload = yaml.safe_load(explicit.read_text(encoding="utf-8"))
+    assert payload["escalations"][0]["story"] == "s1"
+    # Default path must NOT be written when --output is explicit.
+    assert not (tmp_path / ".forge" / "assignment_history.yaml").exists()
+
+
+def test_export_assignment_history_fails_without_audit_inputs(tmp_path: Path, capsys) -> None:
+    from theforge.cli import audits as audits_cli
+
+    forge_yaml = _setup_project(tmp_path)
+    rc = audits_cli.cmd_audits(
+        SimpleNamespace(
+            config=str(forge_yaml),
+            audits_command="export-assignment-history",
+            output=None,
+        )
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no audit records found" in err
+
+
+def test_export_assignment_history_parser_wired_under_audits(tmp_path: Path, capsys) -> None:
+    """Regression guard: parser must register under `forge audits`."""
+    import argparse
+
+    from theforge.cli import audits as audits_cli
+
+    parser = argparse.ArgumentParser(prog="forge")
+    sub = parser.add_subparsers(dest="command")
+    audits_cli.register_parser(sub)
+
+    forge_yaml = _setup_project(tmp_path)
+    _seed_substrate(tmp_path, [_audit_record(run_id="r1", slug="s1", success=True)])
+    out_path = tmp_path / "snap.yaml"
+    args = parser.parse_args(
+        [
+            "audits",
+            "export-assignment-history",
+            "--config",
+            str(forge_yaml),
+            "--output",
+            str(out_path),
+        ]
+    )
+    rc = audits_cli.cmd_audits(args)
+    assert rc == 0
+    assert out_path.exists()

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -650,8 +650,8 @@ def test_record_run_memory_is_called_from_resume_path(tmp_path):
     assert source.count("_record_run_memory(") >= 3  # 1 def + 2 calls
 
 
-def test_record_run_memory_writes_profiles_and_history(tmp_path):
-    """Unit test of the shared helper: both files written when gates are met."""
+def test_record_run_memory_writes_profiles_and_skips_history(tmp_path):
+    """Helper writes model_profiles.yaml; assignment_history snapshot is dropped (#793)."""
     from dataclasses import replace as _replace
 
     from theforge.coordinator.engine import _record_run_memory
@@ -686,7 +686,10 @@ def test_record_run_memory_writes_profiles_and_history(tmp_path):
     profiles_path = tmp_path / ".forge" / "model_profiles.yaml"
     history_path = tmp_path / ".forge" / "assignment_history.yaml"
     assert profiles_path.exists()
-    assert history_path.exists()
+    assert not history_path.exists(), (
+        "assignment_history.yaml is now derived from the audit substrate, "
+        "not written on each completed run (#793)."
+    )
 
 
 def test_record_run_memory_skips_when_preflight_complexity_missing(tmp_path, caplog):

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -358,10 +358,10 @@ class TestDevModelEscalationIntegration:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_done_path_writes_assignment_history_without_import_error(
+    def test_done_path_does_not_write_assignment_history_snapshot(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """DONE with agents + escalation memory writes assignment history successfully."""
+        """DONE with escalation memory no longer rewrites the YAML snapshot (#793)."""
         config = replace(
             _make_config(tmp_path),
             agents=[
@@ -398,8 +398,10 @@ class TestDevModelEscalationIntegration:
 
         assert result.success is True
         history_path = tmp_path / ".forge" / "assignment_history.yaml"
-        assert history_path.exists()
-        assert "outcome: DONE" in history_path.read_text(encoding="utf-8")
+        assert not history_path.exists(), (
+            "assignment_history.yaml is now derived from the audit substrate; "
+            "completed runs must not rewrite the shared snapshot (#793)."
+        )
 
     def test_coordinator_never_imports_assignment_from_coordinator_package(self):
         """Assignment helpers live at theforge.assignment, not the coordinator package."""


### PR DESCRIPTION
## Summary

Prior P1 coverage gaps are resolved, and the derived assignment-history implementation satisfies the acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $7.60
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Assignment history becomes a derived view (GitHub Issue #793)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #793