### PR TITLE
chore: disable deepseek-reasoner reviewer pending adaptive fitness routing

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -9,8 +9,9 @@ models:
     - claude/sonnet
     - claude/opus
     - openai/gpt-5.4
-    - openai/gpt-5.5  
-    - deepseek/deepseek-reasoner
+    - openai/gpt-5.5
+    # - deepseek/deepseek-reasoner  # disabled 2026-05-09: flaky + slow; cycle-3 hang on #1424 + cycle-1 crash on same story.
+    #                                  Re-enable when adaptive routing can decide reviewer fitness automatically.
     - google/gemini-3.1-pro-preview
   custom:
     # GPT-5.5 — added via the user-declared registry overlay shipped in #1184


### PR DESCRIPTION
Removes \`deepseek/deepseek-reasoner\` from the enabled models list in \`forge.yaml\` while adaptive routing gains the capability to evaluate reviewer fitness automatically.

## Operator-observed pattern

Sprint \`9dc545b2c65b\` against issue #1424 on 2026-05-09:
- **Cycle 1**: deepseek-reasoner crashed with \`exit=1\`. Pool reviewer failed; sprint proceeded with gpt-5.5's verdict alone.
- **Cycle 3**: deepseek-reasoner entered a non-converging loop — 33 \`read_file\`/\`grep\`/\`bash\` tool calls over 8+ minutes without ever calling \`submit_review\`. gpt-5.5 finished its verdict in 66 seconds; the pool waited 59 minutes for deepseek to also finish; outer 60-minute story timeout reaped the worker. Net: \$10.12 spent, no usable verdict from this reviewer.
- **Cycles 1+2**: deepseek-reasoner emitted contract-inconsistent verdicts (verdict text vs \`ac_verification\` block) requiring multiple parser retries — see #1326 closed sprint trace for the same pattern.

This is a model-quality issue with deepseek-reasoner specifically, not a TheForge bug. Until adaptive routing can decide reviewer fitness from per-model performance history (escalation rate, hang rate, time-to-verdict, parse-failure rate), operators must drop the model manually.

## Future re-enablement

Re-add the line (currently commented in \`forge.yaml\`) once adaptive routing supports per-model fitness scoring. Likely composes with:
- [#1391](https://github.com/fuzzypete/theforge/issues/1391) — router explainability surfaces candidate pool, exclusions, and rationale
- v0.11 audit substrate consumer migration ([#1324](https://github.com/fuzzypete/theforge/issues/1324)) — already records per-reviewer cost and outcome that fitness scoring needs

A sibling capability worth thinking about: review pool needs a per-reviewer time/iteration cap so silent hangs are bounded — see today's #1424 incident for the canonical case. Not part of this PR's scope.

## Verification

- Diff is one-line behavior change: a comment-out plus inline rationale. No code changes.
- The pool composition for code review on the next sprint will pick from \`{claude/sonnet, claude/opus, openai/gpt-5.5, google/gemini-3.1-pro-preview}\` (excluding the dev_model). With #1468's cross-provider fix landed, gemini becomes a candidate alongside opus/gpt-5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>