### PR TITLE
Review finding schema cannot represent file-scope P1 findings without a line number

### DIFF
--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -398,16 +398,22 @@ def _run_review_pool(
         'summary: "one-line summary"\n'
         "findings:\n"
         "  - severity: P1 | P2\n"
-        '    file: "path"\n'
-        "    line: <number or null>\n"
-        '    description: "what is wrong"\n'
-        '    suggestion: "how to fix"\n'
+        '    file: "path"   # null for architectural findings\n'
+        "    line: <number or null>   # null for file-scope findings "
+        "(file existence, whole-file state, structural hygiene)\n"
+        '    observed: "what is wrong"\n'
+        '    expected: "category-level rule that generalises"\n'
+        '    evidence: "file path, line, or anchor"\n'
+        '    suggestion: "how to fix (optional)"\n'
         "story_compliance:\n"
         "  matches_spec: true | false\n"
         "  mismatches: []\n"
         "test_coverage:\n"
         "  adequate: true | false\n"
         "  gaps: []\n"
+        "Do not drop a P1 finding to satisfy a line-number requirement: "
+        "line: null is valid when the defect is the existence, absence, mode, "
+        "or whole-file state of the path.\n"
     )
     for i, (name, parsed) in enumerate(zip(names, parsed_results)):
         if not parsed.parse_errors:

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -105,13 +105,10 @@ def validate_review_yaml(data: Any) -> list[str]:
             if file_val is not None and not file_val:
                 errors.append(f"findings[{i}].file must be non-empty for P1 findings")
 
-            # P1 with file set must also cite a specific line to be actionable.
-            # P1 with file: null (architectural finding) does not require a line.
-            if file_val and not finding.get("line"):
-                errors.append(
-                    f"findings[{i}].line must be set for P1 findings with a file — "
-                    f"vague P1s block the pipeline without clear fix targets"
-                )
+            # line may be null even when file is set: file-scope findings
+            # (file existence, mode, whole-file state, structural hygiene) target
+            # the path itself, not a specific source line. Architectural findings
+            # (file: null) also do not require a line.
 
         for prose_field in ("observed", "expected", "evidence"):
             value = finding.get(prose_field)

--- a/tests/test_coord_review_phase_pool.py
+++ b/tests/test_coord_review_phase_pool.py
@@ -146,14 +146,15 @@ class TestCoordinatorSchemaErrorOnRequestChanges:
 
         mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
 
-        # Malformed REQUEST_CHANGES: has P1 finding but story_compliance missing fields
+        # Malformed REQUEST_CHANGES: invalid severity (P0 is not a valid finding severity)
         malformed_review = """\
 ```yaml
 verdict: REQUEST_CHANGES
 summary: "Needs work"
 findings:
-  - severity: P1
+  - severity: P0
     file: src/foo.py
+    line: 10
     observed: "Bug"
     expected: "Behaviour conforms to project contract for this category of inputs."
     evidence: "(test fixture evidence)"

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -87,6 +87,38 @@ class TestParseReviewOutput:
         assert result.test_adequate is False
         assert len(result.test_gaps) == 1
 
+    def test_file_scope_p1_with_null_line_parses_cleanly(self):
+        """File-scope P1 (file existence) with line: null preserves REQUEST_CHANGES."""
+        text = (
+            "```yaml\n"
+            "verdict: REQUEST_CHANGES\n"
+            'summary: "Scratch file at repo root"\n'
+            "findings:\n"
+            "  - severity: P1\n"
+            "    file: test_script.sh\n"
+            "    line: null\n"
+            '    observed: "Scratch shell script committed at repo root"\n'
+            '    expected: "Repo root contains only tracked project artefacts; '
+            'transient scratch files must not be committed."\n'
+            '    evidence: "test_script.sh"\n'
+            '    suggestion: "Delete the file"\n'
+            "story_compliance:\n"
+            "  matches_spec: false\n"
+            "  mismatches: []\n"
+            "test_coverage:\n"
+            "  adequate: true\n"
+            "  gaps: []\n"
+            "ac_verification: []\n"
+            "```\n"
+        )
+        result = parse_review_output(text)
+        assert result.parse_errors == []
+        assert result.verdict == "REQUEST_CHANGES"
+        assert len(result.findings) == 1
+        assert result.findings[0].severity == "P1"
+        assert result.findings[0].file == "test_script.sh"
+        assert result.findings[0].line is None
+
     def test_bare_yaml_no_fences(self):
         bare = (
             "verdict: APPROVE\n"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -151,23 +151,24 @@ class TestValidateReviewYaml:
         assert len(errors) == 1
         assert "mapping" in errors[0]
 
-    def test_p1_with_file_and_null_line_is_error(self):
-        """P1 finding with file set and line: null must be a validation error."""
+    def test_p1_with_file_and_null_line_is_valid(self):
+        """P1 file-scope finding (file existence/whole-file state) with line: null
+        is valid — the defect is the file itself, not a specific source line."""
         data = _valid_review()
         data["verdict"] = "REQUEST_CHANGES"
         data["findings"] = [
             {
                 "severity": "P1",
-                "file": "src/foo.py",
+                "file": "test_script.sh",
                 "line": None,
-                "observed": "Bug here",
-                "suggestion": "Fix it",
+                "observed": "Scratch file committed at repo root",
+                "suggestion": "Delete the file",
                 "expected": "project-contract category rule (test fixture)",
                 "evidence": "(test fixture evidence)",
             }
         ]
         errors = validate_review_yaml(data)
-        assert any("line" in e for e in errors)
+        assert errors == []
 
     def test_p1_with_null_file_and_null_line_is_valid(self):
         """P1 finding with file: null and line: null is valid (architectural finding)."""


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change accepts file-scope P1 findings with line:null and keeps retry guidance aligned with that contract. | [google-gemini-3.1-pro-preview] Fixes schema validation to allow file-scope P1 findings without a line number

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.97
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Review finding schema cannot represent file-scope P1 findings without a line number (GitHub Issue #1500)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1500