### PR TITLE
Preflight sizing separates implementation complexity from validation/execution complexity, with cited evidence

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -568,6 +568,12 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "reason": state.preflight_reason,
                 "complexity": state.preflight_complexity,
                 "complexity_score": state.preflight_complexity_score,
+                "implementation_complexity_score": (
+                    state.preflight_implementation_complexity_score
+                ),
+                "validation_complexity_score": state.preflight_validation_complexity_score,
+                "complexity_projection": state.preflight_complexity_projection,
+                "complexity_evidence": list(state.preflight_complexity_evidence or []),
                 "work_type": state.preflight_work_type,
                 "contract_change": state.preflight_contract_change,
                 "bundle_candidate": state.preflight_bundle_candidate,

--- a/src/theforge/coordinator/preflight_cache.py
+++ b/src/theforge/coordinator/preflight_cache.py
@@ -108,6 +108,14 @@ def apply_cached_preflight_state(
     state.preflight_reason = cached_state.preflight_reason
     state.preflight_complexity = cached_state.preflight_complexity
     state.preflight_complexity_score = cached_state.preflight_complexity_score
+    state.preflight_implementation_complexity_score = (
+        cached_state.preflight_implementation_complexity_score
+    )
+    state.preflight_validation_complexity_score = (
+        cached_state.preflight_validation_complexity_score
+    )
+    state.preflight_complexity_projection = cached_state.preflight_complexity_projection
+    state.preflight_complexity_evidence = list(cached_state.preflight_complexity_evidence or [])
     state.preflight_sufficiency = cached_state.preflight_sufficiency
     state.preflight_work_type = cached_state.preflight_work_type
     state.preflight_contract_change = cached_state.preflight_contract_change

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -54,6 +54,11 @@ from .preflight import (
 from .preflight_cache import capture_preflight_cache_snapshot
 from .state import CoordinatorResult, CoordinatorState, Phase
 from .util import _fmt_duration, _log_phase
+from .validation_complexity import (
+    assess_validation_complexity,
+    implementation_evidence,
+    project_complexity_score,
+)
 
 # Tokens that indicate a BLOCKED verdict is based on ambiguity/verifiability
 # concerns rather than a concrete hard blocker.  Two conditions must hold
@@ -202,6 +207,9 @@ def _preflight_phase_end_fields(state: CoordinatorState) -> dict[str, object]:
     return {
         "complexity": state.preflight_complexity,
         "complexity_score": state.preflight_complexity_score,
+        "implementation_complexity_score": state.preflight_implementation_complexity_score,
+        "validation_complexity_score": state.preflight_validation_complexity_score,
+        "complexity_projection": state.preflight_complexity_projection,
         "complexity_routing": routing,
     }
 
@@ -468,6 +476,7 @@ def _run_preflight_phase(
         # bugs — the preflight LLM reads the codebase and should size bugs correctly.
         # The override is load-bearing only for feature/refactor/mechanical stories
         # where imperative spec language reflects genuine cross-cutting scope.
+        large_story_categories: list[str] = []
         if work_type != "bug":
             large_story_categories = _detect_large_preflight_story_categories(story_content)
             if large_story_categories and (
@@ -489,6 +498,44 @@ def _run_preflight_phase(
                 )
                 state.preflight_warnings = list(state.preflight_warnings or []) + [override_reason]
                 _log(f"  ↑ {override_reason}")
+
+        # ── Dual-axis complexity: implementation vs validation envelope ──
+        # The (possibly overridden) model score above is the *implementation*
+        # (code-change) envelope. Assess the *validation/execution* envelope
+        # separately from body-local structural signals, then project the legacy
+        # complexity_score = max(implementation, validation) so existing routing,
+        # timeout, and review-budget consumers get the validation lift without
+        # reading the new fields. Evidence on both axes makes the size auditable.
+        implementation_score = state.preflight_complexity_score
+        validation = assess_validation_complexity(story_content)
+        projected_score, projection_rule = project_complexity_score(
+            implementation_score, validation.score
+        )
+        combined_evidence = (
+            implementation_evidence(
+                implementation_score,
+                large_categories=large_story_categories,
+                contract_change=contract_change,
+            )
+            + validation.evidence
+        )
+        state.preflight_implementation_complexity_score = implementation_score
+        state.preflight_validation_complexity_score = validation.score
+        state.preflight_complexity_projection = projection_rule
+        state.preflight_complexity_evidence = [e.as_dict() for e in combined_evidence]
+        state.preflight_complexity_score = projected_score
+        complexity = score_to_band(projected_score)
+        state.preflight_complexity = complexity
+        if validation.warnings:
+            state.preflight_warnings = list(state.preflight_warnings or []) + validation.warnings
+        if projected_score > (implementation_score or 0):
+            _log(
+                f"  ↑ validation-envelope lift: implementation={implementation_score} "
+                f"validation={validation.score} → complexity_score={projected_score} "
+                f"({projection_rule})"
+            )
+            for w in validation.warnings:
+                _log(f"  ⚠ {w}")
 
         # ── Bounded-bug planning skip ─────────────────────────────────
         # Bounded, diagnosed bugs whose fix is localized to a single area
@@ -652,8 +699,21 @@ def _run_preflight_phase(
     else:
         # Agent failed — skip all parsers; hard-set conservative values so
         # downstream phases plan carefully despite missing classification.
-        state.preflight_complexity = "large"
-        state.preflight_complexity_score = 9
+        # The validation envelope is still assessable from the story body alone
+        # (it needs no codebase read), so both axes stay present per AC.
+        _failed_validation = assess_validation_complexity(story_content)
+        _failed_projected, _failed_projection = project_complexity_score(
+            9, _failed_validation.score
+        )
+        state.preflight_complexity = score_to_band(_failed_projected)
+        state.preflight_complexity_score = _failed_projected
+        state.preflight_implementation_complexity_score = 9
+        state.preflight_validation_complexity_score = _failed_validation.score
+        state.preflight_complexity_projection = _failed_projection
+        state.preflight_complexity_evidence = [
+            e.as_dict()
+            for e in implementation_evidence(9, agent_failed=True) + _failed_validation.evidence
+        ]
         state.preflight_sufficiency = "needs_planning"
         if task.type == "bug":
             state.preflight_work_type = "bug"
@@ -702,6 +762,10 @@ def _run_preflight_phase(
         "reason": reason,
         "complexity": state.preflight_complexity,
         "complexity_score": state.preflight_complexity_score,
+        "implementation_complexity_score": state.preflight_implementation_complexity_score,
+        "validation_complexity_score": state.preflight_validation_complexity_score,
+        "complexity_projection": state.preflight_complexity_projection,
+        "complexity_evidence": list(state.preflight_complexity_evidence or []),
         "sufficiency": state.preflight_sufficiency,
         "contract_change": state.preflight_contract_change,
         "cost_usd": preflight_result.cost_usd,

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -55,6 +55,9 @@ from .preflight_cache import capture_preflight_cache_snapshot
 from .state import CoordinatorResult, CoordinatorState, Phase
 from .util import _fmt_duration, _log_phase
 from .validation_complexity import (
+    DIMENSION_IMPLEMENTATION,
+    VALIDATION_BASELINE_SCORE,
+    ComplexityEvidence,
     assess_validation_complexity,
     implementation_evidence,
     project_complexity_score,
@@ -687,14 +690,37 @@ def _run_preflight_phase(
                 state.preflight_degraded = True
                 state.preflight_degraded_reason = "blocked_downgraded_prior_evidence"
                 # Compensate for missing classification: force planning and
-                # upgrade complexity to at least medium.
+                # upgrade complexity to at least medium. Route the bump through
+                # the dual-axis projection so implementation/validation scores,
+                # the projection rule, and cited evidence stay consistent with
+                # the final complexity_score rather than going stale (issue #1442).
                 if state.preflight_complexity == "small":
-                    state.preflight_complexity = "medium"
-                    if (
-                        state.preflight_complexity_score is not None
-                        and state.preflight_complexity_score < 4
-                    ):
-                        state.preflight_complexity_score = 5
+                    impl_floor = state.preflight_implementation_complexity_score
+                    if impl_floor is None or impl_floor < 5:
+                        impl_floor = 5
+                    validation_score = (
+                        state.preflight_validation_complexity_score
+                        if state.preflight_validation_complexity_score is not None
+                        else VALIDATION_BASELINE_SCORE
+                    )
+                    projected_score, projection_rule = project_complexity_score(
+                        impl_floor, validation_score
+                    )
+                    state.preflight_implementation_complexity_score = impl_floor
+                    state.preflight_validation_complexity_score = validation_score
+                    state.preflight_complexity_score = projected_score
+                    state.preflight_complexity = score_to_band(projected_score)
+                    state.preflight_complexity_projection = projection_rule
+                    override_ev = ComplexityEvidence(
+                        "implementation_ambiguity_downgrade_floor",
+                        "BLOCKED→PROCEED ambiguity downgrade with prior execution "
+                        "evidence: raised implementation floor to 5 to force planning",
+                        DIMENSION_IMPLEMENTATION,
+                    ).as_dict()
+                    state.preflight_complexity_evidence = [
+                        *(state.preflight_complexity_evidence or []),
+                        override_ev,
+                    ]
                 state.preflight_sufficiency = "needs_planning"
     else:
         # Agent failed — skip all parsers; hard-set conservative values so

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -318,7 +318,16 @@ class CoordinatorState:
     preflight_verdict: str | None = None  # "PROCEED" | "ALREADY_DONE" | "BLOCKED"
     preflight_reason: str | None = None
     preflight_complexity: str | None = None  # "small" | "medium" | "large"
-    preflight_complexity_score: int | None = None  # 1-10 bounded integer score
+    preflight_complexity_score: int | None = None  # 1-10 projected legacy score
+    # Dual-axis sizing (issue #1442). The legacy complexity_score above is
+    # projected from these two via preflight_complexity_projection so existing
+    # readers keep working; new consumers may opt into the native axes.
+    preflight_implementation_complexity_score: int | None = None  # code-change envelope
+    preflight_validation_complexity_score: int | None = None  # validation/execution envelope
+    preflight_complexity_projection: str | None = None  # e.g. "max_implementation_validation"
+    # Cited evidence: list of {rule_id, signal, dimension} dicts naming the rules
+    # that fired on each axis. Empty until preflight sizing runs.
+    preflight_complexity_evidence: list[dict] = field(default_factory=list)
     preflight_sufficiency: str | None = None  # "implementation_ready" | "needs_planning"
     preflight_work_type: str | None = None  # "feature" | "refactor" | "mechanical" | "bug"
     preflight_contract_change: bool = False  # story intentionally alters a tested contract

--- a/src/theforge/coordinator/validation_complexity.py
+++ b/src/theforge/coordinator/validation_complexity.py
@@ -1,0 +1,413 @@
+"""Validation/execution complexity assessment for preflight sizing.
+
+Preflight's legacy ``complexity_score`` collapses two independent axes of story
+difficulty into one number: the *implementation* envelope (how much code changes)
+and the *validation/execution* envelope (how much must be exercised and verified
+to prove the work is done). The single score is dominated by code-change signals —
+body length, AC bullet count, file-path mentions — so a story whose code change is
+small but whose validation envelope is large (issue-1326: a real cost-bearing
+``forge sprint`` exercising seven operator-visible surfaces, gating a release) is
+sized as ordinary work and routed with ordinary timeouts and review budgets.
+
+This module derives a *separate* validation-complexity score from body-local
+structural signals so that envelope is sized on its own terms. Detection is
+structural — counted surfaces, parsed dependency lists, verb-object recognition —
+not single-token keyword matching. Every rule that fires records a ``rule_id`` +
+``signal`` evidence pair (parallel to the RCA engine's evidence shape) so the
+score is auditable and a lazy ``TOKEN in body`` rule can be rejected at review.
+
+Pure Python, stdlib-only. The coordinator owns process decisions; this is a
+deterministic sizing input, never an LLM call.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# Integer complexity scale bounds. Kept local (rather than imported from
+# ``preflight``) so this module stays low-dependency and stdlib-only per the
+# pure-data-module convention. These mirror preflight.COMPLEXITY_SCORE_MIN/MAX.
+_SCORE_MIN = 1
+_SCORE_MAX = 10
+
+# A story with no validation signals starts at the floor so its projected
+# complexity is driven entirely by the implementation envelope (projection is a
+# max, so a baseline-1 validation score never lifts an ordinary story).
+VALIDATION_BASELINE_SCORE = 1
+
+# Documented projection rule recorded on the preflight output so consumers can
+# tell a projected legacy score from a native one.
+PROJECTION_MAX_IMPL_VALIDATION = "max_implementation_validation"
+
+# Dimensions an evidence entry can belong to.
+DIMENSION_IMPLEMENTATION = "implementation"
+DIMENSION_VALIDATION = "validation"
+
+
+@dataclass(frozen=True)
+class ComplexityEvidence:
+    """A single rule firing: which rule matched, what it matched, on which axis.
+
+    ``rule_id`` follows the same descriptive-id pattern used by the RCA engine's
+    evidence shape; ``signal`` is the concrete structural observation that fired
+    the rule (a count, a parsed list, a matched verb-object span).
+    """
+
+    rule_id: str
+    signal: str
+    dimension: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"rule_id": self.rule_id, "signal": self.signal, "dimension": self.dimension}
+
+
+@dataclass(frozen=True)
+class ValidationAssessment:
+    """Result of assessing the validation/execution envelope of a story body."""
+
+    score: int
+    evidence: list[ComplexityEvidence] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _RuleHit:
+    """Internal per-rule result before it is folded into an assessment."""
+
+    rule_id: str
+    signal: str
+    contribution: int
+
+
+# ── Structural helpers ────────────────────────────────────────────────────
+
+# Operator-visible artifact extensions. A body reference ending in one of these
+# is a concrete output file / rendered view the deliverable must produce or read.
+_ARTIFACT_EXT = (
+    "yaml",
+    "yml",
+    "jsonl",
+    "json",
+    "log",
+    "md",
+    "sqlite",
+    "db",
+    "toml",
+    "csv",
+    "txt",
+)
+
+_ARTIFACT_RE = re.compile(
+    r"\b[\w./-]+\.(?:" + "|".join(_ARTIFACT_EXT) + r")\b",
+    re.IGNORECASE,
+)
+_FLAG_RE = re.compile(r"(?<![\w-])--[a-z][a-z0-9-]+")
+_BACKTICK_RE = re.compile(r"`([^`]+)`")
+# A multi-word lowercase command invocation, e.g. `audit show`, `forge check-config`.
+_COMMAND_SPAN_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\s+[a-z0-9:_-]+)+$")
+
+
+def _acceptance_region(body: str) -> str:
+    """Return the acceptance-criteria section of a markdown body, else the body.
+
+    Rules that talk about "the AC enumerates ..." look here first so that
+    surfaces mentioned only in background prose do not inflate the count. When no
+    acceptance-criteria heading exists (file-based stories, terse specs), the
+    whole body is used — structural detection still applies, just over more text.
+    """
+    if not body:
+        return ""
+    lines = body.splitlines()
+    start: int | None = None
+    heading_level = 0
+    for idx, line in enumerate(lines):
+        m = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if m and "acceptance" in m.group(2).lower():
+            start = idx + 1
+            heading_level = len(m.group(1))
+            break
+    if start is None:
+        return body
+    collected: list[str] = []
+    for line in lines[start:]:
+        m = re.match(r"^(#{1,6})\s+", line)
+        if m and len(m.group(1)) <= heading_level:
+            break
+        collected.append(line)
+    region = "\n".join(collected).strip()
+    return region or body
+
+
+def _distinct_surfaces(text: str) -> list[str]:
+    """Return the distinct operator-visible surfaces referenced in ``text``.
+
+    A surface is a CLI command invocation, a command flag, or an output/artifact
+    file — the things an operator must each run or inspect to verify the work.
+    Detection is structural: parsed backtick command spans, flag tokens, and
+    filename tokens carrying a known artifact extension. This is deliberately not
+    ``KEYWORD in text`` — it counts *parsed* references and de-duplicates them.
+    """
+    surfaces: set[str] = set()
+    for raw in _BACKTICK_RE.findall(text):
+        span = raw.strip()
+        if _COMMAND_SPAN_RE.match(span):
+            surfaces.add(" ".join(span.split()).lower())
+    for flag in _FLAG_RE.findall(text):
+        surfaces.add(flag.lower())
+    for m in _ARTIFACT_RE.finditer(text):
+        surfaces.add(m.group(0).lower())
+    return sorted(surfaces)
+
+
+# ── Rules ──────────────────────────────────────────────────────────────────
+
+
+def _rule_validation_surface_count(body: str, ac_region: str) -> _RuleHit | None:
+    """AC enumerates multiple operator-visible surfaces that must each be verified."""
+    surfaces = _distinct_surfaces(ac_region)
+    count = len(surfaces)
+    if count >= 5:
+        contribution = 4
+    elif count >= 3:
+        contribution = 2
+    else:
+        return None
+    shown = ", ".join(surfaces[:8])
+    return _RuleHit(
+        rule_id="validation_surface_count",
+        signal=f"{count} operator-visible surfaces enumerated in acceptance criteria: {shown}",
+        contribution=contribution,
+    )
+
+
+_COST_CMD_RE = re.compile(r"\bforge\s+(sprint|run|merge|diagnose|groom|triage)\b", re.IGNORECASE)
+_DIRECTIVE_RE = re.compile(
+    r"\b(run|runs|running|invoke|invokes|invoking|execute|executes|executing|"
+    r"trigger|triggers|triggering|launch|launches|launching|perform|performs|"
+    r"kick\s+off)\b",
+    re.IGNORECASE,
+)
+_FIXTURE_RE = re.compile(
+    r"\b(mock|mocked|mocks|fake|faked|fakes|stub|stubbed|stubs|fixture|fixtures|"
+    r"simulate[ds]?|dry[-\s]run|as\s+a\s+test)\b",
+    re.IGNORECASE,
+)
+
+
+def _rule_cost_bearing_dogfood(body: str, ac_region: str) -> _RuleHit | None:
+    """Deliverable invokes a cost-bearing forge command within its own AC.
+
+    Verb-object recognition: a directive verb (run / invoke / execute / trigger /
+    launch) must precede a cost-bearing ``forge`` subcommand, and the surrounding
+    window must not mark it as a test fixture (mock / fake / stub / simulate /
+    dry-run). Merely mentioning ``forge sprint`` in prose does not fire — the
+    directive verb and fixture exclusion are the structural discriminators.
+    """
+    for m in _COST_CMD_RE.finditer(body):
+        preceding = body[max(0, m.start() - 45) : m.start()]
+        window = body[max(0, m.start() - 45) : m.end() + 25]
+        if _DIRECTIVE_RE.search(preceding) and not _FIXTURE_RE.search(window):
+            command = " ".join(m.group(0).split())
+            verb_match = list(_DIRECTIVE_RE.finditer(preceding))[-1]
+            return _RuleHit(
+                rule_id="cost_bearing_dogfood",
+                signal=(
+                    "acceptance criteria require a real cost-bearing invocation "
+                    f"('{verb_match.group(0).strip()}' … '{command}'), not a test fixture"
+                ),
+                contribution=2,
+            )
+    return None
+
+
+_VERSION_RE = re.compile(r"\bv?\d+\.\d+(?:\.\d+)?\b")
+_GATE_RE = re.compile(
+    r"\b(block|blocks|blocked|blocking|gate|gates|gated|gating)\b", re.IGNORECASE
+)
+_RELEASE_RE = re.compile(r"\brelease[sd]?\b", re.IGNORECASE)
+_UNTIL_PASS_RE = re.compile(
+    r"until\b[^.\n]*\b(pass|passes|passing|green|complete|completes|succeed|succeeds)\b",
+    re.IGNORECASE,
+)
+
+
+def _rule_release_blocking_validation(body: str, ac_region: str) -> _RuleHit | None:
+    """AC contains release-gate language ("block vN.M release", "blocked until …").
+
+    Structural conjunction: a gating verb must sit near the word "release" and
+    near either a version token (vN.M) or an "until … passes" completion clause.
+    Requiring all three in proximity means a bare "release" or a bare "blocked"
+    cannot fire this rule on its own.
+    """
+    for gate in _GATE_RE.finditer(body):
+        window = body[max(0, gate.start() - 90) : gate.end() + 90]
+        if not _RELEASE_RE.search(window):
+            continue
+        version = _VERSION_RE.search(window)
+        until = _UNTIL_PASS_RE.search(window)
+        if version or until:
+            anchor = version.group(0) if version else "until-passes clause"
+            return _RuleHit(
+                rule_id="release_blocking_validation",
+                signal=(
+                    "acceptance criteria gate a release: "
+                    f"'{gate.group(0)}' near 'release' and '{anchor}'"
+                ),
+                contribution=1,
+            )
+    return None
+
+
+_DEP_CONTEXT_RE = re.compile(
+    r"\b(depends?\s+on|dependenc(?:y|ies)|depends_on|blocked\s+by|"
+    r"requires|builds?\s+on|prerequisite[s]?)\b",
+    re.IGNORECASE,
+)
+_ISSUE_REF_RE = re.compile(r"#(\d+)")
+
+
+def _rule_dependency_fan_in(body: str, ac_region: str) -> _RuleHit | None:
+    """Body declares dependencies on multiple other stories in the same release.
+
+    Structural parse: from each dependency-declaring phrase ("depends on",
+    "dependencies", "blocked by", …) scan the following list region and collect
+    issue references. Distinct count >= 2 fires. Issue references that are not in
+    a dependency context ("see #123 for background") are never counted, so a lone
+    mention cannot inflate the score.
+    """
+    found: set[int] = set()
+    for ctx in _DEP_CONTEXT_RE.finditer(body):
+        tail = body[ctx.end() : ctx.end() + 200]
+        # Stop at a blank line — dependency lists do not span paragraph breaks.
+        tail = tail.split("\n\n", 1)[0]
+        for ref in _ISSUE_REF_RE.findall(tail):
+            found.add(int(ref))
+    if len(found) < 2:
+        return None
+    listed = ", ".join(f"#{n}" for n in sorted(found))
+    return _RuleHit(
+        rule_id="dependency_fan_in",
+        signal=f"declared dependencies on {len(found)} other stories: {listed}",
+        contribution=1,
+    )
+
+
+_RULES = (
+    _rule_validation_surface_count,
+    _rule_cost_bearing_dogfood,
+    _rule_release_blocking_validation,
+    _rule_dependency_fan_in,
+)
+
+
+def _build_warnings(hits: dict[str, _RuleHit]) -> list[str]:
+    """Derive operator-facing warnings from the set of fired validation rules."""
+    warnings: list[str] = []
+    surface_hit = hits.get("validation_surface_count")
+    if surface_hit is not None and surface_hit.contribution >= 4:
+        count = surface_hit.signal.split(" ", 1)[0]
+        warnings.append(
+            f"validation envelope spans {count} operator-visible surfaces; "
+            "consider splitting read-only checks from cost-bearing execution"
+        )
+    if "cost_bearing_dogfood" in hits and "release_blocking_validation" in hits:
+        warnings.append("release-blocking dogfood validation")
+    return warnings
+
+
+def assess_validation_complexity(story_content: str | None) -> ValidationAssessment:
+    """Score the validation/execution envelope of a story body from structural signals.
+
+    Returns a :class:`ValidationAssessment` whose ``score`` is in
+    ``[_SCORE_MIN, _SCORE_MAX]`` (baseline 1 for a story with no validation
+    signals), ``evidence`` names each validation rule that fired, and
+    ``warnings`` surfaces the envelope to operators.
+    """
+    body = story_content or ""
+    ac_region = _acceptance_region(body)
+
+    hits: dict[str, _RuleHit] = {}
+    for rule in _RULES:
+        hit = rule(body, ac_region)
+        if hit is not None:
+            hits[hit.rule_id] = hit
+
+    score = VALIDATION_BASELINE_SCORE + sum(hit.contribution for hit in hits.values())
+    score = max(_SCORE_MIN, min(_SCORE_MAX, score))
+
+    evidence = [
+        ComplexityEvidence(hit.rule_id, hit.signal, DIMENSION_VALIDATION) for hit in hits.values()
+    ]
+    return ValidationAssessment(
+        score=score,
+        evidence=evidence,
+        warnings=_build_warnings(hits),
+    )
+
+
+def implementation_evidence(
+    implementation_score: int | None,
+    *,
+    large_categories: tuple[str, ...] | list[str] = (),
+    contract_change: bool = False,
+    agent_failed: bool = False,
+) -> list[ComplexityEvidence]:
+    """Build the implementation-axis evidence accompanying the code-change score.
+
+    The implementation score is the preflight model's code-change sizing (plus any
+    deterministic coordinator overrides). This records where that number came from
+    so the projected legacy score is auditable on both axes.
+    """
+    evidence: list[ComplexityEvidence]
+    if agent_failed:
+        evidence = [
+            ComplexityEvidence(
+                "implementation_agent_failure",
+                "preflight agent failed; implementation envelope set to conservative maximum",
+                DIMENSION_IMPLEMENTATION,
+            )
+        ]
+    else:
+        evidence = [
+            ComplexityEvidence(
+                "implementation_model_score",
+                f"preflight model sized the code-change envelope at {implementation_score}",
+                DIMENSION_IMPLEMENTATION,
+            )
+        ]
+    if contract_change:
+        evidence.append(
+            ComplexityEvidence(
+                "implementation_contract_change",
+                "contract change forces at least medium implementation complexity "
+                "(shared-interface blast radius)",
+                DIMENSION_IMPLEMENTATION,
+            )
+        )
+    for category in large_categories:
+        evidence.append(
+            ComplexityEvidence(
+                "implementation_large_category",
+                f"large-category signal: {category}",
+                DIMENSION_IMPLEMENTATION,
+            )
+        )
+    return evidence
+
+
+def project_complexity_score(
+    implementation_score: int | None,
+    validation_score: int,
+) -> tuple[int, str]:
+    """Project the legacy ``complexity_score`` from the two native scores.
+
+    First-cut projection rule is ``max(implementation, validation)`` so existing
+    routing/timeout/review-budget consumers reading ``complexity_score`` receive
+    the validation lift without reading the new fields. Returns
+    ``(projected_score, projection_rule_id)``.
+    """
+    impl = implementation_score if implementation_score is not None else validation_score
+    projected = max(impl, validation_score)
+    projected = max(_SCORE_MIN, min(_SCORE_MAX, projected))
+    return projected, PROJECTION_MAX_IMPL_VALIDATION

--- a/tests/test_coord_validation_complexity.py
+++ b/tests/test_coord_validation_complexity.py
@@ -397,6 +397,86 @@ class TestDualScoreSeam:
         # Plan skipped for the ordinary bounded story.
         assert mock_plan_agent.call_count == 0
 
+    @patch("theforge.coordinator.preflight_flow._has_prior_execution_evidence", return_value=True)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_ambiguity_downgrade_keeps_dual_axis_consistent(
+        self,
+        mock_shell,
+        mock_dev_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_pool,
+        _mock_prior,
+        tmp_path,
+    ):
+        """An ambiguity BLOCKED→PROCEED downgrade force-bumps complexity_score; the
+        projection, both native axes, and cited evidence must stay consistent with
+        the bumped value rather than going stale (issue #1442 review finding)."""
+        config = _make_plan_config(tmp_path)
+        task = _task_with_text(tmp_path, _STORY_ORDINARY)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        blocked_ambiguous = """\
+```yaml
+verdict: BLOCKED
+reason: "Acceptance criteria are ambiguous and not objectively verifiable."
+complexity: small
+complexity_score: 2
+work_type: feature
+sufficiency: needs_planning
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "Feature X"
+    satisfied: false
+    evidence: "Cannot verify without external API"
+```
+"""
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=blocked_ambiguous, cost_usd=0.05
+        )
+        plan_result = _make_agent_result(success=True, output="# Plan\n\nStep 1.", cost_usd=0.10)
+        dev_result = _make_agent_result(success=True, output="Done.", cost_usd=0.50)
+        call_idx = {"n": 0}
+        results = [plan_result, dev_result]
+
+        def agent_side_effect(**kwargs):
+            idx = min(call_idx["n"], len(results) - 1)
+            call_idx["n"] += 1
+            return results[idx]
+
+        mock_plan_agent.side_effect = mock_dev_agent
+        mock_dev_agent.side_effect = agent_side_effect
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+        state = result.state
+
+        assert result.success is True
+        assert state.preflight_degraded_reason == "blocked_downgraded_prior_evidence"
+        # The force-bump raised the implementation floor and re-projected.
+        assert state.preflight_complexity == "medium"
+        assert state.preflight_implementation_complexity_score == 5
+        assert state.preflight_validation_complexity_score == 1
+        # complexity_score must equal the re-projected max, not a stale value.
+        projected, rule = project_complexity_score(
+            state.preflight_implementation_complexity_score,
+            state.preflight_validation_complexity_score,
+        )
+        assert state.preflight_complexity_score == projected == 5
+        assert state.preflight_complexity_projection == rule == PROJECTION_MAX_IMPL_VALIDATION
+        # Evidence records the override so the derivation stays auditable.
+        fired = {e["rule_id"] for e in state.preflight_complexity_evidence}
+        assert "implementation_ambiguity_downgrade_floor" in fired
+
 
 def test_state_defaults_are_present():
     state = CoordinatorState()

--- a/tests/test_coord_validation_complexity.py
+++ b/tests/test_coord_validation_complexity.py
@@ -1,0 +1,406 @@
+"""Validation-complexity sizing: separate implementation vs validation envelopes
+with cited structural evidence and a projected legacy complexity_score (issue #1442).
+
+Two layers:
+  - Unit tests for the pure structural rule engine in
+    ``theforge.coordinator.validation_complexity`` — surface counting, verb-object
+    cost-bearing detection, release-gate conjunction, parsed dependency fan-in,
+    projection, and negative (non-keyword) discrimination.
+  - Seam tests that drive ``run_task`` end-to-end and assert both native scores,
+    the projection, and cited evidence land on coordinator state and the
+    preflight.yaml artifact.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_plan_config,
+    _shell_with_gate,
+)
+
+from theforge.config import LogConfig
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import CoordinatorState
+from theforge.coordinator.validation_complexity import (
+    PROJECTION_MAX_IMPL_VALIDATION,
+    assess_validation_complexity,
+    implementation_evidence,
+    project_complexity_score,
+)
+from theforge.task import TaskStory
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+# An issue-1326-shaped story: many operator-visible surfaces enumerated in the
+# AC, a real cost-bearing recursive invocation, release-gate language, and a
+# multi-issue dependency fan-in.
+_STORY_1326 = """\
+# Validate v0.11.0 substrate surfaces end-to-end
+
+Depends on #792, #793, #1101, #1324, #1325 — all scheduled in the same release.
+
+## Acceptance criteria
+
+- Run a real `forge sprint` against TheForge and confirm the story lands.
+- `audit show` renders the completed run.
+- `forge check-config` passes against the populated substrate.
+- Resuming an interrupted sprint with `--resume` continues from the last phase.
+- `history.jsonl` is imported one-shot and `sprint-rca.yaml` is rendered.
+- This checklist gates the v0.11.0 release; the release is blocked until it passes.
+"""
+
+# An ordinary tight-AC code-change story with no validation envelope.
+_STORY_ORDINARY = """\
+# Add a debug log line to the config loader
+
+## Acceptance criteria
+
+- A debug log line is emitted when the config file is loaded.
+"""
+
+
+# ── Unit: full envelope ────────────────────────────────────────────────────
+
+
+def test_issue_1326_shaped_story_scores_high_validation():
+    result = assess_validation_complexity(_STORY_1326)
+    assert result.score >= 8
+    fired = {e.rule_id for e in result.evidence}
+    assert fired == {
+        "validation_surface_count",
+        "cost_bearing_dogfood",
+        "release_blocking_validation",
+        "dependency_fan_in",
+    }
+    # Every evidence entry carries a rule_id + non-empty signal on the validation axis.
+    for e in result.evidence:
+        assert e.dimension == "validation"
+        assert e.rule_id and e.signal
+    # Warnings surface the envelope to operators.
+    assert any("operator-visible surfaces" in w for w in result.warnings)
+    assert "release-blocking dogfood validation" in result.warnings
+
+
+def test_ordinary_story_scores_baseline_validation():
+    result = assess_validation_complexity(_STORY_ORDINARY)
+    assert result.score == 1
+    assert result.evidence == []
+    assert result.warnings == []
+
+
+def test_empty_body_is_baseline():
+    result = assess_validation_complexity("")
+    assert result.score == 1
+    assert result.evidence == []
+
+
+# ── Unit: surface counting ─────────────────────────────────────────────────
+
+
+def test_surface_count_fires_on_many_surfaces():
+    body = (
+        "## Acceptance criteria\n"
+        "- `audit show` renders it.\n"
+        "- `forge check-config` passes.\n"
+        "- pass `--resume` to continue.\n"
+        "- `history.jsonl` imported and `sprint-rca.yaml` rendered.\n"
+    )
+    result = assess_validation_complexity(body)
+    ids = {e.rule_id for e in result.evidence}
+    assert "validation_surface_count" in ids
+
+
+def test_surface_count_does_not_fire_on_two_surfaces():
+    body = "## Acceptance criteria\n- `audit show` renders `run.yaml`.\n"
+    result = assess_validation_complexity(body)
+    ids = {e.rule_id for e in result.evidence}
+    assert "validation_surface_count" not in ids
+
+
+def test_surface_count_uses_acceptance_region_not_background():
+    # Surfaces mentioned only in background prose (no AC heading section) must not
+    # inflate the count when an acceptance-criteria section exists with few surfaces.
+    body = (
+        "# Story\n\n"
+        "Background mentions `audit show`, `forge check-config`, `--resume`, "
+        "`history.jsonl`, and `sprint-rca.yaml` for context.\n\n"
+        "## Acceptance criteria\n"
+        "- The loader emits one debug line.\n"
+    )
+    result = assess_validation_complexity(body)
+    ids = {e.rule_id for e in result.evidence}
+    assert "validation_surface_count" not in ids
+
+
+# ── Unit: cost-bearing verb-object recognition ─────────────────────────────
+
+
+def test_cost_bearing_fires_on_directive_plus_command():
+    body = "## Acceptance criteria\n- Run a real `forge sprint` and confirm it lands.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "cost_bearing_dogfood" in ids
+
+
+def test_cost_bearing_does_not_fire_without_directive_verb():
+    # Mentioning the command as a noun ("the forge sprint output format") is not a
+    # directive to invoke it.
+    body = "## Acceptance criteria\n- Document the forge sprint output format.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "cost_bearing_dogfood" not in ids
+
+
+def test_cost_bearing_does_not_fire_for_test_fixture():
+    body = "## Acceptance criteria\n- Run a mocked `forge sprint` as a test fixture.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "cost_bearing_dogfood" not in ids
+
+
+# ── Unit: release-gate conjunction ─────────────────────────────────────────
+
+
+def test_release_blocking_fires_on_version_plus_gate():
+    body = "## Acceptance criteria\n- This gates the v0.11.0 release.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "release_blocking_validation" in ids
+
+
+def test_release_blocking_fires_on_until_passes_clause():
+    body = "## Acceptance criteria\n- The release is blocked until the checklist passes.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "release_blocking_validation" in ids
+
+
+def test_release_blocking_does_not_fire_on_bare_version():
+    body = "## Acceptance criteria\n- v0.11.0 adds a new config flag.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "release_blocking_validation" not in ids
+
+
+def test_release_blocking_does_not_fire_on_bare_block_word():
+    # "block" without a release/version context is a false-positive trap.
+    body = "## Acceptance criteria\n- Add a config block to the loader.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "release_blocking_validation" not in ids
+
+
+# ── Unit: dependency fan-in parsing ────────────────────────────────────────
+
+
+def test_dependency_fan_in_fires_on_parsed_list():
+    body = "Depends on #101, #202, #303.\n\n## Acceptance criteria\n- Do the thing.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "dependency_fan_in" in ids
+
+
+def test_dependency_fan_in_ignores_refs_without_dep_context():
+    # Issue references outside a dependency-declaring phrase are background, not deps.
+    body = "See #101 and #202 for background.\n\n## Acceptance criteria\n- Do it.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "dependency_fan_in" not in ids
+
+
+def test_dependency_fan_in_needs_two_distinct():
+    body = "Depends on #101.\n\n## Acceptance criteria\n- Do it.\n"
+    ids = {e.rule_id for e in assess_validation_complexity(body).evidence}
+    assert "dependency_fan_in" not in ids
+
+
+# ── Unit: projection ───────────────────────────────────────────────────────
+
+
+def test_projection_takes_max():
+    score, rule = project_complexity_score(4, 9)
+    assert score == 9
+    assert rule == PROJECTION_MAX_IMPL_VALIDATION
+
+
+def test_projection_unchanged_when_validation_low():
+    score, rule = project_complexity_score(7, 1)
+    assert score == 7
+    assert rule == PROJECTION_MAX_IMPL_VALIDATION
+
+
+def test_projection_handles_missing_implementation():
+    score, _ = project_complexity_score(None, 5)
+    assert score == 5
+
+
+def test_projection_clamps_to_bounds():
+    assert project_complexity_score(20, 3)[0] == 10
+    assert project_complexity_score(0, 0)[0] == 1
+
+
+def test_implementation_evidence_records_source():
+    ev = implementation_evidence(4, large_categories=["concurrency control"], contract_change=True)
+    ids = {e.rule_id for e in ev}
+    assert "implementation_model_score" in ids
+    assert "implementation_contract_change" in ids
+    assert "implementation_large_category" in ids
+    assert all(e.dimension == "implementation" for e in ev)
+
+
+def test_implementation_evidence_agent_failure():
+    ev = implementation_evidence(9, agent_failed=True)
+    assert {e.rule_id for e in ev} == {"implementation_agent_failure"}
+
+
+# ── Seam: run_task propagates dual scores + evidence to state and artifact ──
+
+_PREFLIGHT_1326 = """\
+```yaml
+verdict: PROCEED
+complexity_score: 4
+complexity: medium
+work_type: feature
+contract_change: false
+reason: "Small code change but a large validation envelope."
+sufficiency: needs_planning
+sufficiency_reason: "Multiple surfaces must be verified against a real sprint."
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "Surfaces verified"
+    satisfied: false
+    evidence: "Not yet run"
+```
+"""
+
+_PREFLIGHT_ORDINARY = """\
+```yaml
+verdict: PROCEED
+complexity_score: 3
+complexity: small
+work_type: feature
+contract_change: false
+reason: "Localized log line addition."
+sufficiency: implementation_ready
+sufficiency_reason: "Bounded single-area change."
+spec_issues: []
+warnings: []
+criteria_checked:
+  - criterion: "Log line emitted"
+    satisfied: false
+    evidence: "Not present"
+```
+"""
+
+
+def _task_with_text(tmp_path: Path, story_text: str) -> TaskStory:
+    spec = tmp_path / "spec.md"
+    spec.write_text(story_text, encoding="utf-8")
+    return TaskStory(name="Story", story_path=spec, slug="test-task", story_text=story_text)
+
+
+class TestDualScoreSeam:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_high_validation_story_lifts_projected_complexity(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        config = dataclasses.replace(_make_plan_config(tmp_path), log=LogConfig(enabled=True))
+        task = _task_with_text(tmp_path, _STORY_1326)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=_PREFLIGHT_1326, cost_usd=0.05
+        )
+        plan_result = _make_agent_result(success=True, output="# Plan\n\nStep 1.", cost_usd=0.10)
+        dev_result = _make_agent_result(success=True, output="Done.", cost_usd=0.50)
+        call_idx = {"n": 0}
+        results = [plan_result, dev_result]
+
+        def agent_side_effect(**kwargs):
+            idx = min(call_idx["n"], len(results) - 1)
+            call_idx["n"] += 1
+            return results[idx]
+
+        mock_plan_agent.side_effect = mock_dev_agent
+        mock_dev_agent.side_effect = agent_side_effect
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+        state = result.state
+
+        assert result.success is True
+        # Native axes present and distinct.
+        assert state.preflight_implementation_complexity_score == 4
+        assert state.preflight_validation_complexity_score >= 8
+        # Legacy score is projected as the max — the validation lift wins.
+        assert state.preflight_complexity_score == state.preflight_validation_complexity_score
+        assert state.preflight_complexity == "large"
+        assert state.preflight_complexity_projection == PROJECTION_MAX_IMPL_VALIDATION
+        # Cited evidence spans both axes and includes the validation rules.
+        fired = {e["rule_id"] for e in state.preflight_complexity_evidence}
+        assert "implementation_model_score" in fired
+        assert {
+            "validation_surface_count",
+            "cost_bearing_dogfood",
+            "release_blocking_validation",
+            "dependency_fan_in",
+        } <= fired
+
+        # Artifact carries the new fields.
+        import yaml as _yaml
+
+        artifact = _yaml.safe_load((state.log_dir / "preflight.yaml").read_text(encoding="utf-8"))
+        assert artifact["implementation_complexity_score"] == 4
+        assert artifact["validation_complexity_score"] >= 8
+        assert artifact["complexity_projection"] == PROJECTION_MAX_IMPL_VALIDATION
+        assert artifact["complexity_evidence"]
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_ordinary_story_projection_equals_implementation(
+        self, mock_shell, mock_dev_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        config = _make_plan_config(tmp_path)
+        task = _task_with_text(tmp_path, _STORY_ORDINARY)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=_PREFLIGHT_ORDINARY, cost_usd=0.05
+        )
+        mock_dev_agent.return_value = _make_agent_result(
+            success=True, output="Done.", cost_usd=0.50
+        )
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+        state = result.state
+
+        assert result.success is True
+        assert state.preflight_implementation_complexity_score == 3
+        assert state.preflight_validation_complexity_score == 1
+        # Projection leaves the legacy score equivalent to today's behavior.
+        assert state.preflight_complexity_score == 3
+        assert state.preflight_complexity == "small"
+        # Plan skipped for the ordinary bounded story.
+        assert mock_plan_agent.call_count == 0
+
+
+def test_state_defaults_are_present():
+    state = CoordinatorState()
+    assert state.preflight_implementation_complexity_score is None
+    assert state.preflight_validation_complexity_score is None
+    assert state.preflight_complexity_projection is None
+    assert state.preflight_complexity_evidence == []


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior ambiguity-downgrade consistency bug is fixed, and the latest iteration did not introduce a blocking regression. | [google-gemini-3.5-flash] The dual-axis preflight sizing implementation is fully consistent, robustly tested, and correctly handles the ambiguity downgrade path. | [claude-sonnet] Cycle 1 fully resolves the sole prior P1 (stale complexity_evidence/projection after the ambiguity-BLOCKED-downgrade override) by routing the bump through project_complexity_score() and appending an implementation_ambiguity_downgrade_floor evidence entry; verified no other post-projection mutation site was missed and no regression was introduced by the fix.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $12.07
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight sizing separates implementation complexity from validation/execution complexity, with cited evidence (GitHub Issue #1442)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1442