### PR TITLE
fix(release): backport #1644 — required_status_checks must be non-null for auto-merge arming

### DIFF
--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -32,7 +32,13 @@ fi
 
 REPO="${ARGS[0]}"
 BRANCH="${ARGS[1]}"
-PROTECTION_BODY='{"required_status_checks":null,"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
+# required_status_checks must be a non-null object (even with empty contexts)
+# for GitHub's enablePullRequestAutoMerge mutation to succeed — a null value
+# "protects" the branch but leaves auto-merge arming refused with
+# "Pull Request Branch does not have required protected branch rules".
+# Confirmed 2026-07-12: release/v0.11's protection (applied with the old
+# null body) blocked every story's auto-merge until re-applied with this body.
+PROTECTION_BODY='{"required_status_checks":{"strict":false,"contexts":[]},"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
 
 if [[ "$DRY_RUN" == true ]]; then
     echo "+ (dry-run) gh api --method PUT repos/$REPO/branches/$BRANCH/protection --input -"

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -10,6 +10,7 @@ critical RC merge path can be exercised under a PATH-mocked `gh`. Covers:
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -25,7 +26,8 @@ def _write_fake_gh(bin_dir: Path, *, get_exit: int, put_exit: int) -> Path:
 
     The fake distinguishes the protection probe (a GET, no --method flag)
     from the protection apply (PUT via --method PUT) and exits with the
-    caller-specified codes for each.
+    caller-specified codes for each. The PUT's stdin (the protection body)
+    is captured to gh.put_body.json for content assertions.
     """
     log = bin_dir / "gh.log"
     fake = bin_dir / "gh"
@@ -37,7 +39,7 @@ def _write_fake_gh(bin_dir: Path, *, get_exit: int, put_exit: int) -> Path:
         '    if [[ "$a" == "PUT" ]]; then is_put=true; fi\n'
         "done\n"
         'if [[ "$is_put" == true ]]; then\n'
-        "    cat >/dev/null\n"
+        f'    cat > "{bin_dir}/gh.put_body.json"\n'
         f"    exit {put_exit}\n"
         "else\n"
         f"    exit {get_exit}\n"
@@ -102,6 +104,17 @@ def test_protection_applied_when_missing(sandbox):
     calls = log.read_text().strip().splitlines()
     assert len(calls) == 2, f"expected probe + PUT, got: {calls}"
     assert "PUT" in calls[1], "second call must be the PUT apply"
+
+    # required_status_checks must be a real (even empty) object, not null:
+    # GitHub's enablePullRequestAutoMerge mutation refuses to arm auto-merge
+    # ("does not have required protected branch rules") when it's null, even
+    # though the branch is otherwise protected. Confirmed live on
+    # release/v0.11 on 2026-07-12 — every story's auto-merge was blocked
+    # until the body below was applied.
+    put_body = json.loads((sandbox / "gh.put_body.json").read_text())
+    assert put_body["required_status_checks"] is not None, (
+        "required_status_checks must not be null or GitHub refuses to arm auto-merge"
+    )
 
 
 def test_put_failure_warns_and_continues(sandbox):


### PR DESCRIPTION
Deliberate main→release backport (rare exception to the release⊆main rule, per the release-floor doctrine: only release-mechanics blockers get backported, one cherry-pick at a time).

#1644 fixes `scripts/apply-branch-protection.sh` to write a non-null `required_status_checks` object — GitHub refuses `enablePullRequestAutoMerge` ("branch does not have required protected branch rules") when it's null. The fix landed on main, but `cut-rc` runs `apply-branch-protection.sh` **from the release branch**, so without this backport the next rc cut from release/v0.11 would re-apply the null body and re-break auto-merge arming — exactly the MERGE_ARMING_FAILED we hit on #1422's sprint.

Cherry-pick of eddf7e6, clean apply. Content is identical to what already passed review on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)