### PR TITLE
forge diagnose emits a confident diagnosis for an already-fixed bug instead of detecting the premise is gone

### DIFF
--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import time
@@ -31,11 +32,14 @@ import yaml
 from theforge.config import ForgeConfig, ModelProfile
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
+    AbsentPremise,
     DiagnosePhase,
     DiagnoseResult,
     DiagnoseState,
     DiagnosisArtifact,
     InspectedFile,
+    PremiseVerdict,
+    render_already_resolved_markdown,
     render_artifact_markdown,
     upsert_diagnosis_section,
 )
@@ -130,6 +134,196 @@ def _baseline_inspected_files(
         InspectedFile(path=f.path, content_sha256=_hash_file_at_sha(f.path, sha, project_root))
         for f in files
     )
+
+
+# ── Premise verification ──────────────────────────────────────────────
+# A confirmed-cause diagnosis is only trustworthy if the code it describes
+# still exists.  These helpers query git for the continued presence of the
+# cited paths/patterns at the diagnosis baseline.  They fail *open*: an
+# "already resolved" verdict is only returned when git positively shows the
+# cited reference existed and was removed by a nameable commit.  A path token
+# we cannot resolve (misparsed, never tracked) yields no deletion commit and
+# is therefore ignored, never diverting a live diagnosis.
+
+_UNIT_SEP = "\x1f"
+
+# Candidate file-path tokens inside a free-text ``affected_code_path`` field:
+# a dotted filename, optionally with directories and a trailing ``:line``.
+_PATH_TOKEN_RE = re.compile(r"[\w./\-]*\w+\.[A-Za-z0-9]+")
+
+
+def _path_exists_at_sha(path: str, sha: str, project_root: Path) -> bool:
+    """Return True when ``path`` is a tracked blob at git ``sha``."""
+    if not path or not sha:
+        return False
+    try:
+        proc = subprocess.run(
+            ["git", "cat-file", "-e", f"{sha}:{path}"],
+            capture_output=True,
+            cwd=str(project_root),
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def _pattern_present_at_sha(path: str, pattern: str, sha: str, project_root: Path) -> bool | None:
+    """Return whether ``pattern`` appears in ``path`` at ``sha``.
+
+    ``None`` when the file cannot be read at that SHA (cannot determine).
+    """
+    if not path or not sha:
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "show", f"{sha}:{path}"],
+            capture_output=True,
+            cwd=str(project_root),
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    text = proc.stdout.decode("utf-8", errors="replace")
+    return pattern in text
+
+
+def _find_deleting_commit(path: str, sha: str, project_root: Path) -> tuple[str, str] | None:
+    """Return (commit_sha, summary) of the most recent commit that deleted ``path``.
+
+    Reachable from ``sha``.  ``None`` when no deletion is recorded (the path
+    was never tracked, or still exists) — the fail-open signal.
+    """
+    return _git_log_first(
+        ["--diff-filter=D", f"--format=%H{_UNIT_SEP}%s", sha, "--", path],
+        project_root,
+    )
+
+
+def _find_pattern_removing_commit(
+    path: str, pattern: str, sha: str, project_root: Path
+) -> tuple[str, str] | None:
+    """Return (commit_sha, summary) of the commit that removed ``pattern`` from ``path``.
+
+    Uses git's pickaxe (``-S``, fixed-string) to find the most recent commit
+    reachable from ``sha`` that changed the number of occurrences of
+    ``pattern`` in ``path``.  ``None`` when the pattern has no such history —
+    the fail-open signal.
+    """
+    if not pattern:
+        return None
+    return _git_log_first(
+        [f"-S{pattern}", f"--format=%H{_UNIT_SEP}%s", sha, "--", path],
+        project_root,
+    )
+
+
+def _git_log_first(extra_args: list[str], project_root: Path) -> tuple[str, str] | None:
+    """Run ``git log -1`` with ``extra_args``; return (sha, summary) or None."""
+    try:
+        proc = subprocess.run(
+            ["git", "log", "-1", *extra_args],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    line = proc.stdout.strip()
+    if not line:
+        return None
+    commit, _, summary = line.partition(_UNIT_SEP)
+    commit = commit.strip()
+    if not commit:
+        return None
+    return commit, summary.strip()
+
+
+def _extract_affected_paths(affected_code_path: str) -> list[str]:
+    """Pull candidate repo-relative file paths out of a free-text field.
+
+    Strips a trailing ``:line`` locator. Order-preserving and deduped.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for token in _PATH_TOKEN_RE.findall(affected_code_path or ""):
+        path = token.strip().strip(".,;()[]`'\"")
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        paths.append(path)
+    return paths
+
+
+def verify_premise(artifact: DiagnosisArtifact, sha: str, project_root: Path) -> PremiseVerdict:
+    """Verify the diagnosis's cited code still exists at baseline ``sha``.
+
+    Returns a resolved verdict only when git positively confirms a cited file
+    or premise pattern was removed by a nameable commit.  Fails open (unresolved)
+    when there is no baseline SHA, or when absence cannot be attributed to a
+    removing commit — this must never turn a live diagnosis into a false
+    "already resolved".
+    """
+    if not sha:
+        return PremiseVerdict(resolved=False)
+
+    absent: list[AbsentPremise] = []
+    covered: set[str] = set()
+
+    for anchor in artifact.premise_anchors:
+        path = anchor.file.strip()
+        pattern = anchor.pattern.strip()
+        if not path:
+            continue
+        if not _path_exists_at_sha(path, sha, project_root):
+            commit = _find_deleting_commit(path, sha, project_root)
+            if commit:
+                absent.append(
+                    AbsentPremise(
+                        file=path,
+                        pattern="",
+                        removing_commit=commit[0],
+                        removing_summary=commit[1],
+                    )
+                )
+                covered.add(path)
+            continue
+        if pattern and _pattern_present_at_sha(path, pattern, sha, project_root) is False:
+            commit = _find_pattern_removing_commit(path, pattern, sha, project_root)
+            if commit:
+                absent.append(
+                    AbsentPremise(
+                        file=path,
+                        pattern=pattern,
+                        removing_commit=commit[0],
+                        removing_summary=commit[1],
+                    )
+                )
+
+    # AC: a diagnosis that cites an affected code path must confirm the path
+    # currently exists. Verify the file(s) named in affected_code_path — but
+    # only report absence backed by a deletion commit (fail open otherwise).
+    for path in _extract_affected_paths(artifact.affected_code_path):
+        if path in covered:
+            continue
+        if not _path_exists_at_sha(path, sha, project_root):
+            commit = _find_deleting_commit(path, sha, project_root)
+            if commit:
+                absent.append(
+                    AbsentPremise(
+                        file=path,
+                        pattern="",
+                        removing_commit=commit[0],
+                        removing_summary=commit[1],
+                    )
+                )
+
+    return PremiseVerdict(resolved=bool(absent), absent=tuple(absent))
 
 
 def _gh_fetch_issue(number: int, project_root: Path) -> dict:
@@ -261,6 +455,16 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
             "sha": state.baseline_sha,
             "captured_at": state.baseline_captured_at,
         },
+        "already_resolved": state.already_resolved,
+        "absent_premises": [
+            {
+                "file": a.file,
+                "pattern": a.pattern,
+                "removing_commit": a.removing_commit,
+                "removing_summary": a.removing_summary,
+            }
+            for a in state.absent_premises
+        ],
         "error": state.error,
     }
     if state.artifact is not None:
@@ -291,6 +495,9 @@ def _artifact_to_dict(artifact: DiagnosisArtifact) -> dict:
         "baseline_captured_at": artifact.baseline_captured_at,
         "inspected_files": [
             {"path": f.path, "content_sha256": f.content_sha256} for f in artifact.inspected_files
+        ],
+        "premise_anchors": [
+            {"file": a.file, "pattern": a.pattern} for a in artifact.premise_anchors
         ],
     }
 
@@ -533,6 +740,37 @@ def run_diagnose_flow(
         state.transition(DiagnosePhase.FAILED, _now_iso())
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
+
+    # ── VERIFY_PREMISE ────────────────────────────────────────────────
+    # A diagnosis is only trustworthy if the code it describes still exists.
+    # Before landing any confirmed cause, verify the cited paths/patterns are
+    # present at the baseline. If a premise was removed by a later commit, the
+    # described symptom cannot reproduce against code that is gone — report
+    # "appears already resolved" (naming the removing commit) and write no
+    # confirmed-cause body, rather than manufacturing a live diagnosis.
+    state.transition(DiagnosePhase.VERIFY_PREMISE, _now_iso())
+    verdict = verify_premise(artifact, state.baseline_sha, project_root)
+    if verdict.resolved:
+        state.already_resolved = True
+        state.absent_premises = verdict.absent
+        state.transition(DiagnosePhase.ALREADY_RESOLVED, _now_iso())
+        report = render_already_resolved_markdown(
+            issue_number=issue_number,
+            baseline_sha=state.baseline_sha,
+            absent=verdict.absent,
+        )
+        if dry_run:
+            print(report)
+        first = verdict.absent[0]
+        extra = f" (+{len(verdict.absent) - 1} more)" if len(verdict.absent) > 1 else ""
+        target = f"{first.file}" + (f":{first.pattern}" if first.pattern else "")
+        message = (
+            f"Issue #{issue_number} appears already resolved — premise `{target}` "
+            f"removed by commit {first.removing_commit[:12]}{extra}. "
+            "No confirmed-cause diagnosis written."
+        )
+        write_diagnose_audit(state, project_root)
+        return DiagnoseResult(success=False, state=state, message=message)
 
     # If essential fields are missing OR the run breached its budget/timeout
     # envelope, treat as TIMEOUT_PARTIAL — return the partial work for operator

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -147,9 +147,12 @@ def _baseline_inspected_files(
 
 _UNIT_SEP = "\x1f"
 
-# Candidate file-path tokens inside a free-text ``affected_code_path`` field:
-# a dotted filename, optionally with directories and a trailing ``:line``.
-_PATH_TOKEN_RE = re.compile(r"[\w./\-]*\w+\.[A-Za-z0-9]+")
+# Candidate references inside a free-text ``affected_code_path`` field: a dotted
+# filename (optionally with directories) plus an optional ``:locator`` — either a
+# line number (``:142``) or a symbol name (``:buggy_func``). The symbol, when
+# present, is a checkable premise: a diagnosis that pins the bug to a function
+# that has been deleted from a still-present file must not land as live.
+_PATH_REF_RE = re.compile(r"([\w./\-]*\w+\.[A-Za-z0-9]+)(?::([A-Za-z_]\w*))?")
 
 
 def _path_exists_at_sha(path: str, sha: str, project_root: Path) -> bool:
@@ -244,20 +247,27 @@ def _git_log_first(extra_args: list[str], project_root: Path) -> tuple[str, str]
     return commit, summary.strip()
 
 
-def _extract_affected_paths(affected_code_path: str) -> list[str]:
-    """Pull candidate repo-relative file paths out of a free-text field.
+def _extract_affected_refs(affected_code_path: str) -> list[tuple[str, str]]:
+    """Pull candidate ``(path, symbol)`` references out of a free-text field.
 
-    Strips a trailing ``:line`` locator. Order-preserving and deduped.
+    ``symbol`` is the non-numeric locator following a ``:`` (a function/class
+    name whose continued presence is checkable); it is empty for a bare path or
+    a numeric ``:line`` locator, which anchors only on the file's existence.
+    Order-preserving and deduped on the full ``(path, symbol)`` pair.
     """
-    paths: list[str] = []
-    seen: set[str] = set()
-    for token in _PATH_TOKEN_RE.findall(affected_code_path or ""):
-        path = token.strip().strip(".,;()[]`'\"")
-        if not path or path in seen:
+    refs: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for path_tok, symbol_tok in _PATH_REF_RE.findall(affected_code_path or ""):
+        path = path_tok.strip().strip(".,;()[]`'\"")
+        symbol = symbol_tok.strip()
+        if not path:
             continue
-        seen.add(path)
-        paths.append(path)
-    return paths
+        key = (path, symbol)
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append(key)
+    return refs
 
 
 def verify_premise(artifact: DiagnosisArtifact, sha: str, project_root: Path) -> PremiseVerdict:
@@ -306,18 +316,35 @@ def verify_premise(artifact: DiagnosisArtifact, sha: str, project_root: Path) ->
                 )
 
     # AC: a diagnosis that cites an affected code path must confirm the path
-    # currently exists. Verify the file(s) named in affected_code_path — but
-    # only report absence backed by a deletion commit (fail open otherwise).
-    for path in _extract_affected_paths(artifact.affected_code_path):
-        if path in covered:
-            continue
+    # currently exists. Verify the file(s) named in affected_code_path — and,
+    # when the citation pins the bug to a named symbol (``path:func``), that the
+    # symbol itself still exists in the (possibly still-present) file. Only
+    # report absence backed by a removing commit (fail open otherwise).
+    for path, symbol in _extract_affected_refs(artifact.affected_code_path):
         if not _path_exists_at_sha(path, sha, project_root):
+            if path in covered:
+                continue
             commit = _find_deleting_commit(path, sha, project_root)
             if commit:
                 absent.append(
                     AbsentPremise(
                         file=path,
                         pattern="",
+                        removing_commit=commit[0],
+                        removing_summary=commit[1],
+                    )
+                )
+                covered.add(path)
+            continue
+        # File is present; if the citation named a symbol that has since been
+        # removed from it, the described bug can no longer reproduce there.
+        if symbol and _pattern_present_at_sha(path, symbol, sha, project_root) is False:
+            commit = _find_pattern_removing_commit(path, symbol, sha, project_root)
+            if commit:
+                absent.append(
+                    AbsentPremise(
+                        file=path,
+                        pattern=symbol,
                         removing_commit=commit[0],
                         removing_summary=commit[1],
                     )

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -21,11 +21,13 @@ class DiagnosePhase(Enum):
     FETCH = auto()  # fetch issue body / inputs
     INVESTIGATE = auto()  # run the investigative agent
     PARSE = auto()  # parse agent output into a structured artifact
+    VERIFY_PREMISE = auto()  # confirm the cited code/symptom still exists in baseline
     LAND = auto()  # publish artifact to comment / body / file
     DONE = auto()
     FAILED = auto()
     TIMEOUT_PARTIAL = auto()  # ran out of time/budget; partial artifact returned
     BUDGET_EXCEEDED = auto()
+    ALREADY_RESOLVED = auto()  # premise absent from baseline; no diagnosis written
 
 
 # Output destinations for a completed diagnosis artifact.
@@ -58,6 +60,48 @@ class InspectedFile:
 
 
 @dataclass(frozen=True)
+class PremiseAnchor:
+    """A falsifiable premise the reported bug depends on.
+
+    ``pattern`` is a literal substring the agent expects to find in ``file``
+    at the diagnosis baseline — a function signature, a code line, an error
+    string — that constitutes the concrete premise of the bug.  The coordinator
+    verifies these mechanically (no LLM judgment): if the file is gone or the
+    pattern is absent at the baseline, the described symptom cannot reproduce
+    against code that no longer exists, and the run reports "already resolved"
+    instead of manufacturing a confirmed cause.  An empty ``pattern`` anchors
+    only on the file's continued existence.
+    """
+
+    file: str
+    pattern: str = ""
+
+
+@dataclass(frozen=True)
+class AbsentPremise:
+    """A cited premise reference that no longer exists in the baseline.
+
+    Carries the commit that removed it so the "already resolved" report can
+    name it, per the diagnose AC.  ``pattern`` is empty when the whole file
+    was removed (as opposed to a specific pattern removed from a file that
+    still exists).
+    """
+
+    file: str
+    pattern: str
+    removing_commit: str
+    removing_summary: str = ""
+
+
+@dataclass(frozen=True)
+class PremiseVerdict:
+    """Result of checking a diagnosis's cited code against the baseline."""
+
+    resolved: bool
+    absent: tuple[AbsentPremise, ...] = ()
+
+
+@dataclass(frozen=True)
 class DiagnosisArtifact:
     """Structured diagnosis output from an investigative agent.
 
@@ -78,6 +122,7 @@ class DiagnosisArtifact:
     baseline_sha: str = ""
     baseline_captured_at: str = ""
     inspected_files: tuple[InspectedFile, ...] = ()
+    premise_anchors: tuple[PremiseAnchor, ...] = ()
 
     def is_complete(self) -> bool:
         """Return True only when every required field is non-empty."""
@@ -150,6 +195,9 @@ class DiagnoseState:
     # (phase_name, ISO timestamp) entries appended on every transition.
     sub_investigations: list[dict] = field(default_factory=list)
     # Optional log of focused sub-investigations spawned during diagnosis.
+    already_resolved: bool = False
+    absent_premises: tuple[AbsentPremise, ...] = ()
+    # Set when the premise check finds the cited code was removed from baseline.
 
     def transition(self, new_phase: DiagnosePhase, when: str) -> None:
         self.phase = new_phase
@@ -248,6 +296,49 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
     )
     if artifact.notes.strip():
         lines.extend(["### Notes", "", artifact.notes.strip(), ""])
+    return "\n".join(lines)
+
+
+def render_already_resolved_markdown(
+    *, issue_number: int, baseline_sha: str, absent: tuple[AbsentPremise, ...]
+) -> str:
+    """Render an "appears already resolved" report naming the removing commit(s).
+
+    Deliberately NOT a ``## Diagnosis`` section: the heading omits the word
+    "diagnosis" so a downstream shape/readiness check does not mistake this
+    note for a fix-ready confirmed-cause diagnosis.  The premise is gone, so
+    the issue is not fix-ready — it needs restating, not implementing.
+    """
+    sha_short = baseline_sha[:12] if baseline_sha else "unknown"
+    lines: list[str] = [
+        "## Premise check — appears already resolved",
+        "",
+        (
+            f"`forge diagnose` checked issue #{issue_number} against baseline "
+            f"`{sha_short}` and found that code the bug's premise depends on no "
+            "longer exists. No confirmed-cause diagnosis was written: the described "
+            "symptom cannot reproduce against code that has been removed."
+        ),
+        "",
+        "**Absent premise references:**",
+        "",
+    ]
+    for a in absent:
+        commit = a.removing_commit[:12] if a.removing_commit else "unknown"
+        summary = f" ({a.removing_summary})" if a.removing_summary else ""
+        if a.pattern:
+            lines.append(
+                f"- `{a.file}` — pattern `{a.pattern}` removed by commit `{commit}`{summary}"
+            )
+        else:
+            lines.append(f"- `{a.file}` — file removed by commit `{commit}`{summary}")
+    lines.extend(
+        [
+            "",
+            "If this issue is still valid, restate its premise against the current "
+            "baseline before re-running `forge diagnose`.",
+        ]
+    )
     return "\n".join(lines)
 
 

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 
 import yaml
 
-from theforge.diagnose_types import DiagnosisArtifact, Hypothesis, InspectedFile
+from theforge.diagnose_types import (
+    DiagnosisArtifact,
+    Hypothesis,
+    InspectedFile,
+    PremiseAnchor,
+)
 
 _DIAGNOSE_PROMPT_TEMPLATE = """\
 You are an investigative diagnosis agent.  A symptom bug has been reported but
@@ -37,6 +42,14 @@ Mode: {mode}
    ``confirmed_cause: ""`` and explain in ``notes`` what evidence is missing.
    **Do NOT guess** — partial honest output is more valuable than a confident
    wrong diagnosis.
+5. Before confirming a cause, verify the bug's premise still exists in the
+   current baseline.  A bug's premise can be silently deleted by an intervening
+   commit — the code it describes may already be gone.  List the concrete,
+   falsifiable premise anchors (file + a literal code substring you actually
+   saw at HEAD) in ``premise_anchors``.  These are checked mechanically after
+   you finish: if a cited file or pattern is absent from the baseline, the run
+   is reported as "already resolved" rather than landed as a live diagnosis.
+   Do NOT emit a confirmed cause for code that no longer exists.
 
 == OUTPUT FORMAT ==
 
@@ -74,6 +87,14 @@ inspected_files:
   # an intervening commit.
   - "<repo-relative path to a file you inspected>"
   - "<repo-relative path to another file you inspected>"
+premise_anchors:
+  # REQUIRED when confirmed_cause is non-empty. Each entry names a file and a
+  # literal code substring the bug's premise depends on and that you verified
+  # is present at HEAD. These are checked mechanically: if a file or pattern
+  # here is absent from the baseline, the diagnosis is reported as "already
+  # resolved" (premise removed) instead of landed as a live confirmed cause.
+  - file: "<repo-relative path the bug lives in>"
+    pattern: "<exact code substring that must exist for the bug to be live>"
 ```
 """
 
@@ -171,6 +192,27 @@ def parse_diagnose_output(
             seen.add(path)
             inspected.append(InspectedFile(path=path, content_sha256=digest))
 
+    raw_anchors = parsed.get("premise_anchors") or []
+    anchors: list[PremiseAnchor] = []
+    if isinstance(raw_anchors, list):
+        seen_anchors: set[tuple[str, str]] = set()
+        for entry in raw_anchors:
+            if isinstance(entry, str):
+                file = entry.strip()
+                pattern = ""
+            elif isinstance(entry, dict):
+                file = str(entry.get("file", "")).strip()
+                pattern = str(entry.get("pattern", "")).strip()
+            else:
+                continue
+            if not file:
+                continue
+            key = (file, pattern)
+            if key in seen_anchors:
+                continue
+            seen_anchors.add(key)
+            anchors.append(PremiseAnchor(file=file, pattern=pattern))
+
     return DiagnosisArtifact(
         issue_number=issue_number,
         observed_symptom=str(parsed.get("observed_symptom", "")).strip(),
@@ -182,4 +224,5 @@ def parse_diagnose_output(
         partial=partial,
         notes=str(parsed.get("notes", "")).strip(),
         inspected_files=tuple(inspected),
+        premise_anchors=tuple(anchors),
     )

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -12,6 +12,8 @@ Covers:
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -781,3 +783,286 @@ class TestDiagnoseState:
         s.transition(DiagnosePhase.INVESTIGATE, "t2")
         assert s.phase == DiagnosePhase.INVESTIGATE
         assert s.phase_transitions == [("FETCH", "t1"), ("INVESTIGATE", "t2")]
+
+
+# ── Premise verification (already-resolved detection) ─────────────────
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "PATH": os.environ.get("PATH", ""),
+    }
+    proc = subprocess.run(
+        ["git", *args], cwd=str(cwd), env=env, capture_output=True, text=True, check=True
+    )
+    return proc.stdout.strip()
+
+
+def _init_repo(root: Path) -> None:
+    _git(["init", "-q"], root)
+
+
+def _commit_file(root: Path, rel: str, content: str, message: str) -> str:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    _git(["add", rel], root)
+    _git(["commit", "-q", "-m", message], root)
+    return _git(["rev-parse", "HEAD"], root)
+
+
+def _remove_file(root: Path, rel: str, message: str) -> str:
+    _git(["rm", "-q", rel], root)
+    _git(["commit", "-q", "-m", message], root)
+    return _git(["rev-parse", "HEAD"], root)
+
+
+def _agent_yaml_with_anchor(*, affected: str, anchor_file: str, anchor_pattern: str) -> str:
+    payload = {
+        "observed_symptom": "The buggy path miscomputes the slot count",
+        "reproduction_or_evidence": "Call the affected function with N=3",
+        "hypotheses": [
+            {
+                "statement": "Off-by-one in the reservation loop",
+                "status": "confirmed",
+                "evidence": "The loop reserves N-1 slots",
+            }
+        ],
+        "confirmed_cause": "Off-by-one reservation in the affected function",
+        "affected_code_path": affected,
+        "fix_success_criterion": "N=3 reserves 3 slots",
+        "notes": "",
+        "premise_anchors": [{"file": anchor_file, "pattern": anchor_pattern}],
+    }
+    return f"```yaml\n{yaml.safe_dump(payload, sort_keys=False)}```"
+
+
+class TestPremiseVerification:
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_pattern_removed_from_file_reports_already_resolved(
+        self, mock_agent, mock_fetch, mock_post, mock_edit, tmp_path
+    ):
+        """Seam test: an agent that confirms a cause anchored to a pattern that a
+        later commit removed must NOT land a confirmed-cause body. The flow must
+        divert to ALREADY_RESOLVED naming the removing commit, leaving the issue
+        body untouched. Exercises the PARSE→VERIFY_PREMISE→(no LAND) boundary."""
+        _init_repo(tmp_path)
+        _commit_file(
+            tmp_path,
+            "src/mod.py",
+            "def buggy_func():\n    return reserve(n - 1)\n",
+            "add buggy func",
+        )
+        removing = _commit_file(
+            tmp_path,
+            "src/mod.py",
+            "def other_func():\n    return reserve(n)\n",
+            "remove buggy func premise",
+        )
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 1494,
+            "title": "buggy func miscounts",
+            "body": "The buggy_func reserves the wrong number of slots.\n",
+            "state": "OPEN",
+        }
+        mock_agent.return_value = _fake_agent_result(
+            _agent_yaml_with_anchor(
+                affected="src/mod.py:1",
+                anchor_file="src/mod.py",
+                anchor_pattern="def buggy_func",
+            )
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1494,
+            config=config,
+            project_root=tmp_path,
+            output_destination="body_section",
+        )
+
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.ALREADY_RESOLVED
+        assert not mock_edit.called, "must not write a confirmed-cause body"
+        assert not mock_post.called
+        assert result.state.landed_location is None
+        # Names the removing commit
+        assert result.state.absent_premises
+        assert result.state.absent_premises[0].removing_commit.startswith(removing[:8])
+        assert removing[:12] in result.message
+        # Audit records the already-resolved verdict
+        audit_files = list((tmp_path / ".forge" / "audits").glob("diagnose-issue-1494-*.yaml"))
+        assert audit_files
+        loaded = yaml.safe_load(audit_files[0].read_text())
+        assert loaded["final_phase"] == "ALREADY_RESOLVED"
+        assert loaded["already_resolved"] is True
+        assert loaded["absent_premises"][0]["pattern"] == "def buggy_func"
+
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_deleted_affected_file_reports_already_resolved(
+        self, mock_agent, mock_fetch, mock_edit, tmp_path
+    ):
+        """A confirmed cause whose affected_code_path file was deleted entirely
+        must report already-resolved, naming the deleting commit — even without
+        premise anchors (AC: a cited code path must currently exist)."""
+        _init_repo(tmp_path)
+        # A second file keeps the repo non-empty after deletion.
+        _commit_file(tmp_path, "keep.txt", "keep\n", "seed")
+        _commit_file(tmp_path, "src/gone.py", "def gone():\n    pass\n", "add gone")
+        deleting = _remove_file(tmp_path, "src/gone.py", "delete gone module")
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 200,
+            "title": "gone module bug",
+            "body": "src/gone.py misbehaves\n",
+            "state": "OPEN",
+        }
+        # No premise_anchors — rely on affected_code_path file-existence check.
+        payload = {
+            "observed_symptom": "s",
+            "reproduction_or_evidence": "r",
+            "hypotheses": [{"statement": "h", "status": "confirmed", "evidence": "e"}],
+            "confirmed_cause": "cause in gone module",
+            "affected_code_path": "src/gone.py:1",
+            "fix_success_criterion": "c",
+        }
+        mock_agent.return_value = _fake_agent_result(
+            f"```yaml\n{yaml.safe_dump(payload, sort_keys=False)}```"
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=200,
+            config=config,
+            project_root=tmp_path,
+            output_destination="body_section",
+        )
+
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.ALREADY_RESOLVED
+        assert not mock_edit.called
+        assert result.state.absent_premises[0].removing_commit.startswith(deleting[:8])
+
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_present_premise_lands_normally(self, mock_agent, mock_fetch, mock_edit, tmp_path):
+        """Given a still-present bug, behavior is unchanged: the premise check
+        passes and the confirmed-cause diagnosis lands normally."""
+        _init_repo(tmp_path)
+        _commit_file(
+            tmp_path,
+            "src/mod.py",
+            "def buggy_func():\n    return reserve(n - 1)\n",
+            "add buggy func",
+        )
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 300,
+            "title": "buggy func miscounts",
+            "body": "The buggy_func reserves the wrong number of slots.\n",
+            "state": "OPEN",
+        }
+        mock_agent.return_value = _fake_agent_result(
+            _agent_yaml_with_anchor(
+                affected="src/mod.py:1",
+                anchor_file="src/mod.py",
+                anchor_pattern="def buggy_func",
+            )
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=300,
+            config=config,
+            project_root=tmp_path,
+            output_destination="body_section",
+        )
+
+        assert result.success
+        assert result.state.phase == DiagnosePhase.DONE
+        assert mock_edit.called
+        new_body = mock_edit.call_args[0][1]
+        assert "## Diagnosis" in new_body
+
+    def test_verify_premise_fails_open_without_baseline(self):
+        """No baseline SHA (non-git checkout) → never diverts a live diagnosis."""
+        from theforge.coordinator.diagnose_flow import verify_premise
+        from theforge.diagnose_types import DiagnosisArtifact, Hypothesis, PremiseAnchor
+
+        artifact = DiagnosisArtifact(
+            issue_number=1,
+            observed_symptom="s",
+            reproduction_or_evidence="r",
+            hypotheses=(Hypothesis("h", "confirmed", "e"),),
+            confirmed_cause="c",
+            affected_code_path="src/anything.py:10",
+            fix_success_criterion="f",
+            premise_anchors=(PremiseAnchor(file="src/anything.py", pattern="def x"),),
+        )
+        verdict = verify_premise(artifact, "", Path("/nonexistent"))
+        assert verdict.resolved is False
+
+    def test_verify_premise_fails_open_when_pattern_never_existed(self, tmp_path):
+        """A pattern that has no removal history yields no removing commit, so the
+        check fails open rather than fabricating an already-resolved verdict."""
+        from theforge.coordinator.diagnose_flow import verify_premise
+        from theforge.diagnose_types import DiagnosisArtifact, Hypothesis, PremiseAnchor
+
+        _init_repo(tmp_path)
+        _commit_file(tmp_path, "src/mod.py", "def present():\n    pass\n", "seed")
+        head = _git(["rev-parse", "HEAD"], tmp_path)
+
+        artifact = DiagnosisArtifact(
+            issue_number=1,
+            observed_symptom="s",
+            reproduction_or_evidence="r",
+            hypotheses=(Hypothesis("h", "confirmed", "e"),),
+            confirmed_cause="c",
+            affected_code_path="src/mod.py",
+            fix_success_criterion="f",
+            # Pattern that was never in the file — absent but no removal commit.
+            premise_anchors=(PremiseAnchor(file="src/mod.py", pattern="never_here"),),
+        )
+        verdict = verify_premise(artifact, head, tmp_path)
+        assert verdict.resolved is False
+
+
+class TestParsePremiseAnchors:
+    def test_parses_premise_anchors(self):
+        payload = (
+            "observed_symptom: s\nreproduction_or_evidence: r\n"
+            "hypotheses:\n  - statement: a\n    status: confirmed\n    evidence: e\n"
+            "confirmed_cause: c\naffected_code_path: p\nfix_success_criterion: f\n"
+            "premise_anchors:\n  - file: src/mod.py\n    pattern: def buggy\n"
+            "  - file: src/other.py\n"
+        )
+        artifact = parse_diagnose_output(payload, issue_number=1)
+        assert artifact is not None
+        assert len(artifact.premise_anchors) == 2
+        assert artifact.premise_anchors[0].file == "src/mod.py"
+        assert artifact.premise_anchors[0].pattern == "def buggy"
+        assert artifact.premise_anchors[1].pattern == ""
+
+    def test_missing_premise_anchors_is_empty_tuple(self):
+        artifact = parse_diagnose_output(_agent_yaml_output(), issue_number=1)
+        assert artifact is not None
+        assert artifact.premise_anchors == ()

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -911,6 +911,120 @@ class TestPremiseVerification:
         assert loaded["absent_premises"][0]["pattern"] == "def buggy_func"
 
     @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_symbol_removed_from_present_file_without_anchors_reports_already_resolved(
+        self, mock_agent, mock_fetch, mock_post, mock_edit, tmp_path
+    ):
+        """Seam test for the review finding: the target file still exists, but the
+        function the diagnosis pins the bug to was removed, and the agent supplied
+        NO premise_anchors — only affected_code_path names the removed symbol
+        (``src/mod.py:buggy_func``). This must still divert to ALREADY_RESOLVED
+        rather than landing a live ## Diagnosis section."""
+        _init_repo(tmp_path)
+        _commit_file(
+            tmp_path,
+            "src/mod.py",
+            "def buggy_func():\n    return reserve(n - 1)\n",
+            "add buggy func",
+        )
+        # File survives; only buggy_func is removed (other_func remains).
+        removing = _commit_file(
+            tmp_path,
+            "src/mod.py",
+            "def other_func():\n    return reserve(n)\n",
+            "remove buggy_func, keep module",
+        )
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 1494,
+            "title": "buggy_func miscounts",
+            "body": "buggy_func reserves the wrong number of slots\n",
+            "state": "OPEN",
+        }
+        # Confirmed cause, NO premise_anchors, symbol locator in affected path.
+        payload = {
+            "observed_symptom": "s",
+            "reproduction_or_evidence": "r",
+            "hypotheses": [{"statement": "h", "status": "confirmed", "evidence": "e"}],
+            "confirmed_cause": "off-by-one in buggy_func",
+            "affected_code_path": "src/mod.py:buggy_func",
+            "fix_success_criterion": "c",
+        }
+        mock_agent.return_value = _fake_agent_result(
+            f"```yaml\n{yaml.safe_dump(payload, sort_keys=False)}```"
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1494,
+            config=config,
+            project_root=tmp_path,
+            output_destination="body_section",
+        )
+
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.ALREADY_RESOLVED
+        assert not mock_edit.called, "must not land a ## Diagnosis section"
+        assert not mock_post.called
+        assert result.state.absent_premises
+        absent = result.state.absent_premises[0]
+        assert absent.file == "src/mod.py"
+        assert absent.pattern == "buggy_func"
+        assert absent.removing_commit.startswith(removing[:8])
+
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_present_symbol_in_affected_path_lands_normally(
+        self, mock_agent, mock_fetch, mock_edit, tmp_path
+    ):
+        """A symbol locator in affected_code_path that still exists must NOT
+        divert: behavior unchanged for a live bug cited as ``path:symbol``."""
+        _init_repo(tmp_path)
+        _commit_file(
+            tmp_path,
+            "src/mod.py",
+            "def buggy_func():\n    return reserve(n - 1)\n",
+            "add buggy func",
+        )
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 301,
+            "title": "buggy_func miscounts",
+            "body": "buggy_func reserves the wrong number of slots\n",
+            "state": "OPEN",
+        }
+        payload = {
+            "observed_symptom": "s",
+            "reproduction_or_evidence": "r",
+            "hypotheses": [{"statement": "h", "status": "confirmed", "evidence": "e"}],
+            "confirmed_cause": "off-by-one in buggy_func",
+            "affected_code_path": "src/mod.py:buggy_func",
+            "fix_success_criterion": "c",
+        }
+        mock_agent.return_value = _fake_agent_result(
+            f"```yaml\n{yaml.safe_dump(payload, sort_keys=False)}```"
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=301,
+            config=config,
+            project_root=tmp_path,
+            output_destination="body_section",
+        )
+
+        assert result.success
+        assert result.state.phase == DiagnosePhase.DONE
+        assert mock_edit.called
+
+    @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
     @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
     @patch("theforge.coordinator.diagnose_flow.run_agent")
     def test_deleted_affected_file_reports_already_resolved(

--- a/tests/test_diagnose_types.py
+++ b/tests/test_diagnose_types.py
@@ -11,11 +11,14 @@ import pytest
 
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
+    AbsentPremise,
     DiagnosePhase,
     DiagnoseResult,
     DiagnoseState,
     DiagnosisArtifact,
     Hypothesis,
+    PremiseAnchor,
+    render_already_resolved_markdown,
     render_artifact_markdown,
     upsert_diagnosis_section,
 )
@@ -45,8 +48,64 @@ class TestDiagnosePhase:
             "DONE",
             "FAILED",
             "TIMEOUT_PARTIAL",
+            "VERIFY_PREMISE",
+            "ALREADY_RESOLVED",
         ):
             assert required in names
+
+
+class TestAlreadyResolvedRendering:
+    def test_names_removing_commit_and_omits_diagnosis_heading(self):
+        md = render_already_resolved_markdown(
+            issue_number=1494,
+            baseline_sha="deadbeefcafefeed",
+            absent=(
+                AbsentPremise(
+                    file="src/mod.py",
+                    pattern="def buggy_func",
+                    removing_commit="817222bd1234",
+                    removing_summary="drop the buggy path",
+                ),
+            ),
+        )
+        assert "already resolved" in md.lower()
+        assert "817222bd1234"[:12] in md
+        assert "def buggy_func" in md
+        assert "src/mod.py" in md
+        # Must NOT present as a fix-ready Diagnosis section: no confirmed-cause
+        # scaffolding a shape gate would read as implementation-ready.
+        assert "## Diagnosis" not in md
+        assert "### Confirmed cause" not in md
+
+    def test_renders_whole_file_removal(self):
+        md = render_already_resolved_markdown(
+            issue_number=1,
+            baseline_sha="abc123",
+            absent=(
+                AbsentPremise(
+                    file="src/gone.py", pattern="", removing_commit="ff00aa", removing_summary=""
+                ),
+            ),
+        )
+        assert "file removed" in md
+        assert "src/gone.py" in md
+
+
+class TestPremiseAnchorField:
+    def test_artifact_carries_premise_anchors(self):
+        artifact = DiagnosisArtifact(
+            issue_number=1,
+            observed_symptom="s",
+            reproduction_or_evidence="r",
+            hypotheses=(Hypothesis("h", "confirmed", "e"),),
+            confirmed_cause="c",
+            affected_code_path="p",
+            fix_success_criterion="f",
+            premise_anchors=(PremiseAnchor(file="a.py", pattern="def x"),),
+        )
+        assert artifact.premise_anchors[0].file == "a.py"
+        # Optional metadata: does not affect completeness.
+        assert artifact.is_complete()
 
 
 class TestDiagnoseOutputDestinations:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior P1 is resolved; the premise verifier now catches removed symbols cited only through affected_code_path before any diagnosis is landed. | [google-gemini-3.5-flash] The implementation successfully gates confirmed-cause diagnoses on baseline premise verification, resolving the prior cycle's symbol-detection gap.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $7.31
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose emits a confident diagnosis for an already-fixed bug instead of detecting the premise is gone (GitHub Issue #1675)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1675