### PR TITLE
Substrate-version warning fires on the documented dogfood model state (released RC orchestrating newer checkout)

### DIFF
--- a/src/theforge/cli/substrate.py
+++ b/src/theforge/cli/substrate.py
@@ -181,16 +181,21 @@ def format_provenance_lines(sub: Substrate | None = None) -> list[str]:
 
 
 def detect_mismatch(cwd: Path | None = None, sub: Substrate | None = None) -> str | None:
-    """Return a one-line warning when CWD's theforge checkout disagrees with the
-    binary's reported version. Returns None when no checkout context applies or
-    the versions agree.
+    """Return a one-line warning when the running substrate's code path is
+    incoherent with the theforge checkout in CWD. Returns None on the documented
+    dogfood happy path (a released RC orchestrating a newer checkout).
 
-    The check is deliberately conservative: it only fires when the CWD is itself
-    a theforge source tree (pyproject.toml ``name = "theforge"``) AND its declared
-    version differs from the running package version. This catches the dominant
-    failure mode (operator runs ``forge sprint`` from theforge's own repo while
-    the installed runtime is a different version) without false-positiving on
-    operators using forge against unrelated projects.
+    The warning fires only when ``sub.editable`` is True — i.e., the running
+    ``forge`` is itself resolving package code out of a source tree — and that
+    source tree's version disagrees with the checkout in CWD. That shape means
+    the operator's ``forge`` is executing code that doesn't match the checkout
+    they're operating on (stale build of this checkout, or an editable install
+    of a *different* theforge repo shadowing this one).
+
+    A non-editable substrate (released wheel) cannot reach into the checkout's
+    source at runtime, so version-string drift between a released RC and a
+    newer dev checkout is the *correct* shape of the dogfood model — not
+    incoherence — and is intentionally silent.
     """
     if sub is None:
         sub = detect_substrate()
@@ -208,6 +213,13 @@ def detect_mismatch(cwd: Path | None = None, sub: Substrate | None = None) -> st
     if 'name = "theforge"' not in text:
         return None
 
+    # Released (non-editable) substrate orchestrating a newer-version theforge
+    # checkout is the documented dogfood model — the orchestrator runtime
+    # never imports the patient's source, so a version-string difference is
+    # expected. Stay silent.
+    if not sub.editable:
+        return None
+
     src_version: str | None = None
     for line in text.splitlines():
         stripped = line.strip()
@@ -222,14 +234,14 @@ def detect_mismatch(cwd: Path | None = None, sub: Substrate | None = None) -> st
     if src_version == sub.version:
         return None
 
-    # If editable and source_root is the same as cwd, the version matches by
-    # definition (importlib reads the same pyproject) — but a stale build can
-    # diverge. Either way, we surface the warning.
+    source_note = f" editable source @ {sub.source_root};" if sub.source_root else ""
     return (
-        f"[forge] WARNING: substrate version {sub.version} (binary: {sub.binary}) "
-        f"does not match this checkout's pyproject version {src_version} "
-        f"(cwd: {cwd}). Editable installs may need `pip install -e .` to refresh; "
-        "released installs may need re-cutting. Pass --force to bypass."
+        f"[forge] WARNING: substrate version {sub.version} (binary: {sub.binary});"
+        f"{source_note} does not match this checkout's pyproject version "
+        f"{src_version} (cwd: {cwd}). The editable install resolving as `forge` "
+        f"is out of sync with this checkout — either a stale build of this tree "
+        f"or an editable install of a different theforge repo is shadowing it. "
+        f"Pass --force to bypass."
     )
 
 

--- a/tests/test_cli_substrate.py
+++ b/tests/test_cli_substrate.py
@@ -67,15 +67,37 @@ def test_detect_mismatch_returns_none_when_versions_match(tmp_path: Path) -> Non
     assert detect_mismatch(cwd=tmp_path, sub=_sub(version="0.10.0rc12")) is None
 
 
-def test_detect_mismatch_warns_on_version_divergence(tmp_path: Path) -> None:
+def test_detect_mismatch_warns_on_editable_version_divergence(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text(
         '[project]\nname = "theforge"\nversion = "0.11.0.dev"\n'
     )
-    warning = detect_mismatch(cwd=tmp_path, sub=_sub(version="0.10.0rc12"))
+    sub = _sub(
+        version="0.10.0rc12",
+        editable=True,
+        source_root="/some/other/theforge",
+    )
+    warning = detect_mismatch(cwd=tmp_path, sub=sub)
     assert warning is not None
     assert "0.10.0rc12" in warning
     assert "0.11.0.dev" in warning
     assert "--force" in warning
+    # Remediation must not nudge the operator toward editable-main, which
+    # contradicts the dogfood model.
+    assert "pip install -e" not in warning
+
+
+def test_detect_mismatch_silent_for_released_substrate_on_newer_checkout(
+    tmp_path: Path,
+) -> None:
+    """Documented dogfood happy path: released RC orchestrating a newer
+    checkout. A non-editable substrate cannot import the patient's source, so
+    a version-string difference is not incoherence and must not warn.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "theforge"\nversion = "0.10.0.dev0"\n'
+    )
+    sub = _sub(version="0.10.0rc14", editable=False)
+    assert detect_mismatch(cwd=tmp_path, sub=sub) is None
 
 
 def test_detect_mismatch_returns_none_when_no_pyproject(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The change silences the documented dogfood happy path while preserving an editable-substrate warning and removing the bad remediation advice.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.71
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Substrate-version warning fires on the documented dogfood model state (released RC orchestrating newer checkout) (GitHub Issue #1529)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1529