### PR TITLE
Migrate runtime readers from history.jsonl to SQLite audit substrate (#1324)

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -105,7 +105,7 @@ plan:
   enabled: true
 
 diagnose:
-  output_destination: comment
+  output_destination: body_section
   budget_usd: 1.50
   timeout_seconds: 600
   autonomous_default: true

--- a/forge.yaml
+++ b/forge.yaml
@@ -105,7 +105,7 @@ plan:
   enabled: true
 
 diagnose:
-  output_destination: body_section
+  output_destination: comment
   budget_usd: 1.50
   timeout_seconds: 600
   autonomous_default: true

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -70,16 +70,6 @@ def _build_task(story_path: Path, slug: str | None = None) -> TaskStory:
     )
 
 
-def _append_history(audits_dir: Path, record: dict) -> None:
-    """Append a record to .forge/audits/history.jsonl (never overwritten)."""
-    history_path = audits_dir / "history.jsonl"
-    try:
-        with open(history_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, default=str) + "\n")
-    except OSError:
-        pass  # best-effort — never block a run on history write failure
-
-
 def _write_audit(result: CoordinatorResult, config: ForgeConfig, task: TaskStory) -> Path:
     """Write the canonical audit log and preserve minimal worktree state on ESCALATE."""
     audit = generate_audit_log(config, task, result)
@@ -88,8 +78,6 @@ def _write_audit(result: CoordinatorResult, config: ForgeConfig, task: TaskStory
     audit_path = audits_dir / "forge_audit.yaml"
     with open(audit_path, "w", encoding="utf-8") as f:
         yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
-    # Append to history log (JSONL, never overwritten).
-    _append_history(audits_dir, audit)
     final_phase = result.phase.name
     if (
         final_phase == "ESCALATE"

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -171,11 +171,83 @@ def _resolve_run_id(run_id: str, project_root: Path) -> bool:
     return False
 
 
-def _show_recent_runs(project_root: Path) -> int:
-    """Print a compact table of recent runs sorted by time (newest first)."""
-    import yaml
+def _historical_row_from_substrate(record: dict) -> tuple[float, str, str, str, str, str] | None:
+    """Project a substrate audit record into a recent-runs table row.
 
+    Returns ``(sort_key, run_id, type, status, cost_str, elapsed_str)`` or
+    ``None`` when the record lacks a usable identity. Sprint-level rollups
+    (records carrying a ``sprint`` block) and single-run records are both
+    handled — the substrate is the single source of truth for both shapes.
+    """
+    if not isinstance(record, dict):
+        return None
+    run_id = str(record.get("run_id") or "")
+    if not run_id:
+        return None
+    timing = record.get("timing") or {}
+    started_at = timing.get("started_at") if isinstance(timing, dict) else None
+    finished_at = timing.get("finished_at") if isinstance(timing, dict) else None
+    sort_key = 0.0
+    for ts in (finished_at, started_at):
+        if isinstance(ts, str) and ts:
+            try:
+                sort_key = datetime.datetime.fromisoformat(ts).timestamp()
+                break
+            except ValueError:
+                continue
+
+    sprint_block = record.get("sprint") if isinstance(record.get("sprint"), dict) else None
+    if sprint_block is not None:
+        run_type = "sprint"
+        stopped = sprint_block.get("stopped_reason")
+        status_str = "stopped" if stopped else "completed"
+        cost_usd = sprint_block.get("total_cost_usd")
+        if cost_usd is None:
+            cost_usd = (record.get("totals") or {}).get("cost_usd")
+        dur_s = sprint_block.get("duration_seconds")
+        if dur_s is None:
+            dur_s = (record.get("totals") or {}).get("duration_s")
+            if dur_s is None:
+                dur_s = timing.get("duration_seconds") if isinstance(timing, dict) else None
+    else:
+        run_type = "single"
+        outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
+        success = outcome.get("success")
+        final_phase = (outcome.get("final_phase") or "").lower() if outcome else ""
+        if success is True:
+            status_str = "completed"
+        elif success is False:
+            status_str = final_phase or "failed"
+        else:
+            status_str = final_phase or "unknown"
+        totals = record.get("totals") if isinstance(record.get("totals"), dict) else {}
+        cost_block = record.get("cost") if isinstance(record.get("cost"), dict) else {}
+        cost_usd = totals.get("cost_usd") if totals else None
+        if cost_usd is None:
+            cost_usd = cost_block.get("total_usd") if cost_block else None
+        dur_s = totals.get("duration_s") if totals else None
+        if dur_s is None and isinstance(timing, dict):
+            dur_s = timing.get("duration_seconds")
+
+    cost_str = f"${cost_usd:.2f}" if isinstance(cost_usd, (int, float)) else "—"
+    if isinstance(dur_s, (int, float)) and dur_s > 0:
+        elapsed_str = f"{int(dur_s // 60)}m"
+    else:
+        elapsed_str = "—"
+    return (sort_key, run_id, run_type, status_str, cost_str, elapsed_str)
+
+
+def _show_recent_runs(project_root: Path) -> int:
+    """Print a compact table of recent runs sorted by time (newest first).
+
+    Active runs come from ``detach.list_active_runs`` (PID-file-backed,
+    includes in-flight cost/elapsed). Historical runs come from the SQLite
+    audit substrate — both sprint-level and single-run records live there
+    after the migration, so legacy backfilled rows imported via
+    ``forge audits rebuild --include-legacy-history`` also appear.
+    """
     from theforge import detach as _detach
+    from theforge.coordinator import audit_substrate
 
     # Rows: (mtime_float, run_id, type, status, cost_str, elapsed_str)
     rows: list[tuple[float, str, str, str, str, str]] = []
@@ -195,52 +267,37 @@ def _show_recent_runs(project_root: Path) -> int:
         rows.append((now, run_id, run_type, "active", cost_str, elapsed_str))
         seen_ids.add(run_id)
 
-    logs_dir = project_root / ".forge" / "logs"
+    # Historical runs — substrate is canonical. A truly fresh repo (no
+    # substrate, no audit inputs) yields no rows. A missing substrate
+    # alongside legacy audit inputs is operator-visible: print the
+    # rebuild command and skip historical rows rather than silently
+    # falling back to logs/.
+    sub_path = audit_substrate.substrate_path(project_root)
+    historical_unavailable_msg: str | None = None
+    if sub_path.exists() or audit_substrate.has_audit_inputs(project_root):
+        try:
+            conn = audit_substrate.require_substrate(project_root)
+        except audit_substrate.SubstrateMissingError as exc:
+            historical_unavailable_msg = f"[forge] historical runs unavailable: {exc}"
+            conn = None
+        except audit_substrate.SubstrateCorruptError as exc:
+            historical_unavailable_msg = f"[forge] historical runs unavailable: {exc}"
+            conn = None
+        if conn is not None:
+            try:
+                for record in audit_substrate.tail_records(conn, 200):
+                    row = _historical_row_from_substrate(record)
+                    if row is None:
+                        continue
+                    if row[1] in seen_ids:
+                        continue
+                    rows.append(row)
+                    seen_ids.add(row[1])
+            finally:
+                conn.close()
 
-    if logs_dir.exists():
-        # Completed sprints — collect with their summary file mtime.
-        for summary in logs_dir.rglob("sprint-summary.yaml"):
-            try:
-                mtime = summary.stat().st_mtime
-            except OSError:
-                continue
-            try:
-                with open(summary, encoding="utf-8") as f:
-                    data = yaml.safe_load(f) or {}
-            except Exception:
-                continue
-            sp = data.get("sprint", {})
-            run_id = sp.get("run_id", "")
-            if not run_id or run_id in seen_ids:
-                continue
-            cost_usd = sp.get("total_cost_usd")
-            dur_s = sp.get("duration_seconds")
-            cost_str = f"${cost_usd:.2f}" if cost_usd is not None else "—"
-            dur_str = f"{int(dur_s // 60)}m" if dur_s is not None else "—"
-            stopped = sp.get("stopped_reason")
-            status_str = "stopped" if stopped else "completed"
-            rows.append((mtime, run_id, "sprint", status_str, cost_str, dur_str))
-            seen_ids.add(run_id)
-
-        # Historical single runs — collect with log file mtime.
-        for log_file in logs_dir.rglob("run-*.log"):
-            run_id = log_file.stem[4:]
-            if run_id in seen_ids:
-                continue
-            try:
-                mtime = log_file.stat().st_mtime
-            except OSError:
-                continue
-            outcome = _detach.read_run_ended(run_id, project_root)
-            if outcome is not None:
-                status_str = outcome
-            else:
-                # Cross-check: a PID file means a run started after the
-                # initial list_active_runs scan — label it active, not orphaned.
-                pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
-                status_str = "active" if pid_file.exists() else "orphaned"
-            rows.append((mtime, run_id, "single", status_str, "—", "—"))
-            seen_ids.add(run_id)
+    if historical_unavailable_msg is not None:
+        print(historical_unavailable_msg, file=sys.stderr)
 
     if not rows:
         print("No recent runs found.")

--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -86,25 +86,20 @@ def _read_history_tail(project_root: Path) -> list[dict]:
     relevant for adaptive iteration learning, so sprint-level records
     are filtered out.
 
-    A truly fresh repo (no audit inputs at all) yields an empty list —
-    adaptive iteration falls back to complexity-only scaling. A
-    *missing* substrate when audit inputs exist is auto-rebuilt by
-    :func:`require_substrate`; a *corrupt* substrate is propagated so
-    the run fails loudly with the recovery command, per spec.
+    A truly fresh repo (no substrate *and* no other audit inputs) yields
+    an empty list — adaptive iteration falls back to complexity-only
+    scaling. Otherwise ``require_substrate`` is the source of truth:
+    a missing substrate with audit inputs on disk surfaces
+    ``SubstrateMissingError`` (operator-facing), and a corrupt index
+    surfaces ``SubstrateCorruptError``. Neither is caught here — silent
+    no-history routing is exactly what the spec forbids.
     """
     from theforge.coordinator import audit_substrate
 
     sub_path = audit_substrate.substrate_path(project_root)
     if not sub_path.exists() and not audit_substrate.has_audit_inputs(project_root):
         return []
-    try:
-        conn = audit_substrate.require_substrate(project_root)
-    except audit_substrate.SubstrateMissingError:
-        # No audit inputs at all and no substrate — fresh repo.
-        return []
-    # SubstrateCorruptError intentionally NOT caught: a corrupt index
-    # must surface as an operator-facing run failure rather than silent
-    # complexity-only fallback.
+    conn = audit_substrate.require_substrate(project_root)
     try:
         # Pull extra so sprint-level rows (no iterations block) can be filtered.
         candidates = audit_substrate.tail_records(conn, _HISTORY_TAIL * 3)

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -158,10 +158,11 @@ def require_substrate(project_root: Path) -> sqlite3.Connection:
     """Open a substrate that must exist and be valid for runtime readers.
 
     Behavior:
-      - Substrate missing + per-run files exist → rebuild from runs/*.json
-        (and auto-import legacy history.jsonl if also present).
-      - Substrate missing + only legacy history.jsonl exists → create
-        empty substrate and run the one-shot legacy import.
+      - Substrate missing + per-run files exist → rebuild from runs/*.json.
+      - Substrate missing + only legacy history.jsonl exists →
+        SubstrateMissingError pointing the operator at
+        ``forge audits rebuild --include-legacy-history``. Runtime readers
+        never silently import legacy history.
       - Substrate missing + no audit inputs at all → SubstrateMissingError.
         Callers that should treat fresh repos as "no history" must check
         :func:`has_audit_inputs` first.
@@ -175,15 +176,14 @@ def require_substrate(project_root: Path) -> sqlite3.Connection:
             raise SubstrateMissingError(
                 f"audit substrate not found at {path}. Run `forge audits rebuild` to create it."
             )
-        # Audit inputs exist — bootstrap from canonical per-run files
-        # first, then layer in legacy history if present.
         if runs_dir(project_root).exists() and any(runs_dir(project_root).glob("*.json")):
             rebuild_from_runs(project_root)
-        else:
-            create_or_open(project_root).close()
-        conn = _open_validated(path)
-        _maybe_run_one_shot_legacy_import(project_root, conn)
-        return conn
+            return _open_validated(path)
+        # Only legacy history.jsonl present — refuse to silently import.
+        raise SubstrateMissingError(
+            f"audit substrate not found at {path} but legacy history.jsonl exists. "
+            f"Run `forge audits rebuild --include-legacy-history` to backfill."
+        )
     conn = _open_validated(path)
     # Validate native rows against the canonical per-run files. Stale
     # state (deleted file or mtime mismatch) triggers a rebuild.
@@ -191,7 +191,6 @@ def require_substrate(project_root: Path) -> sqlite3.Connection:
         conn.close()
         rebuild_from_runs(project_root)
         conn = _open_validated(path)
-    _maybe_run_one_shot_legacy_import(project_root, conn)
     return conn
 
 
@@ -270,50 +269,6 @@ def _native_rows_are_stale(conn: sqlite3.Connection, project_root: Path) -> bool
         if rel not in on_disk_rels:
             return True
     return False
-
-
-def _maybe_run_one_shot_legacy_import(project_root: Path, conn: sqlite3.Connection) -> None:
-    """Run the legacy import once per repo when conditions are met.
-
-    Conditions:
-      - ``history.jsonl`` exists.
-      - meta key ``legacy_import_done`` is unset.
-      - No rows with ``provenance='legacy_history_jsonl'`` exist (defensive).
-    """
-    history = history_jsonl_path(project_root)
-    if not history.exists():
-        return
-    flag = _meta_get(conn, "legacy_import_done")
-    if flag == "1":
-        return
-    existing = conn.execute(
-        "SELECT 1 FROM audit_records WHERE provenance = 'legacy_history_jsonl' LIMIT 1"
-    ).fetchone()
-    if existing is not None:
-        # Already imported in a prior session; just set the flag forward.
-        _meta_set(conn, "legacy_import_done", "1")
-        conn.commit()
-        return
-    print(
-        "[forge] migrating history.jsonl into audit substrate (one-shot)",
-        flush=True,
-    )
-    summary = _import_history_jsonl_into(conn, history)
-    _meta_set(conn, "legacy_import_done", "1")
-    conn.commit()
-    print(
-        f"[forge] imported {summary.imported} records from history.jsonl",
-        flush=True,
-    )
-    print(
-        f"[forge] skipped existing {summary.skipped_existing}, "
-        f"updated/repaired {summary.updated_repaired}, failed {summary.failed}",
-        flush=True,
-    )
-    print(
-        f"[forge] substrate ready at {substrate_path(project_root)}",
-        flush=True,
-    )
 
 
 # ── Meta helpers ─────────────────────────────────────────────────────────
@@ -793,6 +748,11 @@ def derive_assignment_history(conn: sqlite3.Connection) -> list[dict]:
     Audit records that lack the routing/complexity fields needed to
     reconstruct an :class:`EscalationRecord` are skipped — they predate
     adaptive routing and were never represented in the legacy YAML either.
+
+    This is the CLI/export view (mapped complexity bands, derives dev model
+    from preflight routing assignments). Adaptive routing uses the more
+    runtime-faithful :func:`iter_escalation_records` instead, which derives
+    dev model from ``cost.agents`` (the model that actually ran).
     """
     out: list[dict] = []
     for record in iter_records(conn, order_by_started=True):
@@ -833,3 +793,108 @@ def derive_assignment_history(conn: sqlite3.Connection) -> list[dict]:
             }
         )
     return out
+
+
+def iter_escalation_records(conn: sqlite3.Connection) -> Iterable[dict]:
+    """Yield escalation-shaped dicts derived from audit records.
+
+    Each row exposes the fields the adaptive router cares about for promotion
+    bookkeeping: ``story``, ``complexity``, ``dev_model`` (canonicalized when
+    available, else falls back to embedded dev profile name), ``outcome``
+    ("DONE" if the run succeeded else "ESCALATE"), ``timestamp``, and
+    ``complexity_score``. Records ordered by ``started_at`` ascending so
+    callers can take the trailing window directly.
+
+    This is the runtime-routing view (raw complexity string, derives dev
+    model from ``cost.agents`` — the model that actually ran). The CLI/export
+    view :func:`derive_assignment_history` uses preflight assignments
+    instead, which is the *intended* dev model rather than the executed one.
+    """
+    rows = conn.execute("SELECT raw_json FROM audit_records ORDER BY COALESCE(started_at, '') ASC")
+    for row in rows:
+        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        derived = _derive_escalation(record)
+        if derived is not None:
+            yield derived
+
+
+def _derive_escalation(record: dict) -> dict | None:
+    """Project an audit record to its escalation-shape projection."""
+    task = record.get("task") or {}
+    slug = str(task.get("slug") or "").strip()
+    outcome = record.get("outcome") or {}
+    success = outcome.get("success")
+    if not isinstance(success, bool):
+        return None
+    preflight = record.get("preflight") if isinstance(record.get("preflight"), dict) else {}
+    complexity = str(preflight.get("complexity") or "").strip()
+
+    # Canonical dev model identity, derived from the cost.agents block when
+    # present (carries provider/model/cli identity per phase).
+    dev_model = ""
+    cost_block = record.get("cost") if isinstance(record.get("cost"), dict) else {}
+    agents = cost_block.get("agents") if isinstance(cost_block.get("agents"), list) else []
+    for entry in agents:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("phase") != "dev" and entry.get("role") != "dev":
+            continue
+        provider = (entry.get("provider") or "").strip()
+        model = (entry.get("model") or "").strip()
+        cli = (entry.get("cli") or "").strip()
+        if model and provider:
+            transport = "cli" if cli else "api"
+            dev_model = f"{provider}/{model}/{transport}"
+            break
+        if entry.get("name"):
+            dev_model = str(entry["name"])
+            break
+
+    raw_score = preflight.get("complexity_score") if isinstance(preflight, dict) else None
+    if isinstance(raw_score, bool):
+        complexity_score: int | None = None
+    elif isinstance(raw_score, int):
+        complexity_score = raw_score
+    elif isinstance(raw_score, float):
+        complexity_score = int(raw_score)
+    else:
+        complexity_score = None
+
+    timing = record.get("timing") or {}
+    timestamp = str(timing.get("finished_at") or timing.get("started_at") or "")
+
+    escalation_block = (
+        record.get("escalation") if isinstance(record.get("escalation"), dict) else {}
+    )
+    reason = str(escalation_block.get("reason") or "")
+
+    return {
+        "story": slug,
+        "complexity": complexity,
+        "dev_model": dev_model,
+        "outcome": "DONE" if success else "ESCALATE",
+        "reason": reason,
+        "timestamp": timestamp,
+        "complexity_score": complexity_score,
+    }
+
+
+def seed_records(project_root: Path, records: Iterable[dict]) -> None:
+    """Test helper: write records directly into the substrate as native rows.
+
+    This is the supported way to bootstrap a substrate fixture in tests
+    without going through the legacy ``history.jsonl`` import path.
+    """
+    conn = create_or_open(project_root)
+    try:
+        for record in records:
+            upsert_run_record(conn, record, provenance="native")
+        conn.commit()
+    finally:
+        conn.close()

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -840,6 +840,29 @@ def derive_assignment_history(conn: sqlite3.Connection) -> list[dict]:
         dev_raw = assignments.get("dev")
         dev = dev_raw if isinstance(dev_raw, dict) else {}
         dev_model = dev.get("canonical_id") or dev.get("model")
+        # Fallback: when the audit record lacks the preflight.complexity_routing
+        # block (older audits, or audits seeded by tests that bypass routing),
+        # derive the canonical dev model from cost.agents — the model that
+        # actually ran. provider/model/transport gives the same canonical_id
+        # shape the routing block would have provided.
+        if not (isinstance(dev_model, str) and dev_model):
+            cost_block = record.get("cost") if isinstance(record.get("cost"), dict) else {}
+            agents = cost_block.get("agents") if isinstance(cost_block.get("agents"), list) else []
+            for entry in agents:
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("phase") != "dev" and entry.get("role") != "dev":
+                    continue
+                provider = (entry.get("provider") or "").strip()
+                model = (entry.get("model") or "").strip()
+                cli = (entry.get("cli") or "").strip()
+                if model and provider:
+                    transport = "cli" if cli else "api"
+                    dev_model = f"{provider}/{model}/{transport}"
+                    break
+                if entry.get("name"):
+                    dev_model = str(entry["name"])
+                    break
         if not isinstance(dev_model, str) or not dev_model:
             continue
         timing = record.get("timing") or {}

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -543,9 +543,50 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
     and upserts each into a freshly recreated substrate with
     ``provenance='native'``. Records lacking a ``run_id`` are counted as
     failures (they cannot key the substrate deterministically).
+
+    Legacy rows imported from ``history.jsonl`` (provenance =
+    ``legacy_history_jsonl``) are snapshotted before the destructive
+    rebuild and re-applied afterward. Without this preservation, a
+    runtime stale-rebuild triggered by a deleted/mtime-mismatched
+    per-run file would silently drop historical upgrade data, breaking
+    the contract that imported legacy rows stay visible to migrated
+    readers across normal runtime operations. The legacy import flag
+    is also carried forward so a subsequent operator-driven import is
+    still considered already-done.
     """
     path = substrate_path(project_root)
+    legacy_snapshot: list[tuple[str, str, str | None, float | None]] = []
+    legacy_import_done: str | None = None
     if path.exists():
+        try:
+            existing_conn = sqlite3.connect(str(path))
+            try:
+                existing_conn.row_factory = sqlite3.Row
+                # Best-effort schema apply so the SELECT below works on
+                # older substrates that pre-date columns we touch.
+                _apply_schema(existing_conn)
+                rows = existing_conn.execute(
+                    "SELECT raw_json, provenance, source_path, source_mtime "
+                    "FROM audit_records WHERE provenance = 'legacy_history_jsonl'"
+                ).fetchall()
+                for row in rows:
+                    legacy_snapshot.append(
+                        (
+                            row["raw_json"],
+                            row["provenance"],
+                            row["source_path"],
+                            row["source_mtime"],
+                        )
+                    )
+                legacy_import_done = _meta_get(existing_conn, "legacy_import_done")
+            finally:
+                existing_conn.close()
+        except sqlite3.DatabaseError:
+            # Corrupt substrate — nothing usable to preserve. Operator
+            # must run `forge audits rebuild --include-legacy-history`
+            # explicitly to recover legacy data.
+            legacy_snapshot = []
+            legacy_import_done = None
         path.unlink()
     conn = create_or_open(project_root)
     summary = RebuildSummary()
@@ -577,6 +618,30 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
             except sqlite3.DatabaseError as exc:
                 summary.failed += 1
                 summary.failures.append(f"{run_file.name}: {exc}")
+    # Re-apply preserved legacy rows so a runtime rebuild does not silently
+    # drop history.jsonl-imported records. ``upsert_run_record`` with
+    # provenance=legacy_history_jsonl respects the native-row protection
+    # rule, so any identity collision with a freshly-rebuilt native row
+    # leaves the native row in place.
+    for raw_json, provenance, source_path, source_mtime in legacy_snapshot:
+        try:
+            record = json.loads(raw_json)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        try:
+            upsert_run_record(
+                conn,
+                record,
+                provenance=provenance,
+                source_path=source_path,
+                source_mtime=source_mtime,
+            )
+        except sqlite3.DatabaseError:
+            continue
+    if legacy_import_done is not None:
+        _meta_set(conn, "legacy_import_done", legacy_import_done)
     _meta_set(conn, "last_rebuild_at", _now_iso())
     conn.commit()
     conn.close()
@@ -824,6 +889,28 @@ def iter_escalation_records(conn: sqlite3.Connection) -> Iterable[dict]:
             yield derived
 
 
+_COMPLEXITY_BAND_NORMALIZE = {
+    "small": "LOW",
+    "medium": "MEDIUM",
+    "large": "HIGH",
+    "low": "LOW",
+    "high": "HIGH",
+}
+
+
+def _normalize_complexity_band(value: str) -> str:
+    """Map small/medium/large (and other casing) to LOW/MEDIUM/HIGH.
+
+    Mirrors ``theforge.assignment._normalize_complexity`` so substrate-derived
+    escalation history uses the same key the promotion logic compares against.
+    Empty input returns "" so callers can distinguish "no band recorded" from
+    a normalized band.
+    """
+    if not value:
+        return ""
+    return _COMPLEXITY_BAND_NORMALIZE.get(value.lower(), value.upper())
+
+
 def _derive_escalation(record: dict) -> dict | None:
     """Project an audit record to its escalation-shape projection."""
     task = record.get("task") or {}
@@ -833,7 +920,11 @@ def _derive_escalation(record: dict) -> dict | None:
     if not isinstance(success, bool):
         return None
     preflight = record.get("preflight") if isinstance(record.get("preflight"), dict) else {}
-    complexity = str(preflight.get("complexity") or "").strip()
+    raw_complexity = str(preflight.get("complexity") or "").strip()
+    # Promotion checks compare against LOW/MEDIUM/HIGH (see assignment._normalize_complexity).
+    # Audit records persist the lower-case band (small/medium/large), so normalize on the
+    # projection boundary so two ESCALATE rows for the same model actually match.
+    complexity = _normalize_complexity_band(raw_complexity)
 
     # Canonical dev model identity, derived from the cost.agents block when
     # present (carries provider/model/cli identity per phase).

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1052,21 +1052,26 @@ def _record_run_memory(
         return
 
     # ── Adaptive escalation memory ─────────────────────────────────────
-    # Assignment history is now a derived view over the audit substrate
-    # (#793). The per-run audit record written elsewhere already captures
-    # every fact the legacy .forge/assignment_history.yaml snapshot stored,
-    # so completed stories no longer rewrite that shared snapshot. Inspect
-    # the derived view via ``forge audits export-assignment-history``.
+    # Escalation history is now derived from substrate audit records on read
+    # (see coordinator.escalation_history). The audit record this run produces
+    # carries every field the router needs (slug, preflight.complexity,
+    # outcome.success, dev identity in cost.agents). Assignment history is a
+    # derived view; inspect it via ``forge audits export-assignment-history``.
+    # No separate write to the legacy .forge/assignment_history.yaml snapshot.
+    if config.assignment.escalation_memory and config.agents:
+        _log_verbose(
+            f"[adaptive] escalation memory persisted via audit substrate: "
+            f"story={task.slug} outcome={'DONE' if result.success else 'ESCALATE'}"
+        )
 
     # ── Model capability profiles (independent of escalation_memory) ───
     try:
         from .model_profiles_bridge import update_profiles_from_run  # noqa: PLC0415
 
         _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
-        _history_path = config.project_root / ".forge" / "assignment_history.yaml"
         update_profiles_from_run(
             profiles_path=_profiles_path,
-            history_path=_history_path if _history_path.exists() else None,
+            history_path=None,
             config=config,
             state=state,
             success=result.success,

--- a/src/theforge/coordinator/escalation_history.py
+++ b/src/theforge/coordinator/escalation_history.py
@@ -1,0 +1,61 @@
+"""Escalation history derived from the SQLite audit substrate.
+
+Adaptive routing's promotion logic needs the recent run-by-run outcome
+sequence per (complexity, dev_model) to decide whether a model has earned
+its current tier. Pre-substrate, this lived in
+``.forge/assignment_history.yaml``. Post-migration, the canonical record
+is the audit substrate — escalation records are a projection of audit
+records, not a separate file.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from theforge.assignment import EscalationRecord
+from theforge.coordinator import audit_substrate
+
+log = logging.getLogger(__name__)
+
+
+def load_escalation_history_from_substrate(project_root: Path) -> list[EscalationRecord]:
+    """Return escalation records derived from substrate audit rows.
+
+    Returns an empty list when the substrate is missing or unreadable —
+    adaptive routing degrades to its no-history defaults rather than
+    failing the run. (Operator surface: ``forge check-config`` reports a
+    missing/corrupt substrate; runtime simply behaves as a fresh repo.)
+    """
+    sub_path = audit_substrate.substrate_path(project_root)
+    if not sub_path.exists():
+        if not audit_substrate.has_audit_inputs(project_root):
+            return []
+        log.warning(
+            "[adaptive] audit substrate missing at %s; routing without history. "
+            "Run `forge audits rebuild [--include-legacy-history]` to backfill.",
+            sub_path,
+        )
+        return []
+    try:
+        conn = audit_substrate.require_substrate(project_root)
+    except (audit_substrate.SubstrateMissingError, audit_substrate.SubstrateCorruptError) as exc:
+        log.warning("[adaptive] could not open audit substrate (%s); routing without history", exc)
+        return []
+    try:
+        out: list[EscalationRecord] = []
+        for entry in audit_substrate.iter_escalation_records(conn):
+            out.append(
+                EscalationRecord(
+                    story=str(entry.get("story") or ""),
+                    complexity=str(entry.get("complexity") or ""),
+                    dev_model=str(entry.get("dev_model") or ""),
+                    outcome=str(entry.get("outcome") or ""),
+                    reason=str(entry.get("reason") or ""),
+                    timestamp=str(entry.get("timestamp") or ""),
+                    complexity_score=entry.get("complexity_score"),
+                )
+            )
+        return out
+    finally:
+        conn.close()

--- a/src/theforge/coordinator/escalation_history.py
+++ b/src/theforge/coordinator/escalation_history.py
@@ -10,38 +10,37 @@ records, not a separate file.
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 from theforge.assignment import EscalationRecord
 from theforge.coordinator import audit_substrate
 
-log = logging.getLogger(__name__)
-
 
 def load_escalation_history_from_substrate(project_root: Path) -> list[EscalationRecord]:
     """Return escalation records derived from substrate audit rows.
 
-    Returns an empty list when the substrate is missing or unreadable —
-    adaptive routing degrades to its no-history defaults rather than
-    failing the run. (Operator surface: ``forge check-config`` reports a
-    missing/corrupt substrate; runtime simply behaves as a fresh repo.)
+    Behavior:
+      - Truly fresh repo (no substrate file *and* no legacy/per-run audit
+        inputs) → return ``[]``. Adaptive routing has no history to consume
+        and proceeds with its tier-only defaults.
+      - Substrate present and valid → project escalation rows from the
+        audit table.
+      - Substrate missing or corrupt while audit inputs exist → propagate
+        ``SubstrateMissingError`` / ``SubstrateCorruptError``. The spec
+        requires a clear operator-facing error, not silent no-history
+        routing, when historical data is supposed to be readable.
+
+    The "audit inputs exist" branch is the load-bearing one: if the
+    operator already has runs/*.json or a legacy history.jsonl on disk,
+    routing without that data is a wrong answer, not a degraded-but-OK
+    answer. Surfacing the substrate exception lets the caller (preflight)
+    abort the run rather than make a model-routing decision against a
+    silently-empty history.
     """
     sub_path = audit_substrate.substrate_path(project_root)
-    if not sub_path.exists():
-        if not audit_substrate.has_audit_inputs(project_root):
-            return []
-        log.warning(
-            "[adaptive] audit substrate missing at %s; routing without history. "
-            "Run `forge audits rebuild [--include-legacy-history]` to backfill.",
-            sub_path,
-        )
+    if not sub_path.exists() and not audit_substrate.has_audit_inputs(project_root):
         return []
-    try:
-        conn = audit_substrate.require_substrate(project_root)
-    except (audit_substrate.SubstrateMissingError, audit_substrate.SubstrateCorruptError) as exc:
-        log.warning("[adaptive] could not open audit substrate (%s); routing without history", exc)
-        return []
+    conn = audit_substrate.require_substrate(project_root)
     try:
         out: list[EscalationRecord] = []
         for entry in audit_substrate.iter_escalation_records(conn):

--- a/src/theforge/coordinator/escalation_history.py
+++ b/src/theforge/coordinator/escalation_history.py
@@ -43,7 +43,7 @@ def load_escalation_history_from_substrate(project_root: Path) -> list[Escalatio
     conn = audit_substrate.require_substrate(project_root)
     try:
         out: list[EscalationRecord] = []
-        for entry in audit_substrate.iter_escalation_records(conn):
+        for entry in audit_substrate.derive_assignment_history(conn):
             out.append(
                 EscalationRecord(
                     story=str(entry.get("story") or ""),

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -133,32 +133,6 @@ COMPLEXITY_SCORE_MIN = 1
 COMPLEXITY_SCORE_MAX = 10
 
 
-def _load_esc_history_from_substrate(project_root):  # type: ignore[no-untyped-def]
-    """Derive escalation history from the audit substrate.
-
-    Replaces the legacy ``.forge/assignment_history.yaml`` read with a
-    read-on-demand projection over per-run audit records (#793). Returns
-    ``[]`` for fresh repos with no audit inputs at all, or when the
-    substrate cannot be opened — adaptive routing degrades to the same
-    "no prior history" behavior as a missing YAML.
-    """
-    from theforge.assignment import escalation_records_from_dicts  # noqa: PLC0415
-    from theforge.coordinator import audit_substrate  # noqa: PLC0415
-
-    if not audit_substrate.has_audit_inputs(project_root):
-        return []
-    try:
-        conn = audit_substrate.require_substrate(project_root)
-    except audit_substrate.SubstrateError as exc:
-        _log.warning("[adaptive] Could not open audit substrate: %s", exc)
-        return []
-    try:
-        dicts = audit_substrate.derive_assignment_history(conn)
-    finally:
-        conn.close()
-    return escalation_records_from_dicts(dicts)
-
-
 def score_to_band(score: int) -> str:
     """Map a 1-10 complexity score to the legacy small/medium/large enum.
 
@@ -929,8 +903,11 @@ def _apply_preflight_config(
         DEFAULT_DEV_PROFILE as _DEF_DEV,
         DEFAULT_PREFLIGHT_PROFILE as _DEF_PRE,
     )
+    from theforge.coordinator.escalation_history import (  # noqa: PLC0415
+        load_escalation_history_from_substrate as _load_esc_history_substrate,
+    )
 
-    _esc_history = _load_esc_history_from_substrate(config.project_root)
+    _esc_history = _load_esc_history_substrate(config.project_root)
 
     from theforge.model_profiles import load_profiles as _load_profiles  # noqa: PLC0415
 

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -561,14 +560,6 @@ def _write_sprint_audit(
     audit_path = audits_dir / "sprint-audit.yaml"
     with open(audit_path, "w", encoding="utf-8") as f:
         yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
-    # Append to history log (JSONL, never overwritten). Deletion of this
-    # writer is deferred to the v0.12 cycle (#797); the substrate is the
-    # canonical read path now.
-    try:
-        with open(audits_dir / "history.jsonl", "a", encoding="utf-8") as f:
-            f.write(json.dumps(audit, default=str) + "\n")
-    except OSError:
-        pass
     _upsert_into_substrate(project_root, audit)
     _log(f"Audit written: {audit_path}")
 
@@ -965,11 +956,6 @@ def _write_story_audit(
 
     audits_dir = config.project_root / ".forge" / "audits"
     audits_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        with open(audits_dir / "history.jsonl", "a", encoding="utf-8") as f:
-            f.write(json.dumps(audit_data, default=str) + "\n")
-    except OSError:
-        pass
     _upsert_into_substrate(config.project_root, audit_data)
 
     log_dir = result.state.log_dir

--- a/tests/test_adaptive_iterations.py
+++ b/tests/test_adaptive_iterations.py
@@ -365,3 +365,54 @@ def test_budget_headroom_concrete_large_scenario(tmp_path: Path):
     assert result.dev_budget_usd >= 8.44, (
         f"Budget {result.dev_budget_usd:.4f} would have escalated the $8.44 run from issue #1148"
     )
+
+
+def test_read_history_tail_raises_when_substrate_missing_with_legacy(tmp_path: Path):
+    """Legacy history.jsonl present, substrate absent → operator-facing error.
+
+    Adaptive iteration must not silently fall back to no-history routing
+    when audit inputs exist on disk; the spec mandates a clear
+    SubstrateMissingError so the operator runs `forge audits rebuild
+    --include-legacy-history`.
+    """
+    import pytest
+
+    from theforge.coordinator import audit_substrate
+    from theforge.coordinator.adaptive_iterations import _read_history_tail
+
+    audits = tmp_path / ".forge" / "audits"
+    audits.mkdir(parents=True)
+    (audits / "history.jsonl").write_text('{"run_id": "x"}\n', encoding="utf-8")
+
+    with pytest.raises(audit_substrate.SubstrateMissingError):
+        _read_history_tail(tmp_path)
+
+
+def test_read_history_tail_returns_empty_for_truly_fresh_repo(tmp_path: Path):
+    """No substrate, no audit inputs → empty list (the legitimate fresh-repo path)."""
+    from theforge.coordinator.adaptive_iterations import _read_history_tail
+
+    assert _read_history_tail(tmp_path) == []
+
+
+def test_read_history_tail_reads_native_substrate_rows(tmp_path: Path):
+    """Substrate-only fixture: native rows surface as story-level history records."""
+    from theforge.coordinator import audit_substrate
+    from theforge.coordinator.adaptive_iterations import _read_history_tail
+
+    audit_substrate.seed_records(
+        tmp_path,
+        [
+            {
+                "run_id": "rec-1",
+                "task": {"slug": "story-a"},
+                "outcome": {"success": True, "final_phase": "DONE"},
+                "timing": {"started_at": "2026-04-01T10:00:00+00:00"},
+                "preflight": {"complexity": "medium", "complexity_score": 5},
+                "iterations": {"dev_iterations_productive": 2, "review_cycles_total": 1},
+            }
+        ],
+    )
+    records = _read_history_tail(tmp_path)
+    assert len(records) == 1
+    assert records[0]["run_id"] == "rec-1"

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -351,3 +351,184 @@ class TestQueryHelpers:
         assert len(with_landed) == 1
         assert with_landed[0]["run_id"] == "r1"
         assert len(without) == 2
+
+
+class TestEscalationProjection:
+    """The substrate→escalation projection feeds adaptive routing's promotion logic."""
+
+    def _make_run(
+        self,
+        *,
+        run_id: str,
+        slug: str,
+        complexity_band: str,
+        success: bool,
+        provider: str = "anthropic",
+        model: str = "sonnet",
+        cli: str = "claude",
+        started_at: str = "2026-03-01T10:00:00+00:00",
+    ) -> dict:
+        return {
+            "run_id": run_id,
+            "task": {"slug": slug},
+            "outcome": {"success": success, "final_phase": "DONE" if success else "ESCALATE"},
+            "timing": {"started_at": started_at, "duration_seconds": 1.0},
+            "preflight": {"complexity": complexity_band, "complexity_score": 5},
+            "cost": {
+                "total_usd": 1.0,
+                "agents": [
+                    {
+                        "phase": "dev",
+                        "provider": provider,
+                        "model": model,
+                        "cli": cli,
+                        "name": "dev",
+                    }
+                ],
+            },
+        }
+
+    def test_complexity_normalized_to_promotion_keys(self, tmp_path: Path) -> None:
+        """Lower-case audit bands (small/medium/large) project to LOW/MEDIUM/HIGH."""
+        conn = sub.create_or_open(tmp_path)
+        try:
+            for i, band in enumerate(("small", "medium", "large")):
+                sub.upsert_run_record(
+                    conn,
+                    self._make_run(
+                        run_id=f"r{i}",
+                        slug=f"s{i}",
+                        complexity_band=band,
+                        success=False,
+                        started_at=f"2026-03-0{i + 1}T10:00:00+00:00",
+                    ),
+                    provenance="native",
+                )
+            conn.commit()
+            projected = list(sub.iter_escalation_records(conn))
+        finally:
+            conn.close()
+        complexities = [p["complexity"] for p in projected]
+        assert complexities == ["LOW", "MEDIUM", "HIGH"]
+
+    def test_promotion_fires_from_two_substrate_escalations(self, tmp_path: Path) -> None:
+        """Two substrate ESCALATE rows for the same model trigger _check_promotion.
+
+        Regression guard: pre-fix the projection emitted ``medium`` while the
+        promotion comparator used ``MEDIUM``, so the rows never matched.
+        """
+        from theforge.assignment import _check_promotion
+        from theforge.coordinator.escalation_history import (
+            load_escalation_history_from_substrate,
+        )
+
+        conn = sub.create_or_open(tmp_path)
+        try:
+            for i in range(2):
+                sub.upsert_run_record(
+                    conn,
+                    self._make_run(
+                        run_id=f"esc-{i}",
+                        slug=f"story-{i}",
+                        complexity_band="medium",
+                        success=False,
+                        started_at=f"2026-03-0{i + 1}T10:00:00+00:00",
+                    ),
+                    provenance="native",
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        history = load_escalation_history_from_substrate(tmp_path)
+        # All projected rows agree on the canonical dev model identity.
+        assert all(r.dev_model == "anthropic/sonnet/cli" for r in history)
+        result = _check_promotion(
+            "MEDIUM",
+            "anthropic/sonnet/cli",
+            history,
+            sprint_promotions=None,
+            dev_canonical_id="anthropic/sonnet/cli",
+        )
+        assert result == "promoted"
+
+
+class TestLoaderFailsLoudWhenAuditInputsExist:
+    """Adaptive routing must not silently degrade when audit inputs say history exists."""
+
+    def test_loader_raises_when_substrate_missing_with_legacy_history(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy history.jsonl on disk + missing substrate → operator-facing error."""
+        from theforge.coordinator.escalation_history import (
+            load_escalation_history_from_substrate,
+        )
+
+        _write_history(tmp_path, [_make_record(run_id="r1")])
+        with pytest.raises(sub.SubstrateMissingError):
+            load_escalation_history_from_substrate(tmp_path)
+
+    def test_loader_raises_on_corrupt_substrate(self, tmp_path: Path) -> None:
+        """Corrupt substrate must not silently route without history."""
+        from theforge.coordinator.escalation_history import (
+            load_escalation_history_from_substrate,
+        )
+
+        path = sub.substrate_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"not a sqlite file" * 50)
+        with pytest.raises(sub.SubstrateCorruptError):
+            load_escalation_history_from_substrate(tmp_path)
+
+    def test_loader_returns_empty_for_truly_fresh_repo(self, tmp_path: Path) -> None:
+        """No substrate, no audit inputs → empty list (legitimate fresh-repo path)."""
+        from theforge.coordinator.escalation_history import (
+            load_escalation_history_from_substrate,
+        )
+
+        assert load_escalation_history_from_substrate(tmp_path) == []
+
+
+class TestRebuildPreservesLegacyRows:
+    """Runtime stale-rebuild must not silently drop history.jsonl-imported records."""
+
+    def test_legacy_rows_survive_runtime_rebuild(self, tmp_path: Path) -> None:
+        # Bootstrap: import legacy history once via the operator path.
+        legacy = _make_record(run_id="legacy-r1", slug="legacy-slug")
+        _write_history(tmp_path, [legacy])
+        sub.import_history_jsonl(tmp_path)
+        # Confirm the row is present with legacy provenance.
+        conn = sqlite3.connect(str(sub.substrate_path(tmp_path)))
+        try:
+            count_before = conn.execute(
+                "SELECT COUNT(*) FROM audit_records WHERE provenance = 'legacy_history_jsonl'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count_before == 1
+
+        # Now write a native run and trigger a stale-rebuild by mutating the
+        # native source file's mtime so require_substrate's stale check fires.
+        _write_runs(tmp_path, [_make_record(run_id="native-r1", slug="native-slug")])
+        # First require_substrate: rebuilds, indexes the native row.
+        sub.require_substrate(tmp_path).close()
+        # Bump mtime to force a stale check on the next call.
+        run_file = sub.runs_dir(tmp_path) / "native-r1.json"
+        new_mtime = run_file.stat().st_mtime + 10.0
+        import os
+
+        os.utime(run_file, (new_mtime, new_mtime))
+        # Second require_substrate: detects mtime mismatch, rebuilds. Legacy
+        # rows must survive.
+        conn = sub.require_substrate(tmp_path)
+        try:
+            legacy_after = conn.execute(
+                "SELECT raw_json FROM audit_records WHERE provenance = 'legacy_history_jsonl'"
+            ).fetchall()
+            native_after = conn.execute(
+                "SELECT COUNT(*) FROM audit_records WHERE provenance = 'native'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert len(legacy_after) == 1, "legacy row was dropped by runtime rebuild"
+        assert native_after == 1

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -212,17 +212,18 @@ class TestRequireSubstrate:
         with pytest.raises(sub.SubstrateMissingError):
             sub.require_substrate(tmp_path)
 
-    def test_legacy_history_present_auto_imports(self, tmp_path: Path) -> None:
+    def test_legacy_history_alone_raises_no_silent_import(self, tmp_path: Path) -> None:
+        """Substrate missing + only legacy history.jsonl → operator-facing error.
+
+        Runtime readers must never silently fall back to history.jsonl.
+        Recovery requires `forge audits rebuild --include-legacy-history`.
+        """
         _write_history(tmp_path, [_make_record(run_id="r1")])
-        conn = sub.require_substrate(tmp_path)
-        try:
-            count = sub.count_records(conn)
-            row = conn.execute("SELECT value FROM meta WHERE key='legacy_import_done'").fetchone()
-        finally:
-            conn.close()
-        assert count == 1
-        assert row is not None
-        assert (row[0] if not isinstance(row, sqlite3.Row) else row["value"]) == "1"
+        with pytest.raises(sub.SubstrateMissingError) as exc_info:
+            sub.require_substrate(tmp_path)
+        msg = str(exc_info.value)
+        assert "history.jsonl" in msg
+        assert "include-legacy-history" in msg
 
     def test_corrupt_substrate_raises(self, tmp_path: Path) -> None:
         path = sub.substrate_path(tmp_path)

--- a/tests/test_cli_audit_per_run.py
+++ b/tests/test_cli_audit_per_run.py
@@ -74,20 +74,18 @@ class TestPerRunFileWrite:
         if runs_dir.exists():
             assert list(runs_dir.iterdir()) == []
 
-    def test_history_jsonl_still_appended(self, tmp_path: Path) -> None:
-        """Dual-write: history.jsonl must also be appended."""
+    def test_history_jsonl_no_longer_written(self, tmp_path: Path) -> None:
+        """Substrate is the canonical write path; legacy history.jsonl is gone."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
-        result = _make_result(tmp_path, run_id="run-dual-write")
+        result = _make_result(tmp_path, run_id="run-substrate-only")
 
         _write_audit(result, config, task)
 
         history_path = tmp_path / ".forge" / "audits" / "history.jsonl"
-        assert history_path.exists(), "history.jsonl should still be appended"
-        lines = history_path.read_text().strip().splitlines()
-        assert len(lines) == 1
-        record = json.loads(lines[0])
-        assert isinstance(record, dict)
+        assert not history_path.exists(), (
+            "history.jsonl must NOT be written — substrate is the canonical write path"
+        )
 
     def test_two_separate_run_ids_produce_distinct_files(self, tmp_path: Path) -> None:
         """Two runs with different run_ids must produce two distinct files."""

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -332,56 +332,135 @@ class TestStopWritesTerminalMarker:
 # ── Race window: run starts between scans ────────────────────────────────────
 
 
-class TestShowRecentRunsRaceWindow:
-    """_show_recent_runs must not label a live run as orphaned.
+class TestShowRecentRunsFromSubstrate:
+    """_show_recent_runs sources its historical run list from the SQLite substrate.
 
-    Regression for: a run that starts between list_active_runs and the log
-    file scan would have a .pid file but no .ended file and should be shown
-    as 'active', not 'orphaned'.
+    Pre-migration, the recent-list scanned ``.forge/logs/*.log`` and inferred
+    status from PID/.ended markers. Post-migration the substrate is canonical:
+    runs only show up here when they have a substrate audit row, and legacy
+    rows imported via ``forge audits rebuild --include-legacy-history`` are
+    visible alongside native rows.
     """
 
-    def test_run_with_pid_file_but_no_ended_shows_active(
-        self, tmp_path: Path, capsys: object
-    ) -> None:
+    def test_substrate_completed_run_shown(self, tmp_path: Path, capsys: object) -> None:
         from theforge.cli.status import _show_recent_runs
+        from theforge.coordinator import audit_substrate
 
-        # Create a log file so the run appears in the historical scan.
-        log_dir = tmp_path / ".forge" / "logs" / "issues-test"
-        log_dir.mkdir(parents=True)
-        (log_dir / "run-abcd1234.log").write_text("starting\n")
-
-        # Simulate a PID file present (run started after initial active scan).
-        runs_dir = tmp_path / ".forge" / "runs"
-        runs_dir.mkdir(parents=True)
-        (runs_dir / "abcd1234.pid").write_text("99999\nissues-test\n")
-
-        # No .ended file — process is alive but appeared after list_active_runs.
-        with patch("theforge.detach.list_active_runs", return_value=[]):
-            _show_recent_runs(tmp_path)
-
-        out = capsys.readouterr().out
-        assert "active" in out, f"Expected 'active' in output, got:\n{out}"
-        assert "orphaned" not in out, f"Unexpected 'orphaned' in output:\n{out}"
-
-    def test_run_without_pid_file_and_no_ended_shows_orphaned(
-        self, tmp_path: Path, capsys: object
-    ) -> None:
-        from theforge.cli.status import _show_recent_runs
-
-        # Create a log file so the run appears in the historical scan.
-        log_dir = tmp_path / ".forge" / "logs" / "issues-test"
-        log_dir.mkdir(parents=True)
-        (log_dir / "run-dead1234.log").write_text("starting\n")
-
-        # No PID file, no .ended file — truly orphaned.
-        runs_dir = tmp_path / ".forge" / "runs"
-        runs_dir.mkdir(parents=True)
+        audit_substrate.seed_records(
+            tmp_path,
+            [
+                {
+                    "run_id": "abcd1234",
+                    "task": {"slug": "issues-test"},
+                    "outcome": {"success": True, "final_phase": "DONE"},
+                    "timing": {
+                        "started_at": "2026-04-01T10:00:00+00:00",
+                        "finished_at": "2026-04-01T10:01:00+00:00",
+                        "duration_seconds": 60.0,
+                    },
+                    "totals": {"cost_usd": 1.50, "duration_s": 60.0},
+                }
+            ],
+        )
 
         with patch("theforge.detach.list_active_runs", return_value=[]):
             _show_recent_runs(tmp_path)
 
         out = capsys.readouterr().out
-        assert "orphaned" in out, f"Expected 'orphaned' in output, got:\n{out}"
+        assert "abcd1234" in out, f"Substrate row missing from output:\n{out}"
+        assert "completed" in out
+        assert "single" in out
+
+    def test_substrate_sprint_row_shown(self, tmp_path: Path, capsys: object) -> None:
+        from theforge.cli.status import _show_recent_runs
+        from theforge.coordinator import audit_substrate
+
+        audit_substrate.seed_records(
+            tmp_path,
+            [
+                {
+                    "run_id": "sprint-001",
+                    "sprint": {
+                        "sprint_id": "sprint-001",
+                        "total_cost_usd": 7.42,
+                        "duration_seconds": 360.0,
+                    },
+                    "outcome": {"success": True, "final_phase": "DONE"},
+                    "timing": {"started_at": "2026-04-02T10:00:00+00:00"},
+                }
+            ],
+        )
+
+        with patch("theforge.detach.list_active_runs", return_value=[]):
+            _show_recent_runs(tmp_path)
+
+        out = capsys.readouterr().out
+        assert "sprint-001" in out
+        assert "sprint" in out
+        assert "completed" in out
+
+    def test_active_run_overlays_substrate(self, tmp_path: Path, capsys: object) -> None:
+        """Active runs (PID-file-backed) take precedence over the substrate row for the same id."""
+        from theforge.cli.status import _show_recent_runs
+        from theforge.coordinator import audit_substrate
+
+        audit_substrate.seed_records(
+            tmp_path,
+            [
+                {
+                    "run_id": "live01",
+                    "task": {"slug": "issues-test"},
+                    "outcome": {"success": True, "final_phase": "DONE"},
+                    "timing": {"started_at": "2026-04-01T09:00:00+00:00"},
+                    "totals": {"cost_usd": 1.0, "duration_s": 60.0},
+                }
+            ],
+        )
+
+        active = [{"run_id": "live01", "slug": "issues-test"}]
+        status = {"cost_usd": 0.25, "elapsed_seconds": 30.0}
+        with (
+            patch("theforge.detach.list_active_runs", return_value=active),
+            patch("theforge.detach.read_run_status", return_value=status),
+            patch("theforge.cli.status._is_sprint_run", return_value=False),
+        ):
+            _show_recent_runs(tmp_path)
+
+        out = capsys.readouterr().out
+        assert "live01" in out
+        # The active overlay's status string is the one that surfaces.
+        assert "active" in out
+        # And the substrate's "completed" string for the same id is suppressed.
+        assert out.count("live01") == 1
+
+    def test_no_substrate_no_audit_inputs_prints_no_runs(
+        self, tmp_path: Path, capsys: object
+    ) -> None:
+        from theforge.cli.status import _show_recent_runs
+
+        with patch("theforge.detach.list_active_runs", return_value=[]):
+            rc = _show_recent_runs(tmp_path)
+        assert rc == 0
+        assert "No recent runs found." in capsys.readouterr().out
+
+    def test_substrate_missing_with_legacy_inputs_warns(
+        self, tmp_path: Path, capsys: object
+    ) -> None:
+        """Legacy history.jsonl present, substrate absent: show warning, not silent fallback."""
+        from theforge.cli.status import _show_recent_runs
+
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True)
+        (audits / "history.jsonl").write_text(
+            '{"run_id": "leg01", "task": {"slug": "x"}}\n', encoding="utf-8"
+        )
+
+        with patch("theforge.detach.list_active_runs", return_value=[]):
+            _show_recent_runs(tmp_path)
+
+        captured = capsys.readouterr()
+        assert "historical runs unavailable" in captured.err
+        assert "include-legacy-history" in captured.err
 
 
 # ── Parser-level coverage ─────────────────────────────────────────────────────

--- a/tests/test_coord_audit.py
+++ b/tests/test_coord_audit.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -18,11 +17,28 @@ from coord_test_helpers import (
     _shell_with_gate,
 )
 
+from theforge.coordinator import audit_substrate
 from theforge.coordinator.audit import generate_audit_log, has_review_approve
 from theforge.coordinator.engine import run_task
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.runners import AgentResult
 from theforge.task import TaskStory
+
+
+def _seed_substrate(project_root: Path, records: list[dict]) -> None:
+    """Stamp a run_id on each record (when missing) and write it to the substrate.
+
+    The runtime substrate read path does not auto-import history.jsonl any
+    more; tests bootstrap by writing native rows directly.
+    """
+    stamped = []
+    for i, rec in enumerate(records):
+        if not isinstance(rec, dict):
+            continue
+        copy = dict(rec)
+        copy.setdefault("run_id", f"test-run-{i:04d}")
+        stamped.append(copy)
+    audit_substrate.seed_records(project_root, stamped)
 
 
 def _make_result(state: CoordinatorState) -> CoordinatorResult:
@@ -120,53 +136,45 @@ class TestDurationAndCostNoneChecks:
 
 class TestHasReviewApprove:
     def test_no_history_file(self, tmp_path: Path) -> None:
-        """Missing history.jsonl returns False (safe default)."""
+        """Fresh repo (no audit inputs) returns False (safe default)."""
         assert has_review_approve(tmp_path, "my-spec") is False
 
-    def test_empty_history_file(self, tmp_path: Path) -> None:
-        """Empty history.jsonl returns False."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
-        (audits / "history.jsonl").write_text("", encoding="utf-8")
+    def test_empty_substrate(self, tmp_path: Path) -> None:
+        """Substrate exists but has no rows: returns False."""
+        _seed_substrate(tmp_path, [])
+        # Nothing seeded — touch the audits dir so has_audit_inputs evaluates the substrate path
+        audit_substrate.create_or_open(tmp_path).close()
         assert has_review_approve(tmp_path, "my-spec") is False
 
     def test_approve_present(self, tmp_path: Path) -> None:
         """Returns True when a matching slug has an APPROVE review."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec", "name": "My Spec"},
             "reviews": [{"cycle": 1, "verdict": "APPROVE", "summary": "Good"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec") is True
 
     def test_no_approve_request_changes(self, tmp_path: Path) -> None:
         """Returns False when reviews exist but none are APPROVE."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec", "name": "My Spec"},
             "reviews": [{"cycle": 1, "verdict": "REQUEST_CHANGES", "summary": "Fix this"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec") is False
 
     def test_approve_for_different_slug(self, tmp_path: Path) -> None:
         """Returns False when APPROVE exists but for a different slug."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "other-spec", "name": "Other Spec"},
             "reviews": [{"cycle": 1, "verdict": "APPROVE", "summary": "Good"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec") is False
 
     def test_approve_in_second_record(self, tmp_path: Path) -> None:
         """Returns True when APPROVE is in second record, first has REQUEST_CHANGES."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         rec1 = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "REQUEST_CHANGES"}],
@@ -175,73 +183,50 @@ class TestHasReviewApprove:
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        content = json.dumps(rec1) + "\n" + json.dumps(rec2) + "\n"
-        (audits / "history.jsonl").write_text(content, encoding="utf-8")
+        _seed_substrate(tmp_path, [rec1, rec2])
         assert has_review_approve(tmp_path, "my-spec") is True
 
     def test_no_reviews_key(self, tmp_path: Path) -> None:
         """Returns False when record has no 'reviews' key (e.g. ALREADY_DONE run)."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {"task": {"slug": "my-spec"}, "outcome": {"final_phase": "DONE"}}
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec") is False
-
-    def test_malformed_json_line_skipped(self, tmp_path: Path) -> None:
-        """Malformed JSON lines are skipped; valid lines still checked."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
-        record = {
-            "task": {"slug": "my-spec"},
-            "reviews": [{"verdict": "APPROVE"}],
-        }
-        content = "not-valid-json\n" + json.dumps(record) + "\n"
-        (audits / "history.jsonl").write_text(content, encoding="utf-8")
-        assert has_review_approve(tmp_path, "my-spec") is True
 
     def test_empty_reviews_list(self, tmp_path: Path) -> None:
         """Returns False when reviews list is empty."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {"task": {"slug": "my-spec"}, "reviews": []}
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec") is False
 
     def test_stale_approve_branch_ahead(self, tmp_path: Path) -> None:
         """Returns False when APPROVE exists but branch has unmerged commits (abandoned run)."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"3\n", stderr=b"")
         with patch("theforge.coordinator.audit.subprocess.run", return_value=mock_result):
             assert has_review_approve(tmp_path, "my-spec", "main") is False
 
     def test_valid_approve_branch_merged(self, tmp_path: Path) -> None:
         """Returns True when APPROVE exists and branch is merged (0 commits ahead)."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"0\n", stderr=b"")
         with patch("theforge.coordinator.audit.subprocess.run", return_value=mock_result):
             assert has_review_approve(tmp_path, "my-spec", "main") is True
 
     def test_valid_approve_branch_absent(self, tmp_path: Path) -> None:
         """Returns True when APPROVE exists and branch is absent (non-zero git exit)."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         mock_result = subprocess.CompletedProcess(
             args=[], returncode=128, stdout=b"", stderr=b"unknown revision"
         )
@@ -250,87 +235,72 @@ class TestHasReviewApprove:
 
     def test_require_landed_rejects_failed_landing(self, tmp_path: Path) -> None:
         """Landed-only mode ignores APPROVE records whose landing failed."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "landing_status": "failed",
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec", require_landed=True) is False
 
     def test_require_landed_accepts_landed_approve(self, tmp_path: Path) -> None:
         """Landed-only mode keeps working for APPROVE records that actually landed."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "landing_status": "landed",
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec", require_landed=True) is True
 
     def test_no_approve_record_with_base_branch(self, tmp_path: Path) -> None:
         """Returns False when no APPROVE record exists (baseline for new signature)."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "REQUEST_CHANGES"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         assert has_review_approve(tmp_path, "my-spec", "main") is False
 
     def test_stale_approve_subprocess_timeout(self, tmp_path: Path) -> None:
         """Returns True (treat as valid) when git subprocess times out."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         with patch(
             "theforge.coordinator.audit.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd="git", timeout=30),
         ):
-            # Timeout → helper returns False → APPROVE is not stale → True
             assert has_review_approve(tmp_path, "my-spec", "main") is True
 
     def test_stale_approve_non_integer_output(self, tmp_path: Path) -> None:
         """Returns True (treat as valid) when git outputs non-integer."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         mock_result = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=b"not-a-number\n", stderr=b""
         )
         with patch("theforge.coordinator.audit.subprocess.run", return_value=mock_result):
-            # ValueError from int() → helper returns False → APPROVE is not stale → True
             assert has_review_approve(tmp_path, "my-spec", "main") is True
 
     def test_custom_branch_pattern_passed_to_helper(self, tmp_path: Path) -> None:
         """Branch name is forwarded to git — verifies non-default branch patterns work."""
-        audits = tmp_path / ".forge" / "audits"
-        audits.mkdir(parents=True)
         record = {
             "task": {"slug": "my-spec"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        _seed_substrate(tmp_path, [record])
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"0\n", stderr=b"")
         with patch(
             "theforge.coordinator.audit.subprocess.run", return_value=mock_result
         ) as mock_run:
             result = has_review_approve(tmp_path, "my-spec", "main", branch="forge/my-spec")
         assert result is True
-        # Verify the custom branch pattern was used in the git command
         call_args = mock_run.call_args[0][0]
         assert any("forge/my-spec" in arg for arg in call_args)
 
@@ -742,7 +712,8 @@ class TestAuditStartStopPhase:
 
 
 class TestSprintStoryAuditHistory:
-    def test_write_story_audit_appends_history_jsonl(self, tmp_path: Path) -> None:
+    def test_write_story_audit_persists_to_substrate(self, tmp_path: Path) -> None:
+        """Story audit goes into the SQLite substrate; legacy history.jsonl is gone."""
         from theforge.sprint.audit import _write_story_audit
 
         config = _make_config(tmp_path)
@@ -752,19 +723,17 @@ class TestSprintStoryAuditHistory:
         state.workspace_path = tmp_path / task.slug
         state.workspace_path.mkdir(parents=True)
         state.branch_name = f"forge/{task.slug}"
+        state.run_id = "test-run-001"
         result = CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="done")
 
         _write_story_audit(config, task, result)
 
+        # Substrate is the canonical write path — substrate file must exist.
+        sub_path = audit_substrate.substrate_path(tmp_path)
+        assert sub_path.exists()
+        # Legacy jsonl path must NOT be written.
         history_path = tmp_path / ".forge" / "audits" / "history.jsonl"
-        assert history_path.exists()
-        records = [
-            json.loads(line)
-            for line in history_path.read_text(encoding="utf-8").splitlines()
-            if line
-        ]
-        assert len(records) == 1
-        assert records[0]["task"]["slug"] == task.slug
+        assert not history_path.exists()
 
     def test_write_story_audit_logs_generate_failure(self, tmp_path: Path, capsys) -> None:
         from theforge.sprint.audit import _write_story_audit

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -650,8 +650,13 @@ def test_record_run_memory_is_called_from_resume_path(tmp_path):
     assert source.count("_record_run_memory(") >= 3  # 1 def + 2 calls
 
 
-def test_record_run_memory_writes_profiles_and_skips_history(tmp_path):
-    """Helper writes model_profiles.yaml; assignment_history snapshot is dropped (#793)."""
+def test_record_run_memory_writes_profiles_and_no_legacy_history(tmp_path):
+    """Helper writes model_profiles.yaml; legacy assignment_history.yaml is NOT written.
+
+    Escalation memory now flows through the audit substrate (each run writes a
+    canonical audit row; escalation history is derived from those rows). This
+    test guards against regressing back to the old YAML-write path.
+    """
     from dataclasses import replace as _replace
 
     from theforge.coordinator.engine import _record_run_memory

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -358,10 +358,15 @@ class TestDevModelEscalationIntegration:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_done_path_does_not_write_assignment_history_snapshot(
+    def test_done_path_records_escalation_via_substrate_without_import_error(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """DONE with escalation memory no longer rewrites the YAML snapshot (#793)."""
+        """DONE with agents + escalation memory persists outcome via the audit substrate.
+
+        Pre-migration this wrote ``.forge/assignment_history.yaml``. Post-migration
+        the audit substrate is the canonical store and escalation history is a
+        projection of audit rows.
+        """
         config = replace(
             _make_config(tmp_path),
             agents=[
@@ -397,11 +402,21 @@ class TestDevModelEscalationIntegration:
         result = run_task(config, task, cached_preflight_state=cached_state)
 
         assert result.success is True
+        # Legacy YAML file is NOT written — substrate is canonical now.
         history_path = tmp_path / ".forge" / "assignment_history.yaml"
         assert not history_path.exists(), (
             "assignment_history.yaml is now derived from the audit substrate; "
             "completed runs must not rewrite the shared snapshot (#793)."
         )
+        # The substrate-derived loader must run without raising even when no
+        # substrate row exists yet (run_task does not itself flush to disk;
+        # the CLI _write_audit path or sprint runner does that).
+        from theforge.coordinator.escalation_history import (
+            load_escalation_history_from_substrate,
+        )
+
+        records = load_escalation_history_from_substrate(tmp_path)
+        assert isinstance(records, list)
 
     def test_coordinator_never_imports_assignment_from_coordinator_package(self):
         """Assignment helpers live at theforge.assignment, not the coordinator package."""

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -20,6 +20,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.coordinator import audit_substrate
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint import run_sprint
 from theforge.sprint.dag import StoryTriage, _triage_spec
@@ -340,7 +341,6 @@ class TestReadPriorSprintCost:
         self, tmp_path: Path
     ) -> None:
         """Missing worktree plus audit-backed squash-merged branch is treated as merged."""
-        import json
 
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         config = _make_config(tmp_path)
@@ -352,7 +352,8 @@ class TestReadPriorSprintCost:
             "landing_status": "landed",
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        record.setdefault("run_id", "sr-rec")
+        audit_substrate.seed_records(tmp_path, [record])
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
@@ -420,7 +421,6 @@ class TestReadPriorSprintCost:
 
     def test_triage_same_tip_failed_landing_audit_stays_full(self, tmp_path: Path) -> None:
         """A zero-delta APPROVE with failed landing stays eligible during resume."""
-        import json
 
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         config = _make_config(tmp_path)
@@ -432,7 +432,8 @@ class TestReadPriorSprintCost:
             "landing_status": "failed",
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        record.setdefault("run_id", "sr-rec")
+        audit_substrate.seed_records(tmp_path, [record])
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
@@ -460,7 +461,6 @@ class TestReadPriorSprintCost:
         self, tmp_path: Path
     ) -> None:
         """Same-tip branch with audit-backed FF merge should still skip_merged."""
-        import json
 
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         config = _make_config(tmp_path)
@@ -475,7 +475,8 @@ class TestReadPriorSprintCost:
             "landing_status": "landed",
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        record.setdefault("run_id", "sr-rec")
+        audit_substrate.seed_records(tmp_path, [record])
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
@@ -501,7 +502,6 @@ class TestReadPriorSprintCost:
 
     def test_triage_open_issue_with_landed_audit_stays_full(self, tmp_path: Path) -> None:
         """An open issue is contradictory evidence and must not be skipped as merged."""
-        import json
 
         _make_spec_file(tmp_path, "Issue 1071", "issue-1071")
         config = _make_config(tmp_path)
@@ -513,7 +513,8 @@ class TestReadPriorSprintCost:
             "landing_status": "landed",
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        record.setdefault("run_id", "sr-rec")
+        audit_substrate.seed_records(tmp_path, [record])
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
@@ -542,7 +543,6 @@ class TestReadPriorSprintCost:
 
     def test_triage_worktree_with_prior_approve(self, tmp_path: Path) -> None:
         """Worktree has commits ahead and prior APPROVE in audit trail → skip."""
-        import json
 
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         config = _make_config(tmp_path)
@@ -557,7 +557,8 @@ class TestReadPriorSprintCost:
             "task": {"slug": "feature-a"},
             "reviews": [{"verdict": "APPROVE"}],
         }
-        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        record.setdefault("run_id", "sr-rec")
+        audit_substrate.seed_records(tmp_path, [record])
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
@@ -608,7 +609,6 @@ class TestReadPriorSprintCost:
 class TestResumeSprintSkipApproved:
     def test_resume_sprint_skips_approved(self, tmp_path: Path) -> None:
         """Resume sprint: spec with prior APPROVE is treated as already satisfied."""
-        import json
 
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
@@ -621,7 +621,8 @@ class TestResumeSprintSkipApproved:
         audits_dir = tmp_path / ".forge" / "audits"
         audits_dir.mkdir(parents=True)
         record = {"task": {"slug": "feature-a"}, "reviews": [{"verdict": "APPROVE"}]}
-        (audits_dir / "history.jsonl").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        record.setdefault("run_id", "sr-rec")
+        audit_substrate.seed_records(tmp_path, [record])
 
         skip_triage = StoryTriage(
             story_path="feature-a.md",

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -449,9 +449,9 @@ class TestRunIdRolloverReporting:
 
         assert sprint_id_first == sprint_id_second
 
-    def test_history_jsonl_includes_sprint_id(self, tmp_path: Path) -> None:
-        """history.jsonl entries include sprint_id when it is set."""
-        import json
+    def test_substrate_audit_record_includes_sprint_id(self, tmp_path: Path) -> None:
+        """Audit substrate rows carry sprint_id alongside the audit record."""
+        from theforge.coordinator import audit_substrate
 
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
@@ -464,16 +464,20 @@ class TestRunIdRolloverReporting:
         with patch("theforge.sprint.runner.run_task", return_value=result_a):
             run_sprint(config, manifest_path, run_id="run-a-test")
 
-        history_path = tmp_path / ".forge" / "audits" / "history.jsonl"
-        assert history_path.exists()
-        lines = [
-            json.loads(line) for line in history_path.read_text(encoding="utf-8").splitlines()
-        ]
-
-        # Sprint-level audit entry should have sprint_id
-        sprint_entries = [ln for ln in lines if "sprint" in ln and "specs" in ln]
-        assert sprint_entries, "No sprint-level history entry found"
-        assert sprint_entries[0]["sprint"].get("sprint_id") == sprint_id
+        # The substrate must contain at least one row referencing this sprint_id.
+        sub_path = audit_substrate.substrate_path(tmp_path)
+        assert sub_path.exists()
+        conn = audit_substrate.require_substrate(tmp_path)
+        try:
+            sprint_carrying = [
+                rec
+                for rec in audit_substrate.iter_records(conn)
+                if isinstance(rec.get("sprint"), dict)
+                and rec["sprint"].get("sprint_id") == sprint_id
+            ]
+        finally:
+            conn.close()
+        assert sprint_carrying, "No substrate row carries the sprint_id"
 
     def test_resume_persists_already_done_story_before_reexec_handoff(
         self, tmp_path: Path

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -833,20 +833,18 @@ def test_run_sprint_summary_records_run_log(tmp_path: Path) -> None:
 
 def test_is_branch_merged_squash_merge_reads_real_audit_history(tmp_path: Path) -> None:
     """Squash merges use persisted APPROVE history even though branch stays ahead."""
-    import json
+    from theforge.coordinator import audit_substrate
 
-    audits_dir = tmp_path / ".forge" / "audits"
-    audits_dir.mkdir(parents=True)
-    (audits_dir / "history.jsonl").write_text(
-        json.dumps(
+    audit_substrate.seed_records(
+        tmp_path,
+        [
             {
+                "run_id": "rec-landed",
                 "task": {"slug": "story-a"},
                 "landing_status": "landed",
                 "reviews": [{"verdict": "APPROVE"}],
             }
-        )
-        + "\n",
-        encoding="utf-8",
+        ],
     )
 
     def _mock_squash(cmd: list[str], **kwargs: object) -> MagicMock:
@@ -869,20 +867,18 @@ def test_is_branch_merged_squash_merge_reads_real_audit_history(tmp_path: Path) 
 
 def test_is_branch_merged_squash_merge_ignores_failed_landing_audit(tmp_path: Path) -> None:
     """Failed landing history must not satisfy squash-merge detection."""
-    import json
+    from theforge.coordinator import audit_substrate
 
-    audits_dir = tmp_path / ".forge" / "audits"
-    audits_dir.mkdir(parents=True)
-    (audits_dir / "history.jsonl").write_text(
-        json.dumps(
+    audit_substrate.seed_records(
+        tmp_path,
+        [
             {
+                "run_id": "rec-failed",
                 "task": {"slug": "story-a"},
                 "landing_status": "failed",
                 "reviews": [{"verdict": "APPROVE"}],
             }
-        )
-        + "\n",
-        encoding="utf-8",
+        ],
     )
 
     def _mock_squash(cmd: list[str], **kwargs: object) -> MagicMock:

--- a/tests/test_sprint_timeout_audit.py
+++ b/tests/test_sprint_timeout_audit.py
@@ -43,6 +43,14 @@ def test_run_sprint_timeout_writes_story_audit(tmp_path: Path) -> None:
     ):
         run_sprint(config, manifest)
 
-    audit_path = tmp_path / ".forge" / "audits" / "history.jsonl"
-    assert audit_path.exists()
-    assert "feature-a" in audit_path.read_text(encoding="utf-8")
+    # The substrate must record the timed-out story as an audit row.
+    from theforge.coordinator import audit_substrate
+
+    sub_path = audit_substrate.substrate_path(tmp_path)
+    assert sub_path.exists()
+    conn = audit_substrate.require_substrate(tmp_path)
+    try:
+        slugs = {(rec.get("task") or {}).get("slug") for rec in audit_substrate.iter_records(conn)}
+    finally:
+        conn.close()
+    assert "feature-a" in slugs

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,12 +1,12 @@
-"""Tests for cmd_telemetry — aggregation over history.jsonl records."""
+"""Tests for cmd_telemetry — aggregation over the SQLite audit substrate."""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from types import SimpleNamespace
 
 from theforge.cli import cmd_telemetry
+from theforge.coordinator import audit_substrate
 
 # ── Helpers ───────────────────────────────────────────────────────────
 
@@ -65,10 +65,22 @@ def _make_record(
 
 
 def _write_history(history_path: Path, records: list[dict]) -> None:
-    history_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(history_path, "w", encoding="utf-8") as f:
-        for rec in records:
-            f.write(json.dumps(rec) + "\n")
+    """Seed the substrate with native audit rows.
+
+    Tests reference this helper as ``_write_history`` for historical
+    continuity, but it now writes SQLite rows — not the legacy
+    ``history.jsonl`` file. Each record gets a synthetic ``run_id`` so
+    upserts don't collapse onto the same row.
+    """
+    project_root = history_path.parent.parent.parent  # …/.forge/audits/history.jsonl → repo root
+    stamped: list[dict] = []
+    for i, rec in enumerate(records):
+        if not isinstance(rec, dict):
+            continue
+        copy = dict(rec)
+        copy.setdefault("run_id", f"telem-test-{i:04d}")
+        stamped.append(copy)
+    audit_substrate.seed_records(project_root, stamped)
 
 
 def _make_args(
@@ -243,13 +255,37 @@ class TestTelemetryGracefulHandling:
         out = capsys.readouterr().out
         assert "1 run(s) with phase data" in out
 
-    def test_malformed_jsonl_lines_skipped(self, tmp_path: Path, capsys) -> None:
-        """Malformed JSONL lines are skipped without error."""
+    def test_malformed_substrate_rows_skipped(self, tmp_path: Path, capsys) -> None:
+        """Substrate rows that fail to JSON-decode are skipped without error.
+
+        Substrate writers always write canonical JSON, but the iterator is
+        defensively tolerant of corruption — verify a hand-corrupted row
+        is skipped while neighbouring records still surface.
+        """
         _, history_path = _setup_project(tmp_path)
-        history_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(history_path, "w", encoding="utf-8") as f:
-            f.write("{not valid json}\n")
-            f.write(json.dumps(_make_record(slug="good-run")) + "\n")
+        good = _make_record(slug="good-run")
+        _write_history(history_path, [good])
+        # Hand-corrupt one row's raw_json column.
+        import sqlite3
+
+        sub_path = audit_substrate.substrate_path(tmp_path)
+        conn = sqlite3.connect(str(sub_path))
+        try:
+            conn.execute(
+                "INSERT INTO audit_records "
+                "(run_id, slug, started_at, provenance, raw_json) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    "corrupt-row",
+                    "bad-run",
+                    "2026-03-01T09:00:00+00:00",
+                    "native",
+                    "{not valid json",
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
         args = _make_args(tmp_path / "forge.yaml")
         rc = cmd_telemetry(args)
         assert rc == 0


### PR DESCRIPTION
Manual recovery of work paused on May 7 sprint \`6c83b3061455\` and resumed in sprint \`9e984775b118\` on 2026-05-09. The original sprint produced approved dev work but its integration step failed because the worktree was based on a stale main; #1466 captures the underlying \`forge sprint --resume\` bug. This PR carries the recovered work onto current main with conflicts resolved.

## Summary

- All four runtime readers consume the SQLite audit substrate instead of \`history.jsonl\`:
  - Adaptive routing's escalation history (\`coordinator/escalation_history.py\` extracted from \`coordinator/preflight.py\`).
  - Adaptive iteration limits (\`coordinator/adaptive_iterations.py\` reads from substrate).
  - Sprint rollup, telemetry, prior-APPROVE skip-review check (already substrate-aware via #792 / #1429).
  - \`forge status --recent\` (lists historical runs via the substrate).
- New module \`coordinator/escalation_history.py\` is the single seam for adaptive routing's substrate read.
- \`derive_assignment_history\` (the projection consumed by both the CLI export and the new escalation module) gains a fallback path: when an audit record lacks the \`preflight.complexity_routing\` block (older audits or test-seeded fixtures that bypass routing), the canonical dev model identity is reconstructed from \`cost.agents\` (the model that actually ran) instead. Both routing-aware and routing-absent fixtures now project correctly.
- \`coordinator/audit_substrate.py\` retains \`iter_escalation_records\` and \`_derive_escalation\` from the original branch for the regression tests that exercise the cost.agents-only derivation directly. Mild duplication with \`derive_assignment_history\`'s fallback path; can be unified in a small follow-up.

## Recovery context (operator-visible)

The original sprint's dev cycle ran two iterations (REQUEST_CHANGES → APPROVE) and produced 4 commits totaling \$10.46. The integration step's rebase onto main failed with a real merge conflict (5 files: \`coordinator/audit_substrate.py\`, \`coordinator/engine.py\`, \`coordinator/preflight.py\`, \`tests/test_coord_model_profiles_seam.py\`, \`tests/test_coord_preflight_escalation.py\`) because main had absorbed #1432, #1429, #1446, #1457, and #1465 in the intervening 40 hours.

Manual rebase resolution decisions:
- Took branch's intent of extracting \`_load_esc_history_from_substrate\` from preflight.py into a dedicated module (matches the migration's extract-readers theme).
- Combined HEAD's explanatory test-failure messages with branch's broader test scope (substrate load + assertion).
- Combined main's \`derive_assignment_history\` (CLI/export view, routing-aware) with branch's cost.agents derivation as a fallback path — single function, supports both fixture shapes.
- Kept the iter-1 review fixes from the dev cycle that addressed the two P1s the original review pool flagged (silent ignoring of legacy audit inputs and \`forge status --recent\` not reading from substrate).

The fifth, post-rebase commit (\`fix(rebase): derive_assignment_history falls back to cost.agents when routing block absent\`) is the conflict-resolution refinement needed to satisfy both \`tests/test_assignment_history_derived.py\` (main's #1465 test, expects routing-aware projection) and \`tests/test_audit_substrate.py::TestEscalationProjection\` (branch's regression guard against the band-mismatch bug).

Closes #1324.

## Verification

- Full gate green: 4192 passed, 15 skipped, 9 warnings (no new warnings introduced).
- Targeted: \`tests/test_assignment_history_derived.py\` (5 tests) and \`tests/test_audit_substrate.py::TestEscalationProjection\` (3 tests) — both exercise the unified projection path. All pass.
- The new \`coordinator/escalation_history.py\` module's load path runs end-to-end through \`require_substrate\` and surfaces missing-substrate / corrupt-substrate errors to the operator (no silent no-history routing when audit inputs exist on disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>