### PR TITLE
bug: diagnose timeout lands an all-empty artifact and reports it as a partial diagnosis

### DIFF
--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -407,6 +407,23 @@ def run_diagnose_flow(
 
     state.artifact = artifact
 
+    # Content floor — an artifact that parsed but carries no substantive field
+    # is a failure to diagnose, not a partial diagnosis. This is the shape a
+    # killed/timed-out agent emits (empty output still parses to a non-None
+    # all-empty dict). Landing it would pollute the issue body with
+    # structurally-complete-but-content-empty scaffolding and report "partial
+    # diagnosis landed" when there is nothing to review. Fail without mutating
+    # any operator-visible state.
+    if not artifact.has_substantive_content():
+        state.error = (
+            "INVESTIGATE produced no diagnosis: the investigative agent "
+            "terminated (timeout, budget, or empty completion) without emitting "
+            "any substantive content. Nothing landed; issue body left untouched."
+        )
+        state.transition(DiagnosePhase.FAILED, _now_iso())
+        write_diagnose_audit(state, project_root)
+        return DiagnoseResult(success=False, state=state, message=state.error)
+
     # If essential fields are missing OR the run breached its budget/timeout
     # envelope, treat as TIMEOUT_PARTIAL — return the partial work for operator
     # review rather than landing a misleading "fix-ready" artifact.

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -80,11 +80,20 @@ class DiagnosisArtifact:
         headings (structurally complete but content-empty).  ``notes`` is
         deliberately excluded: an investigation that produced only a caveat and
         no diagnosis content has still diagnosed nothing.
+
+        A hypotheses tuple counts only when at least one entry carries real
+        content (a non-blank statement or evidence).  The parser turns an empty
+        YAML entry such as ``hypotheses: [{}]`` into ``Hypothesis(statement='',
+        status='inconclusive', evidence='')``; a tuple of such blank bullets is
+        scaffolding, not investigative content, and must not clear the floor.
         """
+        has_real_hypothesis = any(
+            h.statement.strip() or h.evidence.strip() for h in self.hypotheses
+        )
         return bool(
             self.observed_symptom.strip()
             or self.reproduction_or_evidence.strip()
-            or self.hypotheses
+            or has_real_hypothesis
             or self.confirmed_cause.strip()
             or self.affected_code_path.strip()
             or self.fix_success_criterion.strip()

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -70,6 +70,26 @@ class DiagnosisArtifact:
             and self.fix_success_criterion.strip()
         )
 
+    def has_substantive_content(self) -> bool:
+        """Return True when at least one required diagnosis field carries content.
+
+        Distinct from :meth:`is_complete`, which requires *every* field.  An
+        artifact with no substantive content is a failure to diagnose — not a
+        partial diagnosis — and must never be landed into operator-visible
+        state, because the only thing such a section would carry is its own
+        headings (structurally complete but content-empty).  ``notes`` is
+        deliberately excluded: an investigation that produced only a caveat and
+        no diagnosis content has still diagnosed nothing.
+        """
+        return bool(
+            self.observed_symptom.strip()
+            or self.reproduction_or_evidence.strip()
+            or self.hypotheses
+            or self.confirmed_cause.strip()
+            or self.affected_code_path.strip()
+            or self.fix_success_criterion.strip()
+        )
+
 
 @dataclass
 class DiagnoseState:
@@ -120,7 +140,18 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
     Output format intentionally matches the headings expected by the shape gate
     (DIAGNOSIS_HEADING_PATTERN / DIAGNOSIS_REQUIRED_COMPONENTS in shape_check)
     so a landed artifact makes the issue fix-ready.
+
+    Raises ``ValueError`` when the artifact carries no substantive content.
+    Rendering an all-empty artifact would emit a Diagnosis section whose only
+    content is its own headings — structurally complete but content-empty — and
+    such scaffolding must never reach operator-visible state where a downstream
+    readiness check could be satisfied by the headings alone.
     """
+    if not artifact.has_substantive_content():
+        raise ValueError(
+            "refusing to render a Diagnosis section for an all-empty artifact: "
+            "no substantive content to land"
+        )
     lines: list[str] = ["## Diagnosis"]
     if artifact.partial:
         lines.append("")

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -516,6 +516,56 @@ class TestDiagnoseFlow:
         assert loaded["agent"]["cost_usd"] >= config.diagnose.budget_usd
         assert loaded["artifact"]["partial"] is True
 
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_empty_artifact_from_killed_agent_fails_without_mutating_body(
+        self, mock_agent, mock_fetch, mock_post, mock_edit, tmp_path
+    ):
+        """Seam test for the timeout/empty-output failure mode: an investigative
+        agent killed mid-run emits output that still parses to a non-None but
+        all-empty artifact. That is a failure to diagnose, not a partial
+        diagnosis — the flow must exit FAILED, land nothing, and leave the issue
+        body untouched. This exercises the PARSE→LAND boundary where the
+        content-floor guard lives."""
+        config = self._setup_config(tmp_path)
+        original_body = "Bug report: diagnose lands empty scaffolding.\n"
+        mock_fetch.return_value = {
+            "number": 1575,
+            "title": "broken diagnose",
+            "body": original_body,
+            "state": "OPEN",
+        }
+        # An empty-but-structurally-parseable YAML block — the shape a killed
+        # agent's flushed output takes.
+        empty_yaml = "```yaml\n{}\n```"
+        mock_agent.return_value = _fake_agent_result(empty_yaml, success=False)
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1575,
+            config=config,
+            project_root=tmp_path,
+            output_destination="body_section",
+        )
+
+        # (a) no landing occurred
+        assert not mock_edit.called, "issue body must not be edited"
+        assert not mock_post.called, "no comment must be posted"
+        assert result.state.landed_location is None
+        assert result.state.landing_destination is None
+        # (b) final phase is FAILED (not TIMEOUT_PARTIAL)
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.FAILED
+        assert "Partial diagnosis landed" not in result.message
+        # (c) audit still written so the operator can inspect the killed run
+        audit_files = list((tmp_path / ".forge" / "audits").glob("diagnose-issue-1575-*.yaml"))
+        assert audit_files, "expected an audit for the failed run"
+        loaded = yaml.safe_load(audit_files[0].read_text())
+        assert loaded["final_phase"] == "FAILED"
+
 
 # ── DiagnoseState / phase transitions ─────────────────────────────────
 

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -566,6 +566,46 @@ class TestDiagnoseFlow:
         loaded = yaml.safe_load(audit_files[0].read_text())
         assert loaded["final_phase"] == "FAILED"
 
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_blank_hypothesis_scaffold_fails_without_mutating_body(
+        self, mock_agent, mock_fetch, mock_post, mock_edit, tmp_path
+    ):
+        """Seam test for the empty-scaffold variant: a killed agent can flush a
+        structurally-parseable block whose only content is a blank hypothesis
+        entry (`hypotheses: [{}]`). parse_diagnose_output turns that into a
+        non-empty hypotheses tuple of one blank bullet — but it carries no
+        investigative content, so the content floor must still reject it and
+        the flow must fail without touching the issue body."""
+        config = self._setup_config(tmp_path)
+        original_body = "Bug report: diagnose lands empty scaffolding.\n"
+        mock_fetch.return_value = {
+            "number": 1595,
+            "title": "broken diagnose",
+            "body": original_body,
+            "state": "OPEN",
+        }
+        scaffold_yaml = "```yaml\nhypotheses:\n  - {}\n```"
+        mock_agent.return_value = _fake_agent_result(scaffold_yaml, success=False)
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1595,
+            config=config,
+            project_root=tmp_path,
+            output_destination="body_section",
+        )
+
+        assert not mock_edit.called, "issue body must not be edited"
+        assert not mock_post.called, "no comment must be posted"
+        assert result.state.landed_location is None
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.FAILED
+        assert "Partial diagnosis landed" not in result.message
+
 
 # ── DiagnoseState / phase transitions ─────────────────────────────────
 

--- a/tests/test_diagnose_types.py
+++ b/tests/test_diagnose_types.py
@@ -7,6 +7,8 @@ covers only the dataclasses and rendering/upsert helpers in isolation.
 
 from __future__ import annotations
 
+import pytest
+
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
     DiagnosePhase,
@@ -184,6 +186,29 @@ class TestRenderArtifactMarkdown:
         assert "Operator review required" in md
 
     def test_empty_required_field_renders_placeholder(self):
+        # A partial artifact with *some* content renders explicit placeholders
+        # for its blank fields, so it is never silently shown as a confident,
+        # fully-populated section. At least one field must carry content — an
+        # all-empty artifact is refused (see test below).
+        artifact = DiagnosisArtifact(
+            issue_number=1,
+            observed_symptom="it crashes",
+            reproduction_or_evidence="",
+            hypotheses=(),
+            confirmed_cause="",
+            affected_code_path="",
+            fix_success_criterion="",
+            partial=True,
+        )
+        md = render_artifact_markdown(artifact)
+        assert "_(empty)_" in md
+        assert "_(none recorded)_" in md
+
+    def test_all_empty_artifact_refuses_to_render(self):
+        # Hardening: the renderer must never emit a Diagnosis section whose only
+        # content is its own headings. An all-empty artifact (the shape a
+        # killed/timed-out agent produces) is a failure to diagnose and must not
+        # be landed into operator-visible state.
         artifact = DiagnosisArtifact(
             issue_number=1,
             observed_symptom="",
@@ -194,11 +219,9 @@ class TestRenderArtifactMarkdown:
             fix_success_criterion="",
             partial=True,
         )
-        md = render_artifact_markdown(artifact)
-        # Empty fields render an explicit placeholder so a partial artifact
-        # is never silently rendered as a confident, blank fix-ready section.
-        assert "_(empty)_" in md
-        assert "_(none recorded)_" in md
+        assert not artifact.has_substantive_content()
+        with pytest.raises(ValueError):
+            render_artifact_markdown(artifact)
 
     def test_notes_section_only_emitted_when_non_empty(self):
         artifact = DiagnosisArtifact(

--- a/tests/test_diagnose_types.py
+++ b/tests/test_diagnose_types.py
@@ -100,6 +100,62 @@ class TestDiagnosisArtifact:
         # signal carried alongside complete YAML to flag budget/timeout exits.
         assert self._make(partial=True).is_complete()
 
+    def test_has_substantive_content_true_when_any_field_filled(self):
+        base = dict(
+            observed_symptom="",
+            reproduction_or_evidence="",
+            hypotheses=(),
+            confirmed_cause="",
+            affected_code_path="",
+            fix_success_criterion="",
+        )
+        for field_name in base:
+            if field_name == "hypotheses":
+                filled = self._make(**{**base, field_name: (Hypothesis("real", "confirmed", ""),)})
+            else:
+                filled = self._make(**{**base, field_name: "content"})
+            assert filled.has_substantive_content(), field_name
+
+    def test_has_substantive_content_false_for_all_empty(self):
+        empty = self._make(
+            observed_symptom="",
+            reproduction_or_evidence="   ",
+            hypotheses=(),
+            confirmed_cause="",
+            affected_code_path="",
+            fix_success_criterion="",
+        )
+        assert not empty.has_substantive_content()
+
+    def test_has_substantive_content_false_for_blank_hypothesis_scaffold(self):
+        # parse_diagnose_output turns `hypotheses: [{}]` into a Hypothesis with
+        # blank statement/evidence and default status. A tuple of such blank
+        # bullets is scaffolding, not investigative content — it must not clear
+        # the content floor even though the hypotheses tuple is non-empty.
+        scaffold = self._make(
+            observed_symptom="",
+            reproduction_or_evidence="",
+            hypotheses=(Hypothesis(statement="", status="inconclusive", evidence=""),),
+            confirmed_cause="",
+            affected_code_path="",
+            fix_success_criterion="",
+        )
+        assert not scaffold.has_substantive_content()
+        with pytest.raises(ValueError):
+            render_artifact_markdown(scaffold)
+
+    def test_has_substantive_content_true_when_hypothesis_has_evidence_only(self):
+        # A hypothesis with a blank statement but real evidence is still content.
+        h_evidence = self._make(
+            observed_symptom="",
+            reproduction_or_evidence="",
+            hypotheses=(Hypothesis(statement="", status="ruled_out", evidence="logs show X"),),
+            confirmed_cause="",
+            affected_code_path="",
+            fix_success_criterion="",
+        )
+        assert h_evidence.has_substantive_content()
+
 
 class TestDiagnoseState:
     def test_default_phase_is_init(self):


### PR DESCRIPTION
## Summary

The prior blank-hypothesis content-floor gap is fixed, and the empty-artifact timeout path now fails before any landing mutation.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.72
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: diagnose timeout lands an all-empty artifact and reports it as a partial diagnosis (GitHub Issue #1595)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1595