### PR TITLE
fix(release): cut-rc.sh uses PEP 508 Direct URL syntax for [all] install

### DIFF
--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -253,7 +253,7 @@ if [[ "$NO_INSTALL" == false ]]; then
     fi
     run python3 -m venv "$RC_ENV_DIR"
     run "$RC_ENV_PIP" install --upgrade pip
-    run "$RC_ENV_PIP" install "git+https://github.com/fuzzypete/theforge.git@${RC_TAG}#egg=theforge[all]"
+    run "$RC_ENV_PIP" install "theforge[all] @ git+https://github.com/fuzzypete/theforge.git@${RC_TAG}"
     if [[ "$DRY_RUN" == false ]]; then
         INSTALLED_OUTPUT=$("$RC_ENV_FORGE" version 2>&1 || echo "")
         INSTALLED_VERSION=$(echo "$INSTALLED_OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*' | head -1)
@@ -435,7 +435,7 @@ else
     echo "==> Skipping verification install (--no-install)."
     echo "    To verify manually in an isolated venv:"
     echo "      python3 -m venv \"$RC_ENV_DIR\""
-    echo "      \"$RC_ENV_PIP\" install git+https://github.com/fuzzypete/theforge.git@${RC_TAG}#egg=theforge[all]"
+    echo "      \"$RC_ENV_PIP\" install \"theforge[all] @ git+https://github.com/fuzzypete/theforge.git@${RC_TAG}\""
     echo "      \"$RC_ENV_FORGE\" version"
     echo "      ln -snf \"$RC_ENV_FORGE\" \"$MANAGED_LAUNCHER\""
 fi


### PR DESCRIPTION
Closes #1565.

## Summary

- pip 26.1+ rejects `git+URL#egg=pkg[extras]` as `invalid-egg-fragment`. Commit a97d42e (fix for #1538) introduced this syntax to install with the `[all]` extra; pip 26.1.1 made it a hard error, blocking rc17 verification.
- Switches both occurrences in `scripts/cut-rc.sh` to PEP 508 Direct URL syntax: `theforge[all] @ git+https://github.com/fuzzypete/theforge.git@${RC_TAG}`. The `[all]` extra is preserved.

## Test plan

- [ ] Re-run `scripts/cut-rc.sh --resume 0.10.0 17` and confirm verification install succeeds against the already-pushed `v0.10.0rc17` tag
- [ ] Confirm the operator hint printed under `--no-install` is a valid copy-paste command

🤖 Generated with [Claude Code](https://claude.com/claude-code)