### PR TITLE
Reviewer-count target silently drops below requested for HIGH-score stories when strong-tier provider pool narrows after self-exclusion

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -263,32 +263,32 @@ def _select_reviewers(
     If exclude_model is set, agents with that model are excluded; they are
     only included as a last resort when no other candidates are available.
     """
-    # Build candidate list: prefer strong, fall back to requested tier
-    # Filter by auth availability — skip agents whose API key is missing
-    strong = [a for a in _agents_by_tier(agents, "strong") if _has_auth(a, secrets)]
-    tier_agents = (
-        [a for a in _agents_by_tier(agents, tier) if _has_auth(a, secrets)]
-        if tier != "strong"
-        else []
-    )
-    # Merge: strong first, then same-tier, deduplicated
+    # Build candidate list spanning the full tier ladder (strong → mid → cheap).
+    # Stronger reviewers are always preferred (listed first), but the pool descends
+    # past the requested tier so a panel of N can still be filled when the
+    # requested tier's authed-provider diversity is too narrow after
+    # self-exclusion / cross-provider filtering.  Without the descent, a
+    # strong-tier request would degenerate to strong-only, producing fewer
+    # eyes for higher-risk stories than a mid-tier request sees — see issue
+    # #1542.
+    descending_tiers = ["strong", "mid", "cheap"]
     seen_names: set[str] = set()
     candidates: list[AgentDef] = []
-    for a in strong + tier_agents:
-        if a.name not in seen_names:
-            candidates.append(a)
-            seen_names.add(a.name)
+    for t in descending_tiers:
+        for a in _agents_by_tier(agents, t):
+            if _has_auth(a, secrets) and a.name not in seen_names:
+                candidates.append(a)
+                seen_names.add(a.name)
 
     # If no authed candidates exist, fall back to unauthed agents so the pool
     # is never empty (mirrors the fallback logic in assign_models for dev/planner).
     if not candidates:
-        strong_any = _agents_by_tier(agents, "strong")
-        tier_any = _agents_by_tier(agents, tier) if tier != "strong" else []
         seen_names = set()
-        for a in strong_any + tier_any:
-            if a.name not in seen_names:
-                candidates.append(a)
-                seen_names.add(a.name)
+        for t in descending_tiers:
+            for a in _agents_by_tier(agents, t):
+                if a.name not in seen_names:
+                    candidates.append(a)
+                    seen_names.add(a.name)
 
     if not candidates:
         return []
@@ -901,8 +901,15 @@ def assign_models(
         plan_reviewers = [_agent_to_profile(a, role="review") for a in selected]
         providers = [a.provider for a in selected]
         score_note = f", complexity score {score}" if score is not None else ""
+        shortfall_note = (
+            f" [WARNING: requested {n}, only {len(plan_reviewers)} available "
+            f"after candidate-pool exhaustion (self-exclusion + cross-provider filter)]"
+            if len(plan_reviewers) < n
+            else ""
+        )
         rationale["plan_review"] = (
-            f"{len(plan_reviewers)} reviewer(s), tier {tier}, providers {providers}{score_note}"
+            f"{len(plan_reviewers)} reviewer(s), tier {tier}, "
+            f"providers {providers}{score_note}{shortfall_note}"
         )
 
     # ── Code reviewers ─────────────────────────────────────────────────
@@ -941,8 +948,15 @@ def assign_models(
         code_reviewers = [_agent_to_profile(a, role="review") for a in selected]
         providers = [a.provider for a in selected]
         score_note = f", complexity score {score}" if score is not None else ""
+        shortfall_note = (
+            f" [WARNING: requested {n}, only {len(code_reviewers)} available "
+            f"after candidate-pool exhaustion (self-exclusion + cross-provider filter)]"
+            if len(code_reviewers) < n
+            else ""
+        )
         rationale["code_review"] = (
-            f"{len(code_reviewers)} reviewer(s), tier {tier}, providers {providers}{score_note}"
+            f"{len(code_reviewers)} reviewer(s), tier {tier}, "
+            f"providers {providers}{score_note}{shortfall_note}"
         )
 
     decision = AssignmentDecision(

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1077,3 +1077,107 @@ def test_set_cap_records_preferred_snapshot_in_audit():
     # Audit must never carry the word "budget" in its top-level keys
     assert "budget" not in audit
     assert "budget_cap_usd" not in audit
+
+
+# ── test_reviewer_count_honors_target_via_tier_descent (issue #1542) ──
+
+
+def test_high_score_panel_descends_tier_ladder_when_strong_provider_pool_narrow():
+    """HIGH-score story whose strong tier post-self-exclusion has one provider
+    must still fill its requested panel by descending to lower tiers.
+
+    Regression for #1542: previously `_select_reviewers` built candidates as
+    strong+[] when tier=='strong', so removing the dev model from a
+    same-provider strong pool collapsed the panel to whatever the single
+    remaining provider supplied (often 1). Mid-target stories saw strong∪mid
+    and ended up with wider panels than higher-risk strong-target stories.
+    """
+    agents = [
+        # Two strong agents but same provider after self-exclusion
+        AgentDef("opus", "anthropic", "opus", 8.0, 1200, "strong"),
+        AgentDef("gpt-strong", "openai", "gpt-5", 7.0, 1200, "strong"),
+        # Lower-tier alternatives at distinct providers
+        AgentDef("gemini-mid", "google", "gemini-pro", 4.0, 900, "mid"),
+        AgentDef("haiku", "anthropic", "haiku", 1.0, 600, "cheap"),
+    ]
+    cfg = _make_cfg(
+        min_reviewers=1,
+        max_reviewers=3,
+        prefer_cross_provider=True,
+        max_cost_per_story_usd=1000.0,
+    )
+
+    # HIGH complexity, score 8 → dev tier strong → opus (cheapest anthropic strong?)
+    # Actually cheapest strong is gpt-strong (7.0) — dev picks gpt-strong.
+    # Reviewer pool excludes gpt-5; previously collapsed to 1, must now fill 3.
+    decision = assign_models(agents, cfg, "large", complexity_score=8)
+
+    # Requested n for score=8 is max_reviewers=3. The descent should make
+    # at least 2 reviewers available (opus + gemini-mid + haiku exclude dev).
+    assert len(decision.code_reviewers) >= 2, (
+        f"HIGH-score panel collapsed to {len(decision.code_reviewers)} reviewer(s); "
+        f"rationale: {decision.rationale.get('code_review')}"
+    )
+    # The dev model must never appear in reviewers (self-exclusion holds).
+    dev_model = decision.dev.model
+    assert all(r.model != dev_model for r in decision.code_reviewers)
+
+
+def test_high_score_panel_not_smaller_than_mid_score_panel_same_pool():
+    """Asymmetry guard: a score-8 story must not yield fewer reviewers than a
+    score-5 story drawn from the same agent pool. The bug at #1542 was exactly
+    this inversion."""
+    agents = [
+        AgentDef("opus", "anthropic", "opus", 8.0, 1200, "strong"),
+        AgentDef("gpt-strong", "openai", "gpt-5", 7.0, 1200, "strong"),
+        AgentDef("sonnet", "anthropic", "sonnet", 5.0, 900, "mid"),
+        AgentDef("gemini-mid", "google", "gemini-pro", 4.0, 900, "mid"),
+    ]
+    cfg = _make_cfg(
+        min_reviewers=1,
+        max_reviewers=3,
+        prefer_cross_provider=True,
+        max_cost_per_story_usd=1000.0,
+    )
+
+    mid_score = assign_models(agents, cfg, "medium", complexity_score=5)
+    high_score = assign_models(agents, cfg, "large", complexity_score=8)
+
+    assert len(high_score.code_reviewers) >= len(mid_score.code_reviewers), (
+        f"Inverted panel sizes: mid-score={len(mid_score.code_reviewers)} "
+        f"vs high-score={len(high_score.code_reviewers)}. "
+        f"high rationale: {high_score.rationale.get('code_review')}"
+    )
+
+
+def test_reviewer_shortfall_emits_warning_in_rationale():
+    """When the candidate pool genuinely cannot satisfy n, the rationale must
+    record an explicit shortfall warning rather than silently truncating."""
+    # Only two agents both at strong tier, same provider — n=3 cannot be honored
+    # cross-provider even with descent.
+    agents = [
+        AgentDef("opus", "anthropic", "opus", 8.0, 1200, "strong"),
+        AgentDef("sonnet", "anthropic", "sonnet", 5.0, 900, "mid"),
+    ]
+    cfg = _make_cfg(
+        min_reviewers=3,
+        max_reviewers=3,
+        prefer_cross_provider=True,
+        max_cost_per_story_usd=1000.0,
+    )
+    decision = assign_models(agents, cfg, "large", complexity_score=8)
+
+    assert len(decision.code_reviewers) < 3
+    assert "WARNING" in decision.rationale["code_review"]
+    assert "requested 3" in decision.rationale["code_review"]
+
+
+def test_reviewer_panel_full_no_shortfall_warning():
+    """When the panel is fully populated, the rationale must NOT mention a shortfall."""
+    agents = _make_agents_cross_provider()
+    cfg = _make_cfg(min_reviewers=2, max_reviewers=2, prefer_cross_provider=True)
+
+    decision = assign_models(agents, cfg, "medium")
+
+    assert len(decision.code_reviewers) == 2
+    assert "WARNING" not in decision.rationale["code_review"]


### PR DESCRIPTION
## Summary

The change fixes the reviewer-count inversion and surfaces genuine reviewer shortfalls in routing rationale.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.44
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Reviewer-count target silently drops below requested for HIGH-score stories when strong-tier provider pool narrows after self-exclusion (GitHub Issue #1542)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1542