### PR TITLE
[P2] issue-1154: --verbose / -v flag is registered in register_parser bu

### DIFF
--- a/src/theforge/cli/diagnose.py
+++ b/src/theforge/cli/diagnose.py
@@ -14,7 +14,10 @@ from pathlib import Path
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
 from theforge.coordinator.diagnose_flow import run_diagnose_flow
+from theforge.coordinator.util import set_log_level as coordinator_set_log_level
 from theforge.diagnose_types import DIAGNOSE_OUTPUT_DESTINATIONS
+from theforge.runners import LogLevel
+from theforge.runners import set_log_level as runner_set_log_level
 
 
 def _parse_issue_refs(refs: list[str]) -> list[int]:
@@ -62,6 +65,10 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
     # Mode selection: interactive (operator-in-the-loop) or autonomous.
     # Default follows config.diagnose.autonomous_default; --interactive forces
     # the operator-in-the-loop path; --autonomous forces autonomous.
+    if getattr(args, "verbose", False):
+        coordinator_set_log_level(LogLevel.VERBOSE)
+        runner_set_log_level(LogLevel.VERBOSE)
+
     if args.interactive and args.autonomous:
         print("--interactive and --autonomous are mutually exclusive", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Verbose flag is now wired to coordinator and runner log level sinks, matching sprint/run pattern.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.44
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-1154: --verbose / -v flag is registered in register_parser bu (GitHub Issue #1305)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1305