### PR TITLE
Groomer regex token list flags context-free word matches, dropping legitimate ACs

### DIFF
--- a/src/theforge/intake/groom.py
+++ b/src/theforge/intake/groom.py
@@ -21,27 +21,51 @@ from ..shape_check.parsing import (
 )
 from .findings import FixType, IntakeFinding, IntakeSeverity
 
-# Tokens that strongly suggest a how/implementation-shaped AC line. These are
-# intentionally conservative — false positives would cause the grooming check
-# to drop runnable stories.
-_HOW_TOKENS: tuple[str, ...] = (
+# HOW-detection is deliberately context-aware. A flat substring list over raw
+# AC text misfires whenever a flagged word functions as a domain verb, field
+# name, or command rather than an implementation prescription — e.g. "Import
+# output includes...", "Export saves...", "Rename target file to...". Those are
+# legitimate WHAT-language and must not be dropped. So detection is split into
+# two rules:
+#
+#   1. Strong tokens: phrases that describe *manipulating code* and have no
+#      plausible domain reading (e.g. "refactor", "implement using"). These
+#      flag on their own.
+#   2. Verb + code-construct proximity: an implementation verb ("extract",
+#      "rename", "split", ...) is HOW-shaped only when it operates on a code
+#      construct ("class", "method", "module", ...). The same verb applied to a
+#      domain object ("Rename target file", "Extract records from CSV") is not.
+#
+# Note: the ingest verb "import" is intentionally NOT in the verb list — it is
+# the single most common domain-verb false positive ("Import output includes
+# ..."). Genuine import-machinery prescriptions still trip a strong token
+# (e.g. "implement using the existing import machinery").
+_STRONG_HOW_TOKENS: tuple[str, ...] = (
     "refactor",
-    "extract",
-    "rename",
     "implement using",
     "implemented using",
     "implementation:",
-    "use the ",
-    "using the ",
-    "import ",
-    "function ",
-    "class ",
-    "method ",
-    "module ",
     "subclass",
 )
 
-_HOW_RE = re.compile("|".join(re.escape(tok) for tok in _HOW_TOKENS), re.IGNORECASE)
+_STRONG_HOW_RE = re.compile("|".join(re.escape(tok) for tok in _STRONG_HOW_TOKENS), re.IGNORECASE)
+
+# An implementation verb operating on a code construct within the same clause.
+# The verb list excludes "import" (see above); the construct list matches the
+# code nouns that distinguish "restructure code" from "describe behavior".
+_IMPL_VERB_CONSTRUCT_RE = re.compile(
+    r"\b(?:add|create|extract|implement|introduce|modify|move|refactor|"
+    r"rename|split|update|use)\b"
+    r".{0,60}?\b(?:class|method|function|module|subclass)\b",
+    re.IGNORECASE,
+)
+
+
+def _looks_how_shaped(text: str) -> bool:
+    """True when a bullet reads as implementation-prescriptive (HOW), not WHAT."""
+    return bool(_STRONG_HOW_RE.search(text) or _IMPL_VERB_CONSTRUCT_RE.search(text))
+
+
 _EXAMPLE_FILE_DIRECTIVE_RE = re.compile(
     r"\b(?:add|create|edit|implement|modify|remove|rename|update)\b"
     r".{0,100}\b(?:src/|tests/|docs/|[\w./-]+\.(?:py|pyi|js|jsx|ts|tsx|yaml|yml|json|sh|toml|rs|go|java|rb|md))",
@@ -79,7 +103,7 @@ def _ac_lines_look_how_shaped(section: str) -> list[str]:
     return [
         bullet.text
         for bullet in extract_contextual_bullets(section)
-        if not bullet.in_example_section and _HOW_RE.search(bullet.text)
+        if not bullet.in_example_section and _looks_how_shaped(bullet.text)
     ]
 
 

--- a/src/theforge/intake/remediation.py
+++ b/src/theforge/intake/remediation.py
@@ -200,6 +200,31 @@ def _blocking(findings: list[IntakeFinding]) -> list[IntakeFinding]:
     return [f for f in findings if f.severity is IntakeSeverity.BLOCK]
 
 
+# Divergence note appended to a DROPPED_AFTER_FIX detail when the rerun drop is
+# driven solely by the sprint-time grooming gate. The shape-check gate (which
+# posts the operator-visible "runnable / no findings" Action) does not run the
+# grooming rules at all, so the two signals can legitimately disagree on the
+# same body. Surface that explicitly so the drop doesn't look like a silent
+# contradiction of the shape-check verdict.
+_GROOM_SHAPE_DIVERGENCE_NOTE = (
+    "NOTE: this is a sprint-time grooming-gate rejection (groom_* rule) and is "
+    "NOT corroborated by the shape-check gate, which does not run these rules — "
+    "the shape-check Action may still report this issue as runnable"
+)
+
+
+def _grooming_divergence_suffix(rerun_blocking: list[IntakeFinding]) -> str:
+    """Return the divergence note (prefixed with a separator) when the rerun
+    drop is caused only by grooming (``groom_*``) findings; else empty string.
+
+    A drop that includes any shape-check finding is corroborated by the
+    shape-check gate and needs no divergence warning.
+    """
+    if rerun_blocking and all(f.code.startswith("groom_") for f in rerun_blocking):
+        return f" — {_GROOM_SHAPE_DIVERGENCE_NOTE}"
+    return ""
+
+
 def _format_remediation_comment(
     findings: list[IntakeFinding],
     replacement: str | None,
@@ -434,6 +459,7 @@ def _remediate_one(
                     "rerun gate still failing; comment post failed and candidate "
                     "artifact write failed"
                 )
+            detail += _grooming_divergence_suffix(rerun_blocking)
             return IntakeOutcome(
                 slug=slug,
                 kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
@@ -489,7 +515,10 @@ def _remediate_one(
             kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
             findings=tuple(rerun_blocking),
             proposed_replacement=proposed_body,
-            detail="comment mode: posted replacement; rerun gate still failing",
+            detail=(
+                "comment mode: posted replacement; rerun gate still failing"
+                + _grooming_divergence_suffix(rerun_blocking)
+            ),
             audit=_build_audit(
                 consumed=_consumed,
                 semantic_remaining=semantic_remaining,

--- a/tests/test_intake/test_groom.py
+++ b/tests/test_intake/test_groom.py
@@ -34,6 +34,48 @@ def test_groom_no_findings_on_empty_body():
     assert groom_check("Title", "", []) == []
 
 
+def test_groom_does_not_flag_import_as_domain_verb():
+    """Regression for #1428: 'Import output includes...' uses 'import' as the
+    issue's own domain verb (data ingestion), not an implementation directive."""
+    body = (
+        "## Acceptance criteria\n\n"
+        "- Import output includes an operator-visible summary: imported, "
+        "skipped-as-existing, updated/repaired, and failed records\n"
+    )
+    assert groom_check("Title", body, ["bug"]) == []
+
+
+def test_groom_does_not_flag_domain_verbs_as_field_or_command_names():
+    """Flagged tokens used as domain verbs / field names must not trip."""
+    body = (
+        "## Acceptance criteria\n\n"
+        "- Export saves the generated report to the configured location\n"
+        "- Rename target file to its canonical slug before writing\n"
+        "- Extract records from the uploaded CSV and validate each row\n"
+    )
+    assert groom_check("Title", body, ["enhancement"]) == []
+
+
+def test_groom_still_flags_verb_operating_on_code_construct():
+    """Genuine implementation-prescriptive language must still be flagged even
+    without a standalone strong token."""
+    body = "## Acceptance criteria\n\n- Refactor the FooService class to extract a helper method\n"
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"
+
+
+def test_groom_still_flags_implement_using_domain_import_machinery():
+    """'implement using' is a strong token; it flags even when the object is
+    the issue's own domain vocabulary ('import machinery')."""
+    body = (
+        "## Acceptance criteria\n\n- Implement using the existing import machinery in loader.py\n"
+    )
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"
+
+
 def test_groom_ignores_yaml_example_block_under_example_heading_in_ac():
     body = (
         "## Acceptance criteria\n\n"

--- a/tests/test_intake/test_remediation.py
+++ b/tests/test_intake/test_remediation.py
@@ -12,6 +12,18 @@ from theforge.task import TaskStory
 # Issue body that fails shape gate (missing AC, missing example).
 _FAILING_BODY = "## What\n\nDo a thing.\n\n## Why\n\nReason.\n"
 
+# Body that passes shape check but trips ONLY the grooming gate
+# (groom_how_shaped_ac) — the exact contradiction #1428 is about.
+_GROOM_ONLY_FAILING_BODY = (
+    "## What\n\nUsers can export.\n\n"
+    "## Why\n\nLegal needs it.\n\n"
+    "## Acceptance criteria\n\n"
+    "- Refactor the export pipeline into an ExportService class\n"
+    "- The download is available within 60 seconds for accounts with <1k users\n\n"
+    "## Example\n\n"
+    "```csv\nuser_id,email\n1,a@example.com\n```\n"
+)
+
 # A valid body that passes shape and grooming.
 _PASSING_BODY = (
     "## What\n\nUsers can export.\n\n"
@@ -168,6 +180,71 @@ def test_auto_fix_edit_mode_keeps_failing_body_off_issue():
     out = outcomes[task.slug]
     assert out.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
     assert edit_calls == []  # never wrote a still-failing body
+
+
+def test_grooming_only_drop_surfaces_shape_check_divergence():
+    """When a rerun drop is driven solely by the grooming gate (groom_* codes),
+    the outcome detail must state that this is NOT corroborated by the
+    shape-check gate — otherwise the shape-check Action ('runnable') and the
+    intake drop appear to silently contradict each other (#1428)."""
+    task = _make_task()
+    post_comment, _ = _record_calls()
+    edit_body, edit_calls = _record_calls()
+
+    def agent(body, findings, comments=()):
+        # Agent's rewrite still trips grooming only (keeps a HOW-shaped AC).
+        return AgentRewriteResult(
+            replacement=_GROOM_ONLY_FAILING_BODY, detail="agent produced replacement"
+        )
+
+    outcomes = run_intake_remediation(
+        [task],
+        None,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="edit",
+        agent_caller=agent,
+        fetch_detail=_make_fetch(
+            {"title": "T", "body": _GROOM_ONLY_FAILING_BODY, "labels": ["enhancement"]}
+        ),
+        post_comment=post_comment,
+        edit_body=edit_body,
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
+    assert edit_calls == []
+    assert all(f.code.startswith("groom_") for f in out.findings)
+    # The divergence must be spelled out for the operator.
+    assert "grooming-gate rejection" in out.detail
+    assert "shape-check" in out.detail
+
+
+def test_shape_backed_drop_does_not_claim_divergence():
+    """A drop whose rerun findings include a shape-check code IS corroborated by
+    the shape-check gate, so the divergence note must NOT be attached."""
+    task = _make_task()
+    post_comment, _ = _record_calls()
+    edit_body, _ = _record_calls()
+
+    def agent(body, findings, comments=()):
+        # Rewrite still fails shape (missing AC + example) → shape-backed drop.
+        return AgentRewriteResult(replacement=_FAILING_BODY, detail="agent produced replacement")
+
+    outcomes = run_intake_remediation(
+        [task],
+        None,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="edit",
+        agent_caller=agent,
+        fetch_detail=_make_fetch({"title": "T", "body": _FAILING_BODY, "labels": ["enhancement"]}),
+        post_comment=post_comment,
+        edit_body=edit_body,
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
+    assert any(not f.code.startswith("groom_") for f in out.findings)
+    assert "grooming-gate rejection" not in out.detail
 
 
 def test_agent_called_at_most_once_per_story():


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the grooming false-positive fix and surfaces grooming-only rerun drops through intake outcome detail; targeted tests pass. | [google-gemini-3.5-flash] The grooming gate's HOW-shaped AC detector is now context-aware and correctly surfaces shape-check divergence.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.70
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Groomer regex token list flags context-free word matches, dropping legitimate ACs (GitHub Issue #1428)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1428