### PR TITLE
bug: Codex CLI transport hardcodes cost_usd=None so every dev run records $0.00 spend

### DIFF
--- a/src/theforge/cli/profiles.py
+++ b/src/theforge/cli/profiles.py
@@ -261,25 +261,32 @@ def _scope_label(canonical_id: str, role: str | None, complexity: str | None) ->
     return " ".join(parts)
 
 
+def _unmeasured_suffix(summary: dict[str, Any]) -> str:
+    """`` (N cost-unmeasured)`` note so operators can tell free from unmeasured."""
+    unknown = int(summary.get("cost_unknown_runs", 0))
+    return f" ({unknown} cost-unmeasured)" if unknown > 0 else ""
+
+
 def _format_summary(summary: dict[str, Any]) -> str:
     role = summary["role"]
     complexity = summary.get("complexity")
     prefix = role if complexity is None else f"{role}/{complexity}"
+    suffix = _unmeasured_suffix(summary)
     if role == "dev":
         return (
             f"{prefix}: {summary.get('runs', 0)} runs, {summary.get('successes', 0)} successes, "
-            f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost, "
+            f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost{suffix}, "
             f"{float(summary.get('avg_iterations', 0.0)):.1f} avg iterations"
         )
     if role == "review":
         return (
             f"{prefix}: {summary.get('runs', 0)} runs, "
             f"{float(summary.get('avg_findings', 0.0)):.1f} avg findings, "
-            f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost"
+            f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost{suffix}"
         )
     return (
         f"{prefix}: {summary.get('runs', 0)} runs, "
-        f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost"
+        f"${float(summary.get('avg_cost_usd', 0.0)):.2f} avg cost{suffix}"
     )
 
 

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -58,7 +58,9 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         dev_cli=getattr(config.dev_profile, "cli", None),
         dev_success=bool(success),
         dev_iterations=dev_iterations,
-        dev_cost_usd=float(state.total_dev_cost or 0.0),
+        # Pass the cost-unknown signal through (None) instead of coercing to
+        # $0.00, so unmeasured CLI-transport runs are recorded as unmeasured.
+        dev_cost_usd=state.total_dev_cost_measured,
         preflight_model=config.preflight_profile.name
         if getattr(config, "preflight_profile", None)
         else None,
@@ -71,7 +73,7 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         preflight_cli=getattr(config.preflight_profile, "cli", None)
         if getattr(config, "preflight_profile", None)
         else None,
-        preflight_cost_usd=float(state.total_preflight_cost or 0.0),
+        preflight_cost_usd=state.total_preflight_cost_measured,
         reviewers=_extract_reviewers(state),
     )
 

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -516,6 +516,21 @@ class CoordinatorState:
         return sum(r.cost_usd or 0.0 for r in self.dev_results)
 
     @property
+    def total_dev_cost_measured(self) -> float | None:
+        """Dev cost, or ``None`` when any dev attempt's cost was unmeasured.
+
+        Unlike :attr:`total_dev_cost` (which coerces an unmeasured ``None`` to
+        ``$0.00``), this preserves the cost-unknown signal so the ledger never
+        silently records unmeasured spend as free. If *any* contributing dev
+        result reports ``cost_usd is None``, the whole aggregate is unknown —
+        collapsing a mix to a measured subtotal would hide the unmeasured
+        attempt. Empty ``dev_results`` means no spend, so ``0.0``.
+        """
+        if any(r.cost_usd is None for r in self.dev_results):
+            return None
+        return sum(r.cost_usd or 0.0 for r in self.dev_results)
+
+    @property
     def total_review_cost(self) -> float:
         return sum(r.cost_usd or 0.0 for r in self.review_agent_results)
 
@@ -527,6 +542,26 @@ class CoordinatorState:
         if isinstance(attempts, list):
             return sum(float(a.get("cost_usd") or 0.0) for a in attempts if isinstance(a, dict))
         return self.preflight_result.cost_usd or 0.0
+
+    @property
+    def total_preflight_cost_measured(self) -> float | None:
+        """Preflight cost, or ``None`` when a preflight attempt's cost was unmeasured.
+
+        Mirrors :attr:`total_dev_cost_measured`: preflight can run over a CLI
+        transport (e.g. codex) that reports no cost, and coercing that to
+        ``$0.00`` would hide the spend. No preflight result means preflight did
+        not run, so ``0.0`` (genuinely no spend). A result whose cost is ``None``
+        — or whose attempts include an unmeasured one — is cost-unknown.
+        """
+        if self.preflight_result is None:
+            return 0.0
+        attempts = self.preflight_result.raw.get("attempts")
+        if isinstance(attempts, list):
+            costs = [a.get("cost_usd") for a in attempts if isinstance(a, dict)]
+            if any(c is None for c in costs):
+                return None
+            return sum(float(c or 0.0) for c in costs)
+        return self.preflight_result.cost_usd
 
     @property
     def total_plan_cost(self) -> float:

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -22,8 +22,15 @@ Schema on disk::
           runs, avg_cost_usd
 
 Underscore-prefixed siblings (``_successes``, ``_iterations_sum``, ``_cost_sum``,
-``_findings_sum``) are the running accumulators used to update the derived
-fields in place. They are part of the persisted schema.
+``_findings_sum``, ``_cost_unknown_runs``) are the running accumulators used to
+update the derived fields in place. They are part of the persisted schema.
+
+``_cost_unknown_runs`` counts runs whose transport could not measure cost (a
+``None`` cost signal, e.g. a CLI runner that emits no token usage). Those runs
+are *not* folded into ``_cost_sum`` and ``avg_cost_usd`` is averaged over
+measured runs only (``runs - _cost_unknown_runs``). This keeps a genuinely free
+($0.00 measured) run distinct from an unmeasured one so spend never silently
+disappears from the ledger.
 """
 
 from __future__ import annotations
@@ -62,7 +69,7 @@ class RunOutcome:
     dev_model: str
     dev_success: bool
     dev_iterations: int
-    dev_cost_usd: float
+    dev_cost_usd: float | None  # None = the transport could not measure cost
     complexity_score: int | None = None
     preflight_model: str | None = None
     dev_actual_model: str | None = None
@@ -71,7 +78,7 @@ class RunOutcome:
     preflight_actual_model: str | None = None
     preflight_provider: str | None = None
     preflight_cli: str | None = None
-    preflight_cost_usd: float = 0.0
+    preflight_cost_usd: float | None = None  # None = cost unmeasured
     reviewers: dict[str, tuple[int, int, float]] = field(default_factory=dict)
 
 
@@ -222,40 +229,70 @@ def _ensure_model(
     return entry
 
 
+def _entry_model_label(entry: dict) -> str:
+    ident = entry.get("_identity")
+    if isinstance(ident, dict):
+        return str(ident.get("model") or "?")
+    return "?"
+
+
+def _fold_cost(bucket: dict, cost_usd: float | None, *, unknown_count: int = 1) -> None:
+    """Fold one run's cost into ``bucket``; needs ``bucket['runs']`` already set.
+
+    ``cost_usd is None`` means the transport could not measure cost: the run is
+    tallied in ``_cost_unknown_runs`` (never added to ``_cost_sum``) and
+    ``avg_cost_usd`` is averaged over MEASURED runs only. ``unknown_count`` lets
+    the review path attribute more than one unmeasured run in a single call.
+    """
+    cost_sum = float(bucket.get("_cost_sum", 0.0))
+    unknown = int(bucket.get("_cost_unknown_runs", 0))
+    if cost_usd is None:
+        unknown += unknown_count
+    else:
+        cost_sum += float(cost_usd)
+    bucket["_cost_sum"] = cost_sum
+    bucket["_cost_unknown_runs"] = unknown
+    measured = int(bucket.get("runs", 0)) - unknown
+    bucket["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
+
+
 def _update_dev(
     entry: dict,
     complexity: str,
     success: bool,
     iterations: int,
-    cost_usd: float,
+    cost_usd: float | None,
     complexity_score: int | None = None,
 ) -> None:
+    if cost_usd is None:
+        log.warning(
+            "[model_profiles] Dev run recorded cost-unmeasured (NOT $0.00): "
+            "model=%s complexity=%s — transport reported no cost.",
+            _entry_model_label(entry),
+            complexity,
+        )
     dev = entry.setdefault("dev", {})
     runs = int(dev.get("runs", 0)) + 1
     successes = int(dev.get("_successes", 0)) + (1 if success else 0)
     iter_sum = float(dev.get("_iterations_sum", 0.0)) + float(iterations)
-    cost_sum = float(dev.get("_cost_sum", 0.0)) + float(cost_usd)
     dev["runs"] = runs
     dev["_successes"] = successes
     dev["_iterations_sum"] = iter_sum
-    dev["_cost_sum"] = cost_sum
     dev["success_rate"] = round(successes / runs, 4)
     dev["avg_iterations"] = round(iter_sum / runs, 4)
-    dev["avg_cost_usd"] = round(cost_sum / runs, 6)
+    _fold_cost(dev, cost_usd)
 
     by = dev.setdefault("by_complexity", {})
     bc = by.setdefault(complexity, {})
     bc_runs = int(bc.get("runs", 0)) + 1
     bc_successes = int(bc.get("_successes", 0)) + (1 if success else 0)
     bc_iter_sum = float(bc.get("_iterations_sum", 0.0)) + float(iterations)
-    bc_cost_sum = float(bc.get("_cost_sum", 0.0)) + float(cost_usd)
     bc["runs"] = bc_runs
     bc["_successes"] = bc_successes
     bc["_iterations_sum"] = bc_iter_sum
-    bc["_cost_sum"] = bc_cost_sum
     bc["success_rate"] = round(bc_successes / bc_runs, 4)
     bc["avg_iterations"] = round(bc_iter_sum / bc_runs, 4)
-    bc["avg_cost_usd"] = round(bc_cost_sum / bc_runs, 6)
+    _fold_cost(bc, cost_usd)
 
     if complexity_score is not None:
         score_key = str(int(complexity_score))
@@ -264,37 +301,44 @@ def _update_dev(
         sc_runs = int(sc.get("runs", 0)) + 1
         sc_successes = int(sc.get("_successes", 0)) + (1 if success else 0)
         sc_iter_sum = float(sc.get("_iterations_sum", 0.0)) + float(iterations)
-        sc_cost_sum = float(sc.get("_cost_sum", 0.0)) + float(cost_usd)
         sc["runs"] = sc_runs
         sc["_successes"] = sc_successes
         sc["_iterations_sum"] = sc_iter_sum
-        sc["_cost_sum"] = sc_cost_sum
         sc["success_rate"] = round(sc_successes / sc_runs, 4)
         sc["avg_iterations"] = round(sc_iter_sum / sc_runs, 4)
-        sc["avg_cost_usd"] = round(sc_cost_sum / sc_runs, 6)
+        _fold_cost(sc, cost_usd)
 
 
-def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float) -> None:
+def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float | None) -> None:
     if cycles <= 0:
         return
+    if cost_usd is None:
+        log.warning(
+            "[model_profiles] Review run recorded cost-unmeasured (NOT $0.00): "
+            "model=%s cycles=%d — transport reported no cost.",
+            _entry_model_label(entry),
+            cycles,
+        )
     rev = entry.setdefault("review", {})
     runs = int(rev.get("runs", 0)) + cycles
     find_sum = float(rev.get("_findings_sum", 0.0)) + float(findings)
-    cost_sum = float(rev.get("_cost_sum", 0.0)) + float(cost_usd)
     rev["runs"] = runs
     rev["_findings_sum"] = find_sum
-    rev["_cost_sum"] = cost_sum
     rev["avg_findings"] = round(find_sum / runs, 4)
-    rev["avg_cost_usd"] = round(cost_sum / runs, 6)
+    _fold_cost(rev, cost_usd, unknown_count=cycles)
 
 
-def _update_preflight(entry: dict, cost_usd: float) -> None:
+def _update_preflight(entry: dict, cost_usd: float | None) -> None:
+    if cost_usd is None:
+        log.warning(
+            "[model_profiles] Preflight run recorded cost-unmeasured (NOT $0.00): "
+            "model=%s — transport reported no cost.",
+            _entry_model_label(entry),
+        )
     pf = entry.setdefault("preflight", {})
     runs = int(pf.get("runs", 0)) + 1
-    cost_sum = float(pf.get("_cost_sum", 0.0)) + float(cost_usd)
     pf["runs"] = runs
-    pf["_cost_sum"] = cost_sum
-    pf["avg_cost_usd"] = round(cost_sum / runs, 6)
+    _fold_cost(pf, cost_usd)
 
 
 def _zero_dev_bucket(bucket: dict) -> None:
@@ -302,6 +346,7 @@ def _zero_dev_bucket(bucket: dict) -> None:
     bucket["_successes"] = 0
     bucket["_iterations_sum"] = 0.0
     bucket["_cost_sum"] = 0.0
+    bucket["_cost_unknown_runs"] = 0
     bucket["success_rate"] = 0.0
     bucket["avg_iterations"] = 0.0
     bucket["avg_cost_usd"] = 0.0
@@ -311,6 +356,7 @@ def _zero_review_section(section: dict) -> None:
     section["runs"] = 0
     section["_findings_sum"] = 0.0
     section["_cost_sum"] = 0.0
+    section["_cost_unknown_runs"] = 0
     section["avg_findings"] = 0.0
     section["avg_cost_usd"] = 0.0
 
@@ -318,6 +364,7 @@ def _zero_review_section(section: dict) -> None:
 def _zero_preflight_section(section: dict) -> None:
     section["runs"] = 0
     section["_cost_sum"] = 0.0
+    section["_cost_unknown_runs"] = 0
     section["avg_cost_usd"] = 0.0
 
 
@@ -327,19 +374,23 @@ def _recompute_dev_section(section: dict) -> None:
     successes = 0
     iterations = 0.0
     cost = 0.0
+    cost_unknown = 0
     for band in COMPLEXITY_BANDS:
         bucket = by.setdefault(band, {})
         runs += int(bucket.get("runs", 0))
         successes += int(bucket.get("_successes", 0))
         iterations += float(bucket.get("_iterations_sum", 0.0))
         cost += float(bucket.get("_cost_sum", 0.0))
+        cost_unknown += int(bucket.get("_cost_unknown_runs", 0))
     section["runs"] = runs
     section["_successes"] = successes
     section["_iterations_sum"] = iterations
     section["_cost_sum"] = cost
+    section["_cost_unknown_runs"] = cost_unknown
     section["success_rate"] = round(successes / runs, 4) if runs > 0 else 0.0
     section["avg_iterations"] = round(iterations / runs, 4) if runs > 0 else 0.0
-    section["avg_cost_usd"] = round(cost / runs, 6) if runs > 0 else 0.0
+    measured = runs - cost_unknown
+    section["avg_cost_usd"] = round(cost / measured, 6) if measured > 0 else 0.0
 
 
 def apply_run(data: dict, outcome: RunOutcome) -> dict:
@@ -507,6 +558,7 @@ def get_dev_complexity_stats(
         return None
     band = _normalize_band(complexity)
     runs = 0
+    measured_runs = 0
     iterations_sum = 0.0
     cost_sum = 0.0
     for _, entry in matching:
@@ -524,6 +576,9 @@ def get_dev_complexity_stats(
         if entry_iterations is None or entry_cost is None:
             return None
         runs += entry_runs
+        # Cost is a MEASURED-run average: divide by (runs - unmeasured), never by
+        # total runs, so unmeasured runs don't dilute the average toward zero.
+        measured_runs += entry_runs - int(bc.get("_cost_unknown_runs", 0))
         iterations_sum += entry_iterations
         cost_sum += entry_cost
     if runs < min_runs or runs <= 0:
@@ -531,7 +586,7 @@ def get_dev_complexity_stats(
     return {
         "runs": float(runs),
         "avg_iterations": round(iterations_sum / runs, 4),
-        "avg_cost_usd": round(cost_sum / runs, 6),
+        "avg_cost_usd": round(cost_sum / measured_runs, 6) if measured_runs > 0 else 0.0,
     }
 
 
@@ -627,6 +682,7 @@ def summarize_profile_scope(
                         "successes": 0,
                         "avg_iterations": 0.0,
                         "avg_cost_usd": 0.0,
+                        "cost_unknown_runs": 0,
                     }
                 )
             continue
@@ -644,6 +700,7 @@ def summarize_profile_scope(
                         "successes": int(bucket.get("_successes", 0)),
                         "avg_iterations": float(bucket.get("avg_iterations", 0.0)),
                         "avg_cost_usd": float(bucket.get("avg_cost_usd", 0.0)),
+                        "cost_unknown_runs": int(bucket.get("_cost_unknown_runs", 0)),
                     }
                 )
                 continue
@@ -655,6 +712,7 @@ def summarize_profile_scope(
                     "successes": int(section.get("_successes", 0)),
                     "avg_iterations": float(section.get("avg_iterations", 0.0)),
                     "avg_cost_usd": float(section.get("avg_cost_usd", 0.0)),
+                    "cost_unknown_runs": int(section.get("_cost_unknown_runs", 0)),
                     "by_complexity": deepcopy(section.get("by_complexity") or {}),
                 }
             )
@@ -665,6 +723,7 @@ def summarize_profile_scope(
             "complexity": None,
             "runs": int(section.get("runs", 0)),
             "avg_cost_usd": float(section.get("avg_cost_usd", 0.0)),
+            "cost_unknown_runs": int(section.get("_cost_unknown_runs", 0)),
         }
         if current_role == "review":
             summary["avg_findings"] = float(section.get("avg_findings", 0.0))
@@ -976,14 +1035,17 @@ def _merge_dev(target: dict, src: dict) -> None:
             src.get("runs", 0)
         )
 
+    cost_unknown = int(target.get("_cost_unknown_runs", 0)) + int(src.get("_cost_unknown_runs", 0))
     target["runs"] = runs
     target["_successes"] = successes
     target["_iterations_sum"] = iter_sum
     target["_cost_sum"] = cost_sum
+    target["_cost_unknown_runs"] = cost_unknown
     if runs > 0:
         target["success_rate"] = round(successes / runs, 4)
         target["avg_iterations"] = round(iter_sum / runs, 4)
-        target["avg_cost_usd"] = round(cost_sum / runs, 6)
+        measured = runs - cost_unknown
+        target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
 
     src_by = src.get("by_complexity") or {}
     if src_by:
@@ -1011,14 +1073,21 @@ def _merge_dev(target: dict, src: dict) -> None:
                     float(bc_src.get("avg_cost_usd", 0.0)) * int(bc_src.get("runs", 0)),
                 )
             )
+            bc_unknown = int(bc_target.get("_cost_unknown_runs", 0)) + int(
+                bc_src.get("_cost_unknown_runs", 0)
+            )
             bc_target["runs"] = bc_runs
             bc_target["_successes"] = bc_succ
             bc_target["_iterations_sum"] = bc_iter
             bc_target["_cost_sum"] = bc_cost
+            bc_target["_cost_unknown_runs"] = bc_unknown
             if bc_runs > 0:
                 bc_target["success_rate"] = round(bc_succ / bc_runs, 4)
                 bc_target["avg_iterations"] = round(bc_iter / bc_runs, 4)
-                bc_target["avg_cost_usd"] = round(bc_cost / bc_runs, 6)
+                bc_measured = bc_runs - bc_unknown
+                bc_target["avg_cost_usd"] = (
+                    round(bc_cost / bc_measured, 6) if bc_measured > 0 else 0.0
+                )
 
     src_by_score = src.get("by_complexity_score") or {}
     if src_by_score:
@@ -1046,14 +1115,21 @@ def _merge_dev(target: dict, src: dict) -> None:
                     float(sc_src.get("avg_cost_usd", 0.0)) * int(sc_src.get("runs", 0)),
                 )
             )
+            sc_unknown = int(sc_target.get("_cost_unknown_runs", 0)) + int(
+                sc_src.get("_cost_unknown_runs", 0)
+            )
             sc_target["runs"] = sc_runs
             sc_target["_successes"] = sc_succ
             sc_target["_iterations_sum"] = sc_iter
             sc_target["_cost_sum"] = sc_cost
+            sc_target["_cost_unknown_runs"] = sc_unknown
             if sc_runs > 0:
                 sc_target["success_rate"] = round(sc_succ / sc_runs, 4)
                 sc_target["avg_iterations"] = round(sc_iter / sc_runs, 4)
-                sc_target["avg_cost_usd"] = round(sc_cost / sc_runs, 6)
+                sc_measured = sc_runs - sc_unknown
+                sc_target["avg_cost_usd"] = (
+                    round(sc_cost / sc_measured, 6) if sc_measured > 0 else 0.0
+                )
 
 
 def _merge_review(target: dict, src: dict) -> None:
@@ -1064,12 +1140,15 @@ def _merge_review(target: dict, src: dict) -> None:
     cost_sum = float(target.get("_cost_sum", 0.0)) + float(
         src.get("_cost_sum", float(src.get("avg_cost_usd", 0.0)) * int(src.get("runs", 0)))
     )
+    cost_unknown = int(target.get("_cost_unknown_runs", 0)) + int(src.get("_cost_unknown_runs", 0))
     target["runs"] = runs
     target["_findings_sum"] = find_sum
     target["_cost_sum"] = cost_sum
+    target["_cost_unknown_runs"] = cost_unknown
     if runs > 0:
         target["avg_findings"] = round(find_sum / runs, 4)
-        target["avg_cost_usd"] = round(cost_sum / runs, 6)
+        measured = runs - cost_unknown
+        target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
 
 
 def _merge_preflight(target: dict, src: dict) -> None:
@@ -1077,10 +1156,13 @@ def _merge_preflight(target: dict, src: dict) -> None:
     cost_sum = float(target.get("_cost_sum", 0.0)) + float(
         src.get("_cost_sum", float(src.get("avg_cost_usd", 0.0)) * int(src.get("runs", 0)))
     )
+    cost_unknown = int(target.get("_cost_unknown_runs", 0)) + int(src.get("_cost_unknown_runs", 0))
     target["runs"] = runs
     target["_cost_sum"] = cost_sum
+    target["_cost_unknown_runs"] = cost_unknown
     if runs > 0:
-        target["avg_cost_usd"] = round(cost_sum / runs, 6)
+        measured = runs - cost_unknown
+        target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
 
 
 def _merge_entry(target: dict, src: dict) -> None:

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -1031,10 +1031,20 @@ def _merge_dev(target: dict, src: dict) -> None:
             src.get("avg_iterations", 0.0)
         ) * int(src.get("runs", 0))
     if "_cost_sum" not in src and "runs" in src:
+        # Legacy reconstruction: this ``avg_cost_usd * runs`` fallback assumes
+        # ``avg_cost_usd`` was computed over TOTAL runs. Since #1616 the average
+        # is over MEASURED runs only (``runs - _cost_unknown_runs``), so this
+        # reconstruction is only exact when ``_cost_unknown_runs == 0`` — i.e.
+        # for pre-#1616 profiles, which never recorded unmeasured runs. Do not
+        # rely on it when an old entry both omits ``_cost_sum`` and carries
+        # unmeasured runs (a combination that cannot occur in practice, since
+        # ``_cost_sum`` has always been persisted alongside ``avg_cost_usd``).
         cost_sum = float(target.get("_cost_sum", 0.0)) + float(src.get("avg_cost_usd", 0.0)) * int(
             src.get("runs", 0)
         )
 
+    # Same measured-vs-total caveat as above applies to the by_complexity /
+    # by_complexity_score and review/preflight ``avg_cost_usd * runs`` fallbacks.
     cost_unknown = int(target.get("_cost_unknown_runs", 0)) + int(src.get("_cost_unknown_runs", 0))
     target["runs"] = runs
     target["_successes"] = successes

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 import time
@@ -15,13 +16,17 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from theforge.agent_types import AgentResult
+from theforge.agent_types import AgentResult, ModelUsage
 from theforge.log_util import _log_line
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
 from theforge.workspace_env import build_workspace_env
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
+from .schema_utils import _estimate_cost
+
+# Emit the cost-unmeasured warning at most once per model to avoid log spam.
+_COST_UNMEASURED_WARNED: set[str] = set()
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -136,6 +141,112 @@ def _get_codex_session_id(*, min_mtime: float) -> str | None:
     return best_id
 
 
+def _coerce_int(value: Any) -> int | None:
+    """Parse an int from a JSON value or a ``"12,345"``-style string; None if not."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        digits = value.replace(",", "").strip()
+        if digits.isdigit():
+            return int(digits)
+    return None
+
+
+def _usage_from_json(result_json: dict[str, Any]) -> tuple[int, int] | None:
+    """Best-effort (input_tokens, output_tokens) from a parsed codex JSON blob.
+
+    Tolerates several plausible shapes: a ``usage``/``token_usage``/``token_count``
+    dict keyed by ``input_tokens``/``prompt_tokens``/``input`` (and the output
+    analogues). Returns None when a usable input+output pair cannot be found.
+    """
+    if not isinstance(result_json, dict):
+        return None
+    for key in ("usage", "token_usage", "token_count", "tokens"):
+        block = result_json.get(key)
+        if not isinstance(block, dict):
+            continue
+        input_tokens = None
+        for in_key in ("input_tokens", "prompt_tokens", "input", "prompt"):
+            input_tokens = _coerce_int(block.get(in_key))
+            if input_tokens is not None:
+                break
+        output_tokens = None
+        for out_key in ("output_tokens", "completion_tokens", "output", "completion"):
+            output_tokens = _coerce_int(block.get(out_key))
+            if output_tokens is not None:
+                break
+        if input_tokens is not None and output_tokens is not None:
+            return (input_tokens, output_tokens)
+    return None
+
+
+_USAGE_LINE_RE = re.compile(
+    r"input[^0-9]*(?P<input>[\d,]+).*?output[^0-9]*(?P<output>[\d,]+)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _usage_from_text(text: str) -> tuple[int, int] | None:
+    """Best-effort (input_tokens, output_tokens) from a codex stdout summary line.
+
+    Scans for a token-usage summary that names both input and output token
+    counts (e.g. ``tokens used: input 2,800 output 621``). Returns None when no
+    such split is present — a bare total is not enough to price honestly.
+    """
+    if not text:
+        return None
+    match = _USAGE_LINE_RE.search(text)
+    if not match:
+        return None
+    input_tokens = _coerce_int(match.group("input"))
+    output_tokens = _coerce_int(match.group("output"))
+    if input_tokens is None or output_tokens is None:
+        return None
+    return (input_tokens, output_tokens)
+
+
+def _extract_codex_cost(
+    *,
+    profile: ModelProfile,
+    result_json: dict[str, Any],
+    stdout: str,
+) -> tuple[float | None, tuple[ModelUsage, ...]]:
+    """Recover real cost from codex output; never fabricate a zero.
+
+    Returns ``(cost_usd, model_usage)``. When token usage can be recovered we
+    price it via the shared pricing table and populate ``model_usage``; when it
+    cannot, ``cost_usd`` is ``None`` (cost-unknown, surfaced loudly) — never
+    ``0.0``, so an unmeasured run stays distinct from a genuinely free one.
+    """
+    usage = _usage_from_json(result_json) or _usage_from_text(stdout)
+    if usage is None:
+        model = profile.model or "?"
+        if model not in _COST_UNMEASURED_WARNED:
+            _COST_UNMEASURED_WARNED.add(model)
+            _log(
+                f"WARNING: Codex CLI run for model={model} completed cost-unmeasured "
+                "(no token usage in output); recording cost-unknown, NOT $0.00."
+            )
+        return None, ()
+    input_tokens, output_tokens = usage
+    cost = _estimate_cost("openai", profile.model, input_tokens, output_tokens)
+    model_usage = (
+        ModelUsage(
+            model=profile.model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            cost_usd=cost,
+        ),
+    )
+    return cost, model_usage
+
+
 def _run_codex(
     *,
     prompt: str,
@@ -234,16 +345,25 @@ def _run_codex(
         # picking up a sibling invocation's entry from the global index.
         extracted_sid = None if is_pool else _get_codex_session_id(min_mtime=start_wall)
 
+        # Best-effort real cost from codex output. Unrecoverable → cost-unknown
+        # (None), surfaced loudly, never a fabricated $0.00.
+        cost_usd, model_usage = _extract_codex_cost(
+            profile=profile,
+            result_json=result_json,
+            stdout=proc.stdout or "",
+        )
+
         if result_json:
             _json_output = result_json.get("result", output_text)
             return AgentResult(
                 success=proc.returncode == 0,
                 output=_json_output,
                 session_id=extracted_sid,
-                cost_usd=None,
+                cost_usd=cost_usd,
                 exit_code=proc.returncode,
                 raw=result_json,
                 profile_name=profile.name,
+                model_usage=model_usage,
                 dev_handoff=_try_parse_handoff(_json_output),
             )
 
@@ -251,10 +371,11 @@ def _run_codex(
             success=proc.returncode == 0,
             output=output_text,
             session_id=extracted_sid,
-            cost_usd=None,
+            cost_usd=cost_usd,
             exit_code=proc.returncode,
             raw={},
             profile_name=profile.name,
+            model_usage=model_usage,
             dev_handoff=_try_parse_handoff(output_text),
         )
     finally:

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -159,9 +159,14 @@ def _coerce_int(value: Any) -> int | None:
 def _usage_from_json(result_json: dict[str, Any]) -> tuple[int, int] | None:
     """Best-effort (input_tokens, output_tokens) from a parsed codex JSON blob.
 
-    Tolerates several plausible shapes: a ``usage``/``token_usage``/``token_count``
-    dict keyed by ``input_tokens``/``prompt_tokens``/``input`` (and the output
-    analogues). Returns None when a usable input+output pair cannot be found.
+    Defensive fallback only. The default codex transport writes its last message
+    to the ``-o`` file as PLAIN TEXT (``--output-last-message``), not JSON, so
+    this path does not fire on a normal run — it exists to opportunistically pick
+    up a usage block when codex is invoked in a structured-output mode
+    (e.g. ``--output-schema``) that happens to emit one. Tolerates several
+    plausible shapes: a ``usage``/``token_usage``/``token_count`` dict keyed by
+    ``input_tokens``/``prompt_tokens``/``input`` (and the output analogues).
+    Returns None when a usable input+output pair cannot be found.
     """
     if not isinstance(result_json, dict):
         return None
@@ -184,18 +189,32 @@ def _usage_from_json(result_json: dict[str, Any]) -> tuple[int, int] | None:
     return None
 
 
+# Verified against Codex CLI v0.142.x: the human-readable run summary reports
+# only a TOTAL token count, on its own line, e.g.::
+#     tokens used
+#     11,374
+# A bare total cannot be priced with the (input, output) pricing table, so the
+# default human transport is intentionally recorded cost-unknown rather than
+# fabricating a split. This regex therefore matches ONLY a single-line summary
+# that both names tokens AND carries an explicit input+output split (as a
+# structured/JSON-style summary would). It is deliberately tight:
+#   * anchored to a line containing "token" (MULTILINE ``^``), and
+#   * confined to one line (``[^\n]`` instead of DOTALL ``.*?``),
+# so it cannot fabricate a cost by matching unrelated "input … output" prose
+# elsewhere in the agent's stdout.
 _USAGE_LINE_RE = re.compile(
-    r"input[^0-9]*(?P<input>[\d,]+).*?output[^0-9]*(?P<output>[\d,]+)",
-    re.IGNORECASE | re.DOTALL,
+    r"^[^\n]*token[^\n]*?input[^0-9]*(?P<input>[\d,]+)[^\n]*?output[^0-9]*(?P<output>[\d,]+)",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 
 def _usage_from_text(text: str) -> tuple[int, int] | None:
     """Best-effort (input_tokens, output_tokens) from a codex stdout summary line.
 
-    Scans for a token-usage summary that names both input and output token
-    counts (e.g. ``tokens used: input 2,800 output 621``). Returns None when no
-    such split is present — a bare total is not enough to price honestly.
+    Scans for a single-line token-usage summary that names both input and output
+    token counts (e.g. ``tokens used: input 2,800 output 621``). Returns None
+    when no such split is present — including the real CLI's total-only ``tokens
+    used`` line — because a bare total cannot be priced honestly.
     """
     if not text:
         return None

--- a/tests/fake_bin/npx
+++ b/tests/fake_bin/npx
@@ -4,7 +4,10 @@
 Routes to fake codex or gemini behaviour based on the package argument.
 
 Codex (FAKE_CODEX_MODE):
-  happy  — write "Task complete." to the -o output file, exit 0 (default)
+  happy         — write "Task complete." to the -o output file, exit 0 (default)
+  usage         — write a JSON blob with a token `usage` block to the -o file
+  usage_stdout  — write plain text to the -o file, print a token-usage summary
+                  line to stdout (exercises the stdout-scan cost path)
 
 Gemini (FAKE_GEMINI_MODE):
   happy  — print {"response": "Task complete."} to stdout, exit 0 (default)
@@ -28,14 +31,31 @@ def _find_flag(flag: str) -> str | None:
 
 if "@openai/codex" in args:
     mode = os.environ.get("FAKE_CODEX_MODE", "happy")
+    output_file = _find_flag("-o")
     if mode == "happy":
-        output_file = _find_flag("-o")
         output_text = "Task complete."
         if output_file:
             with open(output_file, "w") as fh:
                 fh.write(output_text + "\n")
         else:
             print(output_text)
+        sys.exit(0)
+    if mode == "usage":
+        blob = {
+            "result": "Task complete.",
+            "usage": {"input_tokens": 1000, "output_tokens": 500},
+        }
+        if output_file:
+            with open(output_file, "w") as fh:
+                fh.write(json.dumps(blob) + "\n")
+        else:
+            print(json.dumps(blob))
+        sys.exit(0)
+    if mode == "usage_stdout":
+        if output_file:
+            with open(output_file, "w") as fh:
+                fh.write("Task complete.\n")
+        print("tokens used: input 1,000 output 500")
         sys.exit(0)
     sys.stderr.write(f"fake npx(codex): unknown FAKE_CODEX_MODE={mode!r}\n")
     sys.exit(1)

--- a/tests/fake_bin/npx
+++ b/tests/fake_bin/npx
@@ -6,8 +6,14 @@ Routes to fake codex or gemini behaviour based on the package argument.
 Codex (FAKE_CODEX_MODE):
   happy         — write "Task complete." to the -o output file, exit 0 (default)
   usage         — write a JSON blob with a token `usage` block to the -o file
-  usage_stdout  — write plain text to the -o file, print a token-usage summary
-                  line to stdout (exercises the stdout-scan cost path)
+  usage_stdout  — write plain text to the -o file, print a SINGLE-LINE token
+                  summary carrying an input+output split to stdout (a synthetic
+                  structured-style summary that exercises the stdout-scan cost
+                  path; the real CLI's human output is total-only, see below)
+  total_only    — write plain text to the -o file, print the REAL Codex CLI
+                  v0.142.x human summary (a bare `tokens used` total, no split)
+                  to stdout, so tests can assert it is recorded cost-unknown
+                  rather than fabricating a cost from a total alone
 
 Gemini (FAKE_GEMINI_MODE):
   happy  — print {"response": "Task complete."} to stdout, exit 0 (default)
@@ -56,6 +62,14 @@ if "@openai/codex" in args:
             with open(output_file, "w") as fh:
                 fh.write("Task complete.\n")
         print("tokens used: input 1,000 output 500")
+        sys.exit(0)
+    if mode == "total_only":
+        if output_file:
+            with open(output_file, "w") as fh:
+                fh.write("hi\n")
+        # Real Codex CLI v0.142.x human summary: a bare total on its own line.
+        print("tokens used")
+        print("11,374")
         sys.exit(0)
     sys.stderr.write(f"fake npx(codex): unknown FAKE_CODEX_MODE={mode!r}\n")
     sys.exit(1)

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -41,6 +41,67 @@ def test_apply_run_records_dev_stats():
     assert dev["by_complexity"]["medium"]["avg_cost_usd"] == 1.5
 
 
+def test_apply_run_records_unmeasured_dev_cost_distinct_from_zero():
+    """A None dev cost is tallied in _cost_unknown_runs, never folded into
+    _cost_sum, and avg_cost_usd is averaged over measured runs only."""
+    data: dict = {"models": {}}
+    # First run: cost unmeasured (None).
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=None,
+        ),
+    )
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev["runs"] == 1
+    assert dev["_cost_unknown_runs"] == 1
+    assert dev["_cost_sum"] == 0.0
+    assert dev["avg_cost_usd"] == 0.0
+
+    # Second run: a real $2.00 measured cost. avg is over the ONE measured run.
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=2.00,
+        ),
+    )
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev["runs"] == 2
+    assert dev["_cost_unknown_runs"] == 1
+    assert dev["_cost_sum"] == 2.0
+    assert dev["avg_cost_usd"] == 2.0  # 2.0 / (2 runs - 1 unmeasured)
+
+
+def test_get_dev_complexity_stats_averages_cost_over_measured_runs():
+    """avg_cost_usd from the reader divides by measured runs, so unmeasured runs
+    do not dilute the average toward zero for downstream budget sizing."""
+    data: dict = {"models": {}}
+    for cost in (2.0, None, None):
+        apply_run(
+            data,
+            RunOutcome(
+                complexity="medium",
+                dev_model="sonnet",
+                dev_success=True,
+                dev_iterations=1,
+                dev_cost_usd=cost,
+            ),
+        )
+    stats = get_dev_complexity_stats(data, "sonnet", "medium", min_runs=1)
+    assert stats is not None
+    assert stats["runs"] == 3.0
+    # $2.00 over the single measured run, not $2.00/3 = $0.67.
+    assert stats["avg_cost_usd"] == 2.0
+
+
 def test_apply_run_averages_across_runs():
     data: dict = {"models": {}}
     apply_run(

--- a/tests/test_model_profiles_bridge.py
+++ b/tests/test_model_profiles_bridge.py
@@ -115,3 +115,79 @@ def test_update_profiles_from_run_writes_file(tmp_path):
     assert data["models"]["deepseek-r1"]["preflight"]["runs"] == 1
     assert data["models"]["gemini"]["review"]["runs"] == 1
     assert data["models"]["opus"]["review"]["runs"] == 1
+
+
+@dataclass
+class _AR:
+    cost_usd: float | None = 0.0
+
+
+def _state_with_dev_costs(costs: list[float | None]) -> CoordinatorState:
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.dev_trace_count = 1
+    state.dev_results = [_AR(cost_usd=c) for c in costs]
+    return state
+
+
+def test_unmeasured_dev_cost_threads_none_through_bridge():
+    """A CoordinatorState whose dev_results are all cost-unmeasured yields a
+    RunOutcome with dev_cost_usd is None — the bridge must not coerce to $0.00."""
+    state = _state_with_dev_costs([None])
+    outcome = build_run_outcome(_Cfg(), state, success=True)
+    assert outcome.dev_cost_usd is None
+
+
+def test_unmeasured_dev_cost_records_cost_unknown_not_zero(tmp_path):
+    """update_from_run records the run as cost-unmeasured (not folded into
+    _cost_sum) so an unmeasured run stays distinct from a genuinely free one."""
+    state = _state_with_dev_costs([None])
+    cfg = _Cfg(project_root=str(tmp_path))
+    profiles_path = tmp_path / "model_profiles.yaml"
+
+    data = update_profiles_from_run(
+        profiles_path=profiles_path,
+        history_path=None,
+        config=cfg,
+        state=state,
+        success=True,
+    )
+
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev["runs"] == 1
+    assert dev["_cost_unknown_runs"] == 1
+    assert dev["_cost_sum"] == 0.0
+    # avg is over measured runs only (0 here) — not a polluted $0.00 average.
+    assert dev["avg_cost_usd"] == 0.0
+    bucket = dev["by_complexity"]["medium"]
+    assert bucket["_cost_unknown_runs"] == 1
+    assert bucket["_cost_sum"] == 0.0
+
+
+def test_measured_zero_dev_cost_is_not_counted_unmeasured(tmp_path):
+    """A genuinely free ($0.00 measured) run increments neither _cost_unknown_runs."""
+    state = _state_with_dev_costs([0.0])
+    cfg = _Cfg(project_root=str(tmp_path))
+    profiles_path = tmp_path / "model_profiles.yaml"
+
+    data = update_profiles_from_run(
+        profiles_path=profiles_path,
+        history_path=None,
+        config=cfg,
+        state=state,
+        success=True,
+    )
+
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev["runs"] == 1
+    assert dev["_cost_unknown_runs"] == 0
+    assert dev["_cost_sum"] == 0.0
+    assert dev["avg_cost_usd"] == 0.0
+
+
+def test_mixed_measured_and_unmeasured_dev_costs_are_unknown_aggregate():
+    """If any dev attempt is unmeasured, the whole aggregate is cost-unknown —
+    collapsing to a measured subtotal would hide the unmeasured attempt."""
+    state = _state_with_dev_costs([0.30, None])
+    outcome = build_run_outcome(_Cfg(), state, success=True)
+    assert outcome.dev_cost_usd is None

--- a/tests/test_profiles_reset.py
+++ b/tests/test_profiles_reset.py
@@ -116,6 +116,7 @@ def test_reset_profile_data_role_scoped_reset_preserves_other_roles():
             "complexity": None,
             "runs": 6,
             "avg_cost_usd": 0.15,
+            "cost_unknown_runs": 0,
             "avg_findings": 2.5,
         }
     ]
@@ -135,6 +136,7 @@ def test_reset_profile_data_complexity_scoped_reset_preserves_other_buckets():
             "successes": 3,
             "avg_iterations": 1.25,
             "avg_cost_usd": 0.1,
+            "cost_unknown_runs": 0,
         }
     ]
     dev = updated["models"][CANONICAL_ID]["dev"]
@@ -206,6 +208,7 @@ def test_profiles_reset_command_audits_pre_reset_counts_and_prints_reason(capsys
             "successes": 2,
             "avg_iterations": 1.0,
             "avg_cost_usd": 0.1,
+            "cost_unknown_runs": 0,
         }
     ]
 

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -241,3 +241,50 @@ class TestCodexLifecycle:
         assert result.success is True
         assert "Task complete." in result.output
         assert result.exit_code == 0
+
+    def test_no_usage_records_cost_unknown_not_zero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When codex emits no token usage, cost is None (unmeasured), never $0.00."""
+        self._patch_env(monkeypatch, "happy")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(
+            prompt="do the thing",
+            profile=profile,
+            working_dir=tmp_path,
+        )
+        assert result.cost_usd is None
+        assert result.model_usage == ()
+
+    def test_json_usage_yields_real_estimated_cost(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A codex JSON blob with a usage block is priced via the pricing table."""
+        self._patch_env(monkeypatch, "usage")
+        profile = _make_profile(sandbox_mode="none")  # model o4-mini: (1.10, 4.40)/Mtok
+        result = _run_codex(
+            prompt="do the thing",
+            profile=profile,
+            working_dir=tmp_path,
+        )
+        # 1000 in * 1.10/M + 500 out * 4.40/M = 0.0011 + 0.0022 = 0.0033
+        assert result.cost_usd is not None
+        assert result.cost_usd == pytest.approx(0.0033)
+        assert len(result.model_usage) == 1
+        usage = result.model_usage[0]
+        assert usage.input_tokens == 1000
+        assert usage.output_tokens == 500
+
+    def test_stdout_usage_line_yields_real_estimated_cost(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Cost is recovered from codex's stdout token-usage summary line too."""
+        self._patch_env(monkeypatch, "usage_stdout")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(
+            prompt="do the thing",
+            profile=profile,
+            working_dir=tmp_path,
+        )
+        assert result.cost_usd == pytest.approx(0.0033)
+        assert len(result.model_usage) == 1

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -288,3 +288,22 @@ class TestCodexLifecycle:
         )
         assert result.cost_usd == pytest.approx(0.0033)
         assert len(result.model_usage) == 1
+
+    def test_real_total_only_summary_is_cost_unknown_not_fabricated(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The real Codex CLI human summary is a bare total (no input/output split).
+
+        A total alone can't be priced with the (input, output) table, so the run
+        must be recorded cost-unknown (None) — never a fabricated cost derived by
+        guessing a split from the total.
+        """
+        self._patch_env(monkeypatch, "total_only")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(
+            prompt="do the thing",
+            profile=profile,
+            working_dir=tmp_path,
+        )
+        assert result.cost_usd is None
+        assert result.model_usage == ()


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation preserves Codex CLI unmeasured cost as cost-unknown, keeps it out of cost sums, surfaces warnings, and the focused regression tests pass. | [claude-sonnet] Iteration 2 resolves both carried P2s (regex tightened to single-line MULTILINE match verified against real Codex CLI v0.142.5 output; legacy merge fallback commented) with no regressions found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $14.16
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: Codex CLI transport hardcodes cost_usd=None so every dev run records $0.00 spend (GitHub Issue #1616)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1616