### PR TITLE
[P2] issue-1271: Timeline fetch is capped at per_page=100. An issue with

### DIFF
--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -259,9 +259,8 @@ def _fetch_issue_timeline(number: int, project_root: Path | None) -> list[dict]:
             return events if page > 1 else []
         if not isinstance(data, list):
             return events if page > 1 else []
-        page_events = [item for item in data if isinstance(item, dict)]
-        events.extend(page_events)
-        if len(page_events) < _TIMELINE_PER_PAGE:
+        events.extend(item for item in data if isinstance(item, dict))
+        if len(data) < _TIMELINE_PER_PAGE:
             break
     else:
         _log.warning(

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -220,33 +220,58 @@ def _fetch_issue_detail(number: int, project_root: Path | None) -> dict | None:
     }
 
 
+_TIMELINE_PER_PAGE = 100
+_TIMELINE_MAX_PAGES = 20  # safety cap: 2000 events, far beyond any real issue
+
+
 def _fetch_issue_timeline(number: int, project_root: Path | None) -> list[dict]:
-    """Return raw issue timeline events, or an empty list when unavailable."""
-    try:
-        proc = subprocess.run(
-            [
-                "gh",
-                "api",
-                "-H",
-                "Accept: application/vnd.github+json",
-                f"repos/{{owner}}/{{repo}}/issues/{number}/timeline?per_page=100",
-            ],
-            capture_output=True,
-            text=True,
-            cwd=str(project_root) if project_root else None,
-            timeout=30,
+    """Return raw issue timeline events across all pages, or [] when unavailable.
+
+    Reopen-contract analysis depends on the full timeline: an issue with more
+    than one page of events could silently lose its reopen event to
+    truncation, so this follows pagination until a short page (or the empty
+    tail) signals the end rather than stopping at a single fixed page.
+    """
+    events: list[dict] = []
+    for page in range(1, _TIMELINE_MAX_PAGES + 1):
+        try:
+            proc = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    "-H",
+                    "Accept: application/vnd.github+json",
+                    f"repos/{{owner}}/{{repo}}/issues/{number}/timeline"
+                    f"?per_page={_TIMELINE_PER_PAGE}&page={page}",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(project_root) if project_root else None,
+                timeout=30,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return events if page > 1 else []
+        if proc.returncode != 0:
+            return events if page > 1 else []
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return events if page > 1 else []
+        if not isinstance(data, list):
+            return events if page > 1 else []
+        page_events = [item for item in data if isinstance(item, dict)]
+        events.extend(page_events)
+        if len(page_events) < _TIMELINE_PER_PAGE:
+            break
+    else:
+        _log.warning(
+            "issue #%s timeline exceeded %s pages (%s events); "
+            "reopen analysis may be missing later events",
+            number,
+            _TIMELINE_MAX_PAGES,
+            len(events),
         )
-    except (subprocess.TimeoutExpired, OSError):
-        return []
-    if proc.returncode != 0:
-        return []
-    try:
-        data = json.loads(proc.stdout)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(data, list):
-        return []
-    return [item for item in data if isinstance(item, dict)]
+    return events
 
 
 def _fetch_bot_reason_codes(number: int, project_root: Path | None) -> list[str]:

--- a/tests/test_sprint_shape_gate.py
+++ b/tests/test_sprint_shape_gate.py
@@ -664,6 +664,25 @@ def test_fetch_issue_timeline_stops_at_page_boundary_when_last_page_is_full(
     assert len(events) == 200
 
 
+def test_fetch_issue_timeline_full_page_with_non_dict_entry_still_continues(
+    tmp_path: Path,
+) -> None:
+    """A full page containing a stray non-dict item must not be mistaken for
+    a short (final) page — the continuation check is on the raw page length,
+    not the post-filter dict count."""
+    first_page = [{"event": "commented", "id": i} for i in range(99)] + [None]
+    second_page = [{"event": "reopened", "id": 100}]
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(first_page), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(second_page), stderr=""),
+        ]
+        events = _fetch_issue_timeline(42, tmp_path)
+    assert mock_run.call_count == 2
+    assert len(events) == 100
+    assert events[-1] == {"event": "reopened", "id": 100}
+
+
 def test_fetch_issue_timeline_returns_empty_on_first_page_failure(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_sprint_shape_gate.py
+++ b/tests/test_sprint_shape_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -11,6 +12,7 @@ from theforge.sprint.shape_gate import (
     ShapeGateResult,
     SkippedIssue,
     _fetch_bot_reason_codes,
+    _fetch_issue_timeline,
     apply_shape_gate,
     format_skipped_warning,
 )
@@ -613,6 +615,74 @@ def test_fetch_bot_reason_codes_returns_empty_on_gh_failure(tmp_path: Path) -> N
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="fail")
         assert _fetch_bot_reason_codes(42, tmp_path) == []
+
+
+# ── Timeline pagination (#1271) ────────────────────────────────────────────
+
+
+def test_fetch_issue_timeline_single_short_page_stops_after_one_call(
+    tmp_path: Path,
+) -> None:
+    page = [{"event": "labeled"}, {"event": "closed"}]
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(page), stderr="")
+        events = _fetch_issue_timeline(42, tmp_path)
+    assert events == page
+    assert mock_run.call_count == 1
+
+
+def test_fetch_issue_timeline_follows_pagination_beyond_first_page(
+    tmp_path: Path,
+) -> None:
+    first_page = [{"event": "commented", "id": i} for i in range(100)]
+    second_page = [{"event": "reopened", "id": 100}]
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(first_page), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(second_page), stderr=""),
+        ]
+        events = _fetch_issue_timeline(42, tmp_path)
+    assert mock_run.call_count == 2
+    assert len(events) == 101
+    assert events[-1] == {"event": "reopened", "id": 100}
+
+
+def test_fetch_issue_timeline_stops_at_page_boundary_when_last_page_is_full(
+    tmp_path: Path,
+) -> None:
+    first_page = [{"event": "commented", "id": i} for i in range(100)]
+    second_page = [{"event": "reopened", "id": i} for i in range(100, 200)]
+    third_page: list[dict] = []
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(first_page), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(second_page), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(third_page), stderr=""),
+        ]
+        events = _fetch_issue_timeline(42, tmp_path)
+    assert mock_run.call_count == 3
+    assert len(events) == 200
+
+
+def test_fetch_issue_timeline_returns_empty_on_first_page_failure(
+    tmp_path: Path,
+) -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="fail")
+        assert _fetch_issue_timeline(42, tmp_path) == []
+
+
+def test_fetch_issue_timeline_returns_partial_data_on_later_page_failure(
+    tmp_path: Path,
+) -> None:
+    first_page = [{"event": "commented", "id": i} for i in range(100)]
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(first_page), stderr=""),
+            MagicMock(returncode=1, stdout="", stderr="fail"),
+        ]
+        events = _fetch_issue_timeline(42, tmp_path)
+    assert len(events) == 100
 
 
 # ── Sanity: result dataclass ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Cycle-2 fix correctly bases page-end check on raw len(data), resolving the prior P2; new regression test covers the non-dict-entry edge case; no regressions introduced.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.28
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-1271: Timeline fetch is capped at per_page=100. An issue with (GitHub Issue #1281)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1281