### PR TITLE
Review pipeline conflates YAML syntax errors with schema validation errors in operator-facing logs and audit

### DIFF
--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -106,6 +106,9 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                 }
                 for ac in r.ac_verification
             ]
+            parse_errors_list = [
+                {"stage": pe.stage, "message": pe.message} for pe in r.parse_errors
+            ]
             entry.update(
                 {
                     "verdict": r.verdict,
@@ -115,6 +118,7 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                     "p2_count": sum(1 for f in r.findings if f.severity == "P2"),
                     "findings": findings_list,
                     "ac_verification": ac_verification_list,
+                    "parse_errors": parse_errors_list,
                 }
             )
         reviews.append(entry)

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -418,9 +418,14 @@ def _run_review_pool(
         # Capture original AgentResult for this reviewer (session_id + raw output)
         _original_result = successful[i]
         for _retry_num in range(1, max_review_parse_retries + 1):
-            _error_desc = "; ".join(parsed.parse_errors)
+            _error_desc = "; ".join(str(e) for e in parsed.parse_errors)
+            # Stage breakdown lets operators distinguish parser-layer failures
+            # from schema/contract-layer failures without parsing the message.
+            _stages = sorted({e.stage for e in parsed.parse_errors})
+            _stage_tag = ",".join(_stages) if _stages else "UNKNOWN"
             _log(
-                f"  ↻ {name} parse failed (retry {_retry_num}/{max_review_parse_retries}): "
+                f"  ↻ {name} rejected at {_stage_tag} "
+                f"(retry {_retry_num}/{max_review_parse_retries}): "
                 f"{_error_desc[:120]}"
             )
             # Build corrective prompt — mode-specific to avoid re-review
@@ -472,9 +477,10 @@ def _run_review_pool(
                 state.review_agent_results.append(_retry_result)
                 break
             else:
+                _retry_errors = parse_review_output(_retry_result.output).parse_errors
                 _log_verbose(
-                    f"  {name} retry {_retry_num} still has parse errors: "
-                    f"{parse_review_output(_retry_result.output).parse_errors}"
+                    f"  {name} retry {_retry_num} still rejected: "
+                    f"{[str(e) for e in _retry_errors]}"
                 )
                 parsed = ReviewResult(
                     verdict="REQUEST_CHANGES",
@@ -484,7 +490,7 @@ def _run_review_pool(
                     story_mismatches=[],
                     test_adequate=False,
                     test_gaps=[],
-                    parse_errors=[_error_desc],
+                    parse_errors=_retry_errors or list(parsed.parse_errors),
                     raw_yaml={},
                 )
 

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -52,6 +52,29 @@ def _serialize_review_result(rr: object) -> dict | None:
     return _yaml_safe(dataclasses.asdict(rr))  # type: ignore[arg-type,return-value]
 
 
+def _deserialize_parse_errors(raw: object) -> list:
+    """Reconstruct ParseError instances from sidecar data.
+
+    Backward-compat: bare strings in older sidecars are rehydrated with the
+    SCHEMA_VALIDATION stage so they remain typed without losing information.
+    """
+    from theforge.schemas import SCHEMA_VALIDATION, ParseError  # noqa: PLC0415
+
+    if not raw:
+        return []
+    out: list = []
+    for entry in raw:
+        if isinstance(entry, ParseError):
+            out.append(entry)
+        elif isinstance(entry, dict):
+            stage = entry.get("stage") or SCHEMA_VALIDATION
+            message = entry.get("message") or ""
+            out.append(ParseError(stage=stage, message=message))
+        else:
+            out.append(ParseError(stage=SCHEMA_VALIDATION, message=str(entry)))
+    return out
+
+
 def _deserialize_review_result(data: object) -> object | None:
     """Reconstruct a ReviewResult/ReviewFinding/ACVerification graph from sidecar data."""
     if not isinstance(data, dict):
@@ -91,7 +114,7 @@ def _deserialize_review_result(data: object) -> object | None:
         story_mismatches=list(data.get("story_mismatches") or []),
         test_adequate=bool(data.get("test_adequate", False)),
         test_gaps=list(data.get("test_gaps") or []),
-        parse_errors=list(data.get("parse_errors") or []),
+        parse_errors=_deserialize_parse_errors(data.get("parse_errors")),
         raw_yaml=dict(data.get("raw_yaml") or {}),
         ac_verification=tuple(ac_verification),
         sanitization_audit=dict(data.get("sanitization_audit") or {}),

--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -12,7 +12,13 @@ from dataclasses import dataclass, field
 
 import yaml
 
-from .schemas import repair_review_yaml, validate_review_yaml
+from .schemas import (
+    STRUCTURE,
+    YAML_SYNTAX,
+    ParseError,
+    repair_review_yaml,
+    validate_review_yaml,
+)
 
 
 def _coerce_line(value: object) -> int | None:
@@ -71,7 +77,7 @@ class ReviewResult:
     story_mismatches: list[str]
     test_adequate: bool
     test_gaps: list[str]
-    parse_errors: list[str]  # non-empty if parsing/validation failed
+    parse_errors: list[ParseError]  # non-empty if parsing/validation failed
     raw_yaml: dict  # the parsed YAML data
     ac_verification: tuple[ACVerification, ...] = ()  # per-AC verification table
     sanitization_audit: dict[str, dict[str, int]] = field(default_factory=dict)
@@ -252,7 +258,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
             story_mismatches=[],
             test_adequate=False,
             test_gaps=[],
-            parse_errors=[f"YAML parse error: {e}"],
+            parse_errors=[ParseError(stage=YAML_SYNTAX, message=str(e))],
             raw_yaml={},
         )
 
@@ -265,7 +271,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
             story_mismatches=[],
             test_adequate=False,
             test_gaps=[],
-            parse_errors=["Root element is not a mapping"],
+            parse_errors=[ParseError(stage=STRUCTURE, message="Root element is not a mapping")],
             raw_yaml={},
         )
 
@@ -787,16 +793,16 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
     import logging as _logging
 
     valid: list[tuple[str, ReviewResult]] = []
-    excluded_errors: list[str] = []
+    excluded_errors: list[ParseError] = []
     for name, r in zip(names, results):
         if r.parse_errors:
             _logging.getLogger(__name__).warning(
                 "REVIEW merge: excluding %s due to parse errors: %s",
                 name,
-                "; ".join(r.parse_errors),
+                "; ".join(str(e) for e in r.parse_errors),
             )
             for e in r.parse_errors:
-                excluded_errors.append(f"[{name}] {e}")
+                excluded_errors.append(ParseError(stage=e.stage, message=f"[{name}] {e.message}"))
         else:
             valid.append((name, r))
 
@@ -810,7 +816,13 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
             story_mismatches=[],
             test_adequate=True,
             test_gaps=[],
-            parse_errors=excluded_errors or ["All reviewers failed to produce valid output"],
+            parse_errors=excluded_errors
+            or [
+                ParseError(
+                    stage=STRUCTURE,
+                    message="All reviewers failed to produce valid output",
+                )
+            ],
             raw_yaml={},
         )
 

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -7,11 +7,53 @@ the orchestrator treats it as REQUEST_CHANGES.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 VALID_VERDICTS = ("APPROVE", "REQUEST_CHANGES")
 VALID_SEVERITIES = ("P1", "P2")
 VALID_AC_VERIFICATION_STATUSES = ("VERIFIED", "PARTIAL", "NOT_VERIFIED")
+
+# ── Parse-error taxonomy ─────────────────────────────────────────────
+# Operator-facing logs and audit must distinguish which validation stage
+# rejected an agent's output. The stage identifies the remediation surface:
+# YAML_SYNTAX → parser/sanitizer; SCHEMA_VALIDATION → field shape/type;
+# CONTRACT_CROSS_VALIDATION → verdict-vs-findings or AC contract rules;
+# STRUCTURE → preconditions before schema validation (root is a mapping).
+
+YAML_SYNTAX = "YAML_SYNTAX"
+STRUCTURE = "STRUCTURE"
+SCHEMA_VALIDATION = "SCHEMA_VALIDATION"
+CONTRACT_CROSS_VALIDATION = "CONTRACT_CROSS_VALIDATION"
+
+VALID_PARSE_ERROR_STAGES = (
+    YAML_SYNTAX,
+    STRUCTURE,
+    SCHEMA_VALIDATION,
+    CONTRACT_CROSS_VALIDATION,
+)
+
+
+@dataclass(frozen=True)
+class ParseError:
+    """A single rejection reason tagged with the validation stage that produced it.
+
+    ``stage`` names the remediation surface — operators consume the stage to
+    decide whether to fix the parser (YAML_SYNTAX), the prompt/schema description
+    (SCHEMA_VALIDATION), or the contract rules themselves
+    (CONTRACT_CROSS_VALIDATION). ``message`` is the human-readable detail.
+    """
+
+    stage: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.stage}] {self.message}"
+
+    def __contains__(self, item: object) -> bool:
+        # Substring checks against the rendered form so legacy assertions like
+        # ``"APPROVE" in error`` continue to work after the structural refactor.
+        return isinstance(item, str) and item in str(self)
 
 
 def repair_review_yaml(data: Any) -> Any:
@@ -55,47 +97,57 @@ def repair_review_yaml(data: Any) -> Any:
     return data
 
 
-def validate_review_yaml(data: Any) -> list[str]:
+def validate_review_yaml(data: Any) -> list[ParseError]:
     """Validate review YAML structure. Returns list of errors (empty = valid).
+
+    Each returned :class:`ParseError` carries a ``stage`` tag identifying the
+    validation layer that produced it (``STRUCTURE``, ``SCHEMA_VALIDATION``, or
+    ``CONTRACT_CROSS_VALIDATION``) so operator-facing logs and audit can
+    distinguish parser/schema failures from contract-cross-check failures
+    without parsing the message string.
 
     Cross-validation rules:
     - APPROVE + any P1 → error (can't approve with blocking findings)
     - REQUEST_CHANGES + zero P1s → error (must justify the request)
     """
-    errors: list[str] = []
+    errors: list[ParseError] = []
 
     if not isinstance(data, dict):
-        return ["review output root must be a YAML mapping"]
+        return [ParseError(stage=STRUCTURE, message="review output root must be a YAML mapping")]
+
+    def _schema(msg: str) -> None:
+        errors.append(ParseError(stage=SCHEMA_VALIDATION, message=msg))
+
+    def _cross(msg: str) -> None:
+        errors.append(ParseError(stage=CONTRACT_CROSS_VALIDATION, message=msg))
 
     # ── verdict ───────────────────────────────────────────────────
     verdict = data.get("verdict")
     if verdict not in VALID_VERDICTS:
-        errors.append(f"verdict must be one of {VALID_VERDICTS}, got: {verdict!r}")
+        _schema(f"verdict must be one of {VALID_VERDICTS}, got: {verdict!r}")
 
     # ── summary ───────────────────────────────────────────────────
     summary = data.get("summary")
     if not isinstance(summary, str) or not summary.strip():
-        errors.append("summary must be a non-empty string")
+        _schema("summary must be a non-empty string")
 
     # ── findings ──────────────────────────────────────────────────
     findings = data.get("findings")
     if findings is None:
         findings = []
     if not isinstance(findings, list):
-        errors.append("findings must be a list")
+        _schema("findings must be a list")
         findings = []
 
     p1_count = 0
     for i, finding in enumerate(findings):
         if not isinstance(finding, dict):
-            errors.append(f"findings[{i}] must be a mapping")
+            _schema(f"findings[{i}] must be a mapping")
             continue
 
         severity = finding.get("severity")
         if severity not in VALID_SEVERITIES:
-            errors.append(
-                f"findings[{i}].severity must be one of {VALID_SEVERITIES}, got: {severity!r}"
-            )
+            _schema(f"findings[{i}].severity must be one of {VALID_SEVERITIES}, got: {severity!r}")
         if severity == "P1":
             p1_count += 1
             file_val = finding.get("file")  # None = null (architectural), "" = empty (error)
@@ -103,27 +155,27 @@ def validate_review_yaml(data: Any) -> list[str]:
             # P1 with file set must have a non-empty file path.
             # P1 with file: null is an architectural finding — no file required.
             if file_val is not None and not file_val:
-                errors.append(f"findings[{i}].file must be non-empty for P1 findings")
+                _schema(f"findings[{i}].file must be non-empty for P1 findings")
 
             # P1 with file set must also cite a specific line to be actionable.
             # P1 with file: null (architectural finding) does not require a line.
             if file_val and not finding.get("line"):
-                errors.append(
+                _schema(
                     f"findings[{i}].line must be set for P1 findings with a file — "
                     f"vague P1s block the pipeline without clear fix targets"
                 )
 
         if not finding.get("description"):
-            errors.append(f"findings[{i}].description must be non-empty")
+            _schema(f"findings[{i}].description must be non-empty")
 
     # ── Cross-validation: verdict vs findings ─────────────────────
     if verdict == "APPROVE" and p1_count > 0:
-        errors.append(
+        _cross(
             f"verdict is APPROVE but {p1_count} P1 finding(s) exist — "
             f"cannot approve with blocking findings"
         )
     if verdict == "REQUEST_CHANGES" and p1_count == 0:
-        errors.append(
+        _cross(
             "verdict is REQUEST_CHANGES but no P1 findings exist — "
             "must have at least one P1 to justify REQUEST_CHANGES"
         )
@@ -131,20 +183,20 @@ def validate_review_yaml(data: Any) -> list[str]:
     # ── story_compliance (accept spec_compliance for backward compat) ──
     spec = data.get("story_compliance") or data.get("spec_compliance")
     if spec is None:
-        errors.append("story_compliance section is required")
+        _schema("story_compliance section is required")
     elif not isinstance(spec, dict):
-        errors.append("story_compliance must be a mapping")
+        _schema("story_compliance must be a mapping")
     elif "matches_spec" not in spec:
-        errors.append("story_compliance.matches_spec is required (true/false)")
+        _schema("story_compliance.matches_spec is required (true/false)")
 
     # ── test_coverage ─────────────────────────────────────────────
     tests = data.get("test_coverage")
     if tests is None:
-        errors.append("test_coverage section is required")
+        _schema("test_coverage section is required")
     elif not isinstance(tests, dict):
-        errors.append("test_coverage must be a mapping")
+        _schema("test_coverage must be a mapping")
     elif "adequate" not in tests:
-        errors.append("test_coverage.adequate is required (true/false)")
+        _schema("test_coverage.adequate is required (true/false)")
 
     # ── ac_verification ───────────────────────────────────────────
     # Per-AC verification table. Each entry must declare the criterion text
@@ -157,24 +209,24 @@ def validate_review_yaml(data: Any) -> list[str]:
     if ac_v is None:
         ac_v = []
     if not isinstance(ac_v, list):
-        errors.append("ac_verification must be a list")
+        _schema("ac_verification must be a list")
         ac_v = []
     for i, entry in enumerate(ac_v):
         if not isinstance(entry, dict):
-            errors.append(f"ac_verification[{i}] must be a mapping")
+            _schema(f"ac_verification[{i}] must be a mapping")
             continue
         criterion = entry.get("criterion")
         if not isinstance(criterion, str) or not criterion.strip():
-            errors.append(f"ac_verification[{i}].criterion must be a non-empty string")
+            _schema(f"ac_verification[{i}].criterion must be a non-empty string")
         status = entry.get("status")
         if status not in VALID_AC_VERIFICATION_STATUSES:
-            errors.append(
+            _schema(
                 f"ac_verification[{i}].status must be one of "
                 f"{VALID_AC_VERIFICATION_STATUSES}, got: {status!r}"
             )
         evidence = entry.get("evidence")
         if not isinstance(evidence, str) or not evidence.strip():
-            errors.append(
+            _schema(
                 f"ac_verification[{i}].evidence must be a non-empty string "
                 f"(diff hunks + test pointers for VERIFIED, reason otherwise)"
             )
@@ -183,13 +235,13 @@ def validate_review_yaml(data: Any) -> list[str]:
 
     if verdict == "APPROVE":
         if not ac_v:
-            errors.append(
+            _cross(
                 "verdict is APPROVE but ac_verification is empty — "
                 "reviewers must enumerate each acceptance criterion (or symptom for bugs) "
                 "and mark it VERIFIED with evidence pointers"
             )
         elif non_verified_count > 0:
-            errors.append(
+            _cross(
                 f"verdict is APPROVE but {non_verified_count} ac_verification entry(ies) "
                 f"are PARTIAL or NOT_VERIFIED — cannot approve when any acceptance "
                 f"criterion is unverified"

--- a/tests/test_coord_review_phase_pool.py
+++ b/tests/test_coord_review_phase_pool.py
@@ -548,6 +548,67 @@ class TestReviewParseRetry:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
+    def test_operator_log_classifies_rejection_stage(
+        self,
+        mock_shell,
+        mock_engine_agent,
+        mock_preflight,
+        mock_pool,
+        mock_review_agent,
+        tmp_path,
+        capsys,
+    ):
+        """Operator-facing retry log must name the validation stage that rejected
+        the output (YAML_SYNTAX / SCHEMA_VALIDATION / CONTRACT_CROSS_VALIDATION),
+        not just "parse failed". The spec's RCA workflow depends on this
+        distinction to pick the right remediation surface."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_engine_agent.return_value = _make_agent_result()
+
+        # APPROVE with empty ac_verification — valid YAML, valid types, but a
+        # contract cross-check failure. Pre-fix this would have been logged
+        # identically to a YAML syntax error.
+        cross_validation_output = (
+            "```yaml\n"
+            "verdict: APPROVE\n"
+            'summary: "ok"\n'
+            "findings: []\n"
+            "story_compliance:\n"
+            "  matches_spec: true\n"
+            "  mismatches: []\n"
+            "test_coverage:\n"
+            "  adequate: true\n"
+            "  gaps: []\n"
+            "ac_verification: []\n"
+            "```\n"
+        )
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=cross_validation_output, profile_name="review")
+        ]
+        mock_review_agent.return_value = _make_agent_result(output=cross_validation_output)
+
+        run_task(config, task)
+        captured = capsys.readouterr()
+        log_output = captured.out + captured.err
+
+        assert "CONTRACT_CROSS_VALIDATION" in log_output, (
+            "operator-facing retry log must surface the stage tag; got:\n" + log_output
+        )
+        assert "YAML_SYNTAX" not in log_output, (
+            "schema/contract failure must not be conflated with YAML_SYNTAX"
+        )
+
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
     def test_schema_error_also_retried(
         self, mock_shell, mock_engine_agent, mock_preflight, mock_pool, mock_review_agent, tmp_path
     ):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -101,6 +101,82 @@ class TestParseReviewOutput:
         assert result.verdict == "REQUEST_CHANGES"
         assert len(result.parse_errors) > 0
 
+    def test_yaml_syntax_error_tagged_as_yaml_syntax(self):
+        """Operator-facing: a parser-layer rejection must be tagged YAML_SYNTAX,
+        not lumped with schema/contract failures."""
+        from theforge.schemas import YAML_SYNTAX
+
+        result = parse_review_output("this is not yaml: [[[")
+        assert result.parse_errors
+        stages = {e.stage for e in result.parse_errors}
+        assert stages == {YAML_SYNTAX}
+
+    def test_non_mapping_root_tagged_as_structure(self):
+        from theforge.schemas import STRUCTURE
+
+        # A bare scalar parses as YAML but isn't a mapping.
+        result = parse_review_output("just a string")
+        assert result.parse_errors
+        assert result.parse_errors[0].stage == STRUCTURE
+
+    def test_schema_field_errors_tagged_as_schema_validation(self):
+        """Type/required-field rejections come from the schema layer, not parser."""
+        from theforge.schemas import SCHEMA_VALIDATION
+
+        # Valid YAML, valid mapping, but verdict is wrong type.
+        result = parse_review_output(
+            "```yaml\n"
+            "verdict: MAYBE\n"
+            "summary: ''\n"
+            "findings: []\n"
+            "story_compliance:\n"
+            "  matches_spec: true\n"
+            "test_coverage:\n"
+            "  adequate: true\n"
+            "```\n"
+        )
+        assert result.parse_errors
+        assert all(e.stage == SCHEMA_VALIDATION for e in result.parse_errors)
+
+    def test_contract_cross_validation_tagged_distinctly(self):
+        """APPROVE + P1 and APPROVE + empty ac_verification are contract
+        cross-checks — operators remediate at the prompt/contract layer, not
+        the parser. Stage must distinguish them from YAML_SYNTAX."""
+        from theforge.schemas import CONTRACT_CROSS_VALIDATION, YAML_SYNTAX
+
+        # APPROVE with a P1 finding is a contract contradiction.
+        result = parse_review_output(
+            "```yaml\n"
+            "verdict: APPROVE\n"
+            "summary: 'looks good'\n"
+            "findings:\n"
+            "  - severity: P1\n"
+            "    file: src/x.py\n"
+            "    line: 1\n"
+            "    description: 'blocker'\n"
+            "    suggestion: 'fix it'\n"
+            "story_compliance:\n"
+            "  matches_spec: true\n"
+            "test_coverage:\n"
+            "  adequate: true\n"
+            "ac_verification:\n"
+            "  - criterion: 'AC1'\n"
+            "    status: VERIFIED\n"
+            "    evidence: 'ev'\n"
+            "```\n"
+        )
+        stages = {e.stage for e in result.parse_errors}
+        assert CONTRACT_CROSS_VALIDATION in stages
+        assert YAML_SYNTAX not in stages
+
+    def test_parse_error_str_carries_stage_tag(self):
+        """Rendered form embeds the stage so log/audit consumers that emit
+        the string (not the dataclass) still surface the classification."""
+        from theforge.schemas import YAML_SYNTAX
+
+        result = parse_review_output("not yaml: [[[")
+        assert any(str(e).startswith(f"[{YAML_SYNTAX}]") for e in result.parse_errors)
+
     def test_yaml_with_extra_prose(self):
         text = (
             "Here is my review:\n\n"
@@ -636,15 +712,28 @@ class TestMergeReviewResultsDedup:
         assert set(merged.findings[0].reviewers) == {"reviewer-a", "reviewer-b"}
 
     def test_all_parse_errors_propagated(self):
-        r1 = _make_review_result("REQUEST_CHANGES", parse_errors=["bad yaml"])
-        r2 = _make_review_result("REQUEST_CHANGES", parse_errors=["bad yaml"])
+        from theforge.schemas import YAML_SYNTAX, ParseError
+
+        r1 = _make_review_result(
+            "REQUEST_CHANGES",
+            parse_errors=[ParseError(stage=YAML_SYNTAX, message="bad yaml")],
+        )
+        r2 = _make_review_result(
+            "REQUEST_CHANGES",
+            parse_errors=[ParseError(stage=YAML_SYNTAX, message="bad yaml")],
+        )
         merged = merge_review_results([r1, r2], ["a", "b"])
         assert merged.parse_errors  # propagated for retry loop
 
     def test_mixed_valid_and_parse_error(self):
         finding = _rf("P1", "foo.py", 1, "Bug")
         valid = _make_review_result("REQUEST_CHANGES", findings=[finding])
-        invalid = _make_review_result("REQUEST_CHANGES", parse_errors=["bad"])
+        from theforge.schemas import YAML_SYNTAX, ParseError
+
+        invalid = _make_review_result(
+            "REQUEST_CHANGES",
+            parse_errors=[ParseError(stage=YAML_SYNTAX, message="bad")],
+        )
         merged = merge_review_results([valid, invalid], ["a", "b"])
         assert not merged.parse_errors
         assert len(merged.findings) == 1


### PR DESCRIPTION
## Summary

Structured parse-error stages are carried from review parsing into retry logs and audit rendering; no blocking issues found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $4.91
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Review pipeline conflates YAML syntax errors with schema validation errors in operator-facing logs and audit (GitHub Issue #1544)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1544