### PR TITLE
Forge-created worktrees drop project-scoped .forge/.env secrets when config is loaded from the worktree

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -455,16 +455,41 @@ def _parse_stuck_detection(raw: Any) -> "StuckDetectionConfig":
     return StuckDetectionConfig(**kwargs)
 
 
+def _resolve_project_root(config_path: Path) -> Path:
+    """Resolve the project root for a given forge.yaml path.
+
+    Forge-created worktrees live at ``<project_root>/.forge/worktrees/<slug>/``
+    and contain a synced ``forge.yaml`` but no ``.forge/.env``. When config is
+    loaded from such a worktree, the project-scoped secret store and other
+    project-level state belong to the parent checkout, not the worktree.
+    Detect that layout and walk up so secrets and project_root reference the
+    real project root.
+    """
+    parent = config_path.parent.resolve()
+    grandparent = parent.parent
+    great_grandparent = grandparent.parent
+    if (
+        grandparent.name == "worktrees"
+        and great_grandparent.name == ".forge"
+        and great_grandparent.parent != great_grandparent
+    ):
+        return great_grandparent.parent
+    return parent
+
+
 def load_config(config_path: Path) -> ForgeConfig:
     """Load forge.yaml and return a typed ForgeConfig.
 
-    The config file path is used to derive the project root (its parent directory).
+    The config file path is used to derive the project root (its parent directory),
+    except when ``config_path`` lives inside a forge-created worktree at
+    ``<root>/.forge/worktrees/<slug>/``, in which case the project root is
+    resolved to the parent checkout so project-scoped secrets remain accessible.
     Missing sections fall back to sensible defaults.
 
     Raises ValueError for invalid configurations (empty pool, duplicate names,
     unsupported CLI, missing synthesis profile when pool size > 1).
     """
-    project_root = config_path.parent.resolve()
+    project_root = _resolve_project_root(config_path)
 
     # Load project-scoped secrets before profile validation so _resolve_secret() works.
     env_path = project_root / ".forge" / ".env"

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1006,3 +1006,57 @@ class TestCliPoolCrossProviderRotation:
         assert "None" not in rationale, rationale
         for derived in ("anthropic", "openai", "google"):
             assert derived in rationale, f"expected {derived!r} in rationale: {rationale}"
+
+
+class TestWorktreeProjectRootResolution:
+    """Forge-created worktrees must resolve project_root to the parent checkout
+    so project-scoped secrets (.forge/.env) remain accessible regardless of
+    whether config is loaded from the main checkout or a worktree.
+    """
+
+    def _write_main_checkout(self, root: Path, env_contents: str | None) -> None:
+        (root / "forge.yaml").write_text(yaml.dump({"project": "p"}), encoding="utf-8")
+        if env_contents is not None:
+            (root / ".forge").mkdir(parents=True, exist_ok=True)
+            (root / ".forge" / ".env").write_text(env_contents, encoding="utf-8")
+
+    def _make_worktree(self, root: Path, slug: str) -> Path:
+        wt = root / ".forge" / "worktrees" / slug
+        wt.mkdir(parents=True, exist_ok=True)
+        (wt / "forge.yaml").write_text(yaml.dump({"project": "p"}), encoding="utf-8")
+        return wt
+
+    def test_load_from_main_checkout_reads_secrets(self, tmp_path):
+        self._write_main_checkout(tmp_path, "SLACK_WEBHOOK_URL=https://hooks/x\nFOO=bar\n")
+        config = load_config(tmp_path / "forge.yaml")
+        assert config.secrets.get("SLACK_WEBHOOK_URL") == "https://hooks/x"
+        assert config.secrets.get("FOO") == "bar"
+        assert config.project_root == tmp_path.resolve()
+
+    def test_load_from_worktree_recovers_parent_secrets(self, tmp_path):
+        self._write_main_checkout(tmp_path, "SLACK_WEBHOOK_URL=https://hooks/x\nFOO=bar\n")
+        wt = self._make_worktree(tmp_path, "issue-1503")
+        config = load_config(wt / "forge.yaml")
+        assert config.secrets.get("SLACK_WEBHOOK_URL") == "https://hooks/x"
+        assert config.secrets.get("FOO") == "bar"
+        assert config.project_root == tmp_path.resolve()
+
+    def test_load_from_worktree_with_no_parent_env_returns_empty_secrets(self, tmp_path):
+        self._write_main_checkout(tmp_path, env_contents=None)
+        wt = self._make_worktree(tmp_path, "issue-1503")
+        config = load_config(wt / "forge.yaml")
+        assert config.secrets == {}
+        assert config.project_root == tmp_path.resolve()
+
+    def test_unrelated_directory_named_worktrees_not_treated_as_forge_worktree(self, tmp_path):
+        """Only the canonical .forge/worktrees/<slug>/ layout triggers walk-up.
+        A user project that happens to have a folder named worktrees should not
+        have its project_root silently relocated.
+        """
+        # <tmp>/something/worktrees/<slug>/forge.yaml — grandparent is "worktrees"
+        # but great-grandparent is "something", not ".forge".
+        odd = tmp_path / "something" / "worktrees" / "slug-x"
+        odd.mkdir(parents=True)
+        (odd / "forge.yaml").write_text(yaml.dump({"project": "p"}), encoding="utf-8")
+        config = load_config(odd / "forge.yaml")
+        assert config.project_root == odd.resolve()


### PR DESCRIPTION
## Summary

The change satisfies the bug fix: worktree-rooted config loads now recover the parent checkout secret store, with targeted tests for the observed path.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.68
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Forge-created worktrees drop project-scoped .forge/.env secrets when config is loaded from the worktree (GitHub Issue #1503)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1503