### PR TITLE
ADR-0001: flip Status to Accepted; record v0.11.0 implementation slices

### DIFF
--- a/docs/adr/0001-intake-readiness-workflow.md
+++ b/docs/adr/0001-intake-readiness-workflow.md
@@ -1,10 +1,11 @@
 # ADR-0001: Intake Readiness Workflow
 
-- **Status:** Proposed
-- **Date:** 2026-05-10
+- **Status:** Accepted
+- **Date:** 2026-05-10 (proposed) / 2026-05-11 (accepted)
 - **Deciders:** Peter Wickersham (project lead), with iterative review by Claude and Codex
 - **Affected milestones:** v0.11.x (implementation), v0.12+ (dependency)
 - **Related issues:** #1034, #367, #1450, #1469, #1033
+- **Implementation slices (v0.11.0):** #1509, #1510, #1511, #1512, #1513
 
 ---
 


### PR DESCRIPTION
## Summary

Small follow-up to #1508. ADR-0001's intake-readiness architecture has
converged and the implementation slices are filed under v0.11.0, so the
Status field flips from Proposed to Accepted. Also adds a line linking
the five v0.11.0 slice issues that operationalize the ADR.

## What changed

- \`Status: Proposed\` → \`Status: Accepted\`
- Date line now records both proposed and accepted dates
- Added "Implementation slices (v0.11.0)" line linking #1509–#1513

## What this signals

After this lands, no one should be debating the intake-readiness ontology
anymore. The remaining work is normal issue grooming — split, milestone,
and sprint — already done in the slice issues filed alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)