### PR TITLE
All reviewers unparseable routes through a synthetic dev finding and escalates as no-changes

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from theforge.config import MODEL_REGISTRY, ForgeConfig, apply_model_info
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.review import (
-    ReviewFinding,
     ReviewResult,
     _best_individual_result,
     review_to_dev_handoff,
@@ -293,11 +292,25 @@ class _ReviewOutcome(Enum):
 # ── Review-phase helpers ──────────────────────────────────────────────
 
 
+REVIEW_INFRASTRUCTURE_PARSE_FAILURE_REASON = (
+    "Review infrastructure failure: all reviewers failed to produce parseable output. "
+    "This is a review-layer defect, not an implementation defect — DEV cannot resolve it. "
+    "Manual review required."
+)
+
+
 def _apply_review_parse_fallback(
     candidate: ReviewResult,
     individual_results: list[ReviewResult],
-) -> ReviewResult:
-    """Fall back from a merged candidate with parse errors to best individual or synthetic P1."""
+) -> ReviewResult | None:
+    """Fall back from a merged candidate with parse errors to best individual result.
+
+    Returns the candidate unchanged when it has no parse errors. When the merged
+    candidate has parse errors, returns the best parseable individual result if any
+    reviewer produced one. Returns None when no reviewer produced parseable output —
+    callers must treat this as a review-infrastructure failure and escalate directly
+    rather than routing the run back through DEV with a synthetic finding.
+    """
     if not candidate.parse_errors:
         return candidate
     _log(
@@ -308,37 +321,8 @@ def _apply_review_parse_fallback(
     if _fallback is not None:
         _log(f"  ↩ using best individual result: {_fallback.verdict}")
         return _fallback
-    _log(
-        "  ⚠ all reviewers failed to produce usable output — "
-        "injecting synthetic P1, returning REQUEST_CHANGES"
-    )
-    return ReviewResult(
-        verdict="REQUEST_CHANGES",
-        summary="Review pool failed to produce a usable verdict",
-        findings=[
-            ReviewFinding(
-                severity="P1",
-                file="",
-                line=None,
-                observed=(
-                    "All reviewers failed to produce parseable output. Manual review required."
-                ),
-                expected=(
-                    "The review pool must produce a parseable verdict from at least one "
-                    "reviewer so the pipeline can make an automated decision; a fully "
-                    "unparseable cycle stalls the run regardless of the underlying issue."
-                ),
-                evidence="review pool aggregation (no reviewer produced parseable output)",
-                suggestion="Check reviewer logs for details.",
-            )
-        ],
-        story_matches=False,
-        story_mismatches=[],
-        test_adequate=False,
-        test_gaps=[],
-        parse_errors=[],
-        raw_yaml={},
-    )
+    _log("  ✗ all reviewers failed to produce parseable output — escalating directly")
+    return None
 
 
 def _log_review_findings(
@@ -630,6 +614,24 @@ def _run_review_phase(
 
     # ── Graceful empty-merge fallback ─────────────────────────────────
     parsed_review = _apply_review_parse_fallback(_candidate, _individual_results)
+    if parsed_review is None:
+        # All reviewers failed schema parsing. This is a review-infrastructure
+        # failure, not an actionable code finding — escalate directly rather than
+        # injecting a synthetic P1 and looping back through DEV (which cannot fix
+        # reviewer output) only to later surface as a misleading no-changes
+        # escalation.
+        state.phase = Phase.ESCALATE
+        state.error = REVIEW_INFRASTRUCTURE_PARSE_FAILURE_REASON
+        _log(f"✗ ESCALATE   {state.error}")
+        if logger:
+            logger._safe_emit("phase_end", phase="REVIEW", outcome="escalate")
+            logger._safe_emit("escalate", reason=state.error, phase="REVIEW")
+        _escalate_notify(task, state, notify, config)
+        return (
+            _ReviewOutcome.ESCALATE,
+            CoordinatorResult(success=False, phase=state.phase, state=state, message=state.error),
+            config,
+        )
 
     # Valid verdict — increment review cycle counter
     state.review_cycle += 1

--- a/tests/test_coord_review_phase_pool.py
+++ b/tests/test_coord_review_phase_pool.py
@@ -484,7 +484,7 @@ class TestReviewParseRetry:
     def test_all_parse_retries_exhausted(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, mock_review_agent, tmp_path
     ):
-        """All per-reviewer parse retries exhausted → synthetic P1 → cycles exhaust → ESCALATE."""
+        """All per-reviewer parse retries exhausted → direct review-infrastructure ESCALATE."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -497,7 +497,7 @@ class TestReviewParseRetry:
         mock_review_agent.return_value = _make_agent_result()
 
         # Pool always returns unparseable output; run_agent retries also return "Done." (fails)
-        # Synthetic P1 injected → REQUEST_CHANGES → review cycles exhaust → ESCALATE
+        # All reviewers unparseable → direct ESCALATE with review-infrastructure reason
         mock_pool.return_value = [
             _make_agent_result(
                 success=True, output=PARSE_ERROR_OUTPUT, profile_name="review", cost_usd=0.1
@@ -508,8 +508,11 @@ class TestReviewParseRetry:
 
         assert result.success is False
         assert result.phase == Phase.ESCALATE
-        # Escalation is due to review cycles being exhausted, not "unreliable" pool
-        assert "cycles" in result.message.lower() or "exhausted" in result.message.lower()
+        # Escalation reason is review-infrastructure failure, not exhausted cycles or no-changes
+        assert "review infrastructure" in result.message.lower()
+        assert "parseable" in result.message.lower()
+        # Only one review cycle attempted — no DEV iteration for synthetic finding
+        assert result.state.review_cycle == 0
 
     @patch("theforge.coordinator.review_pool.run_agent")
     @patch("theforge.coordinator.review_pool.run_agent_pool")
@@ -630,7 +633,7 @@ class TestReviewPoolResilience:
     def test_max_review_parse_retries_zero_disables_retry(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
-        """max_review_parse_retries=0 → no per-reviewer retry; synthetic P1 injected."""
+        """max_review_parse_retries=0 → no per-reviewer retry; direct infrastructure ESCALATE."""
         from dataclasses import replace as _dc_replace
 
         from theforge.config import RetryPolicy
@@ -654,9 +657,10 @@ class TestReviewPoolResilience:
 
         result = run_task(config, task)
 
-        # No retries → synthetic P1 → REQUEST_CHANGES → cycles exhaust → ESCALATE
+        # No retries → all reviewers unparseable → direct review-infrastructure ESCALATE
         assert result.success is False
         assert result.phase == Phase.ESCALATE
+        assert "review infrastructure" in result.message.lower()
         # parse_retries == 0 (none attempted)
         assert result.state.review_cycle_metadata[0].parse_retries == 0
 
@@ -705,10 +709,16 @@ class TestReviewPoolResilience:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_synthetic_p1_when_all_reviewers_fail(
+    def test_all_reviewers_unparseable_escalates_as_infrastructure(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, mock_review_agent, tmp_path
     ):
-        """When all reviewers fail to parse and retries fail, synthetic P1 is injected."""
+        """All reviewers unparseable → direct ESCALATE with review-infrastructure reason.
+
+        Regression test for issue #1502: previously the sprint injected a synthetic
+        P1, looped through DEV (which cannot fix reviewer output), and escalated
+        with a misleading no-changes reason. The fix escalates directly at the
+        review layer with a clear infrastructure reason.
+        """
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -727,15 +737,16 @@ class TestReviewPoolResilience:
 
         result = run_task(config, task)
 
-        # Synthetic P1 → REQUEST_CHANGES → cycles exhaust → ESCALATE
+        # All reviewers unparseable → direct ESCALATE at review layer
         assert result.success is False
         assert result.phase == Phase.ESCALATE
-        # At least one review cycle was recorded
-        assert result.state.review_cycle >= 1
-        # The recorded review should have P1 findings (synthetic)
-        last_review = result.state.review_results[-1]
-        assert last_review.verdict == "REQUEST_CHANGES"
-        assert any(f.severity == "P1" for f in last_review.findings)
+        # Reason names review-infrastructure failure, not DEV no-changes or cycles
+        assert "review infrastructure" in result.message.lower()
+        assert "parseable" in result.message.lower()
+        # No review_cycle incremented (escalation happens before increment)
+        assert result.state.review_cycle == 0
+        # No synthetic finding was recorded as an actionable review result
+        assert result.state.review_results == []
 
     @patch("theforge.coordinator.review_pool.run_agent")
     @patch("theforge.coordinator.review_pool.run_agent_pool")


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] All-reviewers-unparseable now escalates at the review layer without recording a synthetic dev-actionable finding. | [google-gemini-3.1-pro-preview] The change correctly escalates review infrastructure failures directly instead of routing through DEV with a synthetic finding.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.05
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

All reviewers unparseable routes through a synthetic dev finding and escalates as no-changes (GitHub Issue #1502)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1502