### PR TITLE
bug: a reviewer that finishes without submitting kills the story on quorum — no retry, no substitute

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -683,6 +683,9 @@ def load_config(config_path: Path) -> ForgeConfig:
             retry_data.get("review_transport_retry_backoff_seconds", 8.0)
         ),
         review_quorum_threshold=int(retry_data.get("review_quorum_threshold", 2)),
+        review_degrade_on_infra_failure=bool(
+            retry_data.get("review_degrade_on_infra_failure", True)
+        ),
         review_transient_failure_codes=tuple(
             str(code)
             for code in retry_data.get(

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -265,6 +265,13 @@ class RetryPolicy:
     # Minimum successful reviewers required to proceed to synthesis without
     # escalating; collapses to 1 when the panel size is 1.
     review_quorum_threshold: int = 2
+    # When True, a review cycle whose quorum shortfall is caused entirely by
+    # non-verdict reviewer failures (a reviewer that finished without emitting a
+    # submit call) degrades to the surviving verdict(s) with an explicit audit
+    # warning instead of failing the story — provided at least one reviewer
+    # delivered a verdict. Story failure is reserved for a total quorum collapse
+    # (zero survivors) or a genuine hard failure blocking the quorum.
+    review_degrade_on_infra_failure: bool = True
     # Failure-code identifiers (from AgentResult.failure_code) that mark a
     # review-pool failure as transient/retryable.
     review_transient_failure_codes: tuple[str, ...] = (

--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -89,6 +89,8 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
             "transient_outcomes": dict(meta.transient_outcomes),
             "quorum_threshold": meta.quorum_threshold,
             "quorum_met": meta.quorum_met,
+            "degraded_quorum": meta.degraded_quorum,
+            "degraded_quorum_warning": meta.degraded_quorum_warning,
         }
         if i < len(state.review_results):
             r = state.review_results[i]

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -75,6 +75,26 @@ def _is_transient_review_failure(result: Any, config: ForgeConfig) -> bool:
     return any(pattern in lower for pattern in config.retry.review_transient_output_patterns)
 
 
+# Failure codes marking a reviewer that completed its turn without delivering a
+# verdict (no submit call). These are infrastructure/behavioral failures, not
+# review outcomes, and must not be able to kill a story on their own.
+_NON_VERDICT_FAILURE_CODES = frozenset({"no_submit_completion"})
+
+
+def _is_non_verdict_completion(result: Any) -> bool:
+    """Return True when a failed reviewer completed cleanly but emitted no verdict.
+
+    A reviewer that finishes its turn without calling submit delivered nothing to
+    synthesize. It is an infrastructure failure (the runner surfaces it via the
+    ``no_submit_completion`` failure code), not a REQUEST_CHANGES outcome, so the
+    pool can recover from it (degrade to surviving verdicts) rather than fail.
+    """
+    if result.success:
+        return False
+    code = (getattr(result, "failure_code", None) or "").lower()
+    return code in _NON_VERDICT_FAILURE_CODES
+
+
 def _resolve_prompt_for_reviewer(review_prompts: str | list[str], index: int) -> str:
     """Return the per-reviewer prompt. Shared string fans out to every reviewer."""
     if isinstance(review_prompts, list):
@@ -546,16 +566,53 @@ def _run_review_pool(
     meta.quorum_threshold = quorum_threshold
     meta.quorum_met = len(successful) >= quorum_threshold
 
+    failed_desc = ", ".join(f"{r.profile_name} (exit={r.exit_code})" for r in failed_results)
     if not meta.quorum_met:
-        state.phase = Phase.ESCALATE
-        failed_desc = ", ".join(f"{r.profile_name} (exit={r.exit_code})" for r in failed_results)
-        state.error = (
-            f"Quorum unmet: {len(successful)}/{pool_size} succeeded "
-            f"< threshold {quorum_threshold}; failed: {failed_desc}"
+        # ── Degraded-quorum recovery ──────────────────────────────────
+        # A reviewer that finishes without a submit call delivered no verdict
+        # — an infrastructure failure, not a review outcome. When the quorum
+        # shortfall is caused *entirely* by such non-verdict completions and
+        # at least one trustworthy verdict survives, degrade to the survivors
+        # with an explicit audit warning rather than killing the story.
+        # Escalation is reserved for a total quorum collapse (zero survivors)
+        # or a genuine hard failure (crash / exhausted transient retry) among
+        # the failures.
+        can_degrade = (
+            config.retry.review_degrade_on_infra_failure
+            and bool(successful)
+            and bool(failed_results)
+            and all(_is_non_verdict_completion(r) for r in failed_results)
         )
-        return successful, failed_results, None, [], []
+        if can_degrade:
+            warning = (
+                f"Degraded quorum: {len(successful)}/{pool_size} reviewer(s) "
+                f"delivered a verdict (threshold {quorum_threshold}); proceeding "
+                f"on surviving verdict(s) after non-verdict reviewer failure(s): "
+                f"{failed_desc}"
+            )
+            meta.degraded_quorum = True
+            meta.degraded_quorum_warning = warning
+            _log(f"  ⚠ {warning}")
+            if logger is not None:
+                logger._safe_emit(
+                    "review_degraded_quorum",
+                    cycle=_cycle_num,
+                    successful=meta.successful,
+                    failed=meta.failed,
+                    failed_detail=meta.failed_detail,
+                    quorum_threshold=quorum_threshold,
+                    pool_size=pool_size,
+                    warning=warning,
+                )
+        else:
+            state.phase = Phase.ESCALATE
+            state.error = (
+                f"Quorum unmet: {len(successful)}/{pool_size} succeeded "
+                f"< threshold {quorum_threshold}; failed: {failed_desc}"
+            )
+            return successful, failed_results, None, [], []
 
-    if failed_results:
+    if failed_results and meta.quorum_met:
         _log(
             f"Panel quorum met ({len(successful)}/{pool_size} reviewers succeeded "
             f"≥ quorum threshold {quorum_threshold}) — proceeding to synthesis"

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -238,6 +238,13 @@ class ReviewCycleMetadata:
     quorum_threshold: int = 0
     # Whether the effective threshold was met (i.e. synthesis proceeded).
     quorum_met: bool = False
+    # Whether synthesis proceeded on a *degraded* quorum: the threshold was NOT
+    # met, but the shortfall was caused entirely by non-verdict reviewer
+    # failures (e.g. a reviewer that finished without calling submit) and at
+    # least one trustworthy verdict survived, so the story was not killed.
+    degraded_quorum: bool = False
+    # Human-readable audit note describing a degraded-quorum decision, or None.
+    degraded_quorum_warning: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -616,6 +616,12 @@ class AgentLoopManager:
         failure_code = None
         if reason.startswith("Agent loop terminated: max iterations reached"):
             failure_code = "max_iterations_reached"
+        elif reason.startswith("Agent finished without calling submit tool"):
+            # The agent completed its turn cleanly but delivered no verdict —
+            # a non-verdict/behavioral completion, distinct from a transport
+            # crash. Tagged so the review pool can recognise and recover from
+            # it (degrade to surviving verdicts) instead of failing the story.
+            failure_code = "no_submit_completion"
         return AgentResult(
             success=False,
             output=reason,

--- a/tests/coord_test_helpers.py
+++ b/tests/coord_test_helpers.py
@@ -87,6 +87,7 @@ def _make_agent_result(
     profile_name: str = "",
     startup_failure: bool = False,
     dev_handoff: dict | None = None,
+    failure_code: str | None = None,
 ) -> AgentResult:
     return AgentResult(
         success=success,
@@ -98,6 +99,7 @@ def _make_agent_result(
         profile_name=profile_name,
         startup_failure=startup_failure,
         dev_handoff=dev_handoff,
+        failure_code=failure_code,
     )
 
 

--- a/tests/test_coord_review_pool.py
+++ b/tests/test_coord_review_pool.py
@@ -743,3 +743,210 @@ class TestTransientRetry:
         assert meta.quorum_threshold == 1
         assert meta.quorum_met is False
         assert meta.transient_outcomes["solo"] == "transient_retried_then_failed"
+
+
+class _CapturingLogger:
+    """Minimal stand-in for the audit logger that records _safe_emit calls."""
+
+    def __init__(self) -> None:
+        self.emits: list[tuple[str, dict]] = []
+
+    def _safe_emit(self, event: str, **fields: object) -> None:
+        self.emits.append((event, dict(fields)))
+
+
+_NO_SUBMIT_OUTPUT = "Agent finished without calling submit tool and produced no output"
+
+
+def _no_submit_result(profile_name: str):
+    """A reviewer that finished its turn without emitting a submit call."""
+    return _make_agent_result(
+        success=False,
+        output=_NO_SUBMIT_OUTPUT,
+        profile_name=profile_name,
+        failure_code="no_submit_completion",
+    )
+
+
+class TestDegradedQuorum:
+    """A no-submit reviewer failure must not kill a story on quorum: with at
+    least one surviving verdict, the pool degrades to the survivors with an
+    explicit audit warning instead of escalating (issue #1598)."""
+
+    def _degrade_config(self, tmp_path, profiles, primary, *, enabled: bool = True):
+        config = _make_pool_config(tmp_path, profiles, primary)
+        return config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    max_review_transport_retries=0,
+                    review_quorum_threshold=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                    review_degrade_on_infra_failure=enabled,
+                ),
+            }
+        )
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_no_submit_degrades_to_surviving_verdict(
+        self, mock_pool, mock_run_agent, _mock_log, tmp_path
+    ):
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = self._degrade_config(tmp_path, [r1, r2], r1)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r1"),
+            _no_submit_result("r2"),
+        ]
+
+        logger = _CapturingLogger()
+        meta = _meta()
+        successful, failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+            logger=logger,
+        )
+
+        # Story lands a verdict instead of failing outright.
+        assert merged is not None
+        assert merged.verdict == "APPROVE"
+        assert state.phase != Phase.ESCALATE
+        assert [r.profile_name for r in successful] == ["r1"]
+        assert [r.profile_name for r in failed] == ["r2"]
+        # Recorded as degraded (threshold genuinely not met) with a warning.
+        assert meta.quorum_met is False
+        assert meta.degraded_quorum is True
+        assert meta.degraded_quorum_warning
+        assert "Degraded quorum" in meta.degraded_quorum_warning
+        # Audit trail carries the degrade decision.
+        assert any(event == "review_degraded_quorum" for event, _ in logger.emits)
+        _, fields = next(e for e in logger.emits if e[0] == "review_degraded_quorum")
+        assert fields["successful"] == ["r1"]
+        assert fields["failed"] == ["r2"]
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_all_no_submit_no_survivor_escalates(
+        self, mock_pool, mock_run_agent, _mock_log, tmp_path
+    ):
+        """Degrade needs a surviving verdict — zero survivors still escalates."""
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = self._degrade_config(tmp_path, [r1, r2], r1)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _no_submit_result("r1"),
+            _no_submit_result("r2"),
+        ]
+
+        meta = _meta()
+        _successful, _failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        assert merged is None
+        assert state.phase == Phase.ESCALATE
+        assert "Quorum unmet" in state.error
+        assert meta.degraded_quorum is False
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_hard_failure_does_not_degrade(self, mock_pool, mock_run_agent, _mock_log, tmp_path):
+        """A genuine hard crash (not a non-verdict completion) still escalates —
+        the degrade path is scoped to infrastructure/no-submit failures."""
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = self._degrade_config(tmp_path, [r1, r2], r1)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r1"),
+            _make_agent_result(success=False, output="ValueError: nope", profile_name="r2"),
+        ]
+
+        meta = _meta()
+        _successful, _failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        assert merged is None
+        assert state.phase == Phase.ESCALATE
+        assert meta.degraded_quorum is False
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_degrade_disabled_escalates(self, mock_pool, mock_run_agent, _mock_log, tmp_path):
+        """review_degrade_on_infra_failure=False preserves fail-closed behavior."""
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = self._degrade_config(tmp_path, [r1, r2], r1, enabled=False)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r1"),
+            _no_submit_result("r2"),
+        ]
+
+        meta = _meta()
+        _successful, _failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+        )
+
+        assert merged is None
+        assert state.phase == Phase.ESCALATE
+        assert meta.degraded_quorum is False

--- a/tests/test_runner_api_loop.py
+++ b/tests/test_runner_api_loop.py
@@ -124,6 +124,28 @@ class TestAgentLoopLifecycle:
         assert result.output == "All looks good."
         assert call_count[0] == 2
 
+    def test_no_submit_empty_output_tagged_as_non_verdict_completion(self, tmp_path):
+        """Agent finishes its turn with no submit call and no text → the failure
+        is tagged ``no_submit_completion`` so the review pool can recover from it
+        instead of failing the story (issue #1598)."""
+
+        def adapter(messages, tools):
+            return LoopTurn(
+                tool_calls=[],
+                text_output="",
+                structured_data=None,
+                usage=_make_usage(),
+            )
+
+        manager = self._make_manager(tmp_path, adapter)
+        result = manager.run(
+            initial_messages=[{"role": "user", "content": "review"}],
+            tool_schemas=[],
+        )
+        assert result.success is False
+        assert result.failure_code == "no_submit_completion"
+        assert "without calling submit tool" in result.output
+
     def test_submit_review_tool_extracts_structured_data(self, tmp_path):
         """Model calls submit_review — loop returns structured_data."""
         review_data = {


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the no-submit reviewer resilience requirement with a scoped degraded-quorum path and targeted tests. | [claude-sonnet] Degraded-quorum recovery correctly scoped to non-verdict (no-submit) failures, gated by config, audited, and covered by tests matching the production symptom string.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $4.82
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: a reviewer that finishes without submitting kills the story on quorum — no retry, no substitute (GitHub Issue #1598)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1598