### PR TITLE
Reviewer-phase agents can write to the worktree, escalating sprints whose review verdicts would otherwise APPROVE

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -755,8 +755,8 @@ def _run_review_phase(
     _review_cost_before_cycle = sum(r.cost_usd or 0.0 for r in state.review_agent_results)
 
     from .workspace_hygiene import (  # noqa: PLC0415
-        check_phase_no_mutation,
         enforce_pre_review_hygiene,
+        reconcile_post_review_mutations,
         snapshot_porcelain,
     )
 
@@ -810,12 +810,27 @@ def _run_review_phase(
     )
     state.last_cycle_reviewer_results = _named_parsed
 
-    _review_ok, _review_diag, _review_offending = check_phase_no_mutation(
-        workspace_path, _review_hygiene_before, "REVIEW"
+    _review_ok, _review_diag, _review_offending, _post_review_audit = (
+        reconcile_post_review_mutations(
+            workspace_path,
+            _review_hygiene_before,
+            _hygiene_run_id,
+            state.review_cycle,
+        )
     )
     state.workspace_hygiene_audit.append(
-        {"phase": "REVIEW", "ok": _review_ok, "offending_paths": _review_offending}
+        {
+            "phase": "REVIEW",
+            "ok": _review_ok,
+            "quarantined": _post_review_audit.get("quarantined", []),
+            "tracked_changes": _post_review_audit.get("tracked_changes", []),
+            "offending_paths": _review_offending,
+        }
     )
+    if _post_review_audit.get("quarantined"):
+        _moved = ", ".join(_post_review_audit["quarantined"])
+        _q_dir = _post_review_audit.get("quarantine_dir")
+        _log(f"  ⚠ REVIEW   quarantined reviewer scratch to {_q_dir}: {_moved}")
     if not _review_ok:
         state.phase = Phase.ESCALATE
         state.error = _review_diag or "REVIEW phase mutated the worktree"

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -824,6 +824,7 @@ def _run_review_phase(
             "ok": _review_ok,
             "quarantined": _post_review_audit.get("quarantined", []),
             "tracked_changes": _post_review_audit.get("tracked_changes", []),
+            "reverted": _post_review_audit.get("reverted", []),
             "offending_paths": _review_offending,
         }
     )
@@ -831,6 +832,9 @@ def _run_review_phase(
         _moved = ", ".join(_post_review_audit["quarantined"])
         _q_dir = _post_review_audit.get("quarantine_dir")
         _log(f"  ⚠ REVIEW   quarantined reviewer scratch to {_q_dir}: {_moved}")
+    if _post_review_audit.get("reverted"):
+        _rev = ", ".join(_post_review_audit["reverted"])
+        _log(f"  ⚠ REVIEW   reverted reviewer-side tracked mutations: {_rev}")
     if not _review_ok:
         state.phase = Phase.ESCALATE
         state.error = _review_diag or "REVIEW phase mutated the worktree"

--- a/src/theforge/coordinator/workspace_hygiene.py
+++ b/src/theforge/coordinator/workspace_hygiene.py
@@ -245,34 +245,30 @@ def enforce_pre_dev_hygiene(
     )
 
 
-def _revert_tracked_path(workspace_path: Path, rel_path: str) -> bool:
-    """Restore ``rel_path`` to HEAD content, undoing reviewer-side mutation.
+def _attempt_tracked_revert(workspace_path: Path, rel_path: str) -> None:
+    """Best-effort: restore ``rel_path`` to HEAD content via reset + checkout.
 
-    Sequence is ``git reset HEAD -- <path>`` (unstage anything the reviewer
-    happened to stage) followed by ``git checkout HEAD -- <path>`` (overwrite
-    the worktree from HEAD). For paths not in HEAD (newly staged adds) the
-    checkout legitimately fails; the residual file becomes untracked and is
-    handled by quarantine in the caller. Returns False only on subprocess
-    failure — i.e. a real filesystem/git error.
+    Subprocess return codes are intentionally ignored here — the caller
+    verifies success by re-reading the porcelain snapshot, not by trusting
+    these calls. ``git reset/checkout`` may legitimately exit nonzero (e.g.
+    path not in HEAD for a newly staged add, or .git/index.lock blocks the
+    operation); the snapshot is the source of truth.
     """
-    try:
-        subprocess.run(
-            ["git", "reset", "-q", "HEAD", "--", rel_path],
-            cwd=str(workspace_path),
-            capture_output=True,
-            timeout=15,
-            check=False,
-        )
-        subprocess.run(
-            ["git", "checkout", "-q", "HEAD", "--", rel_path],
-            cwd=str(workspace_path),
-            capture_output=True,
-            timeout=15,
-            check=False,
-        )
-        return True
-    except (OSError, subprocess.SubprocessError):
-        return False
+    for cmd in (
+        ["git", "reset", "-q", "HEAD", "--", rel_path],
+        ["git", "checkout", "-q", "HEAD", "--", rel_path],
+    ):
+        try:
+            subprocess.run(
+                cmd,
+                cwd=str(workspace_path),
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            # Snapshot will catch unresolved state below.
+            continue
 
 
 def reconcile_post_review_mutations(
@@ -292,13 +288,18 @@ def reconcile_post_review_mutations(
       - Untracked paths (status ``??``) → quarantined to
         ``.forge/quarantine/<run-id>/review-<cycle>-post/`` symmetrically
         with pre-phase hygiene.
-      - Tracked changes (M/D/A/staged-anything) → reverted via
-        ``_revert_tracked_path`` so the worktree returns to HEAD content.
-        Newly-staged-adds become untracked after reset and get quarantined.
+      - Tracked changes (M/D/A/staged-anything) → best-effort
+        ``git reset HEAD -- <path>`` + ``git checkout HEAD -- <path>``,
+        then VERIFIED via a follow-up porcelain snapshot. Subprocess
+        return codes are not trusted; the snapshot is the source of truth.
+        Any path still showing tracked status after the revert attempt is
+        treated as a revert failure (e.g. .git/index.lock present, real
+        filesystem error) and triggers escalation. Newly-staged-adds, after
+        reset, surface as untracked and fold into the quarantine pass.
 
     Returns ``(ok, diagnostic, offending_paths, audit)``. ``ok=False`` is
-    reserved for the failure case where revert or quarantine itself fails
-    (real filesystem/git error); that path still triggers the existing
+    reserved for the failure case where revert or quarantine cannot resolve
+    the worktree to a clean state; that path still triggers the existing
     consensus-capture + resume-replay escalation block in review_phase.
 
     Audit dict keys: ``snapshot_after``, ``quarantined``, ``quarantine_dir``,
@@ -316,52 +317,56 @@ def reconcile_post_review_mutations(
     if not new_entries:
         return True, None, [], audit
 
-    untracked: list[str] = []
-    tracked: list[str] = []
+    untracked_initial: list[str] = []
+    tracked_initial: list[str] = []
     for entry in new_entries:
         path = _path_of(entry)
         if entry[:2] == "??":
-            untracked.append(path)
+            untracked_initial.append(path)
         else:
-            tracked.append(path)
+            tracked_initial.append(path)
+    audit["tracked_changes"] = sorted(tracked_initial)
 
-    audit["tracked_changes"] = sorted(tracked)
+    untracked_all: list[str] = list(untracked_initial)
 
-    revert_failed: list[str] = []
-    reverted: list[str] = []
-    for path in sorted(tracked):
-        if _revert_tracked_path(workspace_path, path):
-            reverted.append(path)
-        else:
-            revert_failed.append(path)
-    audit["reverted"] = reverted
+    if tracked_initial:
+        for path in sorted(tracked_initial):
+            _attempt_tracked_revert(workspace_path, path)
 
-    if revert_failed:
-        rendered = ", ".join(revert_failed)
-        diagnostic = (
-            f"Reviewer-introduced tracked changes could not be reverted "
-            f"after REVIEW: {rendered}. Workspace hygiene gate refuses to "
-            "treat the review as valid against an unresolved dirty tree."
-        )
-        return False, diagnostic, revert_failed, audit
-
-    # After reverting, newly-staged-adds (status "A ") may now show up as
-    # untracked because reset cleared the index entry but left the file —
-    # union them in for quarantine alongside the originally-untracked set.
-    if tracked:
+        # Truth comes from re-snapshotting, not from subprocess return codes.
+        # Anything still showing tracked status is an unresolved revert
+        # (real filesystem/git failure — e.g. index.lock); newly untracked
+        # entries are staged-add residue we can quarantine.
         post_revert = snapshot_porcelain(workspace_path)
         post_revert_new = unexpected_entries(before, post_revert)
+        still_tracked: list[str] = []
+        residual_untracked: list[str] = []
         for entry in post_revert_new:
+            p = _path_of(entry)
             if entry[:2] == "??":
-                p = _path_of(entry)
-                if p not in untracked:
-                    untracked.append(p)
+                residual_untracked.append(p)
+            else:
+                still_tracked.append(p)
 
-    if not untracked:
+        if still_tracked:
+            rendered = ", ".join(sorted(still_tracked))
+            diagnostic = (
+                f"Reviewer-introduced tracked changes could not be reverted "
+                f"after REVIEW: {rendered}. Workspace hygiene gate refuses to "
+                "treat the review as valid against an unresolved dirty tree."
+            )
+            return False, diagnostic, sorted(still_tracked), audit
+
+        audit["reverted"] = sorted(tracked_initial)
+        for p in residual_untracked:
+            if p not in untracked_all:
+                untracked_all.append(p)
+
+    if not untracked_all:
         return True, None, [], audit
 
     quarantine_dir = _quarantine_root(workspace_path, run_id, f"review-{cycle}-post")
-    moved, failed = quarantine_paths(workspace_path, sorted(untracked), quarantine_dir)
+    moved, failed = quarantine_paths(workspace_path, sorted(untracked_all), quarantine_dir)
     audit["quarantined"] = moved
     audit["quarantine_dir"] = str(quarantine_dir.relative_to(workspace_path))
     if failed:

--- a/src/theforge/coordinator/workspace_hygiene.py
+++ b/src/theforge/coordinator/workspace_hygiene.py
@@ -23,12 +23,16 @@ Three layers:
    #1501).
 
 3. ``reconcile_post_review_mutations``: invoked AFTER the REVIEW pool returns.
-   Reviewer agents may improvise scratch files in the worktree (e.g. shell
-   redirects to ``test_script.sh``); auto-quarantine those untracked paths
-   instead of escalating an otherwise-valid review verdict (see issue #1497).
-   Tracked-file mutations during REVIEW remain a hygiene escalation: a
-   reviewer modifying the implementation under review IS real harm and the
-   verdict is no longer trustworthy.
+   Reviewer agents may improvise in the worktree (e.g. shell redirects writing
+   ``test_script.sh``, or accidentally editing a tracked file while exercising
+   the change). All reviewer-side mutations are mechanically reconciled: new
+   untracked paths are auto-quarantined; tracked-file mutations (modifications,
+   deletions, staged adds) are reverted back to HEAD via ``git reset`` +
+   ``git checkout HEAD --``. This way no reviewer-side filesystem effect can
+   invalidate an otherwise-sound review verdict (see issue #1497). Escalation
+   is reserved for the failure case where revert or quarantine itself fails
+   (filesystem error), so the consensus-capture / resume-replay machinery
+   (issue #1499) still has a real failsafe to ride on.
 
 Sanctioned scratch space (``.forge/tmp/<run-id>/``) is provisioned by
 ``ensure_scratch_dir``; ``.forge/`` is already gitignored so the directory is
@@ -241,25 +245,64 @@ def enforce_pre_dev_hygiene(
     )
 
 
+def _revert_tracked_path(workspace_path: Path, rel_path: str) -> bool:
+    """Restore ``rel_path`` to HEAD content, undoing reviewer-side mutation.
+
+    Sequence is ``git reset HEAD -- <path>`` (unstage anything the reviewer
+    happened to stage) followed by ``git checkout HEAD -- <path>`` (overwrite
+    the worktree from HEAD). For paths not in HEAD (newly staged adds) the
+    checkout legitimately fails; the residual file becomes untracked and is
+    handled by quarantine in the caller. Returns False only on subprocess
+    failure — i.e. a real filesystem/git error.
+    """
+    try:
+        subprocess.run(
+            ["git", "reset", "-q", "HEAD", "--", rel_path],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        subprocess.run(
+            ["git", "checkout", "-q", "HEAD", "--", rel_path],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        return True
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def reconcile_post_review_mutations(
     workspace_path: Path,
     before: set[str],
     run_id: str,
     cycle: int,
 ) -> tuple[bool, str | None, list[str], dict]:
-    """Auto-quarantine reviewer-introduced untracked paths after REVIEW.
+    """Mechanically neutralize reviewer-side worktree mutations after REVIEW.
 
-    Issue #1497: REVIEW-phase reviewers occasionally improvise scratch files
-    in the worktree (e.g. ``cat <<EOF > test_script.sh``) while exercising the
-    change under review. Those untracked artifacts must not invalidate an
-    otherwise-valid review verdict, so they are quarantined symmetrically with
-    pre-phase hygiene. Tracked-file mutations remain an escalation — a
-    reviewer modifying the implementation under review IS real harm.
+    Issue #1497: REVIEW-phase reviewers occasionally improvise in the worktree
+    (e.g. ``cat <<EOF > test_script.sh``, or editing a tracked file while
+    exercising the change). No reviewer-side filesystem effect must invalidate
+    an otherwise-sound review verdict.
 
-    Returns ``(ok, diagnostic, offending_paths, audit)`` where ``audit`` is a
-    dict with keys ``snapshot_after``, ``quarantined``, ``quarantine_dir``,
-    ``tracked_changes``. ``ok=False`` triggers the existing post-REVIEW
-    hygiene escalation path (capturing prior consensus etc.).
+    For each new porcelain entry since ``before``:
+      - Untracked paths (status ``??``) → quarantined to
+        ``.forge/quarantine/<run-id>/review-<cycle>-post/`` symmetrically
+        with pre-phase hygiene.
+      - Tracked changes (M/D/A/staged-anything) → reverted via
+        ``_revert_tracked_path`` so the worktree returns to HEAD content.
+        Newly-staged-adds become untracked after reset and get quarantined.
+
+    Returns ``(ok, diagnostic, offending_paths, audit)``. ``ok=False`` is
+    reserved for the failure case where revert or quarantine itself fails
+    (real filesystem/git error); that path still triggers the existing
+    consensus-capture + resume-replay escalation block in review_phase.
+
+    Audit dict keys: ``snapshot_after``, ``quarantined``, ``quarantine_dir``,
+    ``tracked_changes``, ``reverted``.
     """
     after = snapshot_porcelain(workspace_path)
     new_entries = unexpected_entries(before, after)
@@ -268,6 +311,7 @@ def reconcile_post_review_mutations(
         "quarantined": [],
         "quarantine_dir": None,
         "tracked_changes": [],
+        "reverted": [],
     }
     if not new_entries:
         return True, None, [], audit
@@ -283,23 +327,43 @@ def reconcile_post_review_mutations(
 
     audit["tracked_changes"] = sorted(tracked)
 
-    quarantine_dir = _quarantine_root(workspace_path, run_id, f"review-{cycle}-post")
-    moved: list[str] = []
-    failed: list[str] = []
-    if untracked:
-        moved, failed = quarantine_paths(workspace_path, sorted(untracked), quarantine_dir)
-        audit["quarantined"] = moved
-        audit["quarantine_dir"] = str(quarantine_dir.relative_to(workspace_path))
+    revert_failed: list[str] = []
+    reverted: list[str] = []
+    for path in sorted(tracked):
+        if _revert_tracked_path(workspace_path, path):
+            reverted.append(path)
+        else:
+            revert_failed.append(path)
+    audit["reverted"] = reverted
 
-    if tracked:
-        rendered = ", ".join(sorted(tracked))
+    if revert_failed:
+        rendered = ", ".join(revert_failed)
         diagnostic = (
-            f"Workspace hygiene violation: phase REVIEW is not authorized to mutate "
-            f"the repo tree, but introduced unexpected paths: {rendered}. "
-            "Remove or justify."
+            f"Reviewer-introduced tracked changes could not be reverted "
+            f"after REVIEW: {rendered}. Workspace hygiene gate refuses to "
+            "treat the review as valid against an unresolved dirty tree."
         )
-        return False, diagnostic, sorted(tracked), audit
+        return False, diagnostic, revert_failed, audit
 
+    # After reverting, newly-staged-adds (status "A ") may now show up as
+    # untracked because reset cleared the index entry but left the file —
+    # union them in for quarantine alongside the originally-untracked set.
+    if tracked:
+        post_revert = snapshot_porcelain(workspace_path)
+        post_revert_new = unexpected_entries(before, post_revert)
+        for entry in post_revert_new:
+            if entry[:2] == "??":
+                p = _path_of(entry)
+                if p not in untracked:
+                    untracked.append(p)
+
+    if not untracked:
+        return True, None, [], audit
+
+    quarantine_dir = _quarantine_root(workspace_path, run_id, f"review-{cycle}-post")
+    moved, failed = quarantine_paths(workspace_path, sorted(untracked), quarantine_dir)
+    audit["quarantined"] = moved
+    audit["quarantine_dir"] = str(quarantine_dir.relative_to(workspace_path))
     if failed:
         rendered = ", ".join(failed)
         diagnostic = (

--- a/src/theforge/coordinator/workspace_hygiene.py
+++ b/src/theforge/coordinator/workspace_hygiene.py
@@ -6,11 +6,11 @@ mutation. This module provides the mechanical enforcement: snapshot the tree
 before a phase, compare after, and either quarantine stray untracked files or
 fail loudly with the offending paths.
 
-Two layers:
+Three layers:
 
-1. ``check_phase_no_mutation``: invoked around PLAN / PLAN_REVIEW / REVIEW.
-   Any change to the porcelain set fails the phase. ``.forge/`` is gitignored,
-   so coordinator-driven artifact writes are naturally excluded.
+1. ``check_phase_no_mutation``: invoked around PLAN / PLAN_REVIEW. Any change
+   to the porcelain set fails the phase. ``.forge/`` is gitignored, so
+   coordinator-driven artifact writes are naturally excluded.
 
 2. ``enforce_pre_dev_hygiene`` / ``enforce_pre_review_hygiene``: invoked
    symmetrically before DEV iteration 1 and before each REVIEW cycle.
@@ -21,6 +21,14 @@ Two layers:
    mysteriously. REVIEW symmetry exists because stray pollution from a prior
    interrupted iteration would otherwise be visible to reviewers (see issue
    #1501).
+
+3. ``reconcile_post_review_mutations``: invoked AFTER the REVIEW pool returns.
+   Reviewer agents may improvise scratch files in the worktree (e.g. shell
+   redirects to ``test_script.sh``); auto-quarantine those untracked paths
+   instead of escalating an otherwise-valid review verdict (see issue #1497).
+   Tracked-file mutations during REVIEW remain a hygiene escalation: a
+   reviewer modifying the implementation under review IS real harm and the
+   verdict is no longer trustworthy.
 
 Sanctioned scratch space (``.forge/tmp/<run-id>/``) is provisioned by
 ``ensure_scratch_dir``; ``.forge/`` is already gitignored so the directory is
@@ -231,6 +239,77 @@ def enforce_pre_dev_hygiene(
         label=f"iter-{iteration}",
         phase_label="DEV",
     )
+
+
+def reconcile_post_review_mutations(
+    workspace_path: Path,
+    before: set[str],
+    run_id: str,
+    cycle: int,
+) -> tuple[bool, str | None, list[str], dict]:
+    """Auto-quarantine reviewer-introduced untracked paths after REVIEW.
+
+    Issue #1497: REVIEW-phase reviewers occasionally improvise scratch files
+    in the worktree (e.g. ``cat <<EOF > test_script.sh``) while exercising the
+    change under review. Those untracked artifacts must not invalidate an
+    otherwise-valid review verdict, so they are quarantined symmetrically with
+    pre-phase hygiene. Tracked-file mutations remain an escalation — a
+    reviewer modifying the implementation under review IS real harm.
+
+    Returns ``(ok, diagnostic, offending_paths, audit)`` where ``audit`` is a
+    dict with keys ``snapshot_after``, ``quarantined``, ``quarantine_dir``,
+    ``tracked_changes``. ``ok=False`` triggers the existing post-REVIEW
+    hygiene escalation path (capturing prior consensus etc.).
+    """
+    after = snapshot_porcelain(workspace_path)
+    new_entries = unexpected_entries(before, after)
+    audit: dict = {
+        "snapshot_after": sorted(after),
+        "quarantined": [],
+        "quarantine_dir": None,
+        "tracked_changes": [],
+    }
+    if not new_entries:
+        return True, None, [], audit
+
+    untracked: list[str] = []
+    tracked: list[str] = []
+    for entry in new_entries:
+        path = _path_of(entry)
+        if entry[:2] == "??":
+            untracked.append(path)
+        else:
+            tracked.append(path)
+
+    audit["tracked_changes"] = sorted(tracked)
+
+    quarantine_dir = _quarantine_root(workspace_path, run_id, f"review-{cycle}-post")
+    moved: list[str] = []
+    failed: list[str] = []
+    if untracked:
+        moved, failed = quarantine_paths(workspace_path, sorted(untracked), quarantine_dir)
+        audit["quarantined"] = moved
+        audit["quarantine_dir"] = str(quarantine_dir.relative_to(workspace_path))
+
+    if tracked:
+        rendered = ", ".join(sorted(tracked))
+        diagnostic = (
+            f"Workspace hygiene violation: phase REVIEW is not authorized to mutate "
+            f"the repo tree, but introduced unexpected paths: {rendered}. "
+            "Remove or justify."
+        )
+        return False, diagnostic, sorted(tracked), audit
+
+    if failed:
+        rendered = ", ".join(failed)
+        diagnostic = (
+            f"Reviewer-introduced untracked paths could not be quarantined "
+            f"after REVIEW: {rendered}. Workspace hygiene gate refuses to "
+            "treat the review as valid against a still-dirty tree."
+        )
+        return False, diagnostic, failed, audit
+
+    return True, None, [], audit
 
 
 def enforce_pre_review_hygiene(

--- a/tests/test_coord_hygiene_resume.py
+++ b/tests/test_coord_hygiene_resume.py
@@ -66,11 +66,17 @@ def _approve_review() -> ReviewResult:
 
 def _stub_review_pool_with_hygiene_mutation(workspace: Path):
     """Return a side_effect that simulates a reviewer pool producing APPROVE consensus
-    while leaving a stray scratch file behind (workspace hygiene violation)."""
+    while modifying a tracked file (workspace hygiene violation that escalates).
+
+    Untracked reviewer scratch is auto-quarantined post-REVIEW (issue #1497),
+    so to exercise the hygiene-escalation → resume-replay machinery (#1499)
+    we mutate a tracked file: the reviewer secretly editing the implementation
+    is real harm and remains an escalation.
+    """
 
     def _side_effect(*args, **kwargs):
         # Inject a workspace mutation that the hygiene check will catch.
-        (workspace / "reviewer_scratch.txt").write_text("oops\n", encoding="utf-8")
+        (workspace / "README.md").write_text("seed\nreviewer mutation\n", encoding="utf-8")
         candidate = _approve_review()
         named = [("reviewer_a", candidate)]
         return ([], [], candidate, [candidate], named)
@@ -159,8 +165,8 @@ def test_resume_replays_consensus_when_dev_commit_unchanged(tmp_path):
     task = _make_task(tmp_path)
 
     _run_first_pass(workspace, config, task)
-    # Clean up the stray file before "resume" — operator removed it manually.
-    (workspace / "reviewer_scratch.txt").unlink()
+    # Clean up the tracked-file mutation before "resume" — operator restored.
+    (workspace / "README.md").write_text("seed\n", encoding="utf-8")
 
     # Build a fresh state that represents the resume entry: load sidecar.
     resume_state = CoordinatorState(
@@ -231,7 +237,7 @@ def _build_resume_state(workspace: Path) -> CoordinatorState:
 
 
 def test_resume_refuses_replay_when_untracked_mutation_persists(tmp_path):
-    """Reviewer-created untracked file still present at resume → fresh review re-trips hygiene."""
+    """Reviewer tracked-file mutation still present at resume → fresh review re-trips hygiene."""
     workspace = tmp_path / "ws"
     workspace.mkdir()
     head_sha = _init_repo(workspace)
@@ -240,8 +246,8 @@ def test_resume_refuses_replay_when_untracked_mutation_persists(tmp_path):
     task = _make_task(tmp_path)
 
     _run_first_pass(workspace, config, task)
-    # Operator did NOT clean up reviewer_scratch.txt — it is still present.
-    assert (workspace / "reviewer_scratch.txt").exists()
+    # Operator did NOT restore the mutated tracked file — it is still dirty.
+    assert "reviewer mutation" in (workspace / "README.md").read_text()
 
     resume_state = _build_resume_state(workspace)
     assert resume_state.escalate_kind == "hygiene"
@@ -271,7 +277,7 @@ def test_resume_refuses_replay_when_untracked_mutation_persists(tmp_path):
     assert audit is not None
     assert audit["resume_action"] == "rerun_dirty_worktree"
     assert audit["dev_commit_sha_at_resume"] == head_sha
-    assert "reviewer_scratch.txt" in audit["offending_paths"]
+    assert any("README.md" in p for p in audit["offending_paths"])
     # Fail closed: ESCALATE without re-running the pool, so a fresh review's
     # hygiene snapshot can't silently treat the persistent mutation as baseline.
     assert outcome == _ReviewOutcome.ESCALATE
@@ -415,7 +421,7 @@ def test_resume_runs_fresh_review_when_dev_commit_changed(tmp_path):
     task = _make_task(tmp_path)
 
     _run_first_pass(workspace, config, task)
-    (workspace / "reviewer_scratch.txt").unlink()
+    (workspace / "README.md").write_text("seed\n", encoding="utf-8")
 
     # Advance HEAD so the SHA differs at resume.
     (workspace / "more.txt").write_text("more\n", encoding="utf-8")

--- a/tests/test_coord_hygiene_resume.py
+++ b/tests/test_coord_hygiene_resume.py
@@ -65,18 +65,21 @@ def _approve_review() -> ReviewResult:
 
 
 def _stub_review_pool_with_hygiene_mutation(workspace: Path):
-    """Return a side_effect that simulates a reviewer pool producing APPROVE consensus
-    while modifying a tracked file. Combined with patched `_revert_tracked_path`
-    in `_run_first_pass` (filesystem-failure simulation), this drives the
-    post-review reconciler down its escalation branch — the only remaining
-    failsafe for the consensus-capture / resume-replay machinery (#1499)
-    after #1497 made all routine reviewer mutations auto-reconciled.
+    """Return a side_effect that simulates a reviewer pool producing APPROVE
+    consensus while modifying a tracked file AND planting a stale
+    .git/index.lock so the post-review revert cannot resolve. Snapshot-based
+    verification then catches the still-dirty tracked file and escalates —
+    the only remaining failsafe for the #1499 consensus-capture / resume-
+    replay machinery after #1497 made routine reviewer mutations auto-
+    reconciled.
     """
 
     def _side_effect(*args, **kwargs):
-        # Inject a workspace mutation. Under the patched revert below it stays
-        # dirty post-REVIEW so the hygiene gate refuses and escalates.
         (workspace / "README.md").write_text("seed\nreviewer mutation\n", encoding="utf-8")
+        # Stale index.lock causes git reset/checkout to exit 128 without
+        # raising — exercises the real subprocess-failure path the cycle-2
+        # review flagged.
+        (workspace / ".git" / "index.lock").write_text("", encoding="utf-8")
         candidate = _approve_review()
         named = [("reviewer_a", candidate)]
         return ([], [], candidate, [candidate], named)
@@ -100,17 +103,9 @@ def _run_first_pass(workspace: Path, config, task) -> CoordinatorState:
     state.run_id = "test-run-1"
     state.adaptive_review_max = 2
 
-    with (
-        patch(
-            "theforge.coordinator.review_phase._run_review_pool",
-            side_effect=_stub_review_pool_with_hygiene_mutation(workspace),
-        ),
-        # Simulate a filesystem-level revert failure so the reviewer-side
-        # tracked mutation cannot be reconciled and the hygiene gate fires.
-        patch(
-            "theforge.coordinator.workspace_hygiene._revert_tracked_path",
-            return_value=False,
-        ),
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_stub_review_pool_with_hygiene_mutation(workspace),
     ):
         outcome, result, _config2 = _run_review_phase(
             state,
@@ -128,6 +123,11 @@ def _run_first_pass(workspace: Path, config, task) -> CoordinatorState:
 
     assert outcome == _ReviewOutcome.ESCALATE
     assert result is not None
+    # Clean up the stale .git/index.lock the stub planted to drive escalation;
+    # downstream resume assertions need git operations to work normally.
+    lock = workspace / ".git" / "index.lock"
+    if lock.exists():
+        lock.unlink()
     return state
 
 

--- a/tests/test_coord_hygiene_resume.py
+++ b/tests/test_coord_hygiene_resume.py
@@ -66,16 +66,16 @@ def _approve_review() -> ReviewResult:
 
 def _stub_review_pool_with_hygiene_mutation(workspace: Path):
     """Return a side_effect that simulates a reviewer pool producing APPROVE consensus
-    while modifying a tracked file (workspace hygiene violation that escalates).
-
-    Untracked reviewer scratch is auto-quarantined post-REVIEW (issue #1497),
-    so to exercise the hygiene-escalation → resume-replay machinery (#1499)
-    we mutate a tracked file: the reviewer secretly editing the implementation
-    is real harm and remains an escalation.
+    while modifying a tracked file. Combined with patched `_revert_tracked_path`
+    in `_run_first_pass` (filesystem-failure simulation), this drives the
+    post-review reconciler down its escalation branch — the only remaining
+    failsafe for the consensus-capture / resume-replay machinery (#1499)
+    after #1497 made all routine reviewer mutations auto-reconciled.
     """
 
     def _side_effect(*args, **kwargs):
-        # Inject a workspace mutation that the hygiene check will catch.
+        # Inject a workspace mutation. Under the patched revert below it stays
+        # dirty post-REVIEW so the hygiene gate refuses and escalates.
         (workspace / "README.md").write_text("seed\nreviewer mutation\n", encoding="utf-8")
         candidate = _approve_review()
         named = [("reviewer_a", candidate)]
@@ -100,9 +100,17 @@ def _run_first_pass(workspace: Path, config, task) -> CoordinatorState:
     state.run_id = "test-run-1"
     state.adaptive_review_max = 2
 
-    with patch(
-        "theforge.coordinator.review_phase._run_review_pool",
-        side_effect=_stub_review_pool_with_hygiene_mutation(workspace),
+    with (
+        patch(
+            "theforge.coordinator.review_phase._run_review_pool",
+            side_effect=_stub_review_pool_with_hygiene_mutation(workspace),
+        ),
+        # Simulate a filesystem-level revert failure so the reviewer-side
+        # tracked mutation cannot be reconciled and the hygiene gate fires.
+        patch(
+            "theforge.coordinator.workspace_hygiene._revert_tracked_path",
+            return_value=False,
+        ),
     ):
         outcome, result, _config2 = _run_review_phase(
             state,

--- a/tests/test_coord_workspace_hygiene.py
+++ b/tests/test_coord_workspace_hygiene.py
@@ -471,14 +471,56 @@ def test_reconcile_post_review_quarantines_untracked_reviewer_scratch(tmp_path: 
     assert audit["tracked_changes"] == []
 
 
-def test_reconcile_post_review_escalates_on_tracked_mutation(tmp_path: Path) -> None:
-    """Reviewer modifying a tracked file (the implementation under review)
-    is real harm, not scratch — escalate."""
+def test_reconcile_post_review_reverts_tracked_modification(tmp_path: Path) -> None:
+    """Reviewer-side modification to a tracked file is reverted to HEAD content,
+    so an otherwise-APPROVE verdict is not invalidated by reviewer side effects."""
     _init_repo(tmp_path)
     before = snapshot_porcelain(tmp_path)
     (tmp_path / "README.md").write_text("seed\nreviewer-edit\n", encoding="utf-8")
-    # Also add untracked scratch — should still be quarantined regardless.
+    # Untracked scratch is reconciled in the same pass.
     (tmp_path / "test_script.sh").write_text("scratch\n", encoding="utf-8")
+
+    ok, diag, offending, audit = reconcile_post_review_mutations(
+        tmp_path, before, "run-1", cycle=0
+    )
+
+    assert ok is True
+    assert diag is None
+    assert offending == []
+    # README.md restored to HEAD content; scratch quarantined.
+    assert (tmp_path / "README.md").read_text() == "seed\n"
+    assert not (tmp_path / "test_script.sh").exists()
+    assert audit["tracked_changes"] == ["README.md"]
+    assert audit["reverted"] == ["README.md"]
+    assert audit["quarantined"] == ["test_script.sh"]
+
+
+def test_reconcile_post_review_reverts_tracked_deletion(tmp_path: Path) -> None:
+    """Reviewer deleting a tracked file is reverted; file restored from HEAD."""
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / "README.md").unlink()
+
+    ok, _diag, offending, audit = reconcile_post_review_mutations(
+        tmp_path, before, "run-1", cycle=0
+    )
+
+    assert ok is True
+    assert offending == []
+    assert (tmp_path / "README.md").read_text() == "seed\n"
+    assert audit["reverted"] == ["README.md"]
+
+
+def test_reconcile_post_review_escalates_when_revert_fails(tmp_path: Path, monkeypatch) -> None:
+    """If git revert itself fails, escalation fires so the consensus-capture +
+    resume-replay machinery has a real failsafe (#1499) to ride on."""
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / "README.md").write_text("seed\nreviewer-edit\n", encoding="utf-8")
+
+    from theforge.coordinator import workspace_hygiene as wh
+
+    monkeypatch.setattr(wh, "_revert_tracked_path", lambda *a, **kw: False)
 
     ok, diag, offending, audit = reconcile_post_review_mutations(
         tmp_path, before, "run-1", cycle=0
@@ -486,12 +528,10 @@ def test_reconcile_post_review_escalates_on_tracked_mutation(tmp_path: Path) -> 
 
     assert ok is False
     assert diag is not None
-    assert "REVIEW" in diag
     assert "README.md" in diag
+    assert "could not be reverted" in diag
     assert offending == ["README.md"]
-    # Untracked scratch was still quarantined as a side effect.
-    assert audit["quarantined"] == ["test_script.sh"]
-    assert audit["tracked_changes"] == ["README.md"]
+    assert audit["reverted"] == []
 
 
 def test_reconcile_post_review_escalates_when_quarantine_fails(
@@ -598,10 +638,12 @@ def test_run_review_phase_quarantines_reviewer_scratch_after_review(tmp_path: Pa
     assert outcome != _ReviewOutcome.ESCALATE or state.escalate_kind != "hygiene"
 
 
-def test_run_review_phase_escalates_when_reviewer_modifies_tracked_file(
+def test_run_review_phase_reverts_reviewer_tracked_mutation(
     tmp_path: Path,
 ) -> None:
-    """A reviewer modifying a tracked file IS real harm — escalate."""
+    """Issue #1497: a reviewer modifying a tracked file mid-review must NOT
+    escalate an otherwise-APPROVE consensus. The post-review reconciler
+    reverts the mutation back to HEAD and the sprint proceeds."""
     from coord_test_helpers import _make_task  # noqa: PLC0415
 
     from theforge.review import ReviewResult  # noqa: PLC0415
@@ -658,6 +700,14 @@ def test_run_review_phase_escalates_when_reviewer_modifies_tracked_file(
             logger=None,
         )
 
-    assert outcome == _ReviewOutcome.ESCALATE
-    assert state.escalate_kind == "hygiene"
-    assert "src.py" in (state.error or "")
+    assert state.escalate_kind != "hygiene"
+    # The tracked file was restored to HEAD content.
+    assert (tmp_path / "src.py").read_text() == "ok\n"
+    review_entry = next(e for e in state.workspace_hygiene_audit if e.get("phase") == "REVIEW")
+    assert review_entry["ok"] is True
+    assert review_entry["reverted"] == ["src.py"]
+    # Outcome did not escalate on hygiene grounds (may still escalate on
+    # downstream guards, e.g. zero-commits-ahead — that is unrelated).
+    assert outcome != _ReviewOutcome.ESCALATE or state.escalate_kind != "hygiene"
+    # Suppress unused-variable warning from outcome capture.
+    _ = outcome

--- a/tests/test_coord_workspace_hygiene.py
+++ b/tests/test_coord_workspace_hygiene.py
@@ -21,6 +21,7 @@ from theforge.coordinator.workspace_hygiene import (
     enforce_pre_dev_hygiene,
     enforce_pre_review_hygiene,
     ensure_scratch_dir,
+    reconcile_post_review_mutations,
     snapshot_porcelain,
     unexpected_entries,
 )
@@ -431,3 +432,232 @@ def test_run_review_phase_escalates_when_quarantine_fails(tmp_path: Path) -> Non
     assert "quarantine refused" in (state.error or "")
     # Reviewers were never invoked.
     assert pool_called == []
+
+
+# ── reconcile_post_review_mutations (issue #1497) ─────────────────────
+
+
+def test_reconcile_post_review_no_mutation_returns_ok(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    ok, diag, offending, audit = reconcile_post_review_mutations(
+        tmp_path, before, "run-1", cycle=0
+    )
+    assert ok is True
+    assert diag is None
+    assert offending == []
+    assert audit["quarantined"] == []
+    assert audit["tracked_changes"] == []
+
+
+def test_reconcile_post_review_quarantines_untracked_reviewer_scratch(tmp_path: Path) -> None:
+    """The #1497 motivating case: reviewer wrote test_script.sh via shell redirect."""
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / "test_script.sh").write_text("MANAGED_LAUNCHER=...\n", encoding="utf-8")
+
+    ok, diag, offending, audit = reconcile_post_review_mutations(
+        tmp_path, before, "run-xyz", cycle=2
+    )
+
+    assert ok is True
+    assert diag is None
+    assert offending == []
+    assert not (tmp_path / "test_script.sh").exists()
+    quarantine_dir = tmp_path / ".forge" / "quarantine" / "run-xyz" / "review-2-post"
+    assert (quarantine_dir / "test_script.sh").read_text() == "MANAGED_LAUNCHER=...\n"
+    assert audit["quarantined"] == ["test_script.sh"]
+    assert audit["quarantine_dir"] == ".forge/quarantine/run-xyz/review-2-post"
+    assert audit["tracked_changes"] == []
+
+
+def test_reconcile_post_review_escalates_on_tracked_mutation(tmp_path: Path) -> None:
+    """Reviewer modifying a tracked file (the implementation under review)
+    is real harm, not scratch — escalate."""
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / "README.md").write_text("seed\nreviewer-edit\n", encoding="utf-8")
+    # Also add untracked scratch — should still be quarantined regardless.
+    (tmp_path / "test_script.sh").write_text("scratch\n", encoding="utf-8")
+
+    ok, diag, offending, audit = reconcile_post_review_mutations(
+        tmp_path, before, "run-1", cycle=0
+    )
+
+    assert ok is False
+    assert diag is not None
+    assert "REVIEW" in diag
+    assert "README.md" in diag
+    assert offending == ["README.md"]
+    # Untracked scratch was still quarantined as a side effect.
+    assert audit["quarantined"] == ["test_script.sh"]
+    assert audit["tracked_changes"] == ["README.md"]
+
+
+def test_reconcile_post_review_escalates_when_quarantine_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If quarantine_paths fails for any untracked path, the review escalates
+    rather than silently treating the dirty tree as valid."""
+    _init_repo(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / "test_script.sh").write_text("scratch\n", encoding="utf-8")
+
+    from theforge.coordinator import workspace_hygiene as wh
+
+    def _fail_quarantine(workspace_path, paths, quarantine_root):
+        return ([], list(paths))
+
+    monkeypatch.setattr(wh, "quarantine_paths", _fail_quarantine)
+
+    ok, diag, offending, audit = reconcile_post_review_mutations(
+        tmp_path, before, "run-1", cycle=0
+    )
+
+    assert ok is False
+    assert diag is not None
+    assert "test_script.sh" in diag
+    assert offending == ["test_script.sh"]
+
+
+# ── seam: post-REVIEW reviewer scratch is auto-quarantined (issue #1497) ─
+
+
+def test_run_review_phase_quarantines_reviewer_scratch_after_review(tmp_path: Path) -> None:
+    """Issue #1497: a reviewer writing test_script.sh via shell during REVIEW
+    must not escalate an otherwise-APPROVE review."""
+    from coord_test_helpers import _make_task  # noqa: PLC0415
+
+    from theforge.review import ReviewResult  # noqa: PLC0415
+
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "src.py").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "src.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    state.workspace_path = tmp_path
+    state.branch_name = "feat/x"
+    state.run_id = "abcd1234"
+    state.adaptive_review_max = 2
+
+    def _approve_pool(*args, **kwargs):
+        # Reviewer writes a scratch file mid-call.
+        (tmp_path / "test_script.sh").write_text("MANAGED_LAUNCHER=...\n", encoding="utf-8")
+        candidate = ReviewResult(
+            verdict="APPROVE",
+            summary="ok",
+            findings=[],
+            story_matches=True,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={"verdict": "APPROVE"},
+        )
+        return ([], [], candidate, [candidate], [("reviewer_a", candidate)])
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_approve_pool,
+    ):
+        outcome, _result, _config = _run_review_phase(
+            state,
+            config,
+            task,
+            "# spec\n",
+            tmp_path,
+            "feat/x",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    # Did NOT escalate on hygiene grounds — the reviewer scratch was quarantined.
+    assert state.escalate_kind != "hygiene"
+    # The scratch file is gone from the worktree.
+    assert not (tmp_path / "test_script.sh").exists()
+    # And lives under the post-review quarantine subdir.
+    quarantine_dir = tmp_path / ".forge" / "quarantine" / "abcd1234" / "review-0-post"
+    assert (quarantine_dir / "test_script.sh").read_text() == "MANAGED_LAUNCHER=...\n"
+    # Audit recorded the quarantined path under the REVIEW post-phase entry.
+    review_entry = next(e for e in state.workspace_hygiene_audit if e.get("phase") == "REVIEW")
+    assert review_entry["ok"] is True
+    assert review_entry["quarantined"] == ["test_script.sh"]
+    # Outcome reflects the APPROVE consensus, not a hygiene escalation.
+    assert outcome != _ReviewOutcome.ESCALATE or state.escalate_kind != "hygiene"
+
+
+def test_run_review_phase_escalates_when_reviewer_modifies_tracked_file(
+    tmp_path: Path,
+) -> None:
+    """A reviewer modifying a tracked file IS real harm — escalate."""
+    from coord_test_helpers import _make_task  # noqa: PLC0415
+
+    from theforge.review import ReviewResult  # noqa: PLC0415
+
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "src.py").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "src.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(
+        phase=Phase.REVIEW,
+        dev_iteration=0,
+        review_cycle=0,
+        preflight_verdict="SKIPPED",
+    )
+    state.workspace_path = tmp_path
+    state.branch_name = "feat/x"
+    state.run_id = "abcd1234"
+    state.adaptive_review_max = 2
+
+    def _mutating_pool(*args, **kwargs):
+        (tmp_path / "src.py").write_text("ok\nreviewer-edit\n", encoding="utf-8")
+        candidate = ReviewResult(
+            verdict="APPROVE",
+            summary="ok",
+            findings=[],
+            story_matches=True,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={"verdict": "APPROVE"},
+        )
+        return ([], [], candidate, [candidate], [("reviewer_a", candidate)])
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_mutating_pool,
+    ):
+        outcome, _result, _config = _run_review_phase(
+            state,
+            config,
+            task,
+            "# spec\n",
+            tmp_path,
+            "feat/x",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome == _ReviewOutcome.ESCALATE
+    assert state.escalate_kind == "hygiene"
+    assert "src.py" in (state.error or "")

--- a/tests/test_coord_workspace_hygiene.py
+++ b/tests/test_coord_workspace_hygiene.py
@@ -511,20 +511,26 @@ def test_reconcile_post_review_reverts_tracked_deletion(tmp_path: Path) -> None:
     assert audit["reverted"] == ["README.md"]
 
 
-def test_reconcile_post_review_escalates_when_revert_fails(tmp_path: Path, monkeypatch) -> None:
-    """If git revert itself fails, escalation fires so the consensus-capture +
-    resume-replay machinery has a real failsafe (#1499) to ride on."""
+def test_reconcile_post_review_escalates_when_index_lock_blocks_revert(
+    tmp_path: Path,
+) -> None:
+    """Real subprocess-failure mode: stale .git/index.lock causes git reset
+    and git checkout to exit 128 without raising. Snapshot-based verification
+    must catch the still-dirty tracked file and escalate — trusting subprocess
+    return codes (cycle-2 finding) would silently pass the dirty tree."""
     _init_repo(tmp_path)
     before = snapshot_porcelain(tmp_path)
     (tmp_path / "README.md").write_text("seed\nreviewer-edit\n", encoding="utf-8")
 
-    from theforge.coordinator import workspace_hygiene as wh
-
-    monkeypatch.setattr(wh, "_revert_tracked_path", lambda *a, **kw: False)
-
-    ok, diag, offending, audit = reconcile_post_review_mutations(
-        tmp_path, before, "run-1", cycle=0
-    )
+    lock = tmp_path / ".git" / "index.lock"
+    lock.write_text("", encoding="utf-8")
+    try:
+        ok, diag, offending, audit = reconcile_post_review_mutations(
+            tmp_path, before, "run-1", cycle=0
+        )
+    finally:
+        if lock.exists():
+            lock.unlink()
 
     assert ok is False
     assert diag is not None
@@ -532,6 +538,8 @@ def test_reconcile_post_review_escalates_when_revert_fails(tmp_path: Path, monke
     assert "could not be reverted" in diag
     assert offending == ["README.md"]
     assert audit["reverted"] == []
+    # The reviewer's mutation is still in the worktree — NOT silently reported reverted.
+    assert (tmp_path / "README.md").read_text() == "seed\nreviewer-edit\n"
 
 
 def test_reconcile_post_review_escalates_when_quarantine_fails(


### PR DESCRIPTION
## Summary

Cycle 1 and Cycle 2 P1s are resolved; reviewer scratch is quarantined, tracked reviewer mutations are reverted and verified by porcelain, and unresolved dirty state still escalates.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $8.03
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Reviewer-phase agents can write to the worktree, escalating sprints whose review verdicts would otherwise APPROVE (GitHub Issue #1497)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1497