### PR TITLE
Fix worktree eval import fallback to patient source

### DIFF
--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -27,6 +27,7 @@ _subprocess_run = subprocess.run
 # Absolute path to the subprocess eval entry point — invoked by path so the
 # coordinator's own version runs regardless of what the installed package provides.
 _SUBPROCESS_EVAL = Path(__file__).parent / "_subprocess_eval.py"
+_CHECKOUT_SRC = Path(__file__).resolve().parents[2]
 
 # Adaptive timeout fallback uses the same default headroom factor across
 # surfaces when forge.yaml does not provide an explicit complexity-tier
@@ -255,16 +256,26 @@ def _run_worktree_eval(
 
     Prepends workspace_path/src to PYTHONPATH so the subprocess imports
     theforge.* modules from the worktree rather than the coordinator's copies.
-    This is the isolation boundary for self-hosting: project code is never
-    imported into the coordinator's process; it runs only in this subprocess.
+    The checkout src that loaded this module is added as an explicit fallback
+    for sparse synthetic worktrees used by tests; this keeps those subprocesses
+    from falling through to whatever theforge happens to be installed in the
+    ambient Python environment. This is the isolation boundary for self-hosting:
+    project code is never imported into the coordinator's process; it runs only
+    in this subprocess.
 
     Returns the parsed JSON result dict. Raises RuntimeError on subprocess
     failure.
     """
     env = os.environ.copy()
     worktree_src = str((workspace_path / "src").resolve())
+    checkout_src = str(_CHECKOUT_SRC)
     existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = worktree_src + (os.pathsep + existing if existing else "")
+    pythonpath_entries = [worktree_src]
+    if checkout_src != worktree_src:
+        pythonpath_entries.append(checkout_src)
+    if existing:
+        pythonpath_entries.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
 
     result = _subprocess_run(
         [sys.executable, str(_SUBPROCESS_EVAL), command],

--- a/tests/test_worktree_eval_import_boundary.py
+++ b/tests/test_worktree_eval_import_boundary.py
@@ -1,0 +1,39 @@
+"""Regression coverage for worktree-eval import isolation."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from theforge.coordinator import util as coord_util
+
+
+def test_worktree_eval_adds_checkout_src_before_ambient_pythonpath(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+    ambient = str(tmp_path / "ambient-site-packages")
+    monkeypatch.setenv("PYTHONPATH", ambient)
+
+    captured_env: dict[str, str] = {}
+
+    def fake_run(*args, **kwargs):
+        captured_env.update(kwargs["env"])
+
+        class Result:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps({})
+
+        return Result()
+
+    with patch("theforge.coordinator.util._subprocess_run", side_effect=fake_run):
+        coord_util._run_worktree_eval(workspace, "classify_families", {})
+
+    entries = captured_env["PYTHONPATH"].split(os.pathsep)
+    assert entries[0] == str((workspace / "src").resolve())
+    assert entries[1] == str(coord_util._CHECKOUT_SRC)
+    assert entries[2] == ambient


### PR DESCRIPTION
## Summary

- make worktree eval subprocesses search the synthetic worktree src first, then the checkout src that loaded the patient runtime
- keep ambient PYTHONPATH/site-packages after explicit patient sources so sparse fixtures cannot fall through to an installed RC
- add regression coverage for PYTHONPATH ordering

Fixes #1530.

## Validation

- `python -m pytest tests/test_worktree_eval_import_boundary.py -q`
- `python -m pytest tests/test_coord_review_phase_pool.py::TestCoordinatorMultiModelReview::test_pool_of_2_request_changes -q`
- `python -m pytest tests/test_coord_review_resolution_commentary.py::TestResolutionCommentaryBridge::test_unresolved_wording_still_tracks_prior_finding_across_cycles -q`
- `python -m pytest tests/test_coord_review_resolution_commentary.py tests/test_coord_preflight_already_done_verification.py tests/test_coord_gate_fix.py::TestFixPromptRouting tests/test_coord_review_phase_pool.py::TestReviewParseRetry tests/test_coord_review_phase_pool.py::TestCoordinatorMultiModelReview tests/test_coord_preflight_plan.py::TestPlanPhase tests/test_sprint_pipeline_smoke.py::test_make_gate_covers_mocked_sprint_pipeline_smoke_run tests/test_worktree_eval_import_boundary.py -q`
- `make gate`
