### PR TITLE
Completed-sprint postmortem digest: forge status renders LANDED / FAILED-by-class / PARTIAL / SKIPPED / NEXT layout from sprint-rca.yaml

### DIFF
--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -347,16 +347,25 @@ def _read_digest_rca(sprint_log_dir: Path, run_id: str) -> dict | None:
 
     Prefers the durable run-keyed ``run-<id>-sprint-rca.yaml`` so a historical
     run resolves to its own analysis even after a later same-name run overwrote
-    the ``sprint-rca.yaml`` pointer; falls back to the pointer otherwise.
+    the ``sprint-rca.yaml`` pointer. The run-keyed file is trustworthy by name.
+
+    The ``sprint-rca.yaml`` pointer, by contrast, tracks only the *latest* run
+    for a sprint name (``forge rca`` writes it with ``write_pointer=False`` for
+    historical runs). Accept it only when its ``sprint_run_id`` is absent or
+    matches the queried run — otherwise it belongs to a different (later) run and
+    would misattribute another run's failures into this postmortem brief. In
+    that case fall through to the missing-RCA branch rather than lie.
     """
-    candidates = []
     if run_id:
-        candidates.append(sprint_log_dir / f"run-{run_id}-sprint-rca.yaml")
-    candidates.append(sprint_log_dir / RCA_FILENAME)
-    for path in candidates:
-        data = _load_yaml(path)
-        if isinstance(data, dict):
-            return data
+        run_keyed = _load_yaml(sprint_log_dir / f"run-{run_id}-sprint-rca.yaml")
+        if isinstance(run_keyed, dict):
+            return run_keyed
+
+    pointer = _load_yaml(sprint_log_dir / RCA_FILENAME)
+    if isinstance(pointer, dict):
+        pointer_run_id = pointer.get("sprint_run_id")
+        if not pointer_run_id or not run_id or str(pointer_run_id) == str(run_id):
+            return pointer
     return None
 
 

--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -1,0 +1,368 @@
+"""Postmortem digest renderer for completed sprints.
+
+``forge status`` has two renderings that read the *same* on-disk state:
+
+* the wide telemetry table (``cli/sprint_status.py``) — the right view while a
+  sprint is live and the operator is monitoring "what is stuck right now";
+* this postmortem digest — the right view once a sprint is complete and the
+  operator's question shifts from monitoring to recovery: what landed, what
+  failed (and why), what produced partial value, what was skipped, and what to
+  do next.
+
+The digest is a pure *renderer*. Its interface to the rest of the system is the
+two artifacts it reads — ``sprint-summary.yaml`` (the LANDED accounting) and
+``sprint-rca.yaml`` (the recovery signals). It never invokes the RCA engine and
+never touches live coordinator state; that keeps it implementable and testable
+independently of both the live renderer and the classifier.
+
+Layout for a completed sprint with one or more non-DONE stories::
+
+    SPRINT <name>  ·  completed  ·  <duration>m  ·  $<cost>
+
+    LANDED (n of m)
+      ✓ #NNNN  $cost  elapsed  <title>
+
+    FAILED — <primary_failure_class> (n)
+      ✗ #NNNN  $cost  elapsed  <title>
+           primary:      <primary_failure_class>
+           contributing: <factor>, <factor>
+           evidence:     <excerpt> at <source>
+
+    SKIPPED / INTAKE (n)
+      ⊘ #NNNN  —  —  <title>
+           <primary_failure_class> — <detail>
+
+    PARTIAL VALUE (n)
+      ◐ #NNNN  <partial value>; <partial value>
+
+    NEXT
+      - <recommended next action>
+
+A completed sprint whose stories all landed renders the tighter LANDED-only
+digest with none of the recovery sections.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+from theforge.sprint.rca import DONE_OUTCOMES, RCA_FILENAME
+from theforge.sprint.status_reader import (
+    _elapsed_seconds_from_bounds,
+    find_sprint_summary,
+)
+
+# Primary failure classes whose stories never entered DEV — intake shape drops,
+# dependency-blocked skips, and launch-guard collisions. These route to the
+# SKIPPED / INTAKE section rather than getting their own FAILED heading, because
+# the operator's recovery action is reshaping/scheduling, not failure triage.
+_SKIPPED_INTAKE_CLASSES = frozenset(
+    {
+        "intake_shape",
+        "dependency_skip",
+        "launch_collision",
+    }
+)
+
+# Baseline evidence rule that every RCA entry carries; suppressed from the
+# evidence lines because it only restates the outcome shown on the story row.
+_BASELINE_EVIDENCE_RULE = "captured_outcome"
+_MAX_EVIDENCE_LINES = 3
+
+
+def display_sprint_digest(run_id: str, project_root: Path) -> int:
+    """Render the postmortem digest for a completed sprint ``run_id``.
+
+    Reads ``sprint-summary.yaml`` and ``sprint-rca.yaml`` from disk only. Returns
+    0 on success, 1 when no sprint summary can be located for ``run_id``.
+    """
+    summary_path = find_sprint_summary(run_id, project_root)
+    if summary_path is None:
+        print(
+            f"No sprint data found for run ID '{run_id}'.\n"
+            "Is the run ID correct? Use 'forge status' to see active runs.",
+            file=sys.stderr,
+        )
+        return 1
+
+    summary = _load_yaml(summary_path)
+    if not isinstance(summary, dict):
+        print(f"Sprint summary for run ID '{run_id}' is unreadable.", file=sys.stderr)
+        return 1
+
+    sprint_block = summary.get("sprint") if isinstance(summary.get("sprint"), dict) else {}
+    stories = [s for s in (summary.get("stories") or []) if isinstance(s, dict)]
+
+    landed = [s for s in stories if _outcome(s) in DONE_OUTCOMES]
+    non_done = [s for s in stories if _outcome(s) not in DONE_OUTCOMES]
+
+    _print_header(sprint_block, run_id)
+    _print_landed(landed, len(stories))
+
+    # All-DONE sprint: tighter LANDED-only digest, no recovery sections.
+    if not non_done:
+        return 0
+
+    resolved_run_id = str(sprint_block.get("run_id") or run_id)
+    rca = _read_digest_rca(summary_path.parent, resolved_run_id)
+    if rca is None:
+        # Completed sprint with non-DONE stories but no RCA artifact: point the
+        # operator at the on-demand verb and render LANDED only.
+        print()
+        print(
+            f"  No RCA artifact yet — run 'forge rca {run_id}' to classify the "
+            f"{len(non_done)} non-DONE stor{'y' if len(non_done) == 1 else 'ies'}."
+        )
+        return 0
+
+    rca_stories = rca.get("stories") if isinstance(rca.get("stories"), dict) else {}
+
+    _print_failed_by_class(non_done, rca_stories)
+    _print_skipped_intake(non_done, rca_stories)
+    _print_partial_value(non_done, rca_stories)
+    _print_next(stories, rca_stories)
+    return 0
+
+
+# ── Sections ──────────────────────────────────────────────────────────────────
+
+
+def _print_header(sprint_block: dict, run_id: str) -> None:
+    name = str(sprint_block.get("name") or run_id)
+    parts = [f"SPRINT {name}", "completed"]
+    duration = sprint_block.get("duration_seconds")
+    if isinstance(duration, (int, float)) and duration > 0:
+        parts.append(f"{int(duration // 60)}m")
+    cost = sprint_block.get("total_cost_usd")
+    if isinstance(cost, (int, float)):
+        parts.append(f"${cost:.2f}")
+    print("  ·  ".join(parts))
+
+
+def _print_landed(landed: list[dict], total: int) -> None:
+    print()
+    print(f"LANDED ({len(landed)} of {total})")
+    if not landed:
+        print("  (none)")
+        return
+    for story in landed:
+        print(f"  ✓ {_story_row(story)}")
+
+
+def _print_failed_by_class(non_done: list[dict], rca_stories: dict) -> None:
+    """Group failed stories under their literal ``primary_failure_class``.
+
+    Stories whose class routes to SKIPPED / INTAKE are excluded here. Class
+    order follows first appearance in sprint order so the layout stays stable.
+    """
+    grouped: dict[str, list[dict]] = {}
+    for story in non_done:
+        entry = _rca_entry(story, rca_stories)
+        primary = _primary_class(entry)
+        if primary in _SKIPPED_INTAKE_CLASSES:
+            continue
+        grouped.setdefault(primary, []).append(story)
+
+    for primary, group in grouped.items():
+        print()
+        print(f"FAILED — {primary} ({len(group)})")
+        for story in group:
+            entry = _rca_entry(story, rca_stories)
+            print(f"  ✗ {_story_row(story)}")
+            print(f"       primary:      {primary}")
+            contributing = _string_list(entry.get("contributing_factors"))
+            if contributing:
+                print(f"       contributing: {', '.join(contributing)}")
+            evidence_lines = _evidence_lines(entry)
+            for index, line in enumerate(evidence_lines):
+                label = "evidence:    " if index == 0 else "             "
+                print(f"       {label} {line}")
+
+
+def _print_skipped_intake(non_done: list[dict], rca_stories: dict) -> None:
+    rows = [
+        story
+        for story in non_done
+        if _primary_class(_rca_entry(story, rca_stories)) in _SKIPPED_INTAKE_CLASSES
+    ]
+    if not rows:
+        return
+    print()
+    print(f"SKIPPED / INTAKE ({len(rows)})")
+    for story in rows:
+        entry = _rca_entry(story, rca_stories)
+        print(f"  ⊘ {_story_row(story)}")
+        primary = _primary_class(entry)
+        detail = _skip_detail(entry)
+        if detail:
+            print(f"       {primary} — {detail}")
+        else:
+            print(f"       {primary}")
+
+
+def _print_partial_value(non_done: list[dict], rca_stories: dict) -> None:
+    """Stories with non-empty ``partial_value``, regardless of primary class.
+
+    A story appears here *in addition to* its FAILED / SKIPPED placement so the
+    operator gets both the failure-recovery and artifact-reuse views.
+    """
+    rows: list[tuple[dict, list[str]]] = []
+    for story in non_done:
+        entry = _rca_entry(story, rca_stories)
+        values = _string_list(entry.get("partial_value"))
+        if values:
+            rows.append((story, values))
+    if not rows:
+        return
+    print()
+    print(f"PARTIAL VALUE ({len(rows)})")
+    for story, values in rows:
+        print(f"  ◐ {_story_ref(story)}  {'; '.join(values)}")
+
+
+def _print_next(stories: list[dict], rca_stories: dict) -> None:
+    """Flat, deduplicated ``recommended_next_actions`` across the RCA.
+
+    Identical actions collapse to one line; when an action is story-specific and
+    does not already name its originating story, the citation is appended.
+    """
+    order: list[str] = []
+    origins: dict[str, list[str]] = {}
+    for story in stories:
+        entry = _rca_entry(story, rca_stories)
+        num = _issue_number(story)
+        for action in _string_list(entry.get("recommended_next_actions")):
+            if action not in origins:
+                origins[action] = []
+                order.append(action)
+        for action in _string_list(entry.get("recommended_next_actions")):
+            if num and num not in origins[action]:
+                origins[action].append(num)
+
+    if not order:
+        return
+    print()
+    print("NEXT")
+    for action in order:
+        uncited = [n for n in origins[action] if f"#{n}" not in action]
+        if uncited:
+            cite = ", ".join(f"#{n}" for n in uncited)
+            print(f"  - {action} (from {cite})")
+        else:
+            print(f"  - {action}")
+
+
+# ── Row / field helpers ───────────────────────────────────────────────────────
+
+
+def _story_row(story: dict) -> str:
+    """`#NNNN  $cost  elapsed  <title>` for a landed/failed row."""
+    ref = _story_ref(story)
+    cost = story.get("cost_usd")
+    cost_str = f"${cost:.2f}" if isinstance(cost, (int, float)) and cost else "—"
+    elapsed = _elapsed_seconds_from_bounds(story.get("started_at"), story.get("finished_at"))
+    elapsed_str = f"{int(elapsed // 60)}m" if isinstance(elapsed, (int, float)) else "—"
+    title = str(story.get("path") or story.get("slug") or "")
+    return f"{ref}  {cost_str}  {elapsed_str}  {title}"
+
+
+def _story_ref(story: dict) -> str:
+    num = _issue_number(story)
+    if num:
+        return f"#{num}"
+    return str(story.get("slug") or story.get("path") or "story")
+
+
+def _issue_number(story: dict) -> str | None:
+    slug = str(story.get("slug") or "")
+    tail = slug.rsplit("-", 1)[-1] if "-" in slug else slug
+    if tail.isdigit():
+        return tail
+    path = str(story.get("path") or "")
+    if "#" in path:
+        candidate = path.split("#", 1)[1].strip()
+        if candidate.isdigit():
+            return candidate
+    return None
+
+
+def _outcome(story: dict) -> str:
+    return str(story.get("outcome") or "").upper()
+
+
+def _rca_entry(story: dict, rca_stories: dict) -> dict:
+    entry = rca_stories.get(str(story.get("slug") or ""))
+    return entry if isinstance(entry, dict) else {}
+
+
+def _primary_class(entry: dict) -> str:
+    return str(entry.get("primary_failure_class") or "unknown_needs_rca")
+
+
+def _skip_detail(entry: dict) -> str:
+    """First non-baseline evidence excerpt for a SKIPPED / INTAKE row, if any."""
+    for item in _evidence(entry):
+        if item.get("rule_id") == _BASELINE_EVIDENCE_RULE:
+            continue
+        excerpt = str(item.get("excerpt") or "").strip()
+        if excerpt:
+            return excerpt
+    return ""
+
+
+def _evidence_lines(entry: dict) -> list[str]:
+    """`<excerpt> at <source>` lines, baseline evidence suppressed."""
+    lines: list[str] = []
+    for item in _evidence(entry):
+        if item.get("rule_id") == _BASELINE_EVIDENCE_RULE:
+            continue
+        excerpt = str(item.get("excerpt") or "").strip()
+        source = str(item.get("source") or "").strip()
+        if not excerpt:
+            continue
+        lines.append(f"{excerpt} at {source}" if source else excerpt)
+        if len(lines) >= _MAX_EVIDENCE_LINES:
+            break
+    return lines
+
+
+def _evidence(entry: dict) -> list[dict]:
+    items = entry.get("evidence")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _read_digest_rca(sprint_log_dir: Path, run_id: str) -> dict | None:
+    """Read the persisted RCA for ``run_id`` from disk (no classification).
+
+    Prefers the durable run-keyed ``run-<id>-sprint-rca.yaml`` so a historical
+    run resolves to its own analysis even after a later same-name run overwrote
+    the ``sprint-rca.yaml`` pointer; falls back to the pointer otherwise.
+    """
+    candidates = []
+    if run_id:
+        candidates.append(sprint_log_dir / f"run-{run_id}-sprint-rca.yaml")
+    candidates.append(sprint_log_dir / RCA_FILENAME)
+    for path in candidates:
+        data = _load_yaml(path)
+        if isinstance(data, dict):
+            return data
+    return None
+
+
+def _load_yaml(path: Path) -> object:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return None

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -361,8 +361,32 @@ def _show_single_run_status(run_id: str, project_root: Path) -> None:
     print(f"{run_id:<12}  {story_label:<30}  {phase:<12}  {cost_str:>7}  {elapsed_str:>8}")
 
 
+def _is_completed_sprint(run_id: str, project_root: Path) -> bool:
+    """Return True when ``run_id`` is a finished sprint with a summary on disk.
+
+    A live sprint has a PID file; a crashed one has a leftover ``.state`` file.
+    Neither should get the postmortem digest — the live telemetry table stays
+    the rendering for both. Only a run that is truly complete (no PID, no
+    lingering state, but a persisted ``sprint-summary.yaml``) selects the digest.
+    """
+    from theforge.sprint.status_reader import find_sprint_summary
+
+    runs_dir = project_root / ".forge" / "runs"
+    if (runs_dir / f"{run_id}.pid").exists():
+        return False
+    if (runs_dir / f"{run_id}.state").exists():
+        return False
+    return find_sprint_summary(run_id, project_root) is not None
+
+
 def _render_status_blocks(run_ids: list[str], project_root: Path) -> int:
-    """Render one status block per run_id and aggregate return codes."""
+    """Render one status block per run_id and aggregate return codes.
+
+    Completed sprints render the postmortem digest (recovery brief); live and
+    crashed sprints keep the wide telemetry table. Both read the same on-disk
+    state — the digest is a different renderer, not a different data source.
+    """
+    from theforge.cli.sprint_digest import display_sprint_digest
     from theforge.cli.sprint_status import display_sprint_status
 
     rcs: list[int] = []
@@ -370,7 +394,10 @@ def _render_status_blocks(run_ids: list[str], project_root: Path) -> int:
         if index:
             print()
         if _is_sprint_run(run_id, project_root):
-            rc = display_sprint_status(run_id, project_root)
+            if _is_completed_sprint(run_id, project_root):
+                rc = display_sprint_digest(run_id, project_root)
+            else:
+                rc = display_sprint_status(run_id, project_root)
         else:
             _show_single_run_status(run_id, project_root)
             rc = 0

--- a/tests/test_cli_sprint_digest.py
+++ b/tests/test_cli_sprint_digest.py
@@ -415,6 +415,50 @@ def test_run_keyed_rca_preferred_over_pointer(tmp_path: Path) -> None:
     assert "worker_timeout" not in output
 
 
+def test_pointer_from_different_run_is_rejected(tmp_path: Path) -> None:
+    """A pointer belonging to a later run must not be read for the queried run.
+
+    This is exactly the state ``forge rca <historical> --refresh`` leaves behind
+    (write_pointer=False): the ``sprint-rca.yaml`` pointer reflects the latest
+    run while an older run has no run-keyed file. The digest must fall through to
+    the missing-RCA branch rather than misattribute the later run's failures.
+    """
+    name = "mismatch-sprint"
+    run_id = "runOLD"
+    stories = [
+        _landed_story(1, 1.0),
+        {"slug": "issue-2", "path": "Issue #2", "outcome": "FAILED", "cost_usd": 2.0},
+    ]
+    _write_summary(tmp_path, name, run_id, stories)
+    log_dir = tmp_path / ".forge" / "logs" / name
+
+    # Pointer belongs to a *later* run; no run-keyed file exists for runOLD.
+    (log_dir / "sprint-rca.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "sprint_run_id": "runLATER",
+                "stories": {
+                    "issue-2": {
+                        "primary_failure_class": "worker_timeout",
+                        "contributing_factors": [],
+                        "evidence": [],
+                        "partial_value": [],
+                        "recommended_next_actions": [],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    output = _render(tmp_path, run_id)
+    # Falls through to missing-RCA: LANDED only + pointer, no misattributed class.
+    assert "LANDED (1 of 2)" in output
+    assert f"forge rca {run_id}" in output
+    assert "worker_timeout" not in output
+    assert "FAILED —" not in output
+
+
 def test_digest_not_found_returns_1(tmp_path: Path) -> None:
     from theforge.cli.sprint_digest import display_sprint_digest
 

--- a/tests/test_cli_sprint_digest.py
+++ b/tests/test_cli_sprint_digest.py
@@ -1,0 +1,503 @@
+"""Tests for the completed-sprint postmortem digest renderer.
+
+The digest reads two on-disk artifacts — ``sprint-summary.yaml`` (LANDED
+accounting) and ``sprint-rca.yaml`` (recovery signals) — and renders a recovery
+brief grouped by outcome class. It never invokes the RCA engine. These tests
+exercise the renderer directly and the ``forge status`` routing seam that
+selects the digest for completed sprints and the telemetry table for live ones.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _write_summary(
+    tmp_path: Path,
+    sprint_name: str,
+    run_id: str,
+    stories: list[dict],
+    *,
+    total_cost_usd: float = 32.67,
+    duration_seconds: float = 9720.0,
+) -> Path:
+    log_dir = tmp_path / ".forge" / "logs" / sprint_name
+    log_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = log_dir / "sprint-summary.yaml"
+    data = {
+        "sprint": {
+            "name": sprint_name,
+            "run_id": run_id,
+            "total_cost_usd": total_cost_usd,
+            "duration_seconds": duration_seconds,
+            "finished_at": "2026-05-08T03:00:00Z",
+        },
+        "stories": stories,
+    }
+    summary_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return summary_path
+
+
+def _write_rca(tmp_path: Path, sprint_name: str, run_id: str, rca_stories: dict) -> Path:
+    log_dir = tmp_path / ".forge" / "logs" / sprint_name
+    log_dir.mkdir(parents=True, exist_ok=True)
+    rca_path = log_dir / "sprint-rca.yaml"
+    data = {
+        "schema_version": 1,
+        "ruleset_version": 1,
+        "sprint_run_id": run_id,
+        "generated_at": "2026-05-08T03:00:00Z",
+        "generator": "mechanical",
+        "stories": rca_stories,
+    }
+    rca_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return rca_path
+
+
+def _render(tmp_path: Path, run_id: str) -> str:
+    from theforge.cli.sprint_digest import display_sprint_digest
+
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        rc = display_sprint_digest(run_id, tmp_path)
+    assert rc == 0, buf.getvalue()
+    return buf.getvalue()
+
+
+def _landed_story(num: int, cost: float) -> dict:
+    return {
+        "slug": f"issue-{num}",
+        "path": f"Issue #{num}",
+        "outcome": "DONE",
+        "cost_usd": cost,
+        "started_at": "2026-05-08T00:00:00Z",
+        "finished_at": "2026-05-08T00:10:00Z",
+    }
+
+
+# ── Full digest layout ────────────────────────────────────────────────────────
+
+
+def _seed_full_sprint(tmp_path: Path) -> tuple[str, str]:
+    name = "issues-1324,1325,1326,793,1101"
+    run_id = "6c83b3061455"
+    stories = [
+        _landed_story(1101, 3.70),
+        _landed_story(1325, 3.80),
+        {
+            "slug": "issue-1324",
+            "path": "Issue #1324",
+            "outcome": "FAILED",
+            "cost_usd": 19.74,
+            "started_at": "2026-05-08T00:00:00Z",
+            "finished_at": "2026-05-08T00:34:00Z",
+        },
+        {
+            "slug": "issue-1326",
+            "path": "Issue #1326",
+            "outcome": "FAILED",
+            "cost_usd": 5.43,
+            "started_at": "2026-05-08T00:00:00Z",
+            "finished_at": "2026-05-08T01:00:00Z",
+        },
+        {
+            "slug": "issue-793",
+            "path": "Issue #793",
+            "outcome": "DROPPED_SHAPE",
+            "cost_usd": 0.0,
+        },
+    ]
+    rca_stories = {
+        "issue-1324": {
+            "primary_failure_class": "provider_quota",
+            "contributing_factors": ["fallback_not_applied", "operator_gate_timeout"],
+            "evidence": [
+                {
+                    "source": "issue-1324/review-cycle-2/openai.yaml",
+                    "rule_id": "provider_usage_limit",
+                    "excerpt": "codex openai usage limit reached",
+                },
+                {
+                    "source": "run-6c83b3061455.log",
+                    "rule_id": "pending_decision_auto_rejected",
+                    "excerpt": "pending decision timed out after 3600s",
+                },
+                {
+                    "source": "run-6c83b3061455-summary.yaml",
+                    "rule_id": "captured_outcome",
+                    "excerpt": "outcome=FAILED",
+                },
+            ],
+            "partial_value": [],
+            "recommended_next_actions": [
+                "wait for quota reset or switch the provider/model, then re-sprint #1324",
+                "wire the provider fallback so the next failure recovers automatically",
+            ],
+        },
+        "issue-1326": {
+            "primary_failure_class": "worker_timeout",
+            "contributing_factors": ["oversized_validation_scope"],
+            "evidence": [
+                {
+                    "source": "run-6c83b3061455.log",
+                    "rule_id": "worker_thread_timeout",
+                    "excerpt": "worker thread timed out after 3600s",
+                },
+                {
+                    "source": "run-6c83b3061455-summary.yaml",
+                    "rule_id": "captured_outcome",
+                    "excerpt": "outcome=FAILED",
+                },
+            ],
+            "partial_value": [
+                "runbook produced; read-only validations executed",
+                "#1437 filed",
+            ],
+            "recommended_next_actions": [
+                "inspect the worker log for the phase #1326 was in at timeout",
+            ],
+        },
+        "issue-793": {
+            "primary_failure_class": "intake_shape",
+            "contributing_factors": [],
+            "evidence": [
+                {
+                    "source": "run-6c83b3061455-summary.yaml",
+                    "rule_id": "intake_dropped_shape",
+                    "excerpt": "implementation_plan_in_body",
+                },
+                {
+                    "source": "run-6c83b3061455-summary.yaml",
+                    "rule_id": "captured_outcome",
+                    "excerpt": "outcome=DROPPED_SHAPE",
+                },
+            ],
+            "partial_value": [],
+            "recommended_next_actions": [
+                "reshape the #793 issue body to satisfy the intake gate, then re-run",
+            ],
+        },
+    }
+    _write_summary(tmp_path, name, run_id, stories)
+    _write_rca(tmp_path, name, run_id, rca_stories)
+    return name, run_id
+
+
+def test_digest_full_layout_has_all_sections(tmp_path: Path) -> None:
+    _name, run_id = _seed_full_sprint(tmp_path)
+    output = _render(tmp_path, run_id)
+
+    # Header
+    assert "SPRINT issues-1324,1325,1326,793,1101" in output
+    assert "completed" in output
+    assert "$32.67" in output
+
+    # LANDED
+    assert "LANDED (2 of 5)" in output
+    assert "✓ #1101" in output
+    assert "✓ #1325" in output
+
+    # FAILED — literal class headings
+    assert "FAILED — provider_quota (1)" in output
+    assert "FAILED — worker_timeout (1)" in output
+    assert "✗ #1324" in output
+    assert "contributing: fallback_not_applied, operator_gate_timeout" in output
+    # evidence shown, baseline captured_outcome suppressed
+    assert "codex openai usage limit reached at issue-1324/review-cycle-2/openai.yaml" in output
+    assert "outcome=FAILED at" not in output
+
+    # SKIPPED / INTAKE
+    assert "SKIPPED / INTAKE (1)" in output
+    assert "⊘ #793" in output
+    assert "intake_shape — implementation_plan_in_body" in output
+
+    # PARTIAL VALUE
+    assert "PARTIAL VALUE (1)" in output
+    assert "◐ #1326  runbook produced; read-only validations executed; #1437 filed" in output
+
+    # NEXT
+    assert "NEXT" in output
+    assert "- reshape the #793 issue body to satisfy the intake gate, then re-run" in output
+
+
+def test_intake_story_only_in_skipped_not_failed(tmp_path: Path) -> None:
+    """An intake_shape story routes to SKIPPED / INTAKE, never a FAILED heading."""
+    _name, run_id = _seed_full_sprint(tmp_path)
+    output = _render(tmp_path, run_id)
+    assert "FAILED — intake_shape" not in output
+
+
+def test_failed_heading_is_literal_primary_class(tmp_path: Path) -> None:
+    """The FAILED heading is the classifier's literal string, not a re-mapping."""
+    name = "sprint-x"
+    run_id = "runX"
+    stories = [
+        _landed_story(1, 1.0),
+        {"slug": "issue-2", "path": "Issue #2", "outcome": "FAILED", "cost_usd": 2.0},
+    ]
+    rca_stories = {
+        "issue-2": {
+            "primary_failure_class": "merge_arming_failed",
+            "contributing_factors": [],
+            "evidence": [],
+            "partial_value": [],
+            "recommended_next_actions": [],
+        }
+    }
+    _write_summary(tmp_path, name, run_id, stories)
+    _write_rca(tmp_path, name, run_id, rca_stories)
+    output = _render(tmp_path, run_id)
+    assert "FAILED — merge_arming_failed (1)" in output
+
+
+def test_partial_value_appears_in_addition_to_failed(tmp_path: Path) -> None:
+    """A story with partial_value shows under both FAILED and PARTIAL VALUE."""
+    _name, run_id = _seed_full_sprint(tmp_path)
+    output = _render(tmp_path, run_id)
+    # #1326 is a worker_timeout FAILED story AND has partial value.
+    assert "FAILED — worker_timeout (1)" in output
+    failed_idx = output.index("FAILED — worker_timeout")
+    partial_idx = output.index("PARTIAL VALUE")
+    assert output.index("✗ #1326") > 0
+    assert output.index("◐ #1326") > partial_idx > failed_idx
+
+
+def test_next_dedupes_and_cites_originating_stories(tmp_path: Path) -> None:
+    """Identical actions collapse; a shared action cites both origin stories."""
+    name = "dedup-sprint"
+    run_id = "runD"
+    stories = [
+        {"slug": "issue-10", "path": "Issue #10", "outcome": "FAILED", "cost_usd": 1.0},
+        {"slug": "issue-11", "path": "Issue #11", "outcome": "FAILED", "cost_usd": 1.0},
+    ]
+    shared = "wire the provider fallback so the next failure recovers automatically"
+    rca_stories = {
+        "issue-10": {
+            "primary_failure_class": "provider_quota",
+            "contributing_factors": [],
+            "evidence": [],
+            "partial_value": [],
+            "recommended_next_actions": [shared],
+        },
+        "issue-11": {
+            "primary_failure_class": "provider_quota",
+            "contributing_factors": [],
+            "evidence": [],
+            "partial_value": [],
+            "recommended_next_actions": [shared],
+        },
+    }
+    _write_summary(tmp_path, name, run_id, stories)
+    _write_rca(tmp_path, name, run_id, rca_stories)
+    output = _render(tmp_path, run_id)
+
+    # The shared action appears exactly once, citing both origin stories.
+    assert output.count(f"- {shared}") == 1
+    assert f"- {shared} (from #10, #11)" in output
+
+
+def test_next_omits_citation_when_action_names_its_story(tmp_path: Path) -> None:
+    name = "cite-sprint"
+    run_id = "runC"
+    stories = [{"slug": "issue-20", "path": "Issue #20", "outcome": "FAILED", "cost_usd": 1.0}]
+    action = "reshape the #20 issue body to satisfy the intake gate, then re-run"
+    rca_stories = {
+        "issue-20": {
+            "primary_failure_class": "provider_quota",
+            "contributing_factors": [],
+            "evidence": [],
+            "partial_value": [],
+            "recommended_next_actions": [action],
+        }
+    }
+    _write_summary(tmp_path, name, run_id, stories)
+    _write_rca(tmp_path, name, run_id, rca_stories)
+    output = _render(tmp_path, run_id)
+    assert f"- {action}" in output
+    assert "(from #20)" not in output
+
+
+# ── All-DONE tighter digest ───────────────────────────────────────────────────
+
+
+def test_all_done_renders_landed_only(tmp_path: Path) -> None:
+    name = "all-done"
+    run_id = "runAD"
+    stories = [_landed_story(1, 1.0), _landed_story(2, 2.0)]
+    _write_summary(tmp_path, name, run_id, stories)
+    # No RCA file for an all-DONE sprint.
+    output = _render(tmp_path, run_id)
+
+    assert "LANDED (2 of 2)" in output
+    assert "FAILED" not in output
+    assert "SKIPPED" not in output
+    assert "PARTIAL VALUE" not in output
+    assert "NEXT" not in output
+    assert "forge rca" not in output
+
+
+# ── Missing RCA artifact ──────────────────────────────────────────────────────
+
+
+def test_missing_rca_shows_pointer_and_landed_only(tmp_path: Path) -> None:
+    name = "no-rca"
+    run_id = "runNR"
+    stories = [
+        _landed_story(1, 1.0),
+        {"slug": "issue-2", "path": "Issue #2", "outcome": "FAILED", "cost_usd": 2.0},
+    ]
+    _write_summary(tmp_path, name, run_id, stories)
+    # Deliberately no sprint-rca.yaml written.
+    output = _render(tmp_path, run_id)
+
+    assert "LANDED (1 of 2)" in output
+    assert f"forge rca {run_id}" in output
+    assert "FAILED —" not in output
+    assert "NEXT" not in output
+
+
+def test_run_keyed_rca_preferred_over_pointer(tmp_path: Path) -> None:
+    """A historical run resolves to its run-keyed RCA even if the pointer differs."""
+    name = "hist-sprint"
+    run_id = "runH"
+    stories = [
+        _landed_story(1, 1.0),
+        {"slug": "issue-2", "path": "Issue #2", "outcome": "FAILED", "cost_usd": 2.0},
+    ]
+    _write_summary(tmp_path, name, run_id, stories)
+    log_dir = tmp_path / ".forge" / "logs" / name
+
+    # Pointer belongs to a *later* same-name run and must not be used.
+    (log_dir / "sprint-rca.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "sprint_run_id": "runLATER",
+                "stories": {
+                    "issue-2": {
+                        "primary_failure_class": "worker_timeout",
+                        "contributing_factors": [],
+                        "evidence": [],
+                        "partial_value": [],
+                        "recommended_next_actions": [],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Run-keyed durable file for this run.
+    (log_dir / f"run-{run_id}-sprint-rca.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "sprint_run_id": run_id,
+                "stories": {
+                    "issue-2": {
+                        "primary_failure_class": "provider_quota",
+                        "contributing_factors": [],
+                        "evidence": [],
+                        "partial_value": [],
+                        "recommended_next_actions": [],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    output = _render(tmp_path, run_id)
+    assert "FAILED — provider_quota (1)" in output
+    assert "worker_timeout" not in output
+
+
+def test_digest_not_found_returns_1(tmp_path: Path) -> None:
+    from theforge.cli.sprint_digest import display_sprint_digest
+
+    buf = io.StringIO()
+    with patch("sys.stderr", buf):
+        rc = display_sprint_digest("nonexistent", tmp_path)
+    assert rc == 1
+
+
+# ── forge status routing seam ─────────────────────────────────────────────────
+
+
+def test_status_routes_completed_sprint_to_digest(tmp_path: Path) -> None:
+    """A completed sprint run selects the digest, not the telemetry table."""
+    from theforge.cli.status import _render_status_blocks
+
+    _name, run_id = _seed_full_sprint(tmp_path)
+
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        rc = _render_status_blocks([run_id], tmp_path)
+    output = buf.getvalue()
+
+    assert rc == 0
+    # Digest markers present; telemetry-table column header absent.
+    assert "LANDED (2 of 5)" in output
+    assert "NEXT" in output
+    assert "COMPLEXITY" not in output
+
+
+def test_status_routes_live_sprint_to_telemetry_table(tmp_path: Path) -> None:
+    """A live sprint (PID present) keeps the wide telemetry table."""
+    from theforge.cli.status import _render_status_blocks
+
+    name = "live-sprint"
+    run_id = "live1"
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / f"{run_id}.pid").write_text("99999\nlive-sprint\n")
+    state_path = runs_dir / f"{run_id}.state"
+    state_path.write_text(
+        yaml.safe_dump(
+            {
+                "sprint_name": name,
+                "stories": [
+                    {
+                        "slug": "issue-1",
+                        "path": "Issue #1",
+                        "status": "running",
+                        "phase": "DEV",
+                        "cost_usd": 0.1,
+                        "bundle_candidate": False,
+                        "blocked_by": [],
+                        "detail": {},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        rc = _render_status_blocks([run_id], tmp_path)
+    output = buf.getvalue()
+
+    assert rc == 0
+    # Telemetry table markers present; digest markers absent.
+    assert "COMPLEXITY" in output
+    assert "[live]" in output
+    assert "LANDED" not in output
+
+
+def test_is_completed_sprint_detection(tmp_path: Path) -> None:
+    from theforge.cli.status import _is_completed_sprint
+
+    name = "done-sprint"
+    run_id = "runDS"
+    _write_summary(tmp_path, name, run_id, [_landed_story(1, 1.0)])
+    assert _is_completed_sprint(run_id, tmp_path) is True
+
+    # A PID file (live) flips it back to False.
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / f"{run_id}.pid").write_text("1\ndone-sprint\n")
+    assert _is_completed_sprint(run_id, tmp_path) is False

--- a/tests/test_cli_status_integration.py
+++ b/tests/test_cli_status_integration.py
@@ -293,13 +293,44 @@ def test_status_shows_completed_sprint_from_summary_with_all_rows(
             {"slug": "issue-3", "path": "Issue #3", "outcome": "SKIPPED", "cost_usd": 0.0},
         ],
     )
+    # A completed sprint with non-DONE stories renders the postmortem digest,
+    # which reads the persisted RCA artifact to place the failed/skipped rows.
+    (tmp_path / ".forge" / "logs" / "completed-sprint" / "sprint-rca.yaml").write_text(
+        yaml.dump(
+            {
+                "sprint_run_id": "run-123",
+                "stories": {
+                    "issue-2": {
+                        "primary_failure_class": "worker_timeout",
+                        "contributing_factors": [],
+                        "evidence": [],
+                        "partial_value": [],
+                        "recommended_next_actions": ["re-run #2"],
+                    },
+                    "issue-3": {
+                        "primary_failure_class": "dependency_skip",
+                        "contributing_factors": [],
+                        "evidence": [],
+                        "partial_value": [],
+                        "recommended_next_actions": [],
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
 
     rc, out = _run_cmd_status(tmp_path, capsys)
 
     assert rc == 0
-    assert "Sprint: completed-sprint  run: run-123  [completed]" in out
+    # Postmortem digest, not the live telemetry table.
+    assert "SPRINT completed-sprint  ·  completed" in out
+    assert "LANDED (1 of 3)" in out
     assert "Issue #1" in out
+    assert "FAILED — worker_timeout" in out
     assert "Issue #2" in out
+    assert "SKIPPED / INTAKE" in out
     assert "Issue #3" in out
 
 
@@ -331,7 +362,9 @@ def test_status_preserves_prior_story_run_ids_in_completed_sprint_view(
     rc, out = _run_cmd_status(tmp_path, capsys, run_id="run-old")
 
     assert rc == 0
-    assert "Sprint: rollover-sprint  run: run-old  [completed]" in out
+    # All-DONE completed sprint renders the tighter LANDED-only digest.
+    assert "SPRINT rollover-sprint  ·  completed" in out
+    assert "LANDED (2 of 2)" in out
     assert "Issue #959" in out
     assert "Issue #960" in out
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior RCA pointer mismatch bug is fixed, no regression from the iteration-1 fix was found, and the targeted status/digest tests pass. | [google-gemini-3.5-flash] The postmortem digest renderer is fully implemented and verified, with robust handling of the RCA pointer file to prevent run ID mismatch. | [claude-sonnet] Iteration 1 fix correctly guards _read_digest_rca against pointer/run_id mismatch (verified via test_pointer_from_different_run_is_rejected); no regressions found in the touched code, and all other ACs remain met from the prior cycle.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $8.31
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Completed-sprint postmortem digest: forge status renders LANDED / FAILED-by-class / PARTIAL / SKIPPED / NEXT layout from sprint-rca.yaml (GitHub Issue #1440)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1440