### PR TITLE
[P2] issue-1154: DiagnosePhase.BUDGET_EXCEEDED is defined but never tran

### DIFF
--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -472,7 +472,8 @@ def run_diagnose_flow(
 
     # Budget guard — if the agent cost exceeded the configured budget, mark
     # the result as partial regardless of whether the agent reported success.
-    if state.agent_cost_usd > config.diagnose.budget_usd * 1.05:
+    budget_exceeded = state.agent_cost_usd > config.diagnose.budget_usd * 1.05
+    if budget_exceeded:
         partial = True
 
     # ── PARSE ─────────────────────────────────────────────────────────
@@ -510,7 +511,10 @@ def run_diagnose_flow(
     if not artifact.is_complete() or partial:
         artifact = dataclasses.replace(artifact, partial=True)
         state.artifact = artifact
-        state.transition(DiagnosePhase.TIMEOUT_PARTIAL, _now_iso())
+        partial_phase = (
+            DiagnosePhase.BUDGET_EXCEEDED if budget_exceeded else DiagnosePhase.TIMEOUT_PARTIAL
+        )
+        state.transition(partial_phase, _now_iso())
         if interactive and confirm_landing is None:
             confirm_landing = _stdin_confirm
         if interactive and confirm_landing is not None:

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -465,7 +465,7 @@ class TestDiagnoseFlow:
         # confident "fix-ready" landing — even when the YAML happens to be
         # structurally complete.
         assert not result.success
-        assert result.state.phase == DiagnosePhase.TIMEOUT_PARTIAL
+        assert result.state.phase == DiagnosePhase.BUDGET_EXCEEDED
         audit_files = list((tmp_path / ".forge" / "audits").glob("diagnose-issue-8-*.yaml"))
         assert audit_files
         loaded = yaml.safe_load(audit_files[0].read_text())


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Budget-exhausted diagnose runs now emit the reachable BUDGET_EXCEEDED phase with focused coverage for the original symptom. | [google-gemini-3.1-pro-preview] Fixes unreachable BUDGET_EXCEEDED phase by routing budget-exhausted runs to it.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.16
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-1154: DiagnosePhase.BUDGET_EXCEEDED is defined but never tran (GitHub Issue #1304)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1304