### PR TITLE
Intake remediation DROPPED_AFTER_FIX outcome loses actionable findings detail at every operator-facing surface, despite IntakeOutcome.audit already carrying the full structured detail

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -218,6 +218,62 @@ def _run_intake_remediation_pass(
     )
 
 
+def _intake_finding_codes(outcome: IntakeOutcome) -> list[str]:
+    """Stable-sorted list of unique blocking finding codes for an intake outcome."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for finding in outcome.findings:
+        code = finding.code
+        if code and code not in seen:
+            seen.add(code)
+            ordered.append(code)
+    return ordered
+
+
+def _intake_outcome_summary(outcome: IntakeOutcome) -> str:
+    """One-line operator-readable summary: '<codes> — <detail>'.
+
+    Carries enough information for an operator to know which intake rule fired
+    on the dropped story, the agent attempt status, and the rerun-gate result.
+    """
+    codes = _intake_finding_codes(outcome)
+    code_part = "[" + ", ".join(codes) + "]" if codes else ""
+    detail = outcome.detail or outcome.kind.value
+    if code_part and detail:
+        return f"{code_part} {detail}"
+    return code_part or detail
+
+
+def _intake_problem_lines(outcome: IntakeOutcome) -> list[str]:
+    """Human-readable per-finding descriptors: 'code (location): problem'."""
+    lines: list[str] = []
+    for finding in outcome.findings:
+        loc = finding.location or ""
+        head = f"{finding.code} ({loc})" if loc else finding.code
+        problem = (finding.problem or "").strip()
+        lines.append(f"{head}: {problem}" if problem else head)
+    return lines
+
+
+def _intake_error_type(outcome: IntakeOutcome) -> str:
+    """outcome_code-style classifier: dominant rule code, else the kind value."""
+    codes = _intake_finding_codes(outcome)
+    if codes:
+        return codes[0]
+    return outcome.kind.value
+
+
+def _intake_audit_block(outcome: IntakeOutcome) -> dict:
+    """Structured intake_findings block surfaced into audit/summary YAML."""
+    return {
+        "kind": outcome.kind.value,
+        "detail": outcome.detail,
+        "codes": _intake_finding_codes(outcome),
+        "findings": [f.as_dict() for f in outcome.findings],
+        "audit": dict(outcome.audit),
+    }
+
+
 def _filter_normalized_for_intake(
     plan: NormalizedDependencyPlan,
     dropped: set[str],
@@ -1562,6 +1618,62 @@ def run_sprint(
     )
     normalized = normalize_dependency_plan(all_tasks, satisfied=satisfied_slugs)
 
+    # Per-story projection used by audit and summary writers when a slug never
+    # produces a CoordinatorResult (e.g., dropped at the intake gate, blocked
+    # by deps, or skipped pre-launch). Defined here — before the intake gate —
+    # so intake-dropped stories can populate it with their finding detail; the
+    # writers read from this dict to surface error/error_type/intake metadata
+    # that would otherwise be null in audit YAML and sprint summary YAML.
+    current_story_entries_by_ref: dict[str, dict] = {}
+
+    def _record_current_story_entry(
+        slug: str,
+        outcome: str,
+        *,
+        error: str | None = None,
+        error_type: str | None = None,
+        cost_usd: float = 0.0,
+        extras: dict | None = None,
+    ) -> None:
+        task_ctx = slug_to_context.get(slug)
+        if task_ctx is None:
+            return
+        task, _source, canonical_ref = task_ctx
+        display_key = (
+            f"Issue #{canonical_ref.split(':')[1]}"
+            if canonical_ref.startswith("issue:")
+            else canonical_ref
+        )
+        entry: dict = {
+            "path": display_key,
+            "slug": slug,
+            "outcome": outcome,
+            "verdict": None,
+            "cost_usd": cost_usd,
+            "story_run_id": run_id,
+            "preflight": None,
+            "preflight_original_verdict": None,
+            "preflight_source_run_id": None,
+            "error": error,
+            "error_type": error_type,
+            "outcome_code": error_type or outcome.lower(),
+            "merge": False,
+            "batch": 0,
+            "depends_on": list(getattr(task, "depends_on", None) or []),
+            "dependency_warnings": list(getattr(task, "dependency_warnings", None) or []),
+            "inferred_dependencies": {
+                "manifest": [
+                    dep
+                    for dep in (getattr(task, "depends_on", None) or [])
+                    if dep not in (getattr(task, "inferred_dependencies", None) or [])
+                ],
+                "github_blockers": list(getattr(task, "inferred_dependencies", None) or []),
+            },
+        }
+        if extras:
+            entry.update(extras)
+        current_story_entries_by_ref[canonical_ref] = entry
+
     # Intake remediation gate: between dependency normalization and the
     # batch preflight spend, run the shared shape + grooming check on the
     # full normalized task list. When ``intake.auto_fix`` is enabled, semantic
@@ -1600,17 +1712,59 @@ def run_sprint(
                 if outcome.kind is IntakeOutcomeKind.DROPPED_SHAPE
                 else StoryOutcome.DROPPED_AFTER_FIX
             )
+            intake_codes = _intake_finding_codes(outcome)
+            intake_summary = _intake_outcome_summary(outcome)
+            intake_error_type = _intake_error_type(outcome)
+            intake_block = _intake_audit_block(outcome)
+            # Per-issue run-log line so operators reading the live sprint log
+            # learn the blocking rule code(s) and detail without having to open
+            # audit YAML or re-derive them with a Python snippet against
+            # groom_check.
+            task_ctx = slug_to_context.get(slug)
+            if task_ctx is not None:
+                _, _, canonical_ref = task_ctx
+                display_key = (
+                    f"Issue #{canonical_ref.split(':')[1]}"
+                    if canonical_ref.startswith("issue:")
+                    else canonical_ref
+                )
+            else:
+                display_key = slug
+            _log(
+                f"  {outcome_value.name} {display_key}: {intake_summary}"
+                if intake_summary
+                else f"  {outcome_value.name} {display_key}"
+            )
+            for problem_line in _intake_problem_lines(outcome):
+                _log(f"      - {problem_line}")
             _set_outcome(
                 slug,
                 outcome_value,
                 detail={
                     "intake_kind": outcome.kind.value,
                     "intake_findings": [f.as_dict() for f in outcome.findings],
+                    "intake_codes": intake_codes,
+                    "intake_summary": intake_summary,
                     "intake_detail": outcome.detail,
                     "intake_audit": dict(outcome.audit),
                 },
-                reason=outcome.detail or outcome.kind.value,
+                reason=intake_summary or outcome.detail or outcome.kind.value,
             )
+            # Mirror the structured detail into current_story_entries_by_ref so
+            # both audit YAML and sprint summary YAML carry the rule code,
+            # human-readable problem, and the structured intake_findings block —
+            # not just the bare SKIPPED outcome with error: null.
+            if outcome.kind in {
+                IntakeOutcomeKind.DROPPED_SHAPE,
+                IntakeOutcomeKind.DROPPED_AFTER_FIX,
+            }:
+                _record_current_story_entry(
+                    slug,
+                    outcome_value.name,
+                    error=intake_summary,
+                    error_type=intake_error_type,
+                    extras={"intake": intake_block},
+                )
         if dropped_slugs_intake:
             normalized = _filter_normalized_for_intake(normalized, dropped_slugs_intake)
 
@@ -1672,51 +1826,6 @@ def run_sprint(
         dag = build_dag(augmented_tasks, satisfied=satisfied_slugs)
     except ValueError as exc:
         raise ValueError(f"{exc} Synthetic collision edges: {synthetic_edges}") from exc
-
-    current_story_entries_by_ref: dict[str, dict] = {}
-
-    def _record_current_story_entry(
-        slug: str,
-        outcome: str,
-        *,
-        error: str | None = None,
-        error_type: str | None = None,
-    ) -> None:
-        task_ctx = slug_to_context.get(slug)
-        if task_ctx is None:
-            return
-        task, _source, canonical_ref = task_ctx
-        display_key = (
-            f"Issue #{canonical_ref.split(':')[1]}"
-            if canonical_ref.startswith("issue:")
-            else canonical_ref
-        )
-        current_story_entries_by_ref[canonical_ref] = {
-            "path": display_key,
-            "slug": slug,
-            "outcome": outcome,
-            "verdict": None,
-            "cost_usd": 0.0,
-            "story_run_id": run_id,
-            "preflight": None,
-            "preflight_original_verdict": None,
-            "preflight_source_run_id": None,
-            "error": error,
-            "error_type": error_type,
-            "outcome_code": error_type or outcome.lower(),
-            "merge": False,
-            "batch": 0,
-            "depends_on": list(getattr(task, "depends_on", None) or []),
-            "dependency_warnings": list(getattr(task, "dependency_warnings", None) or []),
-            "inferred_dependencies": {
-                "manifest": [
-                    dep
-                    for dep in (getattr(task, "depends_on", None) or [])
-                    if dep not in (getattr(task, "inferred_dependencies", None) or [])
-                ],
-                "github_blockers": list(getattr(task, "inferred_dependencies", None) or []),
-            },
-        }
 
     # Dependencies already satisfied outside this sprint still count as landed
     # for deferred integration ordering.

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -263,6 +263,62 @@ def _intake_error_type(outcome: IntakeOutcome) -> str:
     return outcome.kind.value
 
 
+def _intake_log_lines(outcome: IntakeOutcome, *, outcome_name: str, display_key: str) -> list[str]:
+    """Lines the runner emits to the sprint log for a non-PASSED intake outcome.
+
+    Operators must learn the rule code(s), the per-finding problem strings,
+    and the agent attempt details (whether the LLM ran, cost, model,
+    transport, whether the issue was edited or commented on) — without
+    consulting audit YAML or re-deriving with a Python snippet against
+    groom_check.
+    """
+    summary = _intake_outcome_summary(outcome)
+    lines: list[str] = []
+    if summary:
+        lines.append(f"  {outcome_name} {display_key}: {summary}")
+    else:
+        lines.append(f"  {outcome_name} {display_key}")
+    for problem_line in _intake_problem_lines(outcome):
+        lines.append(f"      - {problem_line}")
+    agent_summary = _intake_agent_summary(outcome)
+    if agent_summary:
+        lines.append(f"      auto-fix: {agent_summary}")
+    return lines
+
+
+def _intake_agent_summary(outcome: IntakeOutcome) -> str:
+    """One-line agent-attempt summary derived from outcome.audit.
+
+    Surfaces ``remediation_source`` plus the agent block fields (attempted,
+    cost_usd, model_used, transport_used) so the run log and forge status
+    DETAIL show whether the auto-fix actually tried and what it cost — not
+    just whether the rerun gate failed.
+    """
+    audit = outcome.audit or {}
+    parts: list[str] = []
+    source = audit.get("remediation_source")
+    if isinstance(source, str) and source and source != "none":
+        parts.append(f"source={source}")
+    agent = audit.get("agent")
+    if isinstance(agent, dict):
+        attempted = bool(agent.get("attempted"))
+        parts.append(f"agent_attempted={'yes' if attempted else 'no'}")
+        cost = agent.get("cost_usd")
+        if isinstance(cost, (int, float)) and cost > 0:
+            parts.append(f"cost=${float(cost):.4f}")
+        model = agent.get("model_used")
+        if isinstance(model, str) and model:
+            parts.append(f"model={model}")
+        transport = agent.get("transport_used")
+        if isinstance(transport, str) and transport:
+            parts.append(f"transport={transport}")
+    if audit.get("issue_updated") is True:
+        parts.append("issue_updated=true")
+    if audit.get("comment_posted") is True:
+        parts.append("comment_posted=true")
+    return ", ".join(parts)
+
+
 def _intake_audit_block(outcome: IntakeOutcome) -> dict:
     """Structured intake_findings block surfaced into audit/summary YAML."""
     return {
@@ -270,6 +326,7 @@ def _intake_audit_block(outcome: IntakeOutcome) -> dict:
         "detail": outcome.detail,
         "codes": _intake_finding_codes(outcome),
         "findings": [f.as_dict() for f in outcome.findings],
+        "agent_summary": _intake_agent_summary(outcome),
         "audit": dict(outcome.audit),
     }
 
@@ -1715,6 +1772,8 @@ def run_sprint(
             intake_codes = _intake_finding_codes(outcome)
             intake_summary = _intake_outcome_summary(outcome)
             intake_error_type = _intake_error_type(outcome)
+            intake_agent_summary = _intake_agent_summary(outcome)
+            intake_problem_lines = _intake_problem_lines(outcome)
             intake_block = _intake_audit_block(outcome)
             # Per-issue run-log line so operators reading the live sprint log
             # learn the blocking rule code(s) and detail without having to open
@@ -1730,13 +1789,10 @@ def run_sprint(
                 )
             else:
                 display_key = slug
-            _log(
-                f"  {outcome_value.name} {display_key}: {intake_summary}"
-                if intake_summary
-                else f"  {outcome_value.name} {display_key}"
-            )
-            for problem_line in _intake_problem_lines(outcome):
-                _log(f"      - {problem_line}")
+            for log_line in _intake_log_lines(
+                outcome, outcome_name=outcome_value.name, display_key=display_key
+            ):
+                _log(log_line)
             _set_outcome(
                 slug,
                 outcome_value,
@@ -1745,6 +1801,8 @@ def run_sprint(
                     "intake_findings": [f.as_dict() for f in outcome.findings],
                     "intake_codes": intake_codes,
                     "intake_summary": intake_summary,
+                    "intake_problem_lines": intake_problem_lines,
+                    "intake_agent_summary": intake_agent_summary,
                     "intake_detail": outcome.detail,
                     "intake_audit": dict(outcome.audit),
                 },

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -311,6 +311,16 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
             canonical_outcome = _nonempty_str(story.get("outcome"))
             final_outcome = canonical_outcome.upper() if canonical_outcome else None
         skip_reason = _nonempty_str(story.get("reason")) if status_val == "skipped" else None
+        # Intake-drop outcomes carry structured rule codes in the detail dict.
+        # Surfacing them in the DETAIL column keeps operators from having to
+        # consult audit YAML to learn which rule fired on a dropped story.
+        if isinstance(final_outcome, str) and final_outcome in {
+            "DROPPED_AFTER_FIX",
+            "DROPPED_SHAPE",
+        }:
+            intake_summary = _nonempty_str(detail_data.get("intake_summary"))
+            if intake_summary:
+                return "", f"{final_outcome} {intake_summary}", complexity
         if (
             skip_reason
             and isinstance(final_outcome, str)
@@ -483,6 +493,15 @@ def _stage_and_detail_from_completed_story(
                 or _nonempty_str(story.get("drop_reason"))
                 or outcome
             )
+        elif outcome in {"DROPPED_AFTER_FIX", "DROPPED_SHAPE"}:
+            # Intake-drop entries carry the rule code + problem in ``error``
+            # and the structured detail in ``intake``. Surface either so the
+            # operator sees more than the bare outcome name.
+            error = _nonempty_str(story.get("error"))
+            if error:
+                detail = f"{outcome} {error}"
+            else:
+                detail = outcome
         elif outcome == "DONE":
             detail = "APPROVE"
         elif outcome == "ALREADY_DONE":

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -272,6 +272,70 @@ def _terminal_phase(
     return outcome or None
 
 
+def _render_intake_drop_detail(final_outcome: str, detail_data: dict) -> str:
+    """Operator-readable DETAIL for an intake-dropped story.
+
+    Includes the primary rule code + finding problem (so the operator knows
+    *what* failed) and an agent attempt summary (whether the LLM ran, cost,
+    model) — the structured data already lives in ``detail.intake_findings``
+    and ``detail.intake_audit``; this renders it instead of reducing to the
+    rule-codes-only ``intake_summary`` string.
+    """
+    findings = detail_data.get("intake_findings") or []
+    primary_code: str | None = None
+    primary_problem: str | None = None
+    if isinstance(findings, list) and findings:
+        first = findings[0]
+        if isinstance(first, dict):
+            code = first.get("code")
+            problem = first.get("problem")
+            if isinstance(code, str) and code:
+                primary_code = code
+            if isinstance(problem, str) and problem.strip():
+                primary_problem = problem.strip()
+    if primary_code is None:
+        codes = detail_data.get("intake_codes")
+        if isinstance(codes, list) and codes and isinstance(codes[0], str):
+            primary_code = codes[0]
+
+    parts: list[str] = [final_outcome]
+    if primary_code:
+        head = f"[{primary_code}]"
+        if primary_problem:
+            head = f"{head} {primary_problem}"
+        parts.append(head)
+    elif primary_problem:
+        parts.append(primary_problem)
+    else:
+        intake_summary = _nonempty_str(detail_data.get("intake_summary"))
+        if intake_summary:
+            parts.append(intake_summary)
+
+    agent_summary = _nonempty_str(detail_data.get("intake_agent_summary"))
+    if not agent_summary:
+        intake_audit = detail_data.get("intake_audit")
+        if isinstance(intake_audit, dict):
+            agent = intake_audit.get("agent")
+            if isinstance(agent, dict):
+                bits: list[str] = []
+                if agent.get("attempted"):
+                    bits.append("agent_attempted=yes")
+                else:
+                    bits.append("agent_attempted=no")
+                cost = agent.get("cost_usd")
+                if isinstance(cost, (int, float)) and cost > 0:
+                    bits.append(f"cost=${float(cost):.4f}")
+                model = agent.get("model_used")
+                if isinstance(model, str) and model:
+                    bits.append(f"model={model}")
+                agent_summary = ", ".join(bits) or None
+    if agent_summary:
+        parts.append(f"({agent_summary})")
+    if len(parts) == 1:
+        return ""
+    return " ".join(parts)
+
+
 def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None]:
     phase_val = story.get("phase")
     status_val = story.get("status", "waiting")
@@ -313,14 +377,15 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
         skip_reason = _nonempty_str(story.get("reason")) if status_val == "skipped" else None
         # Intake-drop outcomes carry structured rule codes in the detail dict.
         # Surfacing them in the DETAIL column keeps operators from having to
-        # consult audit YAML to learn which rule fired on a dropped story.
+        # consult audit YAML to learn which rule fired, what the agent tried,
+        # or why the rerun gate failed.
         if isinstance(final_outcome, str) and final_outcome in {
             "DROPPED_AFTER_FIX",
             "DROPPED_SHAPE",
         }:
-            intake_summary = _nonempty_str(detail_data.get("intake_summary"))
-            if intake_summary:
-                return "", f"{final_outcome} {intake_summary}", complexity
+            rendered = _render_intake_drop_detail(final_outcome, detail_data)
+            if rendered:
+                return "", rendered, complexity
         if (
             skip_reason
             and isinstance(final_outcome, str)
@@ -495,13 +560,25 @@ def _stage_and_detail_from_completed_story(
             )
         elif outcome in {"DROPPED_AFTER_FIX", "DROPPED_SHAPE"}:
             # Intake-drop entries carry the rule code + problem in ``error``
-            # and the structured detail in ``intake``. Surface either so the
-            # operator sees more than the bare outcome name.
-            error = _nonempty_str(story.get("error"))
-            if error:
-                detail = f"{outcome} {error}"
+            # and the structured detail in ``intake``. Render finding problem
+            # + agent attempt summary so the operator can act from this row
+            # alone — not just see the outcome name.
+            intake_block = story.get("intake")
+            synthetic_detail: dict = {}
+            if isinstance(intake_block, dict):
+                synthetic_detail = {
+                    "intake_findings": intake_block.get("findings") or [],
+                    "intake_codes": intake_block.get("codes") or [],
+                    "intake_agent_summary": intake_block.get("agent_summary"),
+                    "intake_audit": intake_block.get("audit") or {},
+                    "intake_summary": _nonempty_str(story.get("error")),
+                }
             else:
-                detail = outcome
+                synthetic_detail = {
+                    "intake_summary": _nonempty_str(story.get("error")),
+                }
+            rendered = _render_intake_drop_detail(outcome, synthetic_detail)
+            detail = rendered or outcome
         elif outcome == "DONE":
             detail = "APPROVE"
         elif outcome == "ALREADY_DONE":

--- a/tests/test_intake/test_runner_drop_surfaces.py
+++ b/tests/test_intake/test_runner_drop_surfaces.py
@@ -1,0 +1,295 @@
+"""Surface-level tests for intake remediation drop reporting.
+
+When intake remediation drops a story (DROPPED_AFTER_FIX or DROPPED_SHAPE),
+every operator-facing surface — run log, audit YAML, sprint summary YAML, and
+forge sprint-status DETAIL column — must carry the rule code(s) that fired,
+the human-readable problem, and the structured intake metadata. These tests
+exercise the helpers that produce that data and the live-status renderer that
+projects it. The runner-level wiring (which sets entry detail / records the
+current_story_entries_by_ref entry) is exercised through the IntakeOutcome
+helper API the runner uses; the runner block itself is hard to call without
+the full sprint pipeline, so we keep the seam test focused on the helpers and
+the renderer that consume their outputs.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import yaml
+
+from theforge.intake.findings import FixType, IntakeFinding, IntakeSeverity
+from theforge.intake.remediation import IntakeOutcome, IntakeOutcomeKind
+from theforge.sprint.audit import _write_sprint_audit, _write_sprint_summary
+from theforge.sprint.manifest import ResolvedSprint, SprintResult
+from theforge.sprint.runner import (
+    _intake_audit_block,
+    _intake_error_type,
+    _intake_finding_codes,
+    _intake_outcome_summary,
+    _intake_problem_lines,
+)
+from theforge.sprint.status_reader import _stage_and_detail_from_live_story
+
+
+def _finding(code: str, problem: str, location: str = "acceptance_criteria") -> IntakeFinding:
+    return IntakeFinding(
+        code=code,
+        severity=IntakeSeverity.BLOCK,
+        location=location,
+        problem=problem,
+        fix_type=FixType.SEMANTIC,
+    )
+
+
+def _outcome(
+    kind: IntakeOutcomeKind = IntakeOutcomeKind.DROPPED_AFTER_FIX,
+    *,
+    findings: tuple[IntakeFinding, ...] = (),
+    detail: str = "rerun gate still failing; did not edit issue",
+    audit: dict | None = None,
+) -> IntakeOutcome:
+    return IntakeOutcome(
+        slug="task-1",
+        kind=kind,
+        findings=findings,
+        detail=detail,
+        audit=audit or {"remediation_source": "agent"},
+    )
+
+
+def test_intake_finding_codes_dedup_and_preserve_order():
+    f1 = _finding("groom_how_shaped_ac", "rule A fired")
+    f2 = _finding("groom_how_shaped_ac", "duplicate of A")
+    f3 = _finding("bug_missing_diagnosis", "rule B fired")
+    outcome = _outcome(findings=(f1, f2, f3))
+    assert _intake_finding_codes(outcome) == ["groom_how_shaped_ac", "bug_missing_diagnosis"]
+
+
+def test_intake_outcome_summary_includes_codes_and_detail():
+    outcome = _outcome(findings=(_finding("groom_how_shaped_ac", "ACs read like a HOW"),))
+    summary = _intake_outcome_summary(outcome)
+    # Operator must see both the rule code (so they know which gate fired) AND
+    # the detail string (so they know whether the agent tried/failed/declined).
+    assert "groom_how_shaped_ac" in summary
+    assert "rerun gate still failing" in summary
+
+
+def test_intake_outcome_summary_falls_back_to_kind_when_no_findings_or_detail():
+    outcome = _outcome(findings=(), detail="")
+    # Even a malformed outcome must surface *something* — never blank.
+    assert _intake_outcome_summary(outcome) == IntakeOutcomeKind.DROPPED_AFTER_FIX.value
+
+
+def test_intake_problem_lines_render_one_per_finding():
+    f1 = _finding("groom_how_shaped_ac", "ACs prescribe implementation steps")
+    f2 = _finding("missing_example", "no example block found", location="examples")
+    outcome = _outcome(findings=(f1, f2))
+    lines = _intake_problem_lines(outcome)
+    assert len(lines) == 2
+    assert "groom_how_shaped_ac" in lines[0]
+    assert "ACs prescribe implementation steps" in lines[0]
+    assert "(examples)" in lines[1]
+    assert "no example block found" in lines[1]
+
+
+def test_intake_error_type_uses_first_rule_code():
+    # The runner uses this for outcome_code so audit/summary YAML and forge
+    # sprint-status all classify dropped stories by the rule code that fired,
+    # not the generic outcome name.
+    outcome = _outcome(findings=(_finding("groom_how_shaped_ac", "p"),))
+    assert _intake_error_type(outcome) == "groom_how_shaped_ac"
+
+
+def test_intake_error_type_falls_back_to_kind_value_when_no_findings():
+    outcome = _outcome(findings=())
+    assert _intake_error_type(outcome) == "dropped_after_fix"
+
+
+def test_intake_audit_block_carries_codes_findings_and_audit():
+    f = _finding("groom_how_shaped_ac", "p")
+    outcome = _outcome(
+        findings=(f,),
+        audit={"remediation_source": "agent", "agent": {"attempted": True, "cost_usd": 0.083}},
+    )
+    block = _intake_audit_block(outcome)
+    assert block["kind"] == "dropped_after_fix"
+    assert block["codes"] == ["groom_how_shaped_ac"]
+    assert block["findings"][0]["code"] == "groom_how_shaped_ac"
+    assert block["findings"][0]["problem"] == "p"
+    assert block["audit"]["agent"]["cost_usd"] == 0.083
+    # detail must round-trip so summary YAML and audit YAML can both read it.
+    assert block["detail"] == "rerun gate still failing; did not edit issue"
+
+
+def test_live_status_detail_for_dropped_after_fix_includes_intake_summary():
+    # Mirrors what the runner writes into SprintStoryState.detail for a story
+    # dropped at the intake gate. status=failed because DROPPED_AFTER_FIX maps
+    # to legacy "failed"; final_outcome carries the canonical name.
+    story = {
+        "status": "failed",
+        "outcome": "dropped_after_fix",
+        "phase": None,
+        "blocked_by": [],
+        "detail": {
+            "final_outcome": "DROPPED_AFTER_FIX",
+            "intake_summary": "[groom_how_shaped_ac] rerun gate still failing; did not edit issue",
+            "intake_codes": ["groom_how_shaped_ac"],
+            "intake_kind": "dropped_after_fix",
+        },
+    }
+    _, detail, _ = _stage_and_detail_from_live_story(story)
+    assert "DROPPED_AFTER_FIX" in detail
+    assert "groom_how_shaped_ac" in detail
+    assert "rerun gate still failing" in detail
+
+
+def test_live_status_detail_for_dropped_shape_includes_intake_summary():
+    story = {
+        "status": "failed",
+        "outcome": "dropped_shape",
+        "phase": None,
+        "blocked_by": [],
+        "detail": {
+            "final_outcome": "DROPPED_SHAPE",
+            "intake_summary": "[missing_acceptance_criteria] auto-fix disabled",
+            "intake_codes": ["missing_acceptance_criteria"],
+            "intake_kind": "dropped_shape",
+        },
+    }
+    _, detail, _ = _stage_and_detail_from_live_story(story)
+    assert "DROPPED_SHAPE" in detail
+    assert "missing_acceptance_criteria" in detail
+
+
+def _build_intake_dropped_entry(canonical_ref: str) -> dict:
+    """Mirror the dict shape that runner._record_current_story_entry writes for
+    a DROPPED_AFTER_FIX story so the audit + summary writers can be tested in
+    isolation from the runner."""
+    f = _finding("groom_how_shaped_ac", "ACs prescribe implementation steps")
+    outcome = IntakeOutcome(
+        slug="task-1",
+        kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
+        findings=(f,),
+        detail="rerun gate still failing; did not edit issue",
+        audit={
+            "remediation_source": "agent",
+            "agent": {"attempted": True, "cost_usd": 0.083, "model_used": "claude"},
+        },
+    )
+    summary = _intake_outcome_summary(outcome)
+    error_type = _intake_error_type(outcome)
+    intake_block = _intake_audit_block(outcome)
+    return {
+        "path": f"Issue #{canonical_ref.split(':')[1]}",
+        "slug": "task-1",
+        "outcome": "DROPPED_AFTER_FIX",
+        "verdict": None,
+        "cost_usd": 0.0,
+        "story_run_id": "run-test",
+        "preflight": None,
+        "preflight_original_verdict": None,
+        "preflight_source_run_id": None,
+        "error": summary,
+        "error_type": error_type,
+        "outcome_code": error_type,
+        "merge": False,
+        "batch": 0,
+        "depends_on": [],
+        "dependency_warnings": [],
+        "inferred_dependencies": {"manifest": [], "github_blockers": []},
+        "intake": intake_block,
+    }
+
+
+def _empty_sprint_result() -> SprintResult:
+    return SprintResult(
+        name="test-sprint",
+        specs_total=0,
+        specs_succeeded=0,
+        specs_failed=0,
+        specs_skipped=0,
+        total_cost_usd=0.0,
+        budget_usd=10.0,
+        results=[],
+    )
+
+
+def _empty_manifest() -> ResolvedSprint:
+    return ResolvedSprint(name="test-sprint", budget_usd=10.0, stories=[], max_parallel=1)
+
+
+def test_audit_yaml_carries_intake_finding_for_dropped_after_fix(tmp_path: Path):
+    canonical_ref = "issue:1473"
+    entry = _build_intake_dropped_entry(canonical_ref)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    _write_sprint_audit(
+        manifest=_empty_manifest(),
+        result=_empty_sprint_result(),
+        canonical_refs=[canonical_ref],
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        project_root=tmp_path,
+        current_story_entries_by_ref={canonical_ref: entry},
+    )
+
+    audit_yaml = yaml.safe_load((tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text())
+    spec = audit_yaml["specs"][0]
+    # Outcome must be DROPPED_AFTER_FIX, not the silent SKIPPED of today.
+    assert spec["outcome"] == "DROPPED_AFTER_FIX"
+    # error/error_type must carry the rule code + problem so operators can act
+    # without re-deriving with a Python snippet.
+    assert "groom_how_shaped_ac" in spec["error"]
+    assert "rerun gate still failing" in spec["error"]
+    assert spec["error_type"] == "groom_how_shaped_ac"
+    assert spec["outcome_code"] == "groom_how_shaped_ac"
+    # Structured intake block must round-trip so the full agent attempt
+    # context is on disk for postmortem.
+    assert spec["intake"]["kind"] == "dropped_after_fix"
+    assert spec["intake"]["codes"] == ["groom_how_shaped_ac"]
+    assert spec["intake"]["audit"]["agent"]["attempted"] is True
+    assert spec["intake"]["audit"]["agent"]["cost_usd"] == 0.083
+
+
+def test_sprint_summary_yaml_carries_intake_finding_for_dropped_after_fix(tmp_path: Path):
+    canonical_ref = "issue:1473"
+    entry = _build_intake_dropped_entry(canonical_ref)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    log_dir = tmp_path / "logs"
+
+    _write_sprint_summary(
+        manifest=_empty_manifest(),
+        result=_empty_sprint_result(),
+        canonical_refs=[canonical_ref],
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        sprint_log_dir=log_dir,
+        current_story_entries_by_ref={canonical_ref: entry},
+    )
+
+    summary = yaml.safe_load((log_dir / "sprint-summary.yaml").read_text())
+    story = summary["stories"][0]
+    assert story["outcome"] == "DROPPED_AFTER_FIX"
+    assert "groom_how_shaped_ac" in story["error"]
+    assert story["error_type"] == "groom_how_shaped_ac"
+    assert story["outcome_code"] == "groom_how_shaped_ac"
+    assert story["intake"]["codes"] == ["groom_how_shaped_ac"]
+    assert story["intake"]["findings"][0]["problem"] == "ACs prescribe implementation steps"
+
+
+def test_live_status_detail_falls_back_when_intake_summary_absent():
+    # Backward-compat: a DROPPED_AFTER_FIX entry written by an older path that
+    # didn't populate intake_summary still renders something meaningful.
+    story = {
+        "status": "failed",
+        "outcome": "dropped_after_fix",
+        "phase": None,
+        "blocked_by": [],
+        "detail": {"final_outcome": "DROPPED_AFTER_FIX"},
+    }
+    _, detail, _ = _stage_and_detail_from_live_story(story)
+    assert detail == "DROPPED_AFTER_FIX"

--- a/tests/test_intake/test_runner_drop_surfaces.py
+++ b/tests/test_intake/test_runner_drop_surfaces.py
@@ -24,9 +24,11 @@ from theforge.intake.remediation import IntakeOutcome, IntakeOutcomeKind
 from theforge.sprint.audit import _write_sprint_audit, _write_sprint_summary
 from theforge.sprint.manifest import ResolvedSprint, SprintResult
 from theforge.sprint.runner import (
+    _intake_agent_summary,
     _intake_audit_block,
     _intake_error_type,
     _intake_finding_codes,
+    _intake_log_lines,
     _intake_outcome_summary,
     _intake_problem_lines,
 )
@@ -107,6 +109,86 @@ def test_intake_error_type_falls_back_to_kind_value_when_no_findings():
     assert _intake_error_type(outcome) == "dropped_after_fix"
 
 
+def test_intake_agent_summary_includes_attempted_cost_model_transport():
+    outcome = _outcome(
+        findings=(_finding("groom_how_shaped_ac", "p"),),
+        audit={
+            "remediation_source": "agent",
+            "agent": {
+                "attempted": True,
+                "cost_usd": 0.083,
+                "model_used": "claude-sonnet-4-6",
+                "transport_used": "cli",
+            },
+            "issue_updated": False,
+            "comment_posted": False,
+        },
+    )
+    summary = _intake_agent_summary(outcome)
+    assert "source=agent" in summary
+    assert "agent_attempted=yes" in summary
+    assert "$0.0830" in summary
+    assert "model=claude-sonnet-4-6" in summary
+    assert "transport=cli" in summary
+
+
+def test_intake_agent_summary_when_agent_did_not_run():
+    """Real DROPPED_SHAPE outcomes always carry an ``agent`` block (built by
+    intake.remediation._build_audit) with attempted=False; the summary must
+    explicitly say so rather than going silent."""
+    outcome = _outcome(
+        kind=IntakeOutcomeKind.DROPPED_SHAPE,
+        findings=(_finding("missing_acceptance_criteria", "p", location="acceptance_criteria"),),
+        detail="auto-fix disabled",
+        audit={
+            "remediation_source": "none",
+            "agent": {
+                "attempted": False,
+                "detail": "",
+                "profile_name": None,
+                "model_used": None,
+                "cost_usd": None,
+                "transport_used": None,
+            },
+        },
+    )
+    summary = _intake_agent_summary(outcome)
+    assert "agent_attempted=no" in summary
+
+
+def test_intake_log_lines_for_dropped_after_fix_include_codes_problem_and_agent_attempt():
+    """The runner emits these lines verbatim — operators reading the run log
+    must learn the rule code, the finding problem string, AND whether the
+    auto-fix tried (cost/model/transport) without opening audit YAML."""
+    f = _finding("groom_how_shaped_ac", "ACs prescribe implementation steps")
+    outcome = _outcome(
+        findings=(f,),
+        detail="rerun gate still failing; did not edit issue",
+        audit={
+            "remediation_source": "agent",
+            "agent": {
+                "attempted": True,
+                "cost_usd": 0.083,
+                "model_used": "claude-sonnet-4-6",
+                "transport_used": "cli",
+            },
+        },
+    )
+    lines = _intake_log_lines(
+        outcome, outcome_name="DROPPED_AFTER_FIX", display_key="Issue #1473"
+    )
+    blob = "\n".join(lines)
+    assert "DROPPED_AFTER_FIX Issue #1473" in blob
+    assert "groom_how_shaped_ac" in blob
+    assert "ACs prescribe implementation steps" in blob
+    # Reviewer-required fields: agent attempted/cost/model/transport.
+    assert "agent_attempted=yes" in blob
+    assert "$0.0830" in blob
+    assert "model=claude-sonnet-4-6" in blob
+    assert "transport=cli" in blob
+    assert "source=agent" in blob
+
+
 def test_intake_audit_block_carries_codes_findings_and_audit():
     f = _finding("groom_how_shaped_ac", "p")
     outcome = _outcome(
@@ -123,29 +205,75 @@ def test_intake_audit_block_carries_codes_findings_and_audit():
     assert block["detail"] == "rerun gate still failing; did not edit issue"
 
 
-def test_live_status_detail_for_dropped_after_fix_includes_intake_summary():
-    # Mirrors what the runner writes into SprintStoryState.detail for a story
-    # dropped at the intake gate. status=failed because DROPPED_AFTER_FIX maps
-    # to legacy "failed"; final_outcome carries the canonical name.
+def _live_intake_detail_dict() -> dict:
+    """Mirror the SprintStoryState.detail dict written by the runner."""
+    return {
+        "final_outcome": "DROPPED_AFTER_FIX",
+        "intake_summary": "[groom_how_shaped_ac] rerun gate still failing; did not edit issue",
+        "intake_codes": ["groom_how_shaped_ac"],
+        "intake_kind": "dropped_after_fix",
+        "intake_findings": [
+            {
+                "code": "groom_how_shaped_ac",
+                "severity": "block",
+                "location": "acceptance_criteria",
+                "problem": "ACs prescribe implementation steps",
+                "suggested_replacement": None,
+                "fix_type": "semantic",
+            }
+        ],
+        "intake_agent_summary": (
+            "source=agent, agent_attempted=yes, cost=$0.0830, model=claude, transport=cli"
+        ),
+        "intake_audit": {
+            "remediation_source": "agent",
+            "agent": {
+                "attempted": True,
+                "cost_usd": 0.083,
+                "model_used": "claude",
+                "transport_used": "cli",
+            },
+        },
+    }
+
+
+def test_live_status_detail_for_dropped_after_fix_renders_problem_and_agent_summary():
     story = {
         "status": "failed",
         "outcome": "dropped_after_fix",
         "phase": None,
         "blocked_by": [],
-        "detail": {
-            "final_outcome": "DROPPED_AFTER_FIX",
-            "intake_summary": "[groom_how_shaped_ac] rerun gate still failing; did not edit issue",
-            "intake_codes": ["groom_how_shaped_ac"],
-            "intake_kind": "dropped_after_fix",
-        },
+        "detail": _live_intake_detail_dict(),
     }
     _, detail, _ = _stage_and_detail_from_live_story(story)
     assert "DROPPED_AFTER_FIX" in detail
     assert "groom_how_shaped_ac" in detail
-    assert "rerun gate still failing" in detail
+    # Finding.problem must be visible — not just the rule code.
+    assert "ACs prescribe implementation steps" in detail
+    # Agent attempt detail must be visible — operator needs to know whether
+    # the auto-fix tried, and at what cost/model.
+    assert "agent_attempted=yes" in detail
+    assert "$0.0830" in detail
 
 
-def test_live_status_detail_for_dropped_shape_includes_intake_summary():
+def test_live_status_detail_synthesizes_agent_summary_from_intake_audit_when_field_missing():
+    """If intake_agent_summary wasn't pre-rendered, derive it from intake_audit."""
+    detail_dict = _live_intake_detail_dict()
+    detail_dict.pop("intake_agent_summary", None)
+    story = {
+        "status": "failed",
+        "outcome": "dropped_after_fix",
+        "phase": None,
+        "blocked_by": [],
+        "detail": detail_dict,
+    }
+    _, detail, _ = _stage_and_detail_from_live_story(story)
+    assert "agent_attempted=yes" in detail
+    assert "$0.0830" in detail
+    assert "model=claude" in detail
+
+
+def test_live_status_detail_for_dropped_shape_includes_problem_string():
     story = {
         "status": "failed",
         "outcome": "dropped_shape",
@@ -156,11 +284,24 @@ def test_live_status_detail_for_dropped_shape_includes_intake_summary():
             "intake_summary": "[missing_acceptance_criteria] auto-fix disabled",
             "intake_codes": ["missing_acceptance_criteria"],
             "intake_kind": "dropped_shape",
+            "intake_findings": [
+                {
+                    "code": "missing_acceptance_criteria",
+                    "severity": "block",
+                    "location": "acceptance_criteria",
+                    "problem": "no acceptance_criteria section found",
+                    "suggested_replacement": None,
+                    "fix_type": "mechanical",
+                }
+            ],
+            "intake_audit": {"remediation_source": "none", "agent": {"attempted": False}},
         },
     }
     _, detail, _ = _stage_and_detail_from_live_story(story)
     assert "DROPPED_SHAPE" in detail
     assert "missing_acceptance_criteria" in detail
+    assert "no acceptance_criteria section found" in detail
+    assert "agent_attempted=no" in detail
 
 
 def _build_intake_dropped_entry(canonical_ref: str) -> dict:
@@ -252,6 +393,11 @@ def test_audit_yaml_carries_intake_finding_for_dropped_after_fix(tmp_path: Path)
     assert spec["intake"]["codes"] == ["groom_how_shaped_ac"]
     assert spec["intake"]["audit"]["agent"]["attempted"] is True
     assert spec["intake"]["audit"]["agent"]["cost_usd"] == 0.083
+    assert spec["intake"]["audit"]["agent"]["model_used"] == "claude"
+    # Pre-rendered agent_summary string must be on disk too so postmortem
+    # tooling does not have to re-derive it from the audit dict.
+    assert "agent_attempted=yes" in spec["intake"]["agent_summary"]
+    assert "$0.0830" in spec["intake"]["agent_summary"]
 
 
 def test_sprint_summary_yaml_carries_intake_finding_for_dropped_after_fix(tmp_path: Path):

--- a/tests/test_intake/test_runner_drop_surfaces.py
+++ b/tests/test_intake/test_runner_drop_surfaces.py
@@ -174,9 +174,7 @@ def test_intake_log_lines_for_dropped_after_fix_include_codes_problem_and_agent_
             },
         },
     )
-    lines = _intake_log_lines(
-        outcome, outcome_name="DROPPED_AFTER_FIX", display_key="Issue #1473"
-    )
+    lines = _intake_log_lines(outcome, outcome_name="DROPPED_AFTER_FIX", display_key="Issue #1473")
     blob = "\n".join(lines)
     assert "DROPPED_AFTER_FIX Issue #1473" in blob
     assert "groom_how_shaped_ac" in blob

--- a/tests/test_intake/test_runner_drop_surfaces.py
+++ b/tests/test_intake/test_runner_drop_surfaces.py
@@ -4,21 +4,20 @@ When intake remediation drops a story (DROPPED_AFTER_FIX or DROPPED_SHAPE),
 every operator-facing surface — run log, audit YAML, sprint summary YAML, and
 forge sprint-status DETAIL column — must carry the rule code(s) that fired,
 the human-readable problem, and the structured intake metadata. These tests
-exercise the helpers that produce that data and the live-status renderer that
-projects it. The runner-level wiring (which sets entry detail / records the
-current_story_entries_by_ref entry) is exercised through the IntakeOutcome
-helper API the runner uses; the runner block itself is hard to call without
-the full sprint pipeline, so we keep the seam test focused on the helpers and
-the renderer that consume their outputs.
+exercise the helpers, the live-status renderer, and (at the bottom) the full
+``run_sprint`` runner path so a regression at the runner state-write boundary
+is caught — not just at the helper or writer level.
 """
 
 from __future__ import annotations
 
 import datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import yaml
 
+from theforge.config.types import IntakeConfig
 from theforge.intake.findings import FixType, IntakeFinding, IntakeSeverity
 from theforge.intake.remediation import IntakeOutcome, IntakeOutcomeKind
 from theforge.sprint.audit import _write_sprint_audit, _write_sprint_summary
@@ -31,6 +30,7 @@ from theforge.sprint.runner import (
     _intake_log_lines,
     _intake_outcome_summary,
     _intake_problem_lines,
+    run_sprint,
 )
 from theforge.sprint.status_reader import _stage_and_detail_from_live_story
 
@@ -423,6 +423,154 @@ def test_sprint_summary_yaml_carries_intake_finding_for_dropped_after_fix(tmp_pa
     assert story["outcome_code"] == "groom_how_shaped_ac"
     assert story["intake"]["codes"] == ["groom_how_shaped_ac"]
     assert story["intake"]["findings"][0]["problem"] == "ACs prescribe implementation steps"
+
+
+def _make_runner_config(tmp_path: Path):
+    """Minimal ForgeConfig wired with intake.grooming/auto_fix on so the runner
+    enters the gate; the gate itself is patched in the test."""
+    from theforge.config import (
+        DEFAULT_DEV_PROFILE,
+        DEFAULT_PREFLIGHT_PROFILE,
+        DEFAULT_REVIEW_PROFILE,
+        DEFAULT_VALIDATION,
+        ForgeConfig,
+        RetryPolicy,
+        WorkspaceConfig,
+    )
+
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        intake=IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="edit"),
+    )
+
+
+def test_run_sprint_dropped_after_fix_propagates_intake_detail_through_full_runner_path(
+    tmp_path: Path,
+    capfd,
+):
+    """End-to-end regression for the original defect: run the actual run_sprint
+    code path with a patched intake remediation result, then assert that the
+    captured run log, sprint-audit.yaml, and sprint-summary.yaml all carry the
+    rule code, finding problem, and agent attempt detail.
+
+    This protects against regressions where run_sprint stops calling
+    _record_current_story_entry, stops passing current_story_entries_by_ref to
+    the writers, or otherwise drops the structured detail at the runner state-
+    write boundary — the exact failure mode the spec describes."""
+    spec_path = tmp_path / "drop-me.md"
+    spec_path.write_text(
+        "---\nname: Drop Me\nslug: drop-me\n---\n# Drop Me\n\nbody\n",
+        encoding="utf-8",
+    )
+    manifest_path = tmp_path / "sprint.yaml"
+    manifest_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "Intake Drop Sprint",
+                "budget_usd": 1.0,
+                "specs": [str(spec_path)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    finding = IntakeFinding(
+        code="groom_how_shaped_ac",
+        severity=IntakeSeverity.BLOCK,
+        location="acceptance_criteria",
+        problem="ACs prescribe implementation steps",
+        fix_type=FixType.SEMANTIC,
+    )
+    intake_outcome = IntakeOutcome(
+        slug="drop-me",
+        kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
+        findings=(finding,),
+        detail="rerun gate still failing; did not edit issue",
+        audit={
+            "remediation_source": "agent",
+            "mechanical_findings": [],
+            "semantic_findings": [finding.as_dict()],
+            "agent": {
+                "attempted": True,
+                "detail": "tried rewrite",
+                "profile_name": "intake-fix",
+                "model_used": "claude-sonnet-4-6",
+                "cost_usd": 0.083,
+                "transport_used": "cli",
+            },
+            "issue_updated": False,
+            "comment_posted": False,
+        },
+    )
+
+    config = _make_runner_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.runner._run_baseline_gate", return_value={"passed": True}),
+        patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+        patch("theforge.sprint.runner.resolve_satisfied_dependencies", return_value=set()),
+        patch(
+            "theforge.sprint.runner._run_intake_remediation_pass",
+            return_value={"drop-me": intake_outcome},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+    ):
+        result = run_sprint(config, manifest_path, no_pull=True)
+
+    log_blob = capfd.readouterr().err
+
+    # ── Run log: rule code + finding problem + agent attempt detail ──
+    assert "DROPPED_AFTER_FIX" in log_blob and "drop-me" in log_blob, log_blob
+    assert "groom_how_shaped_ac" in log_blob
+    assert "ACs prescribe implementation steps" in log_blob
+    assert "agent_attempted=yes" in log_blob
+    assert "$0.0830" in log_blob
+    assert "model=claude-sonnet-4-6" in log_blob
+    assert "transport=cli" in log_blob
+    assert "source=agent" in log_blob
+
+    # ── Audit YAML: error/error_type + structured intake block ──
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    assert audit_path.exists(), f"audit YAML missing; result={result}"
+    audit = yaml.safe_load(audit_path.read_text())
+    spec_entry = next(
+        s for s in audit["specs"] if s.get("slug") == "drop-me" or "drop-me" in str(s)
+    )
+    assert spec_entry["outcome"] == "DROPPED_AFTER_FIX"
+    assert "groom_how_shaped_ac" in (spec_entry.get("error") or "")
+    assert spec_entry["error_type"] == "groom_how_shaped_ac"
+    assert spec_entry["outcome_code"] == "groom_how_shaped_ac"
+    intake = spec_entry["intake"]
+    assert intake["kind"] == "dropped_after_fix"
+    assert intake["codes"] == ["groom_how_shaped_ac"]
+    assert intake["findings"][0]["problem"] == "ACs prescribe implementation steps"
+    assert intake["audit"]["agent"]["attempted"] is True
+    assert intake["audit"]["agent"]["cost_usd"] == 0.083
+    assert intake["audit"]["agent"]["model_used"] == "claude-sonnet-4-6"
+    assert "agent_attempted=yes" in intake["agent_summary"]
+
+    # ── Sprint summary YAML: same fields ──
+    summary_path = tmp_path / ".forge" / "logs" / "Intake Drop Sprint" / "sprint-summary.yaml"
+    assert summary_path.exists(), f"sprint summary YAML missing; result={result}"
+    summary = yaml.safe_load(summary_path.read_text())
+    story = next(s for s in summary["stories"] if s.get("slug") == "drop-me")
+    assert story["outcome"] == "DROPPED_AFTER_FIX"
+    assert "groom_how_shaped_ac" in (story.get("error") or "")
+    assert story["error_type"] == "groom_how_shaped_ac"
+    assert story["intake"]["findings"][0]["problem"] == "ACs prescribe implementation steps"
+    assert story["intake"]["audit"]["agent"]["transport_used"] == "cli"
 
 
 def test_live_status_detail_falls_back_when_intake_summary_absent():


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved: the runner now surfaces DROPPED_AFTER_FIX detail in logs, live/completed status, audit YAML, sprint summary YAML, and has an end-to-end runner regression. | [deepseek-deepseek-reasoner] All prior P1 findings resolved: per-issue run-log detail, audit YAML/sprint summary YAML intake detail, forge status DETAIL rendering, and end-to-end runner test. No regressions introduced. All acceptance criteria verified with concrete tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $18.49
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Intake remediation DROPPED_AFTER_FIX outcome loses actionable findings detail at every operator-facing surface, despite IntakeOutcome.audit already carrying the full structured detail (GitHub Issue #1478)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1478