### PR TITLE
cut-rc.sh installs theforge without [all] extra; every cut RC ships a substrate that can't load a default config

### DIFF
--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -253,7 +253,7 @@ if [[ "$NO_INSTALL" == false ]]; then
     fi
     run python3 -m venv "$RC_ENV_DIR"
     run "$RC_ENV_PIP" install --upgrade pip
-    run "$RC_ENV_PIP" install "git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
+    run "$RC_ENV_PIP" install "git+https://github.com/fuzzypete/theforge.git@${RC_TAG}#egg=theforge[all]"
     if [[ "$DRY_RUN" == false ]]; then
         INSTALLED_OUTPUT=$("$RC_ENV_FORGE" version 2>&1 || echo "")
         INSTALLED_VERSION=$(echo "$INSTALLED_OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*' | head -1)
@@ -435,7 +435,7 @@ else
     echo "==> Skipping verification install (--no-install)."
     echo "    To verify manually in an isolated venv:"
     echo "      python3 -m venv \"$RC_ENV_DIR\""
-    echo "      \"$RC_ENV_PIP\" install git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
+    echo "      \"$RC_ENV_PIP\" install git+https://github.com/fuzzypete/theforge.git@${RC_TAG}#egg=theforge[all]"
     echo "      \"$RC_ENV_FORGE\" version"
     echo "      ln -snf \"$RC_ENV_FORGE\" \"$MANAGED_LAUNCHER\""
 fi


### PR DESCRIPTION
## Summary

cut-rc.sh install line now requests theforge[all]; --no-install hint updated to match. Fix directly addresses the eager-SDK-import failure at config-load. Sibling commit fce8386 (#1537) is already-merged noise on the branch.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.68
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

cut-rc.sh installs theforge without [all] extra; every cut RC ships a substrate that can't load a default config (GitHub Issue #1527)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1527