### PR TITLE
config: refresh model pool for July 2026 catalogs

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -6,18 +6,22 @@ project: theforge
 # See docs/guides/inputs-reference.md for the full schema reference.
 models:
   enabled:
-    - claude/sonnet
-    - claude/opus
-    - openai/gpt-5.4
-    - openai/gpt-5.5
+    - claude/sonnet               # CLI alias auto-tracks: Sonnet 5 as of 2026-07 ($3/$15)
+    - claude/opus                 # CLI alias auto-tracks: Opus 4.8 as of 2026-07 ($5/$25)
+    - openai/gpt-5.4              # value strong tier ($2.50/$15); still served, no deprecation (verified 2026-07-07)
+    - openai/gpt-5.4-mini         # cheap tier ($0.75/$4.50) — pool previously had no cheap tier at all
+    - openai/gpt-5.5              # OpenAI's recommended coding model; overlay entry below
     # - deepseek/deepseek-reasoner  # disabled 2026-05-09: flaky + slow; cycle-3 hang on #1424 + cycle-1 crash on same story.
     #                                  Re-enable when adaptive routing can decide reviewer fitness automatically.
-    - google/gemini-3.1-pro-preview
+    - google/gemini-3.1-pro-preview  # still the only Google pro tier (never GA'd, no 3.5 Pro exists, no shutdown date as of 2026-07-07).
+                                     # Repoint risk: Google killed gemini-3-pro-preview with ~3 weeks notice; provider-health (#1579) is the mitigation.
+                                     # Registry story for v0.11: add stable gemini-3.5-flash ($1.50/$9, beats 3.1-pro on coding per Google).
   custom:
-    # GPT-5.5 — added via the user-declared registry overlay shipped in #1184
-    # (v0.10.0). Disabled pending #1355: AGENT_REGISTRY direct-readers in
-    # model_profiles.py bypass the overlay and crash worker dispatch with
-    # 'Unknown model'. Re-enable when #1355 ships.
+    # GPT-5.5 — user-declared registry overlay (shipped #1184, v0.10.0).
+    # #1355 (overlay bypassed by AGENT_REGISTRY direct-readers) fixed during the
+    # v0.10 rc ladder; #1358 (P2 falsy-dict follow-up) still open but benign for
+    # a non-empty custom block. GPT-5.6 launch imminent (2026-07) — expect a
+    # re-pin here shortly.
     openai/gpt-5.5:
       provider: openai            # routes via Codex CLI; use 'openai-api' for the API adapter
       model: gpt-5.5


### PR DESCRIPTION
## Summary

Model pool refresh after the 8-week pause, verified against official provider docs on 2026-07-07.

- **claude/sonnet, claude/opus — unchanged**: registry maps these to CLI aliases, which auto-track the current generation (Sonnet 5 $3/$15, Opus 4.8 $5/$25). Comments added documenting this.
- **openai/gpt-5.5 — re-enabled**: the blocking overlay bug (#1355) shipped during the rc ladder; `forge check-config` on rc17 confirms the overlay entry dispatches (`✓ ready`). It is OpenAI's recommended coding model.
- **openai/gpt-5.4-mini — added**: cheap tier ($0.75/$4.50); the pool previously had no cheap tier, forcing strong-tier spend on trivial stories.
- **openai/gpt-5.4 — kept**: still served, no deprecation date; value strong tier at $2.50/$15.
- **google/gemini-3.1-pro-preview — kept**: still the only Google pro-tier model (never GA'd). Comment documents preview repoint risk (precedent: gemini-3-pro-preview killed with ~3 weeks notice) and the v0.11 registry story for stable gemini-3.5-flash.

Known incoming churn: GPT-5.6 launches imminently; one more re-pin expected later in July.

Config-only change; validated with `forge check-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)