### PR TITLE
feat(sprint): emit shape-gate verdicts to audit substrate (#1517)

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -225,6 +225,36 @@ def _acquire_launch_locks(
     )
 
 
+def _resolve_base_branch_sha(config: object) -> str | None:
+    """Best-effort lookup of the configured base branch's HEAD SHA.
+
+    Returned as a column on shape-gate verdict events so downstream queries
+    can scope refusal-economics samples to a specific tree state. Returns
+    ``None`` when git is unavailable or the branch is not resolvable —
+    substrate emission must not fail because of a git lookup miss.
+    """
+    import subprocess as _sp
+
+    base = getattr(getattr(config, "workspace", None), "base_branch", None)
+    if not base:
+        return None
+    project_root = getattr(config, "project_root", None)
+    try:
+        proc = _sp.run(
+            ["git", "rev-parse", str(base)],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root) if project_root else None,
+            timeout=10,
+        )
+    except (OSError, _sp.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    sha = proc.stdout.strip()
+    return sha or None
+
+
 def _is_reexec() -> bool:
     """Return True when the current process was started by a forge re-exec.
 
@@ -448,6 +478,7 @@ def _run_query_mode(
     _generate_run_id: object,
 ) -> int:
     """Handle --milestone / --label / --issues query mode."""
+    from theforge.coordinator.audit_substrate import record_shape_verdict_event
     from theforge.sprint.dag import resolve_satisfied_dependencies
     from theforge.sprint.query import (
         assign_dependency_batches_with_satisfied,
@@ -512,13 +543,29 @@ def _run_query_mode(
     # Dry-run is a pure dependency preview — bypass the gate there so
     # operators can inspect the DAG without making ``gh`` calls per issue.
     skipped_issues: list = []
+    # Pre-compute the run_id so the shape gate's substrate verdict events
+    # can be correlated with the sprint that produced them. The same id is
+    # reused below where the daemon previously generated it.
+    gate_run_id = _generate_run_id() if not dry_run else None
+    gate_sprint_name = getattr(args, "name", None) or milestone or label or f"issues-{issues_arg}"
     if not dry_run:
         classifier_mode = getattr(getattr(config, "shape_check", None), "classifier", "heuristic")
+        base_branch_sha = _resolve_base_branch_sha(config)
+
+        def _emit_shape_verdict(payload: dict) -> None:
+            event = dict(payload)
+            event.setdefault("run_id", gate_run_id)
+            event.setdefault("sprint_name", gate_sprint_name)
+            event.setdefault("milestone", milestone)
+            event.setdefault("base_branch_sha", base_branch_sha)
+            record_shape_verdict_event(config.project_root, event)
+
         gate_result = apply_shape_gate(
             issues,
             config.project_root,
             classifier_mode=classifier_mode,
             force=force,
+            emit_verdict=_emit_shape_verdict,
         )
         if gate_result.skipped:
             warning = format_skipped_warning(gate_result.skipped)
@@ -622,7 +669,9 @@ def _run_query_mode(
     live_slugs = [s for s in slugs if s not in dropped_slugs]
 
     # ── Daemonization: slug from sprint name, not manifest filename ───────
-    run_id = _generate_run_id()
+    # Reuse the run_id pre-generated for the shape gate so its substrate
+    # verdict events correlate with this sprint's downstream rows.
+    run_id = gate_run_id or _generate_run_id()
     sprint_slug = sprint_name.replace(" ", "-").replace("/", "-").lower()[:50]
 
     if not getattr(args, "fg", False) and not getattr(args, "detach", False):

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -142,6 +142,22 @@ CREATE INDEX IF NOT EXISTS idx_readiness_events_kind ON readiness_events(kind);
 CREATE INDEX IF NOT EXISTS idx_readiness_events_issue ON readiness_events(issue_ref);
 CREATE INDEX IF NOT EXISTS idx_readiness_events_action ON readiness_events(action);
 CREATE INDEX IF NOT EXISTS idx_readiness_events_staleness ON readiness_events(staleness_verdict);
+CREATE TABLE IF NOT EXISTS shape_verdict_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id TEXT NOT NULL,
+    verdict TEXT NOT NULL,
+    base_branch_sha TEXT,
+    run_id TEXT,
+    sprint_name TEXT,
+    milestone TEXT,
+    source TEXT,
+    emitted_at TEXT NOT NULL,
+    raw_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_verdict ON shape_verdict_events(verdict);
+CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_issue ON shape_verdict_events(issue_id);
+CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_milestone ON shape_verdict_events(milestone);
+CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_run ON shape_verdict_events(run_id);
 """
 
 
@@ -1326,6 +1342,75 @@ def iter_readiness_events(conn: sqlite3.Connection, *, kind: str | None = None) 
     else:
         cur = conn.execute("SELECT raw_json FROM readiness_events ORDER BY event_id DESC")
     for row in cur:
+        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
+        try:
+            yield json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+
+def record_shape_verdict_event(project_root: Path, event: dict) -> int:
+    """Insert a shape-gate verdict row into the audit substrate.
+
+    Each event captures the verdict assigned to a single issue at sprint
+    entry so refusal-economics queries (verdict distribution per milestone,
+    per-issue verdict trajectory) can run against the substrate without
+    re-deriving from YAML/log surfaces. Returns the inserted row's
+    ``event_id``. Raises :class:`SubstrateError` on missing required keys
+    or I/O failure so callers can decide whether to swallow (sprint gate
+    treats this as observability, not gating).
+    """
+    required = {"issue_id", "verdict"}
+    missing = required - set(event)
+    if missing:
+        raise SubstrateError(f"shape verdict event missing required keys: {sorted(missing)}")
+    raw_json = _canonical_json(event)
+    emitted_at = event.get("emitted_at") or _now_iso()
+    conn = create_or_open(project_root)
+    try:
+        cur = conn.execute(
+            "INSERT INTO shape_verdict_events "
+            "(issue_id, verdict, base_branch_sha, run_id, sprint_name, "
+            "milestone, source, emitted_at, raw_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(event["issue_id"]),
+                str(event["verdict"]),
+                event.get("base_branch_sha"),
+                event.get("run_id"),
+                event.get("sprint_name"),
+                event.get("milestone"),
+                event.get("source"),
+                emitted_at,
+                raw_json,
+            ),
+        )
+        conn.commit()
+        return int(cur.lastrowid or 0)
+    finally:
+        conn.close()
+
+
+def iter_shape_verdict_events(
+    conn: sqlite3.Connection,
+    *,
+    issue_id: str | None = None,
+    verdict: str | None = None,
+) -> Iterable[dict]:
+    """Yield shape-verdict event dicts (parsed from raw_json), oldest first."""
+    sql = "SELECT raw_json FROM shape_verdict_events"
+    clauses: list[str] = []
+    params: list = []
+    if issue_id is not None:
+        clauses.append("issue_id = ?")
+        params.append(issue_id)
+    if verdict is not None:
+        clauses.append("verdict = ?")
+        params.append(verdict)
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    sql += " ORDER BY emitted_at ASC, event_id ASC"
+    for row in conn.execute(sql, tuple(params)):
         raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
         try:
             yield json.loads(raw)

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -15,14 +15,20 @@ drops.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Callable
 
 from ..shape_check import Shape, ShapeResult, ShapeVerdict, check
 from ..shape_check.types import VERDICT_DESCRIPTIONS, Severity
 from .reopen_context import analyze_reopen_contract, format_reopen_stale_detail
+
+_log = logging.getLogger(__name__)
+
+VerdictEmitter = Callable[[dict], None]
 
 NEEDS_GROOMING_LABEL = "needs-grooming"
 REOPENED_STALE_CONTRACT_CODE = "reopened_stale_contract"
@@ -274,6 +280,10 @@ def _resolve_classifier(classifier_mode: str, llm_caller=None) -> str:
     return classifier_mode
 
 
+def _noop_emit_verdict(_event: dict) -> None:
+    return None
+
+
 def apply_shape_gate(
     issues: list[dict],
     project_root: Path | None,
@@ -282,6 +292,7 @@ def apply_shape_gate(
     force: bool = False,
     fetch_detail=_fetch_issue_detail,
     llm_caller=None,
+    emit_verdict: VerdictEmitter = _noop_emit_verdict,
 ) -> ShapeGateResult:
     """Partition issues into runnable vs skipped before preflight runs.
 
@@ -302,6 +313,20 @@ def apply_shape_gate(
     effective_mode = _resolve_classifier(classifier_mode, llm_caller=llm_caller)
     runnable: list[dict] = []
     skipped: list[SkippedIssue] = []
+
+    def _safe_emit(payload: dict) -> None:
+        # Substrate emission is observability, not gating: a write failure
+        # must not block the sprint. Log at WARNING so operators notice but
+        # the gate continues to partition issues exactly as before.
+        try:
+            emit_verdict(payload)
+        except Exception as exc:  # noqa: BLE001
+            _log.warning(
+                "shape-gate verdict substrate write failed for issue=%s verdict=%s: %s",
+                payload.get("issue_id"),
+                payload.get("verdict"),
+                exc,
+            )
 
     for issue in issues:
         number = int(issue["number"])
@@ -345,6 +370,14 @@ def apply_shape_gate(
                     verdict_description=VERDICT_DESCRIPTIONS[verdict],
                 )
             )
+            _safe_emit(
+                {
+                    "issue_id": str(number),
+                    "verdict": verdict.value,
+                    "source": "label",
+                    "reason_codes": list(codes),
+                }
+            )
             continue
 
         if reopen_state.has_stale_body:
@@ -359,6 +392,14 @@ def apply_shape_gate(
                     verdict=verdict.value,
                     verdict_description=VERDICT_DESCRIPTIONS[verdict],
                 )
+            )
+            _safe_emit(
+                {
+                    "issue_id": str(number),
+                    "verdict": verdict.value,
+                    "source": "local_check",
+                    "reason_codes": [REOPENED_STALE_CONTRACT_CODE],
+                }
             )
             continue
 
@@ -382,6 +423,14 @@ def apply_shape_gate(
                     verdict=ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN.value,
                     verdict_description=VERDICT_DESCRIPTIONS[ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN],
                 )
+            )
+            _safe_emit(
+                {
+                    "issue_id": str(number),
+                    "verdict": ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN.value,
+                    "source": "local_check",
+                    "reason_codes": list(codes),
+                }
             )
             continue
 
@@ -407,6 +456,14 @@ def apply_shape_gate(
                     verdict_description=VERDICT_DESCRIPTIONS[verdict],
                 )
             )
+            _safe_emit(
+                {
+                    "issue_id": str(number),
+                    "verdict": verdict.value,
+                    "source": "local_check",
+                    "reason_codes": list(codes),
+                }
+            )
             continue
 
         # Runnable: attach the verdict to the dict so downstream audit/summary
@@ -414,6 +471,14 @@ def apply_shape_gate(
         issue_with_verdict = dict(issue)
         issue_with_verdict["shape_verdict"] = ShapeVerdict.RUNNABLE.value
         runnable.append(issue_with_verdict)
+        _safe_emit(
+            {
+                "issue_id": str(number),
+                "verdict": ShapeVerdict.RUNNABLE.value,
+                "source": "local_check",
+                "reason_codes": [],
+            }
+        )
 
     if force:
         # Escape hatch: caller wants to run every input issue. Skip list is

--- a/tests/test_shape_gate_substrate_emission.py
+++ b/tests/test_shape_gate_substrate_emission.py
@@ -1,0 +1,228 @@
+"""Seam-level coverage for shape-gate → audit-substrate verdict emission.
+
+Issue #1517: every shape-gate verdict (skipped *and* runnable) must land in
+the SQLite audit substrate so refusal-economics queries can run against a
+single source. Substrate write failures must be observability-only — the
+gate must continue to partition issues and the failure must surface as a
+WARNING log.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from theforge.coordinator.audit_substrate import (
+    iter_shape_verdict_events,
+    record_shape_verdict_event,
+    substrate_path,
+)
+from theforge.shape_check import ShapeVerdict
+from theforge.sprint.shape_gate import apply_shape_gate
+
+_RUNNABLE_BODY = textwrap.dedent(
+    """\
+    ## What
+    Add a small toggle so callers can opt in.
+
+    ## Why
+    Operators need a way to silence the warning during local runs.
+
+    ## Acceptance criteria
+    - The toggle defaults to off.
+    - When on, the warning is suppressed.
+
+    ## Example
+    Before: warning printed every run. After: silent when toggle on.
+    """
+)
+
+_BAD_BODY = "no headings, just a sentence."
+
+
+def _emit_to_substrate(project_root: Path):
+    def _emit(event: dict) -> None:
+        event = dict(event)
+        event.setdefault("run_id", "run-test-1")
+        event.setdefault("sprint_name", "sprint-test")
+        event.setdefault("milestone", "v0.11.0")
+        event.setdefault("base_branch_sha", "deadbeef")
+        record_shape_verdict_event(project_root, event)
+
+    return _emit
+
+
+def _fake_detail(body: str, labels: list[str]):
+    def _fetch(_number, _root):
+        return {"title": "issue", "body": body, "labels": labels}
+
+    return _fetch
+
+
+def test_runnable_verdict_lands_in_substrate(tmp_path: Path) -> None:
+    issues = [{"number": 42, "title": "well-formed"}]
+
+    apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_RUNNABLE_BODY, ["enhancement"]),
+        emit_verdict=_emit_to_substrate(tmp_path),
+    )
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        rows = conn.execute(
+            "SELECT issue_id, verdict, milestone, run_id, base_branch_sha, sprint_name, source "
+            "FROM shape_verdict_events"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row[0] == "42"
+    assert row[1] == ShapeVerdict.RUNNABLE.value
+    assert row[2] == "v0.11.0"
+    assert row[3] == "run-test-1"
+    assert row[4] == "deadbeef"
+    assert row[5] == "sprint-test"
+    assert row[6] == "local_check"
+
+
+def test_skipped_verdict_lands_in_substrate(tmp_path: Path) -> None:
+    issues = [{"number": 7, "title": "malformed"}]
+
+    apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_BAD_BODY, []),
+        emit_verdict=_emit_to_substrate(tmp_path),
+    )
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        events = list(iter_shape_verdict_events(conn, issue_id="7"))
+    finally:
+        conn.close()
+
+    assert len(events) == 1
+    assert events[0]["issue_id"] == "7"
+    assert events[0]["verdict"] != ShapeVerdict.RUNNABLE.value
+    assert events[0]["source"] == "local_check"
+
+
+def test_verdict_distribution_query_groups_by_verdict_and_milestone(
+    tmp_path: Path,
+) -> None:
+    apply_shape_gate(
+        [{"number": 1, "title": "ok"}],
+        tmp_path,
+        fetch_detail=_fake_detail(_RUNNABLE_BODY, ["enhancement"]),
+        emit_verdict=_emit_to_substrate(tmp_path),
+    )
+    apply_shape_gate(
+        [{"number": 2, "title": "bad"}],
+        tmp_path,
+        fetch_detail=_fake_detail(_BAD_BODY, []),
+        emit_verdict=_emit_to_substrate(tmp_path),
+    )
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        rows = conn.execute(
+            "SELECT verdict, milestone, COUNT(*) FROM shape_verdict_events "
+            "GROUP BY verdict, milestone"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    counts = {(verdict, milestone): n for verdict, milestone, n in rows}
+    assert counts[(ShapeVerdict.RUNNABLE.value, "v0.11.0")] == 1
+    # The malformed issue produces some non-runnable verdict — exact code is
+    # owned by the shape-check classifier; assert there is exactly one row
+    # for milestone v0.11.0 that is not RUNNABLE.
+    non_runnable = [
+        n for (v, m), n in counts.items() if m == "v0.11.0" and v != ShapeVerdict.RUNNABLE.value
+    ]
+    assert sum(non_runnable) == 1
+
+
+def test_per_issue_trajectory_query_orders_by_timestamp(tmp_path: Path) -> None:
+    # First emission: malformed → some non-runnable verdict.
+    apply_shape_gate(
+        [{"number": 99, "title": "draft"}],
+        tmp_path,
+        fetch_detail=_fake_detail(_BAD_BODY, []),
+        emit_verdict=_emit_to_substrate(tmp_path),
+    )
+    # Second emission: same issue is now runnable.
+    apply_shape_gate(
+        [{"number": 99, "title": "draft"}],
+        tmp_path,
+        fetch_detail=_fake_detail(_RUNNABLE_BODY, ["enhancement"]),
+        emit_verdict=_emit_to_substrate(tmp_path),
+    )
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        rows = conn.execute(
+            "SELECT verdict FROM shape_verdict_events "
+            "WHERE issue_id = ? ORDER BY emitted_at ASC, event_id ASC",
+            ("99",),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 2
+    assert rows[0][0] != ShapeVerdict.RUNNABLE.value
+    assert rows[-1][0] == ShapeVerdict.RUNNABLE.value
+
+
+def test_substrate_write_failure_does_not_block_gate(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    issues = [
+        {"number": 1, "title": "good"},
+        {"number": 2, "title": "bad"},
+    ]
+
+    def _fetch(number, _root):
+        if number == 1:
+            return {"title": "good", "body": _RUNNABLE_BODY, "labels": ["enhancement"]}
+        return {"title": "bad", "body": _BAD_BODY, "labels": []}
+
+    def _exploding_emit(_event: dict) -> None:
+        raise RuntimeError("substrate offline")
+
+    with caplog.at_level(logging.WARNING, logger="theforge.sprint.shape_gate"):
+        result = apply_shape_gate(
+            issues,
+            tmp_path,
+            fetch_detail=_fetch,
+            emit_verdict=_exploding_emit,
+        )
+
+    # Gate must still partition issues — observability is not gating.
+    assert [r["number"] for r in result.runnable] == [1]
+    assert [s.issue_number for s in result.skipped] == [2]
+    # And the failure must be visible as a WARNING.
+    warning_messages = [
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.WARNING
+    ]
+    assert any("shape-gate verdict substrate write failed" in m for m in warning_messages)
+
+
+def test_record_shape_verdict_event_requires_issue_id_and_verdict(
+    tmp_path: Path,
+) -> None:
+    from theforge.coordinator.audit_substrate import SubstrateError
+
+    with pytest.raises(SubstrateError):
+        record_shape_verdict_event(tmp_path, {"verdict": "runnable"})
+    with pytest.raises(SubstrateError):
+        record_shape_verdict_event(tmp_path, {"issue_id": "1"})


### PR DESCRIPTION
## Summary

Adds a `shape_verdict_events` table and a `record_shape_verdict_event` writer so every sprint-entry verdict (skipped and runnable) lands in the SQLite substrate. `apply_shape_gate` now takes an `emit_verdict` callable and the sprint CLI wires in a writer that captures `run_id`, `sprint_name`, `milestone`, and the resolved base-branch SHA. Substrate write failures are logged at WARNING and never block the gate, keeping emission strictly observability per ADR-0001's refusal-economics intent.

This PR is the manual landing of dev/review work from sprint `7ce7af910a47` (2026-05-11). The sprint's automatic integration step hit the rebase-conflict failure documented in [#1402](https://github.com/fuzzypete/theforge/issues/1402) (reopened) — the collision-DAG correctly serialized #1516 → #1517 → #1522 at preflight, but the dependent's worktree base wasn't refreshed before integration. Manual rebase resolved a trivial schema-additive conflict in `audit_substrate.py` (HEAD added `idx_readiness_events_staleness`, this branch added the `shape_verdict_events` table — both kept).

## Review (from sprint)

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.5, google-gemini-3.1-pro-preview
- **Cost:** $3.77
- **Dev iterations:** 1

## Tests

- 6/6 in `tests/test_shape_gate_substrate_emission.py` pass after rebase.

Closes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)