### PR TITLE
chore(config): revert mini-first model order, bump gate_timeout 45→60

### DIFF
--- a/forge.yaml
+++ b/forge.yaml
@@ -9,7 +9,10 @@ models:
     - claude/sonnet               # CLI alias auto-tracks: Sonnet 5 as of 2026-07 ($3/$15)
     - claude/opus                 # CLI alias auto-tracks: Opus 4.8 as of 2026-07 ($5/$25)
     - openai/gpt-5.4              # value strong tier ($2.50/$15); still served, no deprecation (verified 2026-07-07)
-    - openai/gpt-5.4-mini         # cheap tier ($0.75/$4.50) — pool previously had no cheap tier at all
+    - openai/gpt-5.4-mini         # cheap tier ($0.75/$4.50). Tried list-first 2026-07-11 to force dispatch via
+    #                                 the cheap-bucket tie-break: got 4 preflights (at sonnet-equal cost, no
+    #                                 savings) but zero dev runs — profile reranker starves zero-history models
+    #                                 regardless of order. Reverted same day; real fix is #1617.
     - openai/gpt-5.5              # OpenAI's recommended coding model; overlay entry below
     # - deepseek/deepseek-reasoner  # disabled 2026-05-09: flaky + slow; cycle-3 hang on #1424 + cycle-1 crash on same story.
     #                                  Re-enable when adaptive routing can decide reviewer fitness automatically.
@@ -62,7 +65,10 @@ validation:
   gate_command: "make gate"
   # Canonical intermediate test command dev agents should use while working.
   test_command: ".venv/bin/python -m pytest tests/ -v -n auto --dist worksteal"
-  gate_timeout: 45
+  # 45→60 (2026-07-11): story #1243 hit identical 45s gate timeouts twice under
+  # --parallel 3 load, then passed instantly when resumed solo. Modest bump to
+  # absorb parallel contention; revisit if timeouts persist at 60.
+  gate_timeout: 60
 
 conventions:
   hard:


### PR DESCRIPTION
Two operator-config changes from today's dogfood session:

**Model order revert:** `openai/gpt-5.4-mini` was moved to the top of `models.enabled` on 2026-07-11 to force cheap-tier dispatch via the list-order tie-break. The experiment ran one sprint: mini received 4 preflight dispatches at sonnet-equal cost ($0.268 vs $0.273 avg — no savings) and zero dev dispatches, because the profile reranker sorts zero-history models strictly last regardless of list order. Live confirmation recorded on #1617, which is the real fix. Reverting to sonnet-first; the inline comment preserves the experiment's result.

**gate_timeout 45→60:** story #1243 failed with identical 45s gate timeouts on consecutive iterations while 3 parallel stories loaded the machine, then passed the same gate instantly when resumed solo (`--parallel 1`). Modest bump to absorb parallel contention; inline comment records the evidence and the revisit condition (timeouts persisting at 60s on a quiet machine would indicate a suite problem instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)