### PR TITLE
land_story silently takes early-return paths; landing decision should be logged with reason

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -863,10 +863,24 @@ def _merge_pr(
             merged_pr = next((pr for pr in merged_prs if pr.get("mergedAt")), None)
             if merged_pr is not None:
                 pr_url = merged_pr.get("url")
+                pr_number = merged_pr.get("number")
+                merged_at = merged_pr.get("mergedAt")
+                guard_evidence = {
+                    "branch": branch_name,
+                    "pr_number": pr_number,
+                    "pr_url": pr_url,
+                    "merged_at": merged_at,
+                }
+                _log(
+                    f"LANDING already-merged short-circuit: branch {branch_name} matched "
+                    f"merged PR #{pr_number} (mergedAt={merged_at}) — "
+                    f"skipping push/PR/merge, cleaning up worktree"
+                )
                 _pr_log.info(
-                    "PR already merged for branch %s; skipping PR recreation and merge retry: %s",
+                    "land_story already-merged short-circuit: branch=%s pr=%s mergedAt=%s",
                     branch_name,
                     pr_url,
+                    merged_at,
                 )
                 if "cleanup" not in merge_state.completed_steps:
                     _step_cleanup(
@@ -886,6 +900,8 @@ def _merge_pr(
                     "auto_merge_queued": False,
                     "success": True,
                     "error": None,
+                    "landing_path": "already-merged",
+                    "guard_evidence": guard_evidence,
                 }
         else:
             err = merged_pr_proc.stderr.strip() or merged_pr_proc.stdout.strip()
@@ -951,9 +967,16 @@ def _merge_pr(
                 )
             if create_result["pr_url"] is None:
                 # Zero-delta branch: no commits ahead of base, nothing to merge.
+                ahead_commit_count = create_result.get("ahead_commit_count", 0)
+                guard_evidence = {
+                    "branch": branch_name,
+                    "base_branch": base_branch,
+                    "ahead_commit_count": ahead_commit_count,
+                }
                 _log(
-                    f"  Skipping merge: branch {branch_name} has no commits ahead of "
-                    f"origin/{base_branch}"
+                    f"LANDING zero-delta short-circuit: branch {branch_name} has "
+                    f"{ahead_commit_count} commits ahead of origin/{base_branch} "
+                    f"— nothing to merge"
                 )
                 delete_merge_state(worktree_path)
                 return {
@@ -966,6 +989,8 @@ def _merge_pr(
                     "error": None,
                     "skipped": True,
                     "skip_reason": "zero-delta branch",
+                    "landing_path": "zero-delta",
+                    "guard_evidence": guard_evidence,
                 }
             merge_state.pr_url = create_result["pr_url"]
             _complete_step(merge_state, "create_pr", pr_url=merge_state.pr_url)
@@ -1053,6 +1078,12 @@ def _merge_pr(
         "success": True,
         "error": None,
         "auto_merge_queued": auto_merge_queued,
+        "landing_path": "fresh-merge",
+        "guard_evidence": {
+            "branch": branch_name,
+            "pr_url": merge_state.pr_url,
+            "merge_queued": merge_queued,
+        },
     }
 
 
@@ -1167,8 +1198,20 @@ def land_story(
 
     elif effective_on_approve == "merge-pr":
         if parsed_review is None:
-            _log("WARN: land_story called for merge-pr but parsed_review is None — skipping")
-            return {"merged": False, "error": "no review result available"}, "failed"
+            _log(
+                "LANDING missing-review short-circuit: land_story called for merge-pr but "
+                f"parsed_review is None for branch {branch_name} — skipping"
+            )
+            return (
+                {
+                    "action": "merge-pr",
+                    "merged": False,
+                    "error": "no review result available",
+                    "landing_path": "missing-review",
+                    "guard_evidence": {"branch": branch_name},
+                },
+                "failed",
+            )
 
         merge_info = _merge_pr(config, task, branch_name, parsed_review, state)
         if logger:

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -287,7 +287,18 @@ def _merge_branch(
     ok, log_out = _cu._run_shell(f"git log {base_branch}..{branch_name} --oneline", project_root)
     if not ok or not log_out.strip():
         info["error"] = f"Branch {branch_name!r} has no commits ahead of {base_branch!r}"
-        _cu._log(f"Auto-merge skipped: {info['error']}")
+        info["landing_path"] = "zero-delta"
+        info["skipped"] = True
+        info["skip_reason"] = "zero-delta branch"
+        info["guard_evidence"] = {
+            "branch": branch_name,
+            "base_branch": base_branch,
+            "ahead_commit_count": 0,
+        }
+        _cu._log(
+            f"LANDING zero-delta short-circuit: branch {branch_name} has 0 commits ahead of "
+            f"{base_branch} — nothing to merge"
+        )
         return info
 
     _deindex_forge_artifacts(workspace_path, purge=True)
@@ -322,6 +333,11 @@ def _merge_branch(
             return info
 
     info["merged"] = True
+    info["landing_path"] = "fresh-merge"
+    info["guard_evidence"] = {
+        "branch": branch_name,
+        "base_branch": base_branch,
+    }
     _cu._log(f"Auto-merge succeeded: {branch_name} → {base_branch}")
 
     if auto_push:

--- a/tests/test_coord_landing_decision_log.py
+++ b/tests/test_coord_landing_decision_log.py
@@ -1,0 +1,273 @@
+"""Tests that land_story / _merge_pr / _merge_branch surface their landing
+decision via both an operator-visible log line and structured fields in the
+returned (audit-bound) merge dict.
+
+Story #1423: silent early-return paths (already-merged, zero-delta) must name
+the path taken and the evidence acted on so the audit trail is reviewable
+without re-reading source.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.coordinator.completion import _merge_pr
+from theforge.coordinator.workspace import _merge_branch
+
+PR_URL = "https://github.com/owner/repo/pull/1143"
+
+
+def _ok(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def _make_config(tmp_path: Path):
+    from theforge.config import (
+        DEFAULT_DEV_PROFILE,
+        DEFAULT_PREFLIGHT_PROFILE,
+        DEFAULT_REVIEW_PROFILE,
+        DEFAULT_VALIDATION,
+        ForgeConfig,
+        LogConfig,
+        RetryPolicy,
+        WorkspaceConfig,
+    )
+
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+            on_approve="merge-pr",
+            auto_push=True,
+            merge_strategy="squash",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _make_task(tmp_path: Path):
+    from theforge.task import TaskStory
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Test", encoding="utf-8")
+    return TaskStory(name="Test Task", story_path=spec, slug="test-task")
+
+
+def _make_review():
+    from theforge.review import ReviewResult
+
+    return ReviewResult(
+        verdict="APPROVE",
+        summary="Looks good.",
+        findings=[],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+class TestMergePrAlreadyMergedShortCircuit:
+    def test_emits_operator_log_line_and_audit_fields(self, tmp_path: Path, capfd) -> None:
+        """already-merged guard must log LANDING line + populate landing_path/guard_evidence."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        merged_pr_payload = json.dumps(
+            [
+                {
+                    "number": 1143,
+                    "url": PR_URL,
+                    "mergedAt": "2026-04-30T14:21:12Z",
+                }
+            ]
+        )
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout=merged_pr_payload)
+            return _ok(0, stdout="")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch("theforge.coordinator.completion._create_pr") as mock_create_pr,
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/issue-1135", review, state)
+
+        # AC1: Operator-visible log line names path + evidence.
+        captured = capfd.readouterr()
+        log_text = captured.err + captured.out
+        assert "LANDING already-merged short-circuit" in log_text
+        assert "branch forge/issue-1135" in log_text
+        assert "PR #1143" in log_text
+        assert "mergedAt=2026-04-30T14:21:12Z" in log_text
+
+        # AC2/AC3: Audit-bound dict identifies guard + evidence.
+        assert result["success"] is True
+        assert result["merged"] is True
+        assert result["landing_path"] == "already-merged"
+        ge = result["guard_evidence"]
+        assert ge["pr_number"] == 1143
+        assert ge["pr_url"] == PR_URL
+        assert ge["merged_at"] == "2026-04-30T14:21:12Z"
+        assert ge["branch"] == "forge/issue-1135"
+
+        # No fresh PR was created — distinguishes a guard fire from a real merge.
+        mock_create_pr.assert_not_called()
+
+
+class TestMergePrZeroDeltaShortCircuit:
+    def test_emits_operator_log_line_and_audit_fields(self, tmp_path: Path, capfd) -> None:
+        """zero-delta must log LANDING line + populate landing_path/guard_evidence."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        zero_delta_pr_result = {
+            "action": "pr",
+            "pr_url": None,
+            "success": True,
+            "error": None,
+            "skipped": True,
+            "skip_reason": "zero-delta branch",
+            "ahead_commit_count": 0,
+        }
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value=zero_delta_pr_result,
+            ),
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/issue-1135", review, state)
+
+        captured = capfd.readouterr()
+        log_text = captured.err + captured.out
+        assert "LANDING zero-delta short-circuit" in log_text
+        assert "branch forge/issue-1135" in log_text
+        assert "0 commits ahead of origin/main" in log_text
+
+        assert result["success"] is True
+        assert result["pr_url"] is None
+        assert result["landing_path"] == "zero-delta"
+        ge = result["guard_evidence"]
+        assert ge["branch"] == "forge/issue-1135"
+        assert ge["base_branch"] == "main"
+        assert ge["ahead_commit_count"] == 0
+
+
+class TestMergePrFreshMergeAnnotation:
+    def test_fresh_merge_includes_landing_path_for_audit_distinguishability(
+        self, tmp_path: Path
+    ) -> None:
+        """A normal landing must annotate landing_path so reviewers can tell it
+        from a guard short-circuit reading the audit alone."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review()
+        state = MagicMock()
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def fake_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "list"]:
+                return _ok(0, stdout="[]")
+            return _ok(0, stdout="MERGED")
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": PR_URL,
+                    "success": True,
+                    "error": None,
+                },
+            ),
+            patch("theforge.coordinator.completion._deindex_forge_artifacts"),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["success"] is True
+        assert result["landing_path"] == "fresh-merge"
+        assert result["guard_evidence"]["pr_url"] == PR_URL
+        assert result["guard_evidence"]["branch"] == "forge/test-task"
+
+
+class TestMergeBranchZeroDelta:
+    def test_zero_delta_local_merge_logs_landing_line_and_annotates_info(
+        self, tmp_path: Path, capfd
+    ) -> None:
+        """The local _merge_branch path (effective_on_approve='merge') must
+        also surface the zero-delta short-circuit."""
+
+        # Stub _run_shell so base branch exists, project root is clean, but
+        # the branch has no commits ahead.
+        def fake_shell(cmd, cwd):
+            cmd_s = str(cmd)
+            if "git branch --list" in cmd_s:
+                return True, "main\n"
+            if "git status --porcelain" in cmd_s:
+                return True, ""
+            if "git log" in cmd_s:
+                return True, ""  # no commits ahead
+            return True, ""
+
+        with patch(
+            "theforge.coordinator.workspace._cu._run_shell",
+            side_effect=fake_shell,
+        ):
+            info = _merge_branch(
+                project_root=tmp_path,
+                base_branch="main",
+                branch_name="forge/issue-1135",
+                slug="issue-1135",
+                workspace_path=tmp_path / "issue-1135",
+            )
+
+        captured = capfd.readouterr()
+        log_text = captured.err + captured.out
+        assert "LANDING zero-delta short-circuit" in log_text
+        assert "branch forge/issue-1135" in log_text
+
+        assert info["merged"] is False
+        assert info["landing_path"] == "zero-delta"
+        assert info["skipped"] is True
+        assert info["skip_reason"] == "zero-delta branch"
+        ge = info["guard_evidence"]
+        assert ge["branch"] == "forge/issue-1135"
+        assert ge["base_branch"] == "main"
+        assert ge["ahead_commit_count"] == 0

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -289,6 +289,13 @@ class TestMergePrFunction:
             "auto_merge_queued": False,
             "success": True,
             "error": None,
+            "landing_path": "already-merged",
+            "guard_evidence": {
+                "branch": "forge/test-task",
+                "pr_number": None,
+                "pr_url": "https://github.com/fuzzypete/theforge/pull/42",
+                "merged_at": "2025-01-01T00:00:00Z",
+            },
         }
         mock_create_pr.assert_not_called()
         assert calls[0][:3] == ["gh", "pr", "list"]


### PR DESCRIPTION
## Summary

The change satisfies the landing-decision logging and audit traceability requirements; no blocking issues found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.67
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

land_story silently takes early-return paths; landing decision should be logged with reason (GitHub Issue #1423)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1423