### PR TITLE
ci: close story issue when its PR merges to a release branch (#1651)

### DIFF
--- a/.github/workflows/close-on-merge.yml
+++ b/.github/workflows/close-on-merge.yml
@@ -1,0 +1,69 @@
+name: Close story issue on merge
+
+# Stories merge into release/* (a non-default branch). GitHub's native
+# "Closes #N" keyword only closes an issue when the PR merges into the DEFAULT
+# branch (main), so story issues never auto-close. This replicates that
+# behavior for release branches: on a merged PR, close the issues its body
+# references. (#1651)
+#
+# Event-scoped, NOT a sweep: it reads only the single PR in the event payload
+# (github.event.pull_request) and closes the issues that PR's body references.
+# It never enumerates the repository's open issues.
+#
+# Decoupled from forward-port.yml by design: that triggers on `push`, this on
+# `pull_request closed` — separate workflows, no shared logic. A story issue
+# closes when the story merges to its base branch, NOT when its content later
+# reaches main.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: ["release/**"]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  close-referenced-issues:
+    # Only merged PRs; a PR closed without merging is a no-op.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced by the merged PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Passed via env (not inline ${{ }}) so a hostile PR body cannot
+          # inject shell — it is only ever read as data, never evaluated.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Extract issue numbers that follow a closing keyword (the same set
+          # GitHub honors on the default branch), case-insensitive.
+          nums=$(printf '%s\n' "$PR_BODY" \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u)
+
+          if [ -z "$nums" ]; then
+            echo "PR #$PR_NUMBER references no closing keywords; nothing to close (by design)."
+            exit 0
+          fi
+
+          for n in $nums; do
+            state=$(gh issue view "$n" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "MISSING")
+            case "$state" in
+              OPEN)
+                echo "Closing #$n (referenced by merged PR #$PR_NUMBER)"
+                gh issue close "$n" --repo "$REPO" \
+                  --comment "Closed by merged PR #$PR_NUMBER."
+                ;;
+              CLOSED)
+                echo "#$n already closed; skipping (idempotent with the sprint's synchronous close)."
+                ;;
+              *)
+                echo "#$n not found or unreadable; skipping."
+                ;;
+            esac
+          done


### PR DESCRIPTION
Closes #1651.

## What
New `close-on-merge.yml`: on a merged PR into `release/**`, closes the issues its body references (`Closes/Fixes/Resolves #N`).

## Why
Stories merge to `release/*` (non-default), so GitHub's native keyword close never fires, and the coordinator's synchronous close ([sprint/sources.py:410](src/theforge/sprint/sources.py:410)) misses merges that complete after the sprint exits. #1422/#1439 both had to be hand-closed.

## Design (per issue ACs)
- **Event-scoped, not a sweep**: reads only `github.event.pull_request`; never enumerates open issues.
- **Idempotent**: already-closed issue → no-op, safe alongside the sprint's sync close.
- **Injection-safe**: PR body passed via env, read as data only.
- **Decoupled from forward-port**: different trigger (`pull_request closed` vs `push`), separate file, no shared logic.
- A merged PR with no closing keyword closes nothing, by design.

## Note
Like #1653, a workflow change `make gate` can't exercise; validates on the next real story merge to `release/v0.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)