### PR TITLE
bug: explicit --run combined with --watch enters sprint render path for non-sprint runs

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -453,11 +453,14 @@ def cmd_status(args: object) -> int:
     if watch_interval is not None:
         from theforge.cli import status_watch
 
-        watch_run_ids = (
-            [explicit_run_id]
-            if explicit_run_id is not None
-            else _resolve_watch_run_ids(active_run_ids, project_root)
-        )
+        if explicit_run_id is not None:
+            watch_run_ids = (
+                [explicit_run_id]
+                if _await_watchable_sprint_run(explicit_run_id, project_root)
+                else []
+            )
+        else:
+            watch_run_ids = _resolve_watch_run_ids(active_run_ids, project_root)
         if status_watch.is_tty() and watch_run_ids:
             color = status_watch.color_enabled(no_color)
             return status_watch.run_watch_loop(

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -266,6 +266,9 @@ class TestCmdStatusRouting:
             patch("theforge.detach.read_run_status", return_value=mock_status),
             patch("theforge.pending.cleanup_stale"),
             patch("theforge.pending.list_pending", return_value=[]),
+            # Force the TTY branch: the defect only manifests when is_tty() is
+            # True, so the test must reach that guard to catch a regression.
+            patch("theforge.cli.status_watch.is_tty", return_value=True),
             patch("theforge.cli.status_watch.run_watch_loop") as mock_run_watch_loop,
         ):
             result = cmd_status(args)

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -232,6 +232,49 @@ class TestCmdStatusRouting:
 
         assert result == 1
 
+    def test_explicit_run_id_with_watch_falls_back_for_non_sprint_run(
+        self, tmp_path: Path, capsys: object
+    ) -> None:
+        """forge status <run-id> --watch on a non-sprint run must not enter the
+        sprint render path; it should fall back to a single snapshot."""
+        from theforge.cli import cmd_status
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(
+            run_id="explicit-run",
+            recent=False,
+            last=False,
+            watch=2,
+            no_color=False,
+        )
+
+        mock_status = {
+            "phase": "DEV",
+            "cost_usd": 0.10,
+            "elapsed_seconds": 30,
+            "log_path": None,
+        }
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+            patch("theforge.cli.status._resolve_run_id", return_value=True),
+            patch("theforge.cli.status._is_sprint_run", return_value=False),
+            patch("theforge.cli.status._await_watchable_sprint_run", return_value=False),
+            patch("theforge.detach.read_run_status", return_value=mock_status),
+            patch("theforge.pending.cleanup_stale"),
+            patch("theforge.pending.list_pending", return_value=[]),
+            patch("theforge.cli.status_watch.run_watch_loop") as mock_run_watch_loop,
+        ):
+            result = cmd_status(args)
+
+        assert result == 0
+        mock_run_watch_loop.assert_not_called()
+        captured = capsys.readouterr()
+        assert "explicit-run" in captured.out
+
     def test_last_flag_shows_most_recent_completed(self, tmp_path: Path, capsys: object) -> None:
         """forge status --last shows the most recent completed run."""
         from theforge.cli import cmd_status


### PR DESCRIPTION
## Summary

Prior P1 resolved: regression test now forces is_tty()=True, verified to fail on pre-fix source and pass on fixed source; production fix correct.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $3.41
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: explicit --run combined with --watch enters sprint render path for non-sprint runs (GitHub Issue #1258)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1258