### PR TITLE
ci: forward-port workflow on release/v0.11 (backport of #1635)

### DIFF
--- a/.github/workflows/forward-port.yml
+++ b/.github/workflows/forward-port.yml
@@ -1,0 +1,126 @@
+name: Forward-port release to main
+
+# Every merge to a release/* branch is immediately forward-ported to main so
+# main stays a strict superset of every release line (doctrine established
+# 2026-07-11; replaces big-bang ports like #1604).
+#
+# Design notes:
+# - Runs the gate on the merged result BEFORE pushing; the push to main then
+#   triggers the full CI matrix as a backstop. A PR-based flow is not usable
+#   here: PRs opened with the default Actions token do not trigger CI, so
+#   required checks would never run and auto-merge would deadlock.
+# - pyproject.toml and CHANGELOG.md always keep main's version: release-line
+#   commits bump the RC/release version and roll the changelog, and those
+#   must never overwrite main's dev version or its [Unreleased] section.
+# - Any conflict outside those two files aborts the port and files an issue
+#   instead of guessing.
+# - This file must exist on each release/* branch as well as main: push
+#   events execute the workflow definition from the pushed ref.
+
+on:
+  push:
+    branches: ["release/**"]
+
+concurrency:
+  group: forward-port-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  forward-port:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Merge ${{ github.ref_name }} into main
+        id: merge
+        env:
+          RELEASE_REF: ${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "$RELEASE_REF"
+
+          if git merge-base --is-ancestor "origin/$RELEASE_REF" HEAD; then
+            echo "main already contains $RELEASE_REF; nothing to port."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          set +e
+          git merge --no-ff --no-edit "origin/$RELEASE_REF"
+          merge_rc=$?
+          set -e
+
+          if [ "$merge_rc" -ne 0 ]; then
+            conflicts=$(git diff --name-only --diff-filter=U)
+            others=$(printf '%s\n' "$conflicts" | grep -v -E '^(pyproject\.toml|CHANGELOG\.md)$' || true)
+            if [ -n "$others" ]; then
+              echo "Unresolvable conflicts outside version files:"
+              printf '%s\n' "$others"
+              git merge --abort
+              echo "conflict_files<<EOF" >> "$GITHUB_OUTPUT"
+              printf '%s\n' "$others" >> "$GITHUB_OUTPUT"
+              echo "EOF" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+            # Version files conflict on every rc cut / release bump: keep main's.
+            git checkout --ours -- pyproject.toml CHANGELOG.md
+            git add pyproject.toml CHANGELOG.md
+            git commit --no-edit
+          fi
+
+          # Even when the merge is clean, never let release-line version bumps
+          # or changelog rolls land on main.
+          git checkout ORIG_HEAD -- pyproject.toml CHANGELOG.md
+          if ! git diff --cached --quiet -- pyproject.toml CHANGELOG.md || ! git diff --quiet -- pyproject.toml CHANGELOG.md; then
+            git add pyproject.toml CHANGELOG.md
+            git commit --amend --no-edit
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.merge.outputs.skip != 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        if: steps.merge.outputs.skip != 'true'
+        run: pip install -e ".[dev]"
+
+      - name: Gate merged result
+        if: steps.merge.outputs.skip != 'true'
+        run: |
+          make lint
+          make test
+
+      - name: Push to main
+        if: steps.merge.outputs.skip != 'true'
+        run: git push origin HEAD:main
+
+      - name: File issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REF: ${{ github.ref_name }}
+          CONFLICT_FILES: ${{ steps.merge.outputs.conflict_files }}
+        run: |
+          title="forward-port: $RELEASE_REF -> main failed"
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          body="Automatic forward-port of \`$RELEASE_REF\` into main failed for ${{ github.sha }} (run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+Conflicting files outside the version-file allowlist (empty means the gate failed instead):
+\`\`\`
+$CONFLICT_FILES
+\`\`\`
+Until this is resolved and merged manually, main is missing release-line commits and every subsequent port will keep failing."
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body" --label bug
+          fi


### PR DESCRIPTION
Push-triggered workflows execute from the pushed ref, so the forward-port workflow from #1635 must exist on this branch for release/v0.11 pushes to trigger it. Identical file; see #1635 for design.

Merging this PR is also the workflow's first live test: the resulting push to release/v0.11 should forward-port this branch (rc0 cut + this commit) into main automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)