### PR TITLE
fix(release): required_status_checks must be non-null for auto-merge arming

### DIFF
--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -32,7 +32,13 @@ fi
 
 REPO="${ARGS[0]}"
 BRANCH="${ARGS[1]}"
-PROTECTION_BODY='{"required_status_checks":null,"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
+# required_status_checks must be a non-null object (even with empty contexts)
+# for GitHub's enablePullRequestAutoMerge mutation to succeed — a null value
+# "protects" the branch but leaves auto-merge arming refused with
+# "Pull Request Branch does not have required protected branch rules".
+# Confirmed 2026-07-12: release/v0.11's protection (applied with the old
+# null body) blocked every story's auto-merge until re-applied with this body.
+PROTECTION_BODY='{"required_status_checks":{"strict":false,"contexts":[]},"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
 
 if [[ "$DRY_RUN" == true ]]; then
     echo "+ (dry-run) gh api --method PUT repos/$REPO/branches/$BRANCH/protection --input -"

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -10,6 +10,7 @@ critical RC merge path can be exercised under a PATH-mocked `gh`. Covers:
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -25,7 +26,8 @@ def _write_fake_gh(bin_dir: Path, *, get_exit: int, put_exit: int) -> Path:
 
     The fake distinguishes the protection probe (a GET, no --method flag)
     from the protection apply (PUT via --method PUT) and exits with the
-    caller-specified codes for each.
+    caller-specified codes for each. The PUT's stdin (the protection body)
+    is captured to gh.put_body.json for content assertions.
     """
     log = bin_dir / "gh.log"
     fake = bin_dir / "gh"
@@ -37,7 +39,7 @@ def _write_fake_gh(bin_dir: Path, *, get_exit: int, put_exit: int) -> Path:
         '    if [[ "$a" == "PUT" ]]; then is_put=true; fi\n'
         "done\n"
         'if [[ "$is_put" == true ]]; then\n'
-        "    cat >/dev/null\n"
+        f'    cat > "{bin_dir}/gh.put_body.json"\n'
         f"    exit {put_exit}\n"
         "else\n"
         f"    exit {get_exit}\n"
@@ -102,6 +104,17 @@ def test_protection_applied_when_missing(sandbox):
     calls = log.read_text().strip().splitlines()
     assert len(calls) == 2, f"expected probe + PUT, got: {calls}"
     assert "PUT" in calls[1], "second call must be the PUT apply"
+
+    # required_status_checks must be a real (even empty) object, not null:
+    # GitHub's enablePullRequestAutoMerge mutation refuses to arm auto-merge
+    # ("does not have required protected branch rules") when it's null, even
+    # though the branch is otherwise protected. Confirmed live on
+    # release/v0.11 on 2026-07-12 — every story's auto-merge was blocked
+    # until the body below was applied.
+    put_body = json.loads((sandbox / "gh.put_body.json").read_text())
+    assert put_body["required_status_checks"] is not None, (
+        "required_status_checks must not be null or GitHub refuses to arm auto-merge"
+    )
 
 
 def test_put_failure_warns_and_continues(sandbox):


### PR DESCRIPTION
GitHub's `enablePullRequestAutoMerge` mutation refuses to arm auto-merge ("does not have required protected branch rules") when `required_status_checks` is null, even on an otherwise-protected branch. `apply-branch-protection.sh`'s minimal body set this to null, so every story landing on `release/v0.11` (protected by this script at the 2026-07-11 RC cut) had auto-merge arming fail — confirmed live on #1422's PR (#1642), which needed a manual squash-merge to unstick the ladder.

Fix: PUT `{"strict": false, "contexts": []}` instead of null — an empty-but-present object satisfies GitHub's requirement without gating merge on any specific check. Also live-patched `release/v0.11`'s protection directly via the API so the ladder isn't blocked again while this PR lands.

Added a regression assertion on the mocked PUT body's content — the existing test suite only asserted a PUT happened, never what it contained, which is exactly the gap that let a null-valued field ship unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)