### PR TITLE
bug: branch-protection gate test flakes on a SIGPIPE race — fake gh never drains stdin under pipefail

### DIFF
--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -36,7 +36,12 @@ def _write_fake_gh(bin_dir: Path, *, get_exit: int, put_exit: int) -> Path:
         'for a in "$@"; do\n'
         '    if [[ "$a" == "PUT" ]]; then is_put=true; fi\n'
         "done\n"
-        f'if [[ "$is_put" == true ]]; then exit {put_exit}; else exit {get_exit}; fi\n'
+        'if [[ "$is_put" == true ]]; then\n'
+        "    cat >/dev/null\n"
+        f"    exit {put_exit}\n"
+        "else\n"
+        f"    exit {get_exit}\n"
+        "fi\n"
     )
     fake.chmod(0o755)
     return log


### PR DESCRIPTION
## Summary

Fake gh now drains stdin via cat >/dev/null on the PUT branch only, mechanically eliminating the SIGPIPE/pipefail race; GET probe path untouched and never blocks.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.06
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: branch-protection gate test flakes on a SIGPIPE race — fake gh never drains stdin under pipefail (GitHub Issue #1623)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1623