### PR TITLE
Operator-action intake refusal: forge sprint must not dispatch operator-action issues to dev cycles

### DIFF
--- a/docs/guides/authoring.md
+++ b/docs/guides/authoring.md
@@ -33,6 +33,14 @@ Storage is incidental; shape is what matters.
 | Rollup | Title, Why, Acceptance criteria (one per child), Example | Notes |
 | Docs / chore | Title, Why, Acceptance criteria, Example | Notes |
 
+There is also a sixth, deliberately-not-dev-runnable type:
+
+| Use case | Required sections | Required label |
+|----------|------------------|----------------|
+| Operator action | Title, Why, Acceptance criteria | `operator-action` |
+
+See [Operator-action issues](#operator-action-issues) below.
+
 A short shared rule across every use case: the issue body says **what** and
 **why** — never **how**. Do not list file paths, function names, numbered
 implementation steps, or test-strategy hints. Those belong in planning, not in
@@ -377,6 +385,50 @@ The new subsection follows the existing pattern used for `validation:`:
 
 ---
 
+## Operator-action issues
+
+Some work cannot be performed by a dev agent — running real validation
+sprints, capturing live operational evidence, signing a release, filing an
+incident report. The `operator-action` label declares an issue whose
+deliverable is human action by design.
+
+`forge sprint` refuses to dispatch operator-action issues to dev cycles. They
+appear in sprint output as deliberately non-dispatched (operator paid `$0`),
+not as failed and not as "wrong shape." The output uses a distinct status row
+so they cannot be confused with shape-gate skips.
+
+### Required shape
+
+- Apply the `operator-action` label.
+- Include an `## Acceptance criteria` section describing the operator
+  deliverable. The gate refuses operator-action issues without this section
+  (distinct skip code: `operator_action_missing_ac`).
+- Do not also apply `bug`, `enhancement`, `epic`, or `task`. Those are the
+  dev-runnable types and conflict with operator-action by design — pick
+  exactly one. The gate refuses multi-typed issues with the
+  `operator_action_label_conflict` code naming the conflict.
+
+### What the operator sees
+
+```
+$ forge sprint --verbose --issues 1326,1471 --budget 50 --parallel=3
+[forge] 1 issue(s) deliberately non-dispatched (operator-action):
+  - #1471 (label): operator-action — Validate v0.11 substrate
+[sprint] "issues-1326" 1 story budget=$50.00 parallel=3
+$ forge sprint-status <run-id>
+  ⊘ Issue #1471            operator-action       —         ...   not sprintable; operator deliverable
+```
+
+`--force` does not bypass operator-action; the label is the operator's
+deliberate signal, not a shape-gate guard to override.
+
+### What is out of scope
+
+Operator-action issues remain unautomated by design. There is no
+"`forge run-validation-sprint`" macro — the type exists precisely to mark the
+boundary between system-runnable work and operator-runnable work. If you want
+the system to do the work, file a `bug`/`enhancement`/`task` instead.
+
 ## Common reasons sprint entry rejects an issue
 
 If you followed the use-case templates above you should not see these, but
@@ -397,6 +449,10 @@ they are useful to recognize:
   Tracking issues are not runnable — file the runnable children separately.
 - **`too_many_behavioral_clusters`** — AC bullets touch too many distinct
   subsystems. Split the issue.
+- **`operator_action_label_conflict`** — `operator-action` is applied
+  alongside `bug`/`enhancement`/`epic`/`task`. Pick exactly one issue type.
+- **`operator_action_missing_ac`** — `operator-action` issue is missing the
+  `## Acceptance criteria` section describing the operator deliverable.
 
 ---
 

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -338,16 +338,24 @@ def _emit_all_skipped_audit(
             continue
         sk_slug = f"issue-{sk_num}"
         sk_codes = sk_dict.get("reason_codes") or []
+        is_operator_action = "operator_action" in sk_codes
         sk_reason = (
-            ", ".join(sk_codes)
-            if sk_codes
-            else (sk_dict.get("detail") or sk_dict.get("source") or "shape-gate")
+            "operator-action — operator deliverable"
+            if is_operator_action
+            else (
+                ", ".join(sk_codes)
+                if sk_codes
+                else (sk_dict.get("detail") or sk_dict.get("source") or "shape-gate")
+            )
         )
+        sk_outcome = StoryOutcome.OPERATOR_ACTION if is_operator_action else StoryOutcome.SKIPPED
         sk_detail: dict = {
             "shape_gate_source": sk_dict.get("source"),
             "shape_gate_codes": list(sk_codes),
-            "final_outcome": "SKIPPED",
+            "final_outcome": sk_outcome.name,
         }
+        if is_operator_action:
+            sk_detail["operator_action"] = True
         outcome = intake_outcomes.get(sk_num)
         if outcome is not None:
             sk_detail["intake_kind"] = outcome.kind.value
@@ -358,7 +366,7 @@ def _emit_all_skipped_audit(
         story_state.register(
             sk_slug,
             f"Issue #{sk_num}",
-            outcome=StoryOutcome.SKIPPED,
+            outcome=sk_outcome,
             reason=sk_reason,
             canonical_ref=f"issue:{sk_num}",
             detail=sk_detail,
@@ -446,6 +454,7 @@ def _run_query_mode(
     from theforge.sprint.shape_gate import (
         apply_shape_gate,
         format_advisory_warning,
+        format_operator_action_notice,
         format_skipped_warning,
     )
 
@@ -522,17 +531,27 @@ def _run_query_mode(
                 print(warning, file=sys.stderr)
         if gate_result.advisories:
             print(format_advisory_warning(gate_result.advisories), file=sys.stderr)
+        if gate_result.operator_action:
+            # Operator-facing banner — deliberate non-dispatch, distinct from
+            # the malformed-shape skip warning above. The label cannot be
+            # bypassed by --force; the banner prints in both modes.
+            print(format_operator_action_notice(gate_result.operator_action), file=sys.stderr)
         issues = gate_result.runnable
-        skipped_issues = gate_result.skipped
+        # Operator-action issues are persisted alongside shape-gate skips so
+        # the audit/summary surfaces them; the runner inspects reason_codes to
+        # apply the StoryOutcome.OPERATOR_ACTION classification.
+        skipped_issues = list(gate_result.skipped) + list(gate_result.operator_action)
 
         # Bridge to intake remediation: entry-skipped issues bypass the
         # in-runner remediation pass, so route them through here. Suppress
         # remediation under --force, which is the operator's explicit
-        # escape hatch.
+        # escape hatch. Operator-action entries are excluded — the label is
+        # the operator's deliberate signal, not a defect to remediate.
         entry_intake_outcomes: dict[int, object] = {}
-        if skipped_issues and not force:
+        remediation_targets = [sk for sk in gate_result.skipped]
+        if remediation_targets and not force:
             entry_intake_outcomes = remediate_entry_skipped_issues(
-                skipped_issues,
+                remediation_targets,
                 config=config,
                 log=lambda m: print(f"[forge] {m}", file=sys.stderr),
             )

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -128,6 +128,7 @@ def display_sprint_status(run_id: str, project_root: Path) -> int:
         "failed": "✗",
         "skipped": "⊘",
         "blocked": "⊘",
+        "operator-action": "⊘",
     }
 
     # Column header

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1944,16 +1944,26 @@ def run_sprint(
             if _story_state.has(_sk_slug):
                 continue
             _sk_codes = _sk_dict.get("reason_codes") or []
+            _is_operator_action = "operator_action" in _sk_codes
             _sk_reason = (
-                ", ".join(_sk_codes)
-                if _sk_codes
-                else (_sk_dict.get("detail") or _sk_dict.get("source") or "shape-gate")
+                "operator-action — operator deliverable"
+                if _is_operator_action
+                else (
+                    ", ".join(_sk_codes)
+                    if _sk_codes
+                    else (_sk_dict.get("detail") or _sk_dict.get("source") or "shape-gate")
+                )
+            )
+            _sk_outcome = (
+                StoryOutcome.OPERATOR_ACTION if _is_operator_action else StoryOutcome.SKIPPED
             )
             _sk_detail: dict = {
                 "shape_gate_source": _sk_dict.get("source"),
                 "shape_gate_codes": list(_sk_codes),
-                "final_outcome": "SKIPPED",
+                "final_outcome": _sk_outcome.name,
             }
+            if _is_operator_action:
+                _sk_detail["operator_action"] = True
             _sk_intake = (entry_intake_outcomes or {}).get(_sk_num)
             if _sk_intake is not None:
                 _sk_detail["intake_kind"] = _sk_intake.kind.value
@@ -1964,7 +1974,7 @@ def run_sprint(
             _state_writer.register(
                 _sk_slug,
                 f"Issue #{_sk_num}",
-                outcome=StoryOutcome.SKIPPED,
+                outcome=_sk_outcome,
                 reason=_sk_reason,
                 detail=_sk_detail,
             )
@@ -1978,7 +1988,15 @@ def run_sprint(
                 continue
             _sk_slug = f"issue-{_sk_num}"
             _sk_codes = _sk_dict.get("reason_codes") or []
-            _sk_reason = ", ".join(_sk_codes) if _sk_codes else "shape-gate"
+            _is_operator_action = "operator_action" in _sk_codes
+            _sk_reason = (
+                "operator-action — operator deliverable"
+                if _is_operator_action
+                else (", ".join(_sk_codes) if _sk_codes else "shape-gate")
+            )
+            _sk_outcome = (
+                StoryOutcome.OPERATOR_ACTION if _is_operator_action else StoryOutcome.SKIPPED
+            )
             _sk_intake = (entry_intake_outcomes or {}).get(_sk_num)
             _sk_detail = None
             if _sk_intake is not None:
@@ -1989,10 +2007,17 @@ def run_sprint(
                     "intake_audit": dict(_sk_intake.audit),
                     "intake_proposed_replacement": _sk_intake.proposed_replacement,
                 }
+            elif _is_operator_action:
+                _sk_detail = {
+                    "shape_gate_source": _sk_dict.get("source"),
+                    "shape_gate_codes": list(_sk_codes),
+                    "operator_action": True,
+                    "final_outcome": _sk_outcome.name,
+                }
             _story_state.register(
                 _sk_slug,
                 f"Issue #{_sk_num}",
-                outcome=StoryOutcome.SKIPPED,
+                outcome=_sk_outcome,
                 reason=_sk_reason,
                 detail=_sk_detail,
             )

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -339,6 +339,12 @@ def apply_shape_gate(
     skipped: list[SkippedIssue] = []
     advisories: list[SkippedIssue] = []
     operator_action: list[SkippedIssue] = []
+    # Tracks every issue number that carried the operator-action label,
+    # regardless of how it was classified (clean operator-action, label
+    # conflict, or missing-AC). --force must exclude all of them — the
+    # label is the operator's deliberate signal that no dev cycle should
+    # run for this issue, not a guard --force can override.
+    operator_action_label_numbers: set[int] = set()
 
     for issue in issues:
         number = int(issue["number"])
@@ -361,6 +367,7 @@ def apply_shape_gate(
         # operator signals. Refuse here with a label-source skip and stop.
         label_set_lc = {str(lbl).strip().lower() for lbl in labels}
         if OPERATOR_ACTION_LABEL in label_set_lc:
+            operator_action_label_numbers.add(number)
             entry = _classify_operator_action(number, title_short, body, labels)
             if OPERATOR_ACTION_CODE in entry.reason_codes:
                 operator_action.append(entry)
@@ -431,13 +438,16 @@ def apply_shape_gate(
     if force:
         # Escape hatch: caller wants to run every input issue. Skip list is
         # preserved so CLI can render a prominent warning. operator-action is
-        # NOT bypassed by --force: the label is a deliberate operator signal,
-        # not a guard the operator might want to override. The list still
-        # surfaces so the CLI can display the same notice.
+        # NOT bypassed by --force regardless of how the label combined with
+        # other shape signals: clean operator-action, operator-action with a
+        # type-label conflict, and operator-action without an AC section all
+        # remain refused. The label is a deliberate operator signal, not a
+        # guard --force can override. CLI still renders the
+        # operator_action banner and the skipped warning.
         force_runnable = [
             issue
             for issue in issues
-            if int(issue["number"]) not in {entry.issue_number for entry in operator_action}
+            if int(issue["number"]) not in operator_action_label_numbers
         ]
         return ShapeGateResult(
             runnable=force_runnable,

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -445,9 +445,7 @@ def apply_shape_gate(
         # guard --force can override. CLI still renders the
         # operator_action banner and the skipped warning.
         force_runnable = [
-            issue
-            for issue in issues
-            if int(issue["number"]) not in operator_action_label_numbers
+            issue for issue in issues if int(issue["number"]) not in operator_action_label_numbers
         ]
         return ShapeGateResult(
             runnable=force_runnable,

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -21,11 +21,22 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..shape_check import Shape, ShapeResult, check
+from ..shape_check.parsing import extract_ac_section, extract_bullets
 from ..shape_check.types import Severity
 from .reopen_context import analyze_reopen_contract, format_reopen_stale_detail
 
 NEEDS_GROOMING_LABEL = "needs-grooming"
 REOPENED_STALE_CONTRACT_CODE = "reopened_stale_contract"
+
+# operator-action: deliberate non-dispatch type. The label declares an issue
+# whose deliverable is human action no dev agent can perform. The gate refuses
+# to dispatch these issues to dev cycles — distinct from "wrong shape" skips.
+OPERATOR_ACTION_LABEL = "operator-action"
+OPERATOR_ACTION_CODE = "operator_action"
+OPERATOR_ACTION_LABEL_CONFLICT_CODE = "operator_action_label_conflict"
+OPERATOR_ACTION_MISSING_AC_CODE = "operator_action_missing_ac"
+# operator-action is mutually exclusive with the runnable type labels.
+OPERATOR_ACTION_CONFLICT_LABELS = frozenset({"bug", "enhancement", "epic", "task"})
 
 # Bot comments from #806b embed machine-readable reason codes on a single
 # line so local re-runs can match the Action's verdict exactly. Accept either
@@ -61,6 +72,64 @@ class ShapeGateResult:
     runnable: list[dict] = field(default_factory=list)
     skipped: list[SkippedIssue] = field(default_factory=list)
     advisories: list[SkippedIssue] = field(default_factory=list)
+    # Issues correctly labeled ``operator-action``: deliberate non-dispatch.
+    # Distinct from ``skipped`` (wrong shape) so operators can tell "system
+    # refused to run my malformed issue" from "system identified my issue as
+    # operator work". Issues with ``operator-action`` plus a label conflict
+    # or no AC section land in ``skipped`` instead.
+    operator_action: list[SkippedIssue] = field(default_factory=list)
+
+
+def _has_acceptance_criteria(body: str) -> bool:
+    """Return True if the body has a non-empty ``## Acceptance criteria`` section."""
+    section = extract_ac_section(body)
+    if not section:
+        return False
+    return bool(extract_bullets(section))
+
+
+def _classify_operator_action(
+    number: int,
+    title: str,
+    body: str,
+    labels: list[str],
+) -> SkippedIssue:
+    """Return the SkippedIssue describing how an ``operator-action`` issue is handled.
+
+    Caller decides whether to surface this in the deliberate-non-dispatch list
+    or in the wrong-shape skipped list based on the returned ``reason_codes``.
+    """
+    label_set = {str(lbl).strip().lower() for lbl in labels}
+    conflicts = sorted(label_set & OPERATOR_ACTION_CONFLICT_LABELS)
+    if conflicts:
+        return SkippedIssue(
+            issue_number=number,
+            reason_codes=(OPERATOR_ACTION_LABEL_CONFLICT_CODE,),
+            source="label",
+            title=title,
+            detail=(
+                f"'{OPERATOR_ACTION_LABEL}' conflicts with type label(s) "
+                f"{conflicts!r}; pick exactly one issue type."
+            ),
+        )
+    if not _has_acceptance_criteria(body):
+        return SkippedIssue(
+            issue_number=number,
+            reason_codes=(OPERATOR_ACTION_MISSING_AC_CODE,),
+            source="label",
+            title=title,
+            detail=(
+                f"'{OPERATOR_ACTION_LABEL}' issues require an "
+                "'## Acceptance criteria' section describing the operator deliverable."
+            ),
+        )
+    return SkippedIssue(
+        issue_number=number,
+        reason_codes=(OPERATOR_ACTION_CODE,),
+        source="label",
+        title=title,
+        detail="not sprintable; operator deliverable",
+    )
 
 
 def _fetch_issue_detail(number: int, project_root: Path | None) -> dict | None:
@@ -269,6 +338,7 @@ def apply_shape_gate(
     runnable: list[dict] = []
     skipped: list[SkippedIssue] = []
     advisories: list[SkippedIssue] = []
+    operator_action: list[SkippedIssue] = []
 
     for issue in issues:
         number = int(issue["number"])
@@ -282,6 +352,22 @@ def apply_shape_gate(
         labels = detail["labels"]
         title = detail["title"] or title_short
         body = detail["body"]
+
+        # operator-action: short-circuit ahead of the regular shape check.
+        # An operator-action issue is not malformed; it is correctly identified
+        # as work no dev agent can perform. Running the standard shape check on
+        # it would flag it for missing_type (since operator-action is mutually
+        # exclusive with bug/enhancement/epic/task), conflating two distinct
+        # operator signals. Refuse here with a label-source skip and stop.
+        label_set_lc = {str(lbl).strip().lower() for lbl in labels}
+        if OPERATOR_ACTION_LABEL in label_set_lc:
+            entry = _classify_operator_action(number, title_short, body, labels)
+            if OPERATOR_ACTION_CODE in entry.reason_codes:
+                operator_action.append(entry)
+            else:
+                skipped.append(entry)
+            continue
+
         reopen_state = analyze_reopen_contract(detail, detail.get("timeline") or [])
         local = check(
             title,
@@ -344,10 +430,28 @@ def apply_shape_gate(
 
     if force:
         # Escape hatch: caller wants to run every input issue. Skip list is
-        # preserved so CLI can render a prominent warning.
-        return ShapeGateResult(runnable=list(issues), skipped=skipped, advisories=advisories)
+        # preserved so CLI can render a prominent warning. operator-action is
+        # NOT bypassed by --force: the label is a deliberate operator signal,
+        # not a guard the operator might want to override. The list still
+        # surfaces so the CLI can display the same notice.
+        force_runnable = [
+            issue
+            for issue in issues
+            if int(issue["number"]) not in {entry.issue_number for entry in operator_action}
+        ]
+        return ShapeGateResult(
+            runnable=force_runnable,
+            skipped=skipped,
+            advisories=advisories,
+            operator_action=operator_action,
+        )
 
-    return ShapeGateResult(runnable=runnable, skipped=skipped, advisories=advisories)
+    return ShapeGateResult(
+        runnable=runnable,
+        skipped=skipped,
+        advisories=advisories,
+        operator_action=operator_action,
+    )
 
 
 def format_skipped_warning(skipped: list[SkippedIssue]) -> str:
@@ -360,6 +464,23 @@ def format_skipped_warning(skipped: list[SkippedIssue]) -> str:
         title = f" — {entry.title}" if entry.title else ""
         detail = f" [{entry.detail}]" if entry.detail else ""
         lines.append(f"  - #{entry.issue_number} ({entry.source}): {codes}{title}{detail}")
+    return "\n".join(lines)
+
+
+def format_operator_action_notice(operator_action: list[SkippedIssue]) -> str:
+    """Render the deliberate-non-dispatch banner for operator-action issues.
+
+    Phrased as "deliberately non-dispatched" to make clear this is not a
+    failure mode but the system correctly identifying operator deliverables.
+    """
+    if not operator_action:
+        return ""
+    lines = [
+        f"[forge] {len(operator_action)} issue(s) deliberately non-dispatched (operator-action):"
+    ]
+    for entry in operator_action:
+        title = f" — {entry.title}" if entry.title else ""
+        lines.append(f"  - #{entry.issue_number} (label): {OPERATOR_ACTION_LABEL}{title}")
     return "\n".join(lines)
 
 

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -139,6 +139,8 @@ def _outcome_to_status(outcome: str) -> str:
         return "done"
     if outcome == "SKIPPED":
         return "skipped"
+    if outcome == "OPERATOR_ACTION":
+        return "operator-action"
     if outcome in ("ESCALATE", "MERGE_FAILED"):
         return "failed"
     return "failed"
@@ -295,6 +297,9 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
 
     if status_val == "waiting":
         return "", "waiting", complexity
+
+    if status_val == "operator-action":
+        return "", "not sprintable; operator deliverable", complexity
 
     if status_val in {"done", "failed", "skipped", "preserved"}:
         final_outcome = detail_data.get("final_outcome")
@@ -466,7 +471,9 @@ def _stage_and_detail_from_completed_story(
         # on a FAILED/ESCALATED/SKIPPED row from a prior run must not leak.
         _success_outcome = outcome in {"DONE", "ALREADY_DONE"}
         verdict = _nonempty_str(story.get("verdict")) if _success_outcome else None
-        if verdict == "APPROVE":
+        if outcome == "OPERATOR_ACTION":
+            detail = "not sprintable; operator deliverable"
+        elif verdict == "APPROVE":
             detail = "APPROVE"
         elif verdict:
             detail = verdict
@@ -612,7 +619,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                 phase_display = last_phase_str
         stage, detail, complexity = _stage_and_detail_from_live_story(story)
 
-        if status_val in {"skipped", "blocked"}:
+        if status_val in {"skipped", "blocked", "operator-action"}:
             model_val: str | None = None
         else:
             model_raw = story.get("current_model")

--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -51,6 +51,11 @@ class StoryOutcome(str, Enum):
     DROPPED_SHAPE = "dropped_shape"
     REMEDIATED = "remediated"
     DROPPED_AFTER_FIX = "dropped_after_fix"
+    # operator-action: deliberately not run because the deliverable is human
+    # action no dev agent can perform. Distinct from SKIPPED (generic skip) and
+    # from FAILED-bucket outcomes — operator paid $0 and the system correctly
+    # identified the issue as not its work.
+    OPERATOR_ACTION = "operator_action"
 
     @property
     def is_terminal(self) -> bool:
@@ -80,7 +85,11 @@ class StoryOutcome(str, Enum):
 
     @property
     def is_skipped(self) -> bool:
-        return self in {StoryOutcome.SKIPPED, StoryOutcome.PRESERVED}
+        return self in {
+            StoryOutcome.SKIPPED,
+            StoryOutcome.PRESERVED,
+            StoryOutcome.OPERATOR_ACTION,
+        }
 
 
 _TERMINAL_OUTCOMES = {
@@ -94,6 +103,7 @@ _TERMINAL_OUTCOMES = {
     StoryOutcome.DROPPED,
     StoryOutcome.DROPPED_SHAPE,
     StoryOutcome.DROPPED_AFTER_FIX,
+    StoryOutcome.OPERATOR_ACTION,
 }
 
 
@@ -112,6 +122,7 @@ _CANONICAL_TO_LEGACY_STATUS = {
     StoryOutcome.DROPPED_SHAPE: "failed",
     StoryOutcome.DROPPED_AFTER_FIX: "failed",
     StoryOutcome.REMEDIATED: "waiting",
+    StoryOutcome.OPERATOR_ACTION: "operator-action",
 }
 
 
@@ -133,6 +144,8 @@ _STATUS_TO_OUTCOME: dict[str, StoryOutcome] = {
     "dropped_shape": StoryOutcome.DROPPED_SHAPE,
     "remediated": StoryOutcome.REMEDIATED,
     "dropped_after_fix": StoryOutcome.DROPPED_AFTER_FIX,
+    "operator_action": StoryOutcome.OPERATOR_ACTION,
+    "operator-action": StoryOutcome.OPERATOR_ACTION,
 }
 
 

--- a/tests/test_sprint_operator_action.py
+++ b/tests/test_sprint_operator_action.py
@@ -1,0 +1,235 @@
+"""Tests for the operator-action intake refusal at sprint entry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.sprint.shape_gate import (
+    OPERATOR_ACTION_CODE,
+    OPERATOR_ACTION_LABEL,
+    OPERATOR_ACTION_LABEL_CONFLICT_CODE,
+    OPERATOR_ACTION_MISSING_AC_CODE,
+    apply_shape_gate,
+    format_operator_action_notice,
+)
+from theforge.sprint.status_reader import _outcome_to_status
+from theforge.sprint.story_state import StoryOutcome
+
+_OPERATOR_ACTION_BODY = """## What
+
+Run real validation sprints and capture authentic output.
+
+## Why
+
+Confidence in v0.11 audit substrate requires real-world dogfood evidence.
+
+## Acceptance criteria
+
+- operator runs three real sprints back-to-back and captures the audit YAML
+- evidence is filed in the v0.11 retro doc
+"""
+
+
+def _fake_detail(body: str, labels: list[str], title: str = "Operator deliverable"):
+    def _fetch(_number, _project_root):
+        return {"title": title, "body": body, "labels": labels}
+
+    return _fetch
+
+
+# ── Happy path: deliberate non-dispatch ────────────────────────────────────
+
+
+def test_operator_action_label_partitions_to_operator_action_list(tmp_path: Path) -> None:
+    issues = [{"number": 1471, "title": "Validate v0.11 substrate"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL]),
+    )
+
+    assert result.runnable == []
+    assert result.skipped == []
+    assert len(result.operator_action) == 1
+    entry = result.operator_action[0]
+    assert entry.issue_number == 1471
+    assert entry.reason_codes == (OPERATOR_ACTION_CODE,)
+    assert entry.source == "label"
+    assert "operator deliverable" in entry.detail
+
+
+# ── Conflict: type-label mutual exclusion ──────────────────────────────────
+
+
+def test_operator_action_with_bug_conflicts_lands_in_skipped(tmp_path: Path) -> None:
+    issues = [{"number": 1, "title": "ambiguous"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL, "bug"]),
+    )
+
+    assert result.runnable == []
+    assert result.operator_action == []
+    assert len(result.skipped) == 1
+    entry = result.skipped[0]
+    assert entry.reason_codes == (OPERATOR_ACTION_LABEL_CONFLICT_CODE,)
+    assert "bug" in entry.detail
+
+
+def test_operator_action_with_enhancement_conflicts(tmp_path: Path) -> None:
+    issues = [{"number": 2, "title": "ambiguous2"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL, "enhancement"]),
+    )
+
+    assert result.skipped[0].reason_codes == (OPERATOR_ACTION_LABEL_CONFLICT_CODE,)
+
+
+def test_operator_action_with_epic_conflicts(tmp_path: Path) -> None:
+    issues = [{"number": 3, "title": "tracking"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL, "epic"]),
+    )
+
+    assert result.skipped[0].reason_codes == (OPERATOR_ACTION_LABEL_CONFLICT_CODE,)
+
+
+def test_operator_action_with_task_conflicts(tmp_path: Path) -> None:
+    issues = [{"number": 4, "title": "ambiguous4"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL, "task"]),
+    )
+
+    assert result.skipped[0].reason_codes == (OPERATOR_ACTION_LABEL_CONFLICT_CODE,)
+
+
+# ── AC requirement ────────────────────────────────────────────────────────
+
+
+def test_operator_action_without_ac_section_is_refused_with_distinct_code(
+    tmp_path: Path,
+) -> None:
+    body_no_ac = "## What\n\nDo something operator-shaped.\n\n## Why\n\nReasons.\n"
+    issues = [{"number": 5, "title": "no AC"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(body_no_ac, [OPERATOR_ACTION_LABEL]),
+    )
+
+    assert result.operator_action == []
+    assert len(result.skipped) == 1
+    entry = result.skipped[0]
+    assert entry.reason_codes == (OPERATOR_ACTION_MISSING_AC_CODE,)
+    # Distinct from the generic missing_acceptance_criteria code:
+    assert entry.reason_codes != ("missing_acceptance_criteria",)
+    assert "Acceptance criteria" in entry.detail
+
+
+# ── --force does not bypass operator-action ────────────────────────────────
+
+
+def test_force_does_not_bypass_operator_action(tmp_path: Path) -> None:
+    """The label is the operator's deliberate signal — --force still surfaces it
+    in the operator_action list and excludes it from runnable."""
+    issues = [{"number": 1471, "title": "deliberate"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL]),
+        force=True,
+    )
+
+    assert result.runnable == []
+    assert len(result.operator_action) == 1
+    assert result.operator_action[0].reason_codes == (OPERATOR_ACTION_CODE,)
+
+
+# ── Banner formatting ──────────────────────────────────────────────────────
+
+
+def test_format_operator_action_notice_uses_distinct_phrasing(tmp_path: Path) -> None:
+    issues = [{"number": 1471, "title": "Validate v0.11 substrate"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL]),
+    )
+    rendered = format_operator_action_notice(result.operator_action)
+
+    assert "deliberately non-dispatched" in rendered
+    assert "operator-action" in rendered
+    assert "#1471" in rendered
+    assert "Validate v0.11 substrate" in rendered
+
+
+def test_format_operator_action_notice_empty_returns_empty_string() -> None:
+    assert format_operator_action_notice([]) == ""
+
+
+# ── StoryOutcome additions ────────────────────────────────────────────────
+
+
+def test_story_outcome_operator_action_is_terminal_and_skipped() -> None:
+    assert StoryOutcome.OPERATOR_ACTION.is_terminal
+    # Operator paid $0 and the system did not fail — operator-action belongs
+    # in the skipped bucket, NOT the failed bucket.
+    assert StoryOutcome.OPERATOR_ACTION.is_skipped
+    assert not StoryOutcome.OPERATOR_ACTION.is_failed
+    assert not StoryOutcome.OPERATOR_ACTION.is_succeeded
+
+
+def test_outcome_to_status_maps_operator_action_to_distinct_status() -> None:
+    # Distinct from the generic "skipped" string so display can show a row that
+    # is not conflated with shape-gate skips.
+    assert _outcome_to_status("OPERATOR_ACTION") == "operator-action"
+    assert _outcome_to_status("SKIPPED") == "skipped"
+
+
+# ── Mixed sprint partitioning ─────────────────────────────────────────────
+
+
+def test_mixed_sprint_partitions_runnable_skipped_and_operator_action(
+    tmp_path: Path,
+) -> None:
+    issues = [
+        {"number": 100, "title": "runnable"},
+        {"number": 101, "title": "operator"},
+        {"number": 102, "title": "malformed"},
+    ]
+
+    def fetch(number, _project_root):
+        if number == 100:
+            return {
+                "title": "runnable",
+                "body": _OPERATOR_ACTION_BODY,
+                "labels": ["enhancement"],
+            }
+        if number == 101:
+            return {
+                "title": "operator",
+                "body": _OPERATOR_ACTION_BODY,
+                "labels": [OPERATOR_ACTION_LABEL],
+            }
+        return {"title": "malformed", "body": "no structure", "labels": []}
+
+    result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch)
+
+    assert [i["number"] for i in result.runnable] == [100]
+    assert [s.issue_number for s in result.operator_action] == [101]
+    assert [s.issue_number for s in result.skipped] == [102]

--- a/tests/test_sprint_operator_action.py
+++ b/tests/test_sprint_operator_action.py
@@ -159,6 +159,68 @@ def test_force_does_not_bypass_operator_action(tmp_path: Path) -> None:
     assert result.operator_action[0].reason_codes == (OPERATOR_ACTION_CODE,)
 
 
+def test_force_does_not_bypass_operator_action_with_label_conflict(tmp_path: Path) -> None:
+    """Even when operator-action collides with bug/enhancement/etc., --force
+    must NOT promote the issue to runnable. The label is the operator's
+    deliberate non-dispatch signal — it is not a guard --force can override."""
+    issues = [{"number": 2001, "title": "conflicted operator action"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL, "bug"]),
+        force=True,
+    )
+
+    # The malformed operator-action issue must NOT leak into runnable.
+    assert result.runnable == []
+    # It still surfaces as a label-conflict skip so the operator can fix the
+    # collision (rather than the system silently swallowing it).
+    assert len(result.skipped) == 1
+    assert result.skipped[0].reason_codes == (OPERATOR_ACTION_LABEL_CONFLICT_CODE,)
+
+
+def test_force_does_not_bypass_operator_action_missing_ac(tmp_path: Path) -> None:
+    """Missing-AC operator-action issues stay refused under --force."""
+    body_no_ac = "## What\n\nDo something operator-shaped.\n\n## Why\n\nReasons.\n"
+    issues = [{"number": 2002, "title": "operator missing AC"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(body_no_ac, [OPERATOR_ACTION_LABEL]),
+        force=True,
+    )
+
+    assert result.runnable == []
+    assert len(result.skipped) == 1
+    assert result.skipped[0].reason_codes == (OPERATOR_ACTION_MISSING_AC_CODE,)
+
+
+def test_force_passes_through_non_operator_action_issues(tmp_path: Path) -> None:
+    """Sanity: --force still bypasses ordinary shape-gate skips, only
+    operator-action labeled issues are excluded."""
+    issues = [
+        {"number": 3001, "title": "malformed (not operator)"},
+        {"number": 3002, "title": "operator-action"},
+    ]
+
+    def fetch(number, _project_root):
+        if number == 3001:
+            return {"title": "malformed", "body": "no structure", "labels": []}
+        return {
+            "title": "operator-action",
+            "body": _OPERATOR_ACTION_BODY,
+            "labels": [OPERATOR_ACTION_LABEL],
+        }
+
+    result = apply_shape_gate(issues, tmp_path, fetch_detail=fetch, force=True)
+
+    # Non-operator-action issue is forced through; operator-action one is not.
+    assert [i["number"] for i in result.runnable] == [3001]
+    assert [s.issue_number for s in result.operator_action] == [3002]
+
+
 # ── Banner formatting ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

The prior force-path bypass is resolved, and I found no blocking regressions in the final iteration.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $10.94
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Operator-action intake refusal: forge sprint must not dispatch operator-action issues to dev cycles (GitHub Issue #1473)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1473