### PR TITLE
Resume reruns review after hygiene-only escalation instead of preserving prior approval consensus

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -603,9 +603,7 @@ def _maybe_replay_hygiene_consensus(
         _escalate_notify(task, state, notify, config)
         return (
             _ReviewOutcome.ESCALATE,
-            CoordinatorResult(
-                success=False, phase=state.phase, state=state, message=state.error
-            ),
+            CoordinatorResult(success=False, phase=state.phase, state=state, message=state.error),
             config,
         )
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -559,9 +559,11 @@ def _maybe_replay_hygiene_consensus(
     # hygiene escalation (or any new mutation) is still present. Replaying
     # under a dirty tree would let unreviewed reviewer-created changes ride
     # under the prior dev-commit approval — and in merge mode land_story
-    # could auto-commit those changes before merging. Fall through to a
-    # fresh review, which will re-trip the hygiene gate and surface the
-    # offending paths to the operator instead of silently approving them.
+    # could auto-commit those changes before merging. Fail closed: ESCALATE
+    # with the offending paths so the operator either removes/quarantines
+    # them or marks the run rejected — do not fall through to a fresh
+    # review, whose own hygiene snapshot would treat the persistent
+    # mutation as part of the baseline and silently approve it.
     from .workspace_hygiene import snapshot_porcelain  # noqa: PLC0415
 
     _porcelain = snapshot_porcelain(workspace_path)
@@ -583,10 +585,51 @@ def _maybe_replay_hygiene_consensus(
             "  ↺ RESUME   refusing to replay APPROVE consensus — worktree still"
             f" dirty ({len(offending)} unresolved path(s)): {', '.join(offending[:5])}"
         )
-        # Clear escalation-replay state so a subsequent fresh-review APPROVE
-        # does not get short-circuited again. The fresh review re-runs the
-        # hygiene gate and either passes (if the operator cleaned up) or
-        # re-escalates with current offending paths.
+        # Keep escalate_kind='hygiene' so the operator-facing state still
+        # reflects the unresolved hygiene escalation; clear the prior review
+        # so a subsequent extend/retry cycle starts fresh once the workspace
+        # is clean.
+        state.hygiene_escalation_prior_review = None
+        state.phase = Phase.ESCALATE
+        state.error = (
+            "Workspace hygiene escalation has unresolved mutations at resume; "
+            f"remove or quarantine offending paths before retrying: {', '.join(offending)}"
+        )
+        if logger:
+            logger._safe_emit("phase_end", phase="REVIEW", outcome="escalate")
+            logger._safe_emit(
+                "escalate", reason=state.error, phase="REVIEW", escalate_kind="hygiene"
+            )
+        _escalate_notify(task, state, notify, config)
+        return (
+            _ReviewOutcome.ESCALATE,
+            CoordinatorResult(
+                success=False, phase=state.phase, state=state, message=state.error
+            ),
+            config,
+        )
+
+    # Apply the same empty-diff guard as the normal APPROVE path: refuse to
+    # mark DONE on a branch with no commits ahead of base. Without this,
+    # replaying a captured APPROVE on a branch whose commits have been
+    # stripped (or never landed) would silently approve an empty diff.
+    if not _has_commits_ahead_of_base(workspace_path, config.workspace.base_branch):
+        audit = {
+            "resume_action": "rerun_no_commits_ahead",
+            "escalate_kind": state.escalate_kind,
+            "prior_approve_count": state.hygiene_escalation_prior_approve_count,
+            "total_count": state.hygiene_escalation_total_count,
+            "dev_commit_sha_at_hygiene_trip": prior_sha,
+            "dev_commit_sha_at_resume": head_sha,
+            "base_branch": config.workspace.base_branch,
+        }
+        state.hygiene_resume_audit = audit
+        if logger:
+            logger._safe_emit("hygiene_resume", **audit)
+        _log(
+            "  ↺ RESUME   refusing to replay APPROVE consensus — branch has no"
+            f" commits ahead of {config.workspace.base_branch}; running fresh review"
+        )
         state.escalate_kind = None
         state.hygiene_escalation_prior_review = None
         return None

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -66,7 +66,7 @@ from .state import (
     ReviewCycleMetadata,
     ReviewIterationTelemetry,
 )
-from .util import _fmt_duration, _log, _log_phase, _log_verbose
+from .util import _fmt_duration, _log, _log_phase, _log_verbose, _run_shell
 
 
 def _perform_dev_model_escalation(
@@ -444,6 +444,7 @@ def _handle_interactive_review_decision(
 
     if decision in ("escalate", "timeout"):
         state.phase = Phase.ESCALATE
+        state.escalate_kind = "content"
         if decision == "timeout":
             state.error = "Remote review timed out — auto-escalated."
         elif exhausted_cycles:
@@ -505,6 +506,101 @@ def _handle_interactive_review_decision(
     return _ReviewOutcome.RETRY_DEV, None, config
 
 
+def _maybe_replay_hygiene_consensus(
+    state: CoordinatorState,
+    config: ForgeConfig,
+    task: TaskStory,
+    workspace_path: Path,
+    branch_name: str,
+    task_start: float,
+    *,
+    auto_merge: bool,
+    notify: bool,
+    logger: StructuredLogger | None,
+    run_id: str,
+) -> tuple[_ReviewOutcome, CoordinatorResult | None, ForgeConfig] | None:
+    """Replay a prior APPROVE consensus captured at hygiene-escalation time.
+
+    Returns a DONE outcome when the dev commit is unchanged from the hygiene
+    trip and a prior APPROVE candidate was captured.  Returns None to fall
+    through to a fresh review otherwise; in that case escalation-state fields
+    are cleared so a future hygiene escalation does not silently reuse them.
+    """
+    prior_review = state.hygiene_escalation_prior_review
+    prior_sha = state.hygiene_escalation_dev_commit_sha or ""
+    _ok_sha, _sha_out = _run_shell("git rev-parse HEAD", workspace_path)
+    head_sha = _sha_out.strip() if _ok_sha else ""
+
+    if not head_sha or not prior_sha or head_sha != prior_sha:
+        audit = {
+            "resume_action": "rerun_dev_commit_changed"
+            if (head_sha and prior_sha)
+            else "rerun_no_prior_consensus",
+            "escalate_kind": state.escalate_kind,
+            "prior_approve_count": state.hygiene_escalation_prior_approve_count,
+            "total_count": state.hygiene_escalation_total_count,
+            "dev_commit_sha_at_hygiene_trip": prior_sha or None,
+            "dev_commit_sha_at_resume": head_sha or None,
+        }
+        state.hygiene_resume_audit = audit
+        if logger:
+            logger._safe_emit("hygiene_resume", **audit)
+        _log(
+            "  ↺ RESUME   dev commit changed since hygiene escalation"
+            f" (was {prior_sha[:8] or '?'}, now {head_sha[:8] or '?'})"
+            " — running fresh review"
+        )
+        # Clear so a future hygiene escalation in this run does not replay.
+        state.escalate_kind = None
+        state.hygiene_escalation_prior_review = None
+        return None
+
+    state.review_cycle += 1
+    state.review_results.append(prior_review)
+    audit = {
+        "resume_action": "replayed_consensus",
+        "escalate_kind": state.escalate_kind,
+        "prior_approve_count": state.hygiene_escalation_prior_approve_count,
+        "total_count": state.hygiene_escalation_total_count,
+        "dev_commit_sha_at_hygiene_trip": prior_sha,
+        "dev_commit_sha_at_resume": head_sha,
+    }
+    state.hygiene_resume_audit = audit
+    if logger:
+        logger._safe_emit("hygiene_resume", **audit)
+    _log(
+        "  ↺ RESUME   replaying prior APPROVE consensus from hygiene escalation,"
+        f" dev commit {prior_sha[:8]}"
+    )
+    # Clear so a subsequent escalation does not replay the same record.
+    state.escalate_kind = None
+    state.hygiene_escalation_prior_review = None
+    _append_cycle_history(state, prior_review)
+    return (
+        _ReviewOutcome.DONE,
+        _finalize_approve(
+            state,
+            config,
+            task,
+            prior_review,
+            workspace_path,
+            branch_name,
+            task_start,
+            auto_merge=auto_merge,
+            notify=notify,
+            logger=logger,
+            review_cost=0.0,
+            review_elapsed=0.0,
+            message=(
+                f"Task '{task.name}' completed. "
+                f"Replayed prior APPROVE consensus from hygiene escalation. "
+            ),
+            run_id=run_id,
+        ),
+        config,
+    )
+
+
 def _run_review_phase(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -530,6 +626,26 @@ def _run_review_phase(
     config is returned because persistent-P1 model escalation may replace it.
     """
     state.phase = Phase.REVIEW
+
+    # Resume short-circuit: if the prior run escalated due to a workspace-hygiene
+    # mutation but the reviewer pool had already produced an APPROVE consensus
+    # for the dev commit, replay that consensus instead of re-running the pool
+    # against an unchanged dev commit (issue #1499).
+    if state.escalate_kind == "hygiene" and state.hygiene_escalation_prior_review is not None:
+        _resume_result = _maybe_replay_hygiene_consensus(
+            state,
+            config,
+            task,
+            workspace_path,
+            branch_name,
+            task_start,
+            auto_merge=auto_merge,
+            notify=notify,
+            logger=logger,
+            run_id=run_id,
+        )
+        if _resume_result is not None:
+            return _resume_result
     if state_update_fn is not None:
         state_update_fn(
             {
@@ -593,10 +709,41 @@ def _run_review_phase(
     if not _review_ok:
         state.phase = Phase.ESCALATE
         state.error = _review_diag or "REVIEW phase mutated the worktree"
+        state.escalate_kind = "hygiene"
+        # Capture prior reviewer consensus so `forge sprint --resume` can replay
+        # the APPROVE outcome for an unchanged dev commit instead of re-exposing
+        # the run to reviewer flakiness on a hygiene-only escalation.
+        _approve_count = sum(1 for _, rr in _named_parsed if rr.verdict == "APPROVE")
+        _total_count = len(_named_parsed)
+        state.hygiene_escalation_prior_approve_count = _approve_count
+        state.hygiene_escalation_total_count = _total_count
+        if (
+            _candidate is not None
+            and not _candidate.parse_errors
+            and _candidate.verdict == "APPROVE"
+        ):
+            _ok_sha, _sha_out = _run_shell("git rev-parse HEAD", workspace_path)
+            if _ok_sha and _sha_out.strip():
+                state.hygiene_escalation_dev_commit_sha = _sha_out.strip()
+                state.hygiene_escalation_prior_review = _candidate
+                _log(
+                    f"  ↺ Captured prior APPROVE consensus "
+                    f"({_approve_count}/{_total_count}) at dev commit "
+                    f"{state.hygiene_escalation_dev_commit_sha[:8]} for resume replay"
+                )
+        save_trajectory_state(workspace_path, state)
         _log(f"✗ ESCALATE   {state.error}")
         if logger:
             logger._safe_emit("phase_end", phase="REVIEW", outcome="escalate")
-            logger._safe_emit("escalate", reason=state.error, phase="REVIEW")
+            logger._safe_emit(
+                "escalate",
+                reason=state.error,
+                phase="REVIEW",
+                escalate_kind="hygiene",
+                prior_approve_count=_approve_count,
+                total_count=_total_count,
+                dev_commit_sha=state.hygiene_escalation_dev_commit_sha,
+            )
         _escalate_notify(task, state, notify, config)
         return (
             _ReviewOutcome.ESCALATE,
@@ -893,6 +1040,7 @@ def _run_review_phase(
             # Blocking P1 persists but reviewer has converged — escalate so
             # the persistent issue gets human attention rather than looping.
             state.phase = Phase.ESCALATE
+            state.escalate_kind = "content"
             state.error = (
                 f"Review converged with unresolved blocking P1(s) after "
                 f"{_zero_stop} consecutive zero-new-findings cycles."
@@ -927,6 +1075,7 @@ def _run_review_phase(
         workspace_path, config.workspace.base_branch
     ):
         state.phase = Phase.ESCALATE
+        state.escalate_kind = "content"
         state.error = (
             "Review verdict APPROVE on a branch with no commits ahead of base — "
             "refusing to mark DONE on an empty diff"
@@ -1064,6 +1213,7 @@ def _run_review_phase(
             )
         else:
             state.phase = Phase.ESCALATE
+            state.escalate_kind = "content"
             state.error = (
                 f"Review requested changes after {state.review_cycle} cycles. "
                 f"Max cycles ({_adaptive_review_max}) exhausted."

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -555,6 +555,42 @@ def _maybe_replay_hygiene_consensus(
         state.hygiene_escalation_prior_review = None
         return None
 
+    # Refuse to replay if the worktree mutation that caused the original
+    # hygiene escalation (or any new mutation) is still present. Replaying
+    # under a dirty tree would let unreviewed reviewer-created changes ride
+    # under the prior dev-commit approval — and in merge mode land_story
+    # could auto-commit those changes before merging. Fall through to a
+    # fresh review, which will re-trip the hygiene gate and surface the
+    # offending paths to the operator instead of silently approving them.
+    from .workspace_hygiene import snapshot_porcelain  # noqa: PLC0415
+
+    _porcelain = snapshot_porcelain(workspace_path)
+    if _porcelain:
+        offending = sorted(entry[3:] if len(entry) > 3 else entry for entry in _porcelain)
+        audit = {
+            "resume_action": "rerun_dirty_worktree",
+            "escalate_kind": state.escalate_kind,
+            "prior_approve_count": state.hygiene_escalation_prior_approve_count,
+            "total_count": state.hygiene_escalation_total_count,
+            "dev_commit_sha_at_hygiene_trip": prior_sha,
+            "dev_commit_sha_at_resume": head_sha,
+            "offending_paths": offending,
+        }
+        state.hygiene_resume_audit = audit
+        if logger:
+            logger._safe_emit("hygiene_resume", **audit)
+        _log(
+            "  ↺ RESUME   refusing to replay APPROVE consensus — worktree still"
+            f" dirty ({len(offending)} unresolved path(s)): {', '.join(offending[:5])}"
+        )
+        # Clear escalation-replay state so a subsequent fresh-review APPROVE
+        # does not get short-circuited again. The fresh review re-runs the
+        # hygiene gate and either passes (if the operator cleaned up) or
+        # re-escalates with current offending paths.
+        state.escalate_kind = None
+        state.hygiene_escalation_prior_review = None
+        return None
+
     state.review_cycle += 1
     state.review_results.append(prior_review)
     audit = {

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -29,6 +29,75 @@ from .state import CoordinatorResult, CoordinatorState, MergeStepState, Phase
 _logger = logging.getLogger(__name__)
 
 
+def _yaml_safe(value: object) -> object:
+    """Recursively coerce tuples to lists so yaml.safe_load can round-trip."""
+    if isinstance(value, tuple):
+        return [_yaml_safe(v) for v in value]
+    if isinstance(value, list):
+        return [_yaml_safe(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _yaml_safe(v) for k, v in value.items()}
+    return value
+
+
+def _serialize_review_result(rr: object) -> dict | None:
+    """Convert a ReviewResult dataclass into a yaml-safe dict for the resume sidecar.
+
+    Imported lazily so this module stays free of theforge.review at import time.
+    """
+    if rr is None:
+        return None
+    import dataclasses  # noqa: PLC0415
+
+    return _yaml_safe(dataclasses.asdict(rr))  # type: ignore[arg-type,return-value]
+
+
+def _deserialize_review_result(data: object) -> object | None:
+    """Reconstruct a ReviewResult/ReviewFinding/ACVerification graph from sidecar data."""
+    if not isinstance(data, dict):
+        return None
+    from theforge.review import ACVerification, ReviewFinding, ReviewResult  # noqa: PLC0415
+
+    findings = []
+    for f in data.get("findings") or []:
+        if not isinstance(f, dict):
+            continue
+        findings.append(
+            ReviewFinding(
+                severity=f.get("severity", "P1"),
+                file=f.get("file", ""),
+                line=f.get("line"),
+                description=f.get("description", ""),
+                suggestion=f.get("suggestion"),
+                reviewers=tuple(f.get("reviewers") or ()),
+            )
+        )
+    ac_verification = []
+    for ac in data.get("ac_verification") or []:
+        if not isinstance(ac, dict):
+            continue
+        ac_verification.append(
+            ACVerification(
+                criterion=ac.get("criterion", ""),
+                status=ac.get("status", ""),
+                evidence=ac.get("evidence", ""),
+            )
+        )
+    return ReviewResult(
+        verdict=data.get("verdict", "REQUEST_CHANGES"),
+        summary=data.get("summary", ""),
+        findings=findings,
+        story_matches=bool(data.get("story_matches", False)),
+        story_mismatches=list(data.get("story_mismatches") or []),
+        test_adequate=bool(data.get("test_adequate", False)),
+        test_gaps=list(data.get("test_gaps") or []),
+        parse_errors=list(data.get("parse_errors") or []),
+        raw_yaml=dict(data.get("raw_yaml") or {}),
+        ac_verification=tuple(ac_verification),
+        sanitization_audit=dict(data.get("sanitization_audit") or {}),
+    )
+
+
 def save_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None:
     """Persist trajectory fields to <workspace_path>/.forge/trajectory.yaml.
 
@@ -53,6 +122,13 @@ def save_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
             [cycle_num, findings] for cycle_num, findings in state.review_cycle_findings
         ],
         "surviving_families": state.surviving_families,
+        "escalate_kind": state.escalate_kind,
+        "hygiene_escalation_dev_commit_sha": state.hygiene_escalation_dev_commit_sha,
+        "hygiene_escalation_prior_approve_count": state.hygiene_escalation_prior_approve_count,
+        "hygiene_escalation_total_count": state.hygiene_escalation_total_count,
+        "hygiene_escalation_prior_review": _serialize_review_result(
+            state.hygiene_escalation_prior_review
+        ),
     }
     sidecar.write_text(yaml.dump(data, allow_unicode=True), encoding="utf-8")
 
@@ -92,6 +168,19 @@ def load_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
         ]
     if "surviving_families" in data and isinstance(data["surviving_families"], list):
         state.surviving_families = data["surviving_families"]
+    if data.get("escalate_kind") in ("hygiene", "content"):
+        state.escalate_kind = data["escalate_kind"]
+    if isinstance(data.get("hygiene_escalation_dev_commit_sha"), str):
+        state.hygiene_escalation_dev_commit_sha = data["hygiene_escalation_dev_commit_sha"]
+    if isinstance(data.get("hygiene_escalation_prior_approve_count"), int):
+        state.hygiene_escalation_prior_approve_count = data[
+            "hygiene_escalation_prior_approve_count"
+        ]
+    if isinstance(data.get("hygiene_escalation_total_count"), int):
+        state.hygiene_escalation_total_count = data["hygiene_escalation_total_count"]
+    _prior_rr = _deserialize_review_result(data.get("hygiene_escalation_prior_review"))
+    if _prior_rr is not None:
+        state.hygiene_escalation_prior_review = _prior_rr  # type: ignore[assignment]
 
 
 def save_merge_state(workspace_path: Path, merge_state: MergeStepState) -> None:

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -390,6 +390,25 @@ class CoordinatorState:
     # to compute git diff --name-only for changed-file correlation.
     escalate_decision: str | None = None  # "approve" | "reject" | "continue"
     escalate_reason: str | None = None  # human-readable escalation reason
+    # Structured escalation kind: "hygiene" (workspace mutation by a non-DEV phase),
+    # "content" (review or gate found a real problem), or None when there is no
+    # active escalation. Distinct from escalate_reason so resume can tell the two
+    # apart without parsing the human-readable string.
+    escalate_kind: str | None = None
+    # Captured at the moment a REVIEW workspace-hygiene escalation fires when the
+    # reviewer pool had already produced an APPROVE-consensus candidate for the
+    # current dev commit. Used by `forge sprint --resume` to replay the prior
+    # consensus instead of re-running the reviewer pool against an unchanged
+    # dev commit. None means either (a) no hygiene escalation occurred, or
+    # (b) the pool did not reach APPROVE consensus before the trip.
+    hygiene_escalation_dev_commit_sha: str | None = None
+    hygiene_escalation_prior_review: ReviewResult | None = None
+    hygiene_escalation_prior_approve_count: int | None = None
+    hygiene_escalation_total_count: int | None = None
+    # Audit record describing how the resume entry handled a prior hygiene
+    # escalation: replayed the consensus, ran a fresh review because the dev
+    # commit moved, or ran a fresh review because no prior consensus existed.
+    hygiene_resume_audit: dict | None = None
     story_validation_result: StoryValidationResult | None = None
     convention_violations: list[dict] = field(default_factory=list)
     plan_validation_findings: list[dict] = field(default_factory=list)

--- a/tests/test_coord_hygiene_resume.py
+++ b/tests/test_coord_hygiene_resume.py
@@ -21,7 +21,13 @@ from theforge.coordinator.state import CoordinatorState, Phase
 from theforge.review import ReviewResult
 
 
-def _init_repo(path: Path) -> str:
+def _init_repo(path: Path, *, with_feature_commit: bool = True) -> str:
+    """Initialize a git repo with a seed on main and (optionally) a feature commit.
+
+    When ``with_feature_commit`` is True, checks out ``forge/test-task`` on top of
+    main with one extra commit so HEAD is one ahead of base — required by the
+    empty-diff guard at REVIEW finalization. Returns the resulting HEAD SHA.
+    """
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
@@ -29,6 +35,13 @@ def _init_repo(path: Path) -> str:
     (path / "README.md").write_text("seed\n", encoding="utf-8")
     subprocess.run(["git", "add", "."], cwd=path, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+    if with_feature_commit:
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", "forge/test-task"], cwd=path, check=True
+        )
+        (path / "feature.py").write_text("# feature\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=path, check=True)
     sha = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=path,
@@ -235,16 +248,12 @@ def test_resume_refuses_replay_when_untracked_mutation_persists(tmp_path):
     resume_state = _build_resume_state(workspace)
     assert resume_state.escalate_kind == "hygiene"
 
-    pool_calls = {"n": 0}
-
-    def _fresh_pool(*args, **kwargs):
-        pool_calls["n"] += 1
-        candidate = _approve_review()
-        return ([], [], candidate, [candidate], [("reviewer_a", candidate)])
+    def _pool_must_not_run(*args, **kwargs):
+        raise AssertionError("review pool must not be invoked when worktree is still dirty")
 
     with patch(
         "theforge.coordinator.review_phase._run_review_pool",
-        side_effect=_fresh_pool,
+        side_effect=_pool_must_not_run,
     ):
         outcome, result, _config2 = _run_review_phase(
             resume_state,
@@ -265,14 +274,12 @@ def test_resume_refuses_replay_when_untracked_mutation_persists(tmp_path):
     assert audit["resume_action"] == "rerun_dirty_worktree"
     assert audit["dev_commit_sha_at_resume"] == head_sha
     assert "reviewer_scratch.txt" in audit["offending_paths"]
-    # Fresh review pool ran once. The run did NOT mark DONE under the prior approval —
-    # control flowed into a fresh review path that ultimately escalated rather than
-    # finalizing approval on the still-dirty worktree.
-    assert pool_calls["n"] == 1
+    # Fail closed: ESCALATE without re-running the pool, so a fresh review's
+    # hygiene snapshot can't silently treat the persistent mutation as baseline.
     assert outcome == _ReviewOutcome.ESCALATE
     assert result is not None
     assert result.success is False
-    assert result.phase != Phase.DONE
+    assert result.phase == Phase.ESCALATE
 
 
 def test_resume_refuses_replay_when_tracked_file_mutated(tmp_path):
@@ -305,6 +312,65 @@ def test_resume_refuses_replay_when_tracked_file_mutated(tmp_path):
     # Mutate a tracked file — HEAD is unchanged, but the worktree is dirty.
     (workspace / "README.md").write_text("seed\nhostile reviewer mutation\n", encoding="utf-8")
 
+    def _pool_must_not_run(*args, **kwargs):
+        raise AssertionError("review pool must not be invoked when worktree is still dirty")
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_pool_must_not_run,
+    ):
+        outcome, result, _config2 = _run_review_phase(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "main",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    audit = state.hygiene_resume_audit
+    assert audit is not None
+    assert audit["resume_action"] == "rerun_dirty_worktree"
+    assert any("README.md" in p for p in audit["offending_paths"])
+    # Critical: the run did NOT mark DONE under the prior dev-commit approval —
+    # it escalated rather than letting a fresh review silently approve the dirty tree.
+    assert outcome == _ReviewOutcome.ESCALATE
+    assert result is not None
+    assert result.phase == Phase.ESCALATE
+
+
+def test_resume_refuses_replay_when_no_commits_ahead_of_base(tmp_path):
+    """Replay must not finalize approval on a branch with no commits ahead of base."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    # No feature commit → HEAD == main HEAD → 0 commits ahead of base.
+    head_sha = _init_repo(workspace, with_feature_commit=False)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    # Stage hygiene-escalation state directly with prior consensus captured at HEAD.
+    state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    state.workspace_path = workspace
+    state.branch_name = "main"
+    state.run_id = "test-empty-diff"
+    state.adaptive_review_max = 2
+    state.escalate_kind = "hygiene"
+    state.hygiene_escalation_dev_commit_sha = head_sha
+    state.hygiene_escalation_prior_review = _approve_review()
+    state.hygiene_escalation_prior_approve_count = 1
+    state.hygiene_escalation_total_count = 1
+
     pool_calls = {"n": 0}
 
     def _fresh_pool(*args, **kwargs):
@@ -332,13 +398,13 @@ def test_resume_refuses_replay_when_tracked_file_mutated(tmp_path):
 
     audit = state.hygiene_resume_audit
     assert audit is not None
-    assert audit["resume_action"] == "rerun_dirty_worktree"
-    assert any("README.md" in p for p in audit["offending_paths"])
-    # Critical: the run did NOT mark DONE under the prior dev-commit approval.
+    assert audit["resume_action"] == "rerun_no_commits_ahead"
+    assert audit["base_branch"] == "main"
+    # Critical: replay did not mark DONE; the empty-diff guard still applies.
     assert outcome != _ReviewOutcome.DONE
     if result is not None:
         assert result.phase != Phase.DONE
-    # The fresh review pool was invoked (then hygiene re-tripped on the modified tracked file).
+    # Fresh review was invoked (and itself escalated on the empty-diff guard).
     assert pool_calls["n"] == 1
 
 

--- a/tests/test_coord_hygiene_resume.py
+++ b/tests/test_coord_hygiene_resume.py
@@ -1,0 +1,282 @@
+"""Seam-level integration tests for hygiene-escalation → resume → consensus replay.
+
+Covers issue #1499: when the REVIEW phase escalates because a non-DEV phase
+mutated the worktree, but the reviewer pool had already produced an APPROVE
+consensus for the current dev commit, a subsequent ``forge sprint --resume``
+must replay that consensus instead of re-running the reviewer pool against
+an unchanged dev commit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.coordinator.review_phase import _ReviewOutcome, _run_review_phase
+from theforge.coordinator.run_setup import load_trajectory_state
+from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.review import ReviewResult
+
+
+def _init_repo(path: Path) -> str:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / ".gitignore").write_text(".forge/\n", encoding="utf-8")
+    (path / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return sha
+
+
+def _approve_review() -> ReviewResult:
+    return ReviewResult(
+        verdict="APPROVE",
+        summary="ok",
+        findings=[],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={"verdict": "APPROVE"},
+    )
+
+
+def _stub_review_pool_with_hygiene_mutation(workspace: Path):
+    """Return a side_effect that simulates a reviewer pool producing APPROVE consensus
+    while leaving a stray scratch file behind (workspace hygiene violation)."""
+
+    def _side_effect(*args, **kwargs):
+        # Inject a workspace mutation that the hygiene check will catch.
+        (workspace / "reviewer_scratch.txt").write_text("oops\n", encoding="utf-8")
+        candidate = _approve_review()
+        named = [("reviewer_a", candidate)]
+        return ([], [], candidate, [candidate], named)
+
+    return _side_effect
+
+
+def _run_first_pass(workspace: Path, config, task) -> CoordinatorState:
+    """Drive _run_review_phase to the hygiene-escalation branch.
+
+    Returns the resulting state with hygiene-escalation fields populated.
+    """
+    state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    state.workspace_path = workspace
+    state.branch_name = "main"
+    state.run_id = "test-run-1"
+    state.adaptive_review_max = 2
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_stub_review_pool_with_hygiene_mutation(workspace),
+    ):
+        outcome, result, _config2 = _run_review_phase(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "main",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome == _ReviewOutcome.ESCALATE
+    assert result is not None
+    return state
+
+
+def test_hygiene_escalation_captures_prior_consensus_and_persists_to_sidecar(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    head_sha = _init_repo(workspace)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    state = _run_first_pass(workspace, config, task)
+
+    assert state.escalate_kind == "hygiene"
+    assert state.hygiene_escalation_dev_commit_sha == head_sha
+    assert state.hygiene_escalation_prior_review is not None
+    assert state.hygiene_escalation_prior_review.verdict == "APPROVE"
+    assert state.hygiene_escalation_prior_approve_count == 1
+    assert state.hygiene_escalation_total_count == 1
+
+    # Sidecar contains the same data round-tripped from disk.
+    sidecar = workspace / ".forge" / "trajectory.yaml"
+    assert sidecar.exists()
+    fresh = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    load_trajectory_state(workspace, fresh)
+    assert fresh.escalate_kind == "hygiene"
+    assert fresh.hygiene_escalation_dev_commit_sha == head_sha
+    assert fresh.hygiene_escalation_prior_review is not None
+    assert fresh.hygiene_escalation_prior_review.verdict == "APPROVE"
+
+
+def test_resume_replays_consensus_when_dev_commit_unchanged(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    head_sha = _init_repo(workspace)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    _run_first_pass(workspace, config, task)
+    # Clean up the stray file before "resume" — operator removed it manually.
+    (workspace / "reviewer_scratch.txt").unlink()
+
+    # Build a fresh state that represents the resume entry: load sidecar.
+    resume_state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    resume_state.workspace_path = workspace
+    resume_state.branch_name = "main"
+    resume_state.run_id = "test-run-2"
+    resume_state.adaptive_review_max = 2
+    load_trajectory_state(workspace, resume_state)
+
+    assert resume_state.escalate_kind == "hygiene"
+    assert resume_state.hygiene_escalation_dev_commit_sha == head_sha
+
+    def _pool_must_not_run(*args, **kwargs):
+        raise AssertionError("review pool must not be invoked when replaying consensus")
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_pool_must_not_run,
+    ):
+        outcome, result, _config2 = _run_review_phase(
+            resume_state,
+            config,
+            task,
+            "story",
+            workspace,
+            "main",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome == _ReviewOutcome.DONE
+    assert result is not None
+    assert result.success is True
+    assert result.phase == Phase.DONE
+    assert len(resume_state.review_results) == 1
+    assert resume_state.review_results[0].verdict == "APPROVE"
+    assert resume_state.review_cycle == 1
+    audit = resume_state.hygiene_resume_audit
+    assert audit is not None
+    assert audit["resume_action"] == "replayed_consensus"
+    assert audit["dev_commit_sha_at_resume"] == head_sha
+    # Replayed flag is cleared so a subsequent escalation does not re-replay.
+    assert resume_state.escalate_kind is None
+    assert resume_state.hygiene_escalation_prior_review is None
+
+
+def test_resume_runs_fresh_review_when_dev_commit_changed(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    _init_repo(workspace)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    _run_first_pass(workspace, config, task)
+    (workspace / "reviewer_scratch.txt").unlink()
+
+    # Advance HEAD so the SHA differs at resume.
+    (workspace / "more.txt").write_text("more\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "more"], cwd=workspace, check=True)
+    new_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    resume_state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    resume_state.workspace_path = workspace
+    resume_state.branch_name = "main"
+    resume_state.run_id = "test-run-3"
+    resume_state.adaptive_review_max = 2
+    load_trajectory_state(workspace, resume_state)
+
+    pool_calls = {"n": 0}
+
+    def _fresh_pool(*args, **kwargs):
+        pool_calls["n"] += 1
+        candidate = _approve_review()
+        return ([], [], candidate, [candidate], [("reviewer_a", candidate)])
+
+    # Patch the empty-diff guard to True so the fresh review reaches the APPROVE path.
+    with (
+        patch(
+            "theforge.coordinator.review_phase._run_review_pool",
+            side_effect=_fresh_pool,
+        ),
+        patch(
+            "theforge.coordinator.review_phase._has_commits_ahead_of_base",
+            return_value=True,
+        ),
+    ):
+        outcome, _result, _config2 = _run_review_phase(
+            resume_state,
+            config,
+            task,
+            "story",
+            workspace,
+            "main",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    assert pool_calls["n"] == 1, "fresh review pool must be invoked on dev-commit-changed resume"
+    audit = resume_state.hygiene_resume_audit
+    assert audit is not None
+    assert audit["resume_action"] == "rerun_dev_commit_changed"
+    assert audit["dev_commit_sha_at_resume"] == new_head
+    # Stale escalation state cleared so a future hygiene escalation does not replay.
+    assert resume_state.escalate_kind is None or resume_state.escalate_kind == "hygiene"
+    # Outcome is DONE because the fresh APPROVE landed on a non-empty diff.
+    assert outcome == _ReviewOutcome.DONE

--- a/tests/test_coord_hygiene_resume.py
+++ b/tests/test_coord_hygiene_resume.py
@@ -204,6 +204,144 @@ def test_resume_replays_consensus_when_dev_commit_unchanged(tmp_path):
     assert resume_state.hygiene_escalation_prior_review is None
 
 
+def _build_resume_state(workspace: Path) -> CoordinatorState:
+    state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    state.workspace_path = workspace
+    state.branch_name = "main"
+    state.run_id = "test-resume"
+    state.adaptive_review_max = 2
+    load_trajectory_state(workspace, state)
+    return state
+
+
+def test_resume_refuses_replay_when_untracked_mutation_persists(tmp_path):
+    """Reviewer-created untracked file still present at resume → fresh review re-trips hygiene."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    head_sha = _init_repo(workspace)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    _run_first_pass(workspace, config, task)
+    # Operator did NOT clean up reviewer_scratch.txt — it is still present.
+    assert (workspace / "reviewer_scratch.txt").exists()
+
+    resume_state = _build_resume_state(workspace)
+    assert resume_state.escalate_kind == "hygiene"
+
+    pool_calls = {"n": 0}
+
+    def _fresh_pool(*args, **kwargs):
+        pool_calls["n"] += 1
+        candidate = _approve_review()
+        return ([], [], candidate, [candidate], [("reviewer_a", candidate)])
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_fresh_pool,
+    ):
+        outcome, result, _config2 = _run_review_phase(
+            resume_state,
+            config,
+            task,
+            "story",
+            workspace,
+            "main",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    audit = resume_state.hygiene_resume_audit
+    assert audit is not None
+    assert audit["resume_action"] == "rerun_dirty_worktree"
+    assert audit["dev_commit_sha_at_resume"] == head_sha
+    assert "reviewer_scratch.txt" in audit["offending_paths"]
+    # Fresh review pool ran once. The run did NOT mark DONE under the prior approval —
+    # control flowed into a fresh review path that ultimately escalated rather than
+    # finalizing approval on the still-dirty worktree.
+    assert pool_calls["n"] == 1
+    assert outcome == _ReviewOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert result.phase != Phase.DONE
+
+
+def test_resume_refuses_replay_when_tracked_file_mutated(tmp_path):
+    """Reviewer modified a tracked file (HEAD unchanged) — replay must refuse."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    head_sha = _init_repo(workspace)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    # Stage hygiene-escalation state directly: prior consensus captured,
+    # HEAD unchanged, but a tracked file has been modified after the trip.
+    state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    state.workspace_path = workspace
+    state.branch_name = "main"
+    state.run_id = "test-tracked"
+    state.adaptive_review_max = 2
+    state.escalate_kind = "hygiene"
+    state.hygiene_escalation_dev_commit_sha = head_sha
+    state.hygiene_escalation_prior_review = _approve_review()
+    state.hygiene_escalation_prior_approve_count = 1
+    state.hygiene_escalation_total_count = 1
+
+    # Mutate a tracked file — HEAD is unchanged, but the worktree is dirty.
+    (workspace / "README.md").write_text("seed\nhostile reviewer mutation\n", encoding="utf-8")
+
+    pool_calls = {"n": 0}
+
+    def _fresh_pool(*args, **kwargs):
+        pool_calls["n"] += 1
+        candidate = _approve_review()
+        return ([], [], candidate, [candidate], [("reviewer_a", candidate)])
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_fresh_pool,
+    ):
+        outcome, result, _config2 = _run_review_phase(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "main",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    audit = state.hygiene_resume_audit
+    assert audit is not None
+    assert audit["resume_action"] == "rerun_dirty_worktree"
+    assert any("README.md" in p for p in audit["offending_paths"])
+    # Critical: the run did NOT mark DONE under the prior dev-commit approval.
+    assert outcome != _ReviewOutcome.DONE
+    if result is not None:
+        assert result.phase != Phase.DONE
+    # The fresh review pool was invoked (then hygiene re-tripped on the modified tracked file).
+    assert pool_calls["n"] == 1
+
+
 def test_resume_runs_fresh_review_when_dev_commit_changed(tmp_path):
     workspace = tmp_path / "ws"
     workspace.mkdir()

--- a/tests/test_coord_hygiene_resume.py
+++ b/tests/test_coord_hygiene_resume.py
@@ -36,9 +36,7 @@ def _init_repo(path: Path, *, with_feature_commit: bool = True) -> str:
     subprocess.run(["git", "add", "."], cwd=path, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
     if with_feature_commit:
-        subprocess.run(
-            ["git", "checkout", "-q", "-b", "forge/test-task"], cwd=path, check=True
-        )
+        subprocess.run(["git", "checkout", "-q", "-b", "forge/test-task"], cwd=path, check=True)
         (path / "feature.py").write_text("# feature\n", encoding="utf-8")
         subprocess.run(["git", "add", "."], cwd=path, check=True)
         subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=path, check=True)


### PR DESCRIPTION
## Summary

Prior dirty-worktree and empty-diff replay P1s are fixed; the hygiene-only resume path preserves clean unchanged APPROVE consensus without new blocking regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $11.94
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Resume reruns review after hygiene-only escalation instead of preserving prior approval consensus (GitHub Issue #1499)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1499