### PR TITLE
forge shape MVP — classify rough prose and todo:draft into typed work objects

### DIFF
--- a/docs/guides/authoring.md
+++ b/docs/guides/authoring.md
@@ -9,6 +9,24 @@ TheForge's sprint-entry validation as-is.
 You do not need to read the validator's source to follow this guide. Following
 the per-section rules will produce input that passes.
 
+## Shaping rough drafts first
+
+Before an issue can be authored against the rules below, it has to *be the
+right kind of thing*. If you captured a thought with `forge todo` or filed a
+freshly-rough issue without a clear type, run `forge shape <issue>` first.
+
+`forge shape` proposes one of TheForge's typed work objects — bug,
+enhancement, epic, operator-action, documentation, adr-candidate, or
+duplicate/stale — and prints a body restructure. It is **refusal-capable**:
+when confidence is low it keeps the item as `todo:draft` and asks you
+structured ambiguity questions rather than force-classifying. Use `--apply`
+to commit the proposal via `gh`, and `--next` to print the recommended next
+operator command (`forge diagnose`, `forge groom`, etc.). The next command is
+never auto-invoked — you run it.
+
+Once `forge shape` has put the issue in a typed bucket, the per-use-case
+rules below apply.
+
 ## Storage: GitHub issue vs local story file
 
 TheForge accepts the same content in two storage backends:

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -354,6 +354,41 @@ forge init-hooks
 
 ---
 
+## `forge shape`
+
+Classify a rough draft (issue, file, or stdin) into a typed work object —
+`bug`, `enhancement`, `epic`, `operator-action`, `documentation`,
+`adr-candidate`, or `duplicate/stale`. Refusal-capable: low-confidence inputs
+are kept as `todo:draft` with structured ambiguity questions rather than
+force-classified.
+
+```bash
+forge shape <issue>          # classify a GitHub issue
+forge shape --from-brief FILE
+forge shape --from-stdin
+forge shape <issue> --apply  # commit the label + body edits via gh
+forge shape <issue> --next   # print only the recommended next command
+```
+
+**Use this when:** You captured a rough thought (`forge todo`, a brain-dump
+file, or a freshly-filed issue) and need to know what kind of work object it
+should become before grooming or diagnosing it.
+
+**The command never auto-invokes a producer.** `--next` prints a hint
+(`forge diagnose 123`, `forge groom 123`, etc.); it does not run it.
+`--next` output is human-readable in v0.11; no stable machine-readable
+contract is promised yet.
+
+**ADR candidates** receive a proposed slug and title — the ADR file is not
+written. **Epic** classifications may propose child stories in prose; no
+child issues are created.
+
+Every invocation writes a row into the audit substrate's `shape_events`
+table (issue number, input source, classification, confidence, ambiguity
+question count, whether `--apply` mutated the issue).
+
+---
+
 ## `forge audit`
 
 Display a human-readable summary of an audit file.

--- a/src/theforge/cli/main.py
+++ b/src/theforge/cli/main.py
@@ -20,6 +20,7 @@ from theforge.cli import (
     providers,
     review,
     run,
+    shape,
     sprint,
     status,
     telemetry,
@@ -67,6 +68,7 @@ def build_parser() -> argparse.ArgumentParser:
     eval_cmd.register_parser(subparsers)
     todo.register_parser(subparsers)
     diagnose.register_parser(subparsers)
+    shape.register_parser(subparsers)
     migrate_profiles.register_parser(subparsers)
     profiles.register_parser(subparsers)
     status.register_parsers(subparsers)
@@ -105,6 +107,7 @@ def main() -> None:
         "eval-preflight": eval_cmd.cmd_eval_preflight,
         "todo": todo.cmd_todo,
         "diagnose": diagnose.cmd_diagnose,
+        "shape": shape.cmd_shape,
         "migrate-profiles": migrate_profiles.cmd_migrate_profiles,
         "profiles": profiles.cmd_profiles,
         "status": status.cmd_status,

--- a/src/theforge/cli/shape.py
+++ b/src/theforge/cli/shape.py
@@ -19,6 +19,7 @@ from theforge.cli.shared import _find_config
 from theforge.coordinator.shape_audit import emit_shape_event
 from theforge.intake.shape_classify import (
     Classification,
+    Confidence,
     ShapeProposal,
     classify,
 )
@@ -154,135 +155,125 @@ def _apply_to_github(
     return True
 
 
+def _classify_input_source(args: argparse.Namespace) -> str:
+    """Return the canonical input_source for this invocation up-front.
+
+    Computed before any I/O so the audit row can always record where the
+    operator *tried* to read from, even when the load fails (file missing,
+    `gh` unavailable, no input flags given).
+    """
+    if args.from_brief:
+        return "file"
+    if args.from_stdin:
+        return "stdin"
+    if args.issue is not None:
+        return "issue"
+    return "none"
+
+
 def cmd_shape(args: argparse.Namespace) -> int:
     project_root = _project_root(args)
     if project_root is None:
         return 1
 
-    title: str
-    body: str
-    labels: list[str]
-    issue_number: int | None
-    input_source: str
+    input_source = _classify_input_source(args)
+    issue_number: int | None = args.issue if args.issue is not None else None
+    # Default to an unresolved/low-confidence proposal so an early failure
+    # before classification still produces a meaningful audit row.
+    proposal: ShapeProposal = ShapeProposal(
+        classification=Classification.UNRESOLVED,
+        confidence=Confidence.LOW,
+    )
+    apply_mutated = False
 
-    if args.from_brief:
-        brief_path = Path(args.from_brief)
-        if not brief_path.exists():
-            print(f"--from-brief: file not found: {brief_path}", file=sys.stderr)
+    try:
+        title: str
+        body: str
+        labels: list[str]
+
+        if args.from_brief:
+            brief_path = Path(args.from_brief)
+            if not brief_path.exists():
+                print(f"--from-brief: file not found: {brief_path}", file=sys.stderr)
+                return 1
+            title, body, labels = _load_from_file(brief_path)
+        elif args.from_stdin:
+            raw = sys.stdin.read()
+            title, body = _split_title_body(raw)
+            labels = []
+        elif args.issue is not None:
+            loaded = _load_issue(args.issue, project_root)
+            if loaded is None:
+                return 1
+            title, body, labels = loaded
+        else:
+            print(
+                "forge shape: provide an issue number, --from-brief PATH, or --from-stdin",
+                file=sys.stderr,
+            )
             return 1
-        title, body, labels = _load_from_file(brief_path)
-        issue_number = None
-        input_source = "file"
-    elif args.from_stdin:
-        raw = sys.stdin.read()
-        title, body = _split_title_body(raw)
-        labels = []
-        issue_number = None
-        input_source = "stdin"
-    elif args.issue is not None:
-        loaded = _load_issue(args.issue, project_root)
-        if loaded is None:
-            return 1
-        title, body, labels = loaded
-        issue_number = args.issue
-        input_source = "issue"
-    else:
-        print(
-            "forge shape: provide an issue number, --from-brief PATH, or --from-stdin",
-            file=sys.stderr,
+
+        proposal = classify(title, body, labels)
+
+        # --next: print only the operator-facing next command and exit 0.
+        if args.next:
+            print(next_command(proposal, issue_number))
+            return 0
+
+        source_label = (
+            f"#{issue_number} {title!r}".strip()
+            if issue_number is not None
+            else f"brief: {title!r}"
+            if title
+            else "<draft>"
         )
-        return 1
-
-    proposal = classify(title, body, labels)
-
-    # --next: print only the operator-facing next command and exit 0.
-    if args.next:
+        rendered = render_proposal(
+            proposal,
+            source_label=source_label,
+            current_body=body,
+            show_diff=True,
+        )
+        print(rendered, end="")
         print(next_command(proposal, issue_number))
+
+        if args.apply:
+            if proposal.classification is Classification.UNRESOLVED:
+                print(
+                    "--apply refused: classification is unresolved (kept as todo:draft).",
+                    file=sys.stderr,
+                )
+                return 1
+            if issue_number is None:
+                print(
+                    "--apply requires an issue number; --from-brief and --from-stdin "
+                    "cannot mutate.",
+                    file=sys.stderr,
+                )
+                return 1
+            new_body = restructure_body(proposal, body)
+            ok = _apply_to_github(issue_number, proposal, new_body, project_root)
+            if not ok:
+                return 1
+            print(f"Applied proposal to #{issue_number}.")
+            apply_mutated = True
+            return 0
+
+        # Without --apply: non-zero when changes would be needed.
+        needs_change = (
+            proposal.classification is Classification.UNRESOLVED
+            or bool(proposal.proposed_labels)
+            or bool(proposal.removed_labels)
+            or restructure_body(proposal, body) != body
+        )
+        return 1 if needs_change else 0
+    finally:
         _safe_emit(
             project_root,
             issue_number=issue_number,
             input_source=input_source,
             proposal=proposal,
-            apply_mutated=False,
+            apply_mutated=apply_mutated,
         )
-        return 0
-
-    source_label = (
-        f"#{issue_number} {title!r}".strip()
-        if issue_number is not None
-        else f"brief: {title!r}"
-        if title
-        else "<draft>"
-    )
-    rendered = render_proposal(
-        proposal,
-        source_label=source_label,
-        current_body=body,
-        show_diff=True,
-    )
-    print(rendered, end="")
-    print(next_command(proposal, issue_number))
-
-    mutated = False
-    if args.apply:
-        if proposal.classification is Classification.UNRESOLVED:
-            print(
-                "--apply refused: classification is unresolved (kept as todo:draft).",
-                file=sys.stderr,
-            )
-            _safe_emit(
-                project_root,
-                issue_number=issue_number,
-                input_source=input_source,
-                proposal=proposal,
-                apply_mutated=False,
-            )
-            return 1
-        if issue_number is None:
-            print(
-                "--apply requires an issue number; --from-brief and --from-stdin cannot mutate.",
-                file=sys.stderr,
-            )
-            _safe_emit(
-                project_root,
-                issue_number=issue_number,
-                input_source=input_source,
-                proposal=proposal,
-                apply_mutated=False,
-            )
-            return 1
-        new_body = restructure_body(proposal, body)
-        ok = _apply_to_github(issue_number, proposal, new_body, project_root)
-        if not ok:
-            _safe_emit(
-                project_root,
-                issue_number=issue_number,
-                input_source=input_source,
-                proposal=proposal,
-                apply_mutated=False,
-            )
-            return 1
-        print(f"Applied proposal to #{issue_number}.")
-        mutated = True
-
-    _safe_emit(
-        project_root,
-        issue_number=issue_number,
-        input_source=input_source,
-        proposal=proposal,
-        apply_mutated=mutated,
-    )
-
-    if args.apply:
-        return 0
-    # Without --apply: non-zero when changes would be needed.
-    needs_change = (
-        proposal.classification is Classification.UNRESOLVED
-        or bool(proposal.proposed_labels)
-        or bool(proposal.removed_labels)
-        or restructure_body(proposal, body) != body
-    )
-    return 1 if needs_change else 0
 
 
 def _safe_emit(

--- a/src/theforge/cli/shape.py
+++ b/src/theforge/cli/shape.py
@@ -1,0 +1,347 @@
+"""``forge shape`` — classify rough drafts into typed work objects.
+
+Refusal-capable: when the classifier's confidence is low, the command
+keeps the item as ``todo:draft`` and emits structured ambiguity questions
+rather than forcing a classification. Without ``--apply`` it prints a
+diff and exits non-zero; with ``--apply`` it edits the issue via ``gh``.
+The command never auto-invokes a producer (`forge diagnose`, `forge groom`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from theforge.cli.shared import _find_config
+from theforge.coordinator.shape_audit import emit_shape_event
+from theforge.intake.shape_classify import (
+    Classification,
+    ShapeProposal,
+    classify,
+)
+from theforge.intake.shape_render import (
+    next_command,
+    render_proposal,
+    restructure_body,
+)
+
+
+def _project_root(args: argparse.Namespace) -> Path | None:
+    config_path = Path(args.config).resolve() if getattr(args, "config", None) else _find_config()
+    if config_path is None or not config_path.exists():
+        print(
+            "forge.yaml not found. Run 'forge init' to create one, "
+            "or pass --config path/to/forge.yaml",
+            file=sys.stderr,
+        )
+        return None
+    return config_path.parent
+
+
+def _gh(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, cwd=str(cwd), timeout=30)
+
+
+def _load_issue(issue_number: int, cwd: Path) -> tuple[str, str, list[str]] | None:
+    proc = _gh(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "--json",
+            "title,body,labels",
+        ],
+        cwd,
+    )
+    if proc.returncode != 0:
+        err = proc.stderr.strip() or proc.stdout.strip() or "gh issue view failed"
+        print(err, file=sys.stderr)
+        return None
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        print(f"gh issue view returned malformed JSON: {exc}", file=sys.stderr)
+        return None
+    title = str(data.get("title") or "")
+    body = str(data.get("body") or "")
+    labels_raw = data.get("labels") or []
+    labels: list[str] = []
+    for entry in labels_raw:
+        if isinstance(entry, dict):
+            name = entry.get("name")
+            if isinstance(name, str):
+                labels.append(name)
+        elif isinstance(entry, str):
+            labels.append(entry)
+    return title, body, labels
+
+
+def _load_from_file(path: Path) -> tuple[str, str, list[str]]:
+    text = path.read_text(encoding="utf-8")
+    title, body = _split_title_body(text)
+    return title, body, []
+
+
+def _split_title_body(text: str) -> tuple[str, str]:
+    lines = text.splitlines()
+    if not lines:
+        return "", ""
+    first = lines[0].strip()
+    if first.startswith("#"):
+        title = first.lstrip("#").strip()
+        body = "\n".join(lines[1:]).lstrip("\n")
+        return title, body
+    return first, "\n".join(lines[1:]).lstrip("\n")
+
+
+def _apply_to_github(
+    issue_number: int,
+    proposal: ShapeProposal,
+    new_body: str,
+    cwd: Path,
+) -> bool:
+    """Apply label edits + body restructure via gh. Returns True on success."""
+    # Add labels (one --add-label per label keeps gh happy across versions).
+    for label in proposal.proposed_labels:
+        proc = _gh(
+            ["gh", "issue", "edit", str(issue_number), "--add-label", label],
+            cwd,
+        )
+        if proc.returncode != 0:
+            err = proc.stderr.strip() or proc.stdout.strip() or "gh issue edit --add-label failed"
+            print(err, file=sys.stderr)
+            return False
+    for label in proposal.removed_labels:
+        proc = _gh(
+            ["gh", "issue", "edit", str(issue_number), "--remove-label", label],
+            cwd,
+        )
+        if proc.returncode != 0:
+            err = (
+                proc.stderr.strip() or proc.stdout.strip() or "gh issue edit --remove-label failed"
+            )
+            print(err, file=sys.stderr)
+            return False
+    # Body restructure goes via --body-file so we don't have to escape.
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w+", encoding="utf-8", suffix=".md", delete=False) as tmp:
+        tmp.write(new_body)
+        tmp.flush()
+        tmp_path = Path(tmp.name)
+    try:
+        proc = _gh(
+            [
+                "gh",
+                "issue",
+                "edit",
+                str(issue_number),
+                "--body-file",
+                str(tmp_path),
+            ],
+            cwd,
+        )
+        if proc.returncode != 0:
+            err = proc.stderr.strip() or proc.stdout.strip() or "gh issue edit --body-file failed"
+            print(err, file=sys.stderr)
+            return False
+    finally:
+        tmp_path.unlink(missing_ok=True)
+    return True
+
+
+def cmd_shape(args: argparse.Namespace) -> int:
+    project_root = _project_root(args)
+    if project_root is None:
+        return 1
+
+    title: str
+    body: str
+    labels: list[str]
+    issue_number: int | None
+    input_source: str
+
+    if args.from_brief:
+        brief_path = Path(args.from_brief)
+        if not brief_path.exists():
+            print(f"--from-brief: file not found: {brief_path}", file=sys.stderr)
+            return 1
+        title, body, labels = _load_from_file(brief_path)
+        issue_number = None
+        input_source = "file"
+    elif args.from_stdin:
+        raw = sys.stdin.read()
+        title, body = _split_title_body(raw)
+        labels = []
+        issue_number = None
+        input_source = "stdin"
+    elif args.issue is not None:
+        loaded = _load_issue(args.issue, project_root)
+        if loaded is None:
+            return 1
+        title, body, labels = loaded
+        issue_number = args.issue
+        input_source = "issue"
+    else:
+        print(
+            "forge shape: provide an issue number, --from-brief PATH, or --from-stdin",
+            file=sys.stderr,
+        )
+        return 1
+
+    proposal = classify(title, body, labels)
+
+    # --next: print only the operator-facing next command and exit 0.
+    if args.next:
+        print(next_command(proposal, issue_number))
+        _safe_emit(
+            project_root,
+            issue_number=issue_number,
+            input_source=input_source,
+            proposal=proposal,
+            apply_mutated=False,
+        )
+        return 0
+
+    source_label = (
+        f"#{issue_number} {title!r}".strip()
+        if issue_number is not None
+        else f"brief: {title!r}"
+        if title
+        else "<draft>"
+    )
+    rendered = render_proposal(
+        proposal,
+        source_label=source_label,
+        current_body=body,
+        show_diff=True,
+    )
+    print(rendered, end="")
+    print(next_command(proposal, issue_number))
+
+    mutated = False
+    if args.apply:
+        if proposal.classification is Classification.UNRESOLVED:
+            print(
+                "--apply refused: classification is unresolved (kept as todo:draft).",
+                file=sys.stderr,
+            )
+            _safe_emit(
+                project_root,
+                issue_number=issue_number,
+                input_source=input_source,
+                proposal=proposal,
+                apply_mutated=False,
+            )
+            return 1
+        if issue_number is None:
+            print(
+                "--apply requires an issue number; --from-brief and --from-stdin cannot mutate.",
+                file=sys.stderr,
+            )
+            _safe_emit(
+                project_root,
+                issue_number=issue_number,
+                input_source=input_source,
+                proposal=proposal,
+                apply_mutated=False,
+            )
+            return 1
+        new_body = restructure_body(proposal, body)
+        ok = _apply_to_github(issue_number, proposal, new_body, project_root)
+        if not ok:
+            _safe_emit(
+                project_root,
+                issue_number=issue_number,
+                input_source=input_source,
+                proposal=proposal,
+                apply_mutated=False,
+            )
+            return 1
+        print(f"Applied proposal to #{issue_number}.")
+        mutated = True
+
+    _safe_emit(
+        project_root,
+        issue_number=issue_number,
+        input_source=input_source,
+        proposal=proposal,
+        apply_mutated=mutated,
+    )
+
+    if args.apply:
+        return 0
+    # Without --apply: non-zero when changes would be needed.
+    needs_change = (
+        proposal.classification is Classification.UNRESOLVED
+        or bool(proposal.proposed_labels)
+        or bool(proposal.removed_labels)
+        or restructure_body(proposal, body) != body
+    )
+    return 1 if needs_change else 0
+
+
+def _safe_emit(
+    project_root: Path,
+    *,
+    issue_number: int | None,
+    input_source: str,
+    proposal: ShapeProposal,
+    apply_mutated: bool,
+) -> None:
+    try:
+        emit_shape_event(
+            project_root,
+            issue_number=issue_number,
+            input_source=input_source,
+            classification=proposal.classification.value,
+            confidence=proposal.confidence.value,
+            ambiguity_question_count=len(proposal.ambiguity_questions),
+            apply_mutated=apply_mutated,
+            diagnosis_state=(
+                proposal.diagnosis_state.value if proposal.diagnosis_state is not None else None
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 — audit emission is fire-and-forget
+        print(f"[forge shape] audit emission failed: {exc}", file=sys.stderr)
+
+
+def register_parser(subparsers: object) -> None:
+    p = subparsers.add_parser(
+        "shape",
+        help="Classify a rough draft into a typed work object (no auto-mutate without --apply)",
+    )
+    p.add_argument("issue", nargs="?", type=int, help="GitHub issue number to shape")
+    p.add_argument("--config", help="Path to forge.yaml (default: auto-detect)")
+    p.add_argument(
+        "--from-brief",
+        dest="from_brief",
+        help="Path to a freeform brief file instead of an issue",
+    )
+    p.add_argument(
+        "--from-stdin",
+        dest="from_stdin",
+        action="store_true",
+        default=False,
+        help="Read a freeform brief from stdin",
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Apply the proposed label edits + body restructure via gh",
+    )
+    p.add_argument(
+        "--next",
+        action="store_true",
+        default=False,
+        help="Print only the recommended next operator command and exit (never auto-invokes it)",
+    )
+    p.set_defaults(func=cmd_shape)
+
+
+__all__ = ["cmd_shape", "register_parser"]

--- a/src/theforge/coordinator/shape_audit.py
+++ b/src/theforge/coordinator/shape_audit.py
@@ -1,0 +1,123 @@
+"""SQLite event emission for `forge shape` invocations.
+
+The audit substrate's primary table (``audit_records``) is keyed on
+per-sprint runs; a shape invocation is too lightweight to fit that shape.
+This module adds a separate ``shape_events`` table to the same substrate
+file so the v0.11 audit consumers can query ``forge shape`` activity —
+in particular the kept-as-``todo:draft`` rate that signals refusal-
+capability for compound-engineering metrics.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import datetime
+import sqlite3
+from pathlib import Path
+
+from theforge.coordinator.audit_substrate import substrate_path
+
+_SHAPE_EVENTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS shape_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    emitted_at TEXT NOT NULL,
+    issue_number INTEGER,
+    input_source TEXT NOT NULL,
+    classification TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    ambiguity_question_count INTEGER NOT NULL DEFAULT 0,
+    apply_mutated INTEGER NOT NULL DEFAULT 0,
+    diagnosis_state TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_shape_events_emitted_at
+    ON shape_events(emitted_at);
+CREATE INDEX IF NOT EXISTS idx_shape_events_classification
+    ON shape_events(classification);
+"""
+
+VALID_INPUT_SOURCES: frozenset[str] = frozenset({"issue", "file", "stdin"})
+
+
+def _ensure_shape_events(conn: sqlite3.Connection) -> None:
+    conn.executescript(_SHAPE_EVENTS_SCHEMA)
+
+
+def _open_or_create(project_root: Path) -> sqlite3.Connection:
+    path = substrate_path(project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    _ensure_shape_events(conn)
+    return conn
+
+
+def emit_shape_event(
+    project_root: Path,
+    *,
+    issue_number: int | None,
+    input_source: str,
+    classification: str,
+    confidence: str,
+    ambiguity_question_count: int,
+    apply_mutated: bool,
+    diagnosis_state: str | None = None,
+) -> int:
+    """Insert a single shape event row. Returns the new ``id``.
+
+    Emission is best-effort wrt schema migrations on older substrates: the
+    ``shape_events`` table is created idempotently before insert. Callers
+    should treat this as fire-and-forget — they must not let an audit
+    failure interrupt the CLI exit path.
+    """
+    if input_source not in VALID_INPUT_SOURCES:
+        raise ValueError(f"input_source {input_source!r} not in {sorted(VALID_INPUT_SOURCES)}")
+    conn = _open_or_create(project_root)
+    try:
+        cur = conn.execute(
+            "INSERT INTO shape_events("
+            "emitted_at, issue_number, input_source, classification, "
+            "confidence, ambiguity_question_count, apply_mutated, diagnosis_state"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                _now_iso(),
+                issue_number,
+                input_source,
+                classification,
+                confidence,
+                int(ambiguity_question_count),
+                1 if apply_mutated else 0,
+                diagnosis_state,
+            ),
+        )
+        conn.commit()
+        return int(cur.lastrowid or 0)
+    finally:
+        conn.close()
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def count_kept_as_draft(project_root: Path) -> int:
+    """Return the number of shape events whose outcome was UNRESOLVED.
+
+    Used by audit consumers checking refusal-capability metrics.
+    """
+    path = substrate_path(project_root)
+    if not path.exists():
+        return 0
+    conn = sqlite3.connect(str(path))
+    try:
+        _ensure_shape_events(conn)
+        row = conn.execute(
+            "SELECT COUNT(*) FROM shape_events WHERE classification = ?",
+            ("unresolved",),
+        ).fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        conn.close()
+
+
+__all__ = ["emit_shape_event", "count_kept_as_draft", "VALID_INPUT_SOURCES"]

--- a/src/theforge/coordinator/shape_audit.py
+++ b/src/theforge/coordinator/shape_audit.py
@@ -36,7 +36,7 @@ CREATE INDEX IF NOT EXISTS idx_shape_events_classification
     ON shape_events(classification);
 """
 
-VALID_INPUT_SOURCES: frozenset[str] = frozenset({"issue", "file", "stdin"})
+VALID_INPUT_SOURCES: frozenset[str] = frozenset({"issue", "file", "stdin", "none"})
 
 
 def _ensure_shape_events(conn: sqlite3.Connection) -> None:

--- a/src/theforge/intake/clarification.py
+++ b/src/theforge/intake/clarification.py
@@ -1,0 +1,69 @@
+"""Reusable clarification Q&A primitives.
+
+Centralizes the structured ambiguity-question records emitted when a
+producer command (today `forge shape`; later `forge story`/#367 and any
+other refusal-capable surface) needs the operator to disambiguate before
+classification can proceed.
+
+The module is intentionally tiny: a typed record, a registry of canonical
+question codes, and a lookup that returns the questions for a named
+situation. Every callable surface that asks the operator a clarification
+question routes through this registry so the question vocabulary stays
+inspectable in one place instead of accreting silently across commands.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ClarificationQuestion:
+    """A single structured question the operator must answer to proceed.
+
+    ``code`` is the stable identifier audit consumers can group on (so
+    repeat occurrences of the same disambiguation surface are countable);
+    ``text`` is the human-facing wording shown in the CLI.
+    """
+
+    code: str
+    text: str
+
+
+# Canonical question vocabulary. Add new entries here so a single grep
+# enumerates every clarification the system can raise.
+QUESTIONS: dict[str, str] = {
+    "what_kind_of_work": (
+        "What kind of work is this — bug, enhancement, docs, or operator action?"
+    ),
+    "observable_outcome": ("What is the observable outcome that signals this is done?"),
+    "deliverable_kind": ("Is the deliverable code behavior, docs, or an operator decision?"),
+    "agent_completable": ("Should a dev agent be able to complete this without human action?"),
+}
+
+
+# Named situations consumers can request a question set for. Keeps the
+# decision of *which* questions to ask out of the call sites.
+SITUATIONS: dict[str, tuple[str, ...]] = {
+    "no_signal": ("what_kind_of_work", "observable_outcome"),
+    "enhancement_vs_operator_action": ("deliverable_kind", "agent_completable"),
+}
+
+
+def build(codes: tuple[str, ...]) -> tuple[ClarificationQuestion, ...]:
+    """Return ClarificationQuestion records for the given codes.
+
+    Unknown codes raise ``KeyError`` — this is intentional. A typo in a
+    code should surface loudly rather than silently dropping a question.
+    """
+    return tuple(ClarificationQuestion(code=code, text=QUESTIONS[code]) for code in codes)
+
+
+def for_situation(name: str) -> tuple[ClarificationQuestion, ...]:
+    """Return the canonical question set for a named disambiguation situation."""
+    return build(SITUATIONS[name])
+
+
+__all__ = ["ClarificationQuestion", "QUESTIONS", "SITUATIONS", "build", "for_situation"]

--- a/src/theforge/intake/shape_classify.py
+++ b/src/theforge/intake/shape_classify.py
@@ -1,0 +1,331 @@
+"""Heuristic classifier for `forge shape`.
+
+Given a rough draft (issue title + body + labels), proposes one of TheForge's
+typed work-object classifications, a confidence band, and — when confidence
+is low — structured ambiguity questions. Stdlib only.
+
+The classifier is intentionally heuristic-first. Per ADR-0001 and project
+convention, the coordinator does not delegate process decisions to LLMs;
+the LLM-refinement seam used by ``shape_check`` is reserved for fuzzy
+verdicts and is not wired into the shape *command* in this slice.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from theforge.shape_check.parsing import (
+    extract_ac_section,
+    extract_section,
+    has_heading,
+)
+
+
+class Classification(str, Enum):
+    BUG = "bug"
+    ENHANCEMENT = "enhancement"
+    EPIC = "epic"
+    OPERATOR_ACTION = "operator-action"
+    DOCUMENTATION = "documentation"
+    ADR_CANDIDATE = "adr-candidate"
+    DUPLICATE_OR_STALE = "duplicate-or-stale"
+    UNRESOLVED = "unresolved"
+
+
+class Confidence(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class DiagnosisState(str, Enum):
+    NO_DIAGNOSIS = "no-diagnosis"
+    DIAGNOSIS_CAUSE_UNKNOWN = "diagnosis-cause-unknown"
+    DIAGNOSIS_CONFIRMED_CAUSE = "diagnosis-confirmed-cause"
+
+
+@dataclass(frozen=True)
+class AmbiguityQuestion:
+    code: str
+    text: str
+
+
+@dataclass(frozen=True)
+class ShapeProposal:
+    classification: Classification
+    confidence: Confidence
+    diagnosis_state: DiagnosisState | None = None
+    proposed_labels: tuple[str, ...] = ()
+    removed_labels: tuple[str, ...] = ()
+    ambiguity_questions: tuple[AmbiguityQuestion, ...] = ()
+    proposed_adr_slug: str | None = None
+    proposed_adr_title: str | None = None
+    proposed_child_stories: tuple[str, ...] = ()
+    rationale: str = ""
+    proposed_body: str | None = None
+
+    @property
+    def kept_as_todo_draft(self) -> bool:
+        return self.classification is Classification.UNRESOLVED
+
+
+_BUG_TITLE_TOKENS = ("bug:", "fix:", "broken", "regression", "fails", "crashes")
+_DOC_TITLE_TOKENS = ("doc:", "docs:", "documentation:")
+_EPIC_TITLE_TOKENS = ("epic:", "[epic]")
+_ADR_TITLE_TOKENS = ("adr:", "[adr]", "architecture decision")
+_DUP_TITLE_TOKENS = ("duplicate of", "supersedes", "superseded by")
+_OPERATOR_TITLE_TOKENS = (
+    "operator:",
+    "operator action",
+    "human action",
+)
+
+
+def _has_any(text: str, tokens: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(tok in lowered for tok in tokens)
+
+
+def _label_set(labels: list[str]) -> set[str]:
+    return {label.strip().lower() for label in labels if label and label.strip()}
+
+
+def _detect_diagnosis_state(body: str) -> DiagnosisState:
+    section = extract_section(body, r"diagnosis|root cause")
+    if section is None:
+        return DiagnosisState.NO_DIAGNOSIS
+    lowered = section.lower()
+    if "confirmed cause" in lowered or "root cause:" in lowered or "fix:" in lowered:
+        return DiagnosisState.DIAGNOSIS_CONFIRMED_CAUSE
+    if "no diagnosis" in lowered or "not yet" in lowered:
+        return DiagnosisState.NO_DIAGNOSIS
+    return DiagnosisState.DIAGNOSIS_CAUSE_UNKNOWN
+
+
+def _looks_like_bug(title: str, body: str, labels: set[str]) -> bool:
+    if "bug" in labels:
+        return True
+    if _has_any(title, _BUG_TITLE_TOKENS):
+        return True
+    if has_heading(body, r"observed|actual behaviou?r|steps to reproduce"):
+        return True
+    return False
+
+
+def _looks_like_enhancement(title: str, body: str, labels: set[str]) -> bool:
+    if "enhancement" in labels or "story" in labels or "feature" in labels:
+        return True
+    if extract_ac_section(body) is not None:
+        return True
+    return False
+
+
+def _looks_like_epic(title: str, body: str, labels: set[str]) -> bool:
+    if "epic" in labels:
+        return True
+    if _has_any(title, _EPIC_TITLE_TOKENS):
+        return True
+    if has_heading(body, r"child (?:stories|issues)|sub[- ]?issues|tasks?\b"):
+        # Multiple child bullets ⇒ epic-shaped only if several are present.
+        section = extract_section(body, r"child (?:stories|issues)|sub[- ]?issues|tasks?\b") or ""
+        bullets = [line for line in section.splitlines() if line.strip().startswith(("-", "*"))]
+        if len(bullets) >= 2:
+            return True
+    return False
+
+
+def _looks_like_documentation(title: str, body: str, labels: set[str]) -> bool:
+    if "documentation" in labels or "docs" in labels:
+        return True
+    if _has_any(title, _DOC_TITLE_TOKENS):
+        return True
+    if "docs/" in body or "README" in body and "documentation" in body.lower():
+        return True
+    return False
+
+
+def _looks_like_adr_candidate(title: str, body: str, labels: set[str]) -> bool:
+    if "adr" in labels or "adr-candidate" in labels:
+        return True
+    if _has_any(title, _ADR_TITLE_TOKENS):
+        return True
+    if has_heading(body, r"decision|alternatives considered|trade[- ]?offs?"):
+        return True
+    return False
+
+
+def _looks_like_operator_action(title: str, body: str, labels: set[str]) -> bool:
+    if "operator-action" in labels:
+        return True
+    if _has_any(title, _OPERATOR_TITLE_TOKENS):
+        return True
+    if has_heading(body, r"operator action|manual step"):
+        return True
+    return False
+
+
+def _looks_like_duplicate_or_stale(title: str, body: str, labels: set[str]) -> bool:
+    if "duplicate" in labels or "stale" in labels or "wontfix" in labels:
+        return True
+    if _has_any(title, _DUP_TITLE_TOKENS):
+        return True
+    if _has_any(body, ("duplicate of #", "superseded by #", "closing as stale")):
+        return True
+    return False
+
+
+def _slugify(text: str, max_len: int = 60) -> str:
+    text = text.strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = text.strip("-")
+    return text[:max_len] or "adr"
+
+
+def _propose_child_stories(body: str) -> tuple[str, ...]:
+    section = extract_section(body, r"child (?:stories|issues)|sub[- ]?issues|tasks?\b")
+    if section is None:
+        return ()
+    bullets: list[str] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("-", "*")):
+            bullets.append(stripped.lstrip("-* ").strip())
+    return tuple(b for b in bullets if b)
+
+
+def classify(title: str, body: str, labels: list[str]) -> ShapeProposal:
+    """Return a heuristic shape proposal for the given draft.
+
+    The classifier prefers high-confidence single-category matches. When two
+    categories present non-trivial signal, the result is downgraded to
+    ``UNRESOLVED`` with ambiguity questions so the operator can disambiguate
+    rather than being silently force-classified.
+    """
+    title = title or ""
+    body = body or ""
+    label_set = _label_set(labels or [])
+
+    matches: list[Classification] = []
+    if _looks_like_duplicate_or_stale(title, body, label_set):
+        matches.append(Classification.DUPLICATE_OR_STALE)
+    if _looks_like_epic(title, body, label_set):
+        matches.append(Classification.EPIC)
+    if _looks_like_adr_candidate(title, body, label_set):
+        matches.append(Classification.ADR_CANDIDATE)
+    if _looks_like_bug(title, body, label_set):
+        matches.append(Classification.BUG)
+    if _looks_like_enhancement(title, body, label_set):
+        matches.append(Classification.ENHANCEMENT)
+    if _looks_like_documentation(title, body, label_set):
+        matches.append(Classification.DOCUMENTATION)
+    if _looks_like_operator_action(title, body, label_set):
+        matches.append(Classification.OPERATOR_ACTION)
+
+    if not matches:
+        # No signal at all → low confidence; ask the operator.
+        return ShapeProposal(
+            classification=Classification.UNRESOLVED,
+            confidence=Confidence.LOW,
+            ambiguity_questions=_default_ambiguity_questions(),
+            rationale=(
+                "No classifying signal in title, body, or labels — the draft is too thin to shape."
+            ),
+        )
+
+    # Disambiguation rules: enhancement vs operator-action is the most common
+    # operator-pain case, so when both fire we keep as todo:draft and ask.
+    if Classification.ENHANCEMENT in matches and Classification.OPERATOR_ACTION in matches:
+        return ShapeProposal(
+            classification=Classification.UNRESOLVED,
+            confidence=Confidence.LOW,
+            ambiguity_questions=(
+                AmbiguityQuestion(
+                    code="deliverable_kind",
+                    text=("Is the deliverable code behavior, docs, or an operator decision?"),
+                ),
+                AmbiguityQuestion(
+                    code="agent_completable",
+                    text=("Should a dev agent be able to complete this without human action?"),
+                ),
+            ),
+            rationale="could be either operator-action or enhancement",
+        )
+
+    # Confidence: HIGH when exactly one category fires; MEDIUM when a high-
+    # priority category fires alongside a low-priority one; otherwise the
+    # caller already handled UNRESOLVED above.
+    primary = matches[0]
+    confidence = Confidence.HIGH if len(matches) == 1 else Confidence.MEDIUM
+
+    proposed_labels: tuple[str, ...]
+    removed_labels: tuple[str, ...] = ("todo:draft",) if "todo:draft" in label_set else ()
+    diagnosis_state: DiagnosisState | None = None
+    proposed_adr_slug: str | None = None
+    proposed_adr_title: str | None = None
+    proposed_child_stories: tuple[str, ...] = ()
+    rationale = ""
+
+    if primary is Classification.BUG:
+        proposed_labels = ("bug",)
+        diagnosis_state = _detect_diagnosis_state(body)
+        rationale = "title/body/labels match bug shape"
+    elif primary is Classification.ENHANCEMENT:
+        proposed_labels = ("enhancement",)
+        rationale = "feature-shaped: acceptance-criteria heading or enhancement label"
+    elif primary is Classification.EPIC:
+        proposed_labels = ("epic",)
+        proposed_child_stories = _propose_child_stories(body)
+        rationale = "epic-shaped: multiple child stories proposed"
+    elif primary is Classification.OPERATOR_ACTION:
+        proposed_labels = ("operator-action",)
+        rationale = "operator-action: deliverable is human action, not dev pipeline"
+    elif primary is Classification.DOCUMENTATION:
+        proposed_labels = ("documentation",)
+        rationale = "docs-shaped change"
+    elif primary is Classification.ADR_CANDIDATE:
+        proposed_labels = ("adr-candidate",)
+        proposed_adr_title = title.strip() or "untitled-design-decision"
+        proposed_adr_slug = _slugify(title)
+        rationale = "design-decision shape: propose ADR slug + title (file not written)"
+    elif primary is Classification.DUPLICATE_OR_STALE:
+        proposed_labels = ("duplicate",)
+        rationale = "duplicate/stale: close or merge instead of sprinting"
+    else:
+        proposed_labels = ()
+
+    return ShapeProposal(
+        classification=primary,
+        confidence=confidence,
+        diagnosis_state=diagnosis_state,
+        proposed_labels=proposed_labels,
+        removed_labels=removed_labels,
+        proposed_adr_slug=proposed_adr_slug,
+        proposed_adr_title=proposed_adr_title,
+        proposed_child_stories=proposed_child_stories,
+        rationale=rationale,
+    )
+
+
+def _default_ambiguity_questions() -> tuple[AmbiguityQuestion, ...]:
+    return (
+        AmbiguityQuestion(
+            code="what_kind_of_work",
+            text="What kind of work is this — bug, enhancement, docs, or operator action?",
+        ),
+        AmbiguityQuestion(
+            code="observable_outcome",
+            text="What is the observable outcome that signals this is done?",
+        ),
+    )
+
+
+__all__ = [
+    "AmbiguityQuestion",
+    "Classification",
+    "Confidence",
+    "DiagnosisState",
+    "ShapeProposal",
+    "classify",
+]

--- a/src/theforge/intake/shape_classify.py
+++ b/src/theforge/intake/shape_classify.py
@@ -16,11 +16,17 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 
+from theforge.intake.clarification import ClarificationQuestion, for_situation
 from theforge.shape_check.parsing import (
     extract_ac_section,
     extract_section,
     has_heading,
 )
+
+# Back-compat alias so existing call sites that imported AmbiguityQuestion
+# continue to work; the canonical home for the type is the clarification
+# module, which the shape classifier reuses rather than re-defining.
+AmbiguityQuestion = ClarificationQuestion
 
 
 class Classification(str, Enum):
@@ -47,19 +53,13 @@ class DiagnosisState(str, Enum):
 
 
 @dataclass(frozen=True)
-class AmbiguityQuestion:
-    code: str
-    text: str
-
-
-@dataclass(frozen=True)
 class ShapeProposal:
     classification: Classification
     confidence: Confidence
     diagnosis_state: DiagnosisState | None = None
     proposed_labels: tuple[str, ...] = ()
     removed_labels: tuple[str, ...] = ()
-    ambiguity_questions: tuple[AmbiguityQuestion, ...] = ()
+    ambiguity_questions: tuple[ClarificationQuestion, ...] = ()
     proposed_adr_slug: str | None = None
     proposed_adr_title: str | None = None
     proposed_child_stories: tuple[str, ...] = ()
@@ -228,7 +228,7 @@ def classify(title: str, body: str, labels: list[str]) -> ShapeProposal:
         return ShapeProposal(
             classification=Classification.UNRESOLVED,
             confidence=Confidence.LOW,
-            ambiguity_questions=_default_ambiguity_questions(),
+            ambiguity_questions=for_situation("no_signal"),
             rationale=(
                 "No classifying signal in title, body, or labels — the draft is too thin to shape."
             ),
@@ -240,16 +240,7 @@ def classify(title: str, body: str, labels: list[str]) -> ShapeProposal:
         return ShapeProposal(
             classification=Classification.UNRESOLVED,
             confidence=Confidence.LOW,
-            ambiguity_questions=(
-                AmbiguityQuestion(
-                    code="deliverable_kind",
-                    text=("Is the deliverable code behavior, docs, or an operator decision?"),
-                ),
-                AmbiguityQuestion(
-                    code="agent_completable",
-                    text=("Should a dev agent be able to complete this without human action?"),
-                ),
-            ),
+            ambiguity_questions=for_situation("enhancement_vs_operator_action"),
             rationale="could be either operator-action or enhancement",
         )
 
@@ -308,22 +299,10 @@ def classify(title: str, body: str, labels: list[str]) -> ShapeProposal:
     )
 
 
-def _default_ambiguity_questions() -> tuple[AmbiguityQuestion, ...]:
-    return (
-        AmbiguityQuestion(
-            code="what_kind_of_work",
-            text="What kind of work is this — bug, enhancement, docs, or operator action?",
-        ),
-        AmbiguityQuestion(
-            code="observable_outcome",
-            text="What is the observable outcome that signals this is done?",
-        ),
-    )
-
-
 __all__ = [
     "AmbiguityQuestion",
     "Classification",
+    "ClarificationQuestion",
     "Confidence",
     "DiagnosisState",
     "ShapeProposal",

--- a/src/theforge/intake/shape_render.py
+++ b/src/theforge/intake/shape_render.py
@@ -1,0 +1,165 @@
+"""Render shape proposals as operator-facing text + body restructure.
+
+Pure text-shaping helpers, stdlib only. No I/O.
+"""
+
+from __future__ import annotations
+
+import difflib
+
+from theforge.intake.shape_classify import (
+    Classification,
+    Confidence,
+    DiagnosisState,
+    ShapeProposal,
+)
+
+
+def restructure_body(proposal: ShapeProposal, current_body: str) -> str:
+    """Return the proposed restructured body for the issue, or ``current_body``
+    unchanged when no restructure is proposed.
+
+    The restructure is intentionally minimal — it adds the scaffolding the
+    downstream producers (diagnose/groom) expect to see, and never deletes
+    existing operator text. The original body is appended under a quoted
+    ``Original`` block so nothing is silently lost.
+    """
+    current_body = current_body or ""
+    if proposal.classification is Classification.BUG:
+        return _restructure_bug(proposal, current_body)
+    if proposal.classification is Classification.ENHANCEMENT:
+        return _restructure_enhancement(current_body)
+    if proposal.classification is Classification.UNRESOLVED:
+        return current_body
+    return current_body
+
+
+def _has_section(body: str, marker: str) -> bool:
+    return marker.lower() in body.lower()
+
+
+def _restructure_bug(proposal: ShapeProposal, current_body: str) -> str:
+    parts: list[str] = []
+    if not _has_section(current_body, "## Observed"):
+        parts.append("## Observed\n\n<fill from current body>\n")
+    if not _has_section(current_body, "## Expected"):
+        parts.append("## Expected\n\n<state the category-level rule that should hold here>\n")
+    if not _has_section(current_body, "### Diagnosis"):
+        state = proposal.diagnosis_state or DiagnosisState.NO_DIAGNOSIS
+        if state is DiagnosisState.NO_DIAGNOSIS:
+            line = "Status: no diagnosis yet. Next step: run `forge diagnose`."
+        elif state is DiagnosisState.DIAGNOSIS_CAUSE_UNKNOWN:
+            line = (
+                "Status: investigation in progress; cause unknown. Next step: continue diagnosis."
+            )
+        else:
+            line = "Status: confirmed cause documented."
+        parts.append(f"### Diagnosis\n\n{line}\n")
+    if not parts:
+        return current_body
+    rendered = "\n".join(parts).rstrip() + "\n"
+    if current_body.strip():
+        rendered += "\n## Original\n\n" + _quote_block(current_body) + "\n"
+    return rendered
+
+
+def _restructure_enhancement(current_body: str) -> str:
+    if _has_section(current_body, "## Acceptance criteria") or _has_section(
+        current_body, "## Acceptance Criteria"
+    ):
+        return current_body
+    suffix = "\n\n## Acceptance criteria\n\n- <state an observable, testable outcome>\n"
+    return (current_body.rstrip() + suffix) if current_body.strip() else suffix.lstrip("\n")
+
+
+def _quote_block(text: str) -> str:
+    return "\n".join(f"> {line}" if line else ">" for line in text.splitlines())
+
+
+def render_proposal(
+    proposal: ShapeProposal,
+    *,
+    source_label: str,
+    current_body: str = "",
+    show_diff: bool = True,
+) -> str:
+    """Render the proposal as a human-readable block for stdout."""
+    lines: list[str] = []
+    lines.append(f"Loaded: {source_label}")
+    lines.append("")
+    if proposal.classification is Classification.UNRESOLVED:
+        lines.append("Classification: unresolved")
+        lines.append("Kept as: todo:draft")
+        if proposal.rationale:
+            lines.append(f"Reason: {proposal.rationale}")
+        if proposal.ambiguity_questions:
+            lines.append("Ambiguity questions:")
+            for q in proposal.ambiguity_questions:
+                lines.append(f"- {q.text}")
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"Proposed classification: {proposal.classification.value}")
+    if proposal.diagnosis_state is not None:
+        lines.append(f"Proposed diagnosis state: {proposal.diagnosis_state.value}")
+    lines.append(f"Confidence: {proposal.confidence.value}")
+    if proposal.rationale:
+        lines.append(f"Rationale: {proposal.rationale}")
+    if proposal.proposed_labels:
+        lines.append(f"Add labels: {', '.join(proposal.proposed_labels)}")
+    if proposal.removed_labels:
+        lines.append(f"Remove labels: {', '.join(proposal.removed_labels)}")
+    if proposal.proposed_adr_slug:
+        lines.append(f"Proposed ADR slug: {proposal.proposed_adr_slug}")
+        lines.append(f"Proposed ADR title: {proposal.proposed_adr_title}")
+        lines.append("(ADR file is NOT written — operator confirms and authors it.)")
+    if proposal.proposed_child_stories:
+        lines.append("Proposed child stories (prose only — no issues will be created):")
+        for child in proposal.proposed_child_stories:
+            lines.append(f"  - {child}")
+
+    if show_diff:
+        new_body = restructure_body(proposal, current_body)
+        if new_body != current_body:
+            lines.append("")
+            lines.append("Proposed body restructure:")
+            diff = difflib.unified_diff(
+                (current_body or "").splitlines(),
+                new_body.splitlines(),
+                fromfile="current",
+                tofile="proposed",
+                lineterm="",
+            )
+            for d in diff:
+                lines.append(d)
+    return "\n".join(lines) + "\n"
+
+
+def next_command(proposal: ShapeProposal, issue_number: int | None) -> str:
+    """Return the operator-facing recommended next command."""
+    if proposal.classification is Classification.UNRESOLVED:
+        return "Next: resolve ambiguity questions, then re-run `forge shape`."
+    target = f" {issue_number}" if issue_number is not None else ""
+    cls = proposal.classification
+    if cls is Classification.BUG:
+        if proposal.diagnosis_state is DiagnosisState.DIAGNOSIS_CONFIRMED_CAUSE:
+            return f"Next: forge groom{target}"
+        return f"Next: forge diagnose{target}"
+    if cls is Classification.ENHANCEMENT:
+        return f"Next: forge groom{target}"
+    if cls is Classification.EPIC:
+        return "Next: split into child stories manually, then `forge shape` each."
+    if cls is Classification.OPERATOR_ACTION:
+        return "Next: perform the operator action; do not enter the dev pipeline."
+    if cls is Classification.DOCUMENTATION:
+        return f"Next: forge groom{target}"
+    if cls is Classification.ADR_CANDIDATE:
+        slug = proposal.proposed_adr_slug or "<slug>"
+        return f"Next: author docs/adr/{slug}.md (operator confirms before writing)."
+    if cls is Classification.DUPLICATE_OR_STALE:
+        return f"Next: gh issue close{target}"
+    return "Next: (no recommendation)"
+
+
+# Confidence is only used through ShapeProposal, but re-export so consumers
+# don't have to import the classify module separately when assembling text.
+__all__ = ["Confidence", "next_command", "render_proposal", "restructure_body"]

--- a/tests/test_cli_shape.py
+++ b/tests/test_cli_shape.py
@@ -1,0 +1,170 @@
+"""Tests for the `forge shape` CLI command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.cli.main import build_parser
+from theforge.cli.shape import cmd_shape
+from theforge.coordinator.audit_substrate import substrate_path
+
+
+def _make_args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project:\n  root: .\n", encoding="utf-8")
+    data: dict[str, object] = {
+        "config": str(forge_yaml),
+        "issue": None,
+        "from_brief": None,
+        "from_stdin": False,
+        "apply": False,
+        "next": False,
+    }
+    data.update(overrides)
+    return argparse.Namespace(**data)
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+def test_parser_registers_shape_command():
+    parser = build_parser()
+    args = parser.parse_args(["shape", "1497"])
+    assert args.command == "shape"
+    assert args.issue == 1497
+    assert args.apply is False
+    assert args.next is False
+
+
+def test_parser_accepts_flags():
+    parser = build_parser()
+    args = parser.parse_args(["shape", "1497", "--apply", "--next"])
+    assert args.apply is True
+    assert args.next is True
+
+
+def test_shape_from_brief_classifies_and_emits_audit(tmp_path, capsys):
+    brief = tmp_path / "brief.md"
+    brief.write_text(
+        "# add forge shape command\n## Acceptance criteria\n- works\n",
+        encoding="utf-8",
+    )
+    args = _make_args(tmp_path, from_brief=str(brief))
+    rc = cmd_shape(args)
+
+    captured = capsys.readouterr()
+    assert "Proposed classification: enhancement" in captured.out
+    assert "Next: forge groom" in captured.out
+    # Without --apply, command exits non-zero when restructure is proposed.
+    # Enhancement already has AC, but proposed_labels=enhancement triggers change.
+    assert rc == 1
+
+    # Audit row exists.
+    db = substrate_path(tmp_path)
+    assert db.exists()
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT input_source, classification, apply_mutated FROM shape_events"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row == ("file", "enhancement", 0)
+
+
+def test_shape_from_stdin_handles_unresolved(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", StringIO("# ???\n\n"))
+    args = _make_args(tmp_path, from_stdin=True)
+    rc = cmd_shape(args)
+    out = capsys.readouterr().out
+    assert "Kept as: todo:draft" in out
+    assert "Ambiguity questions:" in out
+    assert rc == 1
+
+
+def test_shape_next_prints_only_command(tmp_path, capsys):
+    brief = tmp_path / "brief.md"
+    brief.write_text(
+        "# bug: thing is broken\n\n## Observed\nfoo\n",
+        encoding="utf-8",
+    )
+    args = _make_args(tmp_path, from_brief=str(brief), next=True)
+    rc = cmd_shape(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.strip().startswith("Next:")
+    # Audit still emitted.
+    db = substrate_path(tmp_path)
+    assert db.exists()
+
+
+def test_shape_apply_requires_issue_number(tmp_path, capsys):
+    brief = tmp_path / "brief.md"
+    brief.write_text("# bug: broken\n## Observed\nfoo\n", encoding="utf-8")
+    args = _make_args(tmp_path, from_brief=str(brief), apply=True)
+    rc = cmd_shape(args)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--apply requires an issue number" in err
+
+
+def test_shape_apply_refused_for_unresolved(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", StringIO(""))
+    args = _make_args(tmp_path, from_stdin=True, apply=True, issue=42)
+    # Make _load_issue fail by not stubbing it — we won't reach gh because
+    # classify will declare unresolved and refuse before gh runs. But we are
+    # using from_stdin so the issue arg is unused.
+    rc = cmd_shape(args)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "--apply refused" in err
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_shape_issue_calls_gh_and_applies(mock_run, tmp_path, capsys):
+    gh_view = _proc(
+        stdout=json.dumps(
+            {
+                "title": "cut-rc.sh broke something",
+                "body": "happens on every release",
+                "labels": [{"name": "bug"}, {"name": "todo:draft"}],
+            }
+        )
+    )
+    gh_edit = _proc(stdout="ok")
+    # Order: view, then add-label(s), remove-label(s), body-file.
+    mock_run.side_effect = [gh_view, gh_edit, gh_edit, gh_edit]
+    args = _make_args(tmp_path, issue=1497, apply=True)
+    rc = cmd_shape(args)
+    out = capsys.readouterr().out
+    assert "Proposed classification: bug" in out
+    assert "Applied proposal to #1497." in out
+    assert rc == 0
+
+    db = substrate_path(tmp_path)
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT input_source, classification, apply_mutated, diagnosis_state FROM shape_events"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row == ("issue", "bug", 1, "no-diagnosis")
+
+
+def test_shape_no_input_errors(tmp_path, capsys):
+    args = _make_args(tmp_path)
+    rc = cmd_shape(args)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "provide an issue number" in err

--- a/tests/test_cli_shape.py
+++ b/tests/test_cli_shape.py
@@ -168,3 +168,105 @@ def test_shape_no_input_errors(tmp_path, capsys):
     err = capsys.readouterr().err
     assert rc == 1
     assert "provide an issue number" in err
+
+
+def _shape_event_row(tmp_path: Path) -> tuple:
+    """Helper: return the (input_source, classification, apply_mutated)
+    of the single shape_events row written under tmp_path, or None if none."""
+    db = substrate_path(tmp_path)
+    if not db.exists():
+        return None
+    conn = sqlite3.connect(str(db))
+    try:
+        return conn.execute(
+            "SELECT input_source, classification, apply_mutated FROM shape_events"
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def test_audit_emitted_when_from_brief_file_missing(tmp_path, capsys):
+    args = _make_args(tmp_path, from_brief=str(tmp_path / "missing.md"))
+    rc = cmd_shape(args)
+    assert rc == 1
+    assert "file not found" in capsys.readouterr().err
+    # Acceptance criterion: every invocation writes a structured event.
+    assert _shape_event_row(tmp_path) == ("file", "unresolved", 0)
+
+
+def test_audit_emitted_when_no_input_given(tmp_path, capsys):
+    args = _make_args(tmp_path)
+    rc = cmd_shape(args)
+    assert rc == 1
+    assert _shape_event_row(tmp_path) == ("none", "unresolved", 0)
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_audit_emitted_when_gh_issue_view_fails(mock_run, tmp_path, capsys):
+    mock_run.return_value = _proc(returncode=1, stderr="no such issue")
+    args = _make_args(tmp_path, issue=999999)
+    rc = cmd_shape(args)
+    assert rc == 1
+    assert "no such issue" in capsys.readouterr().err
+    assert _shape_event_row(tmp_path) == ("issue", "unresolved", 0)
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_audit_emitted_when_gh_returns_malformed_json(mock_run, tmp_path, capsys):
+    mock_run.return_value = _proc(stdout="not-json")
+    args = _make_args(tmp_path, issue=42)
+    rc = cmd_shape(args)
+    assert rc == 1
+    assert "malformed JSON" in capsys.readouterr().err
+    assert _shape_event_row(tmp_path) == ("issue", "unresolved", 0)
+
+
+def test_parser_help_lists_shape_command(capsys):
+    parser = build_parser()
+    try:
+        parser.parse_args(["--help"])
+    except SystemExit:
+        pass
+    out = capsys.readouterr().out
+    assert "shape" in out
+
+
+def test_classify_treats_story_label_as_enhancement():
+    from theforge.intake.shape_classify import Classification, classify
+
+    proposal = classify("title", "body without ac", ["story"])
+    assert proposal.classification is Classification.ENHANCEMENT
+
+
+def test_classify_treats_feature_label_as_enhancement():
+    from theforge.intake.shape_classify import Classification, classify
+
+    proposal = classify("title", "body without ac", ["feature"])
+    assert proposal.classification is Classification.ENHANCEMENT
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_normal_render_never_invokes_downstream_producers(mock_run, tmp_path, capsys):
+    """Regression: a non-apply, non-next shape run must NOT spawn any
+    subprocess beyond the gh issue view it needs to load the issue."""
+    gh_view = _proc(
+        stdout=json.dumps(
+            {
+                "title": "cut-rc.sh broke",
+                "body": "happens on every release",
+                "labels": [{"name": "bug"}],
+            }
+        )
+    )
+    mock_run.return_value = gh_view
+    args = _make_args(tmp_path, issue=1497)
+    cmd_shape(args)
+    # Exactly one subprocess call — the gh issue view to load the issue.
+    assert mock_run.call_count == 1
+    call_args = mock_run.call_args.args[0]
+    assert call_args[:3] == ["gh", "issue", "view"]
+    # And none of the producer command names appear in any argv.
+    for call in mock_run.call_args_list:
+        argv = call.args[0]
+        for forbidden in ("diagnose", "groom"):
+            assert forbidden not in argv, f"unexpected producer call: {argv}"

--- a/tests/test_intake/test_clarification.py
+++ b/tests/test_intake/test_clarification.py
@@ -1,0 +1,57 @@
+"""Tests for the reusable clarification Q&A engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from theforge.intake import clarification
+from theforge.intake.clarification import (
+    ClarificationQuestion,
+    QUESTIONS,
+    SITUATIONS,
+    build,
+    for_situation,
+)
+
+
+def test_build_returns_records_for_known_codes():
+    out = build(("what_kind_of_work", "observable_outcome"))
+    assert all(isinstance(q, ClarificationQuestion) for q in out)
+    assert tuple(q.code for q in out) == ("what_kind_of_work", "observable_outcome")
+    assert out[0].text == QUESTIONS["what_kind_of_work"]
+
+
+def test_build_raises_on_unknown_code():
+    with pytest.raises(KeyError):
+        build(("does_not_exist",))
+
+
+def test_for_situation_returns_named_set():
+    out = for_situation("no_signal")
+    codes = tuple(q.code for q in out)
+    assert codes == SITUATIONS["no_signal"]
+
+
+def test_for_situation_unknown_raises():
+    with pytest.raises(KeyError):
+        for_situation("nonexistent_situation")
+
+
+def test_situations_only_reference_known_codes():
+    # Every code referenced by a named situation must be in the question
+    # registry, otherwise consumers would silently raise KeyError at runtime.
+    for name, codes in SITUATIONS.items():
+        for code in codes:
+            assert code in QUESTIONS, f"situation {name!r} references missing code {code!r}"
+
+
+def test_shape_classify_reuses_clarification_engine():
+    """Regression: shape_classify must source questions from the shared engine,
+    not re-define them inline."""
+    from theforge.intake.shape_classify import classify
+
+    proposal = classify("???", "", [])
+    expected = for_situation("no_signal")
+    assert proposal.ambiguity_questions == expected
+    # Type identity confirms the alias points at the canonical record type.
+    assert ClarificationQuestion is clarification.ClarificationQuestion

--- a/tests/test_intake/test_clarification.py
+++ b/tests/test_intake/test_clarification.py
@@ -6,9 +6,9 @@ import pytest
 
 from theforge.intake import clarification
 from theforge.intake.clarification import (
-    ClarificationQuestion,
     QUESTIONS,
     SITUATIONS,
+    ClarificationQuestion,
     build,
     for_situation,
 )

--- a/tests/test_intake/test_shape_audit.py
+++ b/tests/test_intake/test_shape_audit.py
@@ -1,0 +1,82 @@
+"""Tests for shape_events emission into the SQLite audit substrate."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from theforge.coordinator.audit_substrate import substrate_path
+from theforge.coordinator.shape_audit import (
+    VALID_INPUT_SOURCES,
+    count_kept_as_draft,
+    emit_shape_event,
+)
+
+
+def test_emit_shape_event_creates_row(tmp_path: Path):
+    rowid = emit_shape_event(
+        tmp_path,
+        issue_number=1497,
+        input_source="issue",
+        classification="bug",
+        confidence="high",
+        ambiguity_question_count=0,
+        apply_mutated=True,
+        diagnosis_state="no-diagnosis",
+    )
+    assert rowid > 0
+    db = substrate_path(tmp_path)
+    assert db.exists()
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT issue_number, input_source, classification, confidence, "
+            "ambiguity_question_count, apply_mutated, diagnosis_state "
+            "FROM shape_events WHERE id = ?",
+            (rowid,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row == (1497, "issue", "bug", "high", 0, 1, "no-diagnosis")
+
+
+def test_emit_rejects_invalid_input_source(tmp_path: Path):
+    with pytest.raises(ValueError):
+        emit_shape_event(
+            tmp_path,
+            issue_number=None,
+            input_source="email",
+            classification="bug",
+            confidence="high",
+            ambiguity_question_count=0,
+            apply_mutated=False,
+        )
+
+
+def test_count_kept_as_draft(tmp_path: Path):
+    assert count_kept_as_draft(tmp_path) == 0
+    emit_shape_event(
+        tmp_path,
+        issue_number=None,
+        input_source="stdin",
+        classification="unresolved",
+        confidence="low",
+        ambiguity_question_count=2,
+        apply_mutated=False,
+    )
+    emit_shape_event(
+        tmp_path,
+        issue_number=None,
+        input_source="stdin",
+        classification="bug",
+        confidence="high",
+        ambiguity_question_count=0,
+        apply_mutated=False,
+    )
+    assert count_kept_as_draft(tmp_path) == 1
+
+
+def test_valid_input_sources_constant():
+    assert VALID_INPUT_SOURCES == {"issue", "file", "stdin"}

--- a/tests/test_intake/test_shape_audit.py
+++ b/tests/test_intake/test_shape_audit.py
@@ -79,4 +79,4 @@ def test_count_kept_as_draft(tmp_path: Path):
 
 
 def test_valid_input_sources_constant():
-    assert VALID_INPUT_SOURCES == {"issue", "file", "stdin"}
+    assert VALID_INPUT_SOURCES == {"issue", "file", "stdin", "none"}

--- a/tests/test_intake/test_shape_classify.py
+++ b/tests/test_intake/test_shape_classify.py
@@ -1,0 +1,92 @@
+"""Unit tests for the heuristic shape classifier."""
+
+from __future__ import annotations
+
+from theforge.intake.shape_classify import (
+    Classification,
+    Confidence,
+    DiagnosisState,
+    classify,
+)
+
+
+def test_classifies_bug_by_label():
+    proposal = classify(
+        title="cut-rc.sh broke something",
+        body="happens on every release",
+        labels=["bug"],
+    )
+    assert proposal.classification is Classification.BUG
+    assert proposal.confidence is Confidence.HIGH
+    assert proposal.diagnosis_state is DiagnosisState.NO_DIAGNOSIS
+
+
+def test_bug_detects_diagnosis_confirmed_cause():
+    body = (
+        "## Observed\nfoo\n\n## Expected\nbar\n\n"
+        "### Diagnosis\nRoot cause: regression in module X.\n"
+    )
+    proposal = classify("bug: regression", body, ["bug"])
+    assert proposal.classification is Classification.BUG
+    assert proposal.diagnosis_state is DiagnosisState.DIAGNOSIS_CONFIRMED_CAUSE
+
+
+def test_classifies_enhancement_by_ac_section():
+    proposal = classify(
+        title="add forge shape command",
+        body="## Acceptance criteria\n- new CLI command exists\n",
+        labels=[],
+    )
+    assert proposal.classification is Classification.ENHANCEMENT
+    assert "enhancement" in proposal.proposed_labels
+
+
+def test_classifies_epic_with_child_stories():
+    body = "## Child stories\n- story one\n- story two\n- story three\n"
+    proposal = classify("epic: multi-tenant", body, ["epic"])
+    assert proposal.classification is Classification.EPIC
+    assert proposal.proposed_child_stories == ("story one", "story two", "story three")
+
+
+def test_classifies_adr_candidate_proposes_slug_and_title():
+    proposal = classify(
+        title="ADR: Adopt SQLite for audit substrate",
+        body="## Decision\nWe will use SQLite.\n## Alternatives considered\n- DuckDB\n",
+        labels=[],
+    )
+    assert proposal.classification is Classification.ADR_CANDIDATE
+    assert proposal.proposed_adr_slug
+    assert proposal.proposed_adr_title is not None
+    assert "sqlite" in proposal.proposed_adr_slug.lower()
+
+
+def test_low_confidence_keeps_as_todo_draft_with_questions():
+    # Conflict between operator-action and enhancement → unresolved.
+    proposal = classify(
+        title="operator should bump the release floor and we also need a CLI",
+        body=(
+            "## Acceptance criteria\n- operator action: bump floor\n"
+            "## Operator action\n- bump floor\n"
+        ),
+        labels=[],
+    )
+    assert proposal.classification is Classification.UNRESOLVED
+    assert proposal.kept_as_todo_draft is True
+    assert len(proposal.ambiguity_questions) >= 2
+
+
+def test_no_signal_returns_unresolved():
+    proposal = classify("???", "", [])
+    assert proposal.classification is Classification.UNRESOLVED
+    assert proposal.confidence is Confidence.LOW
+    assert proposal.ambiguity_questions
+
+
+def test_duplicate_detected_by_label():
+    proposal = classify("foo", "Duplicate of #99\n", ["duplicate"])
+    assert proposal.classification is Classification.DUPLICATE_OR_STALE
+
+
+def test_documentation_detected_by_title():
+    proposal = classify("docs: update CLI reference", "Add forge shape section.", [])
+    assert proposal.classification is Classification.DOCUMENTATION

--- a/tests/test_intake/test_shape_render.py
+++ b/tests/test_intake/test_shape_render.py
@@ -1,0 +1,110 @@
+"""Unit tests for shape proposal rendering + body restructure."""
+
+from __future__ import annotations
+
+from theforge.intake.shape_classify import (
+    AmbiguityQuestion,
+    Classification,
+    Confidence,
+    DiagnosisState,
+    ShapeProposal,
+)
+from theforge.intake.shape_render import (
+    next_command,
+    render_proposal,
+    restructure_body,
+)
+
+
+def _bug_proposal(state: DiagnosisState = DiagnosisState.NO_DIAGNOSIS) -> ShapeProposal:
+    return ShapeProposal(
+        classification=Classification.BUG,
+        confidence=Confidence.HIGH,
+        diagnosis_state=state,
+        proposed_labels=("bug",),
+        removed_labels=("todo:draft",),
+        rationale="bug label present",
+    )
+
+
+def test_restructure_bug_adds_observed_expected_diagnosis():
+    new = restructure_body(_bug_proposal(), "original body")
+    assert "## Observed" in new
+    assert "## Expected" in new
+    assert "### Diagnosis" in new
+    assert "original body" in new  # original preserved in quote block
+
+
+def test_restructure_bug_with_confirmed_cause_says_so():
+    new = restructure_body(
+        _bug_proposal(DiagnosisState.DIAGNOSIS_CONFIRMED_CAUSE),
+        "",
+    )
+    assert "confirmed cause" in new.lower()
+
+
+def test_restructure_enhancement_adds_acceptance_criteria():
+    proposal = ShapeProposal(
+        classification=Classification.ENHANCEMENT,
+        confidence=Confidence.HIGH,
+        proposed_labels=("enhancement",),
+    )
+    new = restructure_body(proposal, "rough idea\n")
+    assert "## Acceptance criteria" in new
+    assert "rough idea" in new
+
+
+def test_restructure_enhancement_idempotent_if_section_present():
+    proposal = ShapeProposal(
+        classification=Classification.ENHANCEMENT,
+        confidence=Confidence.HIGH,
+        proposed_labels=("enhancement",),
+    )
+    body = "## Acceptance criteria\n- thing\n"
+    assert restructure_body(proposal, body) == body
+
+
+def test_render_unresolved_lists_ambiguity_questions():
+    proposal = ShapeProposal(
+        classification=Classification.UNRESOLVED,
+        confidence=Confidence.LOW,
+        ambiguity_questions=(
+            AmbiguityQuestion(code="x", text="Is the deliverable code or docs?"),
+        ),
+        rationale="could be either operator-action or enhancement",
+    )
+    out = render_proposal(proposal, source_label="brief: 'x'")
+    assert "Kept as: todo:draft" in out
+    assert "Is the deliverable code or docs?" in out
+
+
+def test_render_bug_includes_diff():
+    proposal = _bug_proposal()
+    out = render_proposal(proposal, source_label="#42 'foo'", current_body="raw")
+    assert "Proposed classification: bug" in out
+    assert "Confidence: high" in out
+    assert "+## Observed" in out
+
+
+def test_next_command_bug_no_diagnosis_routes_to_diagnose():
+    assert next_command(_bug_proposal(), 1497) == "Next: forge diagnose 1497"
+
+
+def test_next_command_bug_confirmed_cause_routes_to_groom():
+    proposal = _bug_proposal(DiagnosisState.DIAGNOSIS_CONFIRMED_CAUSE)
+    assert next_command(proposal, 1497) == "Next: forge groom 1497"
+
+
+def test_next_command_unresolved():
+    proposal = ShapeProposal(classification=Classification.UNRESOLVED, confidence=Confidence.LOW)
+    assert "ambiguity" in next_command(proposal, None).lower()
+
+
+def test_next_command_adr_uses_slug():
+    proposal = ShapeProposal(
+        classification=Classification.ADR_CANDIDATE,
+        confidence=Confidence.HIGH,
+        proposed_adr_slug="adopt-sqlite",
+        proposed_adr_title="Adopt SQLite",
+    )
+    assert "adopt-sqlite" in next_command(proposal, None)


### PR DESCRIPTION
## Summary

Prior P1 fixes are present, cycle-2 only reordered an import in a test, and I found no blocking regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $8.12
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

forge shape MVP — classify rough prose and todo:draft into typed work objects (GitHub Issue #1510)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1510