### PR TITLE
bug: cross-module surgery heuristic uses TheForge architecture names that trigger on unrelated project stories

### DIFF
--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -148,15 +148,13 @@ _PHASE_TRANSITION_TERMS = (
     "state machine",
 )
 
-_COORDINATOR_COMPONENT_TERMS = (
-    "runner",
-    "engine",
-    "coordinator",
-    "coordinator loop",
-    "phase",
-    "phases",
-)
-
+# NOTE: This heuristic must stay stack-neutral. The orchestrator sizes stories
+# for *arbitrary* managed codebases, so classification signals may not embed
+# TheForge's own architecture vocabulary ("runner", "engine", "coordinator",
+# "phase"). Those words are common in unrelated build/CI/pipeline prose, so
+# using them as triggers mis-sizes stories for every other project. Cross-module
+# surgery is detected from stack-neutral signals (_CROSS_MODULE_TERMS +
+# _COORDINATION_CHANGE_TERMS) instead. See issue #1139.
 _COORDINATION_CHANGE_TERMS = (
     "modify",
     "modifies",
@@ -259,9 +257,8 @@ def _detect_large_preflight_story_categories(story_content: str) -> list[str]:
     ):
         matched.append("concurrency control")
 
-    if _contains_any_phrase(normalized, _CANCELLATION_TERMS) and (
-        _contains_any_phrase(normalized, _CROSS_BOUNDARY_TERMS)
-        or _count_phrase_hits(normalized, _COORDINATOR_COMPONENT_TERMS) >= 2
+    if _contains_any_phrase(normalized, _CANCELLATION_TERMS) and _contains_any_phrase(
+        normalized, _CROSS_BOUNDARY_TERMS
     ):
         matched.append("lifecycle/cancellation propagation across module boundaries")
 
@@ -270,9 +267,8 @@ def _detect_large_preflight_story_categories(story_content: str) -> list[str]:
     ):
         matched.append("multi-phase state-machine modifications")
 
-    if _count_phrase_hits(normalized, _COORDINATOR_COMPONENT_TERMS) >= 2 and (
-        _contains_any_phrase(normalized, _CROSS_MODULE_TERMS)
-        or _contains_any_phrase(normalized, _COORDINATION_CHANGE_TERMS)
+    if _contains_any_phrase(normalized, _CROSS_MODULE_TERMS) and _contains_any_phrase(
+        normalized, _COORDINATION_CHANGE_TERMS
     ):
         matched.append("cross-module coordinator surgery")
 

--- a/tests/test_preflight_complexity_score.py
+++ b/tests/test_preflight_complexity_score.py
@@ -248,6 +248,50 @@ def test_qualified_concurrency_stories_still_trigger_category(story_text: str):
     assert "concurrency control" in _detect_large_preflight_story_categories(story_text)
 
 
+@pytest.mark.parametrize(
+    "story_text",
+    [
+        # A non-TheForge CI/build story mentioning two host-architecture words
+        # ("runner", "phase") plus a coordination-change verb ("update"). These
+        # are ordinary words in build/pipeline prose, not cross-module surgery.
+        "Update the CI runner image and add a lint phase to the build pipeline.",
+        # "engine" + "phase" + "change" — a game/render project, not TheForge.
+        "Change the physics engine tick and add a warmup phase to the render loop.",
+        # "coordinator" + "runner" + "modify" for an unrelated events project.
+        "Modify the event coordinator so the background runner picks up new jobs.",
+    ],
+)
+def test_host_architecture_words_do_not_trigger_cross_module_surgery(story_text: str):
+    """Bare TheForge architecture vocabulary (runner/engine/coordinator/phase)
+    paired with a coordination-change verb must NOT upgrade an unrelated
+    project's story to the LARGE 'cross-module coordinator surgery' category.
+    The heuristic is stack-neutral and may not embed the host project's own
+    architecture names as signals. See issue #1139."""
+    assert "cross-module coordinator surgery" not in _detect_large_preflight_story_categories(
+        story_text
+    )
+
+
+@pytest.mark.parametrize(
+    "story_text",
+    [
+        # Genuine cross-cutting change signalled by stack-neutral vocabulary,
+        # with no reliance on TheForge architecture names.
+        "Change the serialization format across module boundaries so every"
+        " reader and writer stays compatible.",
+        "Update the retry policy in multi-module fashion because correctness"
+        " depends on all sites changing in lockstep.",
+    ],
+)
+def test_genuine_cross_module_surgery_still_triggers(story_text: str):
+    """Stack-neutral cross-module signal (cross/multi-module, 'all sites',
+    'correctness depends') plus a coordination-change verb must still classify
+    as 'cross-module coordinator surgery' without any host-vocabulary hits."""
+    assert "cross-module coordinator surgery" in _detect_large_preflight_story_categories(
+        story_text
+    )
+
+
 # ── consumer: dev-tier routing diverges from enum-only routing ────────
 
 


### PR DESCRIPTION
## Summary

The cross-module surgery heuristic no longer uses TheForge architecture words as trigger terms, and the regression tests cover the reported false-positive shape.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.41
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: cross-module surgery heuristic uses TheForge architecture names that trigger on unrelated project stories (GitHub Issue #1139)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1139