### PR TITLE
Converged budget view: sprint-level governance + per-story estimates (not enforcement)

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -103,8 +103,14 @@ story never gets blocked for going "over budget."
     dollar overrun.
 
 - **Pre-runaway controls (unchanged).** Iteration and timeout adaptation still
-  cap runaway loops *before* they burn cost. Those are separate from post-hoc
-  dollar accounting and are unaffected by the converged model.
+  cap runaway loops *before* they burn cost. The adaptive routing cost target
+  (`assignment.max_cost_per_story_usd`) is likewise a *pre-run* control: it
+  shapes model selection (downgrading tiers so the estimated per-story routing
+  cost stays under the operator's configured value) before any dev/review work
+  runs. Operator and audit surfaces call it a "routing cost target," not a
+  "cap," precisely so it is not confused with post-hoc dollar governance. All of
+  these are separate from post-hoc dollar accounting and unaffected by the
+  converged model.
 
 The per-role `budget_usd` on individual profiles (below) seeds the per-story
 estimate baseline and, for reviewers, still acts as an explicit operator-set

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -78,6 +78,39 @@ stories:
 | `auto_merge` | No | `false` | Auto-merge approved stories to main |
 | `stories` | Yes | — | Ordered list of stories — local file paths or `{issue: N}` dicts |
 
+### Cost governance vs. per-story estimates (converged model)
+
+TheForge has one converged budget view with two distinct roles for dollar
+values. Keeping them straight explains why a sprint stops but an individual
+story never gets blocked for going "over budget."
+
+- **Sprint-level governance (enforced).** The sprint `budget_usd` is the *only*
+  post-hoc dollar enforcement. When cumulative sprint spend reaches it, no new
+  stories launch. This is the surviving cost-governance surface.
+
+- **Per-story dollar values (estimates, not enforced).** The per-story dollar
+  value is a *cost estimate* derived from historical cost data for the model and
+  complexity band (`adaptive_dev_cost_estimate_usd` in state;
+  `chosen_dev_cost_estimate_usd` in the audit trail). It informs routing,
+  timeout scaling, and telemetry — it is **not** a cap. Exceeding it is never,
+  by itself, an operator-actionable overrun; it just means the estimate was low.
+
+  - If a dev attempt exceeds its estimate **and committed usable work**, the run
+    proceeds to validate/review with no operator action. The estimate was low.
+  - If a dev attempt exceeds its estimate **and produced no commits**, the run
+    escalates as an *unproductive attempt* — the message names that no usable
+    output was produced (`Dev attempt produced no usable output (...)`), not a
+    dollar overrun.
+
+- **Pre-runaway controls (unchanged).** Iteration and timeout adaptation still
+  cap runaway loops *before* they burn cost. Those are separate from post-hoc
+  dollar accounting and are unaffected by the converged model.
+
+The per-role `budget_usd` on individual profiles (below) seeds the per-story
+estimate baseline and, for reviewers, still acts as an explicit operator-set
+per-reviewer ceiling. It is not the story-level governance surface — that is the
+sprint `budget_usd` above.
+
 ### Story bundling (relational, scheduler-decided)
 
 When a sprint contains two or more eligible stories, the sprint scheduler may

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -415,7 +415,12 @@ forge run stories/my-feature.md --verbose   # no --resume
 review pools.
 
 **Fix:**
-- Set `budget_usd` in each profile (hard cap)
+- Lower the sprint `budget_usd` — this is the enforced ceiling that stops
+  launching new stories once cumulative spend is consumed
+- Note: the per-story `budget_usd` on the dev profile is a *cost estimate* used
+  for routing/timeout scaling, not a per-story hard cap. Exceeding it does not
+  block a story that produced usable work (see the converged budget model in the
+  [inputs reference](inputs-reference.md#cost-governance-vs-per-story-estimates-converged-model))
 - Use `--dry-run` to estimate prompt sizes before running
 - Use a smaller/cheaper model for dev (sonnet instead of opus)
 

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -465,7 +465,7 @@ def _enforce_budget(
     planner_floor_tier: str | None = None,
     locked_roles: set[str] | None = None,
 ) -> AssignmentDecision:
-    """Downgrade highest-cost non-preflight model if over the per-story routing cost cap.
+    """Downgrade highest-cost non-preflight model if over the per-story routing cost target.
 
     Candidates for downgrade: planner, plan_reviewers, dev, code_reviewers.
     Preflight is excluded to preserve classification quality.
@@ -487,18 +487,18 @@ def _enforce_budget(
 
     if initial_total <= max_cost_per_story_usd:
         rationale = dict(decision.rationale)
-        rationale["per_story_routing_cost_cap"] = (
-            f"within per-story routing cost cap ${max_cost_per_story_usd:.2f} "
+        rationale["per_story_routing_cost_target"] = (
+            f"within per-story routing cost target ${max_cost_per_story_usd:.2f} "
             f"(estimated total ${initial_total:.2f})"
         )
         return _dc_replace(
             decision,
             rationale=rationale,
             budget_audit={
-                "cap_usd": max_cost_per_story_usd,
+                "target_usd": max_cost_per_story_usd,
                 "initial_total_usd": round(initial_total, 2),
                 "final_total_usd": round(initial_total, 2),
-                "within_cap": True,
+                "within_target": True,
                 "downgraded": False,
                 "steps": [],
                 "preferred": preferred_snapshot,
@@ -644,7 +644,7 @@ def _enforce_budget(
         for step in budget_steps
         if isinstance(step, dict) and step.get("role")
     }
-    cap_phrase = f"per-story routing cost cap ${max_cost_per_story_usd:.2f}"
+    cap_phrase = f"per-story routing cost target ${max_cost_per_story_usd:.2f}"
     if "planner" in impacted_roles and "planner" in rationale:
         _p = decision.planner
         rationale["planner"] += f"; {cap_phrase} downgraded to {_p.model} @ ${_p.budget_usd:.2f}"
@@ -664,32 +664,32 @@ def _enforce_budget(
             f"{[p.model for p in decision.code_reviewers]} @ ${_cr_total:.2f}"
         )
     if budget_steps:
-        rationale["per_story_routing_cost_cap"] = (
+        rationale["per_story_routing_cost_target"] = (
             f"{cap_phrase}: downgraded to ${final_total:.2f} via {len(budget_steps)} adjustment(s)"
         )
     elif within_cap:
-        rationale["per_story_routing_cost_cap"] = (
+        rationale["per_story_routing_cost_target"] = (
             f"within {cap_phrase} (estimated total ${final_total:.2f})"
         )
     else:
-        rationale["per_story_routing_cost_cap"] = (
+        rationale["per_story_routing_cost_target"] = (
             f"{cap_phrase} could not be met; estimated total ${final_total:.2f}"
         )
     if protected_roles:
-        rationale["per_story_routing_cost_cap"] += f" (protected roles: {sorted(protected_roles)})"
+        rationale["per_story_routing_cost_target"] += f" (protected roles: {sorted(protected_roles)})"
 
     if not within_cap:
         warnings.warn(
-            f"[adaptive] per-story routing cost cap ${max_cost_per_story_usd:.2f} "
+            f"[adaptive] per-story routing cost target ${max_cost_per_story_usd:.2f} "
             f"cannot be met; actual total ${final_total:.2f}",
             stacklevel=2,
         )
 
     audit: dict[str, object] = {
-        "cap_usd": max_cost_per_story_usd,
+        "target_usd": max_cost_per_story_usd,
         "initial_total_usd": round(initial_total, 2),
         "final_total_usd": round(final_total, 2),
-        "within_cap": within_cap,
+        "within_target": within_cap,
         "downgraded": bool(budget_steps),
         "steps": budget_steps,
         "preferred": preferred_snapshot,
@@ -1069,7 +1069,7 @@ def assign_models(
         rationale=rationale,
     )
 
-    # Enforce per-story routing cost cap — pass dev floor so the enforcer never
+    # Enforce per-story routing cost target — pass dev floor so the enforcer never
     # downgrades dev below the complexity-required tier.  When the cap is unset
     # (None), adaptive's selection is preserved as-is and only the sprint-wide
     # budget_usd guard remains.
@@ -1077,9 +1077,9 @@ def assign_models(
     if cap is None:
         for _role in ("planner", "dev", "plan_review", "code_review"):
             if _role in rationale:
-                rationale[_role] += "; per-story routing cost cap: unset"
-        rationale["per_story_routing_cost_cap"] = (
-            "unset — adaptive routes by complexity; no per-story cap enforcement"
+                rationale[_role] += "; per-story routing cost target: unset"
+        rationale["per_story_routing_cost_target"] = (
+            "unset — adaptive routes by complexity; no per-story routing cost target enforcement"
         )
         from dataclasses import replace as _dc_replace
 
@@ -1088,10 +1088,10 @@ def assign_models(
             decision,
             rationale=rationale,
             budget_audit={
-                "cap_usd": None,
+                "target_usd": None,
                 "initial_total_usd": round(_initial_total, 2),
                 "final_total_usd": round(_initial_total, 2),
-                "within_cap": True,
+                "within_target": True,
                 "downgraded": False,
                 "steps": [],
                 "preferred": _preferred_snapshot(decision, _initial_total),

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -676,7 +676,9 @@ def _enforce_budget(
             f"{cap_phrase} could not be met; estimated total ${final_total:.2f}"
         )
     if protected_roles:
-        rationale["per_story_routing_cost_target"] += f" (protected roles: {sorted(protected_roles)})"
+        rationale["per_story_routing_cost_target"] += (
+            f" (protected roles: {sorted(protected_roles)})"
+        )
 
     if not within_cap:
         warnings.warn(

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -372,11 +372,11 @@ def _format_config(
         _cap = config.assignment.max_cost_per_story_usd
         if _cap is None:
             lines.append(
-                "Per-story routing cost cap: unset "
+                "Per-story routing cost target: unset "
                 "(adaptive routes by complexity; only budget_usd enforces spend)"
             )
         else:
-            lines.append(f"Per-story routing cost cap: ${_cap:.2f}/story")
+            lines.append(f"Per-story routing cost target: ${_cap:.2f}/story")
     lines.append("")
 
     if config.models or config.custom_models:
@@ -534,9 +534,9 @@ def _format_config(
     if config.assignment.enabled:
         a = config.assignment
         if a.max_cost_per_story_usd is None:
-            cap_str = "no per-story routing cost cap configured"
+            cap_str = "no per-story routing cost target configured"
         else:
-            cap_str = f"per-story routing cost cap=${a.max_cost_per_story_usd:.2f}/story"
+            cap_str = f"per-story routing cost target=${a.max_cost_per_story_usd:.2f}/story"
         lines.append(
             f"  assignment:    enabled  (min={a.min_reviewers}, max={a.max_reviewers}, {cap_str})"
         )

--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -1,9 +1,14 @@
-"""Adaptive resource limits: derive per-story dev budgets and review-cycle caps.
+"""Adaptive resource limits: derive per-story dev cost estimates and review caps.
 
 Pure-Python (stdlib only). Given preflight complexity and model capability
-profiles, compute per-story dev ``max_iterations``, ``timeout_seconds``, and
-``budget_usd``. Review-cycle caps continue to use the existing complexity plus
-recent audit-history signal.
+profiles, compute per-story dev ``max_iterations``, ``timeout_seconds``, and a
+per-story dollar ``cost_estimate_usd``. Review-cycle caps continue to use the
+existing complexity plus recent audit-history signal.
+
+The per-story dollar value is an *estimate* derived from historical cost data —
+it informs routing, timeout scaling, and audit telemetry. It is NOT an enforced
+budget: real post-hoc dollar governance lives at the sprint level
+(``forge.yaml: budget_usd``). Nothing here caps or blocks spend after the fact.
 
 Design:
 
@@ -34,10 +39,10 @@ _HISTORY_TAIL = 50
 
 _BAND_TO_SCORE = {"small": 2, "medium": 5, "large": 9}
 _HEADROOM_FACTOR = 1.5
-# Budget headroom is scaled by complexity band because strong-tier models on
+# Estimate headroom is scaled by complexity band because strong-tier models on
 # large stories have higher cost variance than cheap-tier models on small ones.
-# Using a flat 1.5x average produced budgets ~2x too tight for LARGE stories.
-_BUDGET_HEADROOM_BY_BAND: dict[str, float] = {"small": 1.5, "medium": 2.0, "large": 2.5}
+# Using a flat 1.5x average produced estimates ~2x too tight for LARGE stories.
+_ESTIMATE_HEADROOM_BY_BAND: dict[str, float] = {"small": 1.5, "medium": 2.0, "large": 2.5}
 _MIN_PROFILE_RUNS = 3
 
 
@@ -48,7 +53,9 @@ class AdaptiveLimits:
     dev_max: int
     review_max: int
     dev_timeout_seconds: int
-    dev_budget_usd: float
+    # Per-story dollar cost ESTIMATE (historical-cost derived), not an enforced
+    # budget. Used for routing/timeout scaling/telemetry; never caps spend.
+    dev_cost_estimate_usd: float
     audit: dict = field(default_factory=dict)
 
 
@@ -175,7 +182,7 @@ def derive_limits(
     model_provider: str | None = None,
     model_cli: str | None = None,
     base_timeout_seconds: int,
-    base_budget_usd: float,
+    base_cost_estimate_usd: float,
     static_dev_max: int,
     review_history_path: Path | None,  # repurposed: project_root (None disables history)
     model_profiles: dict | None,
@@ -207,7 +214,7 @@ def derive_limits(
         "headroom_factor": _HEADROOM_FACTOR,
         "min_profile_runs": _MIN_PROFILE_RUNS,
         "base_timeout_seconds": base_timeout_seconds,
-        "base_budget_usd": base_budget_usd,
+        "base_dev_cost_estimate_usd": base_cost_estimate_usd,
         "static_dev_max": static_dev_max,
     }
 
@@ -217,7 +224,7 @@ def derive_limits(
             dev_max=static_dev_max,
             review_max=floor_review,
             dev_timeout_seconds=base_timeout_seconds,
-            dev_budget_usd=base_budget_usd,
+            dev_cost_estimate_usd=base_cost_estimate_usd,
             audit=audit,
         )
 
@@ -230,7 +237,7 @@ def derive_limits(
             dev_max=static_dev_max,
             review_max=floor_review,
             dev_timeout_seconds=base_timeout_seconds,
-            dev_budget_usd=base_budget_usd,
+            dev_cost_estimate_usd=base_cost_estimate_usd,
             audit=audit,
         )
 
@@ -263,7 +270,7 @@ def derive_limits(
     if profile_stats is None:
         chosen_dev = static_dev_max
         chosen_timeout = base_timeout_seconds
-        chosen_budget = base_budget_usd
+        chosen_estimate = base_cost_estimate_usd
         dev_rationale = (
             "insufficient profile history for complexity band; using static configured dev limits"
         )
@@ -272,21 +279,21 @@ def derive_limits(
         chosen_dev = max(floor_dev, min(cap_dev, _ceil_int(raw_dev)))
         timeout_per_iteration = base_timeout_seconds / max(static_dev_max, 1)
         chosen_timeout = _ceil_int(chosen_dev * timeout_per_iteration)
-        _budget_headroom = _BUDGET_HEADROOM_BY_BAND.get(
+        _estimate_headroom = _ESTIMATE_HEADROOM_BY_BAND.get(
             (complexity_band or "").lower(), _HEADROOM_FACTOR
         )
-        chosen_budget = _round_money(profile_stats["avg_cost_usd"] * _budget_headroom)
+        chosen_estimate = _round_money(profile_stats["avg_cost_usd"] * _estimate_headroom)
         audit["profile_raw_dev_max"] = round(raw_dev, 4)
-        audit["budget_headroom_factor"] = _budget_headroom
+        audit["estimate_headroom_factor"] = _estimate_headroom
         dev_rationale = (
             f"derived dev limits from {profile_runs} "
             f"{complexity_band or 'unknown'}-band profile runs with "
-            f"{_HEADROOM_FACTOR}x iteration headroom and {_budget_headroom}x "
-            "budget headroom; timeout scaled from static per-iteration baseline."
+            f"{_HEADROOM_FACTOR}x iteration headroom and {_estimate_headroom}x "
+            "cost-estimate headroom; timeout scaled from static per-iteration baseline."
         )
     audit["chosen_dev_max"] = chosen_dev
     audit["chosen_dev_timeout_seconds"] = chosen_timeout
-    audit["chosen_dev_budget_usd"] = round(chosen_budget, 4)
+    audit["chosen_dev_cost_estimate_usd"] = round(chosen_estimate, 4)
 
     # Review history: p75 of matching-complexity runs; records within ±1 of the score.
     history_sample = 0
@@ -322,6 +329,6 @@ def derive_limits(
         dev_max=chosen_dev,
         review_max=chosen_review,
         dev_timeout_seconds=chosen_timeout,
-        dev_budget_usd=chosen_budget,
+        dev_cost_estimate_usd=chosen_estimate,
         audit=audit,
     )

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -942,20 +942,30 @@ def _run_dev_phase(
     if (
         dev_result.success
         and state.error_type != "max_iterations_no_submit"
-        and state.total_dev_cost > (state.adaptive_dev_budget_usd or config.dev_profile.budget_usd)
+        and state.total_dev_cost
+        > (state.adaptive_dev_cost_estimate_usd or config.dev_profile.budget_usd)
     ):
-        _budget_limit = state.adaptive_dev_budget_usd or config.dev_profile.budget_usd
-        _budget_msg = (
-            f"Dev budget exceeded: spent ${state.total_dev_cost:.4f} (limit ${_budget_limit:.4f})"
-        )
-        # If the dev agent successfully committed work, honour the result rather
-        # than retroactively escalating based on post-hoc accounting. The cost is
-        # already spent; blocking PR creation would silently orphan correct work.
+        # The per-story dollar value is a historical-cost ESTIMATE, not an
+        # enforced budget. Post-hoc dollar governance lives at the sprint level
+        # (forge.yaml budget_usd); exceeding the per-story estimate is never, by
+        # itself, an operator-actionable overrun. So there are only two outcomes:
+        #   - committed work → the estimate was simply low; proceed, no action.
+        #   - no commits → the attempt produced no usable output; escalate on the
+        #     unproductive-attempt semantics (what actually went wrong), NOT a
+        #     dollar overrun.
+        _cost_estimate = state.adaptive_dev_cost_estimate_usd or config.dev_profile.budget_usd
         if _commits_exist_strict(workspace_path, config.workspace.base_branch):
-            _log(f"⚠ DEV   {_budget_msg} — committed work found, proceeding to validate/review")
+            _log_verbose(
+                f"  DEV cost ${state.total_dev_cost:.4f} exceeded the per-story estimate "
+                f"${_cost_estimate:.4f} — committed work found; estimate was low, proceeding "
+                "to validate/review (per-story estimates are not enforced budgets)"
+            )
         else:
             state.phase = Phase.ESCALATE
-            state.error = _budget_msg
+            state.error = (
+                f"Dev attempt produced no usable output "
+                f"(${state.total_dev_cost:.4f} spent, no commits)"
+            )
             _log(f"✗ ESCALATE   {state.error}")
             if logger:
                 logger._safe_emit("escalate", reason=state.error, phase="DEV")

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -299,7 +299,7 @@ def _coordinator_loop(
         state.adaptive_dev_max == 0
         or state.adaptive_review_max == 0
         or state.adaptive_dev_timeout_seconds == 0
-        or state.adaptive_dev_budget_usd == 0.0
+        or state.adaptive_dev_cost_estimate_usd == 0.0
     ):
         _static_dev_timeout, _timeout_override_active = resolve_timeout_with_active(
             config.dev_profile.timeout_seconds,
@@ -309,7 +309,7 @@ def _coordinator_loop(
             state.preflight_complexity_score,
         )
         _static_dev_max = config.dev_profile.max_iterations or config.retry.max_dev_iterations
-        _static_dev_budget = config.dev_profile.budget_usd
+        _static_dev_cost_estimate = config.dev_profile.budget_usd
         _explicit_dev_override = "dev" in getattr(state, "_explicit_roles", set())
         # Adaptive iterations now reads the SQLite audit substrate; we pass
         # project_root and let the helper resolve substrate access internally.
@@ -329,7 +329,7 @@ def _coordinator_loop(
             model_provider=config.dev_profile.provider,
             model_cli=config.dev_profile.cli,
             base_timeout_seconds=_static_dev_timeout,
-            base_budget_usd=_static_dev_budget,
+            base_cost_estimate_usd=_static_dev_cost_estimate,
             static_dev_max=_static_dev_max,
             review_history_path=_history_path,
             model_profiles=load_profiles(_profiles_path) if _adaptive_resource_enabled else None,
@@ -363,19 +363,19 @@ def _coordinator_loop(
                 dev_max=_static_dev_max,
                 review_max=_limits.review_max,
                 dev_timeout_seconds=_static_dev_timeout,
-                dev_budget_usd=_static_dev_budget,
+                dev_cost_estimate_usd=_static_dev_cost_estimate,
                 audit=_audit,
             )
         state.adaptive_dev_max = _limits.dev_max
         state.adaptive_review_max = _limits.review_max
         state.adaptive_dev_timeout_seconds = _limits.dev_timeout_seconds
-        state.adaptive_dev_budget_usd = _limits.dev_budget_usd
+        state.adaptive_dev_cost_estimate_usd = _limits.dev_cost_estimate_usd
         state.adaptive_limits_audit = _limits.audit
         _log_verbose(
             "  adaptive limits: "
             f"dev_max={_limits.dev_max} review_max={_limits.review_max} "
             f"dev_timeout={_limits.dev_timeout_seconds}s "
-            f"dev_budget=${_limits.dev_budget_usd:.4f} "
+            f"dev_cost_estimate=${_limits.dev_cost_estimate_usd:.4f} "
             f"({_limits.audit.get('rationale', '')})"
         )
 

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -964,7 +964,7 @@ def _emit_cap_downgrade_warning(
     *,
     story_slug: str | None,
 ) -> None:
-    """Print a visible terminal warning when the per-story routing cost cap forced a downgrade.
+    """Print a visible terminal warning when the per-story routing cost target forced a downgrade.
 
     The warning fires when ``_enforce_budget`` either dropped a reviewer or
     swapped a selected role for a cheaper one — i.e. adaptive's preferred
@@ -972,7 +972,7 @@ def _emit_cap_downgrade_warning(
     """
     if not cap_audit.get("downgraded"):
         return
-    cap = cap_audit.get("cap_usd")
+    cap = cap_audit.get("target_usd")
     preferred = cap_audit.get("preferred") or {}
     if not isinstance(preferred, dict):
         return
@@ -984,9 +984,9 @@ def _emit_cap_downgrade_warning(
     pref_planner = (preferred.get("planner") or {}).get("model")
     story_label = f"story {story_slug}" if story_slug else "story"
     log(
-        f"  ⚠ {story_label}: per-story routing cost cap ${cap:.2f} forces downgrade"
+        f"  ⚠ {story_label}: per-story routing cost target ${cap:.2f} forces downgrade"
         if isinstance(cap, (int, float))
-        else f"  ⚠ {story_label}: per-story routing cost cap forces downgrade"
+        else f"  ⚠ {story_label}: per-story routing cost target forces downgrade"
     )
     pref_total_str = f" @ ~${initial_total:.2f}" if isinstance(initial_total, (int, float)) else ""
     log(
@@ -994,7 +994,7 @@ def _emit_cap_downgrade_warning(
         f"plan_reviewers={pref_pr}, code_reviewers={pref_cr}{pref_total_str}"
     )
     final_total_str = f" @ ~${final_total:.2f}" if isinstance(final_total, (int, float)) else ""
-    log(f"    after cap:         downgraded roles={sorted(downgraded_roles)}{final_total_str}")
+    log(f"    after target:         downgraded roles={sorted(downgraded_roles)}{final_total_str}")
 
 
 def _apply_preflight_config(
@@ -1154,7 +1154,7 @@ def _apply_preflight_config(
         _new_audit["final_total_usd"] = round(_runtime_total, 2)
         if _cap is not None:
             _within = _runtime_total <= _cap
-            _new_audit["within_cap"] = _within
+            _new_audit["within_target"] = _within
             if not _within:
                 _new_audit["override_forced_overrun"] = True
                 _new_audit["locked_roles"] = sorted(set(_explicit.keys()))
@@ -1254,7 +1254,7 @@ def _apply_preflight_config(
             "code_reviewers": [_assignment_entry(p) for p in _decision.code_reviewers],
         },
         "rationale": dict(_decision.rationale),
-        "per_story_routing_cost_cap": _cap_audit,
+        "per_story_routing_cost_target": _cap_audit,
         **({"config_model_routing": _existing_routing_audit} if _existing_routing_audit else {}),
     }
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1491,7 +1491,8 @@ def _run_review_phase(
         and _is_persistent_p1
         and not state.dev_escalated
         and (
-            state.total_dev_cost < (state.adaptive_dev_budget_usd or config.dev_profile.budget_usd)
+            state.total_dev_cost
+            < (state.adaptive_dev_cost_estimate_usd or config.dev_profile.budget_usd)
         )
     ):
         _esc = _perform_dev_model_escalation(config)

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -480,7 +480,10 @@ class CoordinatorState:
     adaptive_dev_max: int = 0
     adaptive_review_max: int = 0
     adaptive_dev_timeout_seconds: int = 0
-    adaptive_dev_budget_usd: float = 0.0
+    # Per-story dollar cost ESTIMATE (historical-cost derived), not an enforced
+    # budget. Informs routing/timeout scaling/telemetry; post-hoc dollar
+    # governance lives at the sprint level (forge.yaml budget_usd), not here.
+    adaptive_dev_cost_estimate_usd: float = 0.0
     adaptive_limits_audit: dict = field(default_factory=dict)
     review_early_terminated: bool = False  # True when early-termination triggered
     workspace_hygiene_audit: list[dict] = field(default_factory=list)

--- a/tests/test_adaptive_iterations.py
+++ b/tests/test_adaptive_iterations.py
@@ -53,7 +53,7 @@ def test_adaptive_disabled_returns_policy_floors(tmp_path: Path):
         _policy(adaptive_iterations=False),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles=_profiles(),
@@ -62,7 +62,7 @@ def test_adaptive_disabled_returns_policy_floors(tmp_path: Path):
     assert result.dev_max == 3
     assert result.review_max == 2
     assert result.dev_timeout_seconds == 900
-    assert result.dev_budget_usd == 10.0
+    assert result.dev_cost_estimate_usd == 10.0
     assert result.audit["enabled"] is False
 
 
@@ -73,7 +73,7 @@ def test_no_score_uses_static_limits(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "missing.jsonl",
         model_profiles=_profiles(),
@@ -90,7 +90,7 @@ def test_profile_history_derives_dev_limits_from_headroom(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "missing.jsonl",
         model_profiles=_profiles(avg_iterations=3.2, avg_cost=1.2),
@@ -99,9 +99,9 @@ def test_profile_history_derives_dev_limits_from_headroom(tmp_path: Path):
     # Budget: medium band uses 2.0x headroom → 1.2 * 2.0 = 2.4
     assert result.dev_max == 5
     assert result.dev_timeout_seconds == 1500
-    assert result.dev_budget_usd == 2.4
+    assert result.dev_cost_estimate_usd == 2.4
     assert result.audit["profile_history_runs"] == 3
-    assert result.audit["budget_headroom_factor"] == 2.0
+    assert result.audit["estimate_headroom_factor"] == 2.0
 
 
 def test_headroom_clamps_dev_iterations_to_cap(tmp_path: Path):
@@ -111,7 +111,7 @@ def test_headroom_clamps_dev_iterations_to_cap(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "missing.jsonl",
         model_profiles=_profiles(avg_iterations=9.0, avg_cost=9.0),
@@ -127,14 +127,14 @@ def test_insufficient_profile_history_falls_back_to_static_limits(tmp_path: Path
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "missing.jsonl",
         model_profiles=_profiles(runs=2, avg_iterations=9.0, avg_cost=9.0),
     )
     assert result.dev_max == 3
     assert result.dev_timeout_seconds == 900
-    assert result.dev_budget_usd == 10.0
+    assert result.dev_cost_estimate_usd == 10.0
     assert result.review_max == 3
     assert result.audit["base_review"] == 3
     assert result.audit["profile_history_runs"] == 0
@@ -150,7 +150,7 @@ def test_deterministic_same_inputs_same_output(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "missing.jsonl",
         model_profiles=profiles,
@@ -161,7 +161,7 @@ def test_deterministic_same_inputs_same_output(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "missing.jsonl",
         model_profiles=profiles,
@@ -178,7 +178,7 @@ def test_band_fallback_when_score_none(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles=_profiles(),
@@ -194,7 +194,7 @@ def test_out_of_range_score_falls_back_to_band(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles={
@@ -229,7 +229,7 @@ def test_corrupt_substrate_propagates_error(tmp_path: Path):
             _policy(),
             model_name="dev",
             base_timeout_seconds=900,
-            base_budget_usd=10.0,
+            base_cost_estimate_usd=10.0,
             static_dev_max=3,
             review_history_path=tmp_path,
             model_profiles=_profiles(),
@@ -263,7 +263,7 @@ def test_insufficient_profile_history_still_uses_review_history_signal(tmp_path:
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path,
         model_profiles=_profiles(runs=2, avg_iterations=9.0, avg_cost=9.0),
@@ -286,14 +286,14 @@ def test_budget_headroom_large_band_uses_2_5x(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles=_profiles(band="large", avg_cost=4.0),
     )
     # large band: 4.0 * 2.5 = 10.0
-    assert result.dev_budget_usd == 10.0
-    assert result.audit["budget_headroom_factor"] == 2.5
+    assert result.dev_cost_estimate_usd == 10.0
+    assert result.audit["estimate_headroom_factor"] == 2.5
 
 
 def test_budget_headroom_medium_band_uses_2_0x(tmp_path: Path):
@@ -303,14 +303,14 @@ def test_budget_headroom_medium_band_uses_2_0x(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles=_profiles(band="medium", avg_cost=3.0),
     )
     # medium band: 3.0 * 2.0 = 6.0
-    assert result.dev_budget_usd == 6.0
-    assert result.audit["budget_headroom_factor"] == 2.0
+    assert result.dev_cost_estimate_usd == 6.0
+    assert result.audit["estimate_headroom_factor"] == 2.0
 
 
 def test_budget_headroom_small_band_uses_1_5x(tmp_path: Path):
@@ -320,14 +320,14 @@ def test_budget_headroom_small_band_uses_1_5x(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles=_profiles(band="small", avg_cost=1.0),
     )
     # small band: 1.0 * 1.5 = 1.5
-    assert result.dev_budget_usd == 1.5
-    assert result.audit["budget_headroom_factor"] == 1.5
+    assert result.dev_cost_estimate_usd == 1.5
+    assert result.audit["estimate_headroom_factor"] == 1.5
 
 
 def test_budget_headroom_unknown_band_falls_back_to_default(tmp_path: Path):
@@ -337,33 +337,35 @@ def test_budget_headroom_unknown_band_falls_back_to_default(tmp_path: Path):
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles=_profiles(band="medium", avg_cost=2.0),
     )
     # No band → falls back to _HEADROOM_FACTOR (1.5x): 2.0 * 1.5 = 3.0
-    assert result.dev_budget_usd == 3.0
-    assert result.audit["budget_headroom_factor"] == 1.5
+    assert result.dev_cost_estimate_usd == 3.0
+    assert result.audit["estimate_headroom_factor"] == 1.5
 
 
-def test_budget_headroom_concrete_large_scenario(tmp_path: Path):
-    # Reproduce the concrete failure from issue #1148:
-    # avg_cost $4.13, actual $8.44.  With old 1.5x: budget = $6.20 → escalate.
-    # With new 2.5x: budget = $10.33 → no escalation.
+def test_estimate_headroom_concrete_large_scenario(tmp_path: Path):
+    # Documents that the per-story dollar value is a historical-cost ESTIMATE,
+    # not a hard cap (issue #1148): avg_cost $4.13, actual $8.44. The old 1.5x
+    # estimate ($6.20) was low; the band-scaled 2.5x estimate ($10.33) tracks
+    # real large-story spend. Post-hoc dollar enforcement no longer lives here
+    # (sprint-level governance owns that), so a low estimate never escalates.
     result = derive_limits(
         9,
         "large",
         _policy(),
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=tmp_path / "none",
         model_profiles=_profiles(band="large", avg_cost=4.13),
     )
-    assert result.dev_budget_usd >= 8.44, (
-        f"Budget {result.dev_budget_usd:.4f} would have escalated the $8.44 run from issue #1148"
+    assert result.dev_cost_estimate_usd >= 8.44, (
+        f"Estimate {result.dev_cost_estimate_usd:.4f} should track the $8.44 run from issue #1148"
     )
 
 

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -599,7 +599,7 @@ def test_explicit_override_records_forced_overrun_when_budget_unmet():
         allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
     )
 
-    with pytest.warns(UserWarning, match="per-story routing cost cap"):
+    with pytest.warns(UserWarning, match="per-story routing cost target"):
         decision = assign_models(
             agents,
             cfg,
@@ -608,7 +608,7 @@ def test_explicit_override_records_forced_overrun_when_budget_unmet():
         )
 
     assert decision.dev.model == "custom-model"
-    assert decision.budget_audit["within_cap"] is False
+    assert decision.budget_audit["within_target"] is False
     assert decision.budget_audit.get("override_forced_overrun") is True
     assert "dev" in decision.budget_audit.get("locked_roles", [])
 
@@ -750,7 +750,7 @@ def test_budget_cap_downgrade_dev_respects_floor():
         f"Dev should stay strong for HIGH; got {decision.dev.name}"
     )
     # Budget cannot be met, so a warning must have been issued
-    assert any("per-story routing cost cap" in str(w.message) for w in caught), (
+    assert any("per-story routing cost target" in str(w.message) for w in caught), (
         "Expected budget-cap warning when floor prevents the cap from being met"
     )
 
@@ -806,10 +806,10 @@ def test_budget_cap_preserves_strong_planner_when_dev_is_also_strong():
 
     assert decision.dev.model == "opus"
     assert decision.planner.model == "opus"
-    assert decision.budget_audit["within_cap"] is False
+    assert decision.budget_audit["within_target"] is False
     assert "planner" in decision.budget_audit.get("protected_roles", [])
-    assert "protected roles" in decision.rationale["per_story_routing_cost_cap"]
-    assert any("per-story routing cost cap" in str(w.message) for w in caught)
+    assert "protected roles" in decision.rationale["per_story_routing_cost_target"]
+    assert any("per-story routing cost target" in str(w.message) for w in caught)
 
 
 def test_budget_cap_records_downgrade_rationale():
@@ -824,7 +824,7 @@ def test_budget_cap_records_downgrade_rationale():
 
     decision = assign_models(agents, cfg, "medium")
 
-    assert "per-story routing cost cap $10.00" in decision.rationale["per_story_routing_cost_cap"]
+    assert "per-story routing cost target $10.00" in decision.rationale["per_story_routing_cost_target"]
     assert decision.budget_audit["downgraded"] is True
     assert decision.budget_audit["final_total_usd"] <= 10.0
     assert decision.budget_audit["steps"]
@@ -843,7 +843,7 @@ def test_budget_cap_keeps_planner_rationale_aligned_with_final_model():
     decision = assign_models(agents, cfg, "medium", complexity_score=4)
 
     assert decision.planner.model == "haiku"
-    assert "per-story routing cost cap $10.00 downgraded to haiku" in decision.rationale["planner"]
+    assert "per-story routing cost target $10.00 downgraded to haiku" in decision.rationale["planner"]
     assert any(step["role"] == "planner" for step in decision.budget_audit["steps"])
 
 
@@ -1185,7 +1185,7 @@ def test_guardrail_mid_promoted_to_strong_for_large():
     assert decision.dev.name == "opus", f"Expected strong (opus) for HIGH, got {decision.dev.name}"
 
 
-# ── per-story routing cost cap (split from sprint budget) ──────────────
+# ── per-story routing cost target (split from sprint budget) ──────────────
 
 
 def test_unset_cap_preserves_adaptive_full_pool_on_high_complexity():
@@ -1213,13 +1213,13 @@ def test_unset_cap_preserves_adaptive_full_pool_on_high_complexity():
 
     assert decision.budget_audit["downgraded"] is False
     assert decision.budget_audit["steps"] == []
-    assert decision.budget_audit["cap_usd"] is None
+    assert decision.budget_audit["target_usd"] is None
     assert len(decision.code_reviewers) == len(ref_decision.code_reviewers)
     assert decision.dev.model == ref_decision.dev.model
     assert [r.model for r in decision.code_reviewers] == [
         r.model for r in ref_decision.code_reviewers
     ]
-    cap_text = decision.rationale["per_story_routing_cost_cap"]
+    cap_text = decision.rationale["per_story_routing_cost_target"]
     assert "unset" in cap_text
     assert "budget" not in cap_text.lower()
 

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -824,7 +824,10 @@ def test_budget_cap_records_downgrade_rationale():
 
     decision = assign_models(agents, cfg, "medium")
 
-    assert "per-story routing cost target $10.00" in decision.rationale["per_story_routing_cost_target"]
+    assert (
+        "per-story routing cost target $10.00"
+        in decision.rationale["per_story_routing_cost_target"]
+    )
     assert decision.budget_audit["downgraded"] is True
     assert decision.budget_audit["final_total_usd"] <= 10.0
     assert decision.budget_audit["steps"]
@@ -843,7 +846,9 @@ def test_budget_cap_keeps_planner_rationale_aligned_with_final_model():
     decision = assign_models(agents, cfg, "medium", complexity_score=4)
 
     assert decision.planner.model == "haiku"
-    assert "per-story routing cost target $10.00 downgraded to haiku" in decision.rationale["planner"]
+    assert (
+        "per-story routing cost target $10.00 downgraded to haiku" in decision.rationale["planner"]
+    )
     assert any(step["role"] == "planner" for step in decision.budget_audit["steps"])
 
 

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -543,7 +543,7 @@ class TestCheckConfigAgentsSection:
         ):
             cmd_check_config(_make_args())
         out = capsys.readouterr().out
-        assert "Per-story routing cost cap: $20.00/story" in out
+        assert "Per-story routing cost target: $20.00/story" in out
 
     def test_no_budget_header_when_assignment_disabled(self, tmp_path: Path, capsys) -> None:
         config = _make_forge_config(tmp_path)  # assignment disabled
@@ -557,7 +557,7 @@ class TestCheckConfigAgentsSection:
         ):
             cmd_check_config(_make_args())
         out = capsys.readouterr().out
-        assert "Per-story routing cost cap" not in out
+        assert "Per-story routing cost target" not in out
         assert "Budget:" not in out
 
 

--- a/tests/test_coord_adaptive_iterations.py
+++ b/tests/test_coord_adaptive_iterations.py
@@ -75,13 +75,13 @@ def test_adaptive_limits_populated_in_audit(tmp_path: Path):
     state.adaptive_dev_max = 5
     state.adaptive_review_max = 3
     state.adaptive_dev_timeout_seconds = 1500
-    state.adaptive_dev_budget_usd = 1.8
+    state.adaptive_dev_cost_estimate_usd = 1.8
     state.adaptive_limits_audit = {
         "enabled": True,
         "chosen_dev_max": 5,
         "chosen_review_max": 3,
         "chosen_dev_timeout_seconds": 1500,
-        "chosen_dev_budget_usd": 1.8,
+        "chosen_dev_cost_estimate_usd": 1.8,
         "rationale": "complexity-derived",
     }
     audit = generate_audit_log(
@@ -141,7 +141,7 @@ def test_engine_populates_adaptive_limits_before_dev_loop(tmp_path: Path):
     assert state.adaptive_dev_timeout_seconds == round(
         config.dev_profile.timeout_seconds * LARGE_HEADROOM_FACTOR
     )
-    assert state.adaptive_dev_budget_usd == config.dev_profile.budget_usd
+    assert state.adaptive_dev_cost_estimate_usd == config.dev_profile.budget_usd
     assert state.adaptive_limits_audit.get("enabled") is True
     assert state.adaptive_limits_audit.get("complexity_score_used") == 9
 
@@ -161,14 +161,14 @@ def test_profiles_inform_adaptive_dev_limits(tmp_path: Path):
         policy,
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=None,
         model_profiles=_profiles(avg_iterations=3.2, avg_cost_usd=1.2),
     )
     assert result.dev_max == 5
     assert result.dev_timeout_seconds == 1500
-    assert result.dev_budget_usd == 2.4  # medium band: 1.2 * 2.0x headroom
+    assert result.dev_cost_estimate_usd == 2.4  # medium band: 1.2 * 2.0x headroom
     assert result.audit["profile_history_runs"] == 3
 
 
@@ -217,14 +217,14 @@ def test_fragmented_profile_aliases_inform_adaptive_dev_limits(tmp_path: Path):
         model_provider="openai",
         model_cli="codex",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=None,
         model_profiles=profiles,
     )
     assert result.dev_max == 6
     assert result.dev_timeout_seconds == 1800
-    assert result.dev_budget_usd == 2.5
+    assert result.dev_cost_estimate_usd == 2.5
     assert result.audit["profile_history_runs"] == 4
 
 
@@ -244,7 +244,7 @@ def test_determinism_seam(tmp_path: Path):
         policy,
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=None,
         model_profiles=profiles,
@@ -255,7 +255,7 @@ def test_determinism_seam(tmp_path: Path):
         policy,
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=None,
         model_profiles=profiles,
@@ -357,7 +357,7 @@ def test_adaptive_off_produces_policy_values(tmp_path: Path):
         policy,
         model_name="dev",
         base_timeout_seconds=900,
-        base_budget_usd=10.0,
+        base_cost_estimate_usd=10.0,
         static_dev_max=3,
         review_history_path=None,
         model_profiles=_profiles(),
@@ -439,5 +439,5 @@ def test_explicit_dev_override_wins_over_computed_limits(tmp_path: Path):
 
     assert state.adaptive_dev_max == 4
     assert state.adaptive_dev_timeout_seconds == round(1200 * MEDIUM_HEADROOM_FACTOR)
-    assert state.adaptive_dev_budget_usd == 12.0
+    assert state.adaptive_dev_cost_estimate_usd == 12.0
     assert "explicit dev forge.yaml override" in state.adaptive_limits_audit["rationale"]

--- a/tests/test_coord_cancellation.py
+++ b/tests/test_coord_cancellation.py
@@ -29,7 +29,7 @@ def _seeded_state(tmp_path: Path) -> CoordinatorState:
     state.adaptive_dev_max = 2
     state.adaptive_review_max = 2
     state.adaptive_dev_timeout_seconds = 600
-    state.adaptive_dev_budget_usd = 1.0
+    state.adaptive_dev_cost_estimate_usd = 1.0
     return state
 
 

--- a/tests/test_coord_dev_phase_budget.py
+++ b/tests/test_coord_dev_phase_budget.py
@@ -1,7 +1,14 @@
-"""Tests for coordinator dev phase: budget enforcement and dev notes.
+"""Tests for coordinator dev phase: cost governance and dev notes.
 
-Covers: budget limits for dev and review agents, dev notes injection into review
-prompts.
+Covers: per-story dev cost estimates (surfaced, not enforced), review-agent
+budget ceilings, and dev notes injection into review prompts.
+
+Per-story dollar values are historical-cost estimates, not enforced budgets.
+When a dev attempt exceeds its estimate the outcome depends on whether it
+produced usable output: committed work proceeds (the estimate was low), while a
+no-commit attempt escalates on unproductive-attempt semantics — it names that no
+usable output was produced, not a dollar overrun. Real post-hoc dollar
+governance lives at the sprint level (forge.yaml budget_usd).
 """
 
 from __future__ import annotations
@@ -38,7 +45,7 @@ from theforge.runners import AgentResult
 
 
 class TestCoordinatorBudgetEnforcement:
-    """Test that budget limits are enforced for dev and review agents."""
+    """Per-story dev cost is an estimate (not enforced); review budgets are ceilings."""
 
     def _make_budget_config(
         self, tmp_path: Path, dev_budget: float, review_budget: float
@@ -82,10 +89,10 @@ class TestCoordinatorBudgetEnforcement:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_dev_budget_exceeded_first_call(
+    def test_dev_estimate_exceeded_no_commits_first_call(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
-        """Dev agent exceeds budget on first call → ESCALATE with budget error."""
+        """Dev exceeds estimate with no commits on first call → ESCALATE (unproductive)."""
         config = self._make_budget_config(tmp_path, dev_budget=0.40, review_budget=1.00)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -110,9 +117,11 @@ class TestCoordinatorBudgetEnforcement:
 
         assert result.success is False
         assert result.phase == Phase.ESCALATE
-        assert "budget" in result.message.lower()
+        # No commits + high spend → unproductive-attempt framing, not a dollar overrun.
+        assert "no usable output" in result.message.lower()
+        assert "no commits" in result.message.lower()
+        assert "budget" not in result.message.lower()
         assert "0.5000" in result.message
-        assert "0.4000" in result.message
         # Only one dev invocation — escalated before retry
         assert len(result.state.dev_results) == 1
 
@@ -120,10 +129,10 @@ class TestCoordinatorBudgetEnforcement:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_dev_budget_exceeded_on_retry(
+    def test_dev_estimate_exceeded_no_commits_on_retry(
         self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
-        """Dev agent exceeds budget on second call (retry) → ESCALATE."""
+        """Dev exceeds estimate with no commits on second call (retry) → ESCALATE."""
         config = self._make_budget_config(tmp_path, dev_budget=0.50, review_budget=1.00)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -147,7 +156,8 @@ class TestCoordinatorBudgetEnforcement:
 
         assert result.success is False
         assert result.phase == Phase.ESCALATE
-        assert "budget" in result.message.lower()
+        assert "no usable output" in result.message.lower()
+        assert "budget" not in result.message.lower()
         # Two dev invocations: $0.30 + $0.30 = $0.60 > $0.50
         assert len(result.state.dev_results) == 2
 
@@ -240,10 +250,10 @@ class TestCoordinatorBudgetEnforcement:
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
     @patch("theforge.coordinator.dev_phase._commits_exist_strict", return_value=False)
-    def test_dev_budget_exceeded_no_commits_escalates(
+    def test_dev_estimate_exceeded_no_commits_escalates_unproductive(
         self, mock_commits, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
     ):
-        """Dev exceeds budget with no commits → ESCALATE (no work to salvage)."""
+        """Dev exceeds estimate with no commits → ESCALATE as unproductive (no work to salvage)."""
         config = self._make_budget_config(tmp_path, dev_budget=0.40, review_budget=1.00)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -267,7 +277,9 @@ class TestCoordinatorBudgetEnforcement:
 
         assert result.success is False
         assert result.phase == Phase.ESCALATE
-        assert "budget" in result.message.lower()
+        assert "no usable output" in result.message.lower()
+        assert "no commits" in result.message.lower()
+        assert "budget" not in result.message.lower()
 
 
 # ── Dev notes and handoff validation tests ──────────────────────────────

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -234,7 +234,7 @@ def test_preflight_records_assignment_rationale_in_audit_state(tmp_path, monkeyp
     assert audit["assignments"]["dev"]["model"] == state._adaptive_decision.dev.model
     assert audit["assignments"]["dev"]["source"] == state._adaptive_decision.dev.registry_source
     assert "dev" in audit["rationale"]
-    assert "cap_usd" in audit["per_story_routing_cost_cap"]
+    assert "target_usd" in audit["per_story_routing_cost_target"]
 
 
 def test_preflight_audit_keeps_strong_planner_when_strong_dev_forces_budget_pressure(
@@ -304,8 +304,8 @@ def test_preflight_audit_keeps_strong_planner_when_strong_dev_forces_budget_pres
     assert audit["assignments"]["planner"]["model"] == "opus"
     assert audit["rationale"]["planner"].startswith("complexity score 9 → tier strong")
     assert audit["role_sources"]["planner"] == "adaptive"
-    assert audit["per_story_routing_cost_cap"]["within_cap"] is False
-    assert "planner" in audit["per_story_routing_cost_cap"].get("protected_roles", [])
+    assert audit["per_story_routing_cost_target"]["within_target"] is False
+    assert "planner" in audit["per_story_routing_cost_target"].get("protected_roles", [])
 
 
 def test_preflight_seam_adaptive_on_vs_off_diverges_then_converges(tmp_path, monkeypatch):
@@ -478,7 +478,7 @@ def test_explicit_planner_and_review_pool_threaded_into_assignment(tmp_path, mon
         + decision.dev.budget_usd
         + sum(p.budget_usd for p in decision.code_reviewers)
     )
-    assert audit["per_story_routing_cost_cap"]["final_total_usd"] == round(runtime_total, 2)
+    assert audit["per_story_routing_cost_target"]["final_total_usd"] == round(runtime_total, 2)
 
 
 def test_explicit_review_pool_records_override_forced_overrun_when_over_cap(tmp_path, monkeypatch):
@@ -534,9 +534,9 @@ def test_explicit_review_pool_records_override_forced_overrun_when_over_cap(tmp_
     audit = state.complexity_routing_audit
     assert audit is not None
     assert audit["role_sources"]["code_review"] == "explicit_override"
-    assert audit["per_story_routing_cost_cap"]["within_cap"] is False
-    assert audit["per_story_routing_cost_cap"]["override_forced_overrun"] is True
-    assert "code_review" in audit["per_story_routing_cost_cap"]["locked_roles"]
+    assert audit["per_story_routing_cost_target"]["within_target"] is False
+    assert audit["per_story_routing_cost_target"]["override_forced_overrun"] is True
+    assert "code_review" in audit["per_story_routing_cost_target"]["locked_roles"]
 
 
 def test_models_path_with_explicit_plan_and_review_pool_preserved(tmp_path, monkeypatch):
@@ -755,13 +755,13 @@ def test_apply_preflight_emits_terminal_warning_on_cap_downgrade(tmp_path, monke
     _pf._apply_preflight_config(config, state, log=captured.append, task_slug="story-test")
 
     blob = "\n".join(captured)
-    assert "per-story routing cost cap" in blob
+    assert "per-story routing cost target" in blob
     assert "story-test" in blob
     assert "adaptive selected:" in blob
-    assert "after cap:" in blob
+    assert "after target:" in blob
     # Wording rule: cap warning lines must never use the word "budget"
     for line in captured:
-        if "per-story routing cost cap" in line or "after cap:" in line:
+        if "per-story routing cost target" in line or "after target:" in line:
             assert "budget" not in line.lower(), f"Cap warning must not say 'budget': {line!r}"
 
 
@@ -800,8 +800,8 @@ def test_apply_preflight_skips_warning_when_cap_unset(tmp_path, monkeypatch):
 
     blob = "\n".join(captured)
     assert "forces downgrade" not in blob
-    assert "after cap:" not in blob
+    assert "after target:" not in blob
     # Adaptive's selection survives — strong dev tier preserved
     assert state._adaptive_decision.dev.model == "opus"
-    assert state._adaptive_decision.budget_audit["cap_usd"] is None
+    assert state._adaptive_decision.budget_audit["target_usd"] is None
     assert state._adaptive_decision.budget_audit["downgraded"] is False

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -643,13 +643,13 @@ class TestDevModelEscalationIntegration:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch("theforge.coordinator.util._run_shell")
-    def test_escalation_skipped_when_budget_exhausted(
+    def test_escalation_skipped_when_dev_attempt_unproductive(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):
-        """Budget exhausted before persistent P1 detected → no escalation, no extra dev run."""
-        # Use a very tight budget so the first dev call exhausts it
+        """No-commit dev attempt escalates as unproductive before persistent P1 fires."""
+        # Use a very tight per-story estimate so the first dev call exceeds it
         config = _make_smart_config(tmp_path, max_review_cycles=3)
-        # Override dev budget to be tiny so it's exceeded after first call
+        # Override the dev cost estimate to be tiny so it's exceeded after first call
         from dataclasses import replace as _replace
 
         tight_dev = _replace(config.dev_profile, budget_usd=0.01)
@@ -676,11 +676,12 @@ class TestDevModelEscalationIntegration:
 
         result = run_task(config, task)
 
-        # Dev budget exhausted → ESCALATE immediately after first dev run
+        # No usable output (no commits) → ESCALATE immediately after first dev run
         assert result.success is False
         assert result.phase == Phase.ESCALATE
-        assert "budget" in result.message.lower()
-        # Escalation flag never set (budget guard fired first)
+        assert "no usable output" in result.message.lower()
+        assert "budget" not in result.message.lower()
+        # Escalation flag never set (unproductive-attempt guard fired first)
         assert result.state.dev_escalated is False
 
 

--- a/tests/test_coord_state.py
+++ b/tests/test_coord_state.py
@@ -387,7 +387,7 @@ class TestStructuredLoggingIntegration:
         assert preflight_phase_end["complexity_routing"]["preflight"]
         assert preflight_phase_end["complexity_routing"]["plan_review"]
         assert preflight_phase_end["complexity_routing"]["code_review"]
-        assert preflight_phase_end["complexity_routing"]["per_story_routing_cost_cap"]
+        assert preflight_phase_end["complexity_routing"]["per_story_routing_cost_target"]
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")

--- a/tests/test_generate_audit_log.py
+++ b/tests/test_generate_audit_log.py
@@ -177,11 +177,11 @@ class TestPreflightAudit:
             },
             "rationale": {
                 "dev": "complexity score 7 (MEDIUM) -> tier strong",
-                "per_story_routing_cost_cap": (
-                    "within per-story routing cost cap $30.00 (estimated total $27.00)"
+                "per_story_routing_cost_target": (
+                    "within per-story routing cost target $30.00 (estimated total $27.00)"
                 ),
             },
-            "per_story_routing_cost_cap": {"cap_usd": 30.0, "within_cap": True},
+            "per_story_routing_cost_target": {"target_usd": 30.0, "within_target": True},
         }
 
         log = generate_audit_log(
@@ -197,7 +197,7 @@ class TestPreflightAudit:
         assert routing["role_sources"]["code_review"] == "cap_downgrade"
         assert routing["assignments"]["dev"]["model"] == "opus"
         assert routing["assignments"]["dev"]["source"] == "forge.yaml"
-        assert "per_story_routing_cost_cap" in routing["rationale"]
+        assert "per_story_routing_cost_target" in routing["rationale"]
 
 
 # ── Cost.agents tests ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior adaptive-assignment cap wording is resolved, and I found no blocking regressions in the cycle-2 iteration. | [google-gemini-3.5-flash] The converged budget view is fully implemented, reframing per-story dollar values as estimates and routing targets while preserving sprint-level governance. | [claude-sonnet] Cycle 1's P1 (per-story routing cost surfaced as a cap in rationale/audit/warnings/check-config) is fixed: renamed to 'routing cost target' across assignment.py, check_config.py, and preflight.py, with matching test updates. Iter-2 commit only wraps E501-violating lines with no behavior change. Full targeted suite (284 tests) passes, ruff clean. No regressions found in touched files.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $12.36
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Converged budget view: sprint-level governance + per-story estimates (not enforcement) (GitHub Issue #1367)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1367