### PR TITLE
forge status --watch renders blank during sprint shape-gate / preflight phases instead of showing the issues, run, and phase context that are already known

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -664,6 +664,7 @@ def _run_query_mode(
                     }
                     for issue in issues
                 ],
+                skipped_issues=skipped_issues,
             )
         except Exception:
             # Bootstrap state is a UX nicety; do not block sprint launch on

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -641,6 +641,35 @@ def _run_query_mode(
             locked_fds,
         )
         _detach.install_cleanup_handler(run_id, config.project_root)
+        # Write a bootstrap state file before run_sprint enters its long
+        # baseline-gate / intake-remediation / preflight phases so
+        # `forge status --watch` renders the issue list, sprint phase, and
+        # base-branch / budget / parallel context immediately on attach
+        # rather than displaying an empty table for several minutes.
+        from theforge.sprint.state_writer import write_bootstrap_state
+
+        try:
+            write_bootstrap_state(
+                run_id,
+                config.project_root,
+                sprint_name=sprint_name,
+                sprint_phase="starting",
+                base_branch=getattr(getattr(config, "workspace", None), "base_branch", None),
+                budget_usd=budget_usd,
+                max_parallel=effective_max_parallel,
+                issues=[
+                    {
+                        "number": issue.get("number"),
+                        "title": issue.get("title", ""),
+                    }
+                    for issue in issues
+                ],
+            )
+        except Exception:
+            # Bootstrap state is a UX nicety; do not block sprint launch on
+            # write failure (the runner will still create the canonical
+            # state file once preflight completes).
+            pass
         print("[forge] Detached sprint starting", file=sys.stderr, flush=True)
 
     # Query mode does not support daemon submission (no manifest file to pass)

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -33,13 +33,21 @@ def display_sprint_status(run_id: str, project_root: Path) -> int:
     unexpected_end = False
     total_cost_usd: float | None = None
     duration_seconds: float | None = None
+    sprint_phase: str | None = None
+    base_branch: str | None = None
+    budget_usd: float | None = None
+    max_parallel: int | None = None
 
     if is_live:
         entries = read_live_status(run_id, project_root)
-        if entries is not None:
-            state_path = find_live_state_path(run_id, project_root)
-            if state_path is not None:
-                sprint_name = _read_sprint_name_from_state(state_path)
+        state_path = find_live_state_path(run_id, project_root)
+        if state_path is not None:
+            sprint_name = _read_sprint_name_from_state(state_path)
+            meta = _read_sprint_meta_from_state(state_path)
+            sprint_phase = meta.get("sprint_phase")
+            base_branch = meta.get("base_branch")
+            budget_usd = meta.get("budget_usd")
+            max_parallel = meta.get("max_parallel")
         # Approximate elapsed from the process start time via detach
         try:
             from theforge import detach as _detach
@@ -103,6 +111,8 @@ def display_sprint_status(run_id: str, project_root: Path) -> int:
         state_label = "completed"
 
     header_parts: list[str] = [f"Sprint: {sprint_name}  run: {run_id}  [{state_label}]"]
+    if sprint_phase:
+        header_parts.append(f"phase: {sprint_phase}")
     if total_cost_usd is not None:
         header_parts.append(f"cost: ${total_cost_usd:.2f}")
     if duration_seconds is not None:
@@ -111,6 +121,19 @@ def display_sprint_status(run_id: str, project_root: Path) -> int:
         else:
             header_parts.append(f"duration: {int(duration_seconds // 60)}m")
     print("  ".join(header_parts))
+
+    # Second line: sprint configuration context (base branch, budget, parallel).
+    # These let the operator confirm the sprint launched against the right
+    # branch and ceiling without scrolling back to the launch banner.
+    config_parts: list[str] = []
+    if base_branch:
+        config_parts.append(f"base: {base_branch}")
+    if budget_usd is not None:
+        config_parts.append(f"budget: ${float(budget_usd):.2f}")
+    if max_parallel is not None:
+        config_parts.append(f"parallel: {max_parallel}")
+    if config_parts:
+        print("  ".join(config_parts))
 
     if unexpected_end:
         print("  ⚠  Sprint ended unexpectedly (PID file missing, state file present)")
@@ -173,6 +196,34 @@ def cmd_sprint_status(args: object) -> int:
     project_root = config.project_root
 
     return display_sprint_status(run_id, project_root)
+
+
+def _read_sprint_meta_from_state(state_path: object) -> dict:
+    """Return sprint-level metadata (phase, base_branch, budget, parallel).
+
+    Empty dict on any error or missing fields. Lets the live-status header
+    surface watch-mode context during the pre-preflight window when the
+    SprintStateWriter has not yet replaced the bootstrap state file.
+    """
+    import yaml  # noqa: PLC0415
+
+    try:
+        with open(Path(str(state_path)), encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict = {}
+    if isinstance(data.get("sprint_phase"), str):
+        out["sprint_phase"] = data["sprint_phase"]
+    if isinstance(data.get("base_branch"), str):
+        out["base_branch"] = data["base_branch"]
+    if isinstance(data.get("budget_usd"), (int, float)):
+        out["budget_usd"] = float(data["budget_usd"])
+    if isinstance(data.get("max_parallel"), int):
+        out["max_parallel"] = data["max_parallel"]
+    return out
 
 
 def _read_sprint_name_from_state(state_path: object) -> str:

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1483,6 +1483,13 @@ def run_sprint(
     )
     normalized = normalize_dependency_plan(all_tasks, satisfied=satisfied_slugs)
 
+    # Surface the current sprint phase to forge status --watch so operators
+    # see meaningful progress signals during the multi-minute pre-init window.
+    if run_id:
+        from .state_writer import update_state_phase as _update_state_phase
+
+        _update_state_phase(run_id, config.project_root, "intake-remediation")
+
     # Intake remediation gate: between dependency normalization and the
     # batch preflight spend, run the shared shape + grooming check on the
     # full normalized task list. When ``intake.auto_fix`` is enabled, semantic
@@ -1549,6 +1556,11 @@ def run_sprint(
         if dropped_slugs_intake:
             normalized = _filter_normalized_for_intake(normalized, dropped_slugs_intake)
 
+    if run_id:
+        from .state_writer import update_state_phase as _update_state_phase
+
+        _update_state_phase(run_id, config.project_root, "preflight")
+
     preflight_states = run_batch_preflight(
         normalized.tasks,
         config,
@@ -1603,6 +1615,10 @@ def run_sprint(
         _log(f"Injected synthetic dependency constraints for {len(synthetic_edges)} stories")
     augmented_tasks = inject_synthetic_deps(normalized.tasks, synthetic_edges)
     blocked_slugs = dict(normalized.blocked)
+    if run_id:
+        from .state_writer import update_state_phase as _update_state_phase
+
+        _update_state_phase(run_id, config.project_root, "dag-build")
     try:
         dag = build_dag(augmented_tasks, satisfied=satisfied_slugs)
     except ValueError as exc:
@@ -1875,8 +1891,12 @@ def run_sprint(
             resolved.name,
             sprint_id=_sprint_id,
             story_state=_story_state,
+            budget_usd=resolved.budget_usd,
+            max_parallel=max_parallel,
+            base_branch=getattr(getattr(config, "workspace", None), "base_branch", None),
         )
         _state_writer.init(_initial_stories)
+        _state_writer.set_phase("running")
         # Register shape-gate-skipped issues in the canonical structure so
         # forge status surfaces them with the gate reason. They are visible
         # to every operator surface from this point on.

--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -39,6 +39,10 @@ class SprintStateWriter:
         *,
         sprint_id: str | None = None,
         story_state: SprintStoryState | None = None,
+        sprint_phase: str | None = None,
+        base_branch: str | None = None,
+        budget_usd: float | None = None,
+        max_parallel: int | None = None,
     ) -> None:
         self._run_id = run_id
         self._sprint_name = sprint_name
@@ -48,6 +52,17 @@ class SprintStateWriter:
         # The canonical structure. Surfaces (banner, summary, notifications)
         # all project from this same instance.
         self.story_state: SprintStoryState = story_state or SprintStoryState()
+        # Sprint-level metadata surfaced by forge status / forge sprint-status
+        # before per-story state is rich. Lets the watcher render an informative
+        # header during shape-gate / intake-remediation / preflight phases.
+        self._sprint_phase = sprint_phase
+        self._base_branch = base_branch
+        self._budget_usd = budget_usd
+        self._max_parallel = max_parallel
+        # Preserve any pre-existing top-level metadata (e.g. bootstrap state
+        # written before the writer was constructed) so init() does not erase
+        # base_branch / budget / parallel set by cli/sprint.py at daemonize.
+        self._inherit_existing_metadata()
 
     def init(self, stories: list[dict]) -> None:
         """Register all stories in the canonical structure and write state file.
@@ -116,11 +131,46 @@ class SprintStateWriter:
         except FileNotFoundError:
             pass
 
+    def set_phase(self, phase: str) -> None:
+        """Update sprint-level phase and rewrite the state file atomically."""
+        with self._lock:
+            self._sprint_phase = phase
+            self._write_locked()
+
+    def _inherit_existing_metadata(self) -> None:
+        """Adopt sprint_phase/base_branch/budget/parallel from an existing file.
+
+        cli/sprint.py writes a bootstrap state file before run_sprint creates
+        this writer — without inheriting those fields, the first init() would
+        wipe them out and operators would lose the watch-mode header context.
+        """
+        if not self._state_path.exists():
+            return
+        try:
+            with open(self._state_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except (OSError, yaml.YAMLError):
+            return
+        if not isinstance(data, dict):
+            return
+        if self._sprint_phase is None and isinstance(data.get("sprint_phase"), str):
+            self._sprint_phase = data["sprint_phase"]
+        if self._base_branch is None and isinstance(data.get("base_branch"), str):
+            self._base_branch = data["base_branch"]
+        if self._budget_usd is None and isinstance(data.get("budget_usd"), (int, float)):
+            self._budget_usd = float(data["budget_usd"])
+        if self._max_parallel is None and isinstance(data.get("max_parallel"), int):
+            self._max_parallel = data["max_parallel"]
+
     def _write_locked(self) -> None:
         """Write the state file atomically. Caller must hold self._lock."""
         data: dict = {
             "sprint_name": self._sprint_name,
             "sprint_id": self._sprint_id,
+            "sprint_phase": self._sprint_phase,
+            "base_branch": self._base_branch,
+            "budget_usd": self._budget_usd,
+            "max_parallel": self._max_parallel,
             "stories": self.story_state.as_dict(),
         }
         tmp_path = self._state_path.with_name(self._state_path.name + ".tmp")
@@ -134,3 +184,112 @@ class SprintStateWriter:
                 tmp_path.unlink()
             except Exception:
                 pass
+
+
+def write_bootstrap_state(
+    run_id: str,
+    project_root: Path,
+    *,
+    sprint_name: str,
+    sprint_phase: str,
+    base_branch: str | None = None,
+    budget_usd: float | None = None,
+    max_parallel: int | None = None,
+    issues: list[dict] | None = None,
+) -> Path:
+    """Write a minimal `.state` file before SprintStateWriter exists.
+
+    The state file is the watcher's data source. Without an early write,
+    `forge status --watch` polls during shape-gate / intake-remediation /
+    preflight and finds nothing — operators see only the watch overlay
+    headers with no per-issue rows or sprint phase.
+
+    Each issue dict should provide ``number`` (int) and optional ``title``.
+    Stories are seeded with ``status=waiting`` and no phase; the runner
+    upgrades them through SprintStateWriter once preflight produces real
+    per-story data.
+    """
+    state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    stories: list[dict] = []
+    for issue in issues or []:
+        number = issue.get("number")
+        slug = issue.get("slug") or (f"issue-{number}" if number is not None else None)
+        if not slug:
+            continue
+        path = issue.get("path") or (f"Issue #{number}" if number is not None else slug)
+        canonical_ref = issue.get("canonical_ref")
+        if canonical_ref is None and isinstance(number, int):
+            canonical_ref = f"issue:{number}"
+        stories.append(
+            {
+                "slug": slug,
+                "path": path,
+                "status": "waiting",
+                "outcome": "waiting",
+                "phase": None,
+                "cost_usd": 0.0,
+                "bundle_candidate": False,
+                "blocked_by": [],
+                "complexity": None,
+                "complexity_score": None,
+                "detail": {},
+                "reason": None,
+                "canonical_ref": canonical_ref,
+                "depends_on": [],
+            }
+        )
+
+    data: dict = {
+        "sprint_name": sprint_name,
+        "sprint_id": None,
+        "sprint_phase": sprint_phase,
+        "base_branch": base_branch,
+        "budget_usd": budget_usd,
+        "max_parallel": max_parallel,
+        "stories": stories,
+    }
+    tmp_path = state_path.with_name(state_path.name + ".tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        tmp_path.replace(state_path)
+    except OSError:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+    return state_path
+
+
+def update_state_phase(run_id: str, project_root: Path, sprint_phase: str) -> None:
+    """Update the ``sprint_phase`` field of an existing state file in place.
+
+    No-op when the state file is absent (e.g. headless invocations without a
+    bootstrap write). Called from the runner at phase boundaries that fire
+    before SprintStateWriter is constructed.
+    """
+    state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
+    if not state_path.exists():
+        return
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return
+    if not isinstance(data, dict):
+        return
+    if data.get("sprint_phase") == sprint_phase:
+        return
+    data["sprint_phase"] = sprint_phase
+    tmp_path = state_path.with_name(state_path.name + ".tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        tmp_path.replace(state_path)
+    except OSError:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass

--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -196,6 +196,7 @@ def write_bootstrap_state(
     budget_usd: float | None = None,
     max_parallel: int | None = None,
     issues: list[dict] | None = None,
+    skipped_issues: list | None = None,
 ) -> Path:
     """Write a minimal `.state` file before SprintStateWriter exists.
 
@@ -213,10 +214,11 @@ def write_bootstrap_state(
     state_path.parent.mkdir(parents=True, exist_ok=True)
 
     stories: list[dict] = []
+    seen_slugs: set[str] = set()
     for issue in issues or []:
         number = issue.get("number")
         slug = issue.get("slug") or (f"issue-{number}" if number is not None else None)
-        if not slug:
+        if not slug or slug in seen_slugs:
             continue
         path = issue.get("path") or (f"Issue #{number}" if number is not None else slug)
         canonical_ref = issue.get("canonical_ref")
@@ -240,6 +242,50 @@ def write_bootstrap_state(
                 "depends_on": [],
             }
         )
+        seen_slugs.add(slug)
+
+    # Shape-gate skips already known at daemonize time MUST surface in the
+    # bootstrap state — otherwise operators watching the sprint cannot see
+    # which issues were rejected by the gate until SprintStateWriter.init()
+    # registers them several minutes later, after preflight. They are
+    # rendered as terminal `skipped` rows with the gate reason in `reason`.
+    for sk in skipped_issues or []:
+        sk_dict = sk.as_dict() if hasattr(sk, "as_dict") else dict(sk)
+        sk_num = sk_dict.get("issue_number")
+        if sk_num is None:
+            continue
+        sk_slug = f"issue-{sk_num}"
+        if sk_slug in seen_slugs:
+            continue
+        sk_codes = sk_dict.get("reason_codes") or []
+        sk_reason = (
+            ", ".join(sk_codes)
+            if sk_codes
+            else (sk_dict.get("detail") or sk_dict.get("source") or "shape-gate")
+        )
+        stories.append(
+            {
+                "slug": sk_slug,
+                "path": f"Issue #{sk_num}",
+                "status": "skipped",
+                "outcome": "skipped",
+                "phase": None,
+                "cost_usd": 0.0,
+                "bundle_candidate": False,
+                "blocked_by": [],
+                "complexity": None,
+                "complexity_score": None,
+                "detail": {
+                    "shape_gate_source": sk_dict.get("source"),
+                    "shape_gate_codes": list(sk_codes),
+                    "final_outcome": "SKIPPED",
+                },
+                "reason": sk_reason,
+                "canonical_ref": f"issue:{sk_num}",
+                "depends_on": [],
+            }
+        )
+        seen_slugs.add(sk_slug)
 
     data: dict = {
         "sprint_name": sprint_name,

--- a/tests/test_sprint_status_bootstrap_window.py
+++ b/tests/test_sprint_status_bootstrap_window.py
@@ -1,0 +1,239 @@
+"""Regression: forge status --watch must render meaningfully during the
+shape-gate / intake-remediation / preflight phases that precede the first
+SprintStateWriter init.
+
+Before the bootstrap state file existed, the watcher attached to a live
+sprint and rendered only its overlay headers — operators stared at an empty
+table for several minutes while real work was running. These tests exercise
+the actual data sources (state file on disk, display_sprint_status,
+status_watch.render_frame) — no mocks at the rendering boundary.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+
+def _make_forge_yaml(tmp_path: Path) -> Path:
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    return forge_yaml
+
+
+def _run_sprint_status_cli(tmp_path: Path, run_id: str) -> tuple[int, str]:
+    from theforge.cli.sprint_status import cmd_sprint_status
+
+    forge_yaml = _make_forge_yaml(tmp_path)
+    fake_config = MagicMock()
+    fake_config.project_root = tmp_path
+
+    class _Args:
+        pass
+
+    args = _Args()
+    args.run_id = run_id  # type: ignore[attr-defined]
+
+    buf = io.StringIO()
+    with (
+        patch("theforge.cli.shared._find_config", return_value=forge_yaml),
+        patch("theforge.config.load_config", return_value=fake_config),
+        patch("sys.stdout", buf),
+    ):
+        code = cmd_sprint_status(args)
+    return code, buf.getvalue()
+
+
+def test_write_bootstrap_state_round_trip(tmp_path: Path) -> None:
+    """Bootstrap state file is YAML-readable and contains issue rows + meta."""
+    from theforge.sprint.state_writer import write_bootstrap_state
+
+    write_bootstrap_state(
+        "run-bootstrap-1",
+        tmp_path,
+        sprint_name="issues-1462",
+        sprint_phase="shape-gate",
+        base_branch="main",
+        budget_usd=50.0,
+        max_parallel=3,
+        issues=[{"number": 1462, "title": "watch render"}],
+    )
+
+    state_path = tmp_path / ".forge" / "runs" / "run-bootstrap-1.state"
+    assert state_path.exists()
+    data = yaml.safe_load(state_path.read_text(encoding="utf-8"))
+
+    assert data["sprint_name"] == "issues-1462"
+    assert data["sprint_phase"] == "shape-gate"
+    assert data["base_branch"] == "main"
+    assert data["budget_usd"] == 50.0
+    assert data["max_parallel"] == 3
+
+    stories = data["stories"]
+    assert len(stories) == 1
+    assert stories[0]["slug"] == "issue-1462"
+    assert stories[0]["status"] == "waiting"
+    assert stories[0]["canonical_ref"] == "issue:1462"
+
+
+def test_update_state_phase_preserves_other_fields(tmp_path: Path) -> None:
+    """Phase updates must not erase base_branch / budget / parallel / stories."""
+    from theforge.sprint.state_writer import update_state_phase, write_bootstrap_state
+
+    write_bootstrap_state(
+        "run-phase-1",
+        tmp_path,
+        sprint_name="issues-1,2",
+        sprint_phase="shape-gate",
+        base_branch="develop",
+        budget_usd=25.0,
+        max_parallel=2,
+        issues=[{"number": 1}, {"number": 2}],
+    )
+    update_state_phase("run-phase-1", tmp_path, "preflight")
+
+    state_path = tmp_path / ".forge" / "runs" / "run-phase-1.state"
+    data = yaml.safe_load(state_path.read_text(encoding="utf-8"))
+    assert data["sprint_phase"] == "preflight"
+    assert data["base_branch"] == "develop"
+    assert data["budget_usd"] == 25.0
+    assert data["max_parallel"] == 2
+    assert len(data["stories"]) == 2
+
+
+def test_update_state_phase_noop_when_file_missing(tmp_path: Path) -> None:
+    """update_state_phase must silently no-op for headless / pre-bootstrap runs."""
+    from theforge.sprint.state_writer import update_state_phase
+
+    # Should not raise.
+    update_state_phase("never-written", tmp_path, "preflight")
+    assert not (tmp_path / ".forge" / "runs" / "never-written.state").exists()
+
+
+def test_sprint_state_writer_inherits_bootstrap_metadata(tmp_path: Path) -> None:
+    """SprintStateWriter created over a bootstrap file keeps the operator context.
+
+    Without inheritance the runner's first init() call would erase
+    base_branch / budget / parallel that cli/sprint.py wrote at daemonize time
+    — operators would see the watch header lose context the moment preflight
+    finished.
+    """
+    from theforge.sprint.state_writer import SprintStateWriter, write_bootstrap_state
+
+    write_bootstrap_state(
+        "run-inherit",
+        tmp_path,
+        sprint_name="my-sprint",
+        sprint_phase="preflight",
+        base_branch="main",
+        budget_usd=42.0,
+        max_parallel=4,
+        issues=[{"number": 7}],
+    )
+    writer = SprintStateWriter(
+        "run-inherit",
+        tmp_path,
+        "my-sprint",
+    )
+    writer.init([])
+
+    state_path = tmp_path / ".forge" / "runs" / "run-inherit.state"
+    data = yaml.safe_load(state_path.read_text(encoding="utf-8"))
+    assert data["sprint_phase"] == "preflight"
+    assert data["base_branch"] == "main"
+    assert data["budget_usd"] == 42.0
+    assert data["max_parallel"] == 4
+
+
+def test_display_sprint_status_renders_bootstrap_window(tmp_path: Path) -> None:
+    """display_sprint_status renders issue rows + phase + base_branch + budget
+    + parallel from a bootstrap state file alone (no preflight, no per-story
+    detail). Operators see this output immediately on watch attach.
+    """
+    from theforge.sprint.state_writer import write_bootstrap_state
+
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    # PID file marks the run live.
+    (runs_dir / "run-bw.pid").write_text("12345\nmy-sprint\n", encoding="utf-8")
+
+    write_bootstrap_state(
+        "run-bw",
+        tmp_path,
+        sprint_name="issues-1461,1462",
+        sprint_phase="preflight",
+        base_branch="main",
+        budget_usd=50.0,
+        max_parallel=3,
+        issues=[
+            {"number": 1461, "title": "first"},
+            {"number": 1462, "title": "second"},
+        ],
+    )
+
+    code, output = _run_sprint_status_cli(tmp_path, "run-bw")
+
+    assert code == 0
+    # Header carries phase + base/budget/parallel context.
+    assert "phase: preflight" in output
+    assert "base: main" in output
+    assert "budget: $50.00" in output
+    assert "parallel: 3" in output
+    # Per-issue rows appear with placeholder waiting status.
+    assert "Issue #1461" in output
+    assert "Issue #1462" in output
+    assert "waiting" in output
+
+
+def test_status_watch_renders_bootstrap_first_frame(tmp_path: Path) -> None:
+    """The watcher's render_frame succeeds (snapshot_ok=True) and surfaces
+    issue rows + sprint phase the moment a bootstrap state file exists.
+
+    This is the symptom-resolution test: before the fix, render_frame on
+    the first poll after attach would either exit (no state file) or render
+    only headers (state file with no rows).
+    """
+    from theforge.cli.status_watch import render_frame
+    from theforge.sprint.state_writer import write_bootstrap_state
+
+    forge_yaml = _make_forge_yaml(tmp_path)
+    fake_config = MagicMock()
+    fake_config.project_root = tmp_path
+
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "run-watch.pid").write_text("99999\nmy-sprint\n", encoding="utf-8")
+    write_bootstrap_state(
+        "run-watch",
+        tmp_path,
+        sprint_name="issues-1462",
+        sprint_phase="intake-remediation",
+        base_branch="main",
+        budget_usd=10.0,
+        max_parallel=1,
+        issues=[{"number": 1462}],
+    )
+
+    state: dict = {"costs": {}, "interval": 2.0}
+    with (
+        patch("theforge.cli.shared._find_config", return_value=forge_yaml),
+        patch("theforge.config.load_config", return_value=fake_config),
+    ):
+        text, snapshot_ok, captured_err = render_frame(
+            "run-watch",
+            tmp_path,
+            state,
+            frame_idx=0,
+            color=False,
+        )
+
+    assert snapshot_ok is True, captured_err
+    # Watcher overlay drew header + STORY row table.
+    assert "Live  run=run-watch" in text
+    # Underlying display_sprint_status surfaced bootstrap context.
+    assert "phase: intake-remediation" in text
+    assert "base: main" in text
+    assert "Issue #1462" in text

--- a/tests/test_sprint_status_bootstrap_window.py
+++ b/tests/test_sprint_status_bootstrap_window.py
@@ -188,6 +188,110 @@ def test_display_sprint_status_renders_bootstrap_window(tmp_path: Path) -> None:
     assert "waiting" in output
 
 
+def test_bootstrap_state_includes_shape_gate_skips(tmp_path: Path) -> None:
+    """Shape-gate skips already emitted before daemonize must surface as
+    terminal `skipped` rows in the bootstrap state, with the gate reason
+    populated so operators can see why an issue was rejected without
+    waiting for SprintStateWriter.init() to run after preflight.
+    """
+    from theforge.sprint.state_writer import write_bootstrap_state
+
+    skipped = [
+        {
+            "issue_number": 99,
+            "title": "stale contract",
+            "reason_codes": ["reopened_stale_contract", "missing_acceptance"],
+            "source": "shape_check",
+        }
+    ]
+
+    write_bootstrap_state(
+        "run-skip-1",
+        tmp_path,
+        sprint_name="issues-1,99",
+        sprint_phase="starting",
+        base_branch="main",
+        budget_usd=10.0,
+        max_parallel=1,
+        issues=[{"number": 1, "title": "runnable"}],
+        skipped_issues=skipped,
+    )
+
+    data = yaml.safe_load(
+        (tmp_path / ".forge" / "runs" / "run-skip-1.state").read_text(encoding="utf-8")
+    )
+    stories_by_slug = {s["slug"]: s for s in data["stories"]}
+
+    # Runnable + skipped both present.
+    assert "issue-1" in stories_by_slug
+    assert "issue-99" in stories_by_slug
+
+    sk = stories_by_slug["issue-99"]
+    assert sk["status"] == "skipped"
+    assert sk["reason"] == "reopened_stale_contract, missing_acceptance"
+    assert sk["detail"]["shape_gate_codes"] == [
+        "reopened_stale_contract",
+        "missing_acceptance",
+    ]
+    assert sk["detail"]["shape_gate_source"] == "shape_check"
+    assert sk["canonical_ref"] == "issue:99"
+
+
+def test_display_sprint_status_shows_shape_gate_skip_in_bootstrap(tmp_path: Path) -> None:
+    """display_sprint_status surfaces shape-gate-skipped rows during the
+    pre-preflight bootstrap window — not just runnable issues."""
+    from theforge.sprint.state_writer import write_bootstrap_state
+
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "run-skip-disp.pid").write_text("12345\nmy-sprint\n", encoding="utf-8")
+
+    write_bootstrap_state(
+        "run-skip-disp",
+        tmp_path,
+        sprint_name="issues-1,99",
+        sprint_phase="starting",
+        base_branch="main",
+        budget_usd=10.0,
+        max_parallel=1,
+        issues=[{"number": 1, "title": "runnable"}],
+        skipped_issues=[
+            {
+                "issue_number": 99,
+                "reason_codes": ["reopened_stale_contract"],
+                "source": "shape_check",
+            }
+        ],
+    )
+
+    code, output = _run_sprint_status_cli(tmp_path, "run-skip-disp")
+    assert code == 0
+    assert "Issue #99" in output
+    assert "skipped" in output
+    assert "reopened_stale_contract" in output
+
+
+def test_bootstrap_skipped_issues_dedup_against_runnable(tmp_path: Path) -> None:
+    """A slug present in both `issues` and `skipped_issues` must not appear
+    twice — runnable wins, since the operator sees the issue as still alive."""
+    from theforge.sprint.state_writer import write_bootstrap_state
+
+    write_bootstrap_state(
+        "run-dedup",
+        tmp_path,
+        sprint_name="issues-7",
+        sprint_phase="starting",
+        issues=[{"number": 7}],
+        skipped_issues=[{"issue_number": 7, "reason_codes": ["x"]}],
+    )
+    data = yaml.safe_load(
+        (tmp_path / ".forge" / "runs" / "run-dedup.state").read_text(encoding="utf-8")
+    )
+    slugs = [s["slug"] for s in data["stories"]]
+    assert slugs == ["issue-7"]
+    assert data["stories"][0]["status"] == "waiting"
+
+
 def test_status_watch_renders_bootstrap_first_frame(tmp_path: Path) -> None:
     """The watcher's render_frame succeeds (snapshot_ok=True) and surfaces
     issue rows + sprint phase the moment a bootstrap state file exists.


### PR DESCRIPTION
## Summary

The cycle-1 P1 is resolved: bootstrap state now includes runnable and shape-gate-skipped issues, and the watch/status path renders phase and sprint context from the first frame.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $7.28
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status --watch renders blank during sprint shape-gate / preflight phases instead of showing the issues, run, and phase context that are already known (GitHub Issue #1462)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1462