### PR TITLE
Review phase inherits stray worktree paths because quarantine only runs before dev

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -756,8 +756,41 @@ def _run_review_phase(
 
     from .workspace_hygiene import (  # noqa: PLC0415
         check_phase_no_mutation,
+        enforce_pre_review_hygiene,
         snapshot_porcelain,
     )
+
+    # ── Workspace hygiene gate (every REVIEW cycle entry) ─────────────
+    # Stray untracked paths inherited from a prior interrupted iteration,
+    # resume, or non-DEV phase mutation must be quarantined BEFORE reviewers
+    # observe the tree — otherwise reviewers flag stale pollution as a
+    # finding even though the implementation itself is valid (see #1501).
+    # Symmetric to enforce_pre_dev_hygiene; modified-tracked files are
+    # audited but left in place (validate-phase auto-commit owns cleanup).
+    _hygiene_run_id = run_id or state.run_id or "unknown"
+    _pre_review_ok, _pre_review_diag, _pre_review_audit = enforce_pre_review_hygiene(
+        workspace_path,
+        _hygiene_run_id,
+        cycle=state.review_cycle,
+    )
+    state.workspace_hygiene_audit.append({"phase": "PRE_REVIEW", **_pre_review_audit})
+    if _pre_review_audit.get("quarantined"):
+        _q_paths = ", ".join(_pre_review_audit["quarantined"])
+        _q_dir = _pre_review_audit.get("quarantine_dir")
+        _log(f"  ⚠ REVIEW   quarantined stray paths to {_q_dir}: {_q_paths}")
+    if not _pre_review_ok:
+        state.phase = Phase.ESCALATE
+        state.error = _pre_review_diag or "Workspace hygiene gate refused REVIEW entry"
+        _log(f"✗ ESCALATE   {state.error}")
+        if logger:
+            logger._safe_emit("phase_end", phase="REVIEW", outcome="escalate")
+            logger._safe_emit("escalate", reason=state.error, phase="REVIEW")
+        _escalate_notify(task, state, notify, config)
+        return (
+            _ReviewOutcome.ESCALATE,
+            CoordinatorResult(success=False, phase=state.phase, state=state, message=state.error),
+            config,
+        )
 
     _review_hygiene_before = snapshot_porcelain(workspace_path)
 

--- a/src/theforge/coordinator/workspace_hygiene.py
+++ b/src/theforge/coordinator/workspace_hygiene.py
@@ -12,12 +12,15 @@ Two layers:
    Any change to the porcelain set fails the phase. ``.forge/`` is gitignored,
    so coordinator-driven artifact writes are naturally excluded.
 
-2. ``enforce_pre_dev_hygiene``: invoked before DEV iteration 1. Unexpected
-   untracked paths are moved to ``.forge/quarantine/<run-id>/`` (audited, not
-   silently deleted) and DEV proceeds with a clean tree. If quarantine fails
-   or modifications to tracked files appear, DEV is rejected with a diagnostic
-   pointing at the offending paths instead of being handed to an agent that
-   will fail mysteriously.
+2. ``enforce_pre_dev_hygiene`` / ``enforce_pre_review_hygiene``: invoked
+   symmetrically before DEV iteration 1 and before each REVIEW cycle.
+   Unexpected untracked paths are moved to ``.forge/quarantine/<run-id>/``
+   (audited, not silently deleted) and the phase proceeds with a clean tree.
+   If quarantine fails, the phase is rejected with a diagnostic pointing at
+   the offending paths instead of being handed to an agent that will fail
+   mysteriously. REVIEW symmetry exists because stray pollution from a prior
+   interrupted iteration would otherwise be visible to reviewers (see issue
+   #1501).
 
 Sanctioned scratch space (``.forge/tmp/<run-id>/``) is provisioned by
 ``ensure_scratch_dir``; ``.forge/`` is already gitignored so the directory is
@@ -109,8 +112,8 @@ def ensure_scratch_dir(workspace_path: Path, run_id: str) -> Path:
     return scratch
 
 
-def _quarantine_root(workspace_path: Path, run_id: str, iteration: int) -> Path:
-    return workspace_path / ".forge" / "quarantine" / run_id / f"iter-{iteration}"
+def _quarantine_root(workspace_path: Path, run_id: str, label: str) -> Path:
+    return workspace_path / ".forge" / "quarantine" / run_id / label
 
 
 def quarantine_paths(
@@ -144,20 +147,21 @@ def quarantine_paths(
     return moved, failed
 
 
-def enforce_pre_dev_hygiene(
+def _enforce_phase_entry_hygiene(
     workspace_path: Path,
     run_id: str,
     *,
-    iteration: int,
+    label: str,
+    phase_label: str,
 ) -> tuple[bool, str | None, dict]:
-    """Reject or sanitise the worktree before DEV starts.
+    """Quarantine unexpected untracked paths before a phase starts.
 
     Behaviour:
       - Untracked paths (status ``??``) outside the allow-list → quarantined
-        to ``.forge/quarantine/<run-id>/iter-<n>/``. Audit-trail preserved,
-        worktree returned to a clean baseline, DEV proceeds. This is the
+        to ``.forge/quarantine/<run-id>/<label>/``. Audit-trail preserved,
+        worktree returned to a clean baseline, the phase proceeds. This is the
         primary motivator: stray scratch at repo root that silently sabotages
-        dev runs (issue #1179).
+        agent runs (issues #1179, #1501).
       - Modified tracked files (status M/A/D/...) → audited and left in
         place. These are legitimate worktree-reuse state (work-in-progress
         from a prior interrupted run); validate-phase's auto-commit owns
@@ -198,17 +202,54 @@ def enforce_pre_dev_hygiene(
     if not untracked:
         return True, None, audit
 
-    quarantine_dir = _quarantine_root(workspace_path, run_id, iteration)
+    quarantine_dir = _quarantine_root(workspace_path, run_id, label)
     moved, failed = quarantine_paths(workspace_path, sorted(untracked), quarantine_dir)
     audit["quarantined"] = moved
     audit["quarantine_dir"] = str(quarantine_dir.relative_to(workspace_path))
     if failed:
         rendered = ", ".join(failed)
         diagnostic = (
-            "Unexpected untracked files in worktree before DEV could not be "
+            f"Unexpected untracked files in worktree before {phase_label} could not be "
             f"quarantined: {rendered}. Workspace hygiene gate refuses to hand a "
-            "dirty tree to the dev agent. Resolve manually before retrying."
+            f"dirty tree to the {phase_label.lower()} agent. Resolve manually before retrying."
         )
         return False, diagnostic, audit
 
     return True, None, audit
+
+
+def enforce_pre_dev_hygiene(
+    workspace_path: Path,
+    run_id: str,
+    *,
+    iteration: int,
+) -> tuple[bool, str | None, dict]:
+    """Reject or sanitise the worktree before DEV starts (see #1179)."""
+    return _enforce_phase_entry_hygiene(
+        workspace_path,
+        run_id,
+        label=f"iter-{iteration}",
+        phase_label="DEV",
+    )
+
+
+def enforce_pre_review_hygiene(
+    workspace_path: Path,
+    run_id: str,
+    *,
+    cycle: int,
+) -> tuple[bool, str | None, dict]:
+    """Reject or sanitise the worktree before REVIEW starts (see #1501).
+
+    Symmetric counterpart to ``enforce_pre_dev_hygiene``: stray untracked
+    paths inherited from a prior interrupted iteration, resume, or a
+    non-DEV phase that wrote where it shouldn't are quarantined before any
+    reviewer observes the tree, so reviewers evaluate the implementation
+    rather than stale pollution.
+    """
+    return _enforce_phase_entry_hygiene(
+        workspace_path,
+        run_id,
+        label=f"review-{cycle}",
+        phase_label="REVIEW",
+    )

--- a/tests/test_coord_workspace_hygiene.py
+++ b/tests/test_coord_workspace_hygiene.py
@@ -14,10 +14,12 @@ from unittest.mock import MagicMock, patch
 from coord_test_helpers import _make_agent_result, _make_config
 
 from theforge.coordinator.dev_phase import _run_dev_phase
-from theforge.coordinator.state import CoordinatorState
+from theforge.coordinator.review_phase import _ReviewOutcome, _run_review_phase
+from theforge.coordinator.state import CoordinatorState, Phase
 from theforge.coordinator.workspace_hygiene import (
     check_phase_no_mutation,
     enforce_pre_dev_hygiene,
+    enforce_pre_review_hygiene,
     ensure_scratch_dir,
     snapshot_porcelain,
     unexpected_entries,
@@ -251,3 +253,181 @@ def test_run_dev_phase_skips_hygiene_gate_on_retry_iterations(tmp_path: Path) ->
     assert result is None  # no escalation, no quarantine
     assert (tmp_path / "test_flock.py").exists()
     assert not any(e.get("phase") == "PRE_DEV" for e in state.workspace_hygiene_audit)
+
+
+# ── enforce_pre_review_hygiene ────────────────────────────────────────
+
+
+def test_enforce_pre_review_hygiene_passes_on_clean_worktree(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    ok, diag, audit = enforce_pre_review_hygiene(tmp_path, "run-1", cycle=0)
+    assert ok is True
+    assert diag is None
+    assert audit["modified"] == []
+    assert audit["quarantined"] == []
+
+
+def test_enforce_pre_review_hygiene_quarantines_untracked(tmp_path: Path) -> None:
+    """The #1501 motivating case: stray paths inherited at REVIEW entry."""
+    _init_repo(tmp_path)
+    (tmp_path / "test_script.sh").write_text("oops\n", encoding="utf-8")
+
+    ok, diag, audit = enforce_pre_review_hygiene(tmp_path, "run-xyz", cycle=2)
+
+    assert ok is True
+    assert diag is None
+    assert not (tmp_path / "test_script.sh").exists()
+    quarantine_dir = tmp_path / ".forge" / "quarantine" / "run-xyz" / "review-2"
+    assert (quarantine_dir / "test_script.sh").read_text() == "oops\n"
+    assert audit["quarantined"] == ["test_script.sh"]
+    assert audit["quarantine_dir"] == ".forge/quarantine/run-xyz/review-2"
+
+
+def test_enforce_pre_review_hygiene_records_but_does_not_quarantine_modified(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "README.md").write_text("review-time WIP\n", encoding="utf-8")
+
+    ok, diag, audit = enforce_pre_review_hygiene(tmp_path, "run-1", cycle=0)
+
+    assert ok is True
+    assert diag is None
+    assert audit["modified"] == ["README.md"]
+    assert audit["quarantined"] == []
+    assert (tmp_path / "README.md").exists()
+
+
+# ── seam: _run_review_phase quarantines stray paths before reviewers ──
+
+
+def test_run_review_phase_quarantines_stray_paths_before_reviewers(tmp_path: Path) -> None:
+    """The #1501 seam contract: stray untracked paths inherited at REVIEW
+    entry are quarantined BEFORE any reviewer observes the tree.
+
+    We patch ``_run_review_pool`` to a side-effect that asserts the worktree
+    was clean when the pool was called, proving the hygiene gate ran first.
+    """
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    # Simulate a real dev commit so REVIEW has something to review.
+    (tmp_path / "src.py").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "src.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=tmp_path, check=True)
+    # Stray untracked file the reviewer must NEVER see.
+    (tmp_path / "test_script.sh").write_text("stale scratch\n", encoding="utf-8")
+
+    config = _make_config(tmp_path)
+    spec_path = tmp_path.parent / f"{tmp_path.name}-spec.md"
+    spec_path.write_text("# spec\n", encoding="utf-8")
+    task = TaskStory(name="t", slug="t", story_path=spec_path)
+    state = CoordinatorState()
+    state.run_id = "abcd1234"
+
+    seen_porcelain: list[set[str]] = []
+
+    def _fake_pool(*args, **kwargs):
+        # Record the porcelain set the reviewers would observe.
+        seen_porcelain.append(snapshot_porcelain(tmp_path))
+        # Return all-empty so phase escalates without needing the full
+        # review/synthesis machinery.
+        return ([], [], None, [], [])
+
+    with (
+        patch("theforge.coordinator.review_phase._run_review_pool", side_effect=_fake_pool),
+        patch(
+            "theforge.coordinator.review_phase._run_escalate_gate",
+            return_value=None,
+        ),
+    ):
+        outcome, _result, _config = _run_review_phase(
+            state,
+            config,
+            task,
+            "# spec\n",
+            tmp_path,
+            "feat/x",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    # Stray file is gone from the worktree.
+    assert not (tmp_path / "test_script.sh").exists()
+    # Quarantine directory holds the original.
+    quarantine_dir = tmp_path / ".forge" / "quarantine" / "abcd1234" / "review-0"
+    assert (quarantine_dir / "test_script.sh").read_text() == "stale scratch\n"
+    # The reviewer-observed worktree was clean.
+    assert seen_porcelain, "review pool was never invoked"
+    assert seen_porcelain[0] == set(), f"reviewers observed stray pollution: {seen_porcelain[0]!r}"
+    # Audit recorded under PRE_REVIEW.
+    pre_review_entry = next(e for e in state.workspace_hygiene_audit if e["phase"] == "PRE_REVIEW")
+    assert pre_review_entry["quarantined"] == ["test_script.sh"]
+    # Outcome is unrelated escalate (pool returned empty); it is not the
+    # hygiene-failure ESCALATE because quarantine succeeded.
+    assert outcome in (_ReviewOutcome.ESCALATE, _ReviewOutcome.RETRY_DEV)
+
+
+def test_run_review_phase_escalates_when_quarantine_fails(tmp_path: Path) -> None:
+    """If hygiene gate cannot quarantine, REVIEW escalates BEFORE invoking
+    reviewers — operator-visible failure, not a silent stale-tree review."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "src.py").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "src.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    spec_path = tmp_path.parent / f"{tmp_path.name}-spec.md"
+    spec_path.write_text("# spec\n", encoding="utf-8")
+    task = TaskStory(name="t", slug="t", story_path=spec_path)
+    state = CoordinatorState()
+    state.run_id = "abcd1234"
+
+    pool_called = []
+
+    def _fail_hygiene(*args, **kwargs):
+        return (
+            False,
+            "quarantine refused: stray.txt",
+            {
+                "snapshot": ["?? stray.txt"],
+                "modified": [],
+                "quarantined": [],
+                "quarantine_dir": ".forge/quarantine/abcd1234/review-0",
+            },
+        )
+
+    with (
+        patch(
+            "theforge.coordinator.workspace_hygiene.enforce_pre_review_hygiene",
+            side_effect=_fail_hygiene,
+        ),
+        patch(
+            "theforge.coordinator.review_phase._run_review_pool",
+            side_effect=lambda *a, **kw: pool_called.append(True) or ([], [], None, [], []),
+        ),
+    ):
+        outcome, result, _config = _run_review_phase(
+            state,
+            config,
+            task,
+            "# spec\n",
+            tmp_path,
+            "feat/x",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome == _ReviewOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    assert "quarantine refused" in (state.error or "")
+    # Reviewers were never invoked.
+    assert pool_called == []


### PR DESCRIPTION
## Summary

The change adds a REVIEW-entry hygiene gate before reviewers run, with focused unit and seam coverage for the reported stale-path symptom.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.92
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Review phase inherits stray worktree paths because quarantine only runs before dev (GitHub Issue #1501)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1501