### PR TITLE
fix(release): resolve pyenv forge shims before vetting

### DIFF
--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -300,6 +300,14 @@ if [[ "$NO_INSTALL" == false ]]; then
         INVENV_LAUNCHER_DIR=""
         CURRENT_FORGE="$(command -v forge 2>/dev/null || true)"
         if [[ -n "$CURRENT_FORGE" && "$CURRENT_FORGE" != "$MANAGED_LAUNCHER" ]]; then
+            PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pyenv}"
+            if [[ "$CURRENT_FORGE" == "${PYENV_ROOT}/shims/forge" ]] \
+               && command -v pyenv >/dev/null 2>&1; then
+                PYENV_FORGE="$(pyenv which forge 2>/dev/null || true)"
+                if [[ -n "$PYENV_FORGE" && "$PYENV_FORGE" != "$CURRENT_FORGE" ]]; then
+                    CURRENT_FORGE="$PYENV_FORGE"
+                fi
+            fi
             CURRENT_FORGE_DIR="$(dirname "$CURRENT_FORGE")"
             if [[ -f "${CURRENT_FORGE_DIR}/activate" \
                   || -f "${CURRENT_FORGE_DIR}/../pyvenv.cfg" \

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -835,6 +835,87 @@ def test_venv_resident_forge_with_different_theforge_proceeds_with_note(
     assert "deactivate" not in combined.lower()
 
 
+@pytest.mark.network_integration
+@pytest.mark.skipif(
+    not SCRIPT.exists(),
+    reason="cut-rc.sh not present",
+)
+def test_pyenv_shim_resolves_to_real_launcher_before_vetting(tmp_path: Path) -> None:
+    """A pyenv shim directory may contain generic ``forge``, ``python``, and
+    ``activate`` shims. That must not make the shim itself the launcher being
+    vetted; resolve through ``pyenv which forge`` and inspect the real console
+    script instead.
+    """
+    script_copy, env, fake_home, fake_venv = _build_cut_rc_fixture(
+        tmp_path, installed_theforge_version="0.10.0rc12"
+    )
+
+    pyenv_root = fake_home / ".pyenv"
+    pyenv_shims = pyenv_root / "shims"
+    pyenv_shims.mkdir(parents=True)
+    real_forge = fake_venv / "bin" / "forge"
+    real_python = fake_venv / "bin" / "python"
+
+    pyenv_shim_body = textwrap.dedent(
+        f"""\
+        #!/bin/sh
+        exec "{real_forge}" "$@"
+        """
+    )
+    (pyenv_shims / "forge").write_text(pyenv_shim_body)
+    (pyenv_shims / "forge").chmod(0o755)
+    (pyenv_shims / "python").write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            exec "{real_python}" "$@"
+            """
+        )
+    )
+    (pyenv_shims / "python").chmod(0o755)
+    # This generic pyenv shim was the false-positive trigger: the old
+    # heuristic treated ~/.pyenv/shims as a venv bin/ because activate existed.
+    (pyenv_shims / "activate").write_text("#!/bin/sh\nexit 0\n")
+    (pyenv_shims / "activate").chmod(0o755)
+
+    shim_bin = tmp_path / "shim_bin"
+    pyenv_cmd = shim_bin / "pyenv"
+    pyenv_cmd.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            if [ "$1" = "which" ] && [ "$2" = "forge" ]; then
+                echo "{real_forge}"
+                exit 0
+            fi
+            exit 1
+            """
+        )
+    )
+    pyenv_cmd.chmod(0o755)
+
+    env["PYENV_ROOT"] = str(pyenv_root)
+    env["PATH"] = f"{pyenv_shims}:{fake_home}/.local/bin:{shim_bin}:/usr/bin:/bin"
+
+    repo = tmp_path / "fake_repo"
+    proc = subprocess.run(
+        ["bash", str(script_copy), "0.99.0", "0"],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, (
+        "cut-rc.sh must resolve pyenv shims to the real forge launcher before "
+        f"applying the theforge-console-script vetting check. Output:\n{combined}"
+    )
+    assert "does not look" not in combined
+    assert "0.10.0rc12" in combined
+    assert (fake_home / ".local" / "bin" / "forge").is_symlink()
+
+
 @pytest.mark.skipif(
     not SCRIPT.exists(),
     reason="cut-rc.sh not present",


### PR DESCRIPTION
Closes #1567.

## Summary
- Resolve `~/.pyenv/shims/forge` through `pyenv which forge` before applying the existing launcher-vetting heuristic.
- Keep the stricter console-script vetting for the real launcher path, so foreign wrappers are still refused.
- Add a regression fixture covering pyenv shim dirs that include generic `forge`, `python`, and `activate` shims.

## Test plan
- [x] `pytest tests/test_cut_rc_isolation.py -q`