### PR TITLE
--force does not bypass runner intake remediation; operator's escape valve is structurally incomplete

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -233,6 +233,7 @@ def cmd_sprint(args: object) -> int:
             "resume": resume,
             "config": str(config_path),
             "no_pull": no_pull,
+            "force": force,
         }
         response = _daemon.submit_sprint(config.project_root, str(manifest_path), sprint_args)
         if response.get("ok"):

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -258,6 +258,7 @@ def cmd_sprint(args: object) -> int:
             no_pull=no_pull,
             run_id=run_id,
             dropped_slugs=dropped_slugs,
+            force=force,
         )
     except Exception as exc:
         import traceback
@@ -689,6 +690,7 @@ def _run_query_mode(
             dropped_slugs=dropped_slugs,
             skipped_issues=skipped_issues,
             entry_intake_outcomes=entry_intake_outcomes,
+            force=force,
         )
     except Exception as exc:
         import traceback

--- a/src/theforge/daemon.py
+++ b/src/theforge/daemon.py
@@ -314,6 +314,7 @@ class DaemonServer:
                 resume=args.get("resume", False),
                 state_update_fn=state_update_fn,
                 no_pull=args.get("no_pull", False),
+                force=args.get("force", False),
             )
         finally:
             release_story_locks(locked_fds)

--- a/src/theforge/intake/remediation.py
+++ b/src/theforge/intake/remediation.py
@@ -383,6 +383,7 @@ def run_intake_remediation(
     fetch_detail: FetchIssueDetail = _default_fetch_detail,
     post_comment: PostIssueComment = _default_post_comment,
     edit_body: EditIssueBody = _default_edit_body,
+    force: bool = False,
 ) -> dict[str, IntakeOutcome]:
     """Run the intake remediation pass over the full normalized task list.
 
@@ -396,6 +397,20 @@ def run_intake_remediation(
     shape gate already filtered upstream in ``cli/sprint.py``.)
     """
     outcomes: dict[str, IntakeOutcome] = {}
+
+    if force:
+        # Operator override: --force is a uniform, single-layer bypass of
+        # intake gating. Skip every per-task remediation step (including the
+        # GH detail fetch) so no LLM auto-fix budget is spent and the issue
+        # progresses to preflight regardless of which gate rule would fire.
+        for task in tasks:
+            outcomes[task.slug] = IntakeOutcome(
+                slug=task.slug,
+                kind=IntakeOutcomeKind.PASSED,
+                detail="intake remediation bypassed by --force",
+                audit={"force_bypass": True},
+            )
+        return outcomes
 
     for task in tasks:
         slug = task.slug

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -171,6 +171,7 @@ def _run_intake_remediation_pass(
     config: ForgeConfig,
     tasks: list[TaskStory],
     log: Callable[[str], None],
+    force: bool = False,
 ) -> dict[str, IntakeOutcome]:
     """Run the intake remediation pass on the normalized task list.
 
@@ -186,15 +187,21 @@ def _run_intake_remediation_pass(
     auto_fix_enabled = auto_fix_raw if isinstance(auto_fix_raw, bool) else False
     auto_fix_mode = auto_fix_mode_raw if isinstance(auto_fix_mode_raw, str) else "comment"
     auto_fix_mode = auto_fix_mode or "comment"
-    if not grooming_enabled and not auto_fix_enabled:
+    if not grooming_enabled and not auto_fix_enabled and not force:
         return {}
-    log(
-        "Intake remediation gate: grooming="
-        f"{grooming_enabled} auto_fix={auto_fix_enabled} mode={auto_fix_mode}"
-    )
+    if force:
+        log(
+            "Intake remediation gate bypassed by --force "
+            f"(grooming={grooming_enabled} auto_fix={auto_fix_enabled} mode={auto_fix_mode})"
+        )
+    else:
+        log(
+            "Intake remediation gate: grooming="
+            f"{grooming_enabled} auto_fix={auto_fix_enabled} mode={auto_fix_mode}"
+        )
     agent_caller = None
     missing_agent_detail = "auto-fix enabled but no agent caller wired"
-    if auto_fix_enabled:
+    if auto_fix_enabled and not force:
         agent_caller, missing_agent_detail = _build_intake_agent_caller(
             config=config,
             log=log,
@@ -207,6 +214,7 @@ def _run_intake_remediation_pass(
         auto_fix_mode=auto_fix_mode,
         agent_caller=agent_caller,
         missing_agent_detail=missing_agent_detail,
+        force=force,
     )
 
 
@@ -1283,6 +1291,7 @@ def run_sprint(
     dropped_slugs: "dict[str, str] | None" = None,
     skipped_issues: "list | None" = None,
     entry_intake_outcomes: "dict[int, IntakeOutcome] | None" = None,
+    force: bool = False,
 ) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -1564,6 +1573,7 @@ def run_sprint(
         config=config,
         tasks=normalized.tasks,
         log=_log,
+        force=force,
     )
     if intake_outcomes:
         terminal_kinds = {IntakeOutcomeKind.DROPPED_SHAPE, IntakeOutcomeKind.DROPPED_AFTER_FIX}

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -473,6 +473,116 @@ class TestDaemonNoPull:
         assert kwargs.get("no_pull") is True
 
 
+class TestDaemonForce:
+    """Daemon correctly threads --force from CLI submit through to run_sprint."""
+
+    def test_daemon_sprint_args_includes_force(self, tmp_path):
+        import argparse
+
+        import theforge.cli.sprint as sprint_cli
+
+        manifest_path = tmp_path / "sprint.yaml"
+        manifest_path.touch()
+        (tmp_path / "forge.yaml").touch()
+
+        args = argparse.Namespace(
+            manifest=str(manifest_path),
+            config=None,
+            auto_merge=False,
+            interactive=False,
+            verbose=False,
+            no_notify=False,
+            resume=False,
+            detach=True,
+            fg=False,
+            no_pull=False,
+            force=True,
+        )
+
+        captured: dict = {}
+
+        def capture_submit(root, mpath, sprint_args):
+            captured.update(sprint_args)
+            return {"ok": True, "queued": "sprint", "position": 1}
+
+        with (
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.cli.sprint.load_config", return_value=MagicMock(project_root=tmp_path)
+            ),
+            patch("theforge.cli.sprint.parse_manifest_slugs", return_value=[]),
+            patch("theforge.cli.sprint.release_story_locks"),
+            patch("theforge.daemon.is_daemon_running", return_value=True),
+            patch("theforge.daemon.submit_sprint", side_effect=capture_submit),
+        ):
+            sprint_cli.cmd_sprint(args)
+
+        assert captured.get("force") is True
+
+    def test_daemon_execute_sprint_passes_force(self, tmp_path):
+        from theforge.daemon import DaemonServer
+
+        mock_config = MagicMock()
+        mock_config.project_root = tmp_path
+
+        manifest_path = tmp_path / "sprint.yaml"
+        manifest_path.touch()
+
+        args = {
+            "auto_merge": False,
+            "notify": True,
+            "resume": False,
+            "no_pull": False,
+            "force": True,
+        }
+
+        with (
+            patch("theforge.config.load_config", return_value=mock_config),
+            patch("theforge.sprint.runner.parse_manifest_slugs", return_value=[]),
+            patch("theforge.sprint.lock.acquire_story_locks", return_value=([], [])),
+            patch("theforge.sprint.lock.release_story_locks"),
+            patch("theforge.sprint.run_sprint") as mock_rs,
+        ):
+            mock_rs.return_value = MagicMock(specs_failed=0)
+
+            daemon = object.__new__(DaemonServer)
+            daemon.forge_root = tmp_path
+
+            DaemonServer._execute_sprint(daemon, str(manifest_path), args, state_update_fn=None)
+
+        mock_rs.assert_called_once()
+        _, kwargs = mock_rs.call_args
+        assert kwargs.get("force") is True
+
+    def test_daemon_execute_sprint_defaults_force_false(self, tmp_path):
+        """Args without 'force' key must default to False (no implicit bypass)."""
+        from theforge.daemon import DaemonServer
+
+        mock_config = MagicMock()
+        mock_config.project_root = tmp_path
+        manifest_path = tmp_path / "sprint.yaml"
+        manifest_path.touch()
+
+        args = {"auto_merge": False, "notify": True, "resume": False, "no_pull": False}
+
+        with (
+            patch("theforge.config.load_config", return_value=mock_config),
+            patch("theforge.sprint.runner.parse_manifest_slugs", return_value=[]),
+            patch("theforge.sprint.lock.acquire_story_locks", return_value=([], [])),
+            patch("theforge.sprint.lock.release_story_locks"),
+            patch("theforge.sprint.run_sprint") as mock_rs,
+        ):
+            mock_rs.return_value = MagicMock(specs_failed=0)
+
+            daemon = object.__new__(DaemonServer)
+            daemon.forge_root = tmp_path
+
+            DaemonServer._execute_sprint(daemon, str(manifest_path), args, state_update_fn=None)
+
+        _, kwargs = mock_rs.call_args
+        assert kwargs.get("force") is False
+
+
 # ── Deindex forge artifacts tests ─────────────────────────────────────
 
 

--- a/tests/test_intake/test_remediation.py
+++ b/tests/test_intake/test_remediation.py
@@ -278,3 +278,38 @@ def test_agent_no_output_is_distinguished_in_audit():
     assert out.detail == "model refused rewrite"
     assert out.audit["remediation_source"] == "agent_no_output"
     assert out.audit["agent"]["attempted"] is True
+
+
+def test_force_bypass_skips_fetch_and_agent_for_every_task():
+    task_a = _make_task(slug="a", issue=11)
+    task_b = _make_task(slug="b", issue=12)
+    task_c = _make_task(slug="c", issue=None)
+
+    fetch_calls: list = []
+
+    def fetch(n, root):
+        fetch_calls.append((n, root))
+        return {"title": "T", "body": _FAILING_BODY, "labels": ["enhancement"]}
+
+    def agent(*_a, **_kw):
+        raise AssertionError("agent must not run under --force")
+
+    outcomes = run_intake_remediation(
+        [task_a, task_b, task_c],
+        None,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="edit",
+        agent_caller=agent,
+        fetch_detail=fetch,
+        post_comment=lambda *_: True,
+        edit_body=lambda *_: True,
+        force=True,
+    )
+
+    assert fetch_calls == []
+    for slug in ("a", "b", "c"):
+        out = outcomes[slug]
+        assert out.kind is IntakeOutcomeKind.PASSED
+        assert out.audit.get("force_bypass") is True
+        assert out.detail == "intake remediation bypassed by --force"

--- a/tests/test_intake/test_runner_seam.py
+++ b/tests/test_intake/test_runner_seam.py
@@ -20,8 +20,13 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.config.types import IntakeConfig
 from theforge.sprint.query import NormalizedDependencyPlan
-from theforge.sprint.runner import _build_intake_agent_caller, _filter_normalized_for_intake
+from theforge.sprint.runner import (
+    _build_intake_agent_caller,
+    _filter_normalized_for_intake,
+    _run_intake_remediation_pass,
+)
 from theforge.task import TaskStory
 
 
@@ -74,3 +79,74 @@ def test_build_intake_agent_caller_returns_none_when_profile_unavailable(tmp_pat
 
     assert caller is None
     assert "auth missing" in detail
+
+
+def _config_with_intake(tmp_path, *, grooming: bool, auto_fix: bool) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        intake=IntakeConfig(grooming=grooming, auto_fix=auto_fix, auto_fix_mode="edit"),
+    )
+
+
+def test_run_intake_remediation_pass_force_short_circuits(tmp_path):
+    config = _config_with_intake(tmp_path, grooming=True, auto_fix=True)
+    tasks = [_t("alpha"), _t("beta")]
+    tasks[0] = TaskStory(name="alpha", slug="alpha", github_issue=101)
+    tasks[1] = TaskStory(name="beta", slug="beta", github_issue=102)
+
+    log_lines: list[str] = []
+
+    def fake_run(*_a, force=False, **_kw):
+        # Real run_intake_remediation honors `force`; assert the pass forwards it.
+        assert force is True
+        return {"alpha": "fake", "beta": "fake"}
+
+    with (
+        patch("theforge.sprint.runner.run_intake_remediation", side_effect=fake_run) as patched,
+        patch("theforge.sprint.runner._build_intake_agent_caller") as build_agent,
+    ):
+        outcomes = _run_intake_remediation_pass(
+            config=config, tasks=tasks, log=log_lines.append, force=True
+        )
+
+    # Agent caller must NOT be wired when force is set — bypass means $0 of LLM spend.
+    build_agent.assert_not_called()
+    assert patched.call_count == 1
+    _, kwargs = patched.call_args
+    assert kwargs["force"] is True
+    assert kwargs["agent_caller"] is None
+    assert outcomes == {"alpha": "fake", "beta": "fake"}
+    assert any("bypassed by --force" in line for line in log_lines)
+
+
+def test_run_intake_remediation_pass_force_runs_even_when_disabled(tmp_path):
+    """force=True must enter the pass even when grooming + auto_fix are off,
+    so the bypass logging fires and the empty-passed outcomes are recorded.
+    """
+    config = _config_with_intake(tmp_path, grooming=False, auto_fix=False)
+    task = TaskStory(name="x", slug="x", github_issue=9)
+    log_lines: list[str] = []
+
+    def fake_run(_tasks, _root, **kwargs):
+        assert kwargs.get("force") is True
+        return {"x": "ok"}
+
+    with patch("theforge.sprint.runner.run_intake_remediation", side_effect=fake_run):
+        outcomes = _run_intake_remediation_pass(
+            config=config, tasks=[task], log=log_lines.append, force=True
+        )
+
+    assert outcomes == {"x": "ok"}
+    assert any("bypassed by --force" in line for line in log_lines)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior daemon-side force propagation gap is fixed, and the current code consistently threads --force through CLI, daemon, run_sprint, and runner intake remediation. | [deepseek-deepseek-reasoner] --force is now uniformly threaded from CLI through daemon boundary into run_intake_remediation, closing the runner-side gate gap. All acceptance criteria are met with comprehensive tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $3.79
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

--force does not bypass runner intake remediation; operator's escape valve is structurally incomplete (GitHub Issue #1477)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1477