### PR TITLE
docs: clear v0.10 doc drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml/badge.svg)](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.9.0-orange)](CHANGELOG.md)
+[![Version](https://img.shields.io/github/v/tag/fuzzypete/theforge?sort=semver&label=version&color=orange)](CHANGELOG.md)
 
 **Deterministic multi-LLM development orchestrator.**
 
@@ -168,7 +168,7 @@ recommended patterns.
 
 ## Minimal config
 
-This is the smallest useful mental model for `forge.yaml` in v0.9:
+This is the smallest useful mental model for `forge.yaml`:
 
 ```yaml
 models:

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -51,7 +51,7 @@ looks like.
 
 ---
 
-## Current State (v0.3)
+## Current State (v0.10)
 
 ```
 INIT → WORKSPACE → PREFLIGHT → PLAN → PLAN_REVIEW → DEV → VALIDATE → REVIEW → DONE/ESCALATE
@@ -438,7 +438,7 @@ only the ideation agents are LLMs.
 3. **Multi-model review:** `forge.yaml` configures Claude + Codex + Gemini
    review pools. Tested with real cross-CLI reviews.
 
-4. **Unit tests:** 980+ tests across 29 test files covering all state
+4. **Unit tests:** 4,300+ tests across 230+ test files covering all state
    transitions, budget enforcement, preflight verdicts, pool degradation,
    synthesis, human review, auto-merge, sprint execution, API agent loops,
    provider adapters, tool runtime, and edge cases. All tests mock


### PR DESCRIPTION
Phase-0 leftover from the restart meta-plan: the doc-drift pass.

- **README version badge → live shields tag-badge** (`github/v/tag?sort=semver`): shows v0.10.0rc19 today, flips to v0.10.0 at promotion automatically — this drift class is now mechanically impossible.
- README: stale "in v0.9" qualifier dropped from the minimal-config intro (example itself verified still-valid against `_parse_models_section`).
- docs/vision.md: `Current State (v0.3)` → `(v0.10)`; test-count claim corrected from "980+ across 29 files" to "4,300+ across 230+ files" (verified: 4,383 passing in the rc19 gate).

Docs-only; claims verified against code per doc-review discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)