### PR TITLE
Audit substrate: per-record schema versioning and indexed dimensions for ADR-0002 query obligations

### DIFF
--- a/docs/adr/0002-audit-substrate-and-queryable-run-history.md
+++ b/docs/adr/0002-audit-substrate-and-queryable-run-history.md
@@ -150,7 +150,7 @@ The substrate evolves over the project's lifetime. The contract that keeps that 
 
 **Landed in #1522 (substrate-side reader dispatch):**
 
-- `audit_records` gains indexed columns `record_schema_version`, `milestone`, `issue_id`, `dev_model`, plus indexes on `final_phase` and `outcome_success`, satisfying the minimum-query dimensions named in clause 3. Missing source fields populate as NULL; existing rows pick up the new columns on the next `forge audits rebuild`.
+- `audit_records` gains indexed columns `record_schema_version`, `milestone`, `issue_id`, `dev_model`, and `verdict` (run-level, derived from the final review cycle), plus indexes on `final_phase` and `outcome_success`, satisfying the minimum-query dimensions named in clause 3. The new `verdict` column is distinct from `reviews.verdict` (per-cycle) so `COUNT/GROUP BY` queries at record granularity no longer require joining `reviews`. Missing source fields populate as NULL; existing rows pick up the new columns on the next `forge audits rebuild`.
 - New per-run records are written at `schema_version=2` (`CURRENT_RECORD_SCHEMA_VERSION` in `audit_substrate.py`). Pre-slice records without a `schema_version` field are read as version 1.
 - `audit_substrate._migrate_record(record, from_version=...)` is the reader-side seam. It is a no-op today (no breaking field changes have shipped) but every reader (`iter_records`, `tail_records`, `iter_escalation_records`, `has_review_approve_in_substrate`) now consults the indexed `record_schema_version` and routes the parsed record through it. Future breaking changes register translations there.
 

--- a/docs/adr/0002-audit-substrate-and-queryable-run-history.md
+++ b/docs/adr/0002-audit-substrate-and-queryable-run-history.md
@@ -148,6 +148,12 @@ The substrate evolves over the project's lifetime. The contract that keeps that 
 - Adding a field is non-breaking and does not bump the version. Renaming, removing, or repurposing a field is breaking and MUST bump the version, with migration helpers added in the same PR.
 - The substrate must support reading records from at least the two most recent shipped `schema_version`s at any given time. (Older readers from outside the active support window may skip with a warning, per clause 4.)
 
+**Landed in #1522 (substrate-side reader dispatch):**
+
+- `audit_records` gains indexed columns `record_schema_version`, `milestone`, `issue_id`, `dev_model`, plus indexes on `final_phase` and `outcome_success`, satisfying the minimum-query dimensions named in clause 3. Missing source fields populate as NULL; existing rows pick up the new columns on the next `forge audits rebuild`.
+- New per-run records are written at `schema_version=2` (`CURRENT_RECORD_SCHEMA_VERSION` in `audit_substrate.py`). Pre-slice records without a `schema_version` field are read as version 1.
+- `audit_substrate._migrate_record(record, from_version=...)` is the reader-side seam. It is a no-op today (no breaking field changes have shipped) but every reader (`iter_records`, `tail_records`, `iter_escalation_records`, `has_review_approve_in_substrate`) now consults the indexed `record_schema_version` and routes the parsed record through it. Future breaking changes register translations there.
+
 **Writer-side guard (tracked in #1528):**
 
 - A CI check refuses a `schema_version` bump on the writer side without a matching migration-helper entry. This is the writer-side counterpart to #1522's reader-side dispatch; the two issues are sized to land independently.

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -137,7 +137,7 @@ def _write_per_run_record(
             return
 
         record: dict = {
-            "schema_version": 1,
+            "schema_version": 2,
             "run_id": run_id,
             "parent_run_id": None,
             "forge_version": audit.get("forge_version"),
@@ -145,7 +145,7 @@ def _write_per_run_record(
         record.update(audit)
         # Ensure the envelope fields stay at the top (dict insertion order is preserved).
         # Re-insert them so they shadow any same-named keys from audit.
-        record["schema_version"] = 1
+        record["schema_version"] = 2
         record["run_id"] = run_id
         record["parent_run_id"] = None
         record["forge_version"] = audit.get("forge_version")

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS audit_records (
     milestone TEXT,
     issue_id INTEGER,
     dev_model TEXT,
+    verdict TEXT,
     raw_json TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_audit_records_slug ON audit_records(slug);
@@ -146,6 +147,7 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
         "ALTER TABLE audit_records ADD COLUMN milestone TEXT",
         "ALTER TABLE audit_records ADD COLUMN issue_id INTEGER",
         "ALTER TABLE audit_records ADD COLUMN dev_model TEXT",
+        "ALTER TABLE audit_records ADD COLUMN verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN staleness_verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN diagnosis_baseline_sha TEXT",
     ):
@@ -160,6 +162,7 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_audit_records_milestone ON audit_records(milestone)",
         "CREATE INDEX IF NOT EXISTS idx_audit_records_issue_id ON audit_records(issue_id)",
         "CREATE INDEX IF NOT EXISTS idx_audit_records_dev_model ON audit_records(dev_model)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_records_verdict ON audit_records(verdict)",
         "CREATE INDEX IF NOT EXISTS idx_audit_records_final_phase ON audit_records(final_phase)",
         "CREATE INDEX IF NOT EXISTS idx_audit_records_outcome ON audit_records(outcome_success)",
         "CREATE INDEX IF NOT EXISTS idx_audit_records_record_schema_version "
@@ -487,7 +490,34 @@ def _flat_fields(record: dict) -> dict:
         "milestone": milestone,
         "issue_id": issue_id,
         "dev_model": _derive_dev_model(record),
+        "verdict": _derive_record_verdict(record),
     }
+
+
+def _derive_record_verdict(record: dict) -> str | None:
+    """Return the run-level verdict for indexed record-level verdict queries.
+
+    ADR-0002 §3 names ``verdict`` as a record-level query dimension distinct
+    from ``reviews.verdict`` (which is per-cycle). The run-level value is the
+    verdict of the final review cycle — the verdict that actually decided the
+    run's outcome. Returns ``None`` when no reviews were recorded.
+    """
+    reviews = record.get("reviews")
+    if not isinstance(reviews, list) or not reviews:
+        return None
+    last: dict | None = None
+    last_cycle = -1
+    for idx, rev in enumerate(reviews, start=1):
+        if not isinstance(rev, dict):
+            continue
+        cycle = rev.get("cycle") if isinstance(rev.get("cycle"), int) else idx
+        if cycle >= last_cycle:
+            last_cycle = cycle
+            last = rev
+    if last is None:
+        return None
+    verdict = last.get("verdict")
+    return verdict if isinstance(verdict, str) and verdict else None
 
 
 def _derive_dev_model(record: dict) -> str | None:
@@ -632,6 +662,7 @@ def upsert_run_record(
         flat["milestone"],
         flat["issue_id"],
         flat["dev_model"],
+        flat["verdict"],
         raw_json,
     )
     conn.execute(
@@ -639,8 +670,8 @@ def upsert_run_record(
         "(run_id, slug, started_at, finished_at, total_cost_usd, final_phase, "
         "outcome_success, branch, landing_status, provenance, source_path, "
         "source_mtime, complexity_score, record_schema_version, milestone, "
-        "issue_id, dev_model, raw_json) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+        "issue_id, dev_model, verdict, raw_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
         "ON CONFLICT(run_id) DO UPDATE SET "
         "slug=excluded.slug, started_at=excluded.started_at, "
         "finished_at=excluded.finished_at, total_cost_usd=excluded.total_cost_usd, "
@@ -651,7 +682,8 @@ def upsert_run_record(
         "complexity_score=excluded.complexity_score, "
         "record_schema_version=excluded.record_schema_version, "
         "milestone=excluded.milestone, issue_id=excluded.issue_id, "
-        "dev_model=excluded.dev_model, raw_json=excluded.raw_json",
+        "dev_model=excluded.dev_model, verdict=excluded.verdict, "
+        "raw_json=excluded.raw_json",
         params,
     )
     # Rewrite reviews for this run_id.

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -28,7 +28,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-SUBSTRATE_SCHEMA_VERSION = 2
+SUBSTRATE_SCHEMA_VERSION = 3
+# Current per-record schema version. Records pre-dating the indexed-dimensions
+# slice (#1522) are treated as version 1. The reader-side migration helper
+# (`_migrate_record`) is the seam future breaking changes hang off — today it
+# is a no-op because no breaking field rename/removal has shipped.
+CURRENT_RECORD_SCHEMA_VERSION = 2
 SUBSTRATE_RELPATH = (".forge", "audits", "index.sqlite")
 HISTORY_RELPATH = (".forge", "audits", "history.jsonl")
 RUNS_RELPATH = (".forge", "audits", "runs")
@@ -83,6 +88,10 @@ CREATE TABLE IF NOT EXISTS audit_records (
     source_path TEXT,
     source_mtime REAL,
     complexity_score INTEGER,
+    record_schema_version INTEGER NOT NULL DEFAULT 1,
+    milestone TEXT,
+    issue_id INTEGER,
+    dev_model TEXT,
     raw_json TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_audit_records_slug ON audit_records(slug);
@@ -133,11 +142,31 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
     except sqlite3.OperationalError:
         pass
     for stmt in (
+        "ALTER TABLE audit_records ADD COLUMN record_schema_version INTEGER NOT NULL DEFAULT 1",
+        "ALTER TABLE audit_records ADD COLUMN milestone TEXT",
+        "ALTER TABLE audit_records ADD COLUMN issue_id INTEGER",
+        "ALTER TABLE audit_records ADD COLUMN dev_model TEXT",
         "ALTER TABLE readiness_events ADD COLUMN staleness_verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN diagnosis_baseline_sha TEXT",
     ):
         try:
             conn.execute(stmt)
+        except sqlite3.OperationalError:
+            pass
+    # Indexes on columns added by ALTER TABLE above. Must run after the
+    # ALTER statements so legacy substrates don't fail with
+    # ``no such column`` on first open.
+    for idx_stmt in (
+        "CREATE INDEX IF NOT EXISTS idx_audit_records_milestone ON audit_records(milestone)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_records_issue_id ON audit_records(issue_id)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_records_dev_model ON audit_records(dev_model)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_records_final_phase ON audit_records(final_phase)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_records_outcome ON audit_records(outcome_success)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_records_record_schema_version "
+        "ON audit_records(record_schema_version)",
+    ):
+        try:
+            conn.execute(idx_stmt)
         except sqlite3.OperationalError:
             pass
     conn.execute(
@@ -417,6 +446,33 @@ def _flat_fields(record: dict) -> dict:
     ):
         landing_status = "landed"
 
+    raw_record_version = record.get("schema_version")
+    if isinstance(raw_record_version, bool):
+        record_schema_version = 1
+    elif isinstance(raw_record_version, int):
+        record_schema_version = raw_record_version
+    elif isinstance(raw_record_version, float):
+        record_schema_version = int(raw_record_version)
+    else:
+        record_schema_version = 1
+
+    milestone = record.get("milestone")
+    if not isinstance(milestone, str) or not milestone:
+        task_milestone = task.get("milestone") if isinstance(task, dict) else None
+        milestone = task_milestone if isinstance(task_milestone, str) and task_milestone else None
+
+    raw_issue = task.get("github_issue") if isinstance(task, dict) else None
+    if isinstance(raw_issue, bool):
+        issue_id: int | None = None
+    elif isinstance(raw_issue, int):
+        issue_id = raw_issue
+    elif isinstance(raw_issue, float):
+        issue_id = int(raw_issue)
+    elif isinstance(raw_issue, str) and raw_issue.lstrip("#").strip().isdigit():
+        issue_id = int(raw_issue.lstrip("#").strip())
+    else:
+        issue_id = None
+
     return {
         "slug": task.get("slug"),
         "started_at": timing.get("started_at"),
@@ -427,7 +483,74 @@ def _flat_fields(record: dict) -> dict:
         "branch": workspace.get("branch"),
         "landing_status": landing_status,
         "complexity_score": complexity_score,
+        "record_schema_version": record_schema_version,
+        "milestone": milestone,
+        "issue_id": issue_id,
+        "dev_model": _derive_dev_model(record),
     }
+
+
+def _derive_dev_model(record: dict) -> str | None:
+    """Return the canonical dev model identity recorded for this run.
+
+    Mirrors the `cost.agents` parsing logic in :func:`_derive_escalation` so
+    the indexed `dev_model` column matches the model the adaptive router
+    treats as authoritative (the one that actually ran).
+    """
+    cost_block = record.get("cost") if isinstance(record.get("cost"), dict) else {}
+    agents = cost_block.get("agents") if isinstance(cost_block.get("agents"), list) else []
+    for entry in agents:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("phase") != "dev" and entry.get("role") != "dev":
+            continue
+        provider = (entry.get("provider") or "").strip()
+        model = (entry.get("model") or "").strip()
+        cli = (entry.get("cli") or "").strip()
+        if model and provider:
+            transport = "cli" if cli else "api"
+            return f"{provider}/{model}/{transport}"
+        if entry.get("name"):
+            return str(entry["name"])
+    return None
+
+
+# ── Per-record schema migration ──────────────────────────────────────────
+
+
+def _migrate_record(record: dict, *, from_version: int) -> dict:
+    """Bring an older per-run record up to ``CURRENT_RECORD_SCHEMA_VERSION``.
+
+    Today this is a no-op: no breaking field rename or removal has shipped,
+    so version-1 records remain fully readable. The function exists as the
+    seam future breaking changes hang off — when a new version introduces
+    a structural change, add a branch here that translates the older shape
+    into the newer one before the reader parses it. Reader paths must call
+    this with ``from_version`` taken from the indexed
+    ``record_schema_version`` column rather than parsing ``raw_json``
+    speculatively.
+    """
+    if from_version >= CURRENT_RECORD_SCHEMA_VERSION:
+        return record
+    # No structural migrations registered yet. Future versions register
+    # here in chained `if from_version < N` branches.
+    return record
+
+
+def _load_migrated(raw_json: str, record_schema_version: int | None) -> dict | None:
+    """Parse ``raw_json`` and route through :func:`_migrate_record`.
+
+    Returns ``None`` when ``raw_json`` cannot be decoded so callers can
+    skip rather than abort the iteration.
+    """
+    try:
+        record = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(record, dict):
+        return None
+    ver = record_schema_version if isinstance(record_schema_version, int) else 1
+    return _migrate_record(record, from_version=ver)
 
 
 def _extract_reviews(record: dict) -> list[tuple[int, str | None, int | None, int | None]]:
@@ -505,14 +628,19 @@ def upsert_run_record(
         source_path,
         source_mtime,
         flat["complexity_score"],
+        flat["record_schema_version"],
+        flat["milestone"],
+        flat["issue_id"],
+        flat["dev_model"],
         raw_json,
     )
     conn.execute(
         "INSERT INTO audit_records "
         "(run_id, slug, started_at, finished_at, total_cost_usd, final_phase, "
         "outcome_success, branch, landing_status, provenance, source_path, "
-        "source_mtime, complexity_score, raw_json) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+        "source_mtime, complexity_score, record_schema_version, milestone, "
+        "issue_id, dev_model, raw_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
         "ON CONFLICT(run_id) DO UPDATE SET "
         "slug=excluded.slug, started_at=excluded.started_at, "
         "finished_at=excluded.finished_at, total_cost_usd=excluded.total_cost_usd, "
@@ -520,7 +648,10 @@ def upsert_run_record(
         "branch=excluded.branch, landing_status=excluded.landing_status, "
         "provenance=excluded.provenance, source_path=excluded.source_path, "
         "source_mtime=excluded.source_mtime, "
-        "complexity_score=excluded.complexity_score, raw_json=excluded.raw_json",
+        "complexity_score=excluded.complexity_score, "
+        "record_schema_version=excluded.record_schema_version, "
+        "milestone=excluded.milestone, issue_id=excluded.issue_id, "
+        "dev_model=excluded.dev_model, raw_json=excluded.raw_json",
         params,
     )
     # Rewrite reviews for this run_id.
@@ -762,7 +893,7 @@ def has_review_approve_in_substrate(
     semantics.
     """
     sql = (
-        "SELECT a.raw_json FROM audit_records a "
+        "SELECT a.raw_json, a.record_schema_version FROM audit_records a "
         "JOIN reviews r ON r.run_id = a.run_id "
         "WHERE a.slug = ? AND r.verdict = 'APPROVE'"
     )
@@ -770,39 +901,46 @@ def has_review_approve_in_substrate(
     if require_landed:
         sql += " AND a.landing_status = 'landed'"
     for row in conn.execute(sql, params):
-        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
-        try:
-            yield json.loads(raw)
-        except json.JSONDecodeError:
-            continue
+        if isinstance(row, sqlite3.Row):
+            raw, ver = row["raw_json"], row["record_schema_version"]
+        else:
+            raw, ver = row[0], row[1]
+        record = _load_migrated(raw, ver)
+        if record is not None:
+            yield record
 
 
 def iter_records(conn: sqlite3.Connection, *, order_by_started: bool = True) -> Iterable[dict]:
     """Iterate raw_json dicts for all audit records."""
-    sql = "SELECT raw_json FROM audit_records"
+    sql = "SELECT raw_json, record_schema_version FROM audit_records"
     if order_by_started:
         sql += " ORDER BY started_at ASC"
     for row in conn.execute(sql):
-        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
-        try:
-            yield json.loads(raw)
-        except json.JSONDecodeError:
-            continue
+        if isinstance(row, sqlite3.Row):
+            raw, ver = row["raw_json"], row["record_schema_version"]
+        else:
+            raw, ver = row[0], row[1]
+        record = _load_migrated(raw, ver)
+        if record is not None:
+            yield record
 
 
 def tail_records(conn: sqlite3.Connection, limit: int) -> list[dict]:
     """Return the most-recent ``limit`` records ordered by started_at DESC."""
     rows = conn.execute(
-        "SELECT raw_json FROM audit_records ORDER BY COALESCE(started_at, '') DESC LIMIT ?",
+        "SELECT raw_json, record_schema_version FROM audit_records "
+        "ORDER BY COALESCE(started_at, '') DESC LIMIT ?",
         (max(0, int(limit)),),
     ).fetchall()
     out: list[dict] = []
     for row in rows:
-        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
-        try:
-            out.append(json.loads(raw))
-        except json.JSONDecodeError:
-            continue
+        if isinstance(row, sqlite3.Row):
+            raw, ver = row["raw_json"], row["record_schema_version"]
+        else:
+            raw, ver = row[0], row[1]
+        record = _load_migrated(raw, ver)
+        if record is not None:
+            out.append(record)
     return out
 
 
@@ -926,14 +1064,17 @@ def iter_escalation_records(conn: sqlite3.Connection) -> Iterable[dict]:
     view :func:`derive_assignment_history` uses preflight assignments
     instead, which is the *intended* dev model rather than the executed one.
     """
-    rows = conn.execute("SELECT raw_json FROM audit_records ORDER BY COALESCE(started_at, '') ASC")
+    rows = conn.execute(
+        "SELECT raw_json, record_schema_version FROM audit_records "
+        "ORDER BY COALESCE(started_at, '') ASC"
+    )
     for row in rows:
-        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
-        try:
-            record = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(record, dict):
+        if isinstance(row, sqlite3.Row):
+            raw, ver = row["raw_json"], row["record_schema_version"]
+        else:
+            raw, ver = row[0], row[1]
+        record = _load_migrated(raw, ver)
+        if record is None:
             continue
         derived = _derive_escalation(record)
         if derived is not None:

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -702,6 +702,87 @@ class TestIndexedDimensions:
         ]
 
 
+class TestRecordLevelVerdict:
+    """ADR-0002 §3: verdict at record level, not only per-cycle."""
+
+    def test_record_verdict_populated_from_final_cycle(self, tmp_path: Path) -> None:
+        rec = _make_record(
+            run_id="r1",
+            reviews=[
+                {"cycle": 1, "verdict": "REQUEST_CHANGES"},
+                {"cycle": 2, "verdict": "APPROVE"},
+            ],
+        )
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            row = conn.execute("SELECT verdict FROM audit_records WHERE run_id='r1'").fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "APPROVE"
+
+    def test_record_verdict_null_when_no_reviews(self, tmp_path: Path) -> None:
+        rec = _make_record(run_id="r1", reviews=[])
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            row = conn.execute("SELECT verdict FROM audit_records WHERE run_id='r1'").fetchone()
+        finally:
+            conn.close()
+        assert row[0] is None
+
+    def test_record_verdict_groupby_serves_from_audit_records(self, tmp_path: Path) -> None:
+        """COUNT/GROUP BY verdict runs at record granularity without joining reviews."""
+        records = [
+            _make_record(
+                run_id="r1",
+                slug="a",
+                reviews=[{"cycle": 1, "verdict": "APPROVE"}],
+            ),
+            _make_record(
+                run_id="r2",
+                slug="b",
+                reviews=[
+                    {"cycle": 1, "verdict": "REQUEST_CHANGES"},
+                    {"cycle": 2, "verdict": "APPROVE"},
+                ],
+            ),
+            _make_record(
+                run_id="r3",
+                slug="c",
+                reviews=[{"cycle": 1, "verdict": "REQUEST_CHANGES"}],
+            ),
+        ]
+        conn = sub.create_or_open(tmp_path)
+        try:
+            for rec in records:
+                sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            rows = [
+                tuple(r)
+                for r in conn.execute(
+                    "SELECT verdict, COUNT(*) FROM audit_records "
+                    "WHERE verdict IS NOT NULL GROUP BY verdict ORDER BY verdict"
+                ).fetchall()
+            ]
+        finally:
+            conn.close()
+        assert rows == [("APPROVE", 2), ("REQUEST_CHANGES", 1)]
+
+    def test_record_verdict_index_exists(self, tmp_path: Path) -> None:
+        conn = sub.create_or_open(tmp_path)
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='audit_records'"
+            ).fetchall()
+        finally:
+            conn.close()
+        names = {r[0] for r in rows}
+        assert "idx_audit_records_verdict" in names
+
+
 class TestRecordSchemaMigration:
     """Issue #1522: reader-side per-record schema-version dispatch seam."""
 
@@ -723,6 +804,56 @@ class TestRecordSchemaMigration:
         rec = {"schema_version": sub.CURRENT_RECORD_SCHEMA_VERSION, "task": {"slug": "x"}}
         out = sub._migrate_record(rec, from_version=sub.CURRENT_RECORD_SCHEMA_VERSION)
         assert out is rec
+
+    @pytest.mark.parametrize(
+        "reader",
+        ["iter_records", "tail_records", "iter_escalation_records", "has_review_approve"],
+    )
+    def test_all_readers_route_through_migration_seam(
+        self, tmp_path: Path, monkeypatch, reader: str
+    ) -> None:
+        """Every reader consults record_schema_version via _migrate_record."""
+        rec_v1 = _make_record(
+            run_id="r1",
+            slug="demo",
+            reviews=[{"cycle": 1, "verdict": "APPROVE"}],
+        )
+        rec_v1.pop("schema_version", None)
+        rec_v2 = _make_record(
+            run_id="r2",
+            slug="demo",
+            reviews=[{"cycle": 1, "verdict": "APPROVE"}],
+        )
+        rec_v2["schema_version"] = 2
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec_v1, provenance="native")
+            sub.upsert_run_record(conn, rec_v2, provenance="native")
+            conn.commit()
+        finally:
+            conn.close()
+
+        seen_versions: list[int] = []
+        original = sub._migrate_record
+
+        def tracking(record: dict, *, from_version: int) -> dict:
+            seen_versions.append(from_version)
+            return original(record, from_version=from_version)
+
+        monkeypatch.setattr(sub, "_migrate_record", tracking)
+        conn = sub.create_or_open(tmp_path)
+        try:
+            if reader == "iter_records":
+                list(sub.iter_records(conn))
+            elif reader == "tail_records":
+                sub.tail_records(conn, 10)
+            elif reader == "iter_escalation_records":
+                list(sub.iter_escalation_records(conn))
+            elif reader == "has_review_approve":
+                list(sub.has_review_approve_in_substrate(conn, "demo"))
+        finally:
+            conn.close()
+        assert sorted(seen_versions) == [1, 2]
 
     def test_iter_records_routes_through_migration(self, tmp_path: Path, monkeypatch) -> None:
         rec_v1 = _make_record(run_id="r1")

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -532,3 +532,253 @@ class TestRebuildPreservesLegacyRows:
             conn.close()
         assert len(legacy_after) == 1, "legacy row was dropped by runtime rebuild"
         assert native_after == 1
+
+
+class TestIndexedDimensions:
+    """Issue #1522: indexed columns for ADR-0002 query obligations."""
+
+    def _record_with(
+        self,
+        *,
+        run_id: str = "r1",
+        slug: str = "demo",
+        milestone: str | None = None,
+        github_issue: int | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        cli: str = "",
+        schema_version: int | None = 2,
+    ) -> dict:
+        rec = _make_record(run_id=run_id, slug=slug)
+        if schema_version is not None:
+            rec["schema_version"] = schema_version
+        else:
+            rec.pop("schema_version", None)
+        if milestone is not None:
+            rec["milestone"] = milestone
+        if github_issue is not None:
+            rec["task"]["github_issue"] = github_issue
+        if provider or model:
+            rec["cost"]["agents"] = [
+                {
+                    "phase": "dev",
+                    "provider": provider or "",
+                    "model": model or "",
+                    "cli": cli,
+                }
+            ]
+        return rec
+
+    def test_indexed_columns_populated_from_record(self, tmp_path: Path) -> None:
+        rec = self._record_with(
+            milestone="v0.11",
+            github_issue=1522,
+            provider="anthropic",
+            model="opus",
+            cli="claude",
+            schema_version=2,
+        )
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            row = conn.execute(
+                "SELECT record_schema_version, milestone, issue_id, dev_model "
+                "FROM audit_records WHERE run_id = 'r1'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 2
+        assert row[1] == "v0.11"
+        assert row[2] == 1522
+        assert row[3] == "anthropic/opus/cli"
+
+    def test_missing_optional_dimensions_store_null(self, tmp_path: Path) -> None:
+        rec = self._record_with(schema_version=None)
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            row = conn.execute(
+                "SELECT record_schema_version, milestone, issue_id, dev_model "
+                "FROM audit_records WHERE run_id = 'r1'"
+            ).fetchone()
+        finally:
+            conn.close()
+        # Pre-slice record (no schema_version) is treated as version 1.
+        assert row[0] == 1
+        assert row[1] is None
+        assert row[2] is None
+        assert row[3] is None
+
+    def test_github_issue_string_form_coerces_to_int(self, tmp_path: Path) -> None:
+        rec = self._record_with(run_id="r2", slug="s2")
+        rec["task"]["github_issue"] = "#1234"
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            row = conn.execute("SELECT issue_id FROM audit_records WHERE run_id = 'r2'").fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 1234
+
+    def test_indexes_exist_for_new_dimensions(self, tmp_path: Path) -> None:
+        conn = sub.create_or_open(tmp_path)
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='audit_records'"
+            ).fetchall()
+        finally:
+            conn.close()
+        names = {r[0] for r in rows}
+        assert "idx_audit_records_milestone" in names
+        assert "idx_audit_records_issue_id" in names
+        assert "idx_audit_records_dev_model" in names
+        assert "idx_audit_records_final_phase" in names
+        assert "idx_audit_records_outcome" in names
+
+    def test_refusal_economics_groupby_milestone(self, tmp_path: Path) -> None:
+        """ADR-0002 §3 example: SUM cost GROUP BY milestone runs without parsing JSON."""
+        records = [
+            _make_record(run_id="r1", slug="a", cost=1.0),
+            _make_record(run_id="r2", slug="b", cost=2.0),
+            _make_record(run_id="r3", slug="c", cost=4.0),
+        ]
+        records[0]["milestone"] = "v0.11"
+        records[1]["milestone"] = "v0.11"
+        records[2]["milestone"] = "v0.12"
+        conn = sub.create_or_open(tmp_path)
+        try:
+            for rec in records:
+                sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            rows = [
+                tuple(r)
+                for r in conn.execute(
+                    "SELECT milestone, SUM(total_cost_usd) FROM audit_records "
+                    "WHERE milestone IS NOT NULL GROUP BY milestone ORDER BY milestone"
+                ).fetchall()
+            ]
+        finally:
+            conn.close()
+        assert rows == [("v0.11", 3.0), ("v0.12", 4.0)]
+
+    def test_dev_model_queryable_by_index(self, tmp_path: Path) -> None:
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(
+                conn,
+                self._record_with(
+                    run_id="r1",
+                    provider="anthropic",
+                    model="sonnet",
+                    cli="claude",
+                ),
+                provenance="native",
+            )
+            sub.upsert_run_record(
+                conn,
+                self._record_with(
+                    run_id="r2",
+                    provider="openai",
+                    model="gpt-5",
+                ),
+                provenance="native",
+            )
+            conn.commit()
+            rows = [
+                tuple(r)
+                for r in conn.execute(
+                    "SELECT dev_model, COUNT(*) FROM audit_records "
+                    "WHERE dev_model IS NOT NULL GROUP BY dev_model ORDER BY dev_model"
+                ).fetchall()
+            ]
+        finally:
+            conn.close()
+        assert rows == [
+            ("anthropic/sonnet/cli", 1),
+            ("openai/gpt-5/api", 1),
+        ]
+
+
+class TestRecordSchemaMigration:
+    """Issue #1522: reader-side per-record schema-version dispatch seam."""
+
+    def test_pre_slice_record_treated_as_v1(self, tmp_path: Path) -> None:
+        rec = _make_record(run_id="r1")
+        rec.pop("schema_version", None)
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            row = conn.execute(
+                "SELECT record_schema_version FROM audit_records WHERE run_id='r1'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 1
+
+    def test_migrate_record_is_noop_for_current_version(self) -> None:
+        rec = {"schema_version": sub.CURRENT_RECORD_SCHEMA_VERSION, "task": {"slug": "x"}}
+        out = sub._migrate_record(rec, from_version=sub.CURRENT_RECORD_SCHEMA_VERSION)
+        assert out is rec
+
+    def test_iter_records_routes_through_migration(self, tmp_path: Path, monkeypatch) -> None:
+        rec_v1 = _make_record(run_id="r1")
+        rec_v1.pop("schema_version", None)
+        rec_v2 = _make_record(run_id="r2")
+        rec_v2["schema_version"] = 2
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec_v1, provenance="native")
+            sub.upsert_run_record(conn, rec_v2, provenance="native")
+            conn.commit()
+        finally:
+            conn.close()
+
+        seen_versions: list[int] = []
+        original = sub._migrate_record
+
+        def tracking(record: dict, *, from_version: int) -> dict:
+            seen_versions.append(from_version)
+            return original(record, from_version=from_version)
+
+        monkeypatch.setattr(sub, "_migrate_record", tracking)
+        conn = sub.create_or_open(tmp_path)
+        try:
+            list(sub.iter_records(conn))
+        finally:
+            conn.close()
+        # Both rows must have been routed through the helper; versions taken
+        # from the indexed column rather than re-parsed from raw_json.
+        assert sorted(seen_versions) == [1, 2]
+
+
+class TestRebuildBackfillsNewColumns:
+    """Existing audit_records rows pick up the new columns on next rebuild."""
+
+    def test_rebuild_populates_indexed_dimensions(self, tmp_path: Path) -> None:
+        rec = _make_record(run_id="r1", slug="demo")
+        rec["milestone"] = "v0.11"
+        rec["task"]["github_issue"] = 1522
+        rec["cost"]["agents"] = [
+            {
+                "phase": "dev",
+                "provider": "anthropic",
+                "model": "opus",
+                "cli": "claude",
+            }
+        ]
+        rec["schema_version"] = 2
+        _write_runs(tmp_path, [rec])
+        sub.rebuild_from_runs(tmp_path)
+        conn = sqlite3.connect(str(sub.substrate_path(tmp_path)))
+        try:
+            row = conn.execute(
+                "SELECT milestone, issue_id, dev_model, record_schema_version "
+                "FROM audit_records WHERE run_id='r1'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == ("v0.11", 1522, "anthropic/opus/cli", 2)

--- a/tests/test_cli_audit_per_run.py
+++ b/tests/test_cli_audit_per_run.py
@@ -54,7 +54,9 @@ class TestPerRunFileWrite:
         data = json.loads(run_file.read_text())
 
         assert "schema_version" in data
-        assert data["schema_version"] == 1
+        # Per #1522: new per-run records are written at schema_version=2;
+        # pre-slice records (no field) are read as version 1.
+        assert data["schema_version"] == 2
         assert "run_id" in data
         assert data["run_id"] == "run-envelope-001"
         assert "parent_run_id" in data


### PR DESCRIPTION
## Summary

Prior verdict-indexing P1 is fixed; the new audit schema columns, writer population, migration seam, docs, and targeted tests are in place.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $5.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Audit substrate: per-record schema versioning and indexed dimensions for ADR-0002 query obligations (GitHub Issue #1522)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1522