### PR TITLE
enhancement: P2 cleanup iterations after APPROVE

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -684,6 +684,8 @@ def load_config(config_path: Path) -> ForgeConfig:
         max_dev_iterations_cap=int(retry_data.get("max_dev_iterations_cap", 0)),
         max_review_cycles_cap=int(retry_data.get("max_review_cycles_cap", 0)),
         review_zero_findings_stop=int(retry_data.get("review_zero_findings_stop", 0)),
+        p2_cleanup_enabled=bool(retry_data.get("p2_cleanup_enabled", True)),
+        p2_cleanup_max_iterations=int(retry_data.get("p2_cleanup_max_iterations", 0)),
     )
 
     notifications = _parse_notifications(raw.get("notifications", {}), secrets)

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -270,6 +270,12 @@ class RetryPolicy:
     # Stop the review loop early when this many consecutive iterations produce
     # zero new findings. 0 disables early termination.
     review_zero_findings_stop: int = 0
+    # After APPROVE with open P2 findings, the coordinator re-enters DEV to
+    # address them as advisory cleanup until the dev iteration budget is
+    # exhausted. Enabled by default. p2_cleanup_max_iterations=0 means
+    # "no separate cap — use whatever remains of the per-cycle dev budget".
+    p2_cleanup_enabled: bool = True
+    p2_cleanup_max_iterations: int = 0
 
 
 @dataclass(frozen=True)

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -547,6 +547,30 @@ def _run_dev_phase(
             state.dev_prompt_injected_finding_ids.append([])
             state.retry_reason = None
             state.human_feedback = None
+        case RetryReason.P2_CLEANUP:
+            prompt = build_fix_prompt(
+                task,
+                workspace_path=workspace_path,
+                branch_name=branch_name,
+                allowed_tools=config.dev_profile.allowed_tools,
+                review_findings=state.last_review_findings or "No specific findings provided.",
+                gate_command=_gate_cmd,
+                test_command=_test_cmd,
+                gate_skipped=_is_gate_skip(task.gate_override),
+                iteration=state.dev_iteration,
+                cycle_history=state.cycle_history or None,
+                escalation_note=state.escalation_note,
+                plan_output=state.plan_structured
+                if state.plan_structured is not None
+                else state.plan_output,
+                prior_open_p1s=None,
+                classified_p1s=None,
+                surviving_families=None,
+                conventions=config.conventions_soft,
+                advisory_p2_only=True,
+            )
+            state.dev_prompt_injected_finding_ids.append([])
+            state.escalation_note = None
         case RetryReason.REVIEW_CHANGES | RetryReason.EXTEND if state.last_review_findings:
             carry_forward_p1s = _prior_open_p1s_for_dev_prompt(state)
             current_cycle_p1s = _current_cycle_p1s_for_dev_prompt(state)

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -609,8 +609,12 @@ def _coordinator_loop(
                 state=state,
                 message=f"Stopped at --until {stop_phase.name.lower()}",
             )
-        # RETRY_DEV — reset per-cycle budget counter and loop back
-        state.budget.reset_cycle()
+        # RETRY_DEV — reset per-cycle budget counter and loop back.
+        # Exception: P2 cleanup iterations after APPROVE keep accumulating
+        # against the existing cycle budget so cleanup cannot exceed the
+        # configured dev iteration pool.
+        if not state.p2_cleanup_active:
+            state.budget.reset_cycle()
 
 
 def run_task(

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -297,6 +297,45 @@ def _open_p2_findings(parsed_review: ReviewResult) -> list[ReviewFinding]:
     return [f for f in parsed_review.findings if f.severity == "P2"]
 
 
+def _p2_finding_key(f: ReviewFinding) -> tuple[str, int | None, str]:
+    """Return a stable fingerprint for a P2 finding."""
+    return (f.file or "", f.line, (f.description or "").strip())
+
+
+def _build_carry_findings(
+    parsed_review: ReviewResult,
+    carry_keys: list[tuple[str, int | None, str]],
+) -> list[ReviewFinding]:
+    """Filter the current P2 findings to those still in the carried set."""
+    if not carry_keys:
+        return []
+    carry_set = {tuple(key) for key in carry_keys}
+    return [
+        f for f in parsed_review.findings if f.severity == "P2" and _p2_finding_key(f) in carry_set
+    ]
+
+
+def _carry_handoff(findings: list[ReviewFinding]) -> str:
+    """Render carried P2 findings as a dev-agent handoff body."""
+    if not findings:
+        return "No specific findings provided."
+    lines: list[str] = ["## Carried P2 Findings"]
+    for f in findings:
+        loc = f" (line {f.line})" if f.line is not None else ""
+        lines.append(f"\n### [P2] `{f.file}`{loc}")
+        lines.append(f"**Issue:** {f.description}")
+        if f.suggestion:
+            lines.append(f"**Fix:** {f.suggestion}")
+    return "\n".join(lines)
+
+
+def _clear_p2_cleanup_state(state: CoordinatorState) -> None:
+    """Reset cleanup tracking when the loop exits (clean, regression, cap, etc.)."""
+    state.p2_cleanup_active = False
+    state.p2_cleanup_findings = []
+    state.p2_cleanup_carry_keys = []
+
+
 def _maybe_enter_p2_cleanup(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -305,46 +344,60 @@ def _maybe_enter_p2_cleanup(
     """Decide whether to re-enter DEV for advisory P2 cleanup after APPROVE.
 
     Mutates state when entering cleanup: sets retry_reason=P2_CLEANUP,
-    p2_cleanup_active=True, captures p2_cleanup_findings, and appends an
-    audit entry. Returns True to signal the caller should return RETRY_DEV
-    instead of DONE.
+    p2_cleanup_active=True, captures p2_cleanup_findings filtered to the
+    originally carried P2 set, and appends an audit entry. Returns True to
+    signal the caller should return RETRY_DEV instead of DONE.
+
+    On first entry the current P2 findings are fingerprinted and stored as
+    state.p2_cleanup_carry_keys; on subsequent passes only those carried
+    findings still raised by the reviewer keep the loop running. New P2
+    findings raised after carry capture are recorded but do not extend the
+    loop — preventing an unbounded "follow every new advisory" pattern.
 
     Returns False when:
       - the feature is disabled,
-      - the review has no open P2 findings,
+      - no carried P2 findings remain (or none existed),
       - the dev iteration budget for this cycle is exhausted, or
       - the configured cleanup-iteration cap has been reached.
     """
-    p2s = _open_p2_findings(parsed_review)
+    current_p2s = _open_p2_findings(parsed_review)
+    if not state.p2_cleanup_active:
+        # First evaluation post-APPROVE — capture the carry set from the
+        # P2 findings raised by THIS review.
+        carry_keys = [list(_p2_finding_key(f)) for f in current_p2s]
+    else:
+        carry_keys = list(state.p2_cleanup_carry_keys)
+    remaining_carried = _build_carry_findings(parsed_review, carry_keys)
     audit_base = {
         "review_cycle": state.review_cycle,
         "dev_iteration": state.dev_iteration,
-        "p2_count": len(p2s),
+        "p2_count": len(current_p2s),
+        "carried_p2_count": len(carry_keys),
+        "remaining_carried_p2_count": len(remaining_carried),
         "budget_remaining": state.budget.remaining(),
         "cleanup_iterations": state.p2_cleanup_iterations,
     }
     if not config.retry.p2_cleanup_enabled:
         state.p2_cleanup_audit.append({"action": "skip_disabled", **audit_base})
-        state.p2_cleanup_active = False
+        _clear_p2_cleanup_state(state)
         return False
-    if not p2s:
-        state.p2_cleanup_audit.append(
-            {
-                "action": "exit_clean" if state.p2_cleanup_active else "skip_no_p2",
-                **audit_base,
-            }
-        )
-        state.p2_cleanup_active = False
+    if not remaining_carried:
+        # Either the original review had no P2s, or every carried P2 was
+        # resolved by a prior cleanup pass. Either way we exit the loop.
+        action = "exit_clean" if state.p2_cleanup_active else "skip_no_p2"
+        state.p2_cleanup_audit.append({"action": action, **audit_base})
+        _clear_p2_cleanup_state(state)
         return False
     if state.budget.remaining() <= 0:
         state.p2_cleanup_audit.append({"action": "skip_budget", **audit_base})
-        state.p2_cleanup_active = False
+        _clear_p2_cleanup_state(state)
         return False
     cap = config.retry.p2_cleanup_max_iterations
     if cap > 0 and state.p2_cleanup_iterations >= cap:
         state.p2_cleanup_audit.append({"action": "skip_cap", **audit_base})
-        state.p2_cleanup_active = False
+        _clear_p2_cleanup_state(state)
         return False
+    state.p2_cleanup_carry_keys = carry_keys
     state.p2_cleanup_findings = [
         {
             "severity": f.severity,
@@ -353,14 +406,14 @@ def _maybe_enter_p2_cleanup(
             "description": f.description,
             "suggestion": f.suggestion,
         }
-        for f in p2s
+        for f in remaining_carried
     ]
     action = "continue" if state.p2_cleanup_iterations > 0 else "enter"
     state.p2_cleanup_active = True
     state.p2_cleanup_iterations += 1
     state.retry_reason = RetryReason.P2_CLEANUP
     state.human_feedback = None
-    state.last_review_findings = review_to_dev_handoff(parsed_review)
+    state.last_review_findings = _carry_handoff(remaining_carried)
     state.p2_cleanup_audit.append({"action": action, **audit_base})
     return True
 
@@ -442,6 +495,7 @@ def _handle_interactive_review_decision(
     review_elapsed: float,
     run_id: str,
     exhausted_cycles: bool,
+    history_already_appended: bool = False,
 ) -> tuple[_ReviewOutcome, CoordinatorResult | None, ForgeConfig]:
     """Handle the HUMAN_REVIEW decision flow for an interactive session.
 
@@ -473,7 +527,8 @@ def _handle_interactive_review_decision(
     state.human_review_feedback = feedback
 
     if decision == "approve":
-        _append_cycle_history(state, parsed_review)
+        if not history_already_appended:
+            _append_cycle_history(state, parsed_review)
         if exhausted_cycles:
             _approve_msg = (
                 f"Task '{task.name}' completed. "
@@ -529,7 +584,8 @@ def _handle_interactive_review_decision(
         )
 
     if decision == "extend":
-        _append_cycle_history(state, parsed_review)
+        if not history_already_appended:
+            _append_cycle_history(state, parsed_review)
         state.budget.reset_cycle()
         state.review_cycle = 0
         state.human_review_extra_cycles += 1
@@ -551,7 +607,8 @@ def _handle_interactive_review_decision(
         return _ReviewOutcome.RETRY_DEV, None, config
 
     # decision == "reject"
-    _append_cycle_history(state, parsed_review)
+    if not history_already_appended:
+        _append_cycle_history(state, parsed_review)
     state.budget.reset_cycle()
     state.last_review_findings = None
     state.retry_reason = RetryReason.REJECT
@@ -1319,6 +1376,40 @@ def _run_review_phase(
             f"  ✓ REVIEW   {_verdict_label}  {_p1_count} P1  {_p2_count} P2"
             f"  ${_review_cost:.2f}  {_fmt_duration(_review_elapsed)}"
         )
+        _append_cycle_history(state, parsed_review)
+        # ── P2 cleanup (post-APPROVE advisory iterations) ──────────────
+        # Default behaviour in both interactive and non-interactive modes:
+        # when the review left open P2s and dev iteration budget remains,
+        # re-enter DEV with the carried P2 list. Budget exhaustion, no
+        # remaining carried P2s, an iteration cap, or p2_cleanup_enabled=
+        # false all fall through to the existing approve handler.
+        if _maybe_enter_p2_cleanup(state, config, parsed_review):
+            _entry = state.p2_cleanup_audit[-1]
+            _log(
+                f"  ↻ P2 CLEANUP  entering dev iteration "
+                f"({_entry['remaining_carried_p2_count']} carried P2(s), "
+                f"budget_remaining={_entry['budget_remaining']})"
+            )
+            if logger:
+                logger._safe_emit(
+                    "phase_end",
+                    phase="REVIEW",
+                    outcome="approve_p2_cleanup",
+                    cost_usd=round(_review_cost, 6),
+                    duration_s=round(_review_elapsed, 2),
+                )
+                logger._safe_emit(
+                    "p2_cleanup",
+                    action=_entry["action"],
+                    p2_count=_entry["p2_count"],
+                    carried_p2_count=_entry["carried_p2_count"],
+                    remaining_carried_p2_count=_entry["remaining_carried_p2_count"],
+                    review_cycle=_entry["review_cycle"],
+                    dev_iteration=_entry["dev_iteration"],
+                    budget_remaining=_entry["budget_remaining"],
+                )
+            return _ReviewOutcome.RETRY_DEV, None, config
+        # Cleanup was either skipped or terminated.
         if interactive:
             return _handle_interactive_review_decision(
                 state,
@@ -1334,40 +1425,9 @@ def _run_review_phase(
                 review_elapsed=_review_elapsed,
                 run_id=run_id,
                 exhausted_cycles=False,
+                history_already_appended=True,
             )
         else:
-            _append_cycle_history(state, parsed_review)
-            # ── P2 cleanup (post-APPROVE advisory iterations) ──────────
-            # Re-enter DEV when the review left open P2s and dev iteration
-            # budget remains. Budget exhaustion (or disabled config) falls
-            # through to the DONE return — P2s are advisory, never blocking.
-            if _maybe_enter_p2_cleanup(state, config, parsed_review):
-                _entry = state.p2_cleanup_audit[-1]
-                _log(
-                    f"  ↻ P2 CLEANUP  entering dev iteration "
-                    f"({_entry['p2_count']} open P2(s), "
-                    f"budget_remaining={_entry['budget_remaining']})"
-                )
-                if logger:
-                    logger._safe_emit(
-                        "phase_end",
-                        phase="REVIEW",
-                        outcome="approve_p2_cleanup",
-                        cost_usd=round(_review_cost, 6),
-                        duration_s=round(_review_elapsed, 2),
-                    )
-                    logger._safe_emit(
-                        "p2_cleanup",
-                        action=_entry["action"],
-                        p2_count=_entry["p2_count"],
-                        review_cycle=_entry["review_cycle"],
-                        dev_iteration=_entry["dev_iteration"],
-                        budget_remaining=_entry["budget_remaining"],
-                    )
-                return _ReviewOutcome.RETRY_DEV, None, config
-            # Cleanup was either skipped or terminated; ensure flag cleared
-            # so subsequent paths do not see stale state.
-            state.p2_cleanup_active = False
             return (
                 _ReviewOutcome.DONE,
                 _finalize_approve(
@@ -1409,7 +1469,7 @@ def _run_review_phase(
                 "cleanup_iterations": state.p2_cleanup_iterations,
             }
         )
-        state.p2_cleanup_active = False
+        _clear_p2_cleanup_state(state)
     _is_persistent_p1 = False
     if config.models is not None and len(state.review_results) >= 2:
         _prev_result = state.review_results[-2]

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -292,6 +292,79 @@ class _ReviewOutcome(Enum):
     RETRY_DEV = auto()
 
 
+def _open_p2_findings(parsed_review: ReviewResult) -> list[ReviewFinding]:
+    """Return the P2 findings raised by the current review pass."""
+    return [f for f in parsed_review.findings if f.severity == "P2"]
+
+
+def _maybe_enter_p2_cleanup(
+    state: CoordinatorState,
+    config: ForgeConfig,
+    parsed_review: ReviewResult,
+) -> bool:
+    """Decide whether to re-enter DEV for advisory P2 cleanup after APPROVE.
+
+    Mutates state when entering cleanup: sets retry_reason=P2_CLEANUP,
+    p2_cleanup_active=True, captures p2_cleanup_findings, and appends an
+    audit entry. Returns True to signal the caller should return RETRY_DEV
+    instead of DONE.
+
+    Returns False when:
+      - the feature is disabled,
+      - the review has no open P2 findings,
+      - the dev iteration budget for this cycle is exhausted, or
+      - the configured cleanup-iteration cap has been reached.
+    """
+    p2s = _open_p2_findings(parsed_review)
+    audit_base = {
+        "review_cycle": state.review_cycle,
+        "dev_iteration": state.dev_iteration,
+        "p2_count": len(p2s),
+        "budget_remaining": state.budget.remaining(),
+        "cleanup_iterations": state.p2_cleanup_iterations,
+    }
+    if not config.retry.p2_cleanup_enabled:
+        state.p2_cleanup_audit.append({"action": "skip_disabled", **audit_base})
+        state.p2_cleanup_active = False
+        return False
+    if not p2s:
+        state.p2_cleanup_audit.append(
+            {
+                "action": "exit_clean" if state.p2_cleanup_active else "skip_no_p2",
+                **audit_base,
+            }
+        )
+        state.p2_cleanup_active = False
+        return False
+    if state.budget.remaining() <= 0:
+        state.p2_cleanup_audit.append({"action": "skip_budget", **audit_base})
+        state.p2_cleanup_active = False
+        return False
+    cap = config.retry.p2_cleanup_max_iterations
+    if cap > 0 and state.p2_cleanup_iterations >= cap:
+        state.p2_cleanup_audit.append({"action": "skip_cap", **audit_base})
+        state.p2_cleanup_active = False
+        return False
+    state.p2_cleanup_findings = [
+        {
+            "severity": f.severity,
+            "file": f.file,
+            "line": f.line,
+            "description": f.description,
+            "suggestion": f.suggestion,
+        }
+        for f in p2s
+    ]
+    action = "continue" if state.p2_cleanup_iterations > 0 else "enter"
+    state.p2_cleanup_active = True
+    state.p2_cleanup_iterations += 1
+    state.retry_reason = RetryReason.P2_CLEANUP
+    state.human_feedback = None
+    state.last_review_findings = review_to_dev_handoff(parsed_review)
+    state.p2_cleanup_audit.append({"action": action, **audit_base})
+    return True
+
+
 # ── Review-phase helpers ──────────────────────────────────────────────
 
 
@@ -1264,6 +1337,37 @@ def _run_review_phase(
             )
         else:
             _append_cycle_history(state, parsed_review)
+            # ── P2 cleanup (post-APPROVE advisory iterations) ──────────
+            # Re-enter DEV when the review left open P2s and dev iteration
+            # budget remains. Budget exhaustion (or disabled config) falls
+            # through to the DONE return — P2s are advisory, never blocking.
+            if _maybe_enter_p2_cleanup(state, config, parsed_review):
+                _entry = state.p2_cleanup_audit[-1]
+                _log(
+                    f"  ↻ P2 CLEANUP  entering dev iteration "
+                    f"({_entry['p2_count']} open P2(s), "
+                    f"budget_remaining={_entry['budget_remaining']})"
+                )
+                if logger:
+                    logger._safe_emit(
+                        "phase_end",
+                        phase="REVIEW",
+                        outcome="approve_p2_cleanup",
+                        cost_usd=round(_review_cost, 6),
+                        duration_s=round(_review_elapsed, 2),
+                    )
+                    logger._safe_emit(
+                        "p2_cleanup",
+                        action=_entry["action"],
+                        p2_count=_entry["p2_count"],
+                        review_cycle=_entry["review_cycle"],
+                        dev_iteration=_entry["dev_iteration"],
+                        budget_remaining=_entry["budget_remaining"],
+                    )
+                return _ReviewOutcome.RETRY_DEV, None, config
+            # Cleanup was either skipped or terminated; ensure flag cleared
+            # so subsequent paths do not see stale state.
+            state.p2_cleanup_active = False
             return (
                 _ReviewOutcome.DONE,
                 _finalize_approve(
@@ -1290,6 +1394,22 @@ def _run_review_phase(
             )
 
     # ── REQUEST_CHANGES (blocking P1s present) ───────────────────
+    # If we were in P2 cleanup and this review brought back blocking P1s,
+    # the cleanup pass regressed. Exit cleanup so the engine resets the
+    # per-cycle budget normally for the upcoming blocking-fix cycle.
+    if state.p2_cleanup_active:
+        state.p2_cleanup_audit.append(
+            {
+                "action": "exit_regression",
+                "review_cycle": state.review_cycle,
+                "dev_iteration": state.dev_iteration,
+                "p2_count": _p2_count,
+                "p1_count": _p1_count,
+                "budget_remaining": state.budget.remaining(),
+                "cleanup_iterations": state.p2_cleanup_iterations,
+            }
+        )
+        state.p2_cleanup_active = False
     _is_persistent_p1 = False
     if config.models is not None and len(state.review_results) >= 2:
         _prev_result = state.review_results[-2]

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -481,8 +481,14 @@ class CoordinatorState:
     # > 0; counts against the dev budget either way.
     p2_cleanup_iterations: int = 0
     # P2 findings (as dicts: file/line/description/suggestion) handed to the
-    # dev agent on the next cleanup pass. Repopulated each cleanup entry.
+    # dev agent on the next cleanup pass. Filtered each cleanup pass to the
+    # subset of p2_cleanup_carry_keys still raised by the latest reviewer.
     p2_cleanup_findings: list[dict] = field(default_factory=list)
+    # Stable fingerprints (file, line, description) of the original P2 set
+    # captured at first cleanup entry. The cleanup loop only considers these
+    # carried findings; new P2s raised by the reviewer after the carry is
+    # captured do not extend the loop. Cleared when cleanup exits.
+    p2_cleanup_carry_keys: list[list] = field(default_factory=list)
     # Audit trail for cleanup decisions: one entry per cleanup transition with
     # action ("enter" | "continue" | "exit_clean" | "exit_budget" | "exit_cap"
     # | "exit_regression" | "skip_disabled" | "skip_no_p2" | "skip_budget"

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -87,6 +87,7 @@ class RetryReason(str, Enum):
     TIMEOUT_RESUME = "timeout_resume"
     CONVENTION_VIOLATIONS = "convention_violations"
     MAX_ITERATIONS_NO_SUBMIT = "max_iterations_no_submit"
+    P2_CLEANUP = "p2_cleanup"
 
 
 # ── Disposition enum ──────────────────────────────────────────────────
@@ -468,6 +469,26 @@ class CoordinatorState:
     validate_already_complete: bool = False
     validate_already_complete_commits: list[dict] = field(default_factory=list)
     validate_already_complete_reason: str | None = None
+    # ── P2 cleanup (post-APPROVE advisory iterations) ─────────────────────────
+    # Set True when the coordinator re-enters DEV after an APPROVE that left
+    # open P2 findings; cleared on cleanup-clean APPROVE, REQUEST_CHANGES
+    # regression, or budget exhaustion. While True, the engine does NOT reset
+    # the per-cycle dev budget on RETRY_DEV (cleanup iterations count against
+    # the same pool as the original cycle).
+    p2_cleanup_active: bool = False
+    # Number of post-APPROVE cleanup dev iterations dispatched this run.
+    # Counts against config.retry.p2_cleanup_max_iterations when that cap is
+    # > 0; counts against the dev budget either way.
+    p2_cleanup_iterations: int = 0
+    # P2 findings (as dicts: file/line/description/suggestion) handed to the
+    # dev agent on the next cleanup pass. Repopulated each cleanup entry.
+    p2_cleanup_findings: list[dict] = field(default_factory=list)
+    # Audit trail for cleanup decisions: one entry per cleanup transition with
+    # action ("enter" | "continue" | "exit_clean" | "exit_budget" | "exit_cap"
+    # | "exit_regression" | "skip_disabled" | "skip_no_p2" | "skip_budget"
+    # | "skip_cap"), pre-pass P2 count, post-pass P2 count, budget remaining,
+    # review_cycle, and dev_iteration at the decision point.
+    p2_cleanup_audit: list[dict] = field(default_factory=list)
 
     def __post_init__(self, dev_iteration: int) -> None:
         # Sync the budget's per-cycle counter with the constructor kwarg.

--- a/src/theforge/task/fix_prompts.py
+++ b/src/theforge/task/fix_prompts.py
@@ -7,7 +7,10 @@ from .conventions import render_conventions_block
 from .story import TaskStory
 
 
-def _build_task_framing(surviving_families: list[dict] | None) -> tuple[str, int]:
+def _build_task_framing(
+    surviving_families: list[dict] | None,
+    advisory_p2_only: bool = False,
+) -> tuple[str, int]:
     """Build the first numbered task item(s) for the 'Your Task' section.
 
     Returns (framing_text, next_step_number) so callers can number subsequent
@@ -15,7 +18,22 @@ def _build_task_framing(surviving_families: list[dict] | None) -> tuple[str, int
 
     When surviving families are present the framing switches from
     'fix each P1 finding' to 'reconsider approach for persistent issues'.
+
+    When ``advisory_p2_only`` is set (post-APPROVE P2 cleanup pass), the
+    framing emphasises that the review already approved the work and that
+    these findings are advisory improvements, not blockers — partial cleanup
+    is acceptable and the agent should not redesign the implementation.
     """
+    if advisory_p2_only:
+        text = (
+            "1. **Advisory cleanup pass.** The review already APPROVED the "
+            "implementation; these P2 findings are improvements, not blockers. "
+            "Address what is clearly worth fixing and skip findings whose fix "
+            "would require unrelated refactoring. Do NOT redesign the "
+            "implementation. Do NOT introduce regressions. If a finding looks "
+            "wrong, leaving it untouched is acceptable."
+        )
+        return text, 2
     if surviving_families:
         n = len(surviving_families)
         family_labels = "; ".join(
@@ -52,6 +70,7 @@ def build_fix_prompt(
     classified_p1s: list | None = None,  # list[FindingRecord]
     surviving_families: list[dict] | None = None,
     conventions: list[str] | None = None,
+    advisory_p2_only: bool = False,
 ) -> str:
     """Build a minimal fix prompt for review iteration 2+.
 
@@ -233,7 +252,9 @@ def build_fix_prompt(
 
             {review_findings}""")
 
-    _task_framing, _commit_step = _build_task_framing(surviving_families)
+    _task_framing, _commit_step = _build_task_framing(
+        surviving_families, advisory_p2_only=advisory_p2_only
+    )
     _handoff_step = _commit_step + 1
 
     return dedent(f"""\

--- a/tests/test_coord_dev_phase_routing.py
+++ b/tests/test_coord_dev_phase_routing.py
@@ -515,6 +515,11 @@ test_coverage:
     ):
         """retry_reason='extend' → build_fix_prompt() when human extends after APPROVE."""
         config = _make_config(tmp_path)
+        # Disable post-APPROVE P2 cleanup so this test exercises the original
+        # extend-after-APPROVE+P2 path without an intervening cleanup pass.
+        config = dataclasses.replace(
+            config, retry=dataclasses.replace(config.retry, p2_cleanup_enabled=False)
+        )
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()

--- a/tests/test_coord_review_p2_cleanup.py
+++ b/tests/test_coord_review_p2_cleanup.py
@@ -1,0 +1,294 @@
+"""Tests for post-APPROVE P2 cleanup iterations (issue #621).
+
+Covers the helper decision logic at the review_phase / engine seam and the
+end-to-end loop behaviour when an APPROVE leaves open P2 findings.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_from_review
+from theforge.coordinator.review_phase import _maybe_enter_p2_cleanup
+from theforge.coordinator.state import CoordinatorState, Phase, RetryReason
+from theforge.review import ReviewFinding, ReviewResult
+
+APPROVE_WITH_P2 = """\
+```yaml
+verdict: APPROVE
+summary: "Looks good; some polish opportunities."
+findings:
+  - severity: P2
+    file: src/foo.py
+    line: 12
+    description: "Stale comment references removed helper"
+    suggestion: "Update the docstring"
+  - severity: P2
+    file: src/bar.py
+    line: 7
+    description: "Minor redaction gap in log line"
+    suggestion: "Use redact() helper"
+story_compliance:
+  matches_spec: true
+test_coverage:
+  adequate: true
+ac_verification:
+  - criterion: "Implementation satisfies the spec"
+    status: VERIFIED
+    evidence: "diff hunks present"
+```
+"""
+
+
+def _approve_with_p2_review(n: int = 2) -> ReviewResult:
+    findings = [
+        ReviewFinding(
+            severity="P2",
+            file=f"src/file{i}.py",
+            line=i,
+            description=f"P2 issue {i}",
+            suggestion=None,
+        )
+        for i in range(n)
+    ]
+    return ReviewResult(
+        verdict="APPROVE",
+        summary="ok",
+        findings=findings,
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def _approve_clean_review() -> ReviewResult:
+    return ReviewResult(
+        verdict="APPROVE",
+        summary="clean",
+        findings=[],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+class TestMaybeEnterP2Cleanup:
+    """Helper-level seam tests for the post-APPROVE cleanup decision."""
+
+    def test_enters_cleanup_when_p2s_present_and_budget_remains(self, tmp_path):
+        config = _make_config(tmp_path)  # max_dev_iterations=2
+        state = CoordinatorState()
+        state.budget.max_iterations = config.retry.max_dev_iterations
+        # cycle_count=0 → remaining=2
+
+        entered = _maybe_enter_p2_cleanup(state, config, _approve_with_p2_review())
+
+        assert entered is True
+        assert state.p2_cleanup_active is True
+        assert state.retry_reason == RetryReason.P2_CLEANUP
+        assert state.p2_cleanup_iterations == 1
+        assert len(state.p2_cleanup_findings) == 2
+        assert state.last_review_findings is not None
+        assert state.p2_cleanup_audit[-1]["action"] == "enter"
+
+    def test_does_not_enter_when_no_p2_findings(self, tmp_path):
+        config = _make_config(tmp_path)
+        state = CoordinatorState()
+        state.budget.max_iterations = config.retry.max_dev_iterations
+
+        entered = _maybe_enter_p2_cleanup(state, config, _approve_clean_review())
+
+        assert entered is False
+        assert state.p2_cleanup_active is False
+        assert state.retry_reason is None
+        assert state.p2_cleanup_audit[-1]["action"] == "skip_no_p2"
+
+    def test_does_not_enter_when_budget_exhausted(self, tmp_path):
+        """AC: budget exhaustion with P2s still open exits DONE, not cleanup."""
+        config = _make_config(tmp_path)
+        state = CoordinatorState()
+        state.budget.max_iterations = 2
+        # Consume the full per-cycle budget so remaining()==0.
+        state.budget.cycle_count = 2
+
+        entered = _maybe_enter_p2_cleanup(state, config, _approve_with_p2_review())
+
+        assert entered is False
+        assert state.p2_cleanup_active is False
+        assert state.p2_cleanup_audit[-1]["action"] == "skip_budget"
+
+    def test_does_not_enter_when_disabled(self, tmp_path):
+        """AC: operator may disable cleanup via config."""
+        config = _make_config(tmp_path)
+        config = dataclasses.replace(
+            config, retry=dataclasses.replace(config.retry, p2_cleanup_enabled=False)
+        )
+        state = CoordinatorState()
+        state.budget.max_iterations = 2
+
+        entered = _maybe_enter_p2_cleanup(state, config, _approve_with_p2_review())
+
+        assert entered is False
+        assert state.p2_cleanup_active is False
+        assert state.p2_cleanup_audit[-1]["action"] == "skip_disabled"
+
+    def test_default_config_keeps_cleanup_active(self, tmp_path):
+        """AC: absent explicit configuration, the feature is active by default."""
+        config = _make_config(tmp_path)
+        assert config.retry.p2_cleanup_enabled is True
+
+    def test_respects_cap_when_set(self, tmp_path):
+        """AC: operator may cap the number of cleanup iterations."""
+        config = _make_config(tmp_path)
+        config = dataclasses.replace(
+            config, retry=dataclasses.replace(config.retry, p2_cleanup_max_iterations=1)
+        )
+        state = CoordinatorState()
+        state.budget.max_iterations = 4
+        # First cleanup pass already dispatched.
+        state.p2_cleanup_iterations = 1
+        state.p2_cleanup_active = True
+
+        entered = _maybe_enter_p2_cleanup(state, config, _approve_with_p2_review())
+
+        assert entered is False
+        assert state.p2_cleanup_active is False
+        assert state.p2_cleanup_audit[-1]["action"] == "skip_cap"
+
+
+class TestP2CleanupLoop:
+    """Integration tests for the cleanup loop through run_from_review."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_approve_with_p2s_triggers_cleanup_pass(
+        self, mock_shell, mock_dev, mock_pool, tmp_path
+    ):
+        """AC: APPROVE + open P2s + remaining budget → at least one cleanup dev iteration."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Polished.")
+
+        pool_calls = {"n": 0}
+
+        def pool_side_effect(**kwargs):
+            pool_calls["n"] += 1
+            if pool_calls["n"] == 1:
+                return [
+                    _make_agent_result(success=True, output=APPROVE_WITH_P2, profile_name="review")
+                ]
+            return [_make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")]
+
+        mock_pool.side_effect = pool_side_effect
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        # Exactly one cleanup dev iteration ran (clean re-review exits DONE).
+        assert result.state.p2_cleanup_iterations == 1
+        assert result.state.dev_trace_count == 1
+        assert pool_calls["n"] == 2
+        # Cleanup deactivated by clean re-review.
+        assert result.state.p2_cleanup_active is False
+        # Audit captured both transitions.
+        actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
+        assert "enter" in actions
+        assert "exit_clean" in actions
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_cleanup_disabled_short_circuits_to_done(
+        self, mock_shell, mock_dev, mock_pool, tmp_path
+    ):
+        """AC: with p2_cleanup_enabled=false, APPROVE+P2s exits DONE directly."""
+        config = _make_config(tmp_path)
+        config = dataclasses.replace(
+            config, retry=dataclasses.replace(config.retry, p2_cleanup_enabled=False)
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="should not run")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_WITH_P2, profile_name="review")
+        ]
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        # No cleanup dev iteration dispatched.
+        assert result.state.p2_cleanup_iterations == 0
+        assert mock_dev.call_count == 0
+        # Audit recorded the skip.
+        actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
+        assert actions == ["skip_disabled"]
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_cleanup_budget_exhaustion_exits_done_not_escalate(
+        self, mock_shell, mock_dev, mock_pool, tmp_path
+    ):
+        """AC: budget exhaustion with P2s still open exits DONE, not ESCALATE.
+
+        max_dev_iterations=1 + cleanup cap=1: after one cleanup pass that still
+        leaves P2s open, the next review pass cannot start another cleanup
+        iteration; the run must terminate as DONE.
+        """
+        config = _make_config(tmp_path)
+        config = dataclasses.replace(
+            config,
+            retry=dataclasses.replace(
+                config.retry,
+                max_dev_iterations=1,
+                p2_cleanup_max_iterations=1,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Polished.")
+
+        # Both reviews return APPROVE+P2 (cleanup did not resolve them).
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_WITH_P2, profile_name="review")
+        ]
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.p2_cleanup_iterations == 1
+        # Audit shows the second pass refused another cleanup iteration.
+        actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
+        assert "enter" in actions
+        # Either cap or budget exhaustion blocked the second pass.
+        assert any(a in {"skip_cap", "skip_budget"} for a in actions)

--- a/tests/test_coord_review_p2_cleanup.py
+++ b/tests/test_coord_review_p2_cleanup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import dataclasses
 from unittest.mock import patch
 
+import yaml
 from coord_test_helpers import (
     APPROVE_REVIEW,
     _make_agent_result,
@@ -17,6 +18,7 @@ from coord_test_helpers import (
     _shell_with_gate,
 )
 
+from theforge.config import load_config
 from theforge.coordinator.engine import run_from_review
 from theforge.coordinator.review_phase import _maybe_enter_p2_cleanup
 from theforge.coordinator.state import CoordinatorState, Phase, RetryReason
@@ -152,6 +154,88 @@ class TestMaybeEnterP2Cleanup:
         config = _make_config(tmp_path)
         assert config.retry.p2_cleanup_enabled is True
 
+    def test_new_p2_after_carry_does_not_extend_loop(self, tmp_path):
+        """Loop is bound to the carried P2 set; new P2s do not extend it.
+
+        Reviewer no longer raises the original carried P2s, but raises a
+        brand-new one. The cleanup loop must exit (action=exit_clean)
+        rather than follow the new advisory finding.
+        """
+        config = _make_config(tmp_path)
+        state = CoordinatorState()
+        state.budget.max_iterations = 4
+        state.p2_cleanup_iterations = 1
+        state.p2_cleanup_active = True
+        # Carry set captured at first entry — none of these descriptions
+        # appear in the next review.
+        state.p2_cleanup_carry_keys = [
+            ["src/old.py", 1, "Original P2 A"],
+            ["src/old.py", 2, "Original P2 B"],
+        ]
+
+        # The new review surfaces an entirely different P2 (new finding).
+        new_review = ReviewResult(
+            verdict="APPROVE",
+            summary="ok",
+            findings=[
+                ReviewFinding(
+                    severity="P2",
+                    file="src/new.py",
+                    line=99,
+                    description="Brand new advisory",
+                    suggestion=None,
+                )
+            ],
+            story_matches=True,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={},
+        )
+
+        entered = _maybe_enter_p2_cleanup(state, config, new_review)
+
+        assert entered is False
+        assert state.p2_cleanup_active is False
+        assert state.p2_cleanup_audit[-1]["action"] == "exit_clean"
+
+    def test_carry_keys_capture_only_initial_p2_set(self, tmp_path):
+        """First entry captures the carry set; subsequent passes do not extend it."""
+        config = _make_config(tmp_path)
+        state = CoordinatorState()
+        state.budget.max_iterations = 4
+
+        first = _approve_with_p2_review(n=2)
+        _maybe_enter_p2_cleanup(state, config, first)
+        captured = list(state.p2_cleanup_carry_keys)
+        assert len(captured) == 2
+
+        # Subsequent pass surfaces the original set PLUS a new P2;
+        # carry keys must not grow.
+        second = ReviewResult(
+            verdict="APPROVE",
+            summary="ok",
+            findings=[
+                *first.findings,
+                ReviewFinding(
+                    severity="P2",
+                    file="src/extra.py",
+                    line=42,
+                    description="Late-breaking advisory",
+                    suggestion=None,
+                ),
+            ],
+            story_matches=True,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={},
+        )
+        _maybe_enter_p2_cleanup(state, config, second)
+        assert list(state.p2_cleanup_carry_keys) == captured
+
     def test_respects_cap_when_set(self, tmp_path):
         """AC: operator may cap the number of cleanup iterations."""
         config = _make_config(tmp_path)
@@ -160,15 +244,48 @@ class TestMaybeEnterP2Cleanup:
         )
         state = CoordinatorState()
         state.budget.max_iterations = 4
-        # First cleanup pass already dispatched.
+        # First cleanup pass already dispatched with the same P2 set still
+        # outstanding (carry_keys mirror the review we're about to evaluate).
         state.p2_cleanup_iterations = 1
         state.p2_cleanup_active = True
+        state.p2_cleanup_carry_keys = [
+            ["src/file0.py", 0, "P2 issue 0"],
+            ["src/file1.py", 1, "P2 issue 1"],
+        ]
 
         entered = _maybe_enter_p2_cleanup(state, config, _approve_with_p2_review())
 
         assert entered is False
         assert state.p2_cleanup_active is False
         assert state.p2_cleanup_audit[-1]["action"] == "skip_cap"
+
+
+class TestP2CleanupConfigLoading:
+    """forge.yaml retry.p2_cleanup_* keys must reach RetryPolicy via load_config."""
+
+    def _write_yaml(self, tmp_path, retry_data: dict):
+        config_path = tmp_path / "forge.yaml"
+        config_path.write_text(yaml.dump({"retry": retry_data}), encoding="utf-8")
+        return config_path
+
+    def test_defaults_when_keys_absent(self, tmp_path):
+        config_path = self._write_yaml(tmp_path, {})
+        with patch("importlib.import_module"):
+            cfg = load_config(config_path)
+        assert cfg.retry.p2_cleanup_enabled is True
+        assert cfg.retry.p2_cleanup_max_iterations == 0
+
+    def test_yaml_disables_cleanup(self, tmp_path):
+        config_path = self._write_yaml(tmp_path, {"p2_cleanup_enabled": False})
+        with patch("importlib.import_module"):
+            cfg = load_config(config_path)
+        assert cfg.retry.p2_cleanup_enabled is False
+
+    def test_yaml_caps_cleanup_iterations(self, tmp_path):
+        config_path = self._write_yaml(tmp_path, {"p2_cleanup_max_iterations": 3})
+        with patch("importlib.import_module"):
+            cfg = load_config(config_path)
+        assert cfg.retry.p2_cleanup_max_iterations == 3
 
 
 class TestP2CleanupLoop:
@@ -248,6 +365,51 @@ class TestP2CleanupLoop:
         # Audit recorded the skip.
         actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
         assert actions == ["skip_disabled"]
+
+    @patch("theforge.coordinator.review_phase._human_review")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_interactive_mode_runs_cleanup_before_hitl(
+        self, mock_shell, mock_dev, mock_pool, mock_human_review, tmp_path
+    ):
+        """Interactive APPROVE with open P2s + remaining budget runs cleanup,
+        not the HITL prompt (the human is asked only when cleanup terminates).
+        """
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Polished.")
+
+        # Reviewer flips clean after the cleanup dev pass.
+        pool_calls = {"n": 0}
+
+        def pool_side_effect(**kwargs):
+            pool_calls["n"] += 1
+            if pool_calls["n"] == 1:
+                return [
+                    _make_agent_result(success=True, output=APPROVE_WITH_P2, profile_name="review")
+                ]
+            return [_make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")]
+
+        mock_pool.side_effect = pool_side_effect
+
+        # When cleanup completes cleanly the interactive flow surfaces to the
+        # operator on the *second* review; HITL must not run before cleanup.
+        mock_human_review.return_value = ("approve", None)
+
+        result = run_from_review(config, task, workspace, interactive=True)
+
+        assert result.success is True
+        assert result.state.p2_cleanup_iterations == 1
+        # Exactly one HITL call — and it followed the cleanup dev pass.
+        assert mock_human_review.call_count == 1
+        # First REVIEW (with P2s) must NOT have called HITL — verified
+        # implicitly by cleanup dispatching a dev iteration before HITL ran.
+        assert mock_dev.call_count == 1
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.dev_phase.run_agent")


### PR DESCRIPTION
## Summary

Prior P1s are resolved; the P2 cleanup flow is wired through config, focused on the carried P2 set, and runs before interactive HITL.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $13.37
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

enhancement: P2 cleanup iterations after APPROVE (GitHub Issue #621)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #621