### PR TITLE
ci: fix forward-port workflow YAML block-scalar break

### DIFF
--- a/.github/workflows/forward-port.yml
+++ b/.github/workflows/forward-port.yml
@@ -112,13 +112,15 @@ jobs:
         run: |
           title="forward-port: $RELEASE_REF -> main failed"
           existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
-          body="Automatic forward-port of \`$RELEASE_REF\` into main failed for ${{ github.sha }} (run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-
-Conflicting files outside the version-file allowlist (empty means the gate failed instead):
-\`\`\`
-$CONFLICT_FILES
-\`\`\`
-Until this is resolved and merged manually, main is missing release-line commits and every subsequent port will keep failing."
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body=$(printf '%s\n' \
+            "Automatic forward-port of \`$RELEASE_REF\` into main failed for ${{ github.sha }} (run: $run_url)." \
+            "" \
+            "Conflicting files outside the version-file allowlist (empty means the gate failed instead):" \
+            '```' \
+            "$CONFLICT_FILES" \
+            '```' \
+            "Until this is resolved and merged manually, main is missing release-line commits and every subsequent port will keep failing.")
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else


### PR DESCRIPTION
Follow-up to #1635: the failure-issue step's multi-line shell string had continuation lines at column 1, which ends a YAML literal block — the workflow file was invalid and every triggering push produced a 0s failed run with no jobs. The body is now assembled with printf so all lines stay indented. Validated with a local YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)