### PR TITLE
Plan file-count helper returns 0 for plans that declare target files

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -137,6 +137,38 @@ def _scale_stuck_for_complexity(
     )
 
 
+def _plan_files_for_stuck_scaling(
+    state: CoordinatorState,
+    logger: StructuredLogger | None,
+) -> list[str]:
+    """Return the plan's target files for stuck-detection scaling.
+
+    A plan must populate ``state.plan_structured`` before DEV entry (non-resume:
+    plan_flow after the PLAN agent; resume: run_setup.load_plan_state from the
+    worktree's .forge/plan.md). When it is ``None`` here, the plan structure
+    never reached the dev phase, so the +N plan-scope exploration bonus silently
+    collapses to zero (issue #1135). Surface that as a structured warning naming
+    the missing field rather than letting a bare 0 flow into policy — a genuinely
+    file-less plan yields a non-None structure with an empty file list, which is
+    distinct from this degraded case and does not warn.
+    """
+    if state.plan_structured is None:
+        _log_verbose(
+            "  ⚠ DEV   plan_structured missing from state — stuck-detection scaling "
+            "proceeds with 0 plan files (no plan-scope exploration bonus)"
+        )
+        if logger:
+            logger._safe_emit(
+                "plan_structured_missing",
+                phase="DEV",
+                iteration=state.dev_iteration,
+                field="plan_structured",
+                consumer="stuck_detection_scaling",
+            )
+        return []
+    return plan_file_list(state.plan_structured)
+
+
 def _summarize_runner_failure(output: str, indicators: tuple[str, ...]) -> str:
     """Return a short, operator-friendly summary line for a runner crash."""
     lines = [line.strip() for line in output.splitlines() if line.strip()]
@@ -708,7 +740,7 @@ def _run_dev_phase(
         _log(f"  Dev timeout: {_dev_timeout}s ({state.preflight_complexity} complexity)")
     else:
         _log(f"  Dev timeout: {_dev_timeout}s")
-    _plan_files = plan_file_list(state.plan_structured)
+    _plan_files = _plan_files_for_stuck_scaling(state, logger)
     _scaled_stuck = _scale_stuck_for_complexity(
         config.stuck_detection,
         state.preflight_complexity,

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -206,6 +206,46 @@ def load_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
         state.hygiene_escalation_prior_review = _prior_rr  # type: ignore[assignment]
 
 
+def load_plan_state(workspace_path: Path, state: CoordinatorState) -> None:
+    """Restore plan_output / plan_structured from the worktree's ``.forge/plan.md``.
+
+    Called in ``_setup_resume_entry`` so a resumed run stands in for the
+    PLAN_VALIDATION → DEV/REVIEW handoff: without this, ``_setup_resume_entry``
+    allocates a fresh ``CoordinatorState`` whose ``plan_structured`` stays at its
+    ``None`` default, and every plan-derived signal consumed by coordinator
+    policy (stuck-detection scaling, routing, complexity adjustment, audit
+    telemetry) silently degrades to a zero/empty default even though the plan
+    that ran for the story demonstrably declares files (issue #1135).
+
+    Best-effort: a missing plan file leaves state at its defaults (a fresh run
+    that never produced a plan). A present-but-unparseable plan (freeform
+    markdown fallback) restores the raw text into ``plan_output`` and leaves
+    ``plan_structured`` at ``None``, matching how the non-resume PLAN path
+    behaves for freeform plans.
+    """
+    from theforge.artifacts import PLAN_PATH  # noqa: PLC0415
+    from theforge.task.plan_parser import parse_plan_output  # noqa: PLC0415
+
+    plan_file = workspace_path / PLAN_PATH
+    if not plan_file.exists():
+        return
+    try:
+        text = plan_file.read_text(encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("plan.md: failed to read (%s) — ignoring", exc)
+        return
+    if not text.strip():
+        return
+    state.plan_output = text
+    try:
+        parsed = parse_plan_output(text)
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("plan.md: failed to parse (%s) — restoring raw text only", exc)
+        return
+    if parsed is not None:
+        state.plan_structured = parsed
+
+
 def save_merge_state(workspace_path: Path, merge_state: MergeStepState) -> None:
     """Persist merge step state to <workspace_path>/.forge/merge_state.yaml.
 
@@ -361,6 +401,12 @@ def _setup_resume_entry(
 
     # Restore trajectory data from sidecar (survives --resume)
     load_trajectory_state(workspace_path, state)
+
+    # Restore the parsed plan from the worktree's .forge/plan.md. A resumed run
+    # allocates a fresh CoordinatorState that stands in for the PLAN_VALIDATION →
+    # DEV/REVIEW handoff; without this, state.plan_structured stays None and every
+    # plan-derived policy signal degrades to a zero/empty default (issue #1135).
+    load_plan_state(workspace_path, state)
 
     # Sync forge.yaml from project root into the worktree so the run executes
     # with current settings. The source is the operator's live working-tree

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -6,10 +6,37 @@ from unittest.mock import MagicMock, patch
 
 from coord_test_helpers import _make_config, _make_task
 
+from theforge.coordinator.context_scope import plan_file_list
 from theforge.coordinator.engine import _run_resume_coordinator
 from theforge.coordinator.gate import _parse_dirty_files
 from theforge.coordinator.run_setup import _setup_resume_entry
 from theforge.coordinator.state import CoordinatorResult, Phase
+
+_STRUCTURED_PLAN = """---
+plan:
+  approach: Resume the implementation
+  steps:
+    - id: 1
+      description: Update the entry point
+      files:
+        - src/foo.py
+        - tests/test_foo.py
+      action: modify
+      details: Continue the resumed story
+    - id: 2
+      description: Wire the helper
+      files:
+        - src/foo.py
+        - src/helper.py
+      action: modify
+      details: Add the helper call
+"""
+
+
+def _write_plan(workspace: Path, text: str) -> None:
+    plan_dir = workspace / ".forge"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    (plan_dir / "plan.md").write_text(text, encoding="utf-8")
 
 
 def _call_setup(config, task, workspace_path):
@@ -137,6 +164,75 @@ def test_dirty_synced_forge_yaml_excluded_from_story_commit(tmp_path):
     # forge.yaml on the branch still holds the committed mainline content —
     # the operator experiment never reached the story's tree.
     assert _git(workspace, "show", "HEAD:forge.yaml") == committed_forge
+
+
+def test_resume_restores_plan_structured_from_worktree_plan(tmp_path):
+    """Seam regression for issue #1135: the PLAN_VALIDATION → DEV/REVIEW handoff.
+
+    A resumed run allocates a fresh CoordinatorState. Without restoring the plan
+    from the worktree's .forge/plan.md, state.plan_structured stays None and every
+    plan-derived policy signal (stuck-detection scaling, routing, audit telemetry)
+    degrades to zero even when the plan demonstrably declares target files. This
+    drives the real entry point and asserts the restored structure matches the
+    plan on disk, so plan_file_list reports the declared files rather than 0.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_plan(workspace, _STRUCTURED_PLAN)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    result = _call_setup(config, task, workspace)
+
+    assert isinstance(result, tuple)
+    state = result[0]
+    assert state.plan_structured is not None
+    assert state.plan_output == _STRUCTURED_PLAN
+    # The file list downstream policy consumes matches the plan's declared files.
+    assert plan_file_list(state.plan_structured) == [
+        "src/foo.py",
+        "tests/test_foo.py",
+        "src/helper.py",
+    ]
+
+
+def test_resume_freeform_plan_restores_text_but_not_structure(tmp_path):
+    """A freeform-markdown plan restores raw text but leaves plan_structured None.
+
+    This matches the non-resume PLAN path, where an unparseable plan falls back to
+    markdown and plan_structured is legitimately None (distinct from the #1135 bug).
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    freeform = "# Plan\n\nJust do the thing, no YAML block here.\n"
+    _write_plan(workspace, freeform)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    result = _call_setup(config, task, workspace)
+
+    assert isinstance(result, tuple)
+    state = result[0]
+    assert state.plan_output == freeform
+    assert state.plan_structured is None
+
+
+def test_resume_no_plan_leaves_state_defaults(tmp_path):
+    """A resume with no .forge/plan.md leaves plan fields at their defaults."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    result = _call_setup(config, task, workspace)
+
+    assert isinstance(result, tuple)
+    state = result[0]
+    assert state.plan_output is None
+    assert state.plan_structured is None
 
 
 def test_setup_returns_escalate_when_workspace_missing(tmp_path):

--- a/tests/test_stuck_detection_scaling.py
+++ b/tests/test_stuck_detection_scaling.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 from theforge.config import StuckDetectionConfig
-from theforge.coordinator.dev_phase import _scale_stuck_for_complexity
+from theforge.coordinator.dev_phase import (
+    _plan_files_for_stuck_scaling,
+    _scale_stuck_for_complexity,
+)
+from theforge.coordinator.state import CoordinatorState
 
 
 def test_scale_no_complexity_unchanged():
@@ -77,3 +83,56 @@ def test_unchanged_fields_preserved():
     assert out.repeat_threshold == 7
     assert out.error_threshold == 9
     assert out.enabled is False
+
+
+def test_plan_files_for_stuck_scaling_reads_declared_files():
+    """A populated plan_structured yields its declared files — no warning emitted."""
+    state = CoordinatorState()
+    state.plan_structured = {
+        "approach": "x",
+        "steps": [
+            {"id": 1, "files": ["src/a.py", "src/b.py"], "action": "modify"},
+            {"id": 2, "files": ["src/b.py", "tests/test_a.py"], "action": "modify"},
+        ],
+    }
+    logger = MagicMock()
+    files = _plan_files_for_stuck_scaling(state, logger)
+    assert files == ["src/a.py", "src/b.py", "tests/test_a.py"]
+    logger._safe_emit.assert_not_called()
+
+
+def test_plan_files_for_stuck_scaling_empty_plan_no_warning():
+    """A well-formed plan that declares no files returns [] without warning.
+
+    A file-less plan is distinct from a plan structure missing from state; only
+    the latter is a policy-degrading anomaly worth surfacing.
+    """
+    state = CoordinatorState()
+    state.plan_structured = {"approach": "x", "steps": []}
+    logger = MagicMock()
+    files = _plan_files_for_stuck_scaling(state, logger)
+    assert files == []
+    logger._safe_emit.assert_not_called()
+
+
+def test_plan_files_for_stuck_scaling_warns_when_structure_missing():
+    """None plan_structured surfaces a structured warning naming the field."""
+    state = CoordinatorState()
+    state.plan_structured = None
+    state.dev_iteration = 3
+    logger = MagicMock()
+    files = _plan_files_for_stuck_scaling(state, logger)
+    assert files == []
+    logger._safe_emit.assert_called_once()
+    event, kwargs = logger._safe_emit.call_args.args, logger._safe_emit.call_args.kwargs
+    assert event[0] == "plan_structured_missing"
+    assert kwargs["field"] == "plan_structured"
+    assert kwargs["consumer"] == "stuck_detection_scaling"
+    assert kwargs["iteration"] == 3
+
+
+def test_plan_files_for_stuck_scaling_missing_structure_no_logger():
+    """Missing structure with no logger still returns [] without raising."""
+    state = CoordinatorState()
+    state.plan_structured = None
+    assert _plan_files_for_stuck_scaling(state, None) == []


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change restores plan state on resume, wires the helper into stuck-detection scaling, and covers the observed failure mode with focused tests. | [google-gemini-3.5-flash] The implementation successfully restores plan_structured on resume and adds structured warnings for missing plan state. | [claude-sonnet] load_plan_state correctly restores plan_structured at the _setup_resume_entry seam shared by run_from_dev/run_from_review, which covers both explicit --resume and the parallel-mode plan-gate split path (the more common trigger given the canonical --parallel 3 sprint command); the continuous run_task path was never broken since plan_flow.py sets plan_structured on the same in-memory state object.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $4.23
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Plan file-count helper returns 0 for plans that declare target files (GitHub Issue #1135)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1135