### PR TITLE
fix(release): treat pyenv version dirs as env launchers

### DIFF
--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -309,9 +309,14 @@ if [[ "$NO_INSTALL" == false ]]; then
                 fi
             fi
             CURRENT_FORGE_DIR="$(dirname "$CURRENT_FORGE")"
+            CURRENT_FORGE_IS_PYENV_VERSION=false
+            if [[ "$CURRENT_FORGE" == "${PYENV_ROOT}/versions/"*/bin/forge ]]; then
+                CURRENT_FORGE_IS_PYENV_VERSION=true
+            fi
             if [[ -f "${CURRENT_FORGE_DIR}/activate" \
                   || -f "${CURRENT_FORGE_DIR}/../pyvenv.cfg" \
-                  || -f "${CURRENT_FORGE_DIR}/activate.fish" ]]; then
+                  || -f "${CURRENT_FORGE_DIR}/activate.fish" \
+                  || "$CURRENT_FORGE_IS_PYENV_VERSION" == true ]]; then
                 CURRENT_FORGE_PY=""
                 if [[ -x "${CURRENT_FORGE_DIR}/python" ]]; then
                     CURRENT_FORGE_PY="${CURRENT_FORGE_DIR}/python"

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -853,8 +853,14 @@ def test_pyenv_shim_resolves_to_real_launcher_before_vetting(tmp_path: Path) -> 
     pyenv_root = fake_home / ".pyenv"
     pyenv_shims = pyenv_root / "shims"
     pyenv_shims.mkdir(parents=True)
-    real_forge = fake_venv / "bin" / "forge"
-    real_python = fake_venv / "bin" / "python"
+    pyenv_bin = pyenv_root / "versions" / "3.12.12" / "bin"
+    pyenv_bin.mkdir(parents=True)
+    real_forge = pyenv_bin / "forge"
+    real_python = pyenv_bin / "python"
+    real_forge.write_bytes((fake_venv / "bin" / "forge").read_bytes())
+    real_forge.chmod(0o755)
+    real_python.write_bytes((fake_venv / "bin" / "python").read_bytes())
+    real_python.chmod(0o755)
 
     pyenv_shim_body = textwrap.dedent(
         f"""\


### PR DESCRIPTION
Closes #1567.

## Summary
- Treat resolved `PYENV_ROOT/versions/*/bin/forge` paths as Python environment launchers even though pyenv version directories do not carry `pyvenv.cfg`.
- Preserve the existing real-console-script vetting before allowing a pyenv launcher to shadow the managed RC symlink.
- Update the pyenv regression fixture to mirror the actual machine shape: shim resolves through `pyenv which forge` to a version `bin/` directory with no venv marker.

## Test plan
- [x] `pytest tests/test_cut_rc_isolation.py -q`