### PR TITLE
Adaptive cross-provider reviewer selection silently collapses all CLI agents to a single 'None' provider, breaking diversity rotation in multi-CLI pools

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -313,13 +313,17 @@ def _select_reviewers(
     selected: list[AgentDef] = []
     used_providers: set[str] = set()
 
-    # First pass: pick from different providers
+    # First pass: pick from different providers (using effective provider so
+    # CLI-only agents are distinguished by their underlying CLI binary —
+    # claude/codex/gemini map to anthropic/openai/google rather than collapsing
+    # to a shared `None`).
     for a in candidates:
         if len(selected) >= n:
             break
-        if a.provider not in used_providers:
+        eff = a.effective_provider
+        if eff not in used_providers:
             selected.append(a)
-            used_providers.add(a.provider)
+            used_providers.add(eff)
 
     # Second pass: fill remaining from any provider
     for a in candidates:
@@ -898,7 +902,7 @@ def assign_models(
             secrets=secrets,
         )
         plan_reviewers = [_agent_to_profile(a, role="review") for a in selected]
-        providers = [a.provider for a in selected]
+        providers = [a.effective_provider for a in selected]
         score_note = f", complexity score {score}" if score is not None else ""
         rationale["plan_review"] = (
             f"{len(plan_reviewers)} reviewer(s), tier {tier}, providers {providers}{score_note}"
@@ -938,7 +942,7 @@ def assign_models(
             secrets=secrets,
         )
         code_reviewers = [_agent_to_profile(a, role="review") for a in selected]
-        providers = [a.provider for a in selected]
+        providers = [a.effective_provider for a in selected]
         score_note = f", complexity score {score}" if score is not None else ""
         rationale["code_review"] = (
             f"{len(code_reviewers)} reviewer(s), tier {tier}, providers {providers}{score_note}"

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -153,6 +153,13 @@ class ModelInfo:
     transport: TransportSpec | None = None  # the canonical TransportSpec this view was built from
 
 
+_CLI_TO_PROVIDER: dict[str, str] = {
+    "claude": "anthropic",
+    "codex": "openai",
+    "gemini": "google",
+}
+
+
 @dataclass(frozen=True)
 class AgentDef:
     """An agent available in the pool for adaptive model assignment."""
@@ -168,6 +175,23 @@ class AgentDef:
     strengths: tuple[str, ...] = ()
     registry_id: str | None = None
     registry_source: str = "builtin"
+
+    @property
+    def effective_provider(self) -> str | None:
+        """Return the agent's provider for routing/display purposes.
+
+        For API agents this is the explicit ``provider`` field. For CLI-only
+        agents (where ``provider`` is None), this derives the provider from the
+        ``cli`` binary: ``claude`` → ``anthropic``, ``codex`` → ``openai``,
+        ``gemini`` → ``google``. The raw ``provider`` field stays None for CLI
+        agents so dispatch (which reads ``ModelProfile.provider`` to choose
+        between CLI and API runners) is unaffected.
+        """
+        if self.provider is not None:
+            return self.provider
+        if self.cli is not None:
+            return _CLI_TO_PROVIDER.get(self.cli)
+        return None
 
     def to_model_profile(self, *, allowed_tools: tuple[str, ...] = ()) -> ModelProfile:
         """Convert to a ModelProfile for use in coordinator config."""

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -205,6 +205,174 @@ def test_cross_provider_with_three_reviewers():
     assert len(decision.code_reviewers) >= 1
 
 
+# ── test_cross_cli_provider_rotation (issue #1468) ────────────────────
+
+
+def _make_agents_cli_only() -> list[AgentDef]:
+    """Pool with three strong-tier CLI agents (claude/codex/gemini) plus a cheap
+    claude agent that takes the dev role, so the three strong agents remain
+    available as reviewers. provider=None on every agent — distinguished only
+    by their cli binary."""
+    return [
+        AgentDef(
+            name="claude-sonnet",
+            provider=None,
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=600,
+            tier="cheap",
+            cli="claude",
+        ),
+        AgentDef(
+            name="claude-opus",
+            provider=None,
+            model="opus",
+            budget_usd=8.0,
+            timeout_seconds=1200,
+            tier="strong",
+            cli="claude",
+        ),
+        AgentDef(
+            name="codex-gpt-5.4",
+            provider=None,
+            model="gpt-5.4",
+            budget_usd=8.0,
+            timeout_seconds=1200,
+            tier="strong",
+            cli="codex",
+        ),
+        AgentDef(
+            name="gemini-pro",
+            provider=None,
+            model="gemini-2.5-pro",
+            budget_usd=8.0,
+            timeout_seconds=1200,
+            tier="strong",
+            cli="gemini",
+        ),
+    ]
+
+
+def test_effective_provider_derived_from_cli_when_provider_none():
+    """CLI-only agents (provider=None) expose an effective_provider derived from
+    their cli binary so routing/display can distinguish claude/codex/gemini."""
+    agents = [a for a in _make_agents_cli_only() if a.tier == "strong"]
+    by_cli = {a.cli: a.effective_provider for a in agents}
+    assert by_cli == {"claude": "anthropic", "codex": "openai", "gemini": "google"}
+
+
+def test_effective_provider_explicit_provider_wins():
+    """An explicit provider takes precedence over CLI-derived value."""
+    a = AgentDef(
+        name="custom",
+        provider="deepseek",
+        model="x",
+        budget_usd=1.0,
+        timeout_seconds=60,
+        tier="strong",
+        cli="claude",
+    )
+    assert a.effective_provider == "deepseek"
+
+
+def test_cross_provider_cli_only_pool_yields_distinct_providers():
+    """Three CLI agents (claude+codex+gemini) with prefer_cross_provider must
+    produce three reviewers with distinct effective providers — the bug from
+    issue #1468 collapsed all CLI agents to provider=None and excluded all but
+    the first from the cross-provider rotation."""
+    agents = _make_agents_cli_only()
+    cfg = _make_cfg(
+        min_reviewers=3,
+        max_reviewers=3,
+        prefer_cross_provider=True,
+        max_cost_per_story_usd=1000.0,
+    )
+    # complexity=small lets dev pick the cheap claude-sonnet so the three strong
+    # reviewers (one per CLI binary) all remain available.
+    decision = assign_models(agents, cfg, "small")
+
+    assert len(decision.code_reviewers) == 3
+    cli_set = {r.cli for r in decision.code_reviewers}
+    assert cli_set == {"claude", "codex", "gemini"}, (
+        f"Expected one reviewer per CLI binary, got {cli_set}"
+    )
+
+
+def test_cross_provider_rationale_never_shows_none_for_cli_pool():
+    """The rationale display string must show derived provider names
+    (anthropic/openai/google), not the literal None that CLI agents carry on
+    AgentDef.provider."""
+    agents = _make_agents_cli_only()
+    cfg = _make_cfg(
+        min_reviewers=2,
+        max_reviewers=2,
+        prefer_cross_provider=True,
+        max_cost_per_story_usd=1000.0,
+    )
+    decision = assign_models(agents, cfg, "small")
+
+    rationale = decision.rationale.get("code_review", "")
+    assert "None" not in rationale, f"Rationale leaked None for CLI pool: {rationale}"
+    # At least two of the derived providers must appear in the rationale.
+    derived = {"anthropic", "openai", "google"}
+    appearing = {p for p in derived if p in rationale}
+    assert len(appearing) >= 2, f"Expected ≥2 derived providers in rationale, got {rationale}"
+
+
+def test_cross_provider_mixed_cli_and_api_pool(monkeypatch):
+    """Mixed pool (CLI claude + API deepseek): when both serve as reviewers, they
+    must come from distinct effective providers — claude's effective provider is
+    anthropic (derived from cli=claude), not None, so the diversity check
+    distinguishes it from deepseek."""
+    agents = [
+        AgentDef(
+            name="claude-sonnet",
+            provider=None,
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=600,
+            tier="cheap",
+            cli="claude",
+        ),
+        AgentDef(
+            name="claude-opus",
+            provider=None,
+            model="opus",
+            budget_usd=8.0,
+            timeout_seconds=1200,
+            tier="strong",
+            cli="claude",
+        ),
+        AgentDef(
+            name="deepseek-r1",
+            provider="deepseek",
+            model="deepseek-reasoner",
+            budget_usd=1.0,
+            timeout_seconds=600,
+            tier="strong",
+        ),
+    ]
+    # Pretend the claude CLI is on PATH so auth checks pass — otherwise the
+    # cheap claude agent fails auth, dev fallback picks deepseek, and the
+    # reviewer pool is confounded by the exclude-dev-model logic.
+    monkeypatch.setattr("theforge.config.auth.shutil.which", lambda cmd, *a, **kw: "/usr/bin/x")
+    cfg = _make_cfg(min_reviewers=2, max_reviewers=2, prefer_cross_provider=True)
+    decision = assign_models(agents, cfg, "small")
+
+    assert len(decision.code_reviewers) == 2
+    # The claude reviewer (cli=claude, provider=None) and the deepseek reviewer
+    # (provider=deepseek) must be distinguished — pre-fix, both collapsed into
+    # the same `None` effective provider (or same `deepseek` after first pick)
+    # depending on order, defeating the diversity contract.
+    by_eff = []
+    for r in decision.code_reviewers:
+        if r.cli == "claude":
+            by_eff.append("anthropic")
+        elif r.provider:
+            by_eff.append(r.provider)
+    assert set(by_eff) == {"anthropic", "deepseek"}
+
+
 # ── test_cross_provider_fallback ──────────────────────────────────────
 
 

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -935,3 +935,74 @@ class TestValidationTestCommand:
         )
         with pytest.raises(ValueError, match="v0.8"):
             load_config(config_path)
+
+
+class TestCliPoolCrossProviderRotation:
+    """Issue #1468 — a CLI-only models: pool (claude/codex/gemini) loaded via
+    forge.yaml must, when fed through assign_models with prefer_cross_provider,
+    yield reviewers across all three CLI binaries. Before the fix, every CLI
+    agent collapsed to provider=None and only the first was selected as
+    cross-provider, with the rest excluded by the diversity check."""
+
+    def test_cli_only_pool_yields_distinct_effective_providers(self, tmp_path):
+        from theforge.assignment import assign_models
+
+        config_path = _write_config(
+            {
+                "models": [
+                    "claude/sonnet",
+                    "claude/opus",
+                    "openai/gpt-5.4-pro",
+                    "gemini-cli/gemini-2.5-pro",
+                ],
+                "budget_usd": 30.0,
+                "assignment": {
+                    "enabled": True,
+                    "min_reviewers": 3,
+                    "max_reviewers": 3,
+                    "prefer_cross_provider": True,
+                    "max_cost_per_story_usd": 1000.0,
+                },
+            },
+            tmp_path,
+        )
+        # The conftest scrub blocks `shutil.which("claude" | "codex" | "gemini")`
+        # so load_config's reviewer-auth cross-check would otherwise reject the
+        # whole pool. Pretend each CLI binary is installed for this test.
+        # codex/gemini route through `npx` per theforge.config.auth._NPX_CLIS,
+        # so the auth check is `shutil.which('npx')` for those — list npx too.
+        cli_bins = {
+            "claude": "/usr/bin/claude",
+            "codex": "/usr/bin/codex",
+            "gemini": "/usr/bin/gemini",
+            "npx": "/usr/bin/npx",
+        }
+        with patch(
+            "theforge.config.auth.shutil.which",
+            side_effect=lambda cmd, *a, **kw: cli_bins.get(Path(cmd).name),
+        ):
+            config = load_config(config_path)
+            decision = assign_models(config.agents, config.assignment, complexity="small")
+
+        # Sanity: the pool truly contains four CLI agents whose raw provider
+        # field is None (the bug condition).
+        assert len(config.agents) == 4
+        assert {a.cli for a in config.agents} == {"claude", "codex", "gemini"}
+        assert all(a.provider is None for a in config.agents)
+        # …but their effective providers are derived from the cli binary.
+        assert {a.effective_provider for a in config.agents} == {
+            "anthropic",
+            "openai",
+            "google",
+        }
+
+        assert len(decision.code_reviewers) == 3
+        # Each reviewer must come from a distinct CLI binary — i.e., a distinct
+        # effective provider — even though every agent's raw provider is None.
+        assert {r.cli for r in decision.code_reviewers} == {"claude", "codex", "gemini"}
+        # Rationale must surface the derived provider names, never the literal
+        # `None` that leaked through before the fix.
+        rationale = decision.rationale.get("code_review", "")
+        assert "None" not in rationale, rationale
+        for derived in ("anthropic", "openai", "google"):
+            assert derived in rationale, f"expected {derived!r} in rationale: {rationale}"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Implementation satisfies the bug's behavioral requirements; no blocking findings. | [deepseek-deepseek-reasoner] Correctly fixes silent collapse of CLI agents into a single None provider bucket by adding AgentDef.effective_property that derives provider from CLI binary, and routing the cross-provider diversity check and rationale display through it.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $7.01
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Adaptive cross-provider reviewer selection silently collapses all CLI agents to a single 'None' provider, breaking diversity rotation in multi-CLI pools (GitHub Issue #1468)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1468