### PR TITLE
Groomer flags artifact-shape examples in feature/enhancement issues whose deliverable is a structured file

### DIFF
--- a/src/theforge/intake/groom.py
+++ b/src/theforge/intake/groom.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 import re
 
-from ..shape_check.parsing import extract_ac_section, extract_bullets
+from ..shape_check.parsing import (
+    extract_ac_section,
+    extract_contextual_bullets,
+    extract_contextual_fenced_code_blocks,
+)
 from .findings import FixType, IntakeFinding, IntakeSeverity
 
 # Tokens that strongly suggest a how/implementation-shaped AC line. These are
@@ -38,12 +42,57 @@ _HOW_TOKENS: tuple[str, ...] = (
 )
 
 _HOW_RE = re.compile("|".join(re.escape(tok) for tok in _HOW_TOKENS), re.IGNORECASE)
+_EXAMPLE_FILE_DIRECTIVE_RE = re.compile(
+    r"\b(?:add|create|edit|implement|modify|remove|rename|update)\b"
+    r".{0,100}\b(?:src/|tests/|docs/|[\w./-]+\.(?:py|pyi|js|jsx|ts|tsx|yaml|yml|json|sh|toml|rs|go|java|rb|md))",
+    re.IGNORECASE,
+)
+_EXAMPLE_SIGNATURE_RE = re.compile(
+    r"^\s*(?:def|class)\s+\w+\b|^\s*[A-Za-z_]\w*\s*\([^)]*\)\s*(?:->\s*[^:]+)?\s*:\s*$",
+    re.MULTILINE,
+)
+_EXAMPLE_IMPERATIVE_RE = re.compile(
+    r"\b(?:add|create|extract|implement|modify|refactor|rename|update)\b"
+    r".{0,60}\b(?:method|class|function|module|subclass)\b",
+    re.IGNORECASE,
+)
+
+
+def _example_block_directive_preview(block: str) -> str | None:
+    """Return a preview line when an example block contains explicit implementation directives."""
+    for line in block.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _EXAMPLE_FILE_DIRECTIVE_RE.search(stripped):
+            return stripped
+        if _EXAMPLE_IMPERATIVE_RE.search(stripped):
+            return stripped
+    signature_match = _EXAMPLE_SIGNATURE_RE.search(block)
+    if signature_match:
+        return signature_match.group(0).strip()
+    return None
 
 
 def _ac_lines_look_how_shaped(section: str) -> list[str]:
     """Return AC bullet lines that look HOW-shaped (implementation prescriptive)."""
-    bullets = extract_bullets(section)
-    return [line for line in bullets if _HOW_RE.search(line)]
+    return [
+        bullet.text
+        for bullet in extract_contextual_bullets(section)
+        if not bullet.in_example_section and _HOW_RE.search(bullet.text)
+    ]
+
+
+def _example_section_directives(body: str) -> list[str]:
+    """Return explicit implementation directives found inside example-shaped fenced blocks."""
+    findings: list[str] = []
+    for block in extract_contextual_fenced_code_blocks(body):
+        if not block.in_example_section:
+            continue
+        preview = _example_block_directive_preview(block.content)
+        if preview is not None:
+            findings.append(preview)
+    return findings
 
 
 def groom_check(title: str, body: str, labels: list[str]) -> list[IntakeFinding]:
@@ -60,6 +109,7 @@ def groom_check(title: str, body: str, labels: list[str]) -> list[IntakeFinding]
     section = extract_ac_section(body)
     if section:
         how_lines = _ac_lines_look_how_shaped(section)
+        how_lines.extend(_example_section_directives(body))
         if how_lines:
             preview = "; ".join(line.strip()[:80] for line in how_lines[:3])
             findings.append(

--- a/src/theforge/shape_check/parsing.py
+++ b/src/theforge/shape_check/parsing.py
@@ -158,8 +158,6 @@ def extract_contextual_bullets(section: str) -> list[ContextualBullet]:
         if stripped.startswith("```"):
             in_fence = not in_fence
             continue
-        if in_fence:
-            continue
 
         bullet_match = _BULLET_RE.match(line)
         if bullet_match:

--- a/src/theforge/shape_check/parsing.py
+++ b/src/theforge/shape_check/parsing.py
@@ -3,9 +3,33 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 _HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$", re.MULTILINE)
 _BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(?:\[[ xX]\]\s+)?(.+?)\s*$")
+_EXAMPLE_HEADING_RE = re.compile(
+    r"^(?:"
+    r"examples?"
+    r"|target(?:\s+(?:output|state|sketch))?"
+    r"|what\s+it\s+should\s+look\s+like"
+    r"|schema(?:\s+(?:example|output|sketch))?"
+    r"|sample\s+output"
+    r"|expected\s+output"
+    r")$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ContextualBullet:
+    text: str
+    in_example_section: bool
+
+
+@dataclass(frozen=True)
+class ContextualFencedBlock:
+    content: str
+    in_example_section: bool
 
 
 def find_heading(body: str, pattern: str) -> re.Match[str] | None:
@@ -45,6 +69,11 @@ def extract_section(body: str, heading_pattern: str) -> str | None:
 
 def extract_ac_section(body: str) -> str | None:
     return extract_section(body, r"acceptance criteria|done criteria|checklist")
+
+
+def is_example_heading(title: str) -> bool:
+    normalized = re.sub(r"\s+", " ", title.strip().rstrip(":")).lower()
+    return _EXAMPLE_HEADING_RE.fullmatch(normalized) is not None
 
 
 def _bullet_indent(line: str) -> int | None:
@@ -109,6 +138,41 @@ def extract_top_level_bullet_blocks(section: str) -> list[str]:
     return ["\n".join(b) for b in blocks]
 
 
+def extract_contextual_bullets(section: str) -> list[ContextualBullet]:
+    """Return bullets annotated with whether they appear under an example heading."""
+    bullets: list[ContextualBullet] = []
+    example_level: int | None = None
+    in_fence = False
+
+    for line in section.splitlines():
+        stripped = line.strip()
+        heading_match = _HEADING_RE.match(line)
+        if heading_match and not in_fence:
+            level = len(heading_match.group(1))
+            if example_level is not None and level <= example_level:
+                example_level = None
+            if is_example_heading(heading_match.group(2)):
+                example_level = level
+            continue
+
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        bullet_match = _BULLET_RE.match(line)
+        if bullet_match:
+            bullets.append(
+                ContextualBullet(
+                    text=bullet_match.group(1).strip(),
+                    in_example_section=example_level is not None,
+                )
+            )
+
+    return bullets
+
+
 def fenced_code_blocks(body: str) -> list[str]:
     """Return the contents of each triple-backtick fenced code block."""
     blocks: list[str] = []
@@ -125,4 +189,42 @@ def fenced_code_blocks(body: str) -> list[str]:
                 i += 1
             blocks.append("\n".join(buf))
         i += 1
+    return blocks
+
+
+def extract_contextual_fenced_code_blocks(body: str) -> list[ContextualFencedBlock]:
+    """Return fenced blocks annotated with whether they appear under an example heading."""
+    blocks: list[ContextualFencedBlock] = []
+    example_level: int | None = None
+    in_fence = False
+    current: list[str] = []
+
+    for line in body.splitlines():
+        if not in_fence:
+            heading_match = _HEADING_RE.match(line)
+            if heading_match:
+                level = len(heading_match.group(1))
+                if example_level is not None and level <= example_level:
+                    example_level = None
+                if is_example_heading(heading_match.group(2)):
+                    example_level = level
+                continue
+
+        if re.match(r"^\s*```", line):
+            if in_fence:
+                blocks.append(
+                    ContextualFencedBlock(
+                        content="\n".join(current),
+                        in_example_section=example_level is not None,
+                    )
+                )
+                current = []
+                in_fence = False
+            else:
+                in_fence = True
+            continue
+
+        if in_fence:
+            current.append(line)
+
     return blocks

--- a/tests/test_intake/test_groom.py
+++ b/tests/test_intake/test_groom.py
@@ -32,3 +32,49 @@ def test_groom_flags_how_shaped_ac():
 
 def test_groom_no_findings_on_empty_body():
     assert groom_check("Title", "", []) == []
+
+
+def test_groom_ignores_yaml_example_block_under_example_heading_in_ac():
+    body = (
+        "## Acceptance criteria\n\n"
+        "- Sprint RCA file is emitted.\n"
+        "- The file contains the expected fields.\n\n"
+        "### Example\n\n"
+        "```yaml\n"
+        "primary_failure_class: flaky-tests\n"
+        "contributing_factors:\n"
+        "  - missing test class coverage\n"
+        "```\n"
+    )
+
+    assert groom_check("Title", body, ["enhancement"]) == []
+
+
+def test_groom_ignores_schema_heading_example_blocks():
+    body = (
+        "## Acceptance criteria\n\n"
+        "- The CLI writes the structured artifact.\n\n"
+        "### Schema\n\n"
+        "```yaml\n"
+        "function_signature: str\n"
+        "module_layout: nested\n"
+        "```\n"
+    )
+
+    assert groom_check("Title", body, ["enhancement"]) == []
+
+
+def test_groom_flags_directives_inside_example_block():
+    body = (
+        "## Acceptance criteria\n\n"
+        "- Export output is available.\n\n"
+        "## Target output\n\n"
+        "```python\n"
+        "def implement_export_pipeline(records):\n"
+        "    return records\n"
+        "```\n"
+    )
+
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"

--- a/tests/test_intake/test_groom.py
+++ b/tests/test_intake/test_groom.py
@@ -78,3 +78,48 @@ def test_groom_flags_directives_inside_example_block():
     findings = groom_check("Title", body, ["enhancement"])
     assert len(findings) == 1
     assert findings[0].code == "groom_how_shaped_ac"
+
+
+def test_groom_flags_how_shaped_bullet_inside_non_example_fenced_block():
+    body = (
+        "## Acceptance criteria\n\n"
+        "- Export output is available.\n\n"
+        "### Notes\n\n"
+        "```markdown\n"
+        "- Refactor the export pipeline into an ExportService class\n"
+        "```\n"
+    )
+
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"
+
+
+def test_groom_flags_file_directive_inside_example_block():
+    body = (
+        "## Acceptance criteria\n\n"
+        "- Export output is available.\n\n"
+        "## Example\n\n"
+        "```python\n"
+        "# modify src/theforge/export.py\n"
+        "```\n"
+    )
+
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"
+
+
+def test_groom_flags_imperative_inside_example_block():
+    body = (
+        "## Acceptance criteria\n\n"
+        "- Export output is available.\n\n"
+        "## Example\n\n"
+        "```text\n"
+        "add method render to class ExportPresenter\n"
+        "```\n"
+    )
+
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -27,6 +27,10 @@ from theforge.shape_check.heuristics import (
     check_too_many_behavioral_clusters,
     check_untriaged_finding,
 )
+from theforge.shape_check.parsing import (
+    extract_contextual_bullets,
+    extract_contextual_fenced_code_blocks,
+)
 
 WELL_FORMED_AC = textwrap.dedent(
     """\
@@ -461,6 +465,47 @@ class TestNoObservableDoneState:
 
     def test_with_verb(self):
         assert check_no_observable_done_state("T", WELL_FORMED_AC, []) is None
+
+
+class TestExampleParsingContext:
+    def test_extract_contextual_bullets_marks_example_subsections(self):
+        section = textwrap.dedent(
+            """\
+            - The artifact is written.
+
+            ### Example
+            - function_signature: str
+
+            ### Notes
+            - The command returns 0.
+            """
+        )
+
+        bullets = extract_contextual_bullets(section)
+        assert [bullet.text for bullet in bullets] == [
+            "The artifact is written.",
+            "function_signature: str",
+            "The command returns 0.",
+        ]
+        assert [bullet.in_example_section for bullet in bullets] == [False, True, False]
+
+    def test_extract_contextual_fenced_blocks_marks_schema_heading(self):
+        body = textwrap.dedent(
+            """\
+            ## Schema
+            ```yaml
+            primary_failure_class: flaky-tests
+            ```
+
+            ## Notes
+            ```yaml
+            function_signature: str
+            ```
+            """
+        )
+
+        blocks = extract_contextual_fenced_code_blocks(body)
+        assert [block.in_example_section for block in blocks] == [True, False]
 
 
 class TestTooManyBehavioralClusters:

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -489,6 +489,25 @@ class TestExampleParsingContext:
         ]
         assert [bullet.in_example_section for bullet in bullets] == [False, True, False]
 
+    def test_extract_contextual_bullets_keeps_non_example_fenced_bullets(self):
+        section = textwrap.dedent(
+            """\
+            - The artifact is written.
+
+            ### Notes
+            ```markdown
+            - Refactor the export pipeline into an ExportService class
+            ```
+            """
+        )
+
+        bullets = extract_contextual_bullets(section)
+        assert [bullet.text for bullet in bullets] == [
+            "The artifact is written.",
+            "Refactor the export pipeline into an ExportService class",
+        ]
+        assert [bullet.in_example_section for bullet in bullets] == [False, False]
+
     def test_extract_contextual_fenced_blocks_marks_schema_heading(self):
         body = textwrap.dedent(
             """\


### PR DESCRIPTION
## Summary

[claude-opus] Cycle-1 P1 is resolved: non-example fenced HOW-shaped bullets in acceptance criteria now surface to the grooming scan and trigger groom_how_shaped_ac, while example-heading fences stay exempt. The iter-1 change (removing the in_fence skip in extract_contextual_bullets) introduces no regression; the #1439 exemption case still passes and all 79 tests are green. A previously-raised, spec-sanctioned P2 about file-path directive over-flagging remains deferred. | [openai-gpt-5.5] Prior P1 is fixed; the touched grooming and parsing paths satisfy the structured-example exemption without new blocking regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.75
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Groomer flags artifact-shape examples in feature/enhancement issues whose deliverable is a structured file (GitHub Issue #1441)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1441