### PR TITLE
forge status against earlier completed run reports 'No sprint data found' when a later run sharing the same sprint name has overwritten sprint-summary.yaml

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -117,7 +117,12 @@ def _find_most_recent_run(project_root: Path) -> tuple[str, bool] | None:
     best: tuple[str, bool] | None = None
 
     # Sprint summaries are only written on completion — always historical.
-    for summary in logs_dir.rglob("sprint-summary.yaml"):
+    # Per-run files (run-<id>-summary.yaml) are the durable per-run record;
+    # scan those so historical runs whose name-keyed file was overwritten
+    # by a later same-name run are still discoverable.
+    summary_paths = list(logs_dir.rglob("run-*-summary.yaml"))
+    summary_paths.extend(logs_dir.rglob("sprint-summary.yaml"))
+    for summary in summary_paths:
         try:
             mtime = summary.stat().st_mtime
         except OSError:

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -151,6 +151,14 @@ def _resolve_sprint_log_dir(run_id: str, project_root: Path) -> Path | None:
 
     if not logs_dir.exists():
         return None
+    # Run-id-keyed file is the canonical per-run record (#1480); match it
+    # directly by name so we don't have to scan every legacy file's YAML.
+    try:
+        for per_run in logs_dir.glob(f"*/run-{run_id}-summary.yaml"):
+            if per_run.is_file():
+                return per_run.parent
+    except OSError:
+        return None
     try:
         for summary in logs_dir.glob("*/sprint-summary.yaml"):
             try:

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -342,6 +342,7 @@ def _write_sprint_audit(
     skipped_issues: "list | None" = None,
     current_story_entries_by_ref: "dict[str, dict] | None" = None,
     triage_actions_by_ref: "dict[str, str] | None" = None,
+    run_id: str | None = None,
 ) -> None:
     """Write sprint-audit.yaml to the project root."""
     story_times = story_times or {}
@@ -585,6 +586,14 @@ def _write_sprint_audit(
     audit_path = audits_dir / "sprint-audit.yaml"
     with open(audit_path, "w", encoding="utf-8") as f:
         yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
+    # Run-id-keyed canonical copy: the name-keyed file at sprint-audit.yaml
+    # is overwritten every sprint, so historical audits would otherwise be
+    # lost. Keep the legacy file as a "latest" pointer for convenience and
+    # back-compat; treat the per-run file as the durable record.
+    if run_id:
+        per_run_audit_path = audits_dir / f"run-{run_id}-sprint-audit.yaml"
+        with open(per_run_audit_path, "w", encoding="utf-8") as f:
+            yaml.dump(audit, f, default_flow_style=False, sort_keys=False)
     _upsert_into_substrate(project_root, audit)
     _log(f"Audit written: {audit_path}")
 
@@ -941,7 +950,17 @@ def _write_sprint_summary(
         summary_path = sprint_log_dir / "sprint-summary.yaml"
         with open(summary_path, "w", encoding="utf-8") as f:
             yaml.dump(summary, f, default_flow_style=False, sort_keys=False)
-        _log(f"Sprint summary written: {summary_path}")
+        # Run-id-keyed canonical copy. The legacy name-keyed path is
+        # overwritten by every later run sharing the sprint name, so it
+        # cannot be the durable per-run record (issue #1480). The legacy
+        # file remains as a convenience "latest run" pointer.
+        if run_id:
+            per_run_summary_path = sprint_log_dir / f"run-{run_id}-summary.yaml"
+            with open(per_run_summary_path, "w", encoding="utf-8") as f:
+                yaml.dump(summary, f, default_flow_style=False, sort_keys=False)
+            _log(f"Sprint summary written: {summary_path} (and {per_run_summary_path.name})")
+        else:
+            _log(f"Sprint summary written: {summary_path}")
     except Exception as exc:
         _log(f"Warning: sprint summary write failed: {exc}")
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1345,6 +1345,7 @@ def run_sprint(
             sprint_id=_sprint_id,
             dropped_slugs=dropped_slugs,
             skipped_issues=skipped_issues,
+            run_id=run_id,
         )
         raise RuntimeError(str(baseline_gate.get("message", "Broken baseline")))
 
@@ -2702,6 +2703,7 @@ def run_sprint(
         triage_actions_by_ref={
             canonical_ref: triage.action for canonical_ref, triage in triages.items()
         },
+        run_id=run_id,
     )
 
     # Write sprint-summary.yaml to .forge/logs/<sprint-name>/

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -104,6 +104,17 @@ def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
     logs_dir = project_root / ".forge" / "logs"
     if not logs_dir.exists():
         return None
+
+    # Run-id-keyed file is the canonical per-run record (issue #1480) — try
+    # it first so an earlier run's summary is still queryable after later
+    # same-name runs have overwritten the legacy name-keyed file.
+    for candidate_id in candidate_ids:
+        if not candidate_id:
+            continue
+        for per_run_path in logs_dir.glob(f"*/run-{candidate_id}-summary.yaml"):
+            if per_run_path.is_file():
+                return per_run_path
+
     try:
         sprint_dirs = sorted(d for d in logs_dir.iterdir() if d.is_dir())
     except OSError:

--- a/tests/test_sprint_summary_per_run_persistence.py
+++ b/tests/test_sprint_summary_per_run_persistence.py
@@ -1,0 +1,225 @@
+"""Regression: sprint-summary persistence is keyed by run_id, not sprint name.
+
+When two sprints share a sprint name (the common dogfood pattern: repeatedly
+sprinting the same issue produces deterministic name like ``issues-1326``),
+the later run's summary write must not destroy the earlier run's history.
+``forge status <earlier-run-id>`` against any prior run must still return that
+run's correct sprint state — outcome, cost, duration, per-story status —
+regardless of how many later same-name runs have completed since.
+
+This test exercises the actual writer (``_write_sprint_summary``) and the
+actual ``forge status`` reader path (``find_sprint_summary`` + the
+``cli.sprint_status`` lookup helpers), per the fix-success criterion in
+issue #1480.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from theforge.sprint.audit import _write_sprint_audit, _write_sprint_summary
+from theforge.sprint.status_reader import find_sprint_summary, read_completed_status
+
+
+def _make_result(run_cost: float, succeeded: int, failed: int) -> SimpleNamespace:
+    state = SimpleNamespace(
+        preflight_verdict="PROCEED",
+        review_results=[],
+        total_cost=run_cost,
+        error=None,
+        error_type=None,
+        review_cycle_metadata=[],
+        dev_iteration_telemetry=[],
+        review_iteration_telemetry=[],
+        preflight_cached=False,
+    )
+    return SimpleNamespace(
+        results=[
+            (
+                "issue:1326",
+                SimpleNamespace(
+                    state=state,
+                    phase=SimpleNamespace(name="DONE" if succeeded else "ESCALATE"),
+                    success=bool(succeeded),
+                    merge=None,
+                ),
+            )
+        ],
+        name="issues-1326",
+        total_cost_usd=run_cost,
+        specs_total=1,
+        specs_succeeded=succeeded,
+        specs_failed=failed,
+        specs_skipped=0,
+        stopped_reason=None,
+    )
+
+
+def _write_summary_for_run(
+    *, project_root: Path, sprint_name: str, run_id: str, run_cost: float, outcome_done: bool
+) -> None:
+    manifest = SimpleNamespace(name=sprint_name, budget_usd=10.0, max_parallel=1)
+    result = _make_result(
+        run_cost,
+        succeeded=1 if outcome_done else 0,
+        failed=0 if outcome_done else 1,
+    )
+    started_at = datetime.datetime(2026, 5, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    finished_at = datetime.datetime(2026, 5, 9, 12, 5, 0, tzinfo=datetime.timezone.utc)
+    sprint_log_dir = project_root / ".forge" / "logs" / sprint_name
+    _write_sprint_summary(
+        manifest=manifest,
+        result=result,
+        canonical_refs=["issue:1326"],
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=300.0,
+        sprint_log_dir=sprint_log_dir,
+        slug_map={"issue:1326": "issue-1326"},
+        run_id=run_id,
+        project_root=project_root,
+    )
+
+
+def test_two_runs_same_sprint_name_each_run_id_resolves_to_its_own_summary(
+    tmp_path: Path,
+) -> None:
+    """The motivating scenario from issue #1480.
+
+    Both runs use ``--issues 1326`` and share sprint name ``issues-1326``.
+    After the second run completes, ``forge status <first-run-id>`` must
+    return run-1's data, not "No sprint data found" and not run-2's data.
+    """
+    sprint_name = "issues-1326"
+    first_run_id = "d7ac606000ef"
+    second_run_id = "9e984775b118"
+
+    _write_summary_for_run(
+        project_root=tmp_path,
+        sprint_name=sprint_name,
+        run_id=first_run_id,
+        run_cost=1.23,
+        outcome_done=True,
+    )
+    _write_summary_for_run(
+        project_root=tmp_path,
+        sprint_name=sprint_name,
+        run_id=second_run_id,
+        run_cost=4.56,
+        outcome_done=False,
+    )
+
+    legacy_path = tmp_path / ".forge" / "logs" / sprint_name / "sprint-summary.yaml"
+    legacy = yaml.safe_load(legacy_path.read_text())
+    assert legacy["sprint"]["run_id"] == second_run_id
+
+    first_path = find_sprint_summary(first_run_id, tmp_path)
+    second_path = find_sprint_summary(second_run_id, tmp_path)
+
+    assert first_path is not None, "earlier run lookup must not return None"
+    assert second_path is not None
+    assert first_path != second_path
+
+    first = yaml.safe_load(first_path.read_text())
+    second = yaml.safe_load(second_path.read_text())
+
+    assert first["sprint"]["run_id"] == first_run_id
+    assert first["sprint"]["total_cost_usd"] == 1.23
+    assert first["sprint"]["specs_succeeded"] == 1
+
+    assert second["sprint"]["run_id"] == second_run_id
+    assert second["sprint"]["total_cost_usd"] == 4.56
+    assert second["sprint"]["specs_failed"] == 1
+
+
+def test_read_completed_status_returns_per_run_entries_after_overwrite(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: read_completed_status against the resolved per-run path
+    yields each run's own per-story status — proving the historical run is
+    queryable through the actual forge-status reader, not just the path."""
+    sprint_name = "issues-1326"
+    first_run_id = "run-alpha"
+    second_run_id = "run-beta"
+
+    _write_summary_for_run(
+        project_root=tmp_path,
+        sprint_name=sprint_name,
+        run_id=first_run_id,
+        run_cost=0.50,
+        outcome_done=True,
+    )
+    _write_summary_for_run(
+        project_root=tmp_path,
+        sprint_name=sprint_name,
+        run_id=second_run_id,
+        run_cost=2.00,
+        outcome_done=False,
+    )
+
+    first_path = find_sprint_summary(first_run_id, tmp_path)
+    assert first_path is not None
+    first_entries = read_completed_status(first_path)
+    assert len(first_entries) == 1
+    assert first_entries[0].slug == "issue-1326"
+    assert first_entries[0].status == "done"
+
+    second_path = find_sprint_summary(second_run_id, tmp_path)
+    assert second_path is not None
+    second_entries = read_completed_status(second_path)
+    assert len(second_entries) == 1
+    assert second_entries[0].status == "failed"
+
+
+def test_sprint_audit_yaml_per_run_record_survives_later_same_name_run(
+    tmp_path: Path,
+) -> None:
+    """The project-level sprint-audit.yaml is also overwritten by later runs;
+    the per-run-keyed copy at audits/run-<id>-sprint-audit.yaml must preserve
+    earlier runs' audit data."""
+    sprint_name = "issues-1326"
+    first_run_id = "audit-alpha"
+    second_run_id = "audit-beta"
+
+    manifest = SimpleNamespace(name=sprint_name, budget_usd=10.0, max_parallel=1)
+    started_at = datetime.datetime(2026, 5, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    finished_at = datetime.datetime(2026, 5, 9, 12, 5, 0, tzinfo=datetime.timezone.utc)
+
+    _write_sprint_audit(
+        manifest=manifest,
+        result=_make_result(0.75, succeeded=1, failed=0),
+        canonical_refs=["issue:1326"],
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=300.0,
+        project_root=tmp_path,
+        slug_map={"issue:1326": "issue-1326"},
+        run_id=first_run_id,
+    )
+    _write_sprint_audit(
+        manifest=manifest,
+        result=_make_result(3.25, succeeded=0, failed=1),
+        canonical_refs=["issue:1326"],
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=300.0,
+        project_root=tmp_path,
+        slug_map={"issue:1326": "issue-1326"},
+        run_id=second_run_id,
+    )
+
+    audits_dir = tmp_path / ".forge" / "audits"
+    legacy = yaml.safe_load((audits_dir / "sprint-audit.yaml").read_text())
+    assert legacy["sprint"]["total_cost_usd"] == 3.25
+
+    per_run_first = audits_dir / f"run-{first_run_id}-sprint-audit.yaml"
+    assert per_run_first.exists()
+    first_audit = yaml.safe_load(per_run_first.read_text())
+    assert first_audit["sprint"]["total_cost_usd"] == 0.75
+
+    per_run_second = audits_dir / f"run-{second_run_id}-sprint-audit.yaml"
+    assert per_run_second.exists()


### PR DESCRIPTION
## Summary

The change safely preserves per-run sprint summaries and audits while keeping legacy latest-file behavior.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, deepseek-deepseek-reasoner, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $3.16
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status against earlier completed run reports 'No sprint data found' when a later run sharing the same sprint name has overwritten sprint-summary.yaml (GitHub Issue #1480)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1480