### PR TITLE
Substrate redaction pass: extend to programmatic native-insert path (sprint rollups)

### DIFF
--- a/src/theforge/cli/audits.py
+++ b/src/theforge/cli/audits.py
@@ -256,6 +256,7 @@ def _import_with_snapshot(
         _canonical_json,
         create_or_open,
         derive_run_id,
+        secrets_env_path,
         upsert_run_record,
     )
 
@@ -263,6 +264,8 @@ def _import_with_snapshot(
     if not history_path.exists():
         return summary
     conn = create_or_open(project_root)
+    env_file = secrets_env_path(project_root)
+    env_file_arg: Path | None = env_file if env_file.exists() else None
     try:
         try:
             with open(history_path, encoding="utf-8") as fh:
@@ -290,6 +293,7 @@ def _import_with_snapshot(
                         record,
                         provenance="legacy_history_jsonl",
                         source_path=history_path.name,
+                        env_file=env_file_arg,
                     )
                     # A native row with the same identity is canonical and
                     # protected; count those as skipped-existing.

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -174,6 +174,7 @@ def _write_per_run_record(
                 provenance="native",
                 source_path=str(run_file.relative_to(config.project_root)),
                 source_mtime=stat.st_mtime,
+                env_file=env_file if env_file.exists() else None,
             )
             conn.commit()
         finally:

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -38,6 +38,7 @@ SUBSTRATE_RELPATH = (".forge", "audits", "index.sqlite")
 HISTORY_RELPATH = (".forge", "audits", "history.jsonl")
 RUNS_RELPATH = (".forge", "audits", "runs")
 AUDITS_RELPATH = (".forge", "audits")
+SECRETS_RELPATH = (".forge", ".env")
 
 
 class SubstrateError(Exception):
@@ -69,6 +70,16 @@ def runs_dir(project_root: Path) -> Path:
 
 def audits_dir(project_root: Path) -> Path:
     return project_root.joinpath(*AUDITS_RELPATH)
+
+
+def secrets_env_path(project_root: Path) -> Path:
+    """Path to the project's ``.forge/.env`` secrets file.
+
+    Substrate writers pass this (or ``None`` when not applicable) into
+    :func:`upsert_run_record` so the secret values it contains are
+    redacted from every record before it lands in the SQLite index.
+    """
+    return project_root.joinpath(*SECRETS_RELPATH)
 
 
 # ── Schema ───────────────────────────────────────────────────────────────
@@ -622,13 +633,27 @@ def upsert_run_record(
     provenance: str,
     source_path: str | None = None,
     source_mtime: float | None = None,
+    env_file: Path | None = None,
 ) -> UpsertResult:
     """Insert-or-replace a single audit record.
+
+    Redaction contract (ADR-0002 §1): every record written to the
+    substrate is passed through :func:`coordinator.redact.redact`
+    inside this function before any persistence happens. This is the
+    *only* sanctioned write path into the audit substrate, so the
+    redaction guarantee holds for every caller — direct dict bypass is
+    not possible. Callers SHOULD pass ``env_file`` (typically
+    :func:`secrets_env_path`) so values from ``.forge/.env`` are also
+    scrubbed; secret-key-pattern and ``environment``-dict scrubbing
+    happen unconditionally even when ``env_file`` is ``None``.
 
     Returns :class:`UpsertResult` indicating whether this was a fresh
     insert, an update of an existing row with different content, or an
     unchanged row. Reviews flat-table is rewritten on each upsert.
     """
+    from .redact import redact
+
+    record = redact(record, env_file)
     run_id = derive_run_id(record)
     raw_json = _canonical_json(record)
     existing = conn.execute(
@@ -782,6 +807,8 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
     conn = create_or_open(project_root)
     summary = RebuildSummary()
     runs = runs_dir(project_root)
+    env_file = secrets_env_path(project_root)
+    env_file_arg: Path | None = env_file if env_file.exists() else None
     if runs.exists():
         for run_file in sorted(runs.glob("*.json")):
             summary.runs_seen += 1
@@ -804,6 +831,7 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
                     provenance="native",
                     source_path=str(run_file.relative_to(project_root)),
                     source_mtime=stat.st_mtime,
+                    env_file=env_file_arg,
                 )
                 summary.imported += 1
             except sqlite3.DatabaseError as exc:
@@ -828,6 +856,7 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
                 provenance=provenance,
                 source_path=source_path,
                 source_mtime=source_mtime,
+                env_file=env_file_arg,
             )
         except sqlite3.DatabaseError:
             continue
@@ -857,7 +886,11 @@ class ImportSummary:
     failures: list[str] = field(default_factory=list)
 
 
-def _import_history_jsonl_into(conn: sqlite3.Connection, history_path: Path) -> ImportSummary:
+def _import_history_jsonl_into(
+    conn: sqlite3.Connection,
+    history_path: Path,
+    env_file: Path | None = None,
+) -> ImportSummary:
     """Stream ``history.jsonl`` into the open substrate connection."""
     summary = ImportSummary()
     if not history_path.exists():
@@ -884,6 +917,7 @@ def _import_history_jsonl_into(conn: sqlite3.Connection, history_path: Path) -> 
                         record,
                         provenance="legacy_history_jsonl",
                         source_path=str(history_path.name),
+                        env_file=env_file,
                     )
                 except sqlite3.DatabaseError as exc:
                     summary.failed += 1
@@ -900,8 +934,12 @@ def _import_history_jsonl_into(conn: sqlite3.Connection, history_path: Path) -> 
 def import_history_jsonl(project_root: Path) -> ImportSummary:
     """Public entry: open (or create) substrate and import legacy history."""
     conn = create_or_open(project_root)
+    env_file = secrets_env_path(project_root)
+    env_file_arg: Path | None = env_file if env_file.exists() else None
     try:
-        summary = _import_history_jsonl_into(conn, history_jsonl_path(project_root))
+        summary = _import_history_jsonl_into(
+            conn, history_jsonl_path(project_root), env_file=env_file_arg
+        )
         _meta_set(conn, "legacy_import_done", "1")
         conn.commit()
         return summary

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -37,15 +37,25 @@ def _log(msg: str) -> None:
 def _upsert_into_substrate(project_root: Path, record: dict) -> None:
     """Best-effort mirror of a sprint/story audit dict into the SQLite substrate.
 
+    Redaction is enforced inside ``upsert_run_record`` (ADR-0002 §1); we
+    pass the project's ``.forge/.env`` path so env-defined secrets are
+    also scrubbed before the record is indexed.
+
     Failure is logged but not fatal — the per-run JSON / sprint-audit.yaml
     is canonical and `forge audits rebuild` can recover.
     """
     try:
         from ..coordinator import audit_substrate
 
+        env_file = audit_substrate.secrets_env_path(project_root)
         conn = audit_substrate.create_or_open(project_root)
         try:
-            audit_substrate.upsert_run_record(conn, record, provenance="native")
+            audit_substrate.upsert_run_record(
+                conn,
+                record,
+                provenance="native",
+                env_file=env_file if env_file.exists() else None,
+            )
             conn.commit()
         finally:
             conn.close()

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -913,3 +913,112 @@ class TestRebuildBackfillsNewColumns:
         finally:
             conn.close()
         assert row == ("v0.11", 1522, "anthropic/opus/cli", 2)
+
+
+class TestRedactionContract:
+    """ADR-0002 §1 redaction-contract guarantees for substrate writers."""
+
+    def _make_secret_record(self, run_id: str = "r-redact") -> dict:
+        rec = _make_record(run_id=run_id)
+        rec["api_key"] = "sk-supersecrettoken-from-env"
+        rec["environment"] = {"FOO": "1", "BAR": "2"}
+        rec["task"]["notes"] = "leaked: sk-supersecrettoken-from-env"
+        return rec
+
+    def test_upsert_redacts_secret_keyed_value(self, tmp_path: Path) -> None:
+        """Secret-keyed values are scrubbed even when no env_file is provided."""
+        rec = self._make_secret_record()
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            row = conn.execute(
+                "SELECT raw_json FROM audit_records WHERE run_id='r-redact'"
+            ).fetchone()
+        finally:
+            conn.close()
+        stored = json.loads(row[0])
+        assert stored["api_key"] == "[REDACTED]"
+        assert stored["environment"] == ["BAR", "FOO"]
+
+    def test_upsert_scrubs_env_file_secret_value(self, tmp_path: Path) -> None:
+        """Values present in env_file are scrubbed wherever they appear."""
+        env = sub.secrets_env_path(tmp_path)
+        env.parent.mkdir(parents=True, exist_ok=True)
+        env.write_text('SECRET="sk-supersecrettoken-from-env"\n', encoding="utf-8")
+        rec = self._make_secret_record()
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native", env_file=env)
+            conn.commit()
+            row = conn.execute(
+                "SELECT raw_json FROM audit_records WHERE run_id='r-redact'"
+            ).fetchone()
+        finally:
+            conn.close()
+        stored = json.loads(row[0])
+        # The secret value must be gone from every string field.
+        assert "sk-supersecrettoken-from-env" not in row[0]
+        assert "[REDACTED]" in stored["task"]["notes"]
+
+    def test_sprint_rollup_path_redacts_into_substrate(self, tmp_path: Path) -> None:
+        """The programmatic sprint-rollup writer must scrub secrets too.
+
+        Regression test for the ADR-0002 §1 redaction-contract gap where
+        sprint/audit._upsert_into_substrate() called the substrate without
+        first redacting.
+        """
+        from theforge.sprint import audit as sprint_audit
+
+        env = sub.secrets_env_path(tmp_path)
+        env.parent.mkdir(parents=True, exist_ok=True)
+        env.write_text('SECRET="sk-sprint-rollup-secret-xyz"\n', encoding="utf-8")
+        record = _make_record(run_id="r-sprint-rollup")
+        record["api_key"] = "leaked-via-key"
+        record["task"]["notes"] = "embedded sk-sprint-rollup-secret-xyz here"
+
+        sprint_audit._upsert_into_substrate(tmp_path, record)
+
+        conn = sqlite3.connect(str(sub.substrate_path(tmp_path)))
+        try:
+            row = conn.execute(
+                "SELECT raw_json FROM audit_records WHERE run_id='r-sprint-rollup'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert "sk-sprint-rollup-secret-xyz" not in row[0]
+        assert "leaked-via-key" not in row[0]
+        stored = json.loads(row[0])
+        assert stored["api_key"] == "[REDACTED]"
+
+    def test_rebuild_from_runs_does_not_unredact(self, tmp_path: Path) -> None:
+        """Rebuilding from per-run JSON yields a substrate with no unredacted secrets.
+
+        Per-run JSON files are written already-redacted by cli/shared.py; this
+        test asserts the rebuild path inherits that redaction rather than
+        re-introducing raw values (defense-in-depth via the writer-side scrub).
+        """
+        env = sub.secrets_env_path(tmp_path)
+        env.parent.mkdir(parents=True, exist_ok=True)
+        env.write_text('SECRET="rebuild-secret-abc12345"\n', encoding="utf-8")
+
+        # Simulate a per-run JSON file that somehow contains a raw secret.
+        # The writer-side redaction inside upsert_run_record should still
+        # scrub it during rebuild.
+        rec = _make_record(run_id="r-rebuild")
+        rec["api_key"] = "rebuild-secret-abc12345"
+        rec["task"]["notes"] = "contains rebuild-secret-abc12345"
+        _write_runs(tmp_path, [rec])
+
+        sub.rebuild_from_runs(tmp_path)
+
+        conn = sqlite3.connect(str(sub.substrate_path(tmp_path)))
+        try:
+            row = conn.execute(
+                "SELECT raw_json FROM audit_records WHERE run_id='r-rebuild'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert "rebuild-secret-abc12345" not in row[0]


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The substrate writer now enforces redaction at the shared upsert boundary, and the sprint-rollup, per-run, and rebuild paths are covered by targeted tests. | [google-gemini-3.1-pro-preview] Moved secret redaction into `upsert_run_record` to enforce the redaction contract uniformly across all substrate write paths, including sprint rollups.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $4.68
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Substrate redaction pass: extend to programmatic native-insert path (sprint rollups) (GitHub Issue #1526)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1526