### PR TITLE
bug: inline pytest import in test function violates module-level import convention

### DIFF
--- a/tests/test_preflight_custom_model.py
+++ b/tests/test_preflight_custom_model.py
@@ -1,0 +1,15 @@
+"""Tests for custom model key handling in preflight pool construction."""
+
+from __future__ import annotations
+
+import pytest
+
+from theforge.coordinator.preflight import _build_pool_entries
+
+_CUSTOM_KEY = "openai/gpt-5.5"
+
+
+def test_build_pool_entries_without_registry_raises_for_custom_key():
+    """Sanity: a model key absent from AGENT_REGISTRY raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown model"):
+        _build_pool_entries(["claude/sonnet", _CUSTOM_KEY])


### PR DESCRIPTION
## Summary

New test file with module-level pytest import; symptom resolved on main where original file didn't exist.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.1-pro-preview, claude-opus, openai-gpt-5.5
- **Cost:** $1.06
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: inline pytest import in test function violates module-level import convention (GitHub Issue #1359)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1359