### PR TITLE
bug: agent cost is recorded as $0.00 when a run is killed at timeout

### DIFF
--- a/src/theforge/cli/diagnose.py
+++ b/src/theforge/cli/diagnose.py
@@ -91,9 +91,11 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
             dry_run=args.dry_run,
         )
         icon = "✓" if result.success else "✗"
+        _cost = result.state.agent_cost_usd
+        cost_str = f"${_cost:.3f}" if _cost is not None else "unknown"
         print(
             f"[forge] {icon} #{number}: {result.message}  "
-            f"(phase={result.state.phase.name}, cost=${result.state.agent_cost_usd:.3f}, "
+            f"(phase={result.state.phase.name}, cost={cost_str}, "
             f"duration={result.state.agent_duration_s:.1f}s)",
             file=sys.stderr,
         )

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -638,7 +638,10 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "regenerated": state.plan_regen_count > 0,
                 "waited_seconds": round(state.plan_review_waited_seconds or 0, 2),
                 "findings": state.plan_agent_review_findings,
-                "cost_usd": state.total_plan_review_cost,
+                # Same measured source of truth as phases.plan_review.cost_usd, so
+                # the two plan_review surfaces can never diverge on kill-path runs:
+                # an unmeasured (None) cost stays null here too, never coerced 0.0.
+                "cost_usd": _round_cost(state.total_plan_review_cost_measured),
                 **({"per_reviewer": plan_review_per_reviewer} if plan_review_per_reviewer else {}),
                 "plan_finding_registry": [
                     {

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -27,6 +27,18 @@ MAX_KNOWN_VERSION = max(MIGRATION_HELPERS.keys()) if MIGRATION_HELPERS else 0
 __all_schema_exports__ = ("SCHEMA_VERSION", "MIGRATION_HELPERS", "MAX_KNOWN_VERSION")
 
 
+def _round_cost(value: float | None) -> float | None:
+    """Round a cost for the audit, preserving an unmeasured ``None`` as ``None``.
+
+    A ``None`` cost means the phase's spend could not be measured (e.g. a run
+    killed before its cost-bearing result event and no usage was reconstructable).
+    It must stay ``None`` in the audit — a coerced ``0.0`` is indistinguishable
+    from a genuinely free run and corrupts every cost-based view built on the
+    audit substrate.
+    """
+    return round(value, 6) if value is not None else None
+
+
 def _branch_has_unmerged_commits(project_root: Path, branch: str, base: str) -> bool:
     """Return True if branch exists and has commits ahead of base.
 
@@ -109,7 +121,10 @@ def has_review_approve(
 
 def _serialize_plan_review_result(result: object, attempt: int) -> dict:
     profile_name = getattr(result, "profile_name", "") or "unknown"
-    cost_usd = round(getattr(result, "cost_usd", None) or 0.0, 6)
+    # Preserve an unmeasured cost (None) rather than coercing to 0.0 — a
+    # reviewer run killed before its cost-bearing result event still spent money.
+    _raw_cost = getattr(result, "cost_usd", None)
+    cost_usd = round(_raw_cost, 6) if _raw_cost is not None else None
     if not getattr(result, "success", False):
         entry = {
             "attempt": attempt,
@@ -185,7 +200,7 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
     preflight_block: dict | None = None
     if state.preflight_verdict is not None:
         preflight_block = {
-            "cost_usd": round(state.total_preflight_cost, 6),
+            "cost_usd": _round_cost(state.total_preflight_cost_measured),
             "duration_s": round(state.preflight_duration_s, 2)
             if state.preflight_duration_s is not None
             else None,
@@ -196,7 +211,7 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
     plan_block: dict | None = None
     if state.plan_results:
         plan_block = {
-            "cost_usd": round(state.total_plan_cost, 6),
+            "cost_usd": _round_cost(state.total_plan_cost_measured),
             "duration_s": round(sum(state.plan_durations), 2) if state.plan_durations else None,
             "outcome": "success",
             "plan_structured": state.plan_structured,
@@ -210,7 +225,7 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
     if state.plan_review_decision is not None:
         _per_reviewer = _build_plan_review_per_reviewer(state, config)
         plan_review_block = {
-            "cost_usd": round(state.total_plan_review_cost, 6),
+            "cost_usd": _round_cost(state.total_plan_review_cost_measured),
             "duration_s": round(sum(state.plan_review_durations), 2)
             if state.plan_review_durations
             else None,
@@ -228,7 +243,7 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
             for event in item.transport_retry_events
         ]
         dev_block = {
-            "cost_usd": round(state.total_dev_cost, 6),
+            "cost_usd": _round_cost(state.total_dev_cost_measured),
             "duration_s": round(sum(state.dev_durations), 2) if state.dev_durations else None,
             "iterations": len(state.dev_results),
             "outcome": "success" if state.dev_results[-1].success else "failure",
@@ -259,25 +274,38 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
         _last_verdicts: dict[str, str] = {
             name: rr.verdict for name, rr in state.last_cycle_reviewer_results
         }
+        # Accumulate per reviewer, preserving an unmeasured cost: if any of a
+        # reviewer's runs reports cost_usd is None (e.g. killed before its
+        # cost-bearing result event), that reviewer's total is cost-unknown
+        # (None), never a coerced 0.0.
         _reviewer_costs: dict[str, float] = {}
+        _reviewer_unmeasured: set[str] = set()
         for r in state.review_agent_results:
             if r.profile_name and r.profile_name != "synthesis":
-                _reviewer_costs[r.profile_name] = _reviewer_costs.get(r.profile_name, 0.0) + (
-                    r.cost_usd if r.cost_usd is not None else 0.0
-                )
+                if r.cost_usd is None:
+                    _reviewer_unmeasured.add(r.profile_name)
+                else:
+                    _reviewer_costs[r.profile_name] = (
+                        _reviewer_costs.get(r.profile_name, 0.0) + r.cost_usd
+                    )
         per_reviewer = {
             name: {
-                "cost": round(cost, 6),
+                "cost": None if name in _reviewer_unmeasured else round(cost, 6),
                 "verdict": _last_verdicts.get(name),
             }
             for name, cost in _reviewer_costs.items()
         }
+        # A reviewer whose only run(s) were all unmeasured has no entry in
+        # _reviewer_costs; surface it with cost None rather than dropping it.
+        for name in _reviewer_unmeasured:
+            if name not in per_reviewer:
+                per_reviewer[name] = {"cost": None, "verdict": _last_verdicts.get(name)}
         # Final verdict from most recent review cycle
         _final_verdict: str | None = None
         if state.review_results:
             _final_verdict = state.review_results[-1].verdict.lower()
         review_block = {
-            "cost_usd": round(state.total_review_cost, 6),
+            "cost_usd": _round_cost(state.total_review_cost_measured),
             "duration_s": round(sum(state.review_durations), 2)
             if state.review_durations
             else None,
@@ -296,7 +324,7 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
         sum(state.review_durations),
     ]
     totals = {
-        "cost_usd": round(state.total_cost, 6),
+        "cost_usd": _round_cost(state.total_cost_measured),
         "duration_s": round(sum(all_durations), 2),
         "dev_attempts_total": len(state.dev_results),
         "dev_iterations_productive": len(state.dev_results),
@@ -525,9 +553,11 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             ],
         },
         "cost": {
-            "total_usd": state.total_cost,
-            "dev_usd": state.total_dev_cost,
-            "review_usd": state.total_review_cost,
+            # Use *_measured aggregates so an unmeasured kill-path run stays
+            # cost-unknown (None) here rather than being coerced to 0.0.
+            "total_usd": state.total_cost_measured,
+            "dev_usd": state.total_dev_cost_measured,
+            "review_usd": state.total_review_cost_measured,
             "dev_invocations": len(state.dev_results),
             "review_invocations": len(state.review_agent_results),
             "agents": agents,

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -32,8 +32,17 @@ from typing import Iterable
 SUBSTRATE_SCHEMA_VERSION = 3
 # Current per-record schema version. Records pre-dating the indexed-dimensions
 # slice (#1522) are treated as version 1. The reader-side migration helper
-# (`_migrate_record`) is the seam future breaking changes hang off — today it
-# is a no-op because no breaking field rename/removal has shipped.
+# (`_migrate_record`) is the seam future breaking changes hang off — a version
+# bump is warranted only for a breaking field rename/removal that a reader must
+# migrate an old record across.
+#
+# Note (#1596): audit cost fields are ``float | None`` — an unmeasured
+# (killed-at-timeout) run records ``null`` where a measured run records a
+# number. That is a backward-compatible value-domain *widening*, not a breaking
+# shape change: old all-numeric records still read unchanged, and this reader
+# stores the null straight into the nullable ``total_cost_usd`` REAL column. So
+# it does NOT bump this version. The schema guard pins both the measured and the
+# unmeasured shapes so a future accidental re-coercion is still caught.
 CURRENT_RECORD_SCHEMA_VERSION = 4
 SUBSTRATE_RELPATH = (".forge", "audits", "index.sqlite")
 HISTORY_RELPATH = (".forge", "audits", "history.jsonl")

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -246,7 +246,9 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
         "final_phase": state.phase.name,
         "phase_transitions": [{"phase": name, "at": ts} for name, ts in state.phase_transitions],
         "agent": {
-            "cost_usd": round(state.agent_cost_usd, 6),
+            "cost_usd": (
+                round(state.agent_cost_usd, 6) if state.agent_cost_usd is not None else None
+            ),
             "duration_s": round(state.agent_duration_s, 3),
             "raw_output_tail": state.agent_output[-2000:] if state.agent_output else "",
         },
@@ -463,7 +465,12 @@ def run_diagnose_flow(
 
     state.agent_duration_s = time.monotonic() - t0
     state.agent_output = getattr(agent_result, "output", "") or ""
-    state.agent_cost_usd = float(getattr(agent_result, "cost_usd", 0.0) or 0.0)
+    # Preserve an unmeasured cost (None) faithfully — a run killed at timeout
+    # still spent real money, and coercing None to 0.0 would record that spend
+    # as free in the audit. Reconstruction happens in the runner; here we only
+    # avoid destroying the cost-unknown signal it may hand us.
+    _raw_cost = getattr(agent_result, "cost_usd", None)
+    state.agent_cost_usd = float(_raw_cost) if _raw_cost is not None else None
 
     # Treat failure as "possibly partial" rather than abandon — per AC, a
     # diagnosis that can't be confirmed within bounds returns the partial
@@ -472,7 +479,12 @@ def run_diagnose_flow(
 
     # Budget guard — if the agent cost exceeded the configured budget, mark
     # the result as partial regardless of whether the agent reported success.
-    budget_exceeded = state.agent_cost_usd > config.diagnose.budget_usd * 1.05
+    # A cost-unknown run (None) cannot be shown to exceed the budget, so it is
+    # not treated as a budget breach here.
+    budget_exceeded = (
+        state.agent_cost_usd is not None
+        and state.agent_cost_usd > config.diagnose.budget_usd * 1.05
+    )
     if budget_exceeded:
         partial = True
 

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -542,6 +542,19 @@ class CoordinatorState:
         return sum(r.cost_usd or 0.0 for r in self.review_agent_results)
 
     @property
+    def total_review_cost_measured(self) -> float | None:
+        """Review cost, or ``None`` when any review attempt's cost was unmeasured.
+
+        Mirrors :attr:`total_dev_cost_measured`: a run killed before its
+        cost-bearing result event reports ``cost_usd is None``, and coercing that
+        to ``$0.00`` would record unmeasured spend as free in the audit. Empty
+        ``review_agent_results`` means no spend, so ``0.0``.
+        """
+        if any(r.cost_usd is None for r in self.review_agent_results):
+            return None
+        return sum(r.cost_usd or 0.0 for r in self.review_agent_results)
+
+    @property
     def total_preflight_cost(self) -> float:
         if self.preflight_result is None:
             return 0.0
@@ -575,7 +588,31 @@ class CoordinatorState:
         return sum(r.cost_usd or 0.0 for r in self.plan_results)
 
     @property
+    def total_plan_cost_measured(self) -> float | None:
+        """Plan cost, or ``None`` when any plan attempt's cost was unmeasured.
+
+        Mirrors :attr:`total_dev_cost_measured` so a plan run killed before its
+        cost-bearing result event is recorded as cost-unknown rather than free.
+        Empty ``plan_results`` means no spend, so ``0.0``.
+        """
+        if any(r.cost_usd is None for r in self.plan_results):
+            return None
+        return sum(r.cost_usd or 0.0 for r in self.plan_results)
+
+    @property
     def total_plan_review_cost(self) -> float:
+        return sum(r.cost_usd or 0.0 for r in self.plan_review_results)
+
+    @property
+    def total_plan_review_cost_measured(self) -> float | None:
+        """Plan-review cost, or ``None`` when a reviewer attempt's cost was unmeasured.
+
+        Mirrors :attr:`total_dev_cost_measured` so a plan-review run killed before
+        its cost-bearing result event is recorded as cost-unknown rather than
+        free. Empty ``plan_review_results`` means no spend, so ``0.0``.
+        """
+        if any(r.cost_usd is None for r in self.plan_review_results):
+            return None
         return sum(r.cost_usd or 0.0 for r in self.plan_review_results)
 
     @property
@@ -598,6 +635,27 @@ class CoordinatorState:
             + self.total_plan_review_cost
             + self.total_story_validation_cost
         )
+
+    @property
+    def total_cost_measured(self) -> float | None:
+        """Grand-total cost, or ``None`` when any contributing phase was unmeasured.
+
+        Sums the per-phase ``*_measured`` aggregates so a single kill-path run
+        with cost-unknown poisons the whole total to ``None`` rather than letting
+        a coerced ``$0.00`` understate real spend. When every phase is measured,
+        equals :attr:`total_cost`.
+        """
+        parts = [
+            self.total_dev_cost_measured,
+            self.total_review_cost_measured,
+            self.total_preflight_cost_measured,
+            self.total_plan_cost_measured,
+            self.total_plan_review_cost_measured,
+            self.total_story_validation_cost,
+        ]
+        if any(p is None for p in parts):
+            return None
+        return sum(p or 0.0 for p in parts)
 
 
 # dev_iteration property — added after @dataclass so the decorator sees the

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -135,7 +135,10 @@ class DiagnoseState:
     issue_title: str = ""
     issue_body: str = ""
     agent_output: str = ""
-    agent_cost_usd: float = 0.0
+    # None means the agent's cost was unmeasured (e.g. run killed before the
+    # cost-bearing result event and no usage was reconstructable). Distinct from
+    # 0.0, which means a genuinely free run. Never coerce one into the other.
+    agent_cost_usd: float | None = 0.0
     agent_duration_s: float = 0.0
     artifact: DiagnosisArtifact | None = None
     landing_destination: str | None = None

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -89,6 +89,167 @@ def _parse_model_usage(result_json: dict[str, Any]) -> tuple[ModelUsage, ...]:
     return tuple(usages)
 
 
+# ── Partial-cost reconstruction (kill paths) ──────────────────────────
+#
+# When a run is killed (timeout, stuck-pattern, or missing result event) the
+# terminal ``result`` event — which carries ``total_cost_usd`` and the
+# aggregated ``modelUsage`` block — never arrives, so the normal cost path
+# produces nothing. But every ``assistant`` stream event already captured in
+# memory carries a per-message ``usage`` block (Anthropic usage shape). We
+# aggregate those and price them via the shared pricing table so a killed run's
+# real spend is attributed rather than silently dropped to $0.00. Where no
+# usable usage was ever received, cost is recorded as unknown (None) — never a
+# fabricated zero, so "unmeasured" stays distinct from "free".
+
+# Anthropic prompt-cache pricing is expressed as multiples of the base input
+# rate: cache reads bill at 0.1x and 5-minute cache writes at 1.25x (Anthropic
+# pricing docs). The shared PRICING_TABLE only carries (input, output) rates,
+# so we apply these multipliers here to price the cached-token components.
+_CACHE_READ_RATE_MULT = 0.1
+_CACHE_WRITE_RATE_MULT = 1.25
+
+# Models whose kill-path cost could not be reconstructed — warned once each so
+# the log makes cost-unknown runs loud rather than silently zero.
+_COST_UNMEASURED_WARNED: set[str] = set()
+
+
+def _resolve_anthropic_pricing_key(raw_model: str) -> str | None:
+    """Map a stream-event model id to a PRICING_TABLE anthropic key.
+
+    Claude reports the fully-resolved model id (e.g. ``claude-sonnet-4-6`` or a
+    dated variant) in each message, while the pricing table is keyed on the
+    undated family id. Match exactly, then by prefix in either direction so a
+    dated id resolves to its family entry. Returns None when unknown.
+    """
+    from theforge.runners.schema_utils import PRICING_TABLE  # noqa: PLC0415
+
+    if not raw_model:
+        return None
+    if ("anthropic", raw_model) in PRICING_TABLE:
+        return raw_model
+    for provider, key in PRICING_TABLE:
+        if provider != "anthropic":
+            continue
+        if raw_model.startswith(key) or key.startswith(raw_model):
+            return key
+    return None
+
+
+def _estimate_anthropic_cost(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_creation_tokens: int,
+) -> float | None:
+    """Price reconstructed Anthropic token usage; None when model is unpriced."""
+    from theforge.runners.schema_utils import PRICING_TABLE  # noqa: PLC0415
+
+    key = _resolve_anthropic_pricing_key(model)
+    if key is None:
+        return None
+    in_rate, out_rate = PRICING_TABLE[("anthropic", key)]
+    return (
+        (input_tokens / 1_000_000) * in_rate
+        + (output_tokens / 1_000_000) * out_rate
+        + (cache_read_tokens / 1_000_000) * in_rate * _CACHE_READ_RATE_MULT
+        + (cache_creation_tokens / 1_000_000) * in_rate * _CACHE_WRITE_RATE_MULT
+    )
+
+
+def _reconstruct_partial_cost(
+    lines: list[str],
+    profile: ModelProfile,
+) -> tuple[float | None, tuple[ModelUsage, ...]]:
+    """Reconstruct spend and per-model usage from partial stream-json events.
+
+    Aggregates ``message.usage`` blocks across all captured ``assistant`` events
+    and prices them via the pricing table. Returns ``(cost_usd, model_usage)``.
+    ``cost_usd`` is None (cost-unknown, surfaced loudly) when no usable usage was
+    observed or no observed model could be priced — never a fabricated ``0.0``.
+    """
+    per_model: dict[str, dict[str, int]] = {}
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(event, dict) or event.get("type") != "assistant":
+            continue
+        message = event.get("message", {})
+        if not isinstance(message, dict):
+            continue
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        model_name = str(message.get("model") or profile.model or "?")
+        acc = per_model.setdefault(
+            model_name,
+            {"input": 0, "output": 0, "cache_read": 0, "cache_creation": 0},
+        )
+        acc["input"] += int(usage.get("input_tokens", 0) or 0)
+        acc["output"] += int(usage.get("output_tokens", 0) or 0)
+        acc["cache_read"] += int(usage.get("cache_read_input_tokens", 0) or 0)
+        acc["cache_creation"] += int(usage.get("cache_creation_input_tokens", 0) or 0)
+
+    if not per_model:
+        return None, ()
+
+    total_cost = 0.0
+    any_priced = False
+    usages: list[ModelUsage] = []
+    for model_name, acc in per_model.items():
+        cost = _estimate_anthropic_cost(
+            model_name,
+            acc["input"],
+            acc["output"],
+            acc["cache_read"],
+            acc["cache_creation"],
+        )
+        if cost is not None:
+            total_cost += cost
+            any_priced = True
+        usages.append(
+            ModelUsage(
+                model=model_name,
+                input_tokens=acc["input"],
+                output_tokens=acc["output"],
+                cache_read_tokens=acc["cache_read"],
+                cache_creation_tokens=acc["cache_creation"],
+                cost_usd=cost,
+            )
+        )
+    return (total_cost if any_priced else None), tuple(usages)
+
+
+def _partial_cost_or_warn(
+    lines: list[str],
+    profile: ModelProfile,
+    *,
+    kill_reason: str,
+) -> tuple[float | None, tuple[ModelUsage, ...]]:
+    """Reconstruct kill-path cost, logging whether it was measured or unknown."""
+    cost, usage = _reconstruct_partial_cost(lines, profile)
+    label = profile.name or profile.model or "?"
+    if cost is not None:
+        _log(
+            f"  {label} {kill_reason}: reconstructed partial cost ${cost:.4f} "
+            f"from {len(usage)} model(s) of stream usage (result event never arrived)."
+        )
+    else:
+        key = f"{label}:{profile.model}"
+        if key not in _COST_UNMEASURED_WARNED:
+            _COST_UNMEASURED_WARNED.add(key)
+            _log(
+                f"  WARNING: {label} {kill_reason} with no priceable stream usage; "
+                "recording cost-unknown, NOT $0.00."
+            )
+    return cost, usage
+
+
 def _format_tool_input_preview(inp: dict[str, Any]) -> str:
     """Return a short preview string for a tool's input dict."""
     if not inp:
@@ -534,6 +695,9 @@ def _run_claude(
 
     if stuck_monitor.should_terminate:
         partial_output = "".join(lines)
+        _stuck_cost, _stuck_usage = _partial_cost_or_warn(
+            lines, profile, kill_reason="killed on stuck-pattern"
+        )
         return AgentResult(
             success=False,
             output=(
@@ -546,10 +710,11 @@ def _run_claude(
                 fallback_to_file=fallback_to_file,
                 min_mtime=start_wall,
             ),
-            cost_usd=None,
+            cost_usd=_stuck_cost,
             exit_code=-2,
             raw={},
             profile_name=profile.name,
+            model_usage=_stuck_usage,
             failure_code="stuck_pattern",
             dev_handoff=_try_parse_handoff(partial_output),
         )
@@ -560,6 +725,9 @@ def _run_claude(
     if timed_out:
         partial_output = "".join(lines)
         _timeout_output = f"TIMEOUT: Agent exceeded {profile.timeout_seconds}s limit"
+        _timeout_cost, _timeout_usage = _partial_cost_or_warn(
+            lines, profile, kill_reason="killed at timeout"
+        )
         return AgentResult(
             success=False,
             output=_timeout_output,
@@ -569,10 +737,11 @@ def _run_claude(
                 fallback_to_file=fallback_to_file,
                 min_mtime=start_wall,
             ),
-            cost_usd=None,
+            cost_usd=_timeout_cost,
             exit_code=-9,
             raw={},
             profile_name=profile.name,
+            model_usage=_timeout_usage,
             dev_handoff=_try_parse_handoff(partial_output),
         )
 
@@ -605,6 +774,9 @@ def _run_claude(
         _noresult_output = (
             extracted_output or stderr_text or _build_no_text_marker("missing_result_event")
         )
+        _noresult_cost, _noresult_usage = _partial_cost_or_warn(
+            lines, profile, kill_reason="ended without a result event"
+        )
         return AgentResult(
             success=proc.returncode == 0,
             output=_noresult_output,
@@ -614,10 +786,11 @@ def _run_claude(
                 fallback_to_file=fallback_to_file,
                 min_mtime=start_wall,
             ),
-            cost_usd=None,
+            cost_usd=_noresult_cost,
             exit_code=proc.returncode,
             raw={},
             profile_name=profile.name,
+            model_usage=_noresult_usage,
             dev_handoff=_try_parse_handoff(_noresult_output),
         )
 

--- a/tests/test_audit_schema_guard.py
+++ b/tests/test_audit_schema_guard.py
@@ -32,6 +32,7 @@ from theforge.coordinator.audit_substrate import (
 )
 from theforge.coordinator.audit_substrate import MIGRATION_HELPERS
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.runners import AgentResult
 from theforge.task import TaskStory
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -60,11 +61,10 @@ def _collect_schema(value: object, path: str = "") -> dict[str, str]:
     return out
 
 
-def _build_canonical_record(tmp_path: Path) -> dict:
-    """Generate an audit record from a minimal-but-deterministic state."""
+def _make_config(tmp_path: Path) -> ForgeConfig:
     spec_path = tmp_path / "spec.md"
     spec_path.write_text("# spec", encoding="utf-8")
-    config = ForgeConfig(
+    return ForgeConfig(
         project="test",
         project_root=tmp_path,
         workspace=WorkspaceConfig(
@@ -79,11 +79,58 @@ def _build_canonical_record(tmp_path: Path) -> dict:
         synthesis_profile=None,
         retry=RetryPolicy(),
     )
-    task = TaskStory(name="Test", slug="test", story_path=spec_path)
+
+
+def _build_canonical_record(tmp_path: Path) -> dict:
+    """Generate an audit record from a minimal-but-deterministic state."""
+    config = _make_config(tmp_path)
+    task = TaskStory(name="Test", slug="test", story_path=tmp_path / "spec.md")
     state = CoordinatorState()
     state.started_at = "2026-01-01T00:00:00+00:00"
     state.run_id = "deadbeefcafe"
     result = CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="done")
+    return generate_audit_log(config, task, result)
+
+
+def _killed(profile_name: str) -> AgentResult:
+    """An AgentResult whose cost is unmeasured (None) — e.g. killed at timeout."""
+    return AgentResult(
+        success=False,
+        output="TIMEOUT: Agent exceeded limit",
+        session_id=None,
+        cost_usd=None,
+        exit_code=-9,
+        raw={},
+        profile_name=profile_name,
+    )
+
+
+def _build_unmeasured_record(tmp_path: Path) -> dict:
+    """Generate an audit record where every phase cost is unmeasured (None).
+
+    Exercises the kill-path shape the timeout-cost fix introduced: cost fields
+    that are ``float`` in a measured run become ``null`` here. Pins that shape so
+    future drift on the nullable path is caught, and feeds the substrate
+    round-trip test.
+    """
+    config = _make_config(tmp_path)
+    task = TaskStory(name="Test", slug="test", story_path=tmp_path / "spec.md")
+    state = CoordinatorState()
+    state.started_at = "2026-01-01T00:00:00+00:00"
+    state.run_id = "deadbeefcafe"
+    # preflight, plan, plan_review, dev, review — each killed with unmeasured cost.
+    state.preflight_verdict = "PROCEED"
+    state.preflight_result = _killed("preflight")
+    state.plan_results.append(_killed("planner"))
+    state.plan_durations.append(5.0)
+    state.plan_review_decision = "APPROVE"
+    state.plan_review_results.append(_killed("plan-reviewer"))
+    state.plan_review_durations.append(5.0)
+    state.dev_results.append(_killed("dev"))
+    state.dev_durations.append(5.0)
+    state.review_agent_results.append(_killed("reviewer"))
+    state.review_durations.append(5.0)
+    result = CoordinatorResult(success=False, phase=Phase.DONE, state=state, message="killed")
     return generate_audit_log(config, task, result)
 
 
@@ -155,6 +202,67 @@ def test_audit_record_schema_unchanged(tmp_path: Path) -> None:
             diff="\n".join(diff_lines) or "  (no field-level diff; types-only change)",
         )
     )
+
+
+def test_unmeasured_cost_fields_serialize_null_under_same_schema_version(
+    tmp_path: Path,
+) -> None:
+    """Kill-path cost fields serialize null, and that is an intentional widening.
+
+    The timeout-cost fix made every audit cost field ``float | None`` — a
+    measured run records a number, an unmeasured (killed) run records null.
+    This is a backward-compatible value-domain widening, NOT a breaking field
+    rename/removal, so it does not bump the record schema version: old records
+    (all-numeric) still read, and the reader tolerates null (verified by the
+    round-trip test below). The paths asserted here are the exact ones the
+    canonical measured record types as ``float`` — pinning the polymorphism so a
+    future accidental re-coercion to 0.0 (or a new cost field that forgets to
+    preserve None) is caught.
+    """
+    record = _build_unmeasured_record(tmp_path)
+
+    # Same record version as the measured canonical record — no bump.
+    assert record["schema_version"] == SCHEMA_VERSION
+
+    null_cost_paths = [
+        record["phases"]["preflight"]["cost_usd"],
+        record["phases"]["plan"]["cost_usd"],
+        record["phases"]["plan_review"]["cost_usd"],
+        record["phases"]["dev"]["cost_usd"],
+        record["phases"]["review"]["cost_usd"],
+        record["phases"]["review"]["per_reviewer"]["reviewer"]["cost"],
+        record["plan_review"]["cost_usd"],
+        record["totals"]["cost_usd"],
+        record["cost"]["total_usd"],
+        record["cost"]["dev_usd"],
+        record["cost"]["review_usd"],
+    ]
+    for value in null_cost_paths:
+        assert value is None
+
+
+def test_unmeasured_cost_record_round_trips_through_substrate(tmp_path: Path) -> None:
+    """The reader must persist and read back a null-cost record without error.
+
+    This is the seam that the schema concern turns on: a nullable cost field must
+    survive write -> flatten -> sqlite (REAL column) -> read. total_cost_usd lands
+    as SQL NULL, not a coerced 0.0, so cost-based views stay honest.
+    """
+    record = _build_unmeasured_record(tmp_path)
+    audit_substrate.seed_records(tmp_path, [record])
+
+    conn = audit_substrate.create_or_open(tmp_path)
+    try:
+        row = conn.execute(
+            "SELECT total_cost_usd, record_schema_version FROM audit_records WHERE run_id = ?",
+            (record["run_id"],),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row[0] is None  # SQL NULL, not 0.0 — unmeasured stays distinct from free
+    assert row[1] == SCHEMA_VERSION
 
 
 def test_migration_helpers_cover_current_version() -> None:

--- a/tests/test_coord_audit.py
+++ b/tests/test_coord_audit.py
@@ -134,6 +134,99 @@ class TestDurationAndCostNoneChecks:
         assert log["preflight"]["cache_validation"]["reason"] == "worktree_head_changed"
 
 
+class TestUnmeasuredCostPreservedInAudit:
+    """A kill-path run with unmeasured cost (None) must stay null in the audit.
+
+    Covers the runner -> coordinator-state -> audit seam: an AgentResult whose
+    cost_usd is None (e.g. killed before its cost-bearing result event, no usage
+    reconstructable) must serialize to null in every coordinator audit surface,
+    never a coerced 0.0 that reads as "genuinely free".
+    """
+
+    @staticmethod
+    def _unmeasured(profile_name: str = "agent") -> AgentResult:
+        return AgentResult(
+            success=False,
+            output="TIMEOUT: Agent exceeded limit",
+            session_id=None,
+            cost_usd=None,
+            exit_code=-9,
+            raw={},
+            profile_name=profile_name,
+        )
+
+    def test_dev_phase_cost_null_not_zero(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.dev_results.append(self._unmeasured())
+        state.dev_durations.append(5.0)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        assert log["phases"]["dev"]["cost_usd"] is None
+
+    def test_review_phase_and_per_reviewer_cost_null_not_zero(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.review_agent_results.append(self._unmeasured(profile_name="slow-reviewer"))
+        state.review_durations.append(5.0)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        review = log["phases"]["review"]
+        assert review["cost_usd"] is None
+        assert review["per_reviewer"]["slow-reviewer"]["cost"] is None
+
+    def test_preflight_phase_cost_null_not_zero(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        state.preflight_result = self._unmeasured(profile_name="preflight")
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        assert log["phases"]["preflight"]["cost_usd"] is None
+
+    def test_plan_phase_cost_null_not_zero(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.plan_results.append(self._unmeasured(profile_name="planner"))
+        state.plan_durations.append(5.0)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        assert log["phases"]["plan"]["cost_usd"] is None
+
+    def test_plan_review_phase_cost_null_not_zero(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.plan_review_decision = "APPROVE"
+        state.plan_review_results.append(self._unmeasured(profile_name="plan-reviewer"))
+        state.plan_review_durations.append(5.0)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        assert log["phases"]["plan_review"]["cost_usd"] is None
+
+    def test_totals_and_cost_summary_null_when_any_phase_unmeasured(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.dev_results.append(self._unmeasured())
+        state.dev_durations.append(5.0)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        assert log["totals"]["cost_usd"] is None
+        assert log["cost"]["total_usd"] is None
+        assert log["cost"]["dev_usd"] is None
+
+    def test_measured_zero_still_records_zero_not_null(self, tmp_path: Path) -> None:
+        """A genuinely free run (cost 0.0) stays 0.0 — the fix must not null it out."""
+        state = CoordinatorState()
+        r = AgentResult(
+            success=True,
+            output="ok",
+            session_id=None,
+            cost_usd=0.0,
+            exit_code=0,
+            raw={},
+            profile_name="free-dev",
+        )
+        state.dev_results.append(r)
+        state.dev_durations.append(5.0)
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        assert log["phases"]["dev"]["cost_usd"] == 0.0
+
+    def test_serialize_plan_review_result_preserves_none(self) -> None:
+        from theforge.coordinator.audit import _serialize_plan_review_result
+
+        entry = _serialize_plan_review_result(self._unmeasured(profile_name="pr"), attempt=0)
+        assert entry["cost_usd"] is None
+        assert entry["verdict"] == "CRASHED"
+
+
 class TestHasReviewApprove:
     def test_no_history_file(self, tmp_path: Path) -> None:
         """Fresh repo (no audit inputs) returns False (safe default)."""

--- a/tests/test_coord_audit.py
+++ b/tests/test_coord_audit.py
@@ -185,13 +185,17 @@ class TestUnmeasuredCostPreservedInAudit:
         log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
         assert log["phases"]["plan"]["cost_usd"] is None
 
-    def test_plan_review_phase_cost_null_not_zero(self, tmp_path: Path) -> None:
+    def test_plan_review_cost_null_not_zero_on_both_surfaces(self, tmp_path: Path) -> None:
+        """Both plan_review cost surfaces (phases block AND top-level block) stay null."""
         state = CoordinatorState()
         state.plan_review_decision = "APPROVE"
         state.plan_review_results.append(self._unmeasured(profile_name="plan-reviewer"))
         state.plan_review_durations.append(5.0)
         log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _make_result(state))
+        # phases.plan_review.cost_usd and the sibling top-level plan_review.cost_usd
+        # read the same measured source, so neither may coerce None to 0.0.
         assert log["phases"]["plan_review"]["cost_usd"] is None
+        assert log["plan_review"]["cost_usd"] is None
 
     def test_totals_and_cost_summary_null_when_any_phase_unmeasured(self, tmp_path: Path) -> None:
         state = CoordinatorState()

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -201,7 +201,7 @@ class TestPromptBuilder:
 # ── State machine / flow tests ────────────────────────────────────────
 
 
-def _fake_agent_result(output: str, *, success: bool = True, cost: float = 0.05):
+def _fake_agent_result(output: str, *, success: bool = True, cost: float | None = 0.05):
     """Build a minimal AgentResult-shaped object usable as a runner stub."""
     from theforge.agent_types import AgentResult
 
@@ -608,6 +608,58 @@ class TestDiagnoseFlow:
 
 
 # ── dry-run stdout tests ──────────────────────────────────────────────
+
+
+class TestDiagnoseCostFidelity:
+    """A killed diagnose run records real/unknown cost in the audit, never $0.00.
+
+    Covers the runner -> diagnose_flow -> audit seam: a run killed at the timeout
+    deadline still incurred cost, and the audit must reflect that faithfully.
+    """
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_reconstructed_cost_lands_in_audit(self, mock_agent, mock_fetch, tmp_path):
+        """A non-zero (reconstructed) cost from the runner is preserved in the audit."""
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {"number": 1, "title": "x", "body": "y", "state": "OPEN"}
+        mock_agent.return_value = _fake_agent_result(
+            "TIMEOUT: Agent exceeded limit", success=False, cost=0.37
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        audit = tmp_path / ".forge" / "audits" / f"diagnose-issue-1-{result.state.run_id}.yaml"
+        loaded = yaml.safe_load(audit.read_text())
+        assert loaded["agent"]["cost_usd"] == 0.37
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_unmeasured_cost_is_null_not_zero(self, mock_agent, mock_fetch, tmp_path):
+        """An unmeasured cost (None) is written as null, distinct from a free 0.0."""
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {"number": 1, "title": "x", "body": "y", "state": "OPEN"}
+        mock_agent.return_value = _fake_agent_result(
+            "TIMEOUT: Agent exceeded limit", success=False, cost=None
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        audit = tmp_path / ".forge" / "audits" / f"diagnose-issue-1-{result.state.run_id}.yaml"
+        loaded = yaml.safe_load(audit.read_text())
+        assert loaded["agent"]["cost_usd"] is None
 
 
 class TestDryRunPrintsArtifact:

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -792,6 +792,145 @@ class TestRunAgentModelUsage:
         assert "claude-opus-4-6" in models
 
 
+def _assistant_usage_line(
+    *,
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read: int = 0,
+    cache_creation: int = 0,
+) -> str:
+    """Build a stream-json assistant event carrying a per-message usage block."""
+    return (
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "model": model,
+                    "usage": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "cache_read_input_tokens": cache_read,
+                        "cache_creation_input_tokens": cache_creation,
+                    },
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+class TestReconstructPartialCost:
+    """Unit tests for kill-path cost reconstruction from partial stream usage."""
+
+    def test_sums_and_prices_assistant_usage(self, dev_profile: ModelProfile) -> None:
+        lines = [
+            _assistant_usage_line(input_tokens=1000, output_tokens=500),
+            _assistant_usage_line(input_tokens=2000, output_tokens=1000, cache_read=10000),
+        ]
+        cost, usage = runner_claude_mod._reconstruct_partial_cost(lines, dev_profile)
+        # sonnet pricing: input 3.00/Mtok, output 15.00/Mtok, cache_read 0.1x input.
+        expected = (
+            (3000 / 1_000_000) * 3.00
+            + (1500 / 1_000_000) * 15.00
+            + (10000 / 1_000_000) * 3.00 * 0.1
+        )
+        assert cost is not None
+        assert cost == pytest.approx(expected)
+        assert cost > 0.0
+        assert len(usage) == 1
+        assert usage[0].input_tokens == 3000
+        assert usage[0].output_tokens == 1500
+        assert usage[0].cache_read_tokens == 10000
+
+    def test_no_usage_returns_none_not_zero(self, dev_profile: ModelProfile) -> None:
+        lines = [json.dumps({"type": "assistant", "message": {"content": []}}) + "\n"]
+        cost, usage = runner_claude_mod._reconstruct_partial_cost(lines, dev_profile)
+        assert cost is None
+        assert usage == ()
+
+    def test_unpriced_model_records_usage_but_unknown_cost(
+        self, dev_profile: ModelProfile
+    ) -> None:
+        lines = [_assistant_usage_line(model="mystery-model-9", input_tokens=1000)]
+        cost, usage = runner_claude_mod._reconstruct_partial_cost(lines, dev_profile)
+        assert cost is None
+        assert len(usage) == 1
+        assert usage[0].cost_usd is None
+
+    def test_dated_model_id_resolves_to_family_pricing(self, dev_profile: ModelProfile) -> None:
+        lines = [_assistant_usage_line(model="claude-sonnet-4-6-20260115", input_tokens=1000)]
+        cost, _ = runner_claude_mod._reconstruct_partial_cost(lines, dev_profile)
+        assert cost is not None
+        assert cost == pytest.approx((1000 / 1_000_000) * 3.00)
+
+
+class TestTimeoutCostReconstruction:
+    """A run killed at the deadline attributes cost from partial stream usage."""
+
+    def _blocking_after(self, usage_lines: list[str]):
+        class _PartialThenBlockStdout:
+            def __iter__(self):
+                yield from usage_lines
+                time.sleep(0.5)  # longer than the tiny timeout
+                return
+
+        return _PartialThenBlockStdout()
+
+    def _tiny_timeout_profile(self) -> ModelProfile:
+        return ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=1.0,
+            timeout_seconds=0.1,
+            allowed_tools=(),
+        )
+
+    def test_timeout_reconstructs_nonzero_cost(self, tmp_path: Path) -> None:
+        usage_lines = [
+            _assistant_usage_line(input_tokens=5000, output_tokens=2000, cache_read=40000),
+        ]
+        mock_proc = MagicMock()
+        mock_proc.stdout = self._blocking_after(usage_lines)
+        mock_proc.stdin = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.returncode = -1
+        mock_proc.wait.return_value = -1
+        mock_proc.poll.return_value = None
+
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(
+                prompt="test", profile=self._tiny_timeout_profile(), working_dir=tmp_path
+            )
+
+        assert result.exit_code == -9
+        assert "TIMEOUT" in result.output
+        # The whole point: a killed run's cost is reconstructed, not dropped to 0.0.
+        assert result.cost_usd is not None
+        assert result.cost_usd > 0.0
+        assert len(result.model_usage) == 1
+
+    def test_timeout_without_usage_records_unknown_not_zero(self, tmp_path: Path) -> None:
+        no_usage_line = json.dumps({"type": "assistant", "session_id": "s"}) + "\n"
+        mock_proc = MagicMock()
+        mock_proc.stdout = self._blocking_after([no_usage_line])
+        mock_proc.stdin = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.returncode = -1
+        mock_proc.wait.return_value = -1
+        mock_proc.poll.return_value = None
+
+        with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
+            result = run_agent(
+                prompt="test", profile=self._tiny_timeout_profile(), working_dir=tmp_path
+            )
+
+        assert result.exit_code == -9
+        # Unmeasurable cost stays explicitly unknown (None), never a fabricated 0.0.
+        assert result.cost_usd is None
+
+
 class TestRunAgentUnknownCli:
     """Test dispatch for unsupported CLI."""
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 cost-null and schema-guard concerns are resolved; killed Claude runs now reconstruct cost when usage exists and preserve null when cost is unmeasured. | [claude-sonnet] All three prior P1 findings are resolved. Cycle-4 iteration only adds documentation (a comment on CURRENT_RECORD_SCHEMA_VERSION) and test coverage (schema-guard test for the all-unmeasured record shape, plus a substrate round-trip test proving null persists as SQL NULL) — no production behavior changed, and the version-coherence concern from cycle 3 is addressed with a verified, non-breaking rationale. Full suite passes (4798 passed, 24 skipped). | [openai-gpt-5.4] The kill-path cost reconstruction now preserves nonzero spend and unknown cost consistently across diagnose and coordinator audit surfaces, and the prior plan_review/schema consistency P1s are resolved without introducing a new merge blocker.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $27.41
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: agent cost is recorded as $0.00 when a run is killed at timeout (GitHub Issue #1596)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1596