### PR TITLE
forge status conflates resume-skip-merged with preflight ALREADY_DONE — operator cannot distinguish trustworthy already-landed skips from preflight short-circuit verdicts

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -341,6 +341,7 @@ def _write_sprint_audit(
     dropped_slugs: "dict[str, str] | None" = None,
     skipped_issues: "list | None" = None,
     current_story_entries_by_ref: "dict[str, dict] | None" = None,
+    triage_actions_by_ref: "dict[str, str] | None" = None,
 ) -> None:
     """Write sprint-audit.yaml to the project root."""
     story_times = story_times or {}
@@ -350,6 +351,7 @@ def _write_sprint_audit(
     dropped_slugs = dropped_slugs or {}
     skipped_issues = skipped_issues or []
     current_story_entries_by_ref = current_story_entries_by_ref or {}
+    triage_actions_by_ref = triage_actions_by_ref or {}
 
     # Build per-spec entries
     spec_entries = []
@@ -410,9 +412,16 @@ def _write_sprint_audit(
                 if getattr(res.state, "review_iteration_telemetry", [])
                 else None
             )
+            # Tag the source of an ALREADY_DONE outcome so audit / postmortem
+            # consumers can distinguish a preflight short-circuit verdict from
+            # the resume-skip-merged classification without parsing strings.
+            outcome_source: str | None = None
+            if outcome == "ALREADY_DONE" and preflight == "ALREADY_DONE":
+                outcome_source = "preflight_verdict"
             entry: dict = {
                 "path": display_key,
                 "outcome": outcome,
+                "outcome_source": outcome_source,
                 "cost_usd": round(res.state.total_cost, 4),
                 "preflight": preflight,
                 "preflight_original_verdict": getattr(
@@ -471,15 +480,21 @@ def _write_sprint_audit(
             # or preserved-escalated) takes precedence over the generic
             # SKIPPED path — operators need to see drop reasons explicitly.
             drop_reason = dropped_slugs.get(slug)
+            triage_action = triage_actions_by_ref.get(canonical_ref)
             if drop_reason == "preserved-escalated":
                 drop_outcome = "PRESERVED"
             elif drop_reason is not None:
                 drop_outcome = "DROPPED"
+            elif triage_action == "skip_merged":
+                drop_outcome = "ALREADY_DONE"
             else:
                 drop_outcome = "SKIPPED"
             entry = {
                 "path": display_key,
                 "outcome": drop_outcome,
+                "outcome_source": (
+                    "resume_skip_merged" if triage_action == "skip_merged" else None
+                ),
                 "cost_usd": 0.0,
                 "preflight": None,
                 "error": drop_reason,

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -221,11 +221,21 @@ def _load_story_summary_entry_from_audit(
         preflight_block.get("verdict") if isinstance(preflight_block, dict) else None
     )
 
+    # Tag the source of an ALREADY_DONE outcome so downstream renderers can
+    # distinguish a preflight short-circuit verdict from a resume-skip-merged
+    # classification — the two paths have materially different trust
+    # properties for operators (preflight verdict is the historically suspect
+    # path; resume-skip-merged is mechanical and trustworthy).
+    outcome_source: str | None = None
+    if final_phase == "ALREADY_DONE" and preflight_verdict == "ALREADY_DONE":
+        outcome_source = "preflight_verdict"
+
     return {
         "canonical_ref": canonical_ref,
         "path": display_key,
         "slug": slug,
         "outcome": final_phase,
+        "outcome_source": outcome_source,
         "verdict": verdict,
         "cost_usd": round(float(cost_block.get("total_usd", 0.0)), 4)
         if isinstance(cost_block, dict)
@@ -667,10 +677,18 @@ def _write_sprint_summary(
                 _model_used = getattr(_last_dev, "model_used", None)
                 if isinstance(_model_used, str) and _model_used:
                     _dev_model = _model_used
+            # Tag the source of an ALREADY_DONE outcome so renderers can
+            # distinguish a preflight short-circuit verdict from the
+            # resume-skip-merged classification — different trust properties
+            # (see status_reader._already_done_detail).
+            outcome_source: str | None = None
+            if outcome == "ALREADY_DONE" and preflight == "ALREADY_DONE":
+                outcome_source = "preflight_verdict"
             entry: dict = {
                 "path": display_key,
                 "slug": slug,
                 "outcome": outcome,
+                "outcome_source": outcome_source,
                 "verdict": last_verdict or None,
                 "cost_usd": round(res.state.total_cost, 4),
                 "dev_model": _dev_model,
@@ -745,6 +763,9 @@ def _write_sprint_summary(
                 "path": display_key,
                 "slug": slug,
                 "outcome": drop_outcome,
+                "outcome_source": (
+                    "resume_skip_merged" if triage_action == "skip_merged" else None
+                ),
                 "verdict": None,
                 "cost_usd": 0.0,
                 "dev_model": None,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2699,6 +2699,9 @@ def run_sprint(
         dropped_slugs=_dropped_slugs,
         skipped_issues=skipped_issues,
         current_story_entries_by_ref=current_story_entries_by_ref,
+        triage_actions_by_ref={
+            canonical_ref: triage.action for canonical_ref, triage in triages.items()
+        },
     )
 
     # Write sprint-summary.yaml to .forge/logs/<sprint-name>/

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1769,6 +1769,7 @@ def run_sprint(
                 "path": display_key,
                 "slug": slug,
                 "outcome": "ALREADY_DONE",
+                "outcome_source": "resume_skip_merged",
                 "verdict": None,
                 "cost_usd": 0.0,
                 "story_run_id": run_id,
@@ -1843,7 +1844,10 @@ def run_sprint(
                 _detail = {"final_outcome": "ESCALATE"}
             elif _triage and _triage.action == "skip_merged":
                 _status = "done"
-                _detail = {"final_outcome": "ALREADY_DONE"}
+                _detail = {
+                    "final_outcome": "ALREADY_DONE",
+                    "outcome_source": "resume_skip_merged",
+                }
             elif _triage and _triage.action == "skip":
                 _status = "skipped"
                 _detail = {"final_outcome": "SKIPPED"}
@@ -1881,7 +1885,10 @@ def run_sprint(
                     "bundle_candidate": False,
                     "blocked_by": [],
                     "complexity": None,
-                    "detail": {"final_outcome": "ALREADY_DONE"},
+                    "detail": {
+                        "final_outcome": "ALREADY_DONE",
+                        "outcome_source": "resume_skip_merged",
+                    },
                 }
             )
             _initial_story_slugs.add(_closed_slug)
@@ -2462,6 +2469,21 @@ def run_sprint(
                 }
                 if _terminal_model is not None:
                     _outcome_fields["current_model"] = _terminal_model
+                # Tag preflight-verdict ALREADY_DONE outcomes so renderers can
+                # distinguish them from the resume-skip-merged classification —
+                # the two paths have different trust properties and operators
+                # must not have to cross-reference GitHub state to tell them
+                # apart.
+                if (
+                    _classify_outcome == StoryOutcome.ALREADY_DONE
+                    and result.state.preflight_verdict == "ALREADY_DONE"
+                ):
+                    _existing_entry = _story_state.get(task.slug)
+                    _existing_detail = (
+                        dict(_existing_entry.detail) if _existing_entry is not None else {}
+                    )
+                    _existing_detail["outcome_source"] = "preflight_verdict"
+                    _outcome_fields["detail"] = _existing_detail
                 _set_outcome(task.slug, _classify_outcome, **_outcome_fields)
 
                 # Dependent stories in parallel mode need scheduler-side local merge

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -667,7 +667,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
             outcome = str(story.get("outcome", "SKIPPED"))
             depends_on = list(story.get("depends_on") or [])
             detail = _nonempty_str(story.get("verdict")) or outcome
-            if outcome in {"SKIPPED", "DROPPED"} or depends_on:
+            if outcome in {"SKIPPED", "DROPPED", "ALREADY_DONE"} or depends_on:
                 _, detail, _ = _stage_and_detail_from_completed_story(story, None)
             entries.append(
                 StoryStatusEntry(

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -134,6 +134,28 @@ def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
     return None
 
 
+def _already_done_detail(outcome_source: object, reason: str | None = None) -> str:
+    """Render the DETAIL string for an ALREADY_DONE outcome with a source tag.
+
+    The bare string ``ALREADY_DONE`` collapses two structurally distinct paths
+    (resume-skip-merged is mechanical and trustworthy; preflight-verdict
+    short-circuit is the historically-suspect path) into one indistinguishable
+    label. Operators must be able to tell at a glance which classification a
+    given story landed under without running ``gh`` commands. This helper is
+    the single rendering site that materialises that distinction.
+    """
+    if isinstance(outcome_source, str):
+        if outcome_source == "resume_skip_merged":
+            return "ALREADY_DONE (merged)"
+        if outcome_source == "preflight_verdict":
+            if reason:
+                return f"Preflight verdict: {reason}"
+            return "ALREADY_DONE (preflight)"
+    if reason:
+        return f"Preflight verdict: {reason}"
+    return "ALREADY_DONE"
+
+
 def _outcome_to_status(outcome: str) -> str:
     """Map a sprint-summary ``outcome`` value to a display status string."""
     if outcome in ("ALREADY_DONE", "DONE"):
@@ -305,6 +327,12 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
         ):
             return "", skip_reason, complexity
         if isinstance(final_outcome, str) and final_outcome:
+            if final_outcome == "ALREADY_DONE":
+                return (
+                    "",
+                    _already_done_detail(detail_data.get("outcome_source")),
+                    complexity,
+                )
             return "", final_outcome, complexity
         if skip_reason:
             return "", skip_reason, complexity
@@ -404,8 +432,7 @@ def _stage_and_detail_from_completed_story(
     if isinstance(audit_data, dict):
         if outcome == "ALREADY_DONE":
             reason = _nonempty_str(preflight.get("reason"))
-            if reason:
-                detail = f"Preflight verdict: {reason}"
+            detail = _already_done_detail(story.get("outcome_source"), reason)
         # For failure outcomes, the row's detail must describe the failure —
         # not surface a stale review APPROVE that conflates "review approved"
         # with "story is in good standing." Read outcome.message / error first;
@@ -472,7 +499,7 @@ def _stage_and_detail_from_completed_story(
         elif outcome == "DONE":
             detail = "APPROVE"
         elif outcome == "ALREADY_DONE":
-            detail = "ALREADY_DONE"
+            detail = _already_done_detail(story.get("outcome_source"))
         else:
             detail = outcome
 

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -363,7 +363,9 @@ class TestRunIdRolloverReporting:
         assert entries is not None
         stories = {entry.slug: entry for entry in entries}
         assert stories["issue-959"].status == "done"
-        assert stories["issue-959"].detail == "ALREADY_DONE"
+        # Closed-dependency stories surface as resume-skip-merged to
+        # distinguish them from preflight-verdict ALREADY_DONE outcomes.
+        assert stories["issue-959"].detail == "ALREADY_DONE (merged)"
         # issue-960 now surfaces with its canonical terminal outcome — the
         # live status agrees with the banner and summary by construction.
         assert stories["issue-960"].status in {"done", "failed"}

--- a/tests/test_status_reader_already_done_source.py
+++ b/tests/test_status_reader_already_done_source.py
@@ -9,6 +9,7 @@ and which do not, without running ``gh`` commands per story.
 
 from __future__ import annotations
 
+import datetime
 from pathlib import Path
 
 import yaml
@@ -144,3 +145,134 @@ def test_live_state_distinguishes_resume_skip_from_preflight_verdict(
     assert entries["issue-1325"].detail == "ALREADY_DONE (merged)"
     assert entries["issue-1444"].detail == "ALREADY_DONE (preflight)"
     assert entries["issue-1325"].detail != entries["issue-1444"].detail
+
+
+def test_live_state_accumulated_stories_distinguish_already_done_sources(
+    tmp_path: Path,
+) -> None:
+    """read_live_status must respect outcome_source for accumulated stories
+    loaded from the sprint-level state file (cross-process resume), not just
+    stories already in the current run's live .state file."""
+    from theforge.sprint.audit import _save_accumulated_stories
+
+    sprint_id = "sprint-accumulated-ad"
+    _save_accumulated_stories(
+        sprint_id,
+        "live-sprint",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "issue:1101",
+                "slug": "issue-1101",
+                "path": "Issue #1101",
+                "outcome": "ALREADY_DONE",
+                "outcome_source": "resume_skip_merged",
+                "cost_usd": 0.0,
+                "depends_on": [],
+            },
+            {
+                "canonical_ref": "issue:2002",
+                "slug": "issue-2002",
+                "path": "Issue #2002",
+                "outcome": "ALREADY_DONE",
+                "outcome_source": "preflight_verdict",
+                "cost_usd": 0.05,
+                "depends_on": [],
+            },
+        ],
+    )
+
+    run_id = "run-live-ad-acc"
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / f"{run_id}.state").write_text(
+        yaml.dump(
+            {
+                "sprint_name": "live-sprint",
+                "sprint_id": sprint_id,
+                "stories": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    entries = {e.slug: e for e in (read_live_status(run_id, tmp_path) or [])}
+    assert entries["issue-1101"].detail == "ALREADY_DONE (merged)"
+    assert entries["issue-2002"].detail == "ALREADY_DONE (preflight)"
+
+
+def test_write_sprint_audit_carries_outcome_source_for_both_paths(
+    tmp_path: Path,
+) -> None:
+    """Sprint audit YAML must record outcome_source so audit/postmortem
+    consumers can distinguish trust paths without parsing strings."""
+    from unittest.mock import MagicMock
+
+    from theforge.sprint.audit import _write_sprint_audit
+    from theforge.sprint.manifest import ResolvedSprint, SprintResult
+
+    # Preflight ALREADY_DONE story — runs through results path.
+    preflight_state = MagicMock()
+    preflight_state.preflight_cached = False
+    preflight_state.preflight_verdict = "ALREADY_DONE"
+    preflight_state.preflight_cached_original_verdict = None
+    preflight_state.preflight_cached_from_run_id = None
+    preflight_state.total_cost = 0.05
+    preflight_state.error = None
+    preflight_state.error_type = None
+    preflight_state.review_results = []
+    preflight_state.review_cycle_metadata = []
+    preflight_state.dev_iteration_telemetry = []
+    preflight_state.review_iteration_telemetry = []
+    preflight_phase = MagicMock()
+    preflight_phase.name = "DONE"
+    preflight_result = MagicMock()
+    preflight_result.state = preflight_state
+    preflight_result.phase = preflight_phase
+    preflight_result.merge = None
+
+    # Resume-skip-merged story — never produced a CoordinatorResult; reaches
+    # the drop path with triage_action == "skip_merged".
+    resolved = ResolvedSprint(
+        name="audit-source-sprint",
+        budget_usd=10.0,
+        stories=[],
+    )
+    sprint_result = SprintResult(
+        name="audit-source-sprint",
+        specs_total=2,
+        specs_succeeded=2,
+        specs_failed=0,
+        specs_skipped=0,
+        total_cost_usd=0.05,
+        budget_usd=10.0,
+        results=[("issue:2001", preflight_result)],
+        stopped_reason=None,
+    )
+
+    started = datetime.datetime(2026, 5, 9, 9, 0, tzinfo=datetime.timezone.utc)
+    finished = datetime.datetime(2026, 5, 9, 9, 5, tzinfo=datetime.timezone.utc)
+
+    _write_sprint_audit(
+        manifest=resolved,
+        result=sprint_result,
+        canonical_refs=["issue:2001", "issue:1101"],
+        started_at=started,
+        finished_at=finished,
+        duration=300.0,
+        project_root=tmp_path,
+        slug_map={"issue:2001": "issue-2001", "issue:1101": "issue-1101"},
+        triage_actions_by_ref={"issue:1101": "skip_merged"},
+    )
+
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    data = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+    specs_by_path = {entry["path"]: entry for entry in data["specs"]}
+
+    preflight_entry = specs_by_path["Issue #2001"]
+    resume_entry = specs_by_path["Issue #1101"]
+
+    assert preflight_entry["outcome"] == "ALREADY_DONE"
+    assert preflight_entry["outcome_source"] == "preflight_verdict"
+    assert resume_entry["outcome"] == "ALREADY_DONE"
+    assert resume_entry["outcome_source"] == "resume_skip_merged"

--- a/tests/test_status_reader_already_done_source.py
+++ b/tests/test_status_reader_already_done_source.py
@@ -1,0 +1,146 @@
+"""Regression: forge status DETAIL must distinguish ALREADY_DONE source paths.
+
+Resume-skip-merged classifications (mechanical merge detection — trustworthy)
+and preflight-verdict ALREADY_DONE outcomes (historically the suspect path
+hardened by #1446) must not collapse to the same DETAIL string. Operators
+need to tell at a glance which closure decisions warrant manual verification
+and which do not, without running ``gh`` commands per story.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from theforge.sprint.status_reader import (
+    read_completed_status,
+    read_live_status,
+)
+
+
+def _write_summary(tmp_path: Path, stories: list[dict]) -> Path:
+    summary_dir = tmp_path / ".forge" / "logs" / "alread-done-sprint"
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = summary_dir / "sprint-summary.yaml"
+    summary_path.write_text(
+        yaml.dump(
+            {
+                "sprint": {"name": "alread-done-sprint", "run_id": "run-ad"},
+                "stories": stories,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return summary_path
+
+
+def test_completed_summary_distinguishes_resume_skip_from_preflight_verdict(
+    tmp_path: Path,
+) -> None:
+    summary_path = _write_summary(
+        tmp_path,
+        [
+            {
+                "slug": "issue-1101",
+                "path": "Issue #1101",
+                "outcome": "ALREADY_DONE",
+                "outcome_source": "resume_skip_merged",
+                "cost_usd": 0.0,
+            },
+            {
+                "slug": "issue-2001",
+                "path": "Issue #2001",
+                "outcome": "ALREADY_DONE",
+                "outcome_source": "preflight_verdict",
+                "cost_usd": 0.05,
+            },
+        ],
+    )
+
+    entries = {e.slug: e for e in read_completed_status(summary_path)}
+
+    resume_entry = entries["issue-1101"]
+    preflight_entry = entries["issue-2001"]
+
+    assert resume_entry.detail == "ALREADY_DONE (merged)"
+    assert preflight_entry.detail == "ALREADY_DONE (preflight)"
+    assert resume_entry.detail != preflight_entry.detail
+
+
+def test_completed_summary_legacy_already_done_without_source_renders_default(
+    tmp_path: Path,
+) -> None:
+    summary_path = _write_summary(
+        tmp_path,
+        [
+            {
+                "slug": "issue-9999",
+                "path": "Issue #9999",
+                "outcome": "ALREADY_DONE",
+                "cost_usd": 0.0,
+            },
+        ],
+    )
+
+    entries = read_completed_status(summary_path)
+    assert len(entries) == 1
+    assert entries[0].detail == "ALREADY_DONE"
+
+
+def _write_live_state(tmp_path: Path, stories: list[dict]) -> str:
+    run_id = "run-live-ad"
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    state_path = runs_dir / f"{run_id}.state"
+    state_path.write_text(
+        yaml.dump(
+            {
+                "sprint_name": "live-sprint",
+                "sprint_id": None,
+                "stories": stories,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_id
+
+
+def test_live_state_distinguishes_resume_skip_from_preflight_verdict(
+    tmp_path: Path,
+) -> None:
+    run_id = _write_live_state(
+        tmp_path,
+        [
+            {
+                "slug": "issue-1325",
+                "path": "Issue #1325",
+                "status": "done",
+                "outcome": "already_done",
+                "phase": None,
+                "cost_usd": 0.0,
+                "detail": {
+                    "final_outcome": "ALREADY_DONE",
+                    "outcome_source": "resume_skip_merged",
+                },
+            },
+            {
+                "slug": "issue-1444",
+                "path": "Issue #1444",
+                "status": "done",
+                "outcome": "already_done",
+                "phase": "DONE",
+                "cost_usd": 0.04,
+                "detail": {
+                    "final_outcome": "ALREADY_DONE",
+                    "outcome_source": "preflight_verdict",
+                    "preflight_verdict": "ALREADY_DONE",
+                },
+            },
+        ],
+    )
+
+    entries = {e.slug: e for e in (read_live_status(run_id, tmp_path) or [])}
+    assert entries["issue-1325"].detail == "ALREADY_DONE (merged)"
+    assert entries["issue-1444"].detail == "ALREADY_DONE (preflight)"
+    assert entries["issue-1325"].detail != entries["issue-1444"].detail


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Cycle 1 P1s are resolved; the status, live/watch, accumulated-state, and audit paths now preserve distinct ALREADY_DONE sources with focused regression coverage. | [deepseek-deepseek-reasoner] Iteration 1 correctly resolves all three prior P1 findings: (1) sprint-audit.yaml now records outcome_source for both preflight-verdict and resume-skip-merged paths, (2) the drop path accepts triage_actions_by_ref to emit ALREADY_DONE with outcome_source instead of SKIPPED, and (3) read_live_status accumulated-stories branch includes ALREADY_DONE in the set so _stage_and_detail_from_completed_story is invoked for resume-skip-merged accumulated entries without depends_on. The _already_done_detail() renderer produces distinct detail strings, all persisted formats carry the structured outcome_source field, and the regression test suite covers completed-summary, live-state inline, accumulated-stories, and sprint-audit paths. No regressions introduced by the fix. All 43 relevant tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $8.71
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status conflates resume-skip-merged with preflight ALREADY_DONE — operator cannot distinguish trustworthy already-landed skips from preflight short-circuit verdicts (GitHub Issue #1464)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1464