### PR TITLE
Failed review-retry agent outputs are not persisted; system erases the evidence needed to RCA its own escalations

### DIFF
--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -460,16 +460,16 @@ def _run_review_pool(
                 )
                 break
             _retried = _try_parse_review(_retry_result.output, _retry_result.structured_data)
+            write_trace(
+                workspace_path
+                / ".forge/traces"
+                / f"{_cycle_num}-{pool_attempt}-review-{name}-retry{_retry_num}.txt",
+                _retry_result.output,
+            )
             if _retried is not None:
                 _log(f"  ✓ {name} retry {_retry_num} succeeded")
                 parsed_results[i] = _retried
                 state.review_agent_results.append(_retry_result)
-                write_trace(
-                    workspace_path
-                    / ".forge/traces"
-                    / f"{_cycle_num}-{pool_attempt}-review-{name}-retry{_retry_num}.txt",
-                    _retry_result.output,
-                )
                 break
             else:
                 _log_verbose(

--- a/tests/test_coord_review_pool.py
+++ b/tests/test_coord_review_pool.py
@@ -331,3 +331,86 @@ class TestReviewerDemotion:
         assert merged is not None
         assert [r.profile_name for r in successful] == ["r2"]
         assert mock_pool.call_args_list[1].kwargs["profiles"] == [r2]
+
+
+class TestRetryTraceFiles:
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_failed_retry_writes_trace_file(
+        self, mock_pool, mock_run_agent, _mock_log_agent_result, tmp_path
+    ):
+        """Retry attempts that fail to parse must still be written to disk."""
+        reviewer = _make_review_profile("r1")
+        config = _make_pool_config(tmp_path, [reviewer], reviewer)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        # Initial pool call returns unparseable output
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=PARSE_ERROR_OUTPUT, profile_name="r1")
+        ]
+        # Retry via run_agent also returns unparseable output
+        mock_run_agent.return_value = _make_agent_result(
+            success=True, output=PARSE_ERROR_OUTPUT, profile_name="r1"
+        )
+
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            _meta(),
+            notify=False,
+            enforce_budgets=False,
+            max_review_parse_retries=1,
+        )
+
+        # _cycle_num = state.review_cycle + 1 = 1, pool_attempt = 0
+        trace_file = workspace / ".forge" / "traces" / "1-0-review-r1-retry1.txt"
+        assert trace_file.exists(), (
+            "Failed retry must write trace file regardless of parse outcome"
+        )
+        assert trace_file.read_text(encoding="utf-8") == PARSE_ERROR_OUTPUT
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_successful_retry_also_writes_trace_file(
+        self, mock_pool, mock_run_agent, _mock_log_agent_result, tmp_path
+    ):
+        """Successful retries must continue to write trace files (regression guard)."""
+        reviewer = _make_review_profile("r1")
+        config = _make_pool_config(tmp_path, [reviewer], reviewer)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=PARSE_ERROR_OUTPUT, profile_name="r1")
+        ]
+        mock_run_agent.return_value = _make_agent_result(
+            success=True, output=APPROVE_REVIEW, profile_name="r1"
+        )
+
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            _meta(),
+            notify=False,
+            enforce_budgets=False,
+            max_review_parse_retries=1,
+        )
+
+        trace_file = workspace / ".forge" / "traces" / "1-0-review-r1-retry1.txt"
+        assert trace_file.exists(), "Successful retry must also write trace file"
+        assert trace_file.read_text(encoding="utf-8") == APPROVE_REVIEW


### PR DESCRIPTION
## Summary

write_trace moved above the parse-success check; failed retries now persist their raw output. Tests cover both branches.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.85
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Failed review-retry agent outputs are not persisted; system erases the evidence needed to RCA its own escalations (GitHub Issue #1543)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1543