### PR TITLE
[P2] issue-1256: ReviewFinding.suggestion is not passed through sanitize

### DIFF
--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -211,6 +211,14 @@ def _extract_review_payload(
             finding_data.get("evidence", ""),
             field_name=f"findings[{index}].evidence",
         )
+        raw_suggestion = finding_data.get("suggestion")
+        if raw_suggestion is None:
+            suggestion, suggestion_audit = None, {}
+        else:
+            suggestion, suggestion_audit = sanitize_llm_text(
+                raw_suggestion,
+                field_name=f"findings[{index}].suggestion",
+            )
         findings.append(
             ReviewFinding(
                 severity=finding_data.get("severity", "P2"),
@@ -219,11 +227,11 @@ def _extract_review_payload(
                 observed=observed,
                 expected=expected,
                 evidence=evidence,
-                suggestion=finding_data.get("suggestion"),
+                suggestion=suggestion,
             )
         )
         sanitization_audit = _merge_sanitization_audits(
-            sanitization_audit, observed_audit, expected_audit, evidence_audit
+            sanitization_audit, observed_audit, expected_audit, evidence_audit, suggestion_audit
         )
     return summary, findings, sanitization_audit
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -260,6 +260,53 @@ class TestParseReviewOutput:
             "findings[0].expected": {"sanitized_chars": 1},
         }
 
+    def test_parse_review_json_sanitizes_suggestion(self):
+        result = parse_review_json(
+            {
+                "verdict": "APPROVE",
+                "summary": "Safe summary",
+                "findings": [
+                    {
+                        "severity": "P2",
+                        "file": "src/batch.py",
+                        "line": 5,
+                        "observed": "finding text",
+                        "expected": "rule prose",
+                        "evidence": "src/batch.py:5",
+                        "suggestion": "Fix\x00 it\x07 like this",
+                    }
+                ],
+                "story_compliance": {"matches_spec": True, "mismatches": []},
+                "test_coverage": {"adequate": True, "gaps": []},
+            }
+        )
+
+        assert result.findings[0].suggestion == "Fix it like this"
+        assert result.sanitization_audit["findings[0].suggestion"] == {"sanitized_chars": 2}
+
+    def test_parse_review_json_suggestion_missing_stays_none(self):
+        result = parse_review_json(
+            {
+                "verdict": "APPROVE",
+                "summary": "Safe summary",
+                "findings": [
+                    {
+                        "severity": "P2",
+                        "file": "src/batch.py",
+                        "line": 5,
+                        "observed": "finding text",
+                        "expected": "rule prose",
+                        "evidence": "src/batch.py:5",
+                    }
+                ],
+                "story_compliance": {"matches_spec": True, "mismatches": []},
+                "test_coverage": {"adequate": True, "gaps": []},
+            }
+        )
+
+        assert result.findings[0].suggestion is None
+        assert "findings[0].suggestion" not in result.sanitization_audit
+
 
 class TestSanitizeYamlText:
     """Unit tests for _sanitize_yaml_text — apostrophe-in-single-quoted-scalar fix."""


### PR DESCRIPTION
## Summary

suggestion field now sanitized via sanitize_llm_text mirroring observed/expected/evidence, None preserved, audit merged, with regression tests for both paths

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.26
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-1256: ReviewFinding.suggestion is not passed through sanitize (GitHub Issue #1266)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1266