### PR TITLE
Diagnosis readiness records baseline evidence and warns when stale against current base

### DIFF
--- a/src/theforge/cli/groom.py
+++ b/src/theforge/cli/groom.py
@@ -37,6 +37,21 @@ def _print_summary(result: GroomResult) -> None:
     print(f"Type: {result.issue_type or '(none)'}", file=sys.stderr)
     if result.issue_type == "bug":
         print(f"Diagnosis state: {result.bug_state.value}", file=sys.stderr)
+        if result.staleness is not None:
+            sha = result.staleness.baseline_sha or "(none)"
+            print(
+                f"Diagnosis baseline: {sha} (staleness={result.staleness.state.value})",
+                file=sys.stderr,
+            )
+            if result.staleness.changed_files:
+                changed = ", ".join(result.staleness.changed_files)
+                print(f"  Changed since baseline: {changed}", file=sys.stderr)
+            if result.confirm_diagnosis_current and result.staleness.is_stale:
+                print(
+                    "  --confirm-diagnosis-current: operator override applied "
+                    "(decision recorded in audit substrate)",
+                    file=sys.stderr,
+                )
     print(f"Pre-groom verdict:  {result.pre_verdict.value}", file=sys.stderr)
     print(f"Post-groom verdict: {result.post_verdict.value}", file=sys.stderr)
 
@@ -54,6 +69,7 @@ def cmd_groom(args: argparse.Namespace) -> int:
             issue_ref,
             apply_changes=apply_changes,
             project_root=project_root,
+            confirm_diagnosis_current=bool(getattr(args, "confirm_diagnosis_current", False)),
         )
     except GroomError as exc:
         print(f"[forge groom] {exc}", file=sys.stderr)
@@ -84,6 +100,12 @@ def cmd_groom(args: argparse.Namespace) -> int:
             "      Next step: continue diagnosis until a confirmed cause is identified.",
             file=sys.stdout,
         )
+        if result.staleness_notice:
+            print(
+                "\nNOTE: Diagnosis baseline is stale; continued investigation should\n"
+                "      re-run forge diagnose to refresh ruled-out hypotheses.",
+                file=sys.stdout,
+            )
 
     if result.needs_change:
         if apply_changes:
@@ -136,6 +158,17 @@ def register_parser(subparsers: object) -> None:
         help=(
             "Print a recommended next operator command "
             "(output is for humans, not a stable protocol)"
+        ),
+    )
+    p.add_argument(
+        "--confirm-diagnosis-current",
+        dest="confirm_diagnosis_current",
+        action="store_true",
+        default=False,
+        help=(
+            "Operator assertion that the diagnosis is still valid against the current "
+            "base, even if the recorded baseline is stale. Recorded in the audit "
+            "substrate so the decision is auditable rather than silent."
         ),
     )
     p.add_argument(

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -112,11 +112,14 @@ CREATE TABLE IF NOT EXISTS readiness_events (
     bug_diagnosis_state TEXT,
     refusal_reason TEXT,
     emitted_at TEXT NOT NULL,
-    raw_json TEXT NOT NULL
+    raw_json TEXT NOT NULL,
+    staleness_verdict TEXT,
+    diagnosis_baseline_sha TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_readiness_events_kind ON readiness_events(kind);
 CREATE INDEX IF NOT EXISTS idx_readiness_events_issue ON readiness_events(issue_ref);
 CREATE INDEX IF NOT EXISTS idx_readiness_events_action ON readiness_events(action);
+CREATE INDEX IF NOT EXISTS idx_readiness_events_staleness ON readiness_events(staleness_verdict);
 """
 
 
@@ -129,6 +132,14 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE audit_records ADD COLUMN complexity_score INTEGER")
     except sqlite3.OperationalError:
         pass
+    for stmt in (
+        "ALTER TABLE readiness_events ADD COLUMN staleness_verdict TEXT",
+        "ALTER TABLE readiness_events ADD COLUMN diagnosis_baseline_sha TEXT",
+    ):
+        try:
+            conn.execute(stmt)
+        except sqlite3.OperationalError:
+            pass
     conn.execute(
         "INSERT INTO meta(key, value) VALUES (?, ?) "
         "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
@@ -1039,8 +1050,9 @@ def record_readiness_event(project_root: Path, event: dict) -> int:
         cur = conn.execute(
             "INSERT INTO readiness_events "
             "(kind, issue_ref, issue_type, pre_verdict, post_verdict, action, "
-            "applied, bug_diagnosis_state, refusal_reason, emitted_at, raw_json) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "applied, bug_diagnosis_state, refusal_reason, emitted_at, raw_json, "
+            "staleness_verdict, diagnosis_baseline_sha) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 str(event["kind"]),
                 str(event["issue_ref"]),
@@ -1053,6 +1065,8 @@ def record_readiness_event(project_root: Path, event: dict) -> int:
                 event.get("refusal_reason"),
                 emitted_at,
                 raw_json,
+                event.get("staleness_verdict"),
+                event.get("diagnosis_baseline_sha"),
             ),
         )
         conn.commit()

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -16,6 +16,7 @@ fix-ready for a subsequent ``forge sprint`` run.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -34,6 +35,7 @@ from theforge.diagnose_types import (
     DiagnoseResult,
     DiagnoseState,
     DiagnosisArtifact,
+    InspectedFile,
     render_artifact_markdown,
     upsert_diagnosis_section,
 )
@@ -63,6 +65,71 @@ def _generate_run_id() -> str:
 
 
 # ── Issue I/O via gh CLI ──────────────────────────────────────────────
+
+
+# ── Baseline capture ──────────────────────────────────────────────────
+
+
+def _capture_base_sha(project_root: Path) -> str:
+    """Return the current HEAD SHA of the repo at ``project_root``.
+
+    Empty string when ``project_root`` is not a git checkout — the diagnose
+    flow still proceeds; the staleness check downstream simply has no
+    baseline to compare against.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _hash_file_at_sha(path: str, sha: str, project_root: Path) -> str:
+    """Return the sha256 hex digest of ``path`` at git ``sha``.
+
+    Falls back to hashing the working-tree file when the path is not
+    tracked at that SHA (returns "" when neither lookup succeeds). Empty
+    return signals an inspected file we cannot baseline — the staleness
+    check treats those as informational only.
+    """
+    if not sha or not path:
+        return ""
+    try:
+        proc = subprocess.run(
+            ["git", "show", f"{sha}:{path}"],
+            capture_output=True,
+            cwd=str(project_root),
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        proc = None
+    if proc is not None and proc.returncode == 0:
+        return hashlib.sha256(proc.stdout).hexdigest()
+    fs_path = project_root / path
+    try:
+        return hashlib.sha256(fs_path.read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
+def _baseline_inspected_files(
+    files: tuple[InspectedFile, ...], sha: str, project_root: Path
+) -> tuple[InspectedFile, ...]:
+    """Hash each inspected file against the baseline SHA."""
+    if not files:
+        return ()
+    return tuple(
+        InspectedFile(path=f.path, content_sha256=_hash_file_at_sha(f.path, sha, project_root))
+        for f in files
+    )
 
 
 def _gh_fetch_issue(number: int, project_root: Path) -> dict:
@@ -188,6 +255,10 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
             "location": state.landed_location,
         },
         "sub_investigations": list(state.sub_investigations),
+        "baseline": {
+            "sha": state.baseline_sha,
+            "captured_at": state.baseline_captured_at,
+        },
         "error": state.error,
     }
     if state.artifact is not None:
@@ -214,6 +285,11 @@ def _artifact_to_dict(artifact: DiagnosisArtifact) -> dict:
         "fix_success_criterion": artifact.fix_success_criterion,
         "partial": artifact.partial,
         "notes": artifact.notes,
+        "baseline_sha": artifact.baseline_sha,
+        "baseline_captured_at": artifact.baseline_captured_at,
+        "inspected_files": [
+            {"path": f.path, "content_sha256": f.content_sha256} for f in artifact.inspected_files
+        ],
     }
 
 
@@ -346,6 +422,12 @@ def run_diagnose_flow(
 
     state.issue_title = str(issue.get("title", ""))
     state.issue_body = str(issue.get("body", ""))
+    # Capture baseline SHA at the moment the diagnosis is anchored. Done
+    # post-FETCH so a fetch failure doesn't burn a baseline timestamp; done
+    # pre-INVESTIGATE so the agent runs against (and the staleness check
+    # later compares against) one known commit.
+    state.baseline_sha = _capture_base_sha(project_root)
+    state.baseline_captured_at = _now_iso()
     issue_state = str(issue.get("state", "OPEN")).upper()
     if issue_state != "OPEN":
         state.error = f"Issue #{issue_number} is {issue_state.lower()}; refusing to diagnose"
@@ -407,6 +489,19 @@ def run_diagnose_flow(
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
+    # Anchor the artifact to the baseline SHA captured at FETCH time, and
+    # hash each agent-reported inspected file against that SHA so a later
+    # `forge groom` can detect when the diagnosis has gone stale relative
+    # to the current base branch.
+    inspected_with_hashes = _baseline_inspected_files(
+        artifact.inspected_files, state.baseline_sha, project_root
+    )
+    artifact = dataclasses.replace(
+        artifact,
+        baseline_sha=state.baseline_sha,
+        baseline_captured_at=state.baseline_captured_at,
+        inspected_files=inspected_with_hashes,
+    )
     state.artifact = artifact
 
     # If essential fields are missing OR the run breached its budget/timeout

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -5,6 +5,7 @@ stdlib-only imports; no coordinator or runner dependencies.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from enum import Enum, auto
 
@@ -41,6 +42,22 @@ class Hypothesis:
 
 
 @dataclass(frozen=True)
+class InspectedFile:
+    """A file the diagnosis agent inspected, with its content hash at baseline.
+
+    ``content_sha256`` is the hex digest of the file's bytes at
+    ``baseline_sha`` — the staleness check compares this to a fresh hash of
+    the same path against the current base to detect material drift.
+    Untracked or missing-at-baseline files carry an empty ``content_sha256``;
+    they cannot be used for staleness comparison and the groom-side check
+    treats them as informational only.
+    """
+
+    path: str
+    content_sha256: str = ""
+
+
+@dataclass(frozen=True)
 class DiagnosisArtifact:
     """Structured diagnosis output from an investigative agent.
 
@@ -58,6 +75,9 @@ class DiagnosisArtifact:
     fix_success_criterion: str
     partial: bool = False  # True when the agent ran out of time/budget
     notes: str = ""
+    baseline_sha: str = ""
+    baseline_captured_at: str = ""
+    inspected_files: tuple[InspectedFile, ...] = ()
 
     def is_complete(self) -> bool:
         """Return True only when every required field is non-empty."""
@@ -92,6 +112,8 @@ class DiagnoseState:
     landing_destination: str | None = None
     landed_location: str | None = None  # URL / path / comment id
     error: str | None = None
+    baseline_sha: str = ""
+    baseline_captured_at: str = ""
     phase_transitions: list[tuple[str, str]] = field(default_factory=list)
     # (phase_name, ISO timestamp) entries appended on every transition.
     sub_investigations: list[dict] = field(default_factory=list)
@@ -128,6 +150,17 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
             "> ⚠ Partial diagnosis — the investigation hit its budget or "
             "timeout before reaching a confirmed cause. Operator review required."
         )
+    if artifact.baseline_sha:
+        lines.append("")
+        ts = artifact.baseline_captured_at or "unknown"
+        lines.append(f"**Baseline:** `{artifact.baseline_sha}` captured at `{ts}`")
+    if artifact.inspected_files:
+        lines.append("")
+        lines.append("**Inspected files:**")
+        lines.append("")
+        for f in artifact.inspected_files:
+            digest = f.content_sha256 or "unknown"
+            lines.append(f"- `{f.path}` — `sha256:{digest}`")
     lines.extend(
         [
             "",
@@ -199,3 +232,69 @@ def upsert_diagnosis_section(body: str, section_markdown: str) -> str:
             break
     new_lines = lines[:start] + [section.rstrip()] + lines[end:]
     return "\n".join(new_lines).rstrip() + "\n"
+
+
+# ── Baseline metadata extraction ──────────────────────────────────────
+
+
+_BASELINE_LINE_RE = re.compile(
+    r"\*\*Baseline:\*\*\s*`([^`]+)`\s*captured at\s*`([^`]+)`",
+    re.IGNORECASE,
+)
+_INSPECTED_HEADER_RE = re.compile(r"\*\*Inspected files:\*\*", re.IGNORECASE)
+_INSPECTED_BULLET_RE = re.compile(
+    r"^\s*-\s*`([^`]+)`\s*(?:—|--)\s*`sha256:([0-9a-fA-F]*|unknown)`\s*$"
+)
+
+
+@dataclass(frozen=True)
+class BaselineMetadata:
+    """Baseline metadata parsed from a rendered diagnosis section."""
+
+    baseline_sha: str
+    baseline_captured_at: str
+    inspected_files: tuple[InspectedFile, ...]
+
+
+def parse_baseline_metadata(body: str) -> BaselineMetadata | None:
+    """Parse baseline + inspected-file metadata out of an issue body.
+
+    Returns ``None`` when no ``**Baseline:**`` line is present anywhere in
+    the body (a diagnosis written before this baseline-anchoring feature
+    shipped). Returns a :class:`BaselineMetadata` with possibly-empty
+    ``inspected_files`` when a baseline line is present but the inspected
+    block is absent or unparseable.
+    """
+    m = _BASELINE_LINE_RE.search(body)
+    if not m:
+        return None
+    sha = m.group(1).strip()
+    ts = m.group(2).strip()
+
+    files: list[InspectedFile] = []
+    header_match = _INSPECTED_HEADER_RE.search(body)
+    if header_match:
+        tail = body[header_match.end() :]
+        for line in tail.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                if files:
+                    # blank line after at least one bullet ends the block
+                    break
+                continue
+            if stripped.startswith("##") or stripped.startswith("###"):
+                break
+            bm = _INSPECTED_BULLET_RE.match(line)
+            if bm:
+                digest = bm.group(2).strip()
+                if digest.lower() == "unknown":
+                    digest = ""
+                files.append(InspectedFile(path=bm.group(1).strip(), content_sha256=digest))
+            elif files:
+                # non-bullet, non-blank after bullets started — block ended
+                break
+    return BaselineMetadata(
+        baseline_sha=sha,
+        baseline_captured_at=ts,
+        inspected_files=tuple(files),
+    )

--- a/src/theforge/intake/diagnosis_staleness.py
+++ b/src/theforge/intake/diagnosis_staleness.py
@@ -1,0 +1,156 @@
+"""Diagnosis-baseline staleness detection for ``forge groom``.
+
+ADR-0001's three-state diagnosis vocabulary records what the operator knew
+at write time but is silent about how that knowledge ages. ``forge diagnose``
+anchors a diagnosis to a baseline SHA and the content hash of every file
+it inspected; ``forge groom`` uses this module to ask the mechanical
+question "have any inspected files changed since the baseline?" so a stale
+diagnosis cannot silently transition the issue to ``ready``.
+
+Stdlib only — no provider SDK or runner dependencies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+from theforge.diagnose_types import (
+    BaselineMetadata,
+    InspectedFile,
+    parse_baseline_metadata,
+)
+
+
+class StalenessState(str, Enum):
+    """Outcome of comparing a diagnosis baseline against the current base."""
+
+    NOT_APPLICABLE = "not-applicable"  # not a bug, or no diagnosis section
+    NO_BASELINE = "no-baseline"  # diagnosis predates baseline anchoring
+    FRESH = "fresh"  # baseline equals current HEAD (no advance)
+    UNCHANGED = "unchanged"  # base advanced but inspected files unchanged
+    STALE = "stale"  # base advanced AND inspected files changed materially
+
+
+@dataclass(frozen=True)
+class StalenessReport:
+    """Result of a staleness check against current base."""
+
+    state: StalenessState
+    baseline_sha: str = ""
+    baseline_captured_at: str = ""
+    current_sha: str = ""
+    changed_files: tuple[str, ...] = field(default_factory=tuple)
+    unchanged_files: tuple[str, ...] = field(default_factory=tuple)
+    untracked_files: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def is_stale(self) -> bool:
+        return self.state is StalenessState.STALE
+
+
+def _current_head(project_root: Path) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _hash_current(path: str, project_root: Path) -> str:
+    fs_path = project_root / path
+    try:
+        return hashlib.sha256(fs_path.read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
+def evaluate_staleness(
+    body: str,
+    *,
+    project_root: Path | None,
+) -> StalenessReport:
+    """Return a :class:`StalenessReport` for the diagnosis section in ``body``.
+
+    Parses ``**Baseline:**`` + ``**Inspected files:**`` metadata out of the
+    body, asks git for the current HEAD, then re-hashes each inspected file
+    against the working tree.
+
+    Without a usable ``project_root`` (no git checkout, or no inspected
+    files) the report is :attr:`StalenessState.NO_BASELINE` /
+    :attr:`StalenessState.NOT_APPLICABLE` / :attr:`StalenessState.UNCHANGED`
+    rather than ``STALE`` — the staleness gate is a refusal mechanism, so
+    only positive evidence of drift produces a refusal verdict.
+    """
+    metadata = parse_baseline_metadata(body)
+    if metadata is None:
+        return StalenessReport(state=StalenessState.NO_BASELINE)
+
+    if project_root is None:
+        # Without a checkout we cannot compute current hashes; report the
+        # baseline back to callers as informational state only.
+        return StalenessReport(
+            state=StalenessState.UNCHANGED,
+            baseline_sha=metadata.baseline_sha,
+            baseline_captured_at=metadata.baseline_captured_at,
+        )
+
+    current = _current_head(project_root)
+    if current and current == metadata.baseline_sha:
+        # Base hasn't advanced — by definition, no material drift.
+        return StalenessReport(
+            state=StalenessState.FRESH,
+            baseline_sha=metadata.baseline_sha,
+            baseline_captured_at=metadata.baseline_captured_at,
+            current_sha=current,
+            unchanged_files=tuple(f.path for f in metadata.inspected_files),
+        )
+
+    return _diff_inspected(metadata, current, project_root)
+
+
+def _diff_inspected(
+    metadata: BaselineMetadata, current_sha: str, project_root: Path
+) -> StalenessReport:
+    changed: list[str] = []
+    unchanged: list[str] = []
+    untracked: list[str] = []
+    for f in metadata.inspected_files:
+        baseline_digest = (f.content_sha256 or "").lower()
+        current_digest = _hash_current(f.path, project_root).lower()
+        if not baseline_digest or not current_digest:
+            untracked.append(f.path)
+            continue
+        if current_digest != baseline_digest:
+            changed.append(f.path)
+        else:
+            unchanged.append(f.path)
+    state = StalenessState.STALE if changed else StalenessState.UNCHANGED
+    return StalenessReport(
+        state=state,
+        baseline_sha=metadata.baseline_sha,
+        baseline_captured_at=metadata.baseline_captured_at,
+        current_sha=current_sha,
+        changed_files=tuple(changed),
+        unchanged_files=tuple(unchanged),
+        untracked_files=tuple(untracked),
+    )
+
+
+__all__ = [
+    "StalenessState",
+    "StalenessReport",
+    "evaluate_staleness",
+    "InspectedFile",
+]

--- a/src/theforge/intake/diagnosis_staleness.py
+++ b/src/theforge/intake/diagnosis_staleness.py
@@ -17,6 +17,7 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 from theforge.diagnose_types import (
     BaselineMetadata,
@@ -68,12 +69,53 @@ def _current_head(project_root: Path) -> str:
     return proc.stdout.strip()
 
 
-def _hash_current(path: str, project_root: Path) -> str:
+def _hash_at_sha(
+    path: str, sha: str, project_root: Path
+) -> tuple[str, Literal["present", "absent", "unknown"]]:
+    """Return ``(hex_digest, presence)`` for ``path`` at git ``sha``.
+
+    Presence is ``"present"`` when git successfully returned the blob,
+    ``"absent"`` when git confirmed the path does not exist at that commit
+    (a positive deletion signal — treated as a material change by callers),
+    and ``"unknown"`` when git itself is unavailable / errored / there is no
+    sha to query, in which case callers should not flip the staleness verdict.
+    Falls back to the working tree only when git lookup is inconclusive.
+    """
+    if sha:
+        try:
+            proc = subprocess.run(
+                ["git", "cat-file", "-e", f"{sha}:{path}"],
+                capture_output=True,
+                cwd=str(project_root),
+                timeout=10,
+            )
+        except (OSError, subprocess.SubprocessError):
+            proc = None
+        if proc is not None:
+            if proc.returncode == 0:
+                try:
+                    show = subprocess.run(
+                        ["git", "show", f"{sha}:{path}"],
+                        capture_output=True,
+                        cwd=str(project_root),
+                        timeout=10,
+                    )
+                except (OSError, subprocess.SubprocessError):
+                    show = None
+                if show is not None and show.returncode == 0:
+                    return hashlib.sha256(show.stdout).hexdigest(), "present"
+            else:
+                # git is reachable and the path is positively absent at sha.
+                return "", "absent"
     fs_path = project_root / path
     try:
-        return hashlib.sha256(fs_path.read_bytes()).hexdigest()
+        return hashlib.sha256(fs_path.read_bytes()).hexdigest(), "present"
+    except FileNotFoundError:
+        # No git answer and no working-tree file — treat as a real absence
+        # so deletions surface as material changes.
+        return "", "absent"
     except OSError:
-        return ""
+        return "", "unknown"
 
 
 def evaluate_staleness(
@@ -128,11 +170,18 @@ def _diff_inspected(
     untracked: list[str] = []
     for f in metadata.inspected_files:
         baseline_digest = (f.content_sha256 or "").lower()
-        current_digest = _hash_current(f.path, project_root).lower()
+        current_digest, presence = _hash_at_sha(f.path, current_sha, project_root)
+        # Deletion is a material change: a path with a baseline digest that
+        # is positively absent at the current SHA must surface as STALE,
+        # not get hidden in untracked_files (which would let groom promote
+        # a confirmed-cause diagnosis whose evidence has been removed).
+        if baseline_digest and presence == "absent":
+            changed.append(f.path)
+            continue
         if not baseline_digest or not current_digest:
             untracked.append(f.path)
             continue
-        if current_digest != baseline_digest:
+        if current_digest.lower() != baseline_digest:
             changed.append(f.path)
         else:
             unchanged.append(f.path)

--- a/src/theforge/intake/groom_flow.py
+++ b/src/theforge/intake/groom_flow.py
@@ -30,6 +30,7 @@ from ..shape_check.heuristics import (
     is_bug_format_issue,
 )
 from ..shape_check.parsing import find_heading
+from .diagnosis_staleness import StalenessReport, evaluate_staleness
 
 # ── Types ─────────────────────────────────────────────────────────────────
 
@@ -70,6 +71,9 @@ class GroomResult:
     next_command: str | None = None
     investigation_only_notice: bool = False
     labels: tuple[str, ...] = field(default_factory=tuple)
+    staleness: StalenessReport | None = None
+    confirm_diagnosis_current: bool = False
+    staleness_notice: bool = False
 
     @property
     def needs_change(self) -> bool:
@@ -77,7 +81,7 @@ class GroomResult:
 
     def as_event(self) -> dict:
         """Return the SQLite audit-substrate event payload."""
-        return {
+        payload: dict = {
             "kind": "groom",
             "issue_ref": self.issue_ref,
             "issue_type": self.issue_type,
@@ -88,6 +92,14 @@ class GroomResult:
             "applied": self.applied,
             "refusal_reason": self.refusal_reason,
         }
+        if self.staleness is not None:
+            payload["staleness_verdict"] = self.staleness.state.value
+            payload["diagnosis_baseline_sha"] = self.staleness.baseline_sha
+            payload["diagnosis_current_sha"] = self.staleness.current_sha
+            payload["stale_files"] = list(self.staleness.changed_files)
+            if self.confirm_diagnosis_current:
+                payload["confirm_diagnosis_current"] = True
+        return payload
 
 
 # ── I/O seams ─────────────────────────────────────────────────────────────
@@ -404,14 +416,34 @@ def _classify_action(
     bug_state: BugDiagnosisState,
     pre_verdict: ShapeVerdict,
     needs_change: bool,
+    staleness: StalenessReport | None = None,
+    confirm_diagnosis_current: bool = False,
+    issue_ref: str = "<N>",
 ) -> tuple[GroomAction, str | None]:
     """Return (action, refusal_reason).
 
     Pure decision function — does not produce output text. Enforces the
-    three-state bug invariant.
+    three-state bug invariant *and* the baseline-staleness invariant: a
+    stale ``CONFIRMED_CAUSE`` diagnosis cannot transition to ready unless
+    the operator passes ``confirm_diagnosis_current``. Cause-unknown stays
+    investigation-ready regardless of staleness (per spec — staleness is
+    informational for that state, not a refusal).
     """
     if issue_type == "bug" and bug_state is BugDiagnosisState.NO_DIAGNOSIS:
         return GroomAction.REFUSED, "needs diagnosis — run forge diagnose <N> first."
+    if (
+        issue_type == "bug"
+        and bug_state is BugDiagnosisState.CONFIRMED_CAUSE
+        and staleness is not None
+        and staleness.is_stale
+        and not confirm_diagnosis_current
+    ):
+        sha = staleness.baseline_sha or "unknown"
+        reason = (
+            f"diagnosis baseline (SHA {sha}) is stale relative to current base — "
+            f"re-run forge diagnose {issue_ref} or confirm baseline is still valid."
+        )
+        return GroomAction.REFUSED, reason
     if issue_type == "bug" and bug_state is BugDiagnosisState.CAUSE_UNKNOWN:
         return GroomAction.NORMALIZED_ONLY, None
     return GroomAction.RESTRUCTURED, None
@@ -424,6 +456,7 @@ def run_groom(
     project_root: Path | None = None,
     fetch_issue: FetchIssue | None = None,
     edit_issue_body: EditIssueBody | None = None,
+    confirm_diagnosis_current: bool = False,
 ) -> GroomResult:
     """Run the groom flow against a single issue.
 
@@ -446,6 +479,13 @@ def run_groom(
         else BugDiagnosisState.NOT_A_BUG
     )
 
+    staleness: StalenessReport | None = None
+    if issue_type == "bug" and bug_state in (
+        BugDiagnosisState.CONFIRMED_CAUSE,
+        BugDiagnosisState.CAUSE_UNKNOWN,
+    ):
+        staleness = evaluate_staleness(body, project_root=project_root)
+
     # Shape gate's native type vocabulary doesn't include ``docs`` or
     # ``story``; normalize before each check so verdict-derivation runs
     # against a recognized type label.
@@ -460,6 +500,9 @@ def run_groom(
         bug_state=bug_state,
         pre_verdict=pre_verdict,
         needs_change=False,
+        staleness=staleness,
+        confirm_diagnosis_current=confirm_diagnosis_current,
+        issue_ref=str(loaded.number) if loaded.number is not None else issue_ref,
     )
 
     if action is GroomAction.REFUSED:
@@ -484,6 +527,13 @@ def run_groom(
             refusal_reason=refusal_reason,
             next_command=next_cmd,
             labels=tuple(labels),
+            staleness=staleness,
+            confirm_diagnosis_current=confirm_diagnosis_current,
+            staleness_notice=(
+                staleness is not None
+                and staleness.is_stale
+                and bug_state is BugDiagnosisState.CAUSE_UNKNOWN
+            ),
         )
 
     # Body restructure / normalization
@@ -556,4 +606,11 @@ def run_groom(
         next_command=next_cmd,
         investigation_only_notice=(bug_state is BugDiagnosisState.CAUSE_UNKNOWN),
         labels=tuple(labels),
+        staleness=staleness,
+        confirm_diagnosis_current=confirm_diagnosis_current,
+        staleness_notice=(
+            staleness is not None
+            and staleness.is_stale
+            and bug_state is BugDiagnosisState.CAUSE_UNKNOWN
+        ),
     )

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import yaml
 
-from theforge.diagnose_types import DiagnosisArtifact, Hypothesis
+from theforge.diagnose_types import DiagnosisArtifact, Hypothesis, InspectedFile
 
 _DIAGNOSE_PROMPT_TEMPLATE = """\
 You are an investigative diagnosis agent.  A symptom bug has been reported but
@@ -66,6 +66,13 @@ fix_success_criterion: |
 notes: |
   Optional — any caveats, unresolved threads, or partial-investigation
   context the operator should see.
+inspected_files:
+  # REQUIRED. List every file path you read or grepped during the
+  # investigation. This anchors the diagnosis to a baseline so a later
+  # `forge groom` can detect when the diagnosis has gone stale because
+  # one of these files was changed by an intervening commit.
+  - "src/theforge/relative/path/to/file.py"
+  - "tests/relative/path/to/test_file.py"
 ```
 """
 
@@ -145,6 +152,24 @@ def parse_diagnose_output(
                 )
             )
 
+    raw_inspected = parsed.get("inspected_files") or []
+    inspected: list[InspectedFile] = []
+    if isinstance(raw_inspected, list):
+        seen: set[str] = set()
+        for entry in raw_inspected:
+            if isinstance(entry, str):
+                path = entry.strip()
+                digest = ""
+            elif isinstance(entry, dict):
+                path = str(entry.get("path", "")).strip()
+                digest = str(entry.get("content_sha256", "")).strip()
+            else:
+                continue
+            if not path or path in seen:
+                continue
+            seen.add(path)
+            inspected.append(InspectedFile(path=path, content_sha256=digest))
+
     return DiagnosisArtifact(
         issue_number=issue_number,
         observed_symptom=str(parsed.get("observed_symptom", "")).strip(),
@@ -155,4 +180,5 @@ def parse_diagnose_output(
         fix_success_criterion=str(parsed.get("fix_success_criterion", "")).strip(),
         partial=partial,
         notes=str(parsed.get("notes", "")).strip(),
+        inspected_files=tuple(inspected),
     )

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -68,11 +68,12 @@ notes: |
   context the operator should see.
 inspected_files:
   # REQUIRED. List every file path you read or grepped during the
-  # investigation. This anchors the diagnosis to a baseline so a later
-  # `forge groom` can detect when the diagnosis has gone stale because
-  # one of these files was changed by an intervening commit.
-  - "src/theforge/relative/path/to/file.py"
-  - "tests/relative/path/to/test_file.py"
+  # investigation, one repo-relative path per entry. This anchors the
+  # diagnosis to a baseline so a later `forge groom` can detect when the
+  # diagnosis has gone stale because one of these files was changed by
+  # an intervening commit.
+  - "<repo-relative path to a file you inspected>"
+  - "<repo-relative path to another file you inspected>"
 ```
 """
 

--- a/tests/test_intake/test_diagnosis_staleness.py
+++ b/tests/test_intake/test_diagnosis_staleness.py
@@ -1,0 +1,356 @@
+"""Tests for diagnosis-baseline staleness detection.
+
+Covers the seam where ``forge groom`` consults the baseline metadata that
+``forge diagnose`` recorded on a bug issue body. Verifies the spec
+invariants: confirmed-cause + stale → REFUSED; cause-unknown + stale stays
+investigation-ready with a notice; ``--confirm-diagnosis-current`` overrides
+the refusal and lands an audit event.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from theforge.coordinator.audit_substrate import (
+    create_or_open,
+    iter_readiness_events,
+    record_readiness_event,
+)
+from theforge.diagnose_types import (
+    DiagnosisArtifact,
+    Hypothesis,
+    InspectedFile,
+    parse_baseline_metadata,
+    render_artifact_markdown,
+)
+from theforge.intake.diagnosis_staleness import (
+    StalenessState,
+    evaluate_staleness,
+)
+from theforge.intake.groom_flow import (
+    BugDiagnosisState,
+    GroomAction,
+    run_groom,
+)
+
+
+def _git_init(repo: Path) -> None:
+    """Initialize a tiny repo with one commit, returning the project root."""
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, check=True)
+
+
+def _commit_file(repo: Path, rel: str, content: str, msg: str) -> str:
+    """Write/commit a file, returning the new HEAD SHA."""
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", rel], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", msg], cwd=repo, check=True)
+    out = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _bug_body_with_baseline(
+    *,
+    sha: str,
+    files: list[tuple[str, str]],
+    cause_known: bool = True,
+) -> str:
+    """Render a bug body whose Diagnosis section carries baseline metadata.
+
+    Uses the bullet-style diagnosis prose the shape gate's
+    ``diagnosis_completeness`` heuristic recognizes (observed symptom /
+    evidence / ruled out / confirmed cause / affected code path /
+    fix-success criterion), with the ``**Baseline:**`` and
+    ``**Inspected files:**`` lines this story adds nested directly under
+    the ``## Diagnosis`` heading so groom can re-parse them.
+    """
+    inspected_lines = "\n".join(f"- `{p}` — `sha256:{h or 'unknown'}`" for p, h in files)
+    cause_line = (
+        "- Confirmed cause: root cause is X"
+        if cause_known
+        else "- Confirmed cause: not yet identified"
+    )
+    return (
+        "## What happened\n\nThing breaks.\n\n"
+        "## What was expected\n\nThing works.\n\n"
+        "## Diagnosis\n\n"
+        f"**Baseline:** `{sha}` captured at `2026-05-09T03:14:00Z`\n\n"
+        "**Inspected files:**\n\n"
+        f"{inspected_lines}\n\n"
+        "- Observed symptom: thing breaks\n"
+        "- Evidence: log line\n"
+        "- Ruled out: alternative A\n"
+        f"{cause_line}\n"
+        "- Affected code path: src/a.py\n"
+        "- Fix-success criterion: thing works again\n"
+    )
+
+
+# Helpers re-exported so the diagnose-flow test can import them too.
+_ = (DiagnosisArtifact, Hypothesis, InspectedFile, render_artifact_markdown)
+
+
+# ── Baseline metadata round-trip ─────────────────────────────────────────
+
+
+def test_render_then_parse_round_trip():
+    body = _bug_body_with_baseline(
+        sha="abc1234",
+        files=[("src/a.py", _sha256("hello\n")), ("src/b.py", _sha256("world\n"))],
+    )
+    meta = parse_baseline_metadata(body)
+    assert meta is not None
+    assert meta.baseline_sha == "abc1234"
+    assert meta.baseline_captured_at == "2026-05-09T03:14:00Z"
+    assert [f.path for f in meta.inspected_files] == ["src/a.py", "src/b.py"]
+    assert meta.inspected_files[0].content_sha256 == _sha256("hello\n")
+
+
+def test_parse_returns_none_when_no_baseline_line():
+    body = "## Diagnosis\n\n### Observed symptom\n\nOld-style diagnosis with no baseline.\n"
+    assert parse_baseline_metadata(body) is None
+
+
+# ── Staleness evaluation against a real git repo ─────────────────────────
+
+
+def test_fresh_when_baseline_equals_head(tmp_path: Path):
+    _git_init(tmp_path)
+    sha = _commit_file(tmp_path, "src/a.py", "hello\n", "init")
+    body = _bug_body_with_baseline(sha=sha, files=[("src/a.py", _sha256("hello\n"))])
+    report = evaluate_staleness(body, project_root=tmp_path)
+    assert report.state is StalenessState.FRESH
+
+
+def test_stale_when_inspected_file_changed_since_baseline(tmp_path: Path):
+    _git_init(tmp_path)
+    base_sha = _commit_file(tmp_path, "src/a.py", "hello\n", "v1")
+    body = _bug_body_with_baseline(sha=base_sha, files=[("src/a.py", _sha256("hello\n"))])
+    # Advance base + materially change the inspected file.
+    _commit_file(tmp_path, "src/a.py", "hello world\n", "v2")
+    report = evaluate_staleness(body, project_root=tmp_path)
+    assert report.state is StalenessState.STALE
+    assert "src/a.py" in report.changed_files
+
+
+def test_unchanged_when_base_advanced_but_inspected_files_match(tmp_path: Path):
+    _git_init(tmp_path)
+    base_sha = _commit_file(tmp_path, "src/a.py", "hello\n", "v1")
+    body = _bug_body_with_baseline(sha=base_sha, files=[("src/a.py", _sha256("hello\n"))])
+    # Advance base via an unrelated file — inspected file content unchanged.
+    _commit_file(tmp_path, "docs/README.md", "doc\n", "doc-only commit")
+    report = evaluate_staleness(body, project_root=tmp_path)
+    assert report.state is StalenessState.UNCHANGED
+    assert report.changed_files == ()
+
+
+def test_no_baseline_for_legacy_diagnosis(tmp_path: Path):
+    body = "## Diagnosis\n\n### Observed symptom\n\nLegacy diagnosis without baseline.\n"
+    report = evaluate_staleness(body, project_root=tmp_path)
+    assert report.state is StalenessState.NO_BASELINE
+
+
+# ── Groom integration: refusal, override, cause-unknown notice ───────────
+
+
+def test_groom_refuses_confirmed_cause_with_stale_baseline(tmp_path: Path):
+    _git_init(tmp_path)
+    base_sha = _commit_file(tmp_path, "src/a.py", "hello\n", "v1")
+    body = _bug_body_with_baseline(
+        sha=base_sha, files=[("src/a.py", _sha256("hello\n"))], cause_known=True
+    )
+    _commit_file(tmp_path, "src/a.py", "hello world\n", "v2")  # invalidate baseline
+
+    fetch = lambda _n, _r: {"title": "bug", "body": body, "labels": ["bug"]}  # noqa: E731
+    edit = lambda *_a: True  # noqa: E731
+
+    result = run_groom(
+        "1497",
+        project_root=tmp_path,
+        fetch_issue=fetch,
+        edit_issue_body=edit,
+    )
+    assert result.action is GroomAction.REFUSED
+    assert result.bug_state is BugDiagnosisState.CONFIRMED_CAUSE
+    assert result.staleness is not None and result.staleness.is_stale
+    assert "stale" in (result.refusal_reason or "").lower()
+    assert "forge diagnose 1497" in (result.refusal_reason or "")
+    # Audit event surfaces the staleness verdict for downstream queries.
+    ev = result.as_event()
+    assert ev["staleness_verdict"] == "stale"
+    assert ev["diagnosis_baseline_sha"] == base_sha
+    assert "src/a.py" in ev["stale_files"]
+
+
+def test_groom_confirm_override_lets_stale_confirmed_cause_proceed(tmp_path: Path):
+    _git_init(tmp_path)
+    base_sha = _commit_file(tmp_path, "src/a.py", "hello\n", "v1")
+    body = _bug_body_with_baseline(
+        sha=base_sha, files=[("src/a.py", _sha256("hello\n"))], cause_known=True
+    )
+    _commit_file(tmp_path, "src/a.py", "tampered\n", "v2")
+
+    fetch = lambda _n, _r: {"title": "bug", "body": body, "labels": ["bug"]}  # noqa: E731
+
+    result = run_groom(
+        "1497",
+        project_root=tmp_path,
+        fetch_issue=fetch,
+        edit_issue_body=lambda *_a: True,
+        confirm_diagnosis_current=True,
+    )
+    # Override flips the refusal off — bug proceeds along the restructured path.
+    assert result.action is GroomAction.RESTRUCTURED
+    ev = result.as_event()
+    assert ev["staleness_verdict"] == "stale"
+    assert ev["confirm_diagnosis_current"] is True
+
+
+def test_groom_cause_unknown_with_stale_baseline_stays_investigation_ready(
+    tmp_path: Path,
+):
+    _git_init(tmp_path)
+    base_sha = _commit_file(tmp_path, "src/a.py", "hello\n", "v1")
+    body = _bug_body_with_baseline(
+        sha=base_sha, files=[("src/a.py", _sha256("hello\n"))], cause_known=False
+    )
+    _commit_file(tmp_path, "src/a.py", "hello world\n", "v2")
+
+    fetch = lambda _n, _r: {"title": "bug", "body": body, "labels": ["bug"]}  # noqa: E731
+
+    result = run_groom(
+        "1502",
+        project_root=tmp_path,
+        fetch_issue=fetch,
+        edit_issue_body=lambda *_a: True,
+    )
+    # Cause-unknown invariant survives staleness — still investigation-ready.
+    assert result.action is GroomAction.NORMALIZED_ONLY
+    assert result.bug_state is BugDiagnosisState.CAUSE_UNKNOWN
+    assert result.staleness is not None and result.staleness.is_stale
+    assert result.staleness_notice is True
+    # No-ready guarantee from ADR-0001.
+    assert "add-label ready" not in (result.next_command or "")
+
+
+# ── Audit substrate persistence ──────────────────────────────────────────
+
+
+def test_record_readiness_event_persists_staleness_columns(tmp_path: Path):
+    """Staleness verdict is queryable via dedicated columns, not just raw_json."""
+    payload = {
+        "kind": "groom",
+        "issue_ref": "1497",
+        "issue_type": "bug",
+        "action": "refused",
+        "applied": False,
+        "bug_diagnosis_state": "confirmed-cause",
+        "refusal_reason": "stale",
+        "staleness_verdict": "stale",
+        "diagnosis_baseline_sha": "abc1234",
+        "stale_files": ["src/a.py"],
+    }
+    record_readiness_event(tmp_path, payload)
+    conn = create_or_open(tmp_path)
+    try:
+        row = conn.execute(
+            "SELECT staleness_verdict, diagnosis_baseline_sha FROM readiness_events"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "stale"
+        assert row[1] == "abc1234"
+        events = list(iter_readiness_events(conn, kind="groom"))
+        assert events[0]["stale_files"] == ["src/a.py"]
+    finally:
+        conn.close()
+
+
+# ── Diagnose flow seam: baseline injection ───────────────────────────────
+
+
+def test_diagnose_flow_injects_baseline_into_artifact(tmp_path: Path, monkeypatch):
+    """The diagnose flow captures HEAD as the baseline SHA and hashes each
+    inspected file against that SHA before persisting the artifact — so the
+    rendered ``## Diagnosis`` body carries enough metadata for groom's
+    staleness check."""
+    from unittest.mock import patch
+
+    import yaml as yaml_mod
+    from coord_test_helpers import _make_config
+
+    _git_init(tmp_path)
+    head_sha = _commit_file(tmp_path, "src/scheduler.py", "def go(): pass\n", "init")
+
+    agent_payload = {
+        "observed_symptom": "x",
+        "reproduction_or_evidence": "y",
+        "hypotheses": [
+            {"statement": "h", "status": "confirmed", "evidence": "e"},
+        ],
+        "confirmed_cause": "c",
+        "affected_code_path": "src/scheduler.py",
+        "fix_success_criterion": "f",
+        "notes": "",
+        "inspected_files": ["src/scheduler.py"],
+    }
+    agent_yaml = "```yaml\n" + yaml_mod.safe_dump(agent_payload, sort_keys=False) + "```"
+
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.coordinator.diagnose_flow._gh_fetch_issue") as mock_fetch,
+        patch("theforge.coordinator.diagnose_flow.run_agent") as mock_agent,
+    ):
+        mock_fetch.return_value = {
+            "number": 42,
+            "title": "broken",
+            "body": "story 3 never starts",
+            "state": "OPEN",
+        }
+        from tests.test_diagnose_flow import _fake_agent_result  # type: ignore
+
+        mock_agent.return_value = _fake_agent_result(agent_yaml)
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=42,
+            config=config,
+            project_root=tmp_path,
+            output_destination="pr_to_body",
+        )
+
+    assert result.success
+    artifact = result.state.artifact
+    assert artifact is not None
+    assert artifact.baseline_sha == head_sha
+    assert artifact.baseline_captured_at  # non-empty timestamp
+    assert len(artifact.inspected_files) == 1
+    assert artifact.inspected_files[0].path == "src/scheduler.py"
+    # Hash is computed against the baseline SHA via `git show`.
+    expected_hash = hashlib.sha256(b"def go(): pass\n").hexdigest()
+    assert artifact.inspected_files[0].content_sha256 == expected_hash
+
+    # And the rendered markdown lands the metadata so groom can re-parse it.
+    landed = (tmp_path / ".forge" / "diagnoses" / "issue-42.md").read_text()
+    assert head_sha in landed
+    assert "**Inspected files:**" in landed
+    assert "src/scheduler.py" in landed
+
+
+# Force pytest to register helper used above as importable.
+_ = pytest  # noqa: F841

--- a/tests/test_intake/test_diagnosis_staleness.py
+++ b/tests/test_intake/test_diagnosis_staleness.py
@@ -158,6 +158,50 @@ def test_unchanged_when_base_advanced_but_inspected_files_match(tmp_path: Path):
     assert report.changed_files == ()
 
 
+def test_stale_when_inspected_file_deleted_since_baseline(tmp_path: Path):
+    """Deletion is a material change: a path with a baseline digest that
+    is positively absent at current must surface as STALE rather than be
+    silently classified as untracked (which would let a confirmed-cause
+    diagnosis proceed even though its evidence has been removed)."""
+    _git_init(tmp_path)
+    base_sha = _commit_file(tmp_path, "src/a.py", "hello\n", "v1")
+    body = _bug_body_with_baseline(sha=base_sha, files=[("src/a.py", _sha256("hello\n"))])
+    # Advance base by deleting the inspected file.
+    subprocess.run(["git", "rm", "-q", "src/a.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "remove a.py"], cwd=tmp_path, check=True)
+    report = evaluate_staleness(body, project_root=tmp_path)
+    assert report.state is StalenessState.STALE
+    assert "src/a.py" in report.changed_files
+    assert "src/a.py" not in report.untracked_files
+
+
+def test_groom_refuses_confirmed_cause_when_inspected_file_deleted(tmp_path: Path):
+    """End-to-end: a confirmed-cause bug whose inspected file was removed
+    by a later commit must be refused by groom — same refusal path as a
+    content-change, since hash-equality treats deletion as material."""
+    _git_init(tmp_path)
+    base_sha = _commit_file(tmp_path, "src/a.py", "hello\n", "v1")
+    body = _bug_body_with_baseline(
+        sha=base_sha, files=[("src/a.py", _sha256("hello\n"))], cause_known=True
+    )
+    subprocess.run(["git", "rm", "-q", "src/a.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "remove a.py"], cwd=tmp_path, check=True)
+
+    fetch = lambda _n, _r: {"title": "bug", "body": body, "labels": ["bug"]}  # noqa: E731
+    result = run_groom(
+        "1497",
+        project_root=tmp_path,
+        fetch_issue=fetch,
+        edit_issue_body=lambda *_a: True,
+    )
+    assert result.action is GroomAction.REFUSED
+    assert result.staleness is not None and result.staleness.is_stale
+    assert "src/a.py" in result.staleness.changed_files
+    ev = result.as_event()
+    assert ev["staleness_verdict"] == "stale"
+    assert "src/a.py" in ev["stale_files"]
+
+
 def test_no_baseline_for_legacy_diagnosis(tmp_path: Path):
     body = "## Diagnosis\n\n### Observed symptom\n\nLegacy diagnosis without baseline.\n"
     report = evaluate_staleness(body, project_root=tmp_path)


### PR DESCRIPTION
## Summary

Prior deletion staleness bug is resolved; targeted staleness tests pass with no blocking regressions found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $9.66
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Diagnosis readiness records baseline evidence and warns when stale against current base (GitHub Issue #1516)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1516