### PR TITLE
[P2] issue-1355: config.model_registry or None uses falsy-dict evaluatio

### DIFF
--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -399,7 +399,7 @@ def _format_config(
         if config.custom_models:
             custom_details = []
             for model_id in config.custom_models:
-                spec = config.model_registry.get(model_id)
+                spec = (config.model_registry or {}).get(model_id)
                 if spec is None:
                     continue
                 provider_label, transport_label = _split_provider_transport(

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -523,6 +523,9 @@ def model_info_view(
     With ``registry=None`` returns the built-in MODEL_REGISTRY. Pass
     ``ForgeConfig.model_registry`` (the merged built-in + forge.yaml overlay)
     so consumers see user-declared custom models as first-class entries.
+
+    An explicitly empty ``{}`` is honored as-is and returns an empty view — it is
+    not treated as "absent" (only ``None`` selects the built-in default).
     """
     if registry is None:
         return MODEL_REGISTRY
@@ -568,8 +571,12 @@ def resolve_agent_spec(
     Raises ValueError for any key not present in AGENT_REGISTRY — there is no
     provider-prefix-to-CLI guessing. To support a new model, add an explicit
     registry entry.
+
+    ``registry=None`` means "no registry supplied — use the built-in default."
+    An explicitly empty ``{}`` is honored as-is: every key is unknown, so this
+    raises ValueError rather than silently substituting the built-in registry.
     """
-    effective_registry = registry or AGENT_REGISTRY
+    effective_registry = AGENT_REGISTRY if registry is None else registry
     if model_key not in effective_registry:
         known = sorted(effective_registry)
         raise ValueError(

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -604,7 +604,13 @@ class ForgeConfig:
     stuck_detection: StuckDetectionConfig = field(default_factory=StuckDetectionConfig)
     models_budget_usd: float | None = None  # set when models: key is used (v0.8 path)
     models_overrides: dict[str, Any] | None = None  # raw overrides: dict from v0.8 YAML
-    model_registry: dict[str, AgentSpec] = field(default_factory=dict)
+    # None = no registry supplied (a directly-constructed config that never
+    # populated one) → consumers fall back to the built-in default registry.
+    # An explicit {} is an *intentional* empty registry and is honored as-is
+    # (every model key is unknown → resolution fails clearly). Keeping this
+    # Optional is what lets the two cases be told apart; the load path always
+    # sets a populated dict (built-in + forge.yaml overlay).
+    model_registry: dict[str, AgentSpec] | None = None
     model_registry_sources: dict[str, str] = field(default_factory=dict)
     custom_models: tuple[str, ...] = ()
     diagnose: DiagnoseConfig = field(default_factory=DiagnoseConfig)

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -898,7 +898,9 @@ def _run_dev_phase(
             if not state.dev_escalated:
                 _old_model = config.dev_profile.model
                 if config.retry.auto_model_escalation and config.models is not None:
-                    _registry = config.model_registry or None
+                    # Registry passed as-is: an explicitly empty {} stays empty
+                    # instead of collapsing to the built-in default (`... or None`).
+                    _registry = config.model_registry
                     _curr_key = _find_registry_key_for_profile(
                         config.dev_profile, registry=_registry
                     )

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -909,7 +909,9 @@ def _run_plan_agent_review(
             state.plan_regen_count >= config.retry.plan_escalation_threshold
             and not state.plan_escalated
         ):
-            _registry = config.model_registry or None
+            # Registry passed as-is: an explicitly empty {} stays empty instead
+            # of collapsing to the built-in default (`... or None`).
+            _registry = config.model_registry
             _curr_key = _find_registry_key_for_profile(plan_profile, registry=_registry)
             if _curr_key is not None and config.models is not None:
                 _next_key = _escalate_dev_model(_curr_key, config.models, registry=_registry)

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -866,7 +866,10 @@ def _apply_complexity_adaptation(
     if norm is None:
         return config
 
-    _registry = config.model_registry or None
+    # Pass the registry through as-is: an explicitly empty {} must stay empty so
+    # downstream resolution fails clearly rather than silently substituting the
+    # built-in default (which `... or None` would trigger). See config.models.
+    _registry = config.model_registry
     pool_entries = _build_pool_entries(config.models, registry=_registry)
     if not pool_entries:
         return config

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -78,7 +78,9 @@ def _perform_dev_model_escalation(
     model is available. Callers are responsible for updating state flags and emitting
     audit records appropriate to their escalation reason.
     """
-    registry = config.model_registry or None
+    # Pass the registry through as-is: an explicitly empty {} must stay empty
+    # rather than collapsing to the built-in default via `... or None`.
+    registry = config.model_registry
     curr_key = _find_registry_key_for_profile(config.dev_profile, registry=registry)
     if curr_key is None:
         return None

--- a/tests/test_empty_model_registry.py
+++ b/tests/test_empty_model_registry.py
@@ -1,0 +1,137 @@
+"""Regression: an explicitly empty model registry must stay explicit (issue #1355).
+
+Coordinator consumers used ``config.model_registry or None`` before resolving a
+registry. Because ``ForgeConfig.model_registry`` is a plain ``dict`` (never
+``None`` — ``default_factory=dict``), that idiom collapsed an *empty* registry
+``{}`` to ``None``, which the resolution helpers treat as "no registry supplied,
+use the built-in default." The result: a directly-constructed / config-boundary
+value of ``{}`` silently fell back to the built-in registry instead of being
+honored as an intentional empty registry.
+
+These tests pin the corrected contract:
+  * ``None`` still selects the built-in default (unchanged).
+  * an explicit ``{}`` is honored as-is — ``model_info_view`` returns an empty
+    view and ``resolve_agent_spec`` raises ``ValueError`` (fails clearly) rather
+    than substituting the built-in registry.
+  * the preflight seam propagates the empty registry without collapsing it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from theforge.config import (
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    ModelProfile,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.config.models import (
+    AGENT_REGISTRY,
+    MODEL_REGISTRY,
+    model_info_view,
+    resolve_agent_spec,
+)
+from theforge.config.types import PlanConfig
+from theforge.coordinator.preflight import _apply_complexity_adaptation
+
+_BUILTIN_KEY = next(iter(AGENT_REGISTRY))
+
+
+# ── root cause: resolve_agent_spec distinguishes None from {} ──────────
+
+
+def test_resolve_agent_spec_none_uses_builtin_default():
+    """registry=None means 'absent' — resolve against the built-in AGENT_REGISTRY."""
+    spec = resolve_agent_spec(_BUILTIN_KEY, registry=None)
+    assert spec is AGENT_REGISTRY[_BUILTIN_KEY]
+
+
+def test_resolve_agent_spec_empty_dict_fails_clearly():
+    """An explicit empty registry is honored: every key is unknown, so it raises."""
+    with pytest.raises(ValueError, match="Unknown model"):
+        resolve_agent_spec(_BUILTIN_KEY, registry={})
+
+
+def test_model_info_view_none_returns_builtin():
+    assert model_info_view(None) is MODEL_REGISTRY
+
+
+def test_model_info_view_empty_dict_returns_empty_view():
+    """An explicit {} yields an empty view — not silently the built-in default."""
+    assert model_info_view({}) == {}
+
+
+# ── preflight seam: empty registry propagates without collapsing ──────
+
+
+def _make_config(tmp_path: Path, model_registry: dict) -> ForgeConfig:
+    dev = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=6.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    plan = PlanConfig(cli="claude", model="sonnet", budget_usd=0.5, timeout=600)
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev,
+        preflight_profile=dev,
+        review_pool=[dev],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        models=[_BUILTIN_KEY],
+        plan=plan,
+        plan_model_is_default=True,
+        dev_profile_is_default=True,
+        review_pool_is_default=True,
+        model_registry=model_registry,
+    )
+
+
+def test_complexity_adaptation_empty_registry_does_not_silently_use_builtin(tmp_path):
+    """With an explicit empty registry, adaptation fails clearly instead of
+    routing off the built-in registry as if the registry were absent."""
+    config = _make_config(tmp_path, model_registry={})
+    with pytest.raises(ValueError, match="Unknown model"):
+        _apply_complexity_adaptation(config, "medium", complexity_score=7)
+
+
+def test_complexity_adaptation_absent_registry_uses_builtin(tmp_path):
+    """A directly-constructed config leaves model_registry as None (absent) — the
+    consumer boundary falls back to the built-in registry, as before the fix."""
+    config = _make_config(tmp_path, model_registry=None)
+    assert config.model_registry is None
+    adapted = _apply_complexity_adaptation(config, "medium", complexity_score=7)
+    assert adapted.dev_profile.model == AGENT_REGISTRY[_BUILTIN_KEY].model
+
+
+def test_forge_config_registry_field_default_is_none():
+    """The field default is None (absent), not {} — so absence and emptiness
+    are distinguishable at the type level (the root of the falsy-collapse bug)."""
+    from dataclasses import MISSING, fields
+
+    field = next(f for f in fields(ForgeConfig) if f.name == "model_registry")
+    assert field.default is None
+    assert field.default_factory is MISSING
+
+
+def test_complexity_adaptation_populated_registry_routes(tmp_path):
+    """Baseline: a populated registry (the production path) resolves normally,
+    confirming the fix is a no-op for loaded configs."""
+    config = _make_config(tmp_path, model_registry=dict(AGENT_REGISTRY))
+    adapted = _apply_complexity_adaptation(config, "medium", complexity_score=7)
+    # A single-model pool leaves dev on that model; the call must not raise.
+    assert adapted.dev_profile.model == AGENT_REGISTRY[_BUILTIN_KEY].model


### PR DESCRIPTION
## Summary

The change preserves explicit empty registries through the affected coordinator paths, keeps None as the absent/default case, and adds focused regression coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.76
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-1355: config.model_registry or None uses falsy-dict evaluatio (GitHub Issue #1358)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1358