### PR TITLE
[P2] issue-1264: sweep_story_locks releases the flock (via fd.close() in

### DIFF
--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -446,13 +446,15 @@ def sweep_story_locks(
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
                 continue
+            # Unlink while still holding the flock so a concurrent acquirer
+            # cannot take the lock on the file we are about to remove.
+            try:
+                lock_path.unlink(missing_ok=True)
+            except OSError:
+                continue
+            removed.append(lock_path)
         finally:
             fd.close()
-        try:
-            lock_path.unlink(missing_ok=True)
-        except OSError:
-            continue
-        removed.append(lock_path)
 
     return removed
 

--- a/tests/test_sprint_lock.py
+++ b/tests/test_sprint_lock.py
@@ -329,6 +329,59 @@ class TestSweepStoryLocks:
             release_event.set()
             proc.join(timeout=5)
 
+    def test_unlink_runs_while_flock_still_held(self, tmp_path: Path) -> None:
+        """Regression for issue-1264: sweep must hold the flock across unlink.
+
+        If the flock is dropped before the file is unlinked, a concurrent
+        sprint can acquire the about-to-be-deleted lock — the exact race the
+        sweep is supposed to close.
+        """
+        import fcntl as _fcntl
+
+        lock_dir = tmp_path / ".forge" / "locks"
+        lock_dir.mkdir(parents=True)
+        lock_path = lock_dir / "issue-1264.lock"
+        lock_path.write_text("99999|x|fp\n", encoding="utf-8")
+
+        def attempt_flock(path: str, conn: object) -> None:
+            try:
+                fd = open(path, "a+")
+                try:
+                    _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+                    conn.send("acquired")
+                    _fcntl.flock(fd, _fcntl.LOCK_UN)
+                except BlockingIOError:
+                    conn.send("blocked")
+                finally:
+                    fd.close()
+            except FileNotFoundError:
+                conn.send("missing")
+            finally:
+                conn.close()
+
+        observed: list[str] = []
+        real_unlink = Path.unlink
+
+        def observing_unlink(self: Path, *args: object, **kwargs: object) -> None:
+            if self == lock_path:
+                parent_conn, child_conn = _mp.Pipe()
+                proc = _mp.Process(target=attempt_flock, args=(str(self), child_conn))
+                proc.start()
+                child_conn.close()
+                try:
+                    observed.append(parent_conn.recv())
+                except EOFError:
+                    observed.append("eof")
+                proc.join(timeout=5)
+                parent_conn.close()
+            return real_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", observing_unlink):
+            removed = sweep_story_locks(tmp_path)
+
+        assert removed == [lock_path]
+        assert observed == ["blocked"]
+
 
 class TestCheckActiveWorktrees:
     def test_missing_worktree_is_not_active(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The change holds the sweep-owned flock through unlink and adds a regression test for the original acquire-before-delete race.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $0.11
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-1264: sweep_story_locks releases the flock (via fd.close() in (GitHub Issue #1283)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1283