### PR TITLE
Sprint re-exec discards in-memory intake-remediation state and re-reads stale GitHub label data, dropping just-remediated issues

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -296,6 +296,52 @@ def _acquire_launch_locks(
     )
 
 
+_INTAKE_REMEDIATED_ENV = "FORGE_INTAKE_REMEDIATED"
+
+
+def _consume_intake_remediated_env() -> set[int]:
+    """Read and clear the carry-across-re-exec remediated-issues env var.
+
+    Set by an earlier process before ``os.execv`` (see ``pull_base_branch``
+    in coordinator/workspace.py). Cleared on consumption so it never bleeds
+    into a subsequent re-exec or a child subprocess that has no business
+    inheriting the sprint's intake state.
+    """
+    import os
+
+    raw = os.environ.pop(_INTAKE_REMEDIATED_ENV, "")
+    if not raw:
+        return set()
+    numbers: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            numbers.add(int(part))
+        except ValueError:
+            continue
+    return numbers
+
+
+def _publish_intake_remediated_env(numbers: "set[int] | frozenset[int]") -> None:
+    """Stash the just-remediated issue numbers in the environment.
+
+    The sprint runner may re-exec the process if ``git pull`` updates the
+    src/theforge tree between intake remediation and dispatch. Env vars
+    survive ``os.execv``; in-memory dicts do not. Re-entry reads the value
+    via ``_consume_intake_remediated_env`` and threads it into the post-
+    re-exec shape gate so the just-remediated issues aren't dropped on a
+    stale ``needs-grooming`` label that the async labeler hasn't reconciled
+    yet.
+    """
+    import os
+
+    if not numbers:
+        return
+    os.environ[_INTAKE_REMEDIATED_ENV] = ",".join(str(n) for n in sorted(numbers))
+
+
 def _is_reexec() -> bool:
     """Return True when the current process was started by a forge re-exec.
 
@@ -539,6 +585,11 @@ def _run_query_mode(
     # Dry-run is a pure dependency preview — bypass the gate there so
     # operators can inspect the DAG without making ``gh`` calls per issue.
     skipped_issues: list = []
+    # Carry-across-re-exec: a prior process may have intake-remediated some
+    # issues and stashed their numbers in the environment before re-exec.
+    # Consume them here so the post-re-exec gate treats the async-lagging
+    # ``needs-grooming`` label as stale rather than authoritative.
+    carried_remediated_numbers = _consume_intake_remediated_env()
     if not dry_run:
         classifier_mode = getattr(getattr(config, "shape_check", None), "classifier", "heuristic")
         gate_result = apply_shape_gate(
@@ -546,6 +597,7 @@ def _run_query_mode(
             config.project_root,
             classifier_mode=classifier_mode,
             force=force,
+            intake_remediated_numbers=carried_remediated_numbers or None,
         )
         if gate_result.skipped:
             warning = format_skipped_warning(gate_result.skipped)
@@ -599,6 +651,14 @@ def _run_query_mode(
                 skipped_issues = [
                     sk for sk in skipped_issues if sk.issue_number not in remediated_numbers
                 ]
+            # Publish the union of this run's remediations and any that were
+            # carried across an earlier re-exec. If run_sprint re-execs after
+            # a mid-sprint source pull, the next entry into _run_query_mode
+            # must trust the just-remediated bodies over the async-stale
+            # ``needs-grooming`` label.
+            _publish_intake_remediated_env(remediated_numbers | carried_remediated_numbers)
+        elif carried_remediated_numbers:
+            _publish_intake_remediated_env(carried_remediated_numbers)
 
         if not issues:
             print(

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -317,6 +317,7 @@ def apply_shape_gate(
     force: bool = False,
     fetch_detail=_fetch_issue_detail,
     llm_caller=None,
+    intake_remediated_numbers: "set[int] | frozenset[int] | None" = None,
 ) -> ShapeGateResult:
     """Partition issues into runnable vs skipped before preflight runs.
 
@@ -333,7 +334,16 @@ def apply_shape_gate(
 
     ``force=True`` returns every input issue as runnable but still populates
     ``skipped`` so the CLI can surface a prominent warning listing reasons.
+
+    ``intake_remediated_numbers`` lists issues whose bodies this run just
+    authoritatively edited via intake remediation. The async ``needs-grooming``
+    relabeler workflow may not have caught up by re-exec time; for these
+    issues the label is treated as async-stale and the live local check is
+    trusted instead. Without this suppression, a sprint that successfully
+    remediates an issue and then re-execs (source-pull mid-run) drops the
+    just-remediated issue on the post-re-exec gate pass.
     """
+    remediated = frozenset(intake_remediated_numbers or ())
     effective_mode = _resolve_classifier(classifier_mode, llm_caller=llm_caller)
     runnable: list[dict] = []
     skipped: list[SkippedIssue] = []
@@ -384,7 +394,7 @@ def apply_shape_gate(
             llm_caller=llm_caller,
         )
 
-        if NEEDS_GROOMING_LABEL in labels:
+        if NEEDS_GROOMING_LABEL in labels and number not in remediated:
             codes = _blocking_codes(local) or ["needs_grooming_label"]
             skipped.append(
                 SkippedIssue(

--- a/tests/test_cli_sprint_shape_gate.py
+++ b/tests/test_cli_sprint_shape_gate.py
@@ -541,3 +541,139 @@ def test_cli_remediated_issues_not_in_nothing_to_run_message(tmp_path: Path, cap
     assert rc == 0
     err = capsys.readouterr().err
     assert "nothing to run" not in err
+
+
+def test_cli_remediated_issues_publish_env_var_for_reexec_carry(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """After successful intake remediation, the just-remediated issue numbers
+    are stashed in ``FORGE_INTAKE_REMEDIATED`` so they survive ``os.execv``
+    when the runner re-execs on a mid-sprint source pull. Without this,
+    the post-re-exec shape gate re-queries GitHub and drops issues whose
+    ``needs-grooming`` label hasn't been async-reconciled yet."""
+    from theforge.cli.sprint import _INTAKE_REMEDIATED_ENV
+    from theforge.config.types import IntakeConfig
+    from theforge.intake import IntakeOutcome, IntakeOutcomeKind
+
+    monkeypatch.delenv(_INTAKE_REMEDIATED_ENV, raising=False)
+
+    config = _make_config(tmp_path)
+    object.__setattr__(
+        config,
+        "intake",
+        IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="edit"),
+    )
+    args = _query_args(tmp_path)
+
+    fetched = [
+        {"number": 1543, "title": "a"},
+        {"number": 1544, "title": "b"},
+        {"number": 1545, "title": "c"},
+    ]
+    gated = ShapeGateResult(
+        runnable=[],
+        skipped=[
+            SkippedIssue(
+                issue_number=n,
+                reason_codes=("missing_observed",),
+                source="local_check",
+                title=str(n),
+            )
+            for n in (1543, 1544, 1545)
+        ],
+    )
+
+    def fake_remediate(skipped, **_kw):
+        return {
+            sk.issue_number: IntakeOutcome(
+                slug=f"issue-{sk.issue_number}",
+                kind=IntakeOutcomeKind.REMEDIATED,
+                detail="edit mode: issue body updated, gate rerun passed",
+                audit={"remediation_source": "agent"},
+            )
+            for sk in skipped
+        }
+
+    captured_env_at_run_sprint: dict = {}
+
+    def fake_run_sprint(*_a, **_kw):
+        import os as _os
+
+        captured_env_at_run_sprint["val"] = _os.environ.get(_INTAKE_REMEDIATED_ENV)
+        return _ok_result()
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=config),
+        patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+        patch("theforge.sprint.query.fetch_issues_for_milestone", return_value=fetched),
+        patch("theforge.sprint.shape_gate.apply_shape_gate", return_value=gated),
+        patch(
+            "theforge.sprint.entry_intake.remediate_entry_skipped_issues",
+            side_effect=fake_remediate,
+        ),
+        patch(
+            "theforge.sprint.query.build_resolved_sprint",
+            return_value=_resolved([1543, 1544, 1545]),
+        ),
+        patch(
+            "theforge.cli.sprint._acquire_launch_locks",
+            return_value=([], None, {}),
+        ),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint.run_sprint", side_effect=fake_run_sprint),
+    ):
+        cmd_sprint(args)
+
+    # By the time run_sprint runs (and may re-exec via pull_base_branch),
+    # the env var must be set so the post-re-exec gate trusts the
+    # just-remediated bodies over the async-stale label.
+    assert captured_env_at_run_sprint.get("val") == "1543,1544,1545"
+
+
+def test_cli_carries_remediated_numbers_from_env_into_shape_gate(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """On re-exec entry, the gate must receive the carried numbers via the
+    ``intake_remediated_numbers`` kwarg, and the env var must be consumed
+    (cleared) so it doesn't bleed into a downstream subprocess."""
+    from theforge.cli.sprint import _INTAKE_REMEDIATED_ENV
+
+    monkeypatch.setenv(_INTAKE_REMEDIATED_ENV, "1545,1543")
+
+    config = _make_config(tmp_path)
+    args = _query_args(tmp_path)
+
+    fetched = [{"number": 1543, "title": "good"}]
+    gated = ShapeGateResult(runnable=fetched, skipped=[])
+    captured: dict = {}
+
+    def _spy(*_a, **kwargs):
+        captured["kwargs"] = kwargs
+        return gated
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=config),
+        patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+        patch("theforge.sprint.query.fetch_issues_for_milestone", return_value=fetched),
+        patch("theforge.sprint.query.build_resolved_sprint", return_value=_resolved([1543])),
+        patch("theforge.sprint.shape_gate.apply_shape_gate", side_effect=_spy),
+        patch(
+            "theforge.cli.sprint._acquire_launch_locks",
+            return_value=([], None, {}),
+        ),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint.run_sprint", return_value=_ok_result()),
+    ):
+        cmd_sprint(args)
+
+    threaded = captured["kwargs"].get("intake_remediated_numbers")
+    assert threaded is not None
+    assert set(threaded) == {1543, 1545}
+
+    # The env var is re-published with the carried set so a downstream
+    # re-exec (rare but possible if a second source-pull lands mid-run)
+    # still treats the async-stale label as non-authoritative for these
+    # already-remediated issues.
+    import os as _os
+
+    assert _os.environ.get(_INTAKE_REMEDIATED_ENV) == "1543,1545"

--- a/tests/test_sprint_shape_gate.py
+++ b/tests/test_sprint_shape_gate.py
@@ -99,6 +99,74 @@ def test_label_skip_falls_back_to_label_detail_when_live_check_is_runnable(
     assert entry.detail == "issue carries 'needs-grooming' label"
 
 
+# ── Intake-remediated label suppression (re-exec carry) ─────────────────────
+
+
+def test_intake_remediated_issue_with_stale_grooming_label_runs(tmp_path: Path) -> None:
+    """If a sprint just remediated an issue's body, the post-re-exec gate
+    must trust the local re-check over the async-lagging ``needs-grooming``
+    label that the GH labeler workflow has not yet reconciled.
+    """
+    issues = [{"number": 1545, "title": "Just-remediated"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_RUNNABLE_BODY, [NEEDS_GROOMING_LABEL, "enhancement"]),
+        intake_remediated_numbers={1545},
+    )
+
+    assert result.runnable == issues
+    assert result.skipped == []
+
+
+def test_intake_remediated_set_does_not_rescue_unrelated_issues(tmp_path: Path) -> None:
+    """The suppression is per-issue: a remediated issue is rescued, an
+    unrelated needs-grooming issue is still skipped on the same call.
+    """
+    issues = [
+        {"number": 1545, "title": "Just-remediated"},
+        {"number": 9999, "title": "Stale label, not remediated"},
+    ]
+
+    def fetch(number, _project_root):
+        return {
+            "title": f"#{number}",
+            "body": _RUNNABLE_BODY,
+            "labels": [NEEDS_GROOMING_LABEL, "enhancement"],
+        }
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=fetch,
+        intake_remediated_numbers={1545},
+    )
+
+    assert [i["number"] for i in result.runnable] == [1545]
+    assert len(result.skipped) == 1
+    assert result.skipped[0].issue_number == 9999
+
+
+def test_intake_remediated_does_not_paper_over_broken_body(tmp_path: Path) -> None:
+    """Suppression of the label-source skip must NOT bypass the local check.
+    If the body is still malformed (e.g. body-edit didn't actually fix it),
+    the issue still drops via the local_check path.
+    """
+    issues = [{"number": 1545, "title": "Edit didn't fix it"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_BAD_BODY, [NEEDS_GROOMING_LABEL]),
+        intake_remediated_numbers={1545},
+    )
+
+    assert result.runnable == []
+    assert len(result.skipped) == 1
+    assert result.skipped[0].source == "local_check"
+
+
 # ── Local-check-skip path ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Carries remediated issue state across re-exec and suppresses only stale needs-grooming labels; focused tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.62
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint re-exec discards in-memory intake-remediation state and re-reads stale GitHub label data, dropping just-remediated issues (GitHub Issue #1550)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1550