### PR TITLE
cut-rc.sh no longer makes plain forge resolve to the just-cut RC

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,9 +21,22 @@ This document defines how TheForge releases are cut, maintained, and hotfixed.
 
 Releases ship via a release-candidate ladder so dogfood sprints exercise the
 candidate against the next milestone's stories before the final tag is cut.
-The pattern: cut an RC, install it as the dogfood `forge` binary, run a small
-sprint ladder against it, promote when the ladder passes (or cut another RC
-if it doesn't).
+The pattern: cut an RC into an isolated dogfood substrate, point plain
+`forge` at it, run a small sprint ladder, promote when the ladder passes
+(or cut another RC if it doesn't).
+
+### Operator one-time setup: managed `forge` launcher
+
+`cut-rc.sh` repoints plain `forge` at the just-cut RC by writing a symlink
+to a managed launcher path (default: `~/.local/bin/forge`, overridable via
+`FORGE_MANAGED_LAUNCHER`). For this to work, the launcher's directory must
+be on `PATH` **ahead of any Python environment's `bin/`**. If a venv is
+activated whose `bin/forge` precedes the managed launcher, `cut-rc.sh`
+refuses to clobber it (a `pip install -e .` would regenerate the file and
+silently undo the cut-RC binding) and prints guidance.
+
+The simplest setup: ensure your shell's PATH puts `~/.local/bin` before any
+project venv `bin/`, or deactivate the venv before running `cut-rc.sh`.
 
 ### 1. Cut an RC
 
@@ -31,7 +44,7 @@ if it doesn't).
 scripts/cut-rc.sh X.Y.Z         # first RC: cuts vX.Y.ZrcN with N=0
 scripts/cut-rc.sh X.Y.Z 1       # subsequent RCs: explicit RC_NUM
 scripts/cut-rc.sh --dry-run X.Y.Z
-scripts/cut-rc.sh --no-install X.Y.Z   # skip auto-installing the RC into the active env
+scripts/cut-rc.sh --no-install X.Y.Z   # skip the isolated-venv install + launcher repoint
 ```
 
 `cut-rc.sh`:
@@ -42,13 +55,16 @@ scripts/cut-rc.sh --no-install X.Y.Z   # skip auto-installing the RC into the ac
 - bumps `pyproject.toml` to `X.Y.ZrcN` (PEP 440)
 - runs `make gate`
 - commits, tags `vX.Y.ZrcN`, pushes branch and tag
-- pip-installs the RC into the active Python environment (so `forge --version`
-  reports the RC and dogfood sprints exercise the candidate)
-- prints the test ladder
+- creates an isolated venv at `.forge/rc-envs/vX.Y.ZrcN/` and installs the
+  RC into it (no other Python environment is touched)
+- repoints the managed `forge` launcher at the new RC venv, so plain
+  `forge --version` reports the just-cut RC
+- prints the test ladder using plain `forge`
 
-The install step is intentional: cutting an RC and dogfooding it are the same
-muscle-memory action. Use `--no-install` if you need to install on a different
-machine or env.
+The launcher repoint is intentional: cutting an RC and dogfooding it are
+the same muscle-memory action, and the symlink keeps the substrate
+isolated from source-tree edits. Use `--no-install` if you need to install
+on a different machine or env (the managed launcher is left untouched).
 
 ### 2. Run the test ladder against the RC
 
@@ -103,9 +119,13 @@ scripts/promote-rc.sh --dry-run X.Y.Z
 After promotion, the script prints reminders for the manual follow-ups it
 intentionally does **not** automate:
 
-1. Update the dogfood install pin to the new release tag.
-2. Forward-port any RC fixes from `release/vX.Y` to `main` if main has diverged.
-3. Run the post-release doc review.
+1. Forward-port any RC fixes from `release/vX.Y` to `main` if main has diverged.
+2. Run the post-release doc review.
+
+(The managed `forge` launcher continues to point at the last-cut RC venv,
+which contains the same code as the just-promoted final tag. If you want
+plain `forge` to track the final tag specifically, cut a fresh venv from
+`vX.Y.Z` and `ln -snf` the managed launcher at it.)
 
 ### Direct release from main (legacy)
 

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -9,12 +9,20 @@
 # bumps pyproject.toml to X.Y.ZrcN, runs gate, tags vX.Y.ZrcN, pushes
 # branch and tag. Then installs the RC into an ISOLATED Python venv under
 # .forge/rc-envs/v<X.Y.Z>rc<N>/ so dogfood sprints exercise the candidate
-# without mutating the operator's default Python environment (use
-# --no-install to skip the verification install entirely).
+# without mutating any other Python environment (use --no-install to skip
+# the verification install entirely).
 #
-# The operator's shell-default `forge` is never touched by this script.
-# To dogfood the cut RC, invoke the path-qualified binary printed in the
-# Test ladder section below.
+# After the isolated venv install succeeds, the script repoints the
+# operator's managed `forge` launcher (default: ~/.local/bin/forge,
+# overridable via FORGE_MANAGED_LAUNCHER) at the new RC venv's binary, so
+# plain `forge --version` reports the just-cut RC with no shell-config
+# change. The launcher is a symlink — no Python environment is mutated, so
+# editable installs and source-tree edits cannot silently change what
+# plain `forge` runs. If plain `forge` currently resolves to a launcher
+# inside a Python environment's bin/ (an editable-install console script,
+# a pipx shim, etc.), the script refuses to overwrite it and prints
+# guidance, since pip would later regenerate that file and break the
+# binding.
 #
 # Does NOT block on open milestone issues — that's a promote-rc requirement.
 # Prints them informationally so the operator can see what is or isn't in
@@ -166,12 +174,16 @@ run git push origin "$RC_TAG"
 #
 # Earlier versions of this script ran `pip install --force-reinstall` against
 # whatever Python env was active, which silently overwrote the operator's
-# editable install of source. The operator's default env is now never touched
-# by the cut process — verification runs entirely inside the isolated venv.
+# editable install of source. The cut process never installs into any
+# pre-existing Python environment — the RC lives in a fresh venv, and the
+# operator-facing `forge` command is repointed at it via a symlink (step 10).
 RC_ENV_DIR="$(git rev-parse --show-toplevel)/.forge/rc-envs/${RC_TAG}"
 RC_ENV_FORGE="${RC_ENV_DIR}/bin/forge"
 RC_ENV_PIP="${RC_ENV_DIR}/bin/pip"
 RC_ENV_PYTHON="${RC_ENV_DIR}/bin/python"
+
+MANAGED_LAUNCHER="${FORGE_MANAGED_LAUNCHER:-${HOME}/.local/bin/forge}"
+MANAGED_LAUNCHER_DIR="$(dirname "$MANAGED_LAUNCHER")"
 
 if [[ "$NO_INSTALL" == false ]]; then
     echo "==> Verifying $RC_TAG installs cleanly (isolated venv at $RC_ENV_DIR)..."
@@ -197,7 +209,74 @@ if [[ "$NO_INSTALL" == false ]]; then
             echo "       The cut tag may not be publishable; investigate before promoting." >&2
             exit 1
         fi
-        echo "    ✓ $RC_TAG verified — operator's default env is unchanged."
+        echo "    ✓ $RC_TAG installed into isolated venv."
+    fi
+
+    # --- 10. Repoint the operator's managed `forge` launcher at the cut RC ---
+    #
+    # The cut establishes plain `forge` as the just-cut RC by atomically
+    # swapping a forge-managed symlink. We refuse to overwrite a launcher
+    # that lives inside a Python environment's bin/ (editable install,
+    # pipx shim, etc.), since pip would later regenerate that file and
+    # break the binding silently.
+    echo "==> Repointing plain \`forge\` at $RC_TAG ($MANAGED_LAUNCHER -> $RC_ENV_FORGE)..."
+    if [[ "$DRY_RUN" == false ]]; then
+        CURRENT_FORGE="$(command -v forge 2>/dev/null || true)"
+        if [[ -n "$CURRENT_FORGE" && "$CURRENT_FORGE" != "$MANAGED_LAUNCHER" ]]; then
+            CURRENT_FORGE_DIR="$(dirname "$CURRENT_FORGE")"
+            if [[ -f "${CURRENT_FORGE_DIR}/activate" \
+                  || -f "${CURRENT_FORGE_DIR}/../pyvenv.cfg" \
+                  || -f "${CURRENT_FORGE_DIR}/activate.fish" ]]; then
+                echo "" >&2
+                echo "Error: plain \`forge\` currently resolves to" >&2
+                echo "         $CURRENT_FORGE" >&2
+                echo "       which lives inside a Python environment's bin/." >&2
+                echo "       Replacing it would clobber a pip-generated console" >&2
+                echo "       script (e.g. an editable install of source); a later" >&2
+                echo "       \`pip install -e .\` in that environment would regenerate" >&2
+                echo "       the launcher and silently break the cut-RC binding." >&2
+                echo "" >&2
+                echo "       The cut RC is installed and verified at:" >&2
+                echo "         $RC_ENV_FORGE" >&2
+                echo "" >&2
+                echo "       To make plain \`forge\` track cut RCs, ensure" >&2
+                echo "         $MANAGED_LAUNCHER_DIR" >&2
+                echo "       is on PATH ahead of any Python environment's bin/" >&2
+                echo "       (deactivate the venv or reorder PATH), then re-run:" >&2
+                echo "         scripts/cut-rc.sh $VERSION $RC_NUM" >&2
+                exit 1
+            fi
+        fi
+
+        mkdir -p "$MANAGED_LAUNCHER_DIR"
+        ln -snf "$RC_ENV_FORGE" "$MANAGED_LAUNCHER"
+        hash -r 2>/dev/null || true
+
+        RESOLVED_FORGE="$(command -v forge 2>/dev/null || true)"
+        if [[ "$RESOLVED_FORGE" != "$MANAGED_LAUNCHER" ]]; then
+            echo "" >&2
+            echo "Error: after repointing, plain \`forge\` resolves to" >&2
+            echo "         '${RESOLVED_FORGE:-<not found>}'" >&2
+            echo "       expected '$MANAGED_LAUNCHER'." >&2
+            echo "       Ensure $MANAGED_LAUNCHER_DIR is on PATH ahead of any" >&2
+            echo "       Python environment's bin/, then re-run scripts/cut-rc.sh." >&2
+            exit 1
+        fi
+
+        PLAIN_VERSION=$(forge --version 2>/dev/null || echo "")
+        if [[ "$PLAIN_VERSION" != *"$RC_VERSION"* ]]; then
+            echo "" >&2
+            echo "Error: plain \`forge --version\` reports '$PLAIN_VERSION'," >&2
+            echo "       expected to contain $RC_VERSION." >&2
+            echo "       The managed launcher symlink may be broken; investigate" >&2
+            echo "         $MANAGED_LAUNCHER" >&2
+            echo "         $RC_ENV_FORGE" >&2
+            exit 1
+        fi
+
+        echo "    managed launcher : $MANAGED_LAUNCHER -> $RC_ENV_FORGE"
+        echo "    forge --version  : $PLAIN_VERSION"
+        echo "    ✓ plain \`forge\` now tracks $RC_TAG; substrate is isolated."
     fi
 else
     echo "==> Skipping verification install (--no-install)."
@@ -205,19 +284,21 @@ else
     echo "      python3 -m venv \"$RC_ENV_DIR\""
     echo "      \"$RC_ENV_PIP\" install git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
     echo "      \"$RC_ENV_FORGE\" --version"
+    echo "      ln -snf \"$RC_ENV_FORGE\" \"$MANAGED_LAUNCHER\""
 fi
 
-# --- 10. Print test ladder ---
+# --- 11. Print test ladder ---
 echo ""
 echo "==> $RC_TAG cut on $RELEASE_BRANCH."
 echo ""
-echo "Test ladder — run on TheForge's own repo against the cut RC binary."
-echo "The path-qualified binary below is the dogfood substrate; your shell-default"
-echo "\`forge\` is unchanged by this script and remains on whatever you had before."
+echo "Test ladder — run on TheForge's own repo against the cut RC."
+echo "Plain \`forge\` now resolves to the cut RC via the managed launcher"
+echo "($MANAGED_LAUNCHER -> $RC_ENV_FORGE); the substrate is isolated from"
+echo "source-tree edits and editable installs."
 echo ""
-echo "  1. Smoke pass (small story):       $RC_ENV_FORGE sprint --verbose --issues <small-issue>  --budget 50 --parallel 1"
-echo "  2. Boundary pass (medium story):   $RC_ENV_FORGE sprint --verbose --issues <medium-issue> --budget 50 --parallel 1"
-echo "  3. Moneyshot pass (high-complexity story): $RC_ENV_FORGE sprint --verbose --issues <high-complexity-issue> --budget 50 --parallel 1"
+echo "  1. Smoke pass (small story):              forge sprint --verbose --issues <small-issue>  --budget 50 --parallel 1"
+echo "  2. Boundary pass (medium story):          forge sprint --verbose --issues <medium-issue> --budget 50 --parallel 1"
+echo "  3. Moneyshot pass (high-complexity story): forge sprint --verbose --issues <high-complexity-issue> --budget 50 --parallel 1"
 echo ""
 echo "Pick the issues from milestone v$(echo "$VERSION" | awk -F. '{print $1"."$2+1".0"}') (or the next milestone after v$VERSION)."
 echo "Watch for: 'budget' wording in audit/logs (should be 'per-story routing cost cap'), silent tier/pool downgrades without terminal warnings, regressions in any v$VERSION-shipped behavior."

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -14,8 +14,10 @@
 #   - pyproject.toml version is X.Y.ZrcN (an RC was previously cut)
 #   - milestone vX.Y.Z has zero open issues
 #
-# Reminds the operator at the end to merge release branch back to main and
-# update the dogfood install pin.
+# Reminds the operator at the end to forward-port any RC-only fixes to main
+# and to run the post-release doc review. The managed dogfood `forge`
+# launcher (managed by cut-rc.sh) is intentionally not re-linked here — the
+# last-RC venv code already matches the promoted final tag.
 #
 # See RELEASING.md for the end-to-end RC flow.
 
@@ -265,12 +267,13 @@ echo ""
 echo "Promoted v$VERSION (from $RC_TAG)."
 echo ""
 echo "Manual follow-ups:"
-echo "  1. Update the dogfood install pin to the new release:"
-echo "       pip install --force-reinstall git+https://github.com/fuzzypete/theforge.git@v$VERSION"
-echo ""
-echo "  2. Forward-port any RC fixes from $RELEASE_BRANCH to main if main has diverged:"
+echo "  1. Forward-port any RC fixes from $RELEASE_BRANCH to main if main has diverged:"
 echo "       git checkout main"
 echo "       git log main..$RELEASE_BRANCH --oneline    # see what's on the branch but not on main"
 echo "       # cherry-pick or merge as appropriate"
 echo ""
-echo "  3. Run the post-release doc review (issue filed in milestone $NEXT_MILESTONE)."
+echo "  2. Run the post-release doc review (issue filed in milestone $NEXT_MILESTONE)."
+echo ""
+echo "(The managed \`forge\` launcher still points at the last RC venv, whose"
+echo " code matches v$VERSION. To track the final tag specifically, cut a"
+echo " fresh venv from v$VERSION and re-link the managed launcher.)"

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -1,19 +1,25 @@
-"""Regression check: scripts/cut-rc.sh must not mutate the operator's default
-Python environment, and must install the cut RC into an isolated venv under
-.forge/rc-envs/.
+"""Regression checks for ``scripts/cut-rc.sh``.
 
-The historical failure mode this guards: cut-rc.sh used to run
-`pip install --force-reinstall git+...@<RC_TAG>` with no environment
-qualifier, which silently overwrote the operator's editable install of source
-and made every subsequent `forge sprint` run against the cut RC instead of
-source. Subsequent schema divergence between source and the installed RC
-surfaced as cross-environment kwarg mismatches with no visible signal naming
-the runtime in effect.
+Two structural invariants the script must preserve:
 
-The test executes the script under `--dry-run --no-install` so no real venv,
-git tag, push, or pip install runs — `dry_run=true` still echoes the install
-commands the script *would* run, which is enough to verify the isolation
-contract without touching the operator's env.
+1. **Substrate isolation.** Every install of the cut RC must go through the
+   isolated venv's ``pip`` at ``.forge/rc-envs/<RC_TAG>/bin/pip`` — never
+   through whatever Python environment happens to be active when the
+   operator runs the script. The historical failure mode this guards
+   against: an earlier version of the script ran
+   ``pip install --force-reinstall git+...@<RC_TAG>`` with no environment
+   qualifier, which silently overwrote the operator's editable install of
+   source.
+
+2. **Default-command rebinding.** After a successful cut, plain ``forge``
+   in the operator's normal shell must resolve to the just-cut RC. The
+   script accomplishes this by repointing a managed launcher symlink
+   (``~/.local/bin/forge`` by default, overridable via
+   ``FORGE_MANAGED_LAUNCHER``) at the new venv's binary — without
+   mutating any pre-existing Python environment. The script must refuse
+   to overwrite a launcher that lives inside a venv's ``bin/``, since
+   ``pip install -e .`` would later regenerate that file and silently
+   break the binding.
 """
 
 from __future__ import annotations
@@ -31,17 +37,12 @@ SCRIPT = REPO_ROOT / "scripts" / "cut-rc.sh"
 
 
 def test_script_does_not_pip_install_into_operator_default_env() -> None:
-    """The script must not contain a bare `pip install ...` that would target
-    whatever Python env happens to be active when the operator runs the
-    script. Every install must go through the isolated venv's pip.
+    """All executed installs must go through the isolated venv's pip; the
+    historical bare ``pip install ...`` line that mutated the active env is
+    forbidden in code (echoed help text is fine).
     """
     body = SCRIPT.read_text(encoding="utf-8")
 
-    # Allowed: `"$RC_ENV_PIP" install ...` or commented examples in --no-install help.
-    # Disallowed: bare `pip install --force-reinstall git+...` as an executed
-    # command.  The pattern below is the historical line that mutated the
-    # operator's env. Echo'd help/instructions are fine; executed commands are
-    # not. We strip echo'd help lines before scanning.
     code_lines = []
     for line in body.splitlines():
         stripped = line.strip()
@@ -52,7 +53,6 @@ def test_script_does_not_pip_install_into_operator_default_env() -> None:
         code_lines.append(line)
 
     code = "\n".join(code_lines)
-    # No executed `pip install` (without venv qualifier) of the RC tag.
     assert not re.search(
         r"^\s*(run\s+)?pip\s+install\s+.*git\+https://github\.com/fuzzypete/theforge",
         code,
@@ -66,30 +66,66 @@ def test_script_creates_isolated_rc_env() -> None:
     assert "python3 -m venv" in body, "cut-rc.sh must create an isolated venv"
 
 
-def test_script_verification_uses_isolated_binary() -> None:
+def test_script_repoints_managed_launcher_at_isolated_venv() -> None:
+    """The script must symlink a forge-managed launcher path at the
+    isolated venv's binary, not pip-install into any pre-existing env.
+    """
     body = SCRIPT.read_text(encoding="utf-8")
-    # Verification of `forge --version` must come from the isolated venv,
-    # not from the operator's PATH-resolved `forge`.
-    assert "$RC_ENV_FORGE" in body
-    # The bare `forge --version` (PATH-resolved, operator's default env) must
-    # not appear in code (allowed in echo'd help text only).
-    code = "\n".join(
-        line for line in body.splitlines() if not line.lstrip().startswith(("#", "echo "))
+    assert "MANAGED_LAUNCHER" in body, (
+        "cut-rc.sh must define a managed launcher path that gets repointed at the RC"
     )
-    assert "forge --version" not in code or "$RC_ENV_FORGE" in code
+    # The repoint must be a symlink (atomic, no env mutation), pointing at $RC_ENV_FORGE.
+    assert re.search(r'ln\s+-snf\s+"\$RC_ENV_FORGE"\s+"\$MANAGED_LAUNCHER"', body), (
+        "cut-rc.sh must `ln -snf $RC_ENV_FORGE $MANAGED_LAUNCHER` to repoint the launcher"
+    )
 
 
-def test_test_ladder_points_at_isolated_binary() -> None:
+def test_script_refuses_to_overwrite_venv_resident_launcher() -> None:
+    """If plain ``forge`` resolves into a Python env's ``bin/``, the script
+    must refuse rather than clobber a pip-managed console script.
+    """
     body = SCRIPT.read_text(encoding="utf-8")
-    # The Test ladder section's `forge sprint ...` example must be path-
-    # qualified to the isolated venv binary, not bare `forge`.
-    # Match the operator-facing test ladder echo (the "Smoke pass" / "Boundary
-    # pass" / "Moneyshot pass" lines), not the comment header that mentions
-    # "Test ladder section below".
+    # Detection of in-venv launcher: must check for activate / pyvenv.cfg next to the binary.
+    assert "pyvenv.cfg" in body, (
+        "cut-rc.sh must detect a venv-resident launcher via pyvenv.cfg before overwriting"
+    )
+    assert "activate" in body
+    # And it must exit non-zero in that branch.
+    refuse_block = re.search(r"pyvenv\.cfg.*?exit\s+1", body, flags=re.DOTALL)
+    assert refuse_block is not None, (
+        "cut-rc.sh must `exit 1` when plain forge resolves inside a venv bin/"
+    )
+
+
+def test_script_verifies_plain_forge_reports_rc() -> None:
+    """After repointing, the script must invoke plain ``forge --version``
+    (PATH-resolved, no path qualification) and fail loud if the resolved
+    binary doesn't report the RC version.
+    """
+    body = SCRIPT.read_text(encoding="utf-8")
+    # The post-repoint verify uses bare `forge --version` (PATH-resolved).
+    assert re.search(r"PLAIN_VERSION=\$\(forge --version", body), (
+        "cut-rc.sh must verify plain `forge --version` after repointing the launcher"
+    )
+    # And RC_ENV_FORGE is still used for the in-venv install verification.
+    assert "$RC_ENV_FORGE" in body
+
+
+def test_test_ladder_uses_plain_forge() -> None:
+    """The operator-facing test ladder must invoke plain ``forge`` (the
+    repointed default command), not the path-qualified RC venv binary.
+    """
+    body = SCRIPT.read_text(encoding="utf-8")
     ladder = re.search(r"Smoke pass.*?Moneyshot pass[^\n]*", body, flags=re.DOTALL)
     assert ladder is not None
     ladder_text = ladder.group(0)
-    assert "$RC_ENV_FORGE" in ladder_text or ".forge/rc-envs/" in ladder_text
+    assert "$RC_ENV_FORGE" not in ladder_text, (
+        "Test ladder must use plain `forge`, not the path-qualified RC venv binary"
+    )
+    assert ".forge/rc-envs/" not in ladder_text
+    assert re.search(r"forge sprint --verbose --issues", ladder_text), (
+        "Test ladder must show plain `forge sprint ...` invocation"
+    )
 
 
 @pytest.mark.network_integration
@@ -97,24 +133,20 @@ def test_test_ladder_points_at_isolated_binary() -> None:
     not SCRIPT.exists(),
     reason="cut-rc.sh not present",
 )
-def test_full_execution_does_not_mutate_operator_default_env(tmp_path: Path) -> None:
-    """Run scripts/cut-rc.sh through its install seam against a controlled
-    fixture and assert the test process's theforge install is bit-for-bit
-    unchanged afterwards.
+def test_full_execution_repoints_managed_launcher_and_does_not_mutate_operator_env(
+    tmp_path: Path,
+) -> None:
+    """End-to-end install seam test:
 
-    External boundaries are shimmed at PATH so the test never makes a network
-    call: `gh` no-ops, `git push`/`ls-remote` are no-ops (other git commands
-    pass through to the real binary), `make gate` returns success, and
-    `python3 -m venv <DIR>` creates a fake venv populated with shim
-    binaries. The shimmed venv pip records every invocation and never
-    actually installs anything, so the only way the operator's default env
-    could be mutated is if the script ran a bare `pip install` outside the
-    venv pip — which the contract explicitly forbids and this test catches
-    by snapshotting the operator env before and after.
+    Run ``scripts/cut-rc.sh`` against a controlled fixture with all external
+    boundaries shimmed at PATH. Verify that:
 
-    This is the AC's "regression check that runs the actual script" — it
-    runs the real script binary, exercises the real install seam control
-    flow, and verifies the structural property the AC names.
+    - the operator's installed ``theforge`` package is bit-for-bit unchanged
+      (no pip install ever ran outside the isolated venv);
+    - the managed launcher (``$HOME/.local/bin/forge`` in this fixture)
+      exists, is a symlink, and points at the isolated venv's binary;
+    - plain ``forge --version`` (PATH-resolved) reports the cut RC version
+      via the symlink chain.
     """
     import theforge as _theforge_under_test
 
@@ -153,7 +185,6 @@ def test_full_execution_does_not_mutate_operator_default_env(tmp_path: Path) -> 
         textwrap.dedent(
             f"""\
             #!/bin/sh
-            # No-op the network-mutating ops; pass through everything else.
             case "$1" in
                 push) exit 0 ;;
                 ls-remote) exit 0 ;;
@@ -165,9 +196,6 @@ def test_full_execution_does_not_mutate_operator_default_env(tmp_path: Path) -> 
     )
     git_shim.chmod(0o755)
 
-    # Shim python3: when called as `python3 -m venv DIR`, fabricate a venv
-    # populated with shim pip/forge binaries. Real pip is never invoked, so
-    # no real install can leak into the operator's default env.
     pip_log = tmp_path / "pip_calls.log"
     py_shim = bin_dir / "python3"
     py_shim.write_text(
@@ -177,6 +205,9 @@ def test_full_execution_does_not_mutate_operator_default_env(tmp_path: Path) -> 
             if [ "$1" = "-m" ] && [ "$2" = "venv" ]; then
                 VENV="$3"
                 mkdir -p "$VENV/bin"
+                # Mark the dir as a real venv so the script's refuse-to-clobber
+                # heuristic would correctly identify it (defence-in-depth).
+                : > "$VENV/pyvenv.cfg"
                 cat > "$VENV/bin/pip" <<'PIP'
             #!/bin/sh
             echo "$@" >> "{pip_log}"
@@ -200,14 +231,204 @@ def test_full_execution_does_not_mutate_operator_default_env(tmp_path: Path) -> 
     )
     py_shim.chmod(0o755)
 
-    env = os.environ.copy()
-    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    # Isolated HOME so the script's ~/.local/bin/forge symlink lands in tmp,
+    # not in the developer's real home directory.
+    fake_home = tmp_path / "home"
+    (fake_home / ".local" / "bin").mkdir(parents=True)
 
-    # The real script prepends /opt/homebrew/bin to PATH (line 21) so its
-    # interactive operator env is hermetic. For this test we want our shims
-    # to win, so copy the script and strip that single line. Every other
-    # behavior — including the install seam this test exists to verify —
-    # is preserved verbatim.
+    env = os.environ.copy()
+    env["HOME"] = str(fake_home)
+    # Build a hermetic PATH so the test process's own `.venv/bin/forge`
+    # (an editable install) does not leak in and trip the refuse-to-clobber
+    # branch. The managed launcher dir must come BEFORE bin_dir so the
+    # script's post-repoint `command -v forge` lookup resolves to the symlink.
+    env["PATH"] = f"{fake_home}/.local/bin:{bin_dir}:/usr/bin:/bin"
+    # VIRTUAL_ENV would also poison `command -v` heuristics; clear it.
+    env.pop("VIRTUAL_ENV", None)
+
+    script_copy = tmp_path / "cut-rc.sh"
+    script_text = SCRIPT.read_text(encoding="utf-8")
+    # Strip the hardcoded /opt/homebrew PATH override so our shims win.
+    script_text = re.sub(
+        r"^export PATH=\"/opt/homebrew/bin:\$PATH\"\s*$",
+        ": # PATH override stripped for hermetic test",
+        script_text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    script_copy.write_text(script_text)
+    script_copy.chmod(0o755)
+
+    proc = subprocess.run(
+        ["bash", str(script_copy), "0.99.0", "0"],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, (
+        f"cut-rc.sh exited non-zero ({proc.returncode}). Output:\n{combined}"
+    )
+
+    # The isolated venv must exist and be populated.
+    rc_env = repo / ".forge" / "rc-envs" / "v0.99.0rc0"
+    assert rc_env.is_dir(), (
+        "cut-rc.sh did not create the isolated venv; install seam not exercised. "
+        f"Output:\n{combined}"
+    )
+    rc_forge = rc_env / "bin" / "forge"
+    assert rc_forge.is_file()
+
+    # The managed launcher must exist, be a symlink, and point at the RC venv.
+    managed_launcher = fake_home / ".local" / "bin" / "forge"
+    assert managed_launcher.is_symlink(), (
+        f"managed launcher {managed_launcher} is not a symlink. Output:\n{combined}"
+    )
+    assert os.readlink(managed_launcher) == str(rc_forge), (
+        f"managed launcher points at {os.readlink(managed_launcher)}, expected {rc_forge}"
+    )
+
+    # Plain `forge --version` (PATH-resolved through the managed launcher)
+    # must report the cut RC. Substrate provenance: the binary actually
+    # executing is the RC venv's forge, not whatever was on PATH before.
+    plain_check = subprocess.run(
+        ["bash", "-c", "command -v forge && forge --version"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert plain_check.returncode == 0, plain_check.stderr
+    assert str(managed_launcher) in plain_check.stdout
+    assert "0.99.0rc0" in plain_check.stdout, (
+        f"plain forge --version did not report cut RC: {plain_check.stdout}"
+    )
+
+    # Operator env theforge package must be bit-for-bit unchanged.
+    post_mtime = operator_pkg.stat().st_mtime
+    post_size = operator_pkg.stat().st_size
+    post_bytes = operator_pkg.read_bytes()
+    assert post_mtime == pre_mtime
+    assert post_size == pre_size
+    assert post_bytes == pre_bytes, "Operator env theforge contents changed"
+
+    # No bare `pip install` of the RC tag escaped the venv-pip seam.
+    bad_pattern = re.compile(
+        r"^\+ pip install .*git\+https://github\.com/fuzzypete/theforge",
+        flags=re.MULTILINE,
+    )
+    assert not bad_pattern.search(combined)
+
+    if pip_log.exists():
+        log = pip_log.read_text()
+        assert "git+https://github.com/fuzzypete/theforge.git@v0.99.0rc0" in log, (
+            f"Isolated venv pip was not invoked with the RC tag. pip log:\n{log}"
+        )
+
+
+@pytest.mark.network_integration
+@pytest.mark.skipif(
+    not SCRIPT.exists(),
+    reason="cut-rc.sh not present",
+)
+def test_full_execution_refuses_to_clobber_venv_resident_forge(tmp_path: Path) -> None:
+    """If plain ``forge`` resolves into a Python env's ``bin/`` (e.g. an
+    editable install's console script), the script must refuse and exit
+    non-zero rather than overwrite a pip-managed file.
+    """
+    repo = tmp_path / "fake_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "pyproject.toml").write_text('version = "0.99.0"\n')
+    (repo / "Makefile").write_text("gate:\n\t@true\n")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
+
+    real_git = subprocess.run(
+        ["bash", "-c", "command -v git"], capture_output=True, text=True
+    ).stdout.strip()
+
+    bin_dir = tmp_path / "shim_bin"
+    bin_dir.mkdir()
+    (bin_dir / "gh").write_text("#!/bin/sh\nexit 0\n")
+    (bin_dir / "gh").chmod(0o755)
+    (bin_dir / "make").write_text("#!/bin/sh\nexit 0\n")
+    (bin_dir / "make").chmod(0o755)
+    git_shim = bin_dir / "git"
+    git_shim.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            case "$1" in
+                push) exit 0 ;;
+                ls-remote) exit 0 ;;
+                pull) exit 0 ;;
+            esac
+            exec {real_git} "$@"
+            """
+        )
+    )
+    git_shim.chmod(0o755)
+
+    # Fake operator venv with a `forge` console script in its bin/.
+    fake_venv = tmp_path / "operator_venv"
+    (fake_venv / "bin").mkdir(parents=True)
+    (fake_venv / "pyvenv.cfg").write_text("home = /usr/bin\n")
+    venv_forge = fake_venv / "bin" / "forge"
+    venv_forge.write_text("#!/bin/sh\necho 'editable-install forge'\n")
+    venv_forge.chmod(0o755)
+    venv_forge_pre_bytes = venv_forge.read_bytes()
+
+    pip_log = tmp_path / "pip_calls.log"
+    py_shim = bin_dir / "python3"
+    py_shim.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            if [ "$1" = "-m" ] && [ "$2" = "venv" ]; then
+                VENV="$3"
+                mkdir -p "$VENV/bin"
+                : > "$VENV/pyvenv.cfg"
+                cat > "$VENV/bin/pip" <<'PIP'
+            #!/bin/sh
+            echo "$@" >> "{pip_log}"
+            exit 0
+            PIP
+                chmod +x "$VENV/bin/pip"
+                cat > "$VENV/bin/forge" <<'FORGE'
+            #!/bin/sh
+            if [ "$1" = "--version" ]; then
+                echo "TheForge v0.99.0rc0"
+            fi
+            FORGE
+                chmod +x "$VENV/bin/forge"
+                : > "$VENV/bin/python"
+                chmod +x "$VENV/bin/python"
+                exit 0
+            fi
+            exit 0
+            """
+        )
+    )
+    py_shim.chmod(0o755)
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".local" / "bin").mkdir(parents=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(fake_home)
+    # Hermetic PATH (don't inherit the test runner's own venv); fake_venv
+    # is AHEAD of the managed launcher dir to simulate an active venv whose
+    # forge precedes ~/.local/bin on PATH.
+    env["PATH"] = f"{fake_venv}/bin:{fake_home}/.local/bin:{bin_dir}:/usr/bin:/bin"
+    env.pop("VIRTUAL_ENV", None)
+
     script_copy = tmp_path / "cut-rc.sh"
     script_text = SCRIPT.read_text(encoding="utf-8")
     script_text = re.sub(
@@ -230,40 +451,16 @@ def test_full_execution_does_not_mutate_operator_default_env(tmp_path: Path) -> 
     )
     combined = proc.stdout + proc.stderr
 
-    # The script should have reached the install seam.
-    rc_env = repo / ".forge" / "rc-envs" / "v0.99.0rc0"
-    assert rc_env.is_dir(), (
-        "cut-rc.sh did not create the isolated venv; install seam not exercised. "
-        f"Output:\n{combined}"
+    assert proc.returncode != 0, (
+        f"cut-rc.sh should refuse to overwrite a venv-resident forge launcher. Output:\n{combined}"
     )
-    assert (rc_env / "bin" / "forge").is_file()
-
-    # Every pip invocation must have come from the venv's shim pip; the bare
-    # operator pip must never have been called. We verify two ways: (a) the
-    # operator env file is bit-for-bit unchanged; (b) the script's output
-    # contains no `+ pip install` trace targeting bare pip.
-    post_mtime = operator_pkg.stat().st_mtime
-    post_size = operator_pkg.stat().st_size
-    post_bytes = operator_pkg.read_bytes()
-    assert post_mtime == pre_mtime, (
-        f"Operator env theforge mtime changed: {pre_mtime} -> {post_mtime}"
-    )
-    assert post_size == pre_size
-    assert post_bytes == pre_bytes, "Operator env theforge contents changed"
-
-    bad_pattern = re.compile(
-        r"^\+ pip install .*git\+https://github\.com/fuzzypete/theforge",
-        flags=re.MULTILINE,
-    )
-    assert not bad_pattern.search(combined)
-
-    # Sanity: the venv shim pip was called with the RC git URL — proves the
-    # install seam targeted the isolated venv specifically.
-    if pip_log.exists():
-        log = pip_log.read_text()
-        assert "git+https://github.com/fuzzypete/theforge.git@v0.99.0rc0" in log, (
-            f"Isolated venv pip was not invoked with the RC tag. pip log:\n{log}"
-        )
+    # Operator's venv forge must not have been touched.
+    assert venv_forge.read_bytes() == venv_forge_pre_bytes
+    # The error message must guide the operator.
+    assert "inside a Python environment" in combined
+    # The managed launcher must NOT have been created.
+    managed_launcher = fake_home / ".local" / "bin" / "forge"
+    assert not managed_launcher.exists()
 
 
 @pytest.mark.skipif(
@@ -271,18 +468,9 @@ def test_full_execution_does_not_mutate_operator_default_env(tmp_path: Path) -> 
     reason="cut-rc.sh not present",
 )
 def test_dry_run_does_not_emit_default_env_pip_install(tmp_path: Path) -> None:
-    """Running the script under --dry-run echoes the commands it *would*
-    execute. The echoed install command must target the isolated venv's pip,
-    not bare `pip`.
-
-    We cannot run cut-rc.sh end-to-end in a unit test (it would try to git-pull
-    main, create a release branch, tag, push, and install from a real tag).
-    But --dry-run is enough to assert the install seam: the `+ <command>`
-    trace in dry-run output is the contract surface.
+    """In ``--dry-run`` mode, no echoed install command may target bare
+    ``pip``; every install must go through the isolated venv's pip.
     """
-    # Use a fake git repo so the script's git checks succeed in dry-run mode.
-    # In dry-run, the actual git mutations are skipped, but read-only checks
-    # (status, show-ref, rev-parse) still run.
     repo = tmp_path / "fake_repo"
     repo.mkdir()
     subprocess.run(["git", "init", "-q", str(repo)], check=True)
@@ -291,11 +479,9 @@ def test_dry_run_does_not_emit_default_env_pip_install(tmp_path: Path) -> None:
     (repo / "pyproject.toml").write_text('version = "0.99.0"\n')
     subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
     subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "init"], check=True)
-    # Rename branch to main for parity with the script's `git checkout main`.
     subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
 
     env = os.environ.copy()
-    # Avoid network: provide a no-op gh shim in PATH.
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     gh_shim = bin_dir / "gh"
@@ -303,10 +489,7 @@ def test_dry_run_does_not_emit_default_env_pip_install(tmp_path: Path) -> None:
         textwrap.dedent(
             """\
             #!/bin/sh
-            # gh shim — emit nothing for issue list (so OPEN_ISSUES is empty
-            # which the script handles).
             if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
-                # --json number --jq 'length' path
                 if echo "$@" | grep -q -- "--json"; then
                     echo "0"
                 else
@@ -328,10 +511,6 @@ def test_dry_run_does_not_emit_default_env_pip_install(tmp_path: Path) -> None:
         timeout=30,
     )
 
-    # The script may or may not reach the install step in dry-run depending
-    # on the order of git checks; what matters is that any install command it
-    # *did* echo targeted the isolated venv. Scan stdout+stderr for the
-    # historical bug pattern.
     combined = proc.stdout + proc.stderr
     bad_pattern = re.compile(
         r"^\+ pip install .*git\+https://github\.com/fuzzypete/theforge",


### PR DESCRIPTION
## Summary

[claude-opus] Managed launcher symlink repoints plain forge at the cut RC with substrate isolation preserved; refuse-to-clobber guard, post-repoint verification, and end-to-end tests all align with spec. | [openai-gpt-5.5] The change satisfies the release workflow invariant with an isolated RC substrate, managed launcher rebinding, loud failure paths, and targeted regression coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.65
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

cut-rc.sh no longer makes plain forge resolve to the just-cut RC (GitHub Issue #1496)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1496