### PR TITLE
bug: stuck-detector evidence() uses hardcoded threshold instead of configured profile values

### DIFF
--- a/src/theforge/runners/stuck_detection.py
+++ b/src/theforge/runners/stuck_detection.py
@@ -350,12 +350,13 @@ class StuckTracker:
         """
         loop_start: int | None = None
         active_kind: str | None = None
-        if self._repeat_count >= 2:
-            loop_start = self._repeat_start_iter
-            active_kind = PATTERN_REPEAT
-        elif self._error_count >= 2:
-            loop_start = self._error_start_iter
-            active_kind = PATTERN_ERROR_LOOP
+        if self._cfg is not None:
+            if self._repeat_count >= self._cfg.repeat_threshold:
+                loop_start = self._repeat_start_iter
+                active_kind = PATTERN_REPEAT
+            elif self._error_count >= self._cfg.error_threshold:
+                loop_start = self._error_start_iter
+                active_kind = PATTERN_ERROR_LOOP
         return {
             "iterations_observed": self._iteration,
             "iters_without_modification": self._iters_without_mod,

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -577,6 +577,72 @@ class TestAuditObservability:
         assert ev["history"][0]["calls"]
         assert "redacted" in ev["history"][0]["calls"][0]
 
+    def test_evidence_active_kind_matches_configured_repeat_threshold(self):
+        from theforge.runners.stuck_detection import (
+            PATTERN_REPEAT,
+            StuckTracker,
+            build_observation,
+        )
+
+        class _Call:
+            def __init__(self, name, arguments):
+                self.name = name
+                self.arguments = arguments
+
+        cfg = StuckDetectionConfig(
+            enabled=True,
+            repeat_threshold=5,
+            no_progress_iterations=99,
+            error_threshold=99,
+            post_nudge_iterations=99,
+        )
+        profile = _dev_profile(stuck=cfg)
+        tracker = StuckTracker(profile)
+
+        # Two identical calls: below the configured threshold of 5, so
+        # evidence() must not report an active pattern yet.
+        for _ in range(2):
+            obs = build_observation(
+                calls=[_Call("Read", {"path": "x.py"})],
+                results=[{"id": "c1", "name": "Read", "content": "ok"}],
+            )
+            tracker.observe(obs)
+        ev = tracker.evidence()
+        assert ev["repeat_count"] == 2
+        assert ev["active_kind"] is None
+        assert ev["loop_start_iteration"] is None
+
+        # Reaching the configured threshold flips evidence() active.
+        for _ in range(3):
+            obs = build_observation(
+                calls=[_Call("Read", {"path": "x.py"})],
+                results=[{"id": "c1", "name": "Read", "content": "ok"}],
+            )
+            tracker.observe(obs)
+        ev = tracker.evidence()
+        assert ev["repeat_count"] == 5
+        assert ev["active_kind"] == PATTERN_REPEAT
+
+    def test_evidence_handles_missing_cfg(self):
+        from theforge.runners.stuck_detection import StuckTracker, build_observation
+
+        class _Call:
+            def __init__(self, name, arguments):
+                self.name = name
+                self.arguments = arguments
+
+        profile = _dev_profile(stuck=None)
+        tracker = StuckTracker(profile)
+        for _ in range(5):
+            obs = build_observation(
+                calls=[_Call("Read", {"path": "x.py"})],
+                results=[{"id": "c1", "name": "Read", "content": "ok"}],
+            )
+            tracker.observe(obs)
+        ev = tracker.evidence()
+        assert ev["active_kind"] is None
+        assert ev["loop_start_iteration"] is None
+
 
 class TestExplorationTelemetry:
     """Distinct file reads / searches across iterations are recorded as exploration."""


### PR DESCRIPTION
## Summary

evidence() now mirrors _active_pattern()'s cfg-None guard and configured thresholds; regression tests cover both the sub-threshold and missing-cfg cases.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $0.63
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: stuck-detector evidence() uses hardcoded threshold instead of configured profile values (GitHub Issue #1243)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1243