### PR TITLE
fix(release): cut-rc.sh probes use `forge version` subcommand, not `--version`

### DIFF
--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -15,7 +15,7 @@
 # After the isolated venv install succeeds, the script repoints the
 # operator's managed `forge` launcher (default: ~/.local/bin/forge,
 # overridable via FORGE_MANAGED_LAUNCHER) at the new RC venv's binary, so
-# plain `forge --version` reports the just-cut RC with no shell-config
+# plain `forge version` reports the just-cut RC with no shell-config
 # change. The launcher is a symlink — no Python environment is mutated, so
 # editable installs and source-tree edits cannot silently change what
 # plain `forge` runs. If plain `forge` currently resolves to a launcher
@@ -197,9 +197,10 @@ if [[ "$NO_INSTALL" == false ]]; then
     run "$RC_ENV_PIP" install --upgrade pip
     run "$RC_ENV_PIP" install "git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
     if [[ "$DRY_RUN" == false ]]; then
-        INSTALLED_VERSION=$("$RC_ENV_FORGE" --version 2>/dev/null || echo "")
+        INSTALLED_OUTPUT=$("$RC_ENV_FORGE" version 2>&1 || echo "")
+        INSTALLED_VERSION=$(echo "$INSTALLED_OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*' | head -1)
         echo "    isolated forge   : $RC_ENV_FORGE"
-        echo "    forge --version  : $INSTALLED_VERSION"
+        echo "    forge version    : $INSTALLED_VERSION"
         echo "    isolated pip     : $RC_ENV_PIP"
         echo "    isolated python  : $RC_ENV_PYTHON"
         if [[ "$INSTALLED_VERSION" != *"$RC_VERSION"* ]]; then
@@ -263,10 +264,11 @@ if [[ "$NO_INSTALL" == false ]]; then
             exit 1
         fi
 
-        PLAIN_VERSION=$(forge --version 2>/dev/null || echo "")
+        PLAIN_OUTPUT=$(forge version 2>&1 || echo "")
+        PLAIN_VERSION=$(echo "$PLAIN_OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*' | head -1)
         if [[ "$PLAIN_VERSION" != *"$RC_VERSION"* ]]; then
             echo "" >&2
-            echo "Error: plain \`forge --version\` reports '$PLAIN_VERSION'," >&2
+            echo "Error: plain \`forge version\` reports '$PLAIN_VERSION'," >&2
             echo "       expected to contain $RC_VERSION." >&2
             echo "       The managed launcher symlink may be broken; investigate" >&2
             echo "         $MANAGED_LAUNCHER" >&2
@@ -275,7 +277,7 @@ if [[ "$NO_INSTALL" == false ]]; then
         fi
 
         echo "    managed launcher : $MANAGED_LAUNCHER -> $RC_ENV_FORGE"
-        echo "    forge --version  : $PLAIN_VERSION"
+        echo "    forge version    : $PLAIN_VERSION"
         echo "    ✓ plain \`forge\` now tracks $RC_TAG; substrate is isolated."
     fi
 else
@@ -283,7 +285,7 @@ else
     echo "    To verify manually in an isolated venv:"
     echo "      python3 -m venv \"$RC_ENV_DIR\""
     echo "      \"$RC_ENV_PIP\" install git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
-    echo "      \"$RC_ENV_FORGE\" --version"
+    echo "      \"$RC_ENV_FORGE\" version"
     echo "      ln -snf \"$RC_ENV_FORGE\" \"$MANAGED_LAUNCHER\""
 fi
 

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -98,14 +98,14 @@ def test_script_refuses_to_overwrite_venv_resident_launcher() -> None:
 
 
 def test_script_verifies_plain_forge_reports_rc() -> None:
-    """After repointing, the script must invoke plain ``forge --version``
+    """After repointing, the script must invoke plain ``forge version``
     (PATH-resolved, no path qualification) and fail loud if the resolved
     binary doesn't report the RC version.
     """
     body = SCRIPT.read_text(encoding="utf-8")
-    # The post-repoint verify uses bare `forge --version` (PATH-resolved).
-    assert re.search(r"PLAIN_VERSION=\$\(forge --version", body), (
-        "cut-rc.sh must verify plain `forge --version` after repointing the launcher"
+    # The post-repoint verify uses bare `forge version` (PATH-resolved).
+    assert re.search(r"PLAIN_OUTPUT=\$\(forge version", body), (
+        "cut-rc.sh must verify plain `forge version` after repointing the launcher"
     )
     # And RC_ENV_FORGE is still used for the in-venv install verification.
     assert "$RC_ENV_FORGE" in body
@@ -145,7 +145,7 @@ def test_full_execution_repoints_managed_launcher_and_does_not_mutate_operator_e
       (no pip install ever ran outside the isolated venv);
     - the managed launcher (``$HOME/.local/bin/forge`` in this fixture)
       exists, is a symlink, and points at the isolated venv's binary;
-    - plain ``forge --version`` (PATH-resolved) reports the cut RC version
+    - plain ``forge version`` (PATH-resolved) reports the cut RC version
       via the symlink chain.
     """
     import theforge as _theforge_under_test
@@ -216,7 +216,7 @@ def test_full_execution_repoints_managed_launcher_and_does_not_mutate_operator_e
                 chmod +x "$VENV/bin/pip"
                 cat > "$VENV/bin/forge" <<'FORGE'
             #!/bin/sh
-            if [ "$1" = "--version" ]; then
+            if [ "$1" = "version" ]; then
                 echo "TheForge v0.99.0rc0"
             fi
             FORGE
@@ -291,11 +291,11 @@ def test_full_execution_repoints_managed_launcher_and_does_not_mutate_operator_e
         f"managed launcher points at {os.readlink(managed_launcher)}, expected {rc_forge}"
     )
 
-    # Plain `forge --version` (PATH-resolved through the managed launcher)
+    # Plain `forge version` (PATH-resolved through the managed launcher)
     # must report the cut RC. Substrate provenance: the binary actually
     # executing is the RC venv's forge, not whatever was on PATH before.
     plain_check = subprocess.run(
-        ["bash", "-c", "command -v forge && forge --version"],
+        ["bash", "-c", "command -v forge && forge version"],
         env=env,
         capture_output=True,
         text=True,
@@ -304,7 +304,7 @@ def test_full_execution_repoints_managed_launcher_and_does_not_mutate_operator_e
     assert plain_check.returncode == 0, plain_check.stderr
     assert str(managed_launcher) in plain_check.stdout
     assert "0.99.0rc0" in plain_check.stdout, (
-        f"plain forge --version did not report cut RC: {plain_check.stdout}"
+        f"plain forge version did not report cut RC: {plain_check.stdout}"
     )
 
     # Operator env theforge package must be bit-for-bit unchanged.
@@ -403,7 +403,7 @@ def test_full_execution_refuses_to_clobber_venv_resident_forge(tmp_path: Path) -
                 chmod +x "$VENV/bin/pip"
                 cat > "$VENV/bin/forge" <<'FORGE'
             #!/bin/sh
-            if [ "$1" = "--version" ]; then
+            if [ "$1" = "version" ]; then
                 echo "TheForge v0.99.0rc0"
             fi
             FORGE


### PR DESCRIPTION
## Summary

- `cut-rc.sh` invoked `forge --version`, which forge doesn't accept (version is a subcommand). The error was masked by `|| echo ""`, leaving `INSTALLED_VERSION=""` and tripping the mismatch gate.
- `test_cut_rc_isolation.py` stubs answered `--version`, so the buggy contract was the tested one. Both stubs and the assertion regex updated to `version`.
- Version-string parsing now mirrors `main`'s `cut-rc.sh` (grep SemVer token from subcommand output).

## Repro

Caught cutting v0.10.0rc13:
\`\`\`
isolated forge   : .forge/rc-envs/v0.10.0rc13/bin/forge
forge --version  :
Error: isolated forge version does not match RC (0.10.0rc13).
       Got: ''
\`\`\`
The rc13 package installed correctly — only the probe was broken.

## Test plan

- [x] \`pytest tests/test_cut_rc_isolation.py\` — 7 passed, 2 skipped
- [ ] Re-cut as rc14 after merge; expect probe step to print \`forge version    : 0.10.0rc14\` and proceed to the managed-launcher repoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)