### PR TITLE
bug: auto-filed findings are created in un-runnable issue shape

### DIFF
--- a/src/theforge/advisory_conventions.py
+++ b/src/theforge/advisory_conventions.py
@@ -16,11 +16,18 @@ from .config import ForgeConfig
 _LINE_COUNT_RULES = frozenset({"max_module_lines", "max_test_file_lines"})
 _DETAIL_RE = re.compile(r"^(?P<file>.+) has (?P<line_count>\d+) lines \(limit (?P<limit>\d+)\)$")
 
-# Shape-gate-compatible runnable type label. Auto-filed findings must carry a
-# recognized type label or sprint intake refuses to dispatch them — see
-# shape_check.heuristics.check_missing_type. ``task`` is the appropriate type
-# for an operator-driven refactor of an oversized module.
+# Shape-gate-compatible runnable type label. Auto-filed findings must carry
+# exactly one recognized type label or sprint intake refuses to dispatch them
+# — see shape_check.heuristics.check_missing_type. ``task`` is the appropriate
+# type for an operator-driven refactor of an oversized module; the rendered
+# body is task-shaped (Summary + AC), so any other type label (``bug``,
+# ``enhancement``, ``epic``) would either conflict with ``task`` (multiple
+# type labels → missing_type BLOCKING) or demand a body shape we do not
+# render (e.g. ``bug`` requires a complete Diagnosis section). Recognized
+# type labels supplied via ``issue_filing.label`` are therefore dropped from
+# the gh invocation; the resulting issue carries only ``task``.
 _RUNNABLE_TYPE_LABEL = "task"
+_RECOGNIZED_TYPE_LABELS = frozenset({"bug", "enhancement", "epic", "task"})
 
 
 def advisory_artifact_path(config: ForgeConfig) -> Path:
@@ -173,6 +180,25 @@ def _entry_percent_over(entry: dict[str, Any]) -> float | None:
     return (gap / limit) * 100.0
 
 
+def _resolve_issue_labels(configured_label: str) -> list[str]:
+    """Return the labels to attach to an auto-filed advisory issue.
+
+    Always includes the runnable type label. The configured filing label is
+    appended only when it is not itself a recognized type label — a
+    second type label would either conflict with ``task`` (sprint intake's
+    ``check_missing_type`` rejects multi-type issues) or demand a body
+    shape this module does not render (``bug`` requires Diagnosis). Dropping
+    the conflicting label is preferred over refusing to file: the audit
+    trail still attributes the issue to the advisory finding via title and
+    body, and the operator can re-label after triage.
+    """
+    labels: list[str] = [_RUNNABLE_TYPE_LABEL]
+    normalized = configured_label.strip()
+    if normalized and normalized.lower() not in _RECOGNIZED_TYPE_LABELS:
+        labels.append(normalized)
+    return labels
+
+
 def _render_issue_body(entry: dict[str, Any], percent_over: float) -> str:
     """Render a sprint-runnable issue body for an advisory convention finding.
 
@@ -249,19 +275,10 @@ def _maybe_file_issue(config: ForgeConfig, entry: dict[str, Any]) -> dict[str, A
 
     title = f"Advisory convention debt: {entry['rule']} in {entry['file']}"
     body = _render_issue_body(entry, percent_over)
-    command = [
-        "gh",
-        "issue",
-        "create",
-        "--title",
-        title,
-        "--body",
-        body,
-        "--label",
-        _RUNNABLE_TYPE_LABEL,
-        "--label",
-        issue_cfg.label,
-    ]
+    labels = _resolve_issue_labels(issue_cfg.label)
+    command = ["gh", "issue", "create", "--title", title, "--body", body]
+    for label in labels:
+        command.extend(["--label", label])
     if issue_cfg.milestone:
         command.extend(["--milestone", issue_cfg.milestone])
     proc = subprocess.run(
@@ -279,6 +296,7 @@ def _maybe_file_issue(config: ForgeConfig, entry: dict[str, Any]) -> dict[str, A
         "title": title,
         "url": issue_url,
         "label": issue_cfg.label,
+        "labels_applied": labels,
         "milestone": issue_cfg.milestone,
         "filed_at": entry["last_seen"],
     }

--- a/src/theforge/advisory_conventions.py
+++ b/src/theforge/advisory_conventions.py
@@ -16,6 +16,12 @@ from .config import ForgeConfig
 _LINE_COUNT_RULES = frozenset({"max_module_lines", "max_test_file_lines"})
 _DETAIL_RE = re.compile(r"^(?P<file>.+) has (?P<line_count>\d+) lines \(limit (?P<limit>\d+)\)$")
 
+# Shape-gate-compatible runnable type label. Auto-filed findings must carry a
+# recognized type label or sprint intake refuses to dispatch them — see
+# shape_check.heuristics.check_missing_type. ``task`` is the appropriate type
+# for an operator-driven refactor of an oversized module.
+_RUNNABLE_TYPE_LABEL = "task"
+
 
 def advisory_artifact_path(config: ForgeConfig) -> Path:
     """Return the local rolling advisory artifact path."""
@@ -167,6 +173,70 @@ def _entry_percent_over(entry: dict[str, Any]) -> float | None:
     return (gap / limit) * 100.0
 
 
+def _render_issue_body(entry: dict[str, Any], percent_over: float) -> str:
+    """Render a sprint-runnable issue body for an advisory convention finding.
+
+    The body conforms to the ``task``-shape contract enforced by
+    ``shape_check``: a non-empty ``## Acceptance criteria`` section whose
+    bullets contain observable verbs, no ``## Design`` heading, and an
+    ``Implementation target:`` line that opts the body out of the
+    file-path-based implementation-plan check.
+    """
+    rule = entry["rule"]
+    file = entry["file"]
+    line_count = entry["line_count"]
+    limit = entry["limit"]
+    gap = entry["gap"]
+    pct = f"{percent_over:.0f}%"
+    audit_yaml = yaml.safe_dump(
+        {
+            "rule": rule,
+            "file": file,
+            "detail": entry["detail"],
+            "line_count": line_count,
+            "limit": limit,
+            "gap": gap,
+            "blocking": False,
+            "last_run_id": entry.get("last_run_id"),
+            "last_story_slug": entry.get("last_story_slug"),
+        },
+        sort_keys=False,
+    ).strip()
+
+    lines = [
+        "## Summary",
+        "",
+        (
+            f"Advisory convention `{rule}` is exceeded by `{file}`: "
+            f"{line_count} lines vs the configured limit of {limit} "
+            f"(gap of {gap} lines, {pct} over). Refactor the module to bring "
+            "it under the limit by extracting cohesive subunits into sibling "
+            "modules without changing observable behavior."
+        ),
+        "",
+        f"Implementation target: {file}",
+        "",
+        "## Acceptance criteria",
+        "",
+        (
+            f"- Re-running the convention check reports `{file}` at no more "
+            f"than {limit} lines (currently {line_count})."
+        ),
+        "- `make gate` passes after the refactor.",
+        (
+            f"- Existing imports of symbols defined in `{file}` continue to "
+            "resolve; no public name is removed without a re-export."
+        ),
+        "",
+        "## Audit excerpt",
+        "",
+        "```yaml",
+        audit_yaml,
+        "```",
+    ]
+    return "\n".join(lines)
+
+
 def _maybe_file_issue(config: ForgeConfig, entry: dict[str, Any]) -> dict[str, Any] | None:
     issue_cfg = config.conventions_advisory.issue_filing
     if not issue_cfg.enabled:
@@ -178,34 +248,7 @@ def _maybe_file_issue(config: ForgeConfig, entry: dict[str, Any]) -> dict[str, A
         return None
 
     title = f"Advisory convention debt: {entry['rule']} in {entry['file']}"
-    body_lines = [
-        "## Advisory convention violation",
-        "",
-        f"- Rule: `{entry['rule']}`",
-        f"- File: `{entry['file']}`",
-        f"- Detail: {entry['detail']}",
-        f"- Last observed run: `{entry.get('last_run_id') or 'unknown'}`",
-    ]
-    if entry.get("last_story_slug"):
-        body_lines.append(f"- Observed while running: `{entry['last_story_slug']}`")
-    body_lines.extend(
-        [
-            "",
-            "## Audit excerpt",
-            "",
-            "```yaml",
-            yaml.safe_dump(
-                {
-                    "rule": entry["rule"],
-                    "file": entry["file"],
-                    "detail": entry["detail"],
-                    "blocking": False,
-                },
-                sort_keys=False,
-            ).strip(),
-            "```",
-        ]
-    )
+    body = _render_issue_body(entry, percent_over)
     command = [
         "gh",
         "issue",
@@ -213,7 +256,9 @@ def _maybe_file_issue(config: ForgeConfig, entry: dict[str, Any]) -> dict[str, A
         "--title",
         title,
         "--body",
-        "\n".join(body_lines),
+        body,
+        "--label",
+        _RUNNABLE_TYPE_LABEL,
         "--label",
         issue_cfg.label,
     ]

--- a/tests/test_advisory_conventions.py
+++ b/tests/test_advisory_conventions.py
@@ -5,6 +5,7 @@ import datetime as dt
 import subprocess
 from unittest.mock import patch
 
+import pytest
 import yaml
 from coord_test_helpers import _make_config
 
@@ -179,6 +180,54 @@ def test_auto_filed_issue_passes_sprint_intake_shape_check(tmp_path):
 
     # Drive the actual sprint-intake shape check against the rendered body to
     # prove this auto-filed issue would be dispatched, not skipped.
+    result = check(title, body, labels)
+    assert result.shape is Shape.RUNNABLE, [
+        (r.code, r.severity.name, r.detail) for r in result.reasons
+    ]
+
+
+@pytest.mark.parametrize("configured_label", ["bug", "enhancement", "epic", "task", "TASK"])
+def test_auto_filed_issue_drops_recognized_type_filing_label(tmp_path, configured_label):
+    """A configured filing label that is itself a recognized type label
+    must not produce an issue with multiple type labels — sprint intake's
+    ``check_missing_type`` rejects that as missing_type and forge would
+    refuse to run the issue it just filed."""
+    config = dataclasses.replace(
+        _make_config(tmp_path),
+        conventions_advisory=AdvisoryConventionsConfig(
+            issue_filing=AdvisoryIssueFilingConfig(
+                enabled=True,
+                threshold_percent=25.0,
+                label=configured_label,
+            )
+        ),
+    )
+    observed_at = dt.datetime(2026, 5, 2, 18, 45, tzinfo=dt.timezone.utc)
+    gh_result = subprocess.CompletedProcess(
+        args=["gh"],
+        returncode=0,
+        stdout="https://github.com/example/repo/issues/300\n",
+        stderr="",
+    )
+
+    with patch("theforge.advisory_conventions.subprocess.run", return_value=gh_result) as mock_run:
+        update_advisory_violations(
+            config,
+            [_violation()],
+            observed_at=observed_at,
+            run_id="run-collide",
+            story_slug="story-collide",
+        )
+
+    assert mock_run.call_count == 1
+    title, body, labels = _gh_create_kwargs(mock_run.call_args)
+
+    # Exactly one recognized type label, and it is the runnable one.
+    recognized = {"bug", "enhancement", "epic", "task"}
+    type_labels = [lbl for lbl in labels if lbl.lower() in recognized]
+    assert type_labels == ["task"], labels
+
+    # The shape gate must still classify the result as RUNNABLE.
     result = check(title, body, labels)
     assert result.shape is Shape.RUNNABLE, [
         (r.code, r.severity.name, r.detail) for r in result.reasons

--- a/tests/test_advisory_conventions.py
+++ b/tests/test_advisory_conventions.py
@@ -10,6 +10,7 @@ from coord_test_helpers import _make_config
 
 from theforge.advisory_conventions import load_advisory_summary, update_advisory_violations
 from theforge.config import AdvisoryConventionsConfig, AdvisoryIssueFilingConfig
+from theforge.shape_check import Shape, check
 
 
 def _violation(
@@ -127,6 +128,61 @@ def test_update_advisory_violations_files_issue_once_when_enabled(tmp_path):
     assert entry["issue"]["url"] == "https://github.com/example/repo/issues/123"
     assert entry["issue"]["label"] == "refactor-debt"
     assert entry["issue"]["milestone"] == "v0.12.0"
+
+
+def _gh_create_kwargs(call) -> tuple[str, str, list[str]]:
+    """Extract title, body, and label list from a captured ``gh issue create`` call."""
+    command = call.args[0]
+    assert command[:3] == ["gh", "issue", "create"]
+    title = command[command.index("--title") + 1]
+    body = command[command.index("--body") + 1]
+    labels = [command[i + 1] for i, arg in enumerate(command) if arg == "--label"]
+    return title, body, labels
+
+
+def test_auto_filed_issue_passes_sprint_intake_shape_check(tmp_path):
+    config = dataclasses.replace(
+        _make_config(tmp_path),
+        conventions_advisory=AdvisoryConventionsConfig(
+            issue_filing=AdvisoryIssueFilingConfig(
+                enabled=True,
+                threshold_percent=25.0,
+                label="refactor-debt",
+            )
+        ),
+    )
+    observed_at = dt.datetime(2026, 5, 2, 18, 45, tzinfo=dt.timezone.utc)
+    gh_result = subprocess.CompletedProcess(
+        args=["gh"],
+        returncode=0,
+        stdout="https://github.com/example/repo/issues/200\n",
+        stderr="",
+    )
+
+    with patch("theforge.advisory_conventions.subprocess.run", return_value=gh_result) as mock_run:
+        update_advisory_violations(
+            config,
+            [_violation()],
+            observed_at=observed_at,
+            run_id="run-shape",
+            story_slug="story-shape",
+        )
+
+    assert mock_run.call_count == 1
+    title, body, labels = _gh_create_kwargs(mock_run.call_args)
+
+    # The runnable type label must accompany the configured filing label, so
+    # sprint intake recognizes the issue as a runnable task rather than
+    # rejecting it for missing_type.
+    assert "task" in labels
+    assert "refactor-debt" in labels
+
+    # Drive the actual sprint-intake shape check against the rendered body to
+    # prove this auto-filed issue would be dispatched, not skipped.
+    result = check(title, body, labels)
+    assert result.shape is Shape.RUNNABLE, [
+        (r.code, r.severity.name, r.detail) for r in result.reasons
+    ]
 
 
 def test_update_advisory_violations_disabled_filing_does_not_report_prior_issue_as_newly_filed(


### PR DESCRIPTION
## Summary

The prior label-collision P1 is fixed; auto-filed advisory issues now render as runnable task-shaped issues with exactly one recognized type label.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $2.66
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: auto-filed findings are created in un-runnable issue shape (GitHub Issue #1563)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1563