### PR TITLE
bug: sprint summary overwrites a successful story outcome with a later failure instead of preserving outcome history

### DIFF
--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -323,11 +323,13 @@ class SprintStoryState:
             entry = self._stories.get(slug)
             if entry is None:
                 return None
+            outcome_rejected = False
             if outcome is not None:
                 new_outcome = coerce_outcome(outcome)
                 if entry.outcome.is_terminal and not new_outcome.is_terminal:
                     # Reject: monotonicity invariant — once terminal, stay terminal.
                     new_outcome = entry.outcome
+                    outcome_rejected = True
                 elif (
                     entry.outcome.is_terminal
                     and entry.extras.get("landed")
@@ -337,7 +339,15 @@ class SprintStoryState:
                     # non-DONE terminal (e.g. a bogus FAILED from a re-entry after
                     # an unrelated process restart).
                     new_outcome = entry.outcome
+                    outcome_rejected = True
                 entry.outcome = new_outcome
+            if outcome_rejected:
+                # The outcome change was rejected by a monotonicity/landed guard.
+                # The accompanying fields (cost_usd, detail, etc.) describe the
+                # rejected round's attempt and must not clobber the settled
+                # entry's data — e.g. a round-2 failure's cost_usd=0.0 must not
+                # overwrite round-1's recorded cost on a landed DONE.
+                return entry
             for k, v in fields.items():
                 if k == "phase" and isinstance(v, (str, type(None))):
                     entry.phase = v  # type: ignore[assignment]

--- a/tests/test_sprint_story_state.py
+++ b/tests/test_sprint_story_state.py
@@ -72,6 +72,22 @@ def test_landed_done_is_immutable_against_non_done_terminal() -> None:
     assert state.get("a").outcome is StoryOutcome.DONE
 
 
+def test_landed_done_rejects_cost_usd_from_rejected_transition() -> None:
+    """A rejected FAILED transition must not clobber the landed DONE's cost.
+
+    Reproduces the sprint-summary bug where a re-dispatched story's round-2
+    failure ($0.0) overwrote round-1's recorded cost ($0.33) even though the
+    landed-immutability guard correctly kept the outcome at DONE.
+    """
+    state = SprintStoryState()
+    state.register("a", "p", outcome=StoryOutcome.RUNNING)
+    state.transition("a", outcome=StoryOutcome.DONE, landed=True, cost_usd=0.33)
+    state.transition("a", outcome=StoryOutcome.FAILED, cost_usd=0.0)
+    entry = state.get("a")
+    assert entry.outcome is StoryOutcome.DONE
+    assert entry.cost_usd == 0.33
+
+
 def test_unlanded_done_still_permits_terminal_correction() -> None:
     """The legitimate 'queued PR failed to land' path is NOT marked landed and
     must still be correctable from DONE to a failure outcome."""


### PR DESCRIPTION
## Summary

Minimal, correct fix: rejected outcome transitions no longer apply their fields, preserving round-1 cost on a settled DONE; regression test present.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.81
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: sprint summary overwrites a successful story outcome with a later failure instead of preserving outcome history (GitHub Issue #1576)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1576