### PR TITLE
cut-rc.sh launcher repoint is too coarse: refuses even when the existing forge would be safely overwritten

### DIFF
--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -238,10 +238,19 @@ if [[ "$NO_INSTALL" == false ]]; then
     # --- 10. Repoint the operator's managed `forge` launcher at the cut RC ---
     #
     # The cut establishes plain `forge` as the just-cut RC by atomically
-    # swapping a forge-managed symlink. We refuse to overwrite a launcher
-    # that lives inside a Python environment's bin/ (editable install,
-    # pipx shim, etc.), since pip would later regenerate that file and
-    # break the binding silently.
+    # swapping a forge-managed symlink at $MANAGED_LAUNCHER. If plain
+    # `forge` currently resolves into a Python environment's bin/, the
+    # symlink itself doesn't overwrite that file — but we still want to
+    # reason about what we're displacing on PATH, since a pip-managed
+    # console script for an unrelated package would later regenerate
+    # itself and silently shadow the symlink.
+    #
+    # Three-way discrimination on the existing in-venv launcher:
+    #   - Same RC as we're cutting: clobber is identity, proceed silently.
+    #   - Different theforge version: print one-line note (the operator's
+    #     env install is still importable as `python -m theforge`).
+    #   - Unrecognized (no importable theforge, or probe failed): refuse,
+    #     since we cannot reason about what we're displacing.
     echo "==> Repointing plain \`forge\` at $RC_TAG ($MANAGED_LAUNCHER -> $RC_ENV_FORGE)..."
     if [[ "$DRY_RUN" == false ]]; then
         CURRENT_FORGE="$(command -v forge 2>/dev/null || true)"
@@ -250,24 +259,46 @@ if [[ "$NO_INSTALL" == false ]]; then
             if [[ -f "${CURRENT_FORGE_DIR}/activate" \
                   || -f "${CURRENT_FORGE_DIR}/../pyvenv.cfg" \
                   || -f "${CURRENT_FORGE_DIR}/activate.fish" ]]; then
-                echo "" >&2
-                echo "Error: plain \`forge\` currently resolves to" >&2
-                echo "         $CURRENT_FORGE" >&2
-                echo "       which lives inside a Python environment's bin/." >&2
-                echo "       Replacing it would clobber a pip-generated console" >&2
-                echo "       script (e.g. an editable install of source); a later" >&2
-                echo "       \`pip install -e .\` in that environment would regenerate" >&2
-                echo "       the launcher and silently break the cut-RC binding." >&2
-                echo "" >&2
-                echo "       The cut RC is installed and verified at:" >&2
-                echo "         $RC_ENV_FORGE" >&2
-                echo "" >&2
-                echo "       To make plain \`forge\` track cut RCs, ensure" >&2
-                echo "         $MANAGED_LAUNCHER_DIR" >&2
-                echo "       is on PATH ahead of any Python environment's bin/" >&2
-                echo "       (deactivate the venv or reorder PATH), then re-run:" >&2
-                echo "         scripts/cut-rc.sh $VERSION $RC_NUM" >&2
-                exit 1
+                CURRENT_FORGE_PY=""
+                if [[ -x "${CURRENT_FORGE_DIR}/python" ]]; then
+                    CURRENT_FORGE_PY="${CURRENT_FORGE_DIR}/python"
+                elif [[ -x "${CURRENT_FORGE_DIR}/python3" ]]; then
+                    CURRENT_FORGE_PY="${CURRENT_FORGE_DIR}/python3"
+                fi
+                INSTALLED_THEFORGE_VERSION=""
+                if [[ -n "$CURRENT_FORGE_PY" ]]; then
+                    INSTALLED_THEFORGE_VERSION="$("$CURRENT_FORGE_PY" -c 'import importlib.metadata as m; print(m.version("theforge"))' 2>/dev/null || true)"
+                fi
+
+                if [[ -z "$INSTALLED_THEFORGE_VERSION" ]]; then
+                    echo "" >&2
+                    echo "Error: plain \`forge\` currently resolves to" >&2
+                    echo "         $CURRENT_FORGE" >&2
+                    echo "       which lives inside a Python environment's bin/," >&2
+                    echo "       but that environment has no importable \`theforge\`" >&2
+                    echo "       distribution (probe via ${CURRENT_FORGE_PY:-<no python found in that bin/>}" >&2
+                    echo "       returned no version). The script cannot reason about" >&2
+                    echo "       what \`forge\` actually is — it may be a console script" >&2
+                    echo "       for an unrelated package, a hand-written wrapper, or" >&2
+                    echo "       an editable install of a different repo. Refusing to" >&2
+                    echo "       proceed rather than silently displace it on PATH." >&2
+                    echo "" >&2
+                    echo "       The cut RC is installed and verified at:" >&2
+                    echo "         $RC_ENV_FORGE" >&2
+                    echo "" >&2
+                    echo "       If you want plain \`forge\` to track cut RCs, ensure" >&2
+                    echo "         $MANAGED_LAUNCHER_DIR" >&2
+                    echo "       is on PATH ahead of $CURRENT_FORGE_DIR, then re-run:" >&2
+                    echo "         scripts/cut-rc.sh $VERSION $RC_NUM" >&2
+                    exit 1
+                elif [[ "$INSTALLED_THEFORGE_VERSION" == "$RC_VERSION" ]]; then
+                    echo "    note: plain \`forge\` already resolves to theforge==$RC_VERSION"
+                    echo "          in $CURRENT_FORGE_DIR; repoint is identity. Proceeding."
+                else
+                    echo "    note: taking over plain \`forge\`; theforge==$INSTALLED_THEFORGE_VERSION"
+                    echo "          in $CURRENT_FORGE_DIR is still importable as"
+                    echo "          \`$CURRENT_FORGE_PY -m theforge\`."
+                fi
             fi
         fi
 

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -282,12 +282,17 @@ if [[ "$NO_INSTALL" == false ]]; then
                 # An env can have theforge installed while CURRENT_FORGE itself
                 # is a hand-written wrapper or a console script for a different
                 # package. Identify CURRENT_FORGE as the theforge console
-                # script by grepping for theforge.cli (pyproject.toml has
+                # script by requiring an actual non-comment Python import
+                # line — pyproject.toml has
                 # [project.scripts] forge = "theforge.cli:main", so every
-                # pip-generated console script contains this import literal).
+                # pip-generated console script contains a literal
+                # `from theforge.cli import main` (or `import theforge`) at
+                # column 0. Comments and incidental text (e.g. a shell
+                # wrapper with `# copied from theforge`) must not satisfy
+                # the check.
                 CURRENT_FORGE_IS_THEFORGE=false
                 if [[ -f "$CURRENT_FORGE" ]] \
-                   && grep -q -E 'theforge\.cli|from[[:space:]]+theforge' "$CURRENT_FORGE" 2>/dev/null; then
+                   && grep -q -E '^[[:space:]]*(from|import)[[:space:]]+theforge([[:space:].]|$)' "$CURRENT_FORGE" 2>/dev/null; then
                     CURRENT_FORGE_IS_THEFORGE=true
                 fi
 
@@ -304,7 +309,8 @@ if [[ "$NO_INSTALL" == false ]]; then
                         echo "       and that environment has theforge==$INSTALLED_THEFORGE_VERSION" >&2
                         echo "       installed, but the launcher file itself does not look" >&2
                         echo "       like theforge's pip-generated console script (no" >&2
-                        echo "       \`theforge.cli\` / \`from theforge\` reference inside)." >&2
+                        echo "       non-comment \`from theforge\` / \`import theforge\` line" >&2
+                        echo "       at column 0; incidental comment text does not count)." >&2
                     fi
                     echo "       The script cannot reason about what \`forge\` actually" >&2
                     echo "       is — it may be a console script for an unrelated" >&2

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -279,18 +279,38 @@ if [[ "$NO_INSTALL" == false ]]; then
                     INSTALLED_THEFORGE_VERSION="$("$CURRENT_FORGE_PY" -c 'import importlib.metadata as m; print(m.version("theforge"))' 2>/dev/null || true)"
                 fi
 
-                if [[ -z "$INSTALLED_THEFORGE_VERSION" ]]; then
+                # An env can have theforge installed while CURRENT_FORGE itself
+                # is a hand-written wrapper or a console script for a different
+                # package. Identify CURRENT_FORGE as the theforge console
+                # script by grepping for theforge.cli (pyproject.toml has
+                # [project.scripts] forge = "theforge.cli:main", so every
+                # pip-generated console script contains this import literal).
+                CURRENT_FORGE_IS_THEFORGE=false
+                if [[ -f "$CURRENT_FORGE" ]] \
+                   && grep -q -E 'theforge\.cli|from[[:space:]]+theforge' "$CURRENT_FORGE" 2>/dev/null; then
+                    CURRENT_FORGE_IS_THEFORGE=true
+                fi
+
+                if [[ -z "$INSTALLED_THEFORGE_VERSION" || "$CURRENT_FORGE_IS_THEFORGE" == false ]]; then
                     echo "" >&2
                     echo "Error: plain \`forge\` currently resolves to" >&2
                     echo "         $CURRENT_FORGE" >&2
                     echo "       which lives inside a Python environment's bin/," >&2
-                    echo "       but that environment has no importable \`theforge\`" >&2
-                    echo "       distribution (probe via ${CURRENT_FORGE_PY:-<no python found in that bin/>}" >&2
-                    echo "       returned no version). The script cannot reason about" >&2
-                    echo "       what \`forge\` actually is — it may be a console script" >&2
-                    echo "       for an unrelated package, a hand-written wrapper, or" >&2
-                    echo "       an editable install of a different repo. Refusing to" >&2
-                    echo "       proceed rather than silently displace it on PATH." >&2
+                    if [[ -z "$INSTALLED_THEFORGE_VERSION" ]]; then
+                        echo "       but that environment has no importable \`theforge\`" >&2
+                        echo "       distribution (probe via ${CURRENT_FORGE_PY:-<no python found in that bin/>}" >&2
+                        echo "       returned no version)." >&2
+                    else
+                        echo "       and that environment has theforge==$INSTALLED_THEFORGE_VERSION" >&2
+                        echo "       installed, but the launcher file itself does not look" >&2
+                        echo "       like theforge's pip-generated console script (no" >&2
+                        echo "       \`theforge.cli\` / \`from theforge\` reference inside)." >&2
+                    fi
+                    echo "       The script cannot reason about what \`forge\` actually" >&2
+                    echo "       is — it may be a console script for an unrelated" >&2
+                    echo "       package, a hand-written wrapper, or an editable install" >&2
+                    echo "       of a different repo. Refusing to proceed rather than" >&2
+                    echo "       silently displace it on PATH." >&2
                     echo "" >&2
                     echo "       The cut RC is installed and verified at:" >&2
                     echo "         $RC_ENV_FORGE" >&2
@@ -301,8 +321,8 @@ if [[ "$NO_INSTALL" == false ]]; then
                     echo "         scripts/cut-rc.sh $VERSION $RC_NUM" >&2
                     exit 1
                 elif [[ "$INSTALLED_THEFORGE_VERSION" == "$RC_VERSION" ]]; then
-                    echo "    note: plain \`forge\` already resolves to theforge==$RC_VERSION"
-                    echo "          in $CURRENT_FORGE_DIR; repoint is identity. Proceeding."
+                    # Same RC as we're cutting; repoint is identity. Spec says
+                    # this case completes silently — no note.
                     INVENV_LAUNCHER_VERSION="$INSTALLED_THEFORGE_VERSION"
                     INVENV_LAUNCHER_DIR="$CURRENT_FORGE_DIR"
                 else

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -253,6 +253,15 @@ if [[ "$NO_INSTALL" == false ]]; then
     #     since we cannot reason about what we're displacing.
     echo "==> Repointing plain \`forge\` at $RC_TAG ($MANAGED_LAUNCHER -> $RC_ENV_FORGE)..."
     if [[ "$DRY_RUN" == false ]]; then
+        # Populated by the in-venv probe below when CURRENT_FORGE lives in a
+        # Python env with an importable theforge distribution. The post-repoint
+        # validation below uses this to tolerate a still-shadowing env launcher
+        # whose contents we've already vetted: command -v forge may continue
+        # to return the env binary instead of the managed symlink, but that's
+        # by-design when the env bin precedes ~/.local/bin on PATH and the env
+        # has theforge installed.
+        INVENV_LAUNCHER_VERSION=""
+        INVENV_LAUNCHER_DIR=""
         CURRENT_FORGE="$(command -v forge 2>/dev/null || true)"
         if [[ -n "$CURRENT_FORGE" && "$CURRENT_FORGE" != "$MANAGED_LAUNCHER" ]]; then
             CURRENT_FORGE_DIR="$(dirname "$CURRENT_FORGE")"
@@ -294,10 +303,14 @@ if [[ "$NO_INSTALL" == false ]]; then
                 elif [[ "$INSTALLED_THEFORGE_VERSION" == "$RC_VERSION" ]]; then
                     echo "    note: plain \`forge\` already resolves to theforge==$RC_VERSION"
                     echo "          in $CURRENT_FORGE_DIR; repoint is identity. Proceeding."
+                    INVENV_LAUNCHER_VERSION="$INSTALLED_THEFORGE_VERSION"
+                    INVENV_LAUNCHER_DIR="$CURRENT_FORGE_DIR"
                 else
                     echo "    note: taking over plain \`forge\`; theforge==$INSTALLED_THEFORGE_VERSION"
                     echo "          in $CURRENT_FORGE_DIR is still importable as"
                     echo "          \`$CURRENT_FORGE_PY -m theforge\`."
+                    INVENV_LAUNCHER_VERSION="$INSTALLED_THEFORGE_VERSION"
+                    INVENV_LAUNCHER_DIR="$CURRENT_FORGE_DIR"
                 fi
             fi
         fi
@@ -308,30 +321,50 @@ if [[ "$NO_INSTALL" == false ]]; then
 
         RESOLVED_FORGE="$(command -v forge 2>/dev/null || true)"
         if [[ "$RESOLVED_FORGE" != "$MANAGED_LAUNCHER" ]]; then
-            echo "" >&2
-            echo "Error: after repointing, plain \`forge\` resolves to" >&2
-            echo "         '${RESOLVED_FORGE:-<not found>}'" >&2
-            echo "       expected '$MANAGED_LAUNCHER'." >&2
-            echo "       Ensure $MANAGED_LAUNCHER_DIR is on PATH ahead of any" >&2
-            echo "       Python environment's bin/, then re-run scripts/cut-rc.sh." >&2
-            exit 1
+            if [[ -z "$INVENV_LAUNCHER_VERSION" ]]; then
+                echo "" >&2
+                echo "Error: after repointing, plain \`forge\` resolves to" >&2
+                echo "         '${RESOLVED_FORGE:-<not found>}'" >&2
+                echo "       expected '$MANAGED_LAUNCHER'." >&2
+                echo "       Ensure $MANAGED_LAUNCHER_DIR is on PATH ahead of any" >&2
+                echo "       Python environment's bin/, then re-run scripts/cut-rc.sh." >&2
+                exit 1
+            fi
+            # The in-venv probe vetted what plain `forge` resolves to; the env
+            # bin precedes $MANAGED_LAUNCHER_DIR on PATH. Don't require the
+            # symlink to win — it's installed and reachable; PATH ordering is
+            # the operator's call.
         fi
 
         PLAIN_OUTPUT=$(forge version 2>&1 || echo "")
         PLAIN_VERSION=$(echo "$PLAIN_OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*' | head -1)
         if [[ "$PLAIN_VERSION" != *"$RC_VERSION"* ]]; then
-            echo "" >&2
-            echo "Error: plain \`forge version\` reports '$PLAIN_VERSION'," >&2
-            echo "       expected to contain $RC_VERSION." >&2
-            echo "       The managed launcher symlink may be broken; investigate" >&2
-            echo "         $MANAGED_LAUNCHER" >&2
-            echo "         $RC_ENV_FORGE" >&2
-            exit 1
+            if [[ -n "$INVENV_LAUNCHER_VERSION" \
+                  && "$PLAIN_VERSION" == *"$INVENV_LAUNCHER_VERSION"* ]]; then
+                # Symlink is in place; plain `forge` still runs the env's
+                # theforge==<old version> because PATH puts the env bin first.
+                # This is the documented dogfood state — not an error; just
+                # tell the operator how to switch over.
+                echo "    managed launcher : $MANAGED_LAUNCHER -> $RC_ENV_FORGE"
+                echo "    forge version    : $PLAIN_VERSION (env install at $INVENV_LAUNCHER_DIR; shadows symlink)"
+                echo "    note: to make plain \`forge\` track $RC_TAG, either reorder PATH"
+                echo "          so $MANAGED_LAUNCHER_DIR precedes $INVENV_LAUNCHER_DIR,"
+                echo "          or \`pip install theforge==$RC_VERSION\` in that env."
+                echo "    ✓ $RC_TAG symlink installed; substrate is isolated."
+            else
+                echo "" >&2
+                echo "Error: plain \`forge version\` reports '$PLAIN_VERSION'," >&2
+                echo "       expected to contain $RC_VERSION." >&2
+                echo "       The managed launcher symlink may be broken; investigate" >&2
+                echo "         $MANAGED_LAUNCHER" >&2
+                echo "         $RC_ENV_FORGE" >&2
+                exit 1
+            fi
+        else
+            echo "    managed launcher : $MANAGED_LAUNCHER -> $RC_ENV_FORGE"
+            echo "    forge version    : $PLAIN_VERSION"
+            echo "    ✓ plain \`forge\` now tracks $RC_TAG; substrate is isolated."
         fi
-
-        echo "    managed launcher : $MANAGED_LAUNCHER -> $RC_ENV_FORGE"
-        echo "    forge version    : $PLAIN_VERSION"
-        echo "    ✓ plain \`forge\` now tracks $RC_TAG; substrate is isolated."
     fi
 else
     echo "==> Skipping verification install (--no-install)."

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -554,7 +554,23 @@ def _build_cut_rc_fixture(
     (fake_venv / "bin").mkdir(parents=True)
     (fake_venv / "pyvenv.cfg").write_text("home = /usr/bin\n")
     venv_forge = fake_venv / "bin" / "forge"
-    venv_forge.write_text("#!/bin/sh\necho 'in-venv forge'\n")
+    if installed_theforge_version is not None:
+        # Make `forge version` report the env's installed theforge version so
+        # the post-repoint plain-version check has something realistic to
+        # match against, even when this binary still wins PATH after the
+        # symlink is created.
+        venv_forge.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                if [ "$1" = "version" ]; then
+                    echo "TheForge v{installed_theforge_version}"
+                fi
+                """
+            )
+        )
+    else:
+        venv_forge.write_text("#!/bin/sh\necho 'in-venv forge'\n")
     venv_forge.chmod(0o755)
     venv_python = fake_venv / "bin" / "python"
     if installed_theforge_version is not None:
@@ -584,11 +600,11 @@ def _build_cut_rc_fixture(
 
     env = os.environ.copy()
     env["HOME"] = str(fake_home)
-    # fake_venv ahead of ~/.local/bin so the venv's forge is the
-    # CURRENT_FORGE the script discovers; the managed-launcher dir is
-    # still on PATH so the post-repoint resolution can find the symlink
-    # once we put one there.
-    env["PATH"] = f"{fake_home}/.local/bin:{fake_venv}/bin:{bin_dir}:/usr/bin:/bin"
+    # fake_venv/bin is AHEAD of $MANAGED_LAUNCHER_DIR. This is the documented
+    # dogfood operator state (pyenv on PATH ahead of ~/.local/bin) — the
+    # post-repoint check must NOT require the symlink to win PATH for the
+    # in-venv-with-theforge case.
+    env["PATH"] = f"{fake_venv}/bin:{fake_home}/.local/bin:{bin_dir}:/usr/bin:/bin"
     env.pop("VIRTUAL_ENV", None)
 
     script_copy = tmp_path / "cut-rc.sh"
@@ -679,8 +695,13 @@ def test_venv_resident_forge_with_different_theforge_proceeds_with_note(
     assert "0.10.0rc12" in combined
     assert "-m theforge" in combined
     assert str(fake_venv / "bin" / "python") in combined
-    # No "uninstall theforge" remediation must appear anywhere.
+    # Because fake_venv/bin precedes ~/.local/bin on PATH, plain `forge` still
+    # resolves to the env launcher (which reports 0.10.0rc12). The script must
+    # surface that shadowing and tell the operator how to switch, without
+    # erroring out and without recommending "uninstall" / "deactivate".
+    assert "shadow" in combined.lower() or "precedes" in combined.lower()
     assert "uninstall" not in combined.lower()
+    assert "deactivate" not in combined.lower()
 
 
 @pytest.mark.skipif(

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -558,11 +558,15 @@ def _build_cut_rc_fixture(
         # Make `forge version` report the env's installed theforge version so
         # the post-repoint plain-version check has something realistic to
         # match against, even when this binary still wins PATH after the
-        # symlink is created.
+        # symlink is created. Embed the `from theforge.cli import main` marker
+        # the script greps for so this stub identifies as theforge's
+        # pip-generated console script.
         venv_forge.write_text(
             textwrap.dedent(
                 f"""\
                 #!/bin/sh
+                # emulated pip-generated console script:
+                # from theforge.cli import main
                 if [ "$1" = "version" ]; then
                     echo "TheForge v{installed_theforge_version}"
                 fi
@@ -652,9 +656,74 @@ def test_venv_resident_forge_with_same_rc_proceeds(tmp_path: Path) -> None:
     )
     managed_launcher = fake_home / ".local" / "bin" / "forge"
     assert managed_launcher.is_symlink(), f"managed launcher must be created. Output:\n{combined}"
-    # No "uninstall theforge" remediation must appear anywhere.
+    # No "uninstall" / "deactivate" / "re-run" remediation must appear.
     assert "uninstall" not in combined.lower()
     assert "deactivate" not in combined.lower()
+    # Spec: the same-RC path completes silently — no identity note about
+    # what the env already has, no takeover note, no shadowing note.
+    assert "repoint is identity" not in combined
+    assert "taking over plain" not in combined
+    assert "shadow" not in combined.lower()
+
+
+@pytest.mark.network_integration
+@pytest.mark.skipif(
+    not SCRIPT.exists(),
+    reason="cut-rc.sh not present",
+)
+def test_venv_resident_forge_with_theforge_installed_but_foreign_launcher_refuses(
+    tmp_path: Path,
+) -> None:
+    """An environment can have ``theforge`` importable while its ``bin/forge``
+    is a hand-written wrapper or a console script for a different package.
+    In that case the cut script must still refuse — having theforge in the
+    env is not sufficient to vet what plain ``forge`` actually does.
+    """
+    script_copy, env, fake_home, fake_venv = _build_cut_rc_fixture(
+        tmp_path, installed_theforge_version="0.10.0rc12"
+    )
+    # Overwrite the venv's forge with a wrapper that does NOT mention
+    # theforge.cli (i.e., it's not the pip-generated console script). The
+    # env still has theforge importable per the python shim, but bin/forge
+    # is foreign.
+    venv_forge = fake_venv / "bin" / "forge"
+    venv_forge.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            # hand-written wrapper for some other tool; no theforge reference
+            echo "not-theforge-launcher"
+            exit 0
+            """
+        )
+    )
+    venv_forge.chmod(0o755)
+    venv_forge_pre_bytes = venv_forge.read_bytes()
+
+    repo = tmp_path / "fake_repo"
+    proc = subprocess.run(
+        ["bash", str(script_copy), "0.99.0", "0"],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        "cut-rc.sh must refuse when bin/forge is not identifiable as the "
+        "theforge console script, even if the env has theforge importable. "
+        f"Output:\n{combined}"
+    )
+    # Operator's bin/forge must not be touched.
+    assert venv_forge.read_bytes() == venv_forge_pre_bytes
+    # Managed launcher must not be created.
+    managed_launcher = fake_home / ".local" / "bin" / "forge"
+    assert not managed_launcher.exists()
+    # The diagnostic must explain the bin/forge mismatch and reference the
+    # installed-but-not-the-launcher condition.
+    assert "theforge.cli" in combined or "from theforge" in combined
+    assert "0.10.0rc12" in combined
 
 
 @pytest.mark.network_integration

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -456,11 +456,231 @@ def test_full_execution_refuses_to_clobber_venv_resident_forge(tmp_path: Path) -
     )
     # Operator's venv forge must not have been touched.
     assert venv_forge.read_bytes() == venv_forge_pre_bytes
-    # The error message must guide the operator.
+    # The error message must guide the operator and explain why (no
+    # importable theforge in that env).
     assert "inside a Python environment" in combined
+    assert "no importable" in combined or "cannot reason" in combined
     # The managed launcher must NOT have been created.
     managed_launcher = fake_home / ".local" / "bin" / "forge"
     assert not managed_launcher.exists()
+
+
+def _build_cut_rc_fixture(
+    tmp_path: Path,
+    installed_theforge_version: str | None,
+) -> tuple[Path, dict[str, str], Path, Path]:
+    """Shared fixture builder for the venv-resident-forge discrimination tests.
+
+    Constructs a fake repo, a hermetic PATH with shimmed gh/make/git/python3,
+    and a fake operator venv whose ``bin/forge`` is a fake console script. If
+    ``installed_theforge_version`` is not None, the fake venv's ``bin/python``
+    answers ``importlib.metadata.version('theforge')`` with that string.
+
+    Returns (script_copy_path, env_dict, fake_home, fake_venv).
+    """
+    repo = tmp_path / "fake_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "pyproject.toml").write_text('version = "0.99.0"\n')
+    (repo / "Makefile").write_text("gate:\n\t@true\n")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
+
+    real_git = subprocess.run(
+        ["bash", "-c", "command -v git"], capture_output=True, text=True
+    ).stdout.strip()
+
+    bin_dir = tmp_path / "shim_bin"
+    bin_dir.mkdir()
+    (bin_dir / "gh").write_text("#!/bin/sh\nexit 0\n")
+    (bin_dir / "gh").chmod(0o755)
+    (bin_dir / "make").write_text("#!/bin/sh\nexit 0\n")
+    (bin_dir / "make").chmod(0o755)
+    git_shim = bin_dir / "git"
+    git_shim.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            case "$1" in
+                push) exit 0 ;;
+                ls-remote) exit 0 ;;
+                pull) exit 0 ;;
+            esac
+            exec {real_git} "$@"
+            """
+        )
+    )
+    git_shim.chmod(0o755)
+
+    pip_log = tmp_path / "pip_calls.log"
+    py_shim = bin_dir / "python3"
+    py_shim.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            if [ "$1" = "-m" ] && [ "$2" = "venv" ]; then
+                VENV="$3"
+                mkdir -p "$VENV/bin"
+                : > "$VENV/pyvenv.cfg"
+                cat > "$VENV/bin/pip" <<'PIP'
+            #!/bin/sh
+            echo "$@" >> "{pip_log}"
+            exit 0
+            PIP
+                chmod +x "$VENV/bin/pip"
+                cat > "$VENV/bin/forge" <<'FORGE'
+            #!/bin/sh
+            if [ "$1" = "version" ]; then
+                echo "TheForge v0.99.0rc0"
+            fi
+            FORGE
+                chmod +x "$VENV/bin/forge"
+                : > "$VENV/bin/python"
+                chmod +x "$VENV/bin/python"
+                exit 0
+            fi
+            exit 0
+            """
+        )
+    )
+    py_shim.chmod(0o755)
+
+    # Fake operator venv. Its bin/python answers importlib.metadata if
+    # installed_theforge_version is provided; otherwise the probe fails.
+    fake_venv = tmp_path / "operator_venv"
+    (fake_venv / "bin").mkdir(parents=True)
+    (fake_venv / "pyvenv.cfg").write_text("home = /usr/bin\n")
+    venv_forge = fake_venv / "bin" / "forge"
+    venv_forge.write_text("#!/bin/sh\necho 'in-venv forge'\n")
+    venv_forge.chmod(0o755)
+    venv_python = fake_venv / "bin" / "python"
+    if installed_theforge_version is not None:
+        venv_python.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                # Minimal stand-in: respond to the cut-rc probe
+                #   python -c 'import importlib.metadata as m; print(m.version("theforge"))'
+                # by emitting the configured version. Any other invocation is a no-op.
+                case "$*" in
+                    *importlib.metadata*theforge*)
+                        echo "{installed_theforge_version}"
+                        exit 0
+                        ;;
+                esac
+                exit 0
+                """
+            )
+        )
+    else:
+        venv_python.write_text("#!/bin/sh\nexit 1\n")
+    venv_python.chmod(0o755)
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".local" / "bin").mkdir(parents=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(fake_home)
+    # fake_venv ahead of ~/.local/bin so the venv's forge is the
+    # CURRENT_FORGE the script discovers; the managed-launcher dir is
+    # still on PATH so the post-repoint resolution can find the symlink
+    # once we put one there.
+    env["PATH"] = f"{fake_home}/.local/bin:{fake_venv}/bin:{bin_dir}:/usr/bin:/bin"
+    env.pop("VIRTUAL_ENV", None)
+
+    script_copy = tmp_path / "cut-rc.sh"
+    script_text = SCRIPT.read_text(encoding="utf-8")
+    script_text = re.sub(
+        r"^export PATH=\"/opt/homebrew/bin:\$PATH\"\s*$",
+        ": # PATH override stripped for hermetic test",
+        script_text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    script_copy.write_text(script_text)
+    script_copy.chmod(0o755)
+
+    return script_copy, env, fake_home, fake_venv
+
+
+@pytest.mark.network_integration
+@pytest.mark.skipif(
+    not SCRIPT.exists(),
+    reason="cut-rc.sh not present",
+)
+def test_venv_resident_forge_with_same_rc_proceeds(tmp_path: Path) -> None:
+    """When plain ``forge`` lives in a Python env that has ``theforge``
+    pip-installed at the SAME version we're cutting, the repoint is
+    identity — the script must proceed silently and the symlink must land.
+    """
+    script_copy, env, fake_home, _fake_venv = _build_cut_rc_fixture(
+        tmp_path, installed_theforge_version="0.99.0rc0"
+    )
+
+    repo = tmp_path / "fake_repo"
+    proc = subprocess.run(
+        ["bash", str(script_copy), "0.99.0", "0"],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, (
+        "cut-rc.sh must proceed when the in-venv forge is the same RC we're cutting. "
+        f"Output:\n{combined}"
+    )
+    managed_launcher = fake_home / ".local" / "bin" / "forge"
+    assert managed_launcher.is_symlink(), f"managed launcher must be created. Output:\n{combined}"
+    # No "uninstall theforge" remediation must appear anywhere.
+    assert "uninstall" not in combined.lower()
+    assert "deactivate" not in combined.lower()
+
+
+@pytest.mark.network_integration
+@pytest.mark.skipif(
+    not SCRIPT.exists(),
+    reason="cut-rc.sh not present",
+)
+def test_venv_resident_forge_with_different_theforge_proceeds_with_note(
+    tmp_path: Path,
+) -> None:
+    """When plain ``forge`` lives in a Python env that has ``theforge``
+    pip-installed at a DIFFERENT version (older RC, dev install, etc.),
+    the script must proceed, emit a one-line takeover note pointing the
+    operator at ``python -m theforge`` for the displaced install, and
+    land the symlink.
+    """
+    script_copy, env, fake_home, fake_venv = _build_cut_rc_fixture(
+        tmp_path, installed_theforge_version="0.10.0rc12"
+    )
+
+    repo = tmp_path / "fake_repo"
+    proc = subprocess.run(
+        ["bash", str(script_copy), "0.99.0", "0"],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, (
+        "cut-rc.sh must proceed (with a note) when the in-venv forge is a "
+        f"different theforge version. Output:\n{combined}"
+    )
+    managed_launcher = fake_home / ".local" / "bin" / "forge"
+    assert managed_launcher.is_symlink()
+    # Takeover note must mention the displaced version and how to reach it.
+    assert "0.10.0rc12" in combined
+    assert "-m theforge" in combined
+    assert str(fake_venv / "bin" / "python") in combined
+    # No "uninstall theforge" remediation must appear anywhere.
+    assert "uninstall" not in combined.lower()
 
 
 @pytest.mark.skipif(

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -558,18 +558,20 @@ def _build_cut_rc_fixture(
         # Make `forge version` report the env's installed theforge version so
         # the post-repoint plain-version check has something realistic to
         # match against, even when this binary still wins PATH after the
-        # symlink is created. Embed the `from theforge.cli import main` marker
-        # the script greps for so this stub identifies as theforge's
-        # pip-generated console script.
+        # symlink is created. The script's vetting check requires a literal
+        # non-comment `from theforge…` / `import theforge…` line at column 0
+        # (the pip-generated console script has `from theforge.cli import main`).
+        # Place that line after `exit 0` so it lives in the file (and the grep
+        # finds it) without breaking shell parsing.
         venv_forge.write_text(
             textwrap.dedent(
                 f"""\
                 #!/bin/sh
-                # emulated pip-generated console script:
-                # from theforge.cli import main
                 if [ "$1" = "version" ]; then
                     echo "TheForge v{installed_theforge_version}"
                 fi
+                exit 0
+                from theforge.cli import main
                 """
             )
         )
@@ -722,8 +724,68 @@ def test_venv_resident_forge_with_theforge_installed_but_foreign_launcher_refuse
     assert not managed_launcher.exists()
     # The diagnostic must explain the bin/forge mismatch and reference the
     # installed-but-not-the-launcher condition.
-    assert "theforge.cli" in combined or "from theforge" in combined
+    assert "from theforge" in combined or "import theforge" in combined
     assert "0.10.0rc12" in combined
+
+
+@pytest.mark.network_integration
+@pytest.mark.skipif(
+    not SCRIPT.exists(),
+    reason="cut-rc.sh not present",
+)
+def test_venv_resident_forge_with_comment_only_theforge_mention_refuses(
+    tmp_path: Path,
+) -> None:
+    """Stronger refusal: a hand-written wrapper whose only mention of
+    theforge is in COMMENT text (no real Python import line at column 0)
+    must still be refused, even when the env has theforge importable.
+    This guards against the loose text-grep regression: ``# copied from
+    theforge`` or ``# uses theforge.cli`` inside a shell wrapper must not
+    be accepted as evidence that bin/forge is the pip-generated console
+    script.
+    """
+    script_copy, env, fake_home, fake_venv = _build_cut_rc_fixture(
+        tmp_path, installed_theforge_version="0.10.0rc12"
+    )
+    # Overwrite bin/forge with a wrapper whose only theforge mention is in
+    # comment lines. No non-comment `from theforge` / `import theforge`
+    # line — must NOT match the strict probe.
+    venv_forge = fake_venv / "bin" / "forge"
+    venv_forge.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            # hand-written wrapper, copied from theforge originally,
+            # references theforge.cli only in this comment text — not a
+            # real `from theforge` import line.
+            echo "wrapper output"
+            exit 0
+            """
+        )
+    )
+    venv_forge.chmod(0o755)
+    venv_forge_pre_bytes = venv_forge.read_bytes()
+
+    repo = tmp_path / "fake_repo"
+    proc = subprocess.run(
+        ["bash", str(script_copy), "0.99.0", "0"],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        "cut-rc.sh must refuse when bin/forge mentions theforge only in "
+        f"comments — not a real import line. Output:\n{combined}"
+    )
+    assert venv_forge.read_bytes() == venv_forge_pre_bytes
+    managed_launcher = fake_home / ".local" / "bin" / "forge"
+    assert not managed_launcher.exists()
+    # Diagnostic must mention the installed-but-not-the-launcher condition,
+    # naming the strict non-comment requirement.
+    assert "non-comment" in combined or "column 0" in combined
 
 
 @pytest.mark.network_integration


### PR DESCRIPTION
## Summary

The prior P1s are resolved; the launcher probe now distinguishes vetted theforge env launchers from foreign or comment-only wrappers, and the focused cut-rc tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $5.44
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

cut-rc.sh launcher repoint is too coarse: refuses even when the existing forge would be safely overwritten (GitHub Issue #1524)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1524