### PR TITLE
Review-pool reviewer crashes escalate the whole story instead of retrying transiently or proceeding on quorum

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -676,6 +676,25 @@ def load_config(config_path: Path) -> ForgeConfig:
         max_plan_review_transport_retries=int(
             retry_data.get("max_plan_review_transport_retries", 2)
         ),
+        max_review_transport_retries=int(retry_data.get("max_review_transport_retries", 2)),
+        review_transport_retry_backoff_seconds=float(
+            retry_data.get("review_transport_retry_backoff_seconds", 8.0)
+        ),
+        review_quorum_threshold=int(retry_data.get("review_quorum_threshold", 2)),
+        review_transient_failure_codes=tuple(
+            str(code)
+            for code in retry_data.get(
+                "review_transient_failure_codes",
+                ("rate_limit", "provider_internal_error", "connection_reset"),
+            )
+        ),
+        review_transient_output_patterns=tuple(
+            str(p).lower()
+            for p in retry_data.get(
+                "review_transient_output_patterns",
+                RetryPolicy.__dataclass_fields__["review_transient_output_patterns"].default,
+            )
+        ),
         max_plan_regen_attempts=int(retry_data.get("max_plan_regen_attempts", 3)),
         demotion_threshold=int(retry_data.get("demotion_threshold", 2)),
         escalate_policy=str(retry_data.get("escalate_policy", "prompt")),

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -251,6 +251,49 @@ class RetryPolicy:
     max_plan_review_transport_retries: int = (
         2  # per-reviewer retries on transient plan-review transport/provider failure
     )
+    # Per-reviewer retries on transient review-pool transport/provider failure.
+    max_review_transport_retries: int = 2
+    # Initial backoff (seconds) for review-pool transient retry; doubled per retry.
+    review_transport_retry_backoff_seconds: float = 8.0
+    # Minimum successful reviewers required to proceed to synthesis without
+    # escalating; collapses to 1 when the panel size is 1.
+    review_quorum_threshold: int = 2
+    # Failure-code identifiers (from AgentResult.failure_code) that mark a
+    # review-pool failure as transient/retryable.
+    review_transient_failure_codes: tuple[str, ...] = (
+        "rate_limit",
+        "provider_internal_error",
+        "connection_reset",
+    )
+    # Substrings (matched case-insensitively against agent output) treated as
+    # transient signatures for the review pool.
+    review_transient_output_patterns: tuple[str, ...] = (
+        "429",
+        "rate limit",
+        "rate-limited",
+        "resource_exhausted",
+        "resource exhausted",
+        "quota exceeded",
+        "quota_exceeded",
+        "500",
+        "502",
+        "503",
+        "504",
+        "internal error",
+        "server error",
+        "service unavailable",
+        "bad gateway",
+        "gateway timeout",
+        "connection reset",
+        "connection-reset",
+        "econnreset",
+        "connection aborted",
+        "connection refused",
+        "peer closed connection",
+        "temporarily unavailable",
+        "try again later",
+        "timeout awaiting headers",
+    )
     max_plan_regen_attempts: int = 3  # plan review rejection → regen cycles before escalating
     demotion_threshold: int = 2  # parse failures per reviewer per run before exclusion; 0 disables
     plan_escalation_threshold: int = (

--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -85,6 +85,10 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
             "failed_detail": meta.failed_detail,
             "synthesized": meta.synthesized,
             "parse_retries": meta.parse_retries,
+            "transient_retries": dict(meta.transient_retries),
+            "transient_outcomes": dict(meta.transient_outcomes),
+            "quorum_threshold": meta.quorum_threshold,
+            "quorum_met": meta.quorum_met,
         }
         if i < len(state.review_results):
             r = state.review_results[i]

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -53,6 +53,123 @@ if TYPE_CHECKING:
 _log = _cu._log
 _log_verbose = _cu._log_verbose
 
+
+def _is_transient_review_failure(result: Any, config: ForgeConfig) -> bool:
+    """Return True when a failed review-pool invocation looks transient/retryable.
+
+    Treats three signatures as transient:
+    - failure_code matches a configured transient code
+    - output text matches a configured transient signature substring
+    - the spec's exit=1-with-no-model-output case (success=False and empty output)
+    """
+    if result.success:
+        return False
+    failure_code = (getattr(result, "failure_code", None) or "").lower()
+    transient_codes = {c.lower() for c in config.retry.review_transient_failure_codes}
+    if failure_code in transient_codes:
+        return True
+    output = (result.output or "").strip()
+    if not output:
+        return True
+    lower = output.lower()
+    return any(pattern in lower for pattern in config.retry.review_transient_output_patterns)
+
+
+def _resolve_prompt_for_reviewer(review_prompts: str | list[str], index: int) -> str:
+    """Return the per-reviewer prompt. Shared string fans out to every reviewer."""
+    if isinstance(review_prompts, list):
+        return review_prompts[index]
+    return review_prompts
+
+
+def _retry_transient_review_failures(
+    state: CoordinatorState,
+    config: ForgeConfig,
+    pool: list,
+    pool_results: list,
+    review_prompts: str | list[str],
+    workspace_path: Path,
+    *,
+    cycle_num: int,
+    pool_attempt: int,
+    meta: ReviewCycleMetadata,
+    stop_event: "threading.Event | None" = None,
+) -> list:
+    """Retry per-reviewer transient transport failures with exponential backoff.
+
+    Returns updated pool_results (same order as ``pool``). Each retry's
+    AgentResult is appended to state.review_agent_results and a trace + log
+    artifact is written. meta.transient_retries and meta.transient_outcomes
+    are populated for every reviewer (including those that did not need a
+    retry — they record the ``succeeded``/``hard_failed`` outcome).
+    """
+    max_retries = config.retry.max_review_transport_retries
+    backoff_base = config.retry.review_transport_retry_backoff_seconds
+    updated = list(pool_results)
+
+    for index, (profile, result) in enumerate(zip(pool, updated)):
+        if result.success:
+            meta.transient_outcomes[profile.name] = "succeeded"
+            continue
+        if not _is_transient_review_failure(result, config):
+            meta.transient_outcomes[profile.name] = "hard_failed"
+            continue
+        if max_retries <= 0:
+            meta.transient_outcomes[profile.name] = "hard_failed"
+            continue
+
+        retry_count = 0
+        current = result
+        per_reviewer_prompt = _resolve_prompt_for_reviewer(review_prompts, index)
+        while retry_count < max_retries and _is_transient_review_failure(current, config):
+            retry_count += 1
+            backoff = backoff_base * (2 ** (retry_count - 1))
+            _log(
+                f"  ↻ {profile.name} transient transport failure "
+                f"(retry {retry_count}/{max_retries}) in {backoff:.0f}s"
+            )
+            if backoff > 0:
+                time.sleep(backoff)
+            retried = run_agent(
+                prompt=per_reviewer_prompt,
+                profile=profile,
+                working_dir=workspace_path,
+                quiet=True,
+                secrets=config.secrets,
+                session_id=current.session_id if profile.mode == "cli" else None,
+                stop_event=stop_event,
+            )
+            if retried.session_id:
+                state.reviewer_session_ids[profile.name] = retried.session_id
+            state.review_agent_results.append(retried)
+            log_agent_result(retried, f"REVIEW/{retried.profile_name}")
+            _trace_name = (
+                f"{cycle_num}-{pool_attempt}-review-{profile.name}"
+                f"-transport-retry{retry_count}.txt"
+            )
+            write_trace(
+                workspace_path / ".forge/traces" / _trace_name,
+                retried.output,
+            )
+            _write_log_artifact(
+                state.log_dir,
+                f"review-cycle-{cycle_num}/{profile.name}-transport-retry{retry_count}.yaml",
+                retried.output or "",
+            )
+            current = retried
+
+        meta.transient_retries[profile.name] = retry_count
+        if current.success:
+            meta.transient_outcomes[profile.name] = "transient_retried_then_succeeded"
+            _log(f"  ✓ {profile.name} transient retry {retry_count} succeeded")
+        else:
+            meta.transient_outcomes[profile.name] = "transient_retried_then_failed"
+            _log(f"  ✗ {profile.name} transient retries exhausted")
+        updated[index] = current
+
+    return updated
+
+
 # ── Lazy runner slots ─────────────────────────────────────────────────
 # None until first call; tests may replace with mocks before calling
 # run_task. _ensure_runners() skips any slot that is already non-None.
@@ -363,6 +480,24 @@ def _run_review_pool(
             r.output or "",
         )
 
+    # ── Transient transport retry ─────────────────────────────────────
+    # Re-invoke each reviewer whose initial result has a transient transport
+    # signature (rate limit / 5xx / connection reset / empty-output crash) up
+    # to the configured budget with exponential backoff before counting the
+    # reviewer as failed.
+    pool_results = _retry_transient_review_failures(
+        state,
+        config,
+        pool,
+        pool_results,
+        review_prompts,
+        workspace_path,
+        cycle_num=_cycle_num,
+        pool_attempt=pool_attempt,
+        meta=meta,
+        stop_event=stop_event,
+    )
+
     # Per-profile budget enforcement BEFORE synthesis — exclude over-budget
     # reviewers from this cycle's results rather than killing the whole run.
     _budget_excluded: set[str] = set()
@@ -405,11 +540,26 @@ def _run_review_pool(
         for r in failed_results
     }
 
-    if not successful:
+    quorum_threshold = min(config.retry.review_quorum_threshold, pool_size)
+    if quorum_threshold < 1:
+        quorum_threshold = 1
+    meta.quorum_threshold = quorum_threshold
+    meta.quorum_met = len(successful) >= quorum_threshold
+
+    if not meta.quorum_met:
         state.phase = Phase.ESCALATE
         failed_desc = ", ".join(f"{r.profile_name} (exit={r.exit_code})" for r in failed_results)
-        state.error = f"All {len(pool_results)} review agent(s) failed: {failed_desc}"
+        state.error = (
+            f"Quorum unmet: {len(successful)}/{pool_size} succeeded "
+            f"< threshold {quorum_threshold}; failed: {failed_desc}"
+        )
         return successful, failed_results, None, [], []
+
+    if failed_results:
+        _log(
+            f"Panel quorum met ({len(successful)}/{pool_size} reviewers succeeded "
+            f"≥ quorum threshold {quorum_threshold}) — proceeding to synthesis"
+        )
 
     _synthesis_path = (
         workspace_path / ".forge/traces" / f"{_cycle_num}-{pool_attempt}-synthesis.txt"

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -229,6 +229,15 @@ class ReviewCycleMetadata:
     synthesized: bool  # whether synthesis ran
     parse_retries: int = 0  # parse/schema retry count for this cycle
     failed_detail: dict[str, str] = field(default_factory=dict)  # profile → "exit=N"
+    # Per-profile count of transient transport retries attempted this cycle.
+    transient_retries: dict[str, int] = field(default_factory=dict)
+    # Per-profile outcome: succeeded, transient_retried_then_succeeded,
+    # transient_retried_then_failed, hard_failed.
+    transient_outcomes: dict[str, str] = field(default_factory=dict)
+    # Effective quorum threshold for this cycle (after collapse to panel size).
+    quorum_threshold: int = 0
+    # Whether the effective threshold was met (i.e. synthesis proceeded).
+    quorum_met: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -137,9 +137,7 @@ class TestLoadConfig:
         assert config.retry.review_transport_retry_backoff_seconds == 8.0
         assert config.retry.review_quorum_threshold == 2
         assert "rate_limit" in config.retry.review_transient_failure_codes
-        assert any(
-            "rate limit" in p for p in config.retry.review_transient_output_patterns
-        )
+        assert any("rate limit" in p for p in config.retry.review_transient_output_patterns)
 
     def test_auto_model_escalation_defaults_false(self, tmp_path):
         config_path = _write_config({"retry": {}}, tmp_path)

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -109,6 +109,38 @@ class TestLoadConfig:
         assert config.retry.max_dev_transport_retries == 2
         assert config.retry.max_review_cycles == 4
 
+    def test_review_pool_transient_retry_quorum_fields_loaded(self, tmp_path):
+        config_path = _write_config(
+            {
+                "retry": {
+                    "max_review_transport_retries": 4,
+                    "review_transport_retry_backoff_seconds": 2.5,
+                    "review_quorum_threshold": 3,
+                    "review_transient_failure_codes": ["custom_code", "rate_limit"],
+                    "review_transient_output_patterns": ["Boom", "kapow"],
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.retry.max_review_transport_retries == 4
+        assert config.retry.review_transport_retry_backoff_seconds == 2.5
+        assert config.retry.review_quorum_threshold == 3
+        assert config.retry.review_transient_failure_codes == ("custom_code", "rate_limit")
+        # Patterns are normalized to lowercase for case-insensitive matching.
+        assert config.retry.review_transient_output_patterns == ("boom", "kapow")
+
+    def test_review_pool_transient_retry_quorum_defaults(self, tmp_path):
+        config_path = _write_config({"retry": {}}, tmp_path)
+        config = load_config(config_path)
+        assert config.retry.max_review_transport_retries == 2
+        assert config.retry.review_transport_retry_backoff_seconds == 8.0
+        assert config.retry.review_quorum_threshold == 2
+        assert "rate_limit" in config.retry.review_transient_failure_codes
+        assert any(
+            "rate limit" in p for p in config.retry.review_transient_output_patterns
+        )
+
     def test_auto_model_escalation_defaults_false(self, tmp_path):
         config_path = _write_config({"retry": {}}, tmp_path)
         config = load_config(config_path)

--- a/tests/test_coord_review_phase_pool.py
+++ b/tests/test_coord_review_phase_pool.py
@@ -286,6 +286,74 @@ class TestCoordinatorMultiModelReview:
         # run_agent called for DEV only (no synthesis for pool of 1; preflight mocked separately)
         assert mock_agent.call_count == 1
 
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_transient_reviewer_crash_retries_and_meets_quorum(
+        self,
+        mock_shell,
+        mock_dev_agent,
+        mock_preflight,
+        mock_pool,
+        mock_review_agent,
+        tmp_path,
+    ):
+        """Phase-boundary seam: transient crash in a 4-reviewer panel is retried, then
+        partial-failure quorum lets synthesis proceed without escalating."""
+        profiles = [
+            _make_review_profile("r1"),
+            _make_review_profile("r2"),
+            _make_review_profile("r3"),
+            _make_review_profile("r4"),
+        ]
+        config = _make_pool_config(tmp_path, profiles, SYNTHESIS_PROFILE)
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    review_quorum_threshold=2,
+                    max_review_transport_retries=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        # DEV + synthesis (pool of 4 → synthesis runs)
+        mock_dev_agent.side_effect = [
+            _make_agent_result(success=True, output="Implemented.", profile_name="dev"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="synthesis"),
+        ]
+        # r1 crashes transiently (exit=1 + empty output); retries also fail.
+        mock_pool.return_value = [
+            _make_agent_result(success=False, output="", profile_name="r1"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r2"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r3"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r4"),
+        ]
+        mock_review_agent.return_value = _make_agent_result(
+            success=False, output="", profile_name="r1"
+        )
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        # Retries actually fired
+        assert mock_review_agent.call_count == 2
+        # Audit captures retry + quorum metadata
+        meta = result.state.review_cycle_metadata[-1]
+        assert meta.transient_retries["r1"] == 2
+        assert meta.transient_outcomes["r1"] == "transient_retried_then_failed"
+        assert meta.quorum_met is True
+
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
@@ -296,6 +364,11 @@ class TestCoordinatorMultiModelReview:
         """1 of 2 reviewers succeeds → single output used directly (no synthesis)."""
         profiles = [_make_review_profile("r1"), _make_review_profile("r2")]
         config = _make_pool_config(tmp_path, profiles, SYNTHESIS_PROFILE)
+        # Allow single-success quorum so the legacy "degrade to single" path
+        # remains exercised under the new quorum contract.
+        config = config.__class__(
+            **{**config.__dict__, "retry": RetryPolicy(review_quorum_threshold=1)}
+        )
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
@@ -354,6 +427,10 @@ class TestCoordinatorMultiModelReview:
         tight_profile = _make_review_profile("tight", budget_usd=0.10)
         normal_profile = _make_review_profile("normal", budget_usd=5.00)
         config = _make_pool_config(tmp_path, [tight_profile, normal_profile], SYNTHESIS_PROFILE)
+        # Threshold=1 so the remaining reviewer meets quorum after budget exclusion.
+        config = config.__class__(
+            **{**config.__dict__, "retry": RetryPolicy(review_quorum_threshold=1)}
+        )
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()

--- a/tests/test_coord_review_pool.py
+++ b/tests/test_coord_review_pool.py
@@ -414,3 +414,332 @@ class TestRetryTraceFiles:
         trace_file = workspace / ".forge" / "traces" / "1-0-review-r1-retry1.txt"
         assert trace_file.exists(), "Successful retry must also write trace file"
         assert trace_file.read_text(encoding="utf-8") == APPROVE_REVIEW
+
+
+class TestTransientRetryClassifier:
+    def test_failure_code_rate_limit_is_transient(self, tmp_path):
+        from theforge.coordinator.review_pool import _is_transient_review_failure
+
+        config = _make_pool_config(
+            tmp_path, [_make_review_profile("r1")], _make_review_profile("r1")
+        )
+        result = _make_agent_result(success=False, output="boom", profile_name="r1")
+        result = result.__class__(**{**result.__dict__, "failure_code": "rate_limit"})
+        assert _is_transient_review_failure(result, config) is True
+
+    def test_failure_code_provider_internal_error_is_transient(self, tmp_path):
+        from theforge.coordinator.review_pool import _is_transient_review_failure
+
+        config = _make_pool_config(
+            tmp_path, [_make_review_profile("r1")], _make_review_profile("r1")
+        )
+        result = _make_agent_result(success=False, output="boom", profile_name="r1")
+        result = result.__class__(**{**result.__dict__, "failure_code": "provider_internal_error"})
+        assert _is_transient_review_failure(result, config) is True
+
+    def test_failure_code_connection_reset_is_transient(self, tmp_path):
+        from theforge.coordinator.review_pool import _is_transient_review_failure
+
+        config = _make_pool_config(
+            tmp_path, [_make_review_profile("r1")], _make_review_profile("r1")
+        )
+        result = _make_agent_result(success=False, output="boom", profile_name="r1")
+        result = result.__class__(**{**result.__dict__, "failure_code": "connection_reset"})
+        assert _is_transient_review_failure(result, config) is True
+
+    def test_exit1_empty_output_is_transient(self, tmp_path):
+        from theforge.coordinator.review_pool import _is_transient_review_failure
+
+        config = _make_pool_config(
+            tmp_path, [_make_review_profile("r1")], _make_review_profile("r1")
+        )
+        result = _make_agent_result(success=False, output="", profile_name="r1")
+        assert _is_transient_review_failure(result, config) is True
+
+    def test_successful_result_not_transient(self, tmp_path):
+        from theforge.coordinator.review_pool import _is_transient_review_failure
+
+        config = _make_pool_config(
+            tmp_path, [_make_review_profile("r1")], _make_review_profile("r1")
+        )
+        result = _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r1")
+        assert _is_transient_review_failure(result, config) is False
+
+    def test_hard_failure_with_real_output_not_transient(self, tmp_path):
+        from theforge.coordinator.review_pool import _is_transient_review_failure
+
+        config = _make_pool_config(
+            tmp_path, [_make_review_profile("r1")], _make_review_profile("r1")
+        )
+        result = _make_agent_result(
+            success=False, output="ValueError: bad spec format", profile_name="r1"
+        )
+        assert _is_transient_review_failure(result, config) is False
+
+
+class TestTransientRetry:
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_transient_retry_succeeds_within_budget(
+        self, mock_pool, mock_run_agent, _mock_log, tmp_path
+    ):
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = _make_pool_config(tmp_path, [r1, r2], r1)
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    max_review_transport_retries=2,
+                    review_quorum_threshold=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=False, output="", profile_name="r1"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r2"),
+        ]
+        mock_run_agent.return_value = _make_agent_result(
+            success=True, output=APPROVE_REVIEW, profile_name="r1"
+        )
+
+        meta = _meta()
+        successful, failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        assert merged is not None
+        assert sorted(r.profile_name for r in successful) == ["r1", "r2"]
+        assert failed == []
+        assert meta.transient_retries.get("r1") == 1
+        assert meta.transient_outcomes["r1"] == "transient_retried_then_succeeded"
+        assert meta.transient_outcomes["r2"] == "succeeded"
+        assert meta.quorum_met is True
+        assert meta.quorum_threshold == 2
+        assert mock_run_agent.call_count == 1
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_transient_retry_exhausts_budget_records_failed_outcome(
+        self, mock_pool, mock_run_agent, _mock_log, tmp_path
+    ):
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        r3 = _make_review_profile("r3")
+        r4 = _make_review_profile("r4")
+        config = _make_pool_config(tmp_path, [r1, r2, r3, r4], r1)
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    max_review_transport_retries=2,
+                    review_quorum_threshold=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=False, output="", profile_name="r1"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r2"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r3"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r4"),
+        ]
+        mock_run_agent.return_value = _make_agent_result(
+            success=False, output="", profile_name="r1"
+        )
+
+        meta = _meta()
+        successful, failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        # Quorum met (3 of 4 succeeded ≥ threshold 2) — proceed without escalation
+        assert merged is not None
+        assert state.phase != Phase.ESCALATE
+        assert sorted(r.profile_name for r in successful) == ["r2", "r3", "r4"]
+        assert [r.profile_name for r in failed] == ["r1"]
+        assert meta.transient_retries["r1"] == 2
+        assert meta.transient_outcomes["r1"] == "transient_retried_then_failed"
+        assert meta.quorum_met is True
+        assert mock_run_agent.call_count == 2
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_quorum_unmet_escalates(self, mock_pool, mock_run_agent, _mock_log, tmp_path):
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        r3 = _make_review_profile("r3")
+        r4 = _make_review_profile("r4")
+        config = _make_pool_config(tmp_path, [r1, r2, r3, r4], r1)
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    max_review_transport_retries=0,
+                    review_quorum_threshold=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=False, output="ValueError: nope", profile_name="r1"),
+            _make_agent_result(success=False, output="ValueError: nope", profile_name="r2"),
+            _make_agent_result(success=False, output="ValueError: nope", profile_name="r3"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r4"),
+        ]
+
+        meta = _meta()
+        _successful, failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        assert merged is None
+        assert state.phase == Phase.ESCALATE
+        assert "Quorum unmet" in state.error
+        assert len(failed) == 3
+        assert meta.quorum_met is False
+        assert meta.quorum_threshold == 2
+        assert mock_run_agent.call_count == 0
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_panel_size_one_collapses_threshold(
+        self, mock_pool, mock_run_agent, _mock_log, tmp_path
+    ):
+        """Single-reviewer panel: threshold collapses to 1; success still proceeds."""
+        r1 = _make_review_profile("solo")
+        config = _make_pool_config(tmp_path, [r1], r1)
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    max_review_transport_retries=0,
+                    review_quorum_threshold=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="solo")
+        ]
+
+        meta = _meta()
+        _successful, _failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        assert merged is not None
+        assert meta.quorum_threshold == 1
+        assert meta.quorum_met is True
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_panel_size_one_transient_fail_escalates(
+        self, mock_pool, mock_run_agent, _mock_log, tmp_path
+    ):
+        """Panel of 1 with no successful reviewers still escalates (collapsed threshold=1)."""
+        r1 = _make_review_profile("solo")
+        config = _make_pool_config(tmp_path, [r1], r1)
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    max_review_transport_retries=1,
+                    review_quorum_threshold=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=False, output="", profile_name="solo")
+        ]
+        mock_run_agent.return_value = _make_agent_result(
+            success=False, output="", profile_name="solo"
+        )
+
+        meta = _meta()
+        _successful, _failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        assert merged is None
+        assert state.phase == Phase.ESCALATE
+        assert meta.quorum_threshold == 1
+        assert meta.quorum_met is False
+        assert meta.transient_outcomes["solo"] == "transient_retried_then_failed"

--- a/tests/test_coord_state.py
+++ b/tests/test_coord_state.py
@@ -701,6 +701,11 @@ class TestAuditReviewPoolFields:
                 allowed_tools=[],
             ),
         )
+        # Allow single-success quorum to preserve the legacy degraded path
+        # under the new quorum contract.
+        config = config.__class__(
+            **{**config.__dict__, "retry": RetryPolicy(review_quorum_threshold=1)}
+        )
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
@@ -721,7 +726,7 @@ class TestAuditReviewPoolFields:
             ),
             AgentResult(
                 success=False,
-                output="",
+                output="ValueError: hard crash",
                 session_id=None,
                 cost_usd=0.0,
                 exit_code=1,
@@ -777,6 +782,11 @@ class TestAuditReviewPoolFields:
                 allowed_tools=[],
             ),
         )
+        # Allow single-success quorum to preserve the legacy degraded path
+        # under the new quorum contract.
+        config = config.__class__(
+            **{**config.__dict__, "retry": RetryPolicy(review_quorum_threshold=1)}
+        )
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
@@ -796,7 +806,7 @@ class TestAuditReviewPoolFields:
             ),
             AgentResult(
                 success=False,
-                output="",
+                output="ValueError: hard crash",
                 session_id=None,
                 cost_usd=0.0,
                 exit_code=1,
@@ -850,6 +860,11 @@ class TestAuditReviewPoolFields:
                 allowed_tools=[],
             ),
         )
+        # Allow single-success quorum to preserve the legacy degraded path
+        # under the new quorum contract.
+        config = config.__class__(
+            **{**config.__dict__, "retry": RetryPolicy(review_quorum_threshold=1)}
+        )
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
@@ -870,7 +885,7 @@ class TestAuditReviewPoolFields:
             ),
             AgentResult(
                 success=False,
-                output="",
+                output="ValueError: hard crash",
                 session_id=None,
                 cost_usd=0.0,
                 exit_code=1,

--- a/tests/test_coord_state.py
+++ b/tests/test_coord_state.py
@@ -744,6 +744,118 @@ class TestAuditReviewPoolFields:
         assert set(cycle["pool_models"]) == {"opus", "codex"}
         assert cycle["successful"] == ["opus"]
         assert cycle["failed"] == ["codex"]
+        # Quorum + transient outcome metadata is emitted (here threshold=1
+        # collapses against the configured value so quorum is met).
+        assert cycle["quorum_threshold"] == 1
+        assert cycle["quorum_met"] is True
+        assert cycle["transient_outcomes"]["opus"] == "succeeded"
+        assert cycle["transient_outcomes"]["codex"] == "hard_failed"
+        assert "transient_retries" in cycle
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_audit_transient_retry_and_quorum_fields_emitted(
+        self,
+        mock_shell,
+        mock_dev_agent,
+        mock_preflight,
+        mock_pool,
+        mock_review_agent,
+        tmp_path,
+    ):
+        """Audit log emits per-reviewer retry counts/outcomes and quorum metadata."""
+        config = _make_pool_config(
+            tmp_path,
+            profiles=[
+                ModelProfile(
+                    name="opus",
+                    cli="claude",
+                    model="claude-opus-4-6",
+                    budget_usd=5.0,
+                    timeout_seconds=300,
+                    allowed_tools=[],
+                ),
+                ModelProfile(
+                    name="codex",
+                    cli="codex",
+                    model="codex",
+                    budget_usd=5.0,
+                    timeout_seconds=300,
+                    allowed_tools=[],
+                ),
+            ],
+            synthesis=ModelProfile(
+                name="synthesis",
+                cli="claude",
+                model="claude-sonnet-4-6",
+                budget_usd=5.0,
+                timeout_seconds=300,
+                allowed_tools=[],
+            ),
+        )
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    review_quorum_threshold=1,
+                    max_review_transport_retries=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_dev_agent.return_value = _make_agent_result(success=True, output="Done.")
+        # codex returns transient-shape failure (exit=1, empty output); retries
+        # also fail. opus succeeds → quorum_met=True at threshold=1.
+        mock_pool.return_value = [
+            AgentResult(
+                success=True,
+                output=APPROVE_REVIEW,
+                session_id=None,
+                cost_usd=0.10,
+                exit_code=0,
+                raw={},
+                profile_name="opus",
+            ),
+            AgentResult(
+                success=False,
+                output="",
+                session_id=None,
+                cost_usd=0.0,
+                exit_code=1,
+                raw={},
+                profile_name="codex",
+            ),
+        ]
+        mock_review_agent.return_value = AgentResult(
+            success=False,
+            output="",
+            session_id=None,
+            cost_usd=0.0,
+            exit_code=1,
+            raw={},
+            profile_name="codex",
+        )
+
+        result = run_task(config, task)
+        audit = generate_audit_log(config, task, result)
+        cycle = audit["reviews"][0]
+
+        assert cycle["quorum_threshold"] == 1
+        assert cycle["quorum_met"] is True
+        assert cycle["transient_retries"]["codex"] == 2
+        assert cycle["transient_outcomes"]["codex"] == "transient_retried_then_failed"
+        assert cycle["transient_outcomes"]["opus"] == "succeeded"
+        assert mock_review_agent.call_count == 2
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")


### PR DESCRIPTION
## Summary

The prior audit metadata P1 is resolved, and I found no blocking regressions in the latest iteration.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $9.14
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Review-pool reviewer crashes escalate the whole story instead of retrying transiently or proceeding on quorum (GitHub Issue #1434)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1434