### PR TITLE
Escalation Advisor: fresh-context advisory with evidence-backed action choices replaces max-cycles auto-reject

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -713,6 +713,9 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 ),
                 "gate_result": state.gate_decisions[-1] if state.gate_decisions else None,
                 "human_decision": state.escalate_decision,
+                "selected_action": state.escalate_selected_action,
+                "advisory_generated": state.advisory_generated,
+                "advisory": state.advisory_report,
                 "waited_seconds": (
                     round(state.human_review_waited_seconds, 1)
                     if state.human_review_waited_seconds is not None

--- a/src/theforge/coordinator/escalation_advisor_flow.py
+++ b/src/theforge/coordinator/escalation_advisor_flow.py
@@ -1,0 +1,268 @@
+"""Coordinator control flow for the fresh-context escalation advisor.
+
+On escalation, this module assembles an evidence packet from the escalated run's
+state, invokes a **fresh** advisor agent (a new context — never the failed
+dev/review sessions) to produce a constrained advisory report, and records both
+on the state for the audit trail. The pending-gate wiring that turns the report
+into an operator selection lives in ``pending_hitl``/``review_phase``; this module
+owns packet construction and the agent invocation.
+
+The advisor is a reasoning agent that produces *advice* for a human — it does not
+make a routing decision. The coordinator stays pure Python: it requires the
+operator to select an action and never auto-acts on the advisor's recommendation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from theforge.escalation_advisor import (
+    CycleEvidence,
+    EvidencePacket,
+    parse_advisory_report,
+)
+from theforge.task.advisor_prompts import build_advisor_prompt
+
+from . import util as _cu
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from theforge.config import ForgeConfig
+    from theforge.escalation_advisor import AdvisoryReport
+    from theforge.task import TaskStory
+
+    from .state import CoordinatorState
+
+_log = _cu._log
+_log_verbose = _cu._log_verbose
+
+# ── Lazy runner slots (mirrors preflight_flow) ────────────────────────────────
+# None until first call; tests may replace before invoking the advisor.
+# Patch targets:
+#   theforge.coordinator.escalation_advisor_flow.run_agent
+#   theforge.coordinator.escalation_advisor_flow.log_agent_result
+run_agent = None
+log_agent_result = None
+
+# Cap the dev-diff captured into the packet so a large change cannot balloon the
+# advisor prompt.
+_DIFF_MAX_BYTES = 20_000
+
+
+def _ensure_runners() -> None:
+    global run_agent, log_agent_result
+    if run_agent is not None and log_agent_result is not None:
+        return
+    import theforge.runners as _r  # noqa: PLC0415
+
+    if run_agent is None:
+        run_agent = _r.run_agent
+    if log_agent_result is None:
+        log_agent_result = _r.log_agent_result
+
+
+def _issue_ref(task: "TaskStory") -> str:
+    if task.github_issue:
+        return f"#{task.github_issue}"
+    return task.slug
+
+
+def _extract_acceptance_criteria(story_body: str) -> list[str]:
+    """Extract acceptance-criteria bullet lines from a story body.
+
+    Looks for an ``## Acceptance criteria`` (or ``### ...``) heading and collects
+    the bullet items beneath it until the next heading. Best-effort: returns an
+    empty list when no such section is present (the full body is still in the
+    packet).
+    """
+    lines = story_body.splitlines()
+    criteria: list[str] = []
+    in_section = False
+    for raw in lines:
+        line = raw.strip()
+        lowered = line.lower()
+        if lowered.startswith("#"):
+            heading = lowered.lstrip("#").strip()
+            if in_section:
+                # A new heading ends the AC section.
+                if heading.startswith("acceptance"):
+                    continue
+                break
+            if heading.startswith("acceptance"):
+                in_section = True
+            continue
+        if in_section and (line.startswith("- ") or line.startswith("* ")):
+            criteria.append(line[2:].strip())
+    return criteria
+
+
+def _capture_dev_diff(workspace_path: "Path", base_branch: str) -> str:
+    """Capture a bounded summary of the dev's work: commit log + diffstat + diff."""
+    from pathlib import Path  # noqa: PLC0415
+
+    if workspace_path is None or not Path(workspace_path).exists():
+        return ""
+    parts: list[str] = []
+    ok_log, log_out = _cu._run_shell(
+        f"git log --oneline {base_branch}..HEAD", Path(workspace_path)
+    )
+    if ok_log and log_out.strip():
+        parts.append("commits:\n" + log_out.strip())
+    ok_stat, stat_out = _cu._run_shell(
+        f"git diff --stat {base_branch}...HEAD", Path(workspace_path)
+    )
+    if ok_stat and stat_out.strip():
+        parts.append("diffstat:\n" + stat_out.strip())
+    ok_diff, diff_out = _cu._run_shell(f"git diff {base_branch}...HEAD", Path(workspace_path))
+    if ok_diff and diff_out.strip():
+        diff = diff_out.strip()
+        if len(diff) > _DIFF_MAX_BYTES:
+            diff = diff[:_DIFF_MAX_BYTES] + "\n… (diff truncated)"
+        parts.append("diff:\n" + diff)
+    return "\n\n".join(parts)
+
+
+def _capture_test_failures(state: "CoordinatorState") -> str:
+    """Distil gate/test failure evidence from the escalated state."""
+    parts: list[str] = []
+    if state.gate_decisions:
+        parts.append(f"last gate result: {state.gate_decisions[-1]}")
+    if state.review_results:
+        last = state.review_results[-1]
+        if not last.test_adequate and last.test_gaps:
+            parts.append("test coverage gaps: " + "; ".join(last.test_gaps))
+    return "\n".join(parts)
+
+
+def build_evidence_packet(
+    state: "CoordinatorState",
+    task: "TaskStory",
+    config: "ForgeConfig",
+    workspace_path: "Path",
+) -> EvidencePacket:
+    """Assemble the fresh-advisor evidence packet from the escalated run's state.
+
+    Pulls the issue body + acceptance criteria, the per-cycle review
+    summaries/findings/verdicts, the dev diff, gate/test failures, and the final
+    escalation reason. Never carries the dev/review agent sessions.
+    """
+    story_body = state.story_content or task.story_text or ""
+    acceptance_criteria = _extract_acceptance_criteria(story_body)
+
+    cycles: list[CycleEvidence] = []
+    for entry in state.cycle_history:
+        cycles.append(
+            CycleEvidence(
+                cycle=entry.cycle,
+                verdict=entry.verdict,
+                summary=entry.summary,
+                findings=list(entry.p1_findings),
+            )
+        )
+    # Fall back to review_results when cycle_history was not populated (e.g. the
+    # reviewer pool never produced a candidate) so the packet is never cycle-empty.
+    if not cycles and state.review_results:
+        for i, rr in enumerate(state.review_results, start=1):
+            cycles.append(
+                CycleEvidence(
+                    cycle=i,
+                    verdict=rr.verdict,
+                    summary=rr.summary,
+                    findings=[f.description for f in rr.findings],
+                )
+            )
+
+    reviewer_verdicts = {name: rr.verdict for name, rr in state.last_cycle_reviewer_results}
+    final_verdict = state.review_results[-1].verdict if state.review_results else None
+
+    base_branch = config.workspace.base_branch
+    dev_diff = _capture_dev_diff(workspace_path, base_branch)
+    test_failures = _capture_test_failures(state)
+
+    return EvidencePacket(
+        story_name=task.name,
+        issue_ref=_issue_ref(task),
+        issue_body=story_body,
+        acceptance_criteria=acceptance_criteria,
+        cycles=cycles,
+        reviewer_verdicts=reviewer_verdicts,
+        final_verdict=final_verdict,
+        dev_diff=dev_diff,
+        test_failures=test_failures,
+        escalation_reason=state.error or state.escalate_reason or "ESCALATE",
+    )
+
+
+def run_escalation_advisor(
+    state: "CoordinatorState",
+    config: "ForgeConfig",
+    task: "TaskStory",
+    workspace_path: "Path",
+) -> "AdvisoryReport | None":
+    """Generate a fresh-context advisory report for an escalated story.
+
+    Assembles the evidence packet, invokes the advisor agent in a fresh context
+    (the preflight profile, run against a clean baseline checkout — never the
+    failed dev/review sessions), parses the output through the schema boundary,
+    and records the packet + report on ``state`` for the audit trail.
+
+    Returns the parsed ``AdvisoryReport`` (which may carry ``parse_errors``), or
+    ``None`` when the advisor could not be invoked at all. Callers treat a missing
+    or errored report as "preserve the escalation" — never as an auto-decision.
+    """
+    _ensure_runners()
+
+    packet = build_evidence_packet(state, task, config, workspace_path)
+    state.advisory_packet = packet.to_dict()
+
+    prompt = build_advisor_prompt(packet)
+    profile = config.preflight_profile
+
+    _log("─── Escalation Advisor (fresh context) ───")
+    _log(f"  Profile: {profile.model}")
+    _log(f"  Evidence: {len(packet.cycles)} cycle(s), issue {packet.issue_ref}")
+
+    from .preflight_flow import _prepare_preflight_working_dir  # noqa: PLC0415
+
+    baseline_dir: "Path | None" = None
+    cleanup = None
+    try:
+        baseline_dir, cleanup = _prepare_preflight_working_dir(
+            config.project_root, config.workspace.base_branch
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        _log(f"  ⚠ advisor baseline checkout failed: {exc}; using workspace")
+        baseline_dir = workspace_path
+
+    try:
+        result = run_agent(
+            prompt=prompt,
+            profile=profile,
+            working_dir=baseline_dir,
+            secrets=config.secrets,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        _log(f"  ⚠ advisor invocation failed: {exc}")
+        state.advisory_generated = False
+        return None
+    finally:
+        if cleanup is not None:
+            cleanup()
+
+    log_agent_result(result, "ESCALATION_ADVISOR")
+    if not getattr(result, "success", False):
+        _log("  ⚠ advisor agent returned failure — preserving escalation")
+        state.advisory_generated = False
+        return None
+
+    report = parse_advisory_report(result.output or "")
+    state.advisory_report = report.to_dict()
+    state.advisory_generated = report.ok
+    if report.ok:
+        _log(
+            f"  Advisory recommendation: {report.recommendation} ({len(report.options)} option(s))"
+        )
+    else:
+        _log(f"  ⚠ advisory report failed validation: {report.parse_errors}")
+    return report

--- a/src/theforge/coordinator/pending_hitl.py
+++ b/src/theforge/coordinator/pending_hitl.py
@@ -10,6 +10,7 @@ from . import util as _cu
 
 if TYPE_CHECKING:
     from theforge.config import ForgeConfig
+    from theforge.escalation_advisor import AdvisoryReport, EvidencePacket
     from theforge.review import ReviewResult
     from theforge.task import TaskStory
 
@@ -97,9 +98,25 @@ def _pending_escalate_gate(
     reviewer_verdicts: dict[str, str],
     gate_result: "str | None",
     run_id: str = "",
+    advisory: "AdvisoryReport | None" = None,
 ) -> str:
-    """Pending-file-based escalate gate. Returns 'approve' | 'reject' | 'continue'."""
+    """Pending-file-based escalate gate with a fresh-context advisory report.
+
+    When ``advisory`` is a valid report, the pending file presents the fixed
+    action taxonomy (Accept / Land-core-defer-edges / Redirect / Decompose /
+    Elevate / Defer-or-Abandon) as the options and embeds the report + evidence
+    packet as structured payload; the operator must select one of those actions.
+
+    The max-cycles path no longer auto-rejects on timeout: a timeout returns
+    ``"timeout"`` so the caller preserves the escalation for an operator decision
+    rather than discarding the work. Returns the selected taxonomy action (or a
+    legacy ``approve``/``reject``/``continue`` value), or ``"timeout"``.
+    """
     from theforge import pending as _pending
+    from theforge.escalation_advisor import (
+        ACTION_TAXONOMY,
+        render_advisory_for_pending,
+    )
     from theforge.notify_backends import send_notifications
 
     timeout_seconds = config.notifications.human_review_timeout_seconds
@@ -109,23 +126,50 @@ def _pending_escalate_gate(
         f"{approve_count}/{total_count} reviewers APPROVE" if reviewer_verdicts else "no verdicts"
     )
     gate_line = gate_result or ""
-    reason = "\n".join(filter(None, [verdict_line, gate_line, escalate_reason[:120]]))
 
     _eff_run_id = run_id or task.slug
     project_root = getattr(config, "project_root", None)
 
+    advisory_ok = advisory is not None and advisory.ok
+    if advisory_ok:
+        options = list(ACTION_TAXONOMY)
+        extra: dict = {
+            "advisory": advisory.to_dict(),
+            "evidence_packet": state.advisory_packet,
+            "decision_required": True,
+        }
+        reason = render_advisory_for_pending(advisory, _build_packet_stub(state, escalate_reason))
+    else:
+        # No usable advisory (agent failed / malformed). Still require an explicit
+        # operator decision — surface the taxonomy plus the raw escalation context.
+        options = list(ACTION_TAXONOMY)
+        extra = {"decision_required": True, "advisory_unavailable": True}
+        reason = "\n".join(
+            filter(
+                None,
+                [
+                    "ESCALATION — advisory report unavailable; select an action.",
+                    verdict_line,
+                    gate_line,
+                    escalate_reason[:200],
+                ],
+            )
+        )
+
     _cu._log("─── Pending Escalate Gate ───")
     _cu._log(f"  Run ID:  {_eff_run_id}")
     _cu._log(f"  Timeout: {_cu._fmt_duration(timeout_seconds)}")
+    _cu._log(f"  Options: {', '.join(options)}")
 
     _pending.write_pending(
         run_id=_eff_run_id,
         story=task.slug,
         phase="ESCALATE",
         reason=reason,
-        options=["approve", "reject", "continue"],
+        options=options,
         timeout_seconds=timeout_seconds,
         project_root=project_root,
+        extra=extra,
     )
 
     send_notifications(
@@ -145,13 +189,49 @@ def _pending_escalate_gate(
 
     waited_str = _cu._fmt_duration(waited)
     if decision == "timeout":
-        _cu._log(f"  Escalate gate timed out after {waited_str} — auto-rejecting")
-        return "reject"
+        # Contract change (#1664): no auto-reject. Preserve the escalation and its
+        # advisory report so the operator can still select an action.
+        _cu._log(
+            f"  Escalate gate timed out after {waited_str} — preserving for operator decision"
+            " (no auto-reject)"
+        )
+        return "timeout"
 
     _cu._log(f"  Escalate gate decision: {decision!r} (waited {waited_str})")
-    if decision in ("approve", "reject", "continue"):
-        return decision
-    return "reject"
+    return decision
+
+
+def _build_packet_stub(state: "_cs.CoordinatorState", escalate_reason: str) -> "EvidencePacket":
+    """Reconstruct a lightweight EvidencePacket from the serialized state payload.
+
+    ``render_advisory_for_pending`` only reads a few packet fields (story name,
+    issue ref, escalation reason, cycle count); rebuild those from the audit dict
+    stored on state so rendering does not require threading the live packet.
+    """
+    from theforge.escalation_advisor import CycleEvidence, EvidencePacket
+
+    payload = state.advisory_packet or {}
+    cycles = [
+        CycleEvidence(
+            cycle=int(c.get("cycle") or 0),
+            verdict=str(c.get("verdict") or ""),
+            summary=str(c.get("summary") or ""),
+            findings=list(c.get("findings") or []),
+        )
+        for c in (payload.get("cycles") or [])
+    ]
+    return EvidencePacket(
+        story_name=str(payload.get("story_name") or ""),
+        issue_ref=str(payload.get("issue_ref") or ""),
+        issue_body=str(payload.get("issue_body") or ""),
+        acceptance_criteria=list(payload.get("acceptance_criteria") or []),
+        cycles=cycles,
+        reviewer_verdicts=dict(payload.get("reviewer_verdicts") or {}),
+        final_verdict=payload.get("final_verdict"),
+        dev_diff=str(payload.get("dev_diff") or ""),
+        test_failures=str(payload.get("test_failures") or ""),
+        escalation_reason=str(payload.get("escalation_reason") or escalate_reason),
+    )
 
 
 def _pending_plan_review(

--- a/src/theforge/coordinator/pending_hitl.py
+++ b/src/theforge/coordinator/pending_hitl.py
@@ -185,18 +185,37 @@ def _pending_escalate_gate(
     waited = time.monotonic() - _poll_start
     state.human_review_waited_seconds = (state.human_review_waited_seconds or 0.0) + waited
 
-    _pending.cleanup_pending(_eff_run_id, project_root)
-
     waited_str = _cu._fmt_duration(waited)
     if decision == "timeout":
-        # Contract change (#1664): no auto-reject. Preserve the escalation and its
-        # advisory report so the operator can still select an action.
+        # Contract change (#1664): no auto-reject. PRESERVE the pending checkpoint
+        # so the operator can still select an action — do NOT delete the file here
+        # (deleting it would leave the operator with nothing to resolve). Rewrite
+        # it with a refreshed window and an awaiting-decision marker so the stale
+        # sweeper does not immediately remove the still-actionable record and the
+        # advisory report + taxonomy options remain available for selection.
+        extra["timed_out_awaiting_decision"] = True
+        preserve_reason = (
+            "ESCALATION TIMED OUT — awaiting an operator action selection "
+            "(no auto-reject).\n\n" + reason
+        )
+        _pending.write_pending(
+            run_id=_eff_run_id,
+            story=task.slug,
+            phase="ESCALATE",
+            reason=preserve_reason,
+            options=options,
+            timeout_seconds=timeout_seconds,
+            project_root=project_root,
+            extra=extra,
+        )
         _cu._log(
-            f"  Escalate gate timed out after {waited_str} — preserving for operator decision"
-            " (no auto-reject)"
+            f"  Escalate gate timed out after {waited_str} — pending checkpoint preserved"
+            f" for operator decision (no auto-reject): {_eff_run_id}"
         )
         return "timeout"
 
+    # A decision was made — clean up the resolved pending file and return it.
+    _pending.cleanup_pending(_eff_run_id, project_root)
     _cu._log(f"  Escalate gate decision: {decision!r} (waited {waited_str})")
     return decision
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -295,16 +295,22 @@ def _run_escalate_gate(
 
     if disposition == "preserve":
         # Timeout with no explicit selection: the contract change (#1664) is that
-        # this preserves the escalation + advisory report for an operator decision
-        # rather than auto-rejecting and discarding the work.
+        # this preserves the escalation for an operator decision rather than
+        # auto-rejecting and discarding the work. Only the pending-file path
+        # generates an advisory report; remote/interactive timeouts preserve too
+        # but without one, so vary the message on what was actually produced.
         _log("  Escalate gate: no selection (timeout) — preserving for operator decision")
-        return _make_escalate_result(
-            "advisory_pending",
-            message=(
+        if state.advisory_generated:
+            preserve_message = (
                 "Escalation preserved: an advisory report was generated and an "
                 "operator action selection is still required (no auto-reject)."
-            ),
-        )
+            )
+        else:
+            preserve_message = (
+                "Escalation preserved: an operator action selection is still "
+                "required (no auto-reject)."
+            )
+        return _make_escalate_result("advisory_pending", message=preserve_message)
 
     # reject / defer_or_abandon / any unrecognised decision
     return _make_escalate_result("reject")

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -12,6 +12,12 @@ from pathlib import Path
 
 from theforge.config import ForgeConfig, apply_model_info
 from theforge.coordinator.context_scope import plan_file_list
+from theforge.escalation_advisor import (
+    ACTION_FORGE_OPERATIONS,
+    ACTION_LABELS,
+    ACTION_TAXONOMY,
+    action_disposition,
+)
 from theforge.review import (
     ReviewFinding,
     ReviewResult,
@@ -22,6 +28,7 @@ from theforge.task import ContextAssembler, TaskStory, build_review_prompt
 
 from .commit_guard import _has_commits_ahead_of_base
 from .completion import _append_cycle_history, _finalize_approve
+from .escalation_advisor_flow import run_escalation_advisor
 from .logging import StructuredLogger
 from .notify import (
     _escalate_gate_interactive,
@@ -137,15 +144,17 @@ def _run_escalate_gate(
 
     escalate_reason = state.error or "ESCALATE"
 
-    def _make_escalate_result() -> CoordinatorResult:
-        state.escalate_decision = "reject"
+    def _make_escalate_result(
+        decision: str = "reject", message: str | None = None
+    ) -> CoordinatorResult:
+        state.escalate_decision = decision
         state.escalate_reason = escalate_reason
         _escalate_notify(task, state, notify, config)
         return CoordinatorResult(
             success=False,
             phase=state.phase,
             state=state,
-            message=state.error or escalate_reason,
+            message=message or state.error or escalate_reason,
         )
 
     # Policy: reject — preserve current behavior without prompting
@@ -192,8 +201,18 @@ def _run_escalate_gate(
 
     # Determine interaction method
     if _is_pending_file_mode(notify, config):
+        # Generate a fresh-context advisory report so the operator selects from the
+        # fixed action taxonomy instead of the system auto-rejecting on timeout.
+        advisory = run_escalation_advisor(state, config, task, workspace_path)
         decision = _pending_escalate_gate(
-            state, task, config, escalate_reason, reviewer_verdicts, gate_result, run_id=run_id
+            state,
+            task,
+            config,
+            escalate_reason,
+            reviewer_verdicts,
+            gate_result,
+            run_id=run_id,
+            advisory=advisory,
         )
     elif _is_remote_mode(notify, config):
         decision = _escalate_gate_remote(
@@ -210,12 +229,27 @@ def _run_escalate_gate(
 
     state.escalate_reason = escalate_reason
 
-    if decision == "approve":
+    # Normalise legacy (approve/reject/continue) and taxonomy actions into a
+    # coordinator disposition. Taxonomy actions come from the advisory-backed
+    # pending gate; approve/continue/reject may still come from interactive/remote.
+    norm = (decision or "").strip().lower()
+    if norm in ACTION_TAXONOMY:
+        state.escalate_selected_action = norm
+        disposition = action_disposition(norm)  # "approve" | "reject" | "named"
+    elif norm == "approve":
+        disposition = "approve"
+    elif norm == "continue":
+        disposition = "continue"
+    elif norm == "timeout":
+        disposition = "preserve"
+    else:
+        disposition = "reject"
+
+    if disposition == "approve":
         if not state.review_results:
             _log("  ⚠ Approve requested but no review results available — rejecting instead")
-            state.escalate_decision = "reject"
-            return _make_escalate_result()
-        state.escalate_decision = "approve"
+            return _make_escalate_result("reject")
+        state.escalate_decision = norm if norm in ACTION_TAXONOMY else "approve"
         _append_cycle_history(state, state.review_results[-1])
         return _finalize_approve(
             state,
@@ -237,15 +271,43 @@ def _run_escalate_gate(
             run_id=run_id,
         )
 
-    if decision == "continue":
+    if disposition == "continue":
         state.escalate_decision = "continue"
         _log("  Escalate gate: continue — granting one more review cycle")
         state.phase = Phase.REVIEW
         return None
 
-    # reject or any unrecognised decision
-    state.escalate_decision = "reject"
-    return _make_escalate_result()
+    if disposition == "named":
+        # A middle-taxonomy action (redirect / decompose / elevate /
+        # land-core-defer-edges): v1 names the concrete forge operation and
+        # preserves the worktree for the operator to run it — it is not an
+        # auto-reject that discards the work.
+        op = ACTION_FORGE_OPERATIONS.get(norm, norm)
+        label = ACTION_LABELS.get(norm, norm)
+        _log(f"  Escalate gate: {label} selected — next operation: {op}")
+        return _make_escalate_result(
+            norm,
+            message=(
+                f"Escalation resolved as {label}: {op}. "
+                f"Worktree preserved for the operator to run the named operation."
+            ),
+        )
+
+    if disposition == "preserve":
+        # Timeout with no explicit selection: the contract change (#1664) is that
+        # this preserves the escalation + advisory report for an operator decision
+        # rather than auto-rejecting and discarding the work.
+        _log("  Escalate gate: no selection (timeout) — preserving for operator decision")
+        return _make_escalate_result(
+            "advisory_pending",
+            message=(
+                "Escalation preserved: an advisory report was generated and an "
+                "operator action selection is still required (no auto-reject)."
+            ),
+        )
+
+    # reject / defer_or_abandon / any unrecognised decision
+    return _make_escalate_result("reject")
 
 
 def _record_review_iteration_telemetry(

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -414,7 +414,11 @@ class CoordinatorState:
     last_dev_start_commit: str | None = None
     # HEAD commit hash captured before each dev iteration; used by finding_classifier
     # to compute git diff --name-only for changed-file correlation.
-    escalate_decision: str | None = None  # "approve" | "reject" | "continue"
+    # Legacy values: "approve" | "reject" | "continue". Since #1664 this field may
+    # also hold a taxonomy action (see escalation_advisor.ACTION_TAXONOMY: accept,
+    # land_core_defer_edges, redirect, decompose, elevate, defer_or_abandon) or
+    # "advisory_pending" when an escalation timed out awaiting an operator decision.
+    escalate_decision: str | None = None
     escalate_reason: str | None = None  # human-readable escalation reason
     # Fresh-context escalation advisor (issue #1664). The advisor reads a prepared
     # evidence packet and emits a constrained menu of action choices; the operator

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -416,6 +416,14 @@ class CoordinatorState:
     # to compute git diff --name-only for changed-file correlation.
     escalate_decision: str | None = None  # "approve" | "reject" | "continue"
     escalate_reason: str | None = None  # human-readable escalation reason
+    # Fresh-context escalation advisor (issue #1664). The advisor reads a prepared
+    # evidence packet and emits a constrained menu of action choices; the operator
+    # must select one. These fields keep the packet, report, and selected action
+    # visible in the audit trail so an escalation decision can be traced.
+    escalate_selected_action: str | None = None  # taxonomy action the operator selected
+    advisory_generated: bool = False  # True when a valid advisory report was produced
+    advisory_packet: dict | None = None  # serialized EvidencePacket fed to the advisor
+    advisory_report: dict | None = None  # serialized AdvisoryReport the advisor produced
     # Structured escalation kind: "hygiene" (workspace mutation by a non-DEV phase),
     # "content" (review or gate found a real problem), or None when there is no
     # active escalation. Distinct from escalate_reason so resume can tell the two

--- a/src/theforge/escalation_advisor.py
+++ b/src/theforge/escalation_advisor.py
@@ -1,0 +1,390 @@
+"""Escalation advisor: fixed action taxonomy, evidence packet, and report parsing.
+
+When a story escalates (max review cycles exhausted, dev cannot converge), the
+old dead-end was: max-cycles → human-decision timeout → auto-reject. This module
+is the pure-data + integrity boundary for the replacement: a **fresh-context
+advisory report** that reads a prepared **evidence packet** and emits a small,
+constrained menu of evidence-backed action choices. The operator must then
+select one of those actions — the system no longer auto-rejects on timeout.
+
+This module is deliberately low-dependency (stdlib + yaml only): it holds the
+pure-data types (``EvidencePacket``, ``AdvisoryOption``, ``AdvisoryReport``), the
+fixed action taxonomy, and the parser/validator that is the schema integrity
+boundary for advisor output. Prompt construction lives in
+``theforge.task.advisor_prompts``; the coordinator control flow that invokes the
+fresh agent and wires the pending gate lives in
+``theforge.coordinator.escalation_advisor_flow``.
+
+The advisor's recommendation MUST be one of the fixed taxonomy values — free-form
+prose is not an allowed output. Each presented option carries four fields:
+evidence (cited from the packet), action (the concrete forge operation), risk,
+and consequence (what happens if selected).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+import yaml
+
+# ── Fixed action taxonomy ─────────────────────────────────────────────────────
+#
+# The advisor's recommendation and every presented option's ``action`` field must
+# be one of these values. This is the constrained-output contract: the advisor
+# routes an escalation into exactly one of these, never free-form prose.
+ACTION_TAXONOMY: tuple[str, ...] = (
+    "accept",
+    "land_core_defer_edges",
+    "redirect",
+    "decompose",
+    "elevate",
+    "defer_or_abandon",
+)
+
+# Human-readable label per taxonomy action, for rendering the pending report.
+ACTION_LABELS: dict[str, str] = {
+    "accept": "Accept",
+    "land_core_defer_edges": "Land-core-defer-edges",
+    "redirect": "Redirect",
+    "decompose": "Decompose",
+    "elevate": "Elevate",
+    "defer_or_abandon": "Defer-or-Abandon",
+}
+
+# Each taxonomy action names the concrete forge operation it maps to. In v1 the
+# report *names* the operation for every action; mechanical one-click execution
+# is wired only for the accept/defer endpoints (approve/reject), while the middle
+# actions preserve the worktree and surface the named next operation so the
+# operator can run it. This mapping is the single discoverable place that ties
+# the taxonomy to forge operations.
+ACTION_FORGE_OPERATIONS: dict[str, str] = {
+    "accept": "merge (finalize the current work as-is)",
+    "land_core_defer_edges": "land-core (merge the core, file follow-ups for the edges)",
+    "redirect": "re-run with constraint (re-dev under a corrected framing)",
+    "decompose": "split (break the story into smaller runnable pieces)",
+    "elevate": "bump (route to a human design/architecture decision)",
+    "defer_or_abandon": "defer (defer or abandon the story)",
+}
+
+# Coordinator disposition each taxonomy action normalises to at the escalate gate.
+#   approve  → finalize/merge the current work
+#   reject   → escalate-reject (defer/abandon)
+#   named    → preserve the worktree and surface the named next operation
+_ACTION_DISPOSITIONS: dict[str, str] = {
+    "accept": "approve",
+    "defer_or_abandon": "reject",
+    "land_core_defer_edges": "named",
+    "redirect": "named",
+    "decompose": "named",
+    "elevate": "named",
+}
+
+_OPEN_TAG = "<advisory_report>"
+_CLOSE_TAG = "</advisory_report>"
+_FENCED_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+
+# Cap long free-text fields so a runaway agent cannot balloon the packet/report.
+_FIELD_MAX_LEN = 2000
+
+
+def action_disposition(action: str) -> str:
+    """Return the coordinator disposition for a taxonomy action.
+
+    One of ``"approve"`` | ``"reject"`` | ``"named"``. Unknown actions map to
+    ``"reject"`` (fail closed) so a malformed selection never silently merges.
+    """
+    return _ACTION_DISPOSITIONS.get((action or "").strip().lower(), "reject")
+
+
+# ── Evidence packet ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CycleEvidence:
+    """One review cycle's outcome, distilled for the evidence packet.
+
+    The churn pattern across cycles — what reviewers kept flagging, what the dev
+    kept re-breaking — is the most valuable escalation signal, so each cycle
+    carries its verdict, summary, and the finding descriptions that fired.
+    """
+
+    cycle: int
+    verdict: str  # "APPROVE" | "REQUEST_CHANGES"
+    summary: str
+    findings: list[str] = field(default_factory=list)  # finding descriptions this cycle
+
+
+@dataclass(frozen=True)
+class EvidencePacket:
+    """Prepared evidence a fresh advisor reads to recommend an action.
+
+    Assembled by the coordinator (``escalation_advisor_flow.build_evidence_packet``)
+    from the escalated run's state: the issue body + acceptance criteria, the
+    per-cycle review summaries/findings/verdicts, the dev diff, any test/gate
+    failure output, and the final escalation reason. It never contains the failed
+    dev/review agents' sessions — the advisor runs in a fresh context.
+    """
+
+    story_name: str
+    issue_ref: str  # "#1365" or slug — for citing evidence
+    issue_body: str
+    acceptance_criteria: list[str]
+    cycles: list[CycleEvidence]
+    reviewer_verdicts: dict[str, str]
+    final_verdict: str | None
+    dev_diff: str
+    test_failures: str
+    escalation_reason: str
+
+    def to_dict(self) -> dict:
+        """Serialise the packet for the audit trail."""
+        return {
+            "story_name": self.story_name,
+            "issue_ref": self.issue_ref,
+            "issue_body": self.issue_body,
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "cycles": [
+                {
+                    "cycle": c.cycle,
+                    "verdict": c.verdict,
+                    "summary": c.summary,
+                    "findings": list(c.findings),
+                }
+                for c in self.cycles
+            ],
+            "reviewer_verdicts": dict(self.reviewer_verdicts),
+            "final_verdict": self.final_verdict,
+            "dev_diff": self.dev_diff,
+            "test_failures": self.test_failures,
+            "escalation_reason": self.escalation_reason,
+        }
+
+
+# ── Advisory report ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AdvisoryOption:
+    """One evidence-backed action choice presented to the operator.
+
+    Every option carries the four required fields: cited ``evidence`` from the
+    packet, the concrete ``action`` (forge operation), the ``risk`` of taking it,
+    and the ``consequence`` of selecting it.
+    """
+
+    action: str  # one of ACTION_TAXONOMY
+    evidence: str
+    forge_operation: str  # concrete forge operation named for this action
+    risk: str
+    consequence: str
+
+    def to_dict(self) -> dict:
+        return {
+            "action": self.action,
+            "action_label": ACTION_LABELS.get(self.action, self.action),
+            "evidence": self.evidence,
+            "forge_operation": self.forge_operation,
+            "risk": self.risk,
+            "consequence": self.consequence,
+        }
+
+
+@dataclass(frozen=True)
+class AdvisoryReport:
+    """A parsed, validated advisory report.
+
+    ``recommendation`` is one of ``ACTION_TAXONOMY`` and must appear among the
+    presented ``options``. ``parse_errors`` is non-empty when the raw advisor
+    output failed schema validation; callers treat a report with parse errors as
+    unusable and fall back to preserving the escalation.
+    """
+
+    recommendation: str  # one of ACTION_TAXONOMY
+    rationale: str
+    options: list[AdvisoryOption]
+    parse_errors: list[str] = field(default_factory=list)
+    raw: dict = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return not self.parse_errors
+
+    def recommended_option(self) -> AdvisoryOption | None:
+        for opt in self.options:
+            if opt.action == self.recommendation:
+                return opt
+        return None
+
+    def to_dict(self) -> dict:
+        return {
+            "recommendation": self.recommendation,
+            "recommendation_label": ACTION_LABELS.get(self.recommendation, self.recommendation),
+            "rationale": self.rationale,
+            "options": [o.to_dict() for o in self.options],
+            "parse_errors": list(self.parse_errors),
+        }
+
+
+def _truncate(value: object) -> str:
+    text = "" if value is None else str(value).strip()
+    if len(text) > _FIELD_MAX_LEN:
+        return text[: _FIELD_MAX_LEN - 1] + "…"
+    return text
+
+
+def _extract_advisory_block(text: str) -> str | None:
+    """Return the YAML body inside <advisory_report>…</advisory_report>, or None.
+
+    Fenced code blocks are stripped first so an advisor quoting the schema spec
+    in prose does not produce a false match.
+    """
+    stripped = _FENCED_BLOCK_RE.sub("", text)
+    open_positions = [m.start() for m in re.finditer(re.escape(_OPEN_TAG), stripped)]
+    close_positions = [m.start() for m in re.finditer(re.escape(_CLOSE_TAG), stripped)]
+    if not open_positions or not close_positions:
+        return None
+    open_pos = open_positions[0]
+    close_pos = close_positions[0]
+    if close_pos < open_pos + len(_OPEN_TAG):
+        return None
+    body = stripped[open_pos + len(_OPEN_TAG) : close_pos].strip()
+    return body or None
+
+
+def _error_report(errors: list[str], raw: dict | None = None) -> AdvisoryReport:
+    return AdvisoryReport(
+        recommendation="",
+        rationale="",
+        options=[],
+        parse_errors=errors,
+        raw=raw or {},
+    )
+
+
+def parse_advisory_report(text: str) -> AdvisoryReport:
+    """Parse and validate advisor output into an ``AdvisoryReport``.
+
+    This is the schema integrity boundary for advisor output. Validation rules:
+
+    * an ``<advisory_report>`` block must be present and parse as a YAML mapping,
+    * ``recommendation`` must be one of ``ACTION_TAXONOMY``,
+    * ``options`` must be a non-empty list; each option's ``action`` must be a
+      taxonomy value and it must carry non-empty ``evidence``, ``risk``, and
+      ``consequence``,
+    * the ``recommendation`` must appear among the options' actions.
+
+    Any violation yields a report with ``parse_errors`` populated (and empty
+    recommendation/options) so the caller fails closed rather than acting on a
+    malformed recommendation.
+    """
+    body = _extract_advisory_block(text)
+    if body is None:
+        return _error_report(["no <advisory_report> block found in advisor output"])
+
+    try:
+        data = yaml.safe_load(body)
+    except yaml.YAMLError as exc:
+        return _error_report([f"YAML parse error in advisory report: {exc}"])
+
+    if not isinstance(data, dict):
+        return _error_report(
+            [f"advisory report must be a YAML mapping, got {type(data).__name__}"]
+        )
+
+    errors: list[str] = []
+
+    recommendation = str(data.get("recommendation") or "").strip().lower()
+    if recommendation not in ACTION_TAXONOMY:
+        errors.append(
+            f"recommendation must be one of {list(ACTION_TAXONOMY)}, got {recommendation!r}"
+        )
+
+    rationale = _truncate(data.get("rationale"))
+
+    raw_options = data.get("options")
+    options: list[AdvisoryOption] = []
+    if not isinstance(raw_options, list) or not raw_options:
+        errors.append("options must be a non-empty list")
+    else:
+        for i, opt in enumerate(raw_options):
+            if not isinstance(opt, dict):
+                errors.append(f"option[{i}] must be a mapping")
+                continue
+            action = str(opt.get("action") or "").strip().lower()
+            if action not in ACTION_TAXONOMY:
+                errors.append(
+                    f"option[{i}].action must be one of {list(ACTION_TAXONOMY)}, got {action!r}"
+                )
+            evidence = _truncate(opt.get("evidence"))
+            risk = _truncate(opt.get("risk"))
+            consequence = _truncate(opt.get("consequence"))
+            forge_operation = _truncate(
+                opt.get("forge_operation")
+                or opt.get("operation")
+                or ACTION_FORGE_OPERATIONS.get(action, "")
+            )
+            for field_name, val in (
+                ("evidence", evidence),
+                ("risk", risk),
+                ("consequence", consequence),
+            ):
+                if not val:
+                    errors.append(f"option[{i}] ({action or '?'}) missing {field_name}")
+            options.append(
+                AdvisoryOption(
+                    action=action,
+                    evidence=evidence,
+                    forge_operation=forge_operation,
+                    risk=risk,
+                    consequence=consequence,
+                )
+            )
+
+    # Cross-validation: the recommendation must be one of the presented options.
+    if recommendation in ACTION_TAXONOMY and options:
+        if recommendation not in {o.action for o in options}:
+            errors.append(f"recommendation {recommendation!r} is not present among the options")
+
+    if errors:
+        return _error_report(errors, raw=data if isinstance(data, dict) else {})
+
+    return AdvisoryReport(
+        recommendation=recommendation,
+        rationale=rationale,
+        options=options,
+        parse_errors=[],
+        raw=data,
+    )
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+
+def render_advisory_for_pending(report: AdvisoryReport, packet: EvidencePacket) -> str:
+    """Render a human-readable advisory summary for the pending decision file.
+
+    This is the ``reason`` an operator sees when deciding. It leads with the
+    recommendation and then lists each option with its evidence, forge operation,
+    risk, and consequence so the choice is legible without opening the raw packet.
+    """
+    lines: list[str] = []
+    lines.append(f"ESCALATION ADVISORY — {packet.story_name} ({packet.issue_ref})")
+    lines.append(f"Escalation reason: {packet.escalation_reason}")
+    lines.append(f"Review cycles: {len(packet.cycles)}")
+    rec_label = ACTION_LABELS.get(report.recommendation, report.recommendation)
+    lines.append("")
+    lines.append(f"RECOMMENDED ACTION: {rec_label}")
+    if report.rationale:
+        lines.append(f"  Rationale: {report.rationale}")
+    lines.append("")
+    lines.append("Options (select one):")
+    for opt in report.options:
+        label = ACTION_LABELS.get(opt.action, opt.action)
+        marker = " ← recommended" if opt.action == report.recommendation else ""
+        lines.append(f"  • {label} [{opt.action}]{marker}")
+        lines.append(f"      operation: {opt.forge_operation}")
+        lines.append(f"      evidence: {opt.evidence}")
+        lines.append(f"      risk: {opt.risk}")
+        lines.append(f"      consequence: {opt.consequence}")
+    return "\n".join(lines)

--- a/src/theforge/pending.py
+++ b/src/theforge/pending.py
@@ -34,8 +34,14 @@ def write_pending(
     options: list[str],
     timeout_seconds: int,
     project_root: Path | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> Path:
     """Write a pending decision file for the given run.
+
+    ``extra`` holds structured payload beyond the human-readable ``reason`` (for
+    example the escalation advisory report + evidence packet) so an operator or a
+    tool can inspect the machine-readable options rather than parsing prose. Keys
+    in ``extra`` never override the core fields below.
 
     Returns the path to the created file.
     """
@@ -55,6 +61,9 @@ def write_pending(
         "timeout_at": timeout_at.isoformat(),
         "pid": os.getpid(),
     }
+    if extra:
+        for key, value in extra.items():
+            data.setdefault(key, value)
 
     path = pending_dir / f"{run_id}.yaml"
     path.write_text(yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")

--- a/src/theforge/task/advisor_prompts.py
+++ b/src/theforge/task/advisor_prompts.py
@@ -1,0 +1,176 @@
+"""Prompt construction for the fresh-context escalation advisor.
+
+The advisor is a fresh model that did NOT run the failed dev/review cycles — it
+must not inherit the failed framing. It receives a prepared evidence packet and
+must emit a constrained advisory report: a recommendation drawn from the fixed
+action taxonomy plus a menu of evidence-backed options.
+
+This module only builds the prompt string. The output schema/validation lives in
+``theforge.escalation_advisor`` and the coordinator control flow that invokes the
+agent lives in ``theforge.coordinator.escalation_advisor_flow``.
+"""
+
+from __future__ import annotations
+
+from theforge.escalation_advisor import (
+    ACTION_FORGE_OPERATIONS,
+    ACTION_LABELS,
+    ACTION_TAXONOMY,
+    EvidencePacket,
+)
+
+_TAXONOMY_GUIDE: dict[str, str] = {
+    "accept": (
+        "The current work is actually good enough against the acceptance criteria; "
+        "the review churn was over-strict. Finalize/merge as-is."
+    ),
+    "land_core_defer_edges": (
+        "The core deliverable is sound but reviewers kept flagging edge cases. Merge "
+        "the core and file follow-up issues for the edges rather than churning further."
+    ),
+    "redirect": (
+        "The task is winnable but the *approach* the dev kept taking cannot succeed. "
+        "Re-run the dev phase under a corrected framing/constraint that names the "
+        "winnable primitive."
+    ),
+    "decompose": (
+        "The story bundles independent concerns that fight each other in one cycle. "
+        "Split it into smaller runnable pieces."
+    ),
+    "elevate": (
+        "This cannot be resolved by another dev cycle — it is an unmade "
+        "design/architecture decision masquerading as an implementation failure. Route "
+        "it to a crisp human decision. Most escalations are mis-classified design "
+        "decisions; prefer this when the churn is whack-a-mole on an unbounded space."
+    ),
+    "defer_or_abandon": (
+        "The work is not worth continuing now: defer to a later milestone or abandon it."
+    ),
+}
+
+
+def _render_taxonomy() -> str:
+    lines: list[str] = []
+    for action in ACTION_TAXONOMY:
+        label = ACTION_LABELS.get(action, action)
+        guide = _TAXONOMY_GUIDE.get(action, "")
+        op = ACTION_FORGE_OPERATIONS.get(action, "")
+        lines.append(f"- {label} (`{action}`): {guide}")
+        lines.append(f"    forge operation: {op}")
+    return "\n".join(lines)
+
+
+def _render_packet(packet: EvidencePacket) -> str:
+    lines: list[str] = []
+    lines.append(f"## Story: {packet.story_name} ({packet.issue_ref})")
+    lines.append("")
+    lines.append("### Issue body")
+    lines.append(packet.issue_body or "(none)")
+    lines.append("")
+    lines.append("### Acceptance criteria")
+    if packet.acceptance_criteria:
+        for ac in packet.acceptance_criteria:
+            lines.append(f"- {ac}")
+    else:
+        lines.append("(none extracted)")
+    lines.append("")
+    lines.append("### Review cycle history (the churn pattern — the key signal)")
+    if packet.cycles:
+        for c in packet.cycles:
+            lines.append(f"#### Cycle {c.cycle} — verdict {c.verdict}")
+            if c.summary:
+                lines.append(f"summary: {c.summary}")
+            if c.findings:
+                lines.append("findings:")
+                for f in c.findings:
+                    lines.append(f"  - {f}")
+    else:
+        lines.append("(no per-cycle history captured)")
+    lines.append("")
+    lines.append("### Final reviewer verdicts")
+    if packet.reviewer_verdicts:
+        for name, verdict in packet.reviewer_verdicts.items():
+            lines.append(f"- {name}: {verdict}")
+    else:
+        lines.append("(none)")
+    lines.append(f"final merged verdict: {packet.final_verdict or '(unknown)'}")
+    lines.append("")
+    lines.append("### Dev diff (what the dev produced)")
+    lines.append(packet.dev_diff or "(no diff captured)")
+    lines.append("")
+    lines.append("### Test / gate failures")
+    lines.append(packet.test_failures or "(none captured)")
+    lines.append("")
+    lines.append("### Escalation reason")
+    lines.append(packet.escalation_reason or "(none)")
+    return "\n".join(lines)
+
+
+def build_advisor_prompt(packet: EvidencePacket) -> str:
+    """Build the fresh-context escalation-advisor prompt from an evidence packet."""
+    taxonomy = _render_taxonomy()
+    packet_text = _render_packet(packet)
+    example_action = ACTION_TAXONOMY[2]  # "redirect"
+
+    return f"""You are the ESCALATION ADVISOR for an autonomous software-development \
+orchestrator.
+
+A story has escalated: the dev agent could not converge and the review cycles \
+were exhausted. You did NOT run those cycles. Your job is to read the prepared \
+evidence packet BELOW with fresh eyes and route this escalation into a small, \
+constrained menu of evidence-backed action choices for a human operator.
+
+An escalation is not just a failed implementation attempt — it is evidence that \
+the current task framing may be invalid. The churn pattern (what reviewers kept \
+flagging, what the dev kept re-breaking) is the most valuable signal. Look for \
+the case where the dev kept attacking an unbounded space (whack-a-mole) when the \
+issue itself already named a winnable primitive — that is usually a Redirect or \
+an Elevate, not another dev cycle.
+
+## Action taxonomy (your recommendation and every option's `action` MUST be one \
+of these exact values)
+
+{taxonomy}
+
+## Evidence packet
+
+{packet_text}
+
+## Required output
+
+Emit EXACTLY ONE `<advisory_report>` block containing a YAML mapping. Do not put \
+the block inside a code fence. Free-form prose recommendations are NOT allowed — \
+the recommendation must be one of the taxonomy values above.
+
+The YAML mapping must have:
+- `recommendation`: one of {list(ACTION_TAXONOMY)} — your single best action.
+- `rationale`: one or two sentences citing the packet for why.
+- `options`: a non-empty list. Include the recommended action AND any other \
+credible actions. Each option is a mapping with:
+    - `action`: one of {list(ACTION_TAXONOMY)}
+    - `evidence`: what in the packet supports this action (cite cycles/findings/ACs)
+    - `forge_operation`: the concrete forge operation this action triggers
+    - `risk`: the risk of taking this action
+    - `consequence`: what happens if the operator selects this action
+
+The `recommendation` value MUST also appear as one of the `options[].action` values.
+
+Example shape (illustrative only — analyse the real packet):
+
+<advisory_report>
+recommendation: {example_action}
+rationale: "Reviewers flagged a different bypass every cycle; the enforcement \
+approach cannot be complete, while the issue named a winnable end-state invariant."
+options:
+  - action: {example_action}
+    evidence: "Cycles 1-5 each found a new bypass (missing pull, force-push, alias variants)."
+    forge_operation: "re-run with constraint (re-dev under a corrected framing)"
+    risk: "The corrected framing may still be under-specified."
+    consequence: "Dev re-runs against the end-state invariant instead of the blocklist."
+  - action: elevate
+    evidence: "The blocklist-vs-invariant choice is an unmade architecture decision."
+    forge_operation: "bump (route to a human design/architecture decision)"
+    risk: "Adds a human round-trip before any code changes."
+    consequence: "A human picks the enforcement architecture; the story re-enters with it fixed."
+</advisory_report>
+"""

--- a/tests/test_coord_escalation_advisor.py
+++ b/tests/test_coord_escalation_advisor.py
@@ -63,6 +63,17 @@ def _canned_report(recommendation: str = "redirect") -> AdvisoryReport:
     )
 
 
+def _report_with_errors() -> AdvisoryReport:
+    """An invalid advisory report (parse_errors set → .ok is False)."""
+    return AdvisoryReport(
+        recommendation="",
+        rationale="",
+        options=[],
+        parse_errors=["no <advisory_report> block found"],
+        raw={},
+    )
+
+
 def _pending_config(tmp_path: Path, timeout: int = 1):
     """Config that activates pending-file HITL mode (backends non-empty)."""
     base = _make_config(tmp_path)
@@ -209,6 +220,66 @@ class TestPendingEscalateGate:
                 )
         assert decision == "timeout"
 
+    def test_timeout_preserves_selectable_pending_checkpoint(self, tmp_path):
+        # P1 regression: on timeout the pending file must NOT be deleted — the
+        # operator still has to be able to select an action. It must remain on disk
+        # with the taxonomy options + advisory payload and an awaiting-decision marker.
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+        state.advisory_packet = {"cycles": []}
+        report = _canned_report("redirect")
+
+        with patch("theforge.pending.poll_pending", return_value=("timeout", None)):
+            with patch("theforge.notify_backends.send_notifications"):
+                _pending_escalate_gate(
+                    state,
+                    task,
+                    config,
+                    state.error,
+                    {"reviewer-a": "REQUEST_CHANGES"},
+                    None,
+                    run_id="run-preserve",
+                    advisory=report,
+                )
+
+        pending_file = tmp_path / ".forge" / "pending" / "run-preserve.yaml"
+        assert pending_file.exists(), "pending checkpoint must survive a timeout"
+        data = yaml.safe_load(pending_file.read_text())
+        assert data["options"] == list(rp.ACTION_TAXONOMY)
+        assert data["advisory"]["recommendation"] == "redirect"
+        assert data["timed_out_awaiting_decision"] is True
+        assert data.get("decision") is None  # still resolvable — no auto-decision written
+
+        # And the operator can still resolve it after the timeout.
+        from theforge import pending as _pending
+
+        assert _pending.resolve_pending("run-preserve", "redirect", project_root=tmp_path)
+        assert yaml.safe_load(pending_file.read_text())["decision"] == "redirect"
+
+    def test_decision_cleans_up_pending_file(self, tmp_path):
+        # The complementary case: when the operator DOES select, the resolved
+        # pending file is cleaned up (not left dangling).
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+        state.advisory_packet = {"cycles": []}
+
+        with patch("theforge.pending.poll_pending", return_value=("accept", "t")):
+            with patch("theforge.notify_backends.send_notifications"):
+                decision = _pending_escalate_gate(
+                    state,
+                    task,
+                    config,
+                    state.error,
+                    {"reviewer-a": "REQUEST_CHANGES"},
+                    None,
+                    run_id="run-decided",
+                    advisory=_canned_report("accept"),
+                )
+        assert decision == "accept"
+        assert not (tmp_path / ".forge" / "pending" / "run-decided.yaml").exists()
+
 
 # ── _run_escalate_gate: disposition normalisation ─────────────────────────────
 
@@ -220,10 +291,16 @@ class TestRunEscalateGateDispositions:
         state = _escalated_state()
 
         # Fresh advisor + pending decision are both stubbed so we exercise the
-        # normalisation logic in _run_escalate_gate deterministically.
-        monkeypatch.setattr(
-            rp, "run_escalation_advisor", lambda *a, **k: report or _canned_report("redirect")
-        )
+        # normalisation logic in _run_escalate_gate deterministically. The advisor
+        # stub sets state.advisory_generated like the real flow so the preserve
+        # message can distinguish advisory vs no-advisory timeouts.
+        def _fake_advisor(*a, **k):
+            rep = report or _canned_report("redirect")
+            state.advisory_generated = rep.ok
+            state.advisory_report = rep.to_dict()
+            return rep
+
+        monkeypatch.setattr(rp, "run_escalation_advisor", _fake_advisor)
         monkeypatch.setattr(rp, "_pending_escalate_gate", lambda *a, **k: gate_decision)
         # Approve path calls _finalize_approve — stub it to a DONE result.
         monkeypatch.setattr(
@@ -286,6 +363,21 @@ class TestRunEscalateGateDispositions:
         # Contract change: timeout preserves rather than auto-rejecting.
         assert state.escalate_decision == "advisory_pending"
         assert state.escalate_decision != "reject"
+        # Advisory was generated on this (pending-file) path — message says so.
+        assert state.advisory_generated is True
+        assert "advisory report was generated" in result.message
+
+    def test_timeout_preserve_message_omits_advisory_when_none_generated(
+        self, tmp_path, monkeypatch
+    ):
+        # Remote/interactive timeouts also preserve, but no advisory is produced
+        # there — the preserve message must not falsely claim one was generated.
+        state, result = self._call(tmp_path, monkeypatch, "timeout", report=_report_with_errors())
+        assert result.success is False
+        assert state.escalate_decision == "advisory_pending"
+        assert state.advisory_generated is False
+        assert "advisory report was generated" not in result.message
+        assert "operator action selection is still" in result.message
 
     def test_reject_policy_still_short_circuits_without_advisor(self, tmp_path, monkeypatch):
         # escalate_policy=reject must not even generate an advisory.

--- a/tests/test_coord_escalation_advisor.py
+++ b/tests/test_coord_escalation_advisor.py
@@ -1,0 +1,321 @@
+"""Seam-level tests for escalation-advisor wiring at the escalate gate.
+
+Covers the coordinator boundary the story touches:
+
+* ``run_escalation_advisor`` invokes a FRESH agent (not the dev/review sessions)
+  and records the packet + report on state.
+* the pending escalate gate presents the fixed action taxonomy + embeds the
+  advisory payload, and no longer auto-rejects on timeout.
+* ``_run_escalate_gate`` normalises taxonomy actions and timeout into the right
+  coordinator dispositions (approve / reject / named-preserve / timeout-preserve).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from coord_test_helpers import _make_agent_result, _make_config, _make_task
+
+from theforge.config import BackendConfig, NotificationConfig
+from theforge.coordinator import escalation_advisor_flow as flow
+from theforge.coordinator import review_phase as rp
+from theforge.coordinator.pending_hitl import _pending_escalate_gate
+from theforge.coordinator.review_phase import _run_escalate_gate
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.escalation_advisor import AdvisoryOption, AdvisoryReport
+from theforge.review import ReviewFinding, ReviewResult
+
+
+def _review(verdict: str = "REQUEST_CHANGES") -> ReviewResult:
+    return ReviewResult(
+        verdict=verdict,
+        summary="still not there",
+        findings=[
+            ReviewFinding(severity="P1", file="f.py", line=1, observed="bug", suggestion=None)
+        ],
+        story_matches=False,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def _canned_report(recommendation: str = "redirect") -> AdvisoryReport:
+    return AdvisoryReport(
+        recommendation=recommendation,
+        rationale="churn indicates an unbounded approach",
+        options=[
+            AdvisoryOption(
+                action=recommendation,
+                evidence="cycles 1-5 each found a new bypass",
+                forge_operation="re-run with constraint",
+                risk="framing may be under-specified",
+                consequence="dev re-runs against the invariant",
+            ),
+        ],
+        parse_errors=[],
+        raw={},
+    )
+
+
+def _pending_config(tmp_path: Path, timeout: int = 1):
+    """Config that activates pending-file HITL mode (backends non-empty)."""
+    base = _make_config(tmp_path)
+    notifications = NotificationConfig(
+        backend="ntfy",
+        human_review_timeout_seconds=timeout,
+        backends=(BackendConfig(type="ntfy", url="https://ntfy.sh/t"),),
+    )
+    new_retry = dataclasses.replace(base.retry, escalate_policy="prompt")
+    return dataclasses.replace(base, notifications=notifications, retry=new_retry)
+
+
+def _escalated_state() -> CoordinatorState:
+    state = CoordinatorState()
+    state.phase = Phase.ESCALATE
+    state.review_cycle = 5
+    state.story_content = "Body.\n\n## Acceptance criteria\n\n- do the thing\n"
+    rr = _review()
+    state.review_results = [rr]
+    state.last_cycle_reviewer_results = [("reviewer-a", rr)]
+    state.error = "Review requested changes after 5 cycles. Max cycles (5) exhausted."
+    return state
+
+
+# ── run_escalation_advisor: fresh context ─────────────────────────────────────
+
+
+class TestRunEscalationAdvisor:
+    def test_invokes_fresh_agent_and_records_report(self, tmp_path, monkeypatch):
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+
+        advisor_output = """
+<advisory_report>
+recommendation: redirect
+rationale: unbounded blocklist
+options:
+  - action: redirect
+    evidence: cycles 1-5 each found a bypass
+    forge_operation: re-run with constraint
+    risk: rr
+    consequence: cc
+</advisory_report>
+"""
+        captured = {}
+
+        def fake_run_agent(*, prompt, profile, working_dir, secrets):
+            captured["prompt"] = prompt
+            captured["profile"] = profile
+            return _make_agent_result(success=True, output=advisor_output, profile_name="advisor")
+
+        # Patch the flow module's lazy runner slots directly (fresh agent).
+        monkeypatch.setattr(flow, "run_agent", fake_run_agent)
+        monkeypatch.setattr(flow, "log_agent_result", lambda *a, **k: None)
+
+        report = rp.run_escalation_advisor(state, config, task, tmp_path / "ws")
+
+        assert report is not None and report.ok
+        assert report.recommendation == "redirect"
+        # Fresh context: the advisor prompt is not a dev/review prompt and carries
+        # the evidence packet.
+        assert "ESCALATION ADVISOR" in captured["prompt"]
+        assert "Acceptance criteria" in captured["prompt"]
+        # Recorded on state for the audit trail.
+        assert state.advisory_generated is True
+        assert state.advisory_report["recommendation"] == "redirect"
+        assert state.advisory_packet is not None
+
+    def test_agent_failure_returns_none_and_preserves(self, tmp_path, monkeypatch):
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+
+        monkeypatch.setattr(
+            flow,
+            "run_agent",
+            lambda **k: _make_agent_result(success=False, output="", profile_name="advisor"),
+        )
+        monkeypatch.setattr(flow, "log_agent_result", lambda *a, **k: None)
+
+        report = rp.run_escalation_advisor(state, config, task, tmp_path / "ws")
+        assert report is None
+        assert state.advisory_generated is False
+
+
+# ── Pending escalate gate: taxonomy options + no auto-reject on timeout ────────
+
+
+class TestPendingEscalateGate:
+    def test_writes_taxonomy_options_and_advisory_payload(self, tmp_path):
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+        state.advisory_packet = {"story_name": "s", "issue_ref": "#1", "cycles": []}
+        report = _canned_report("redirect")
+
+        seen = {}
+
+        def fake_poll(run_id, timeout_seconds, project_root=None, **kw):
+            path = Path(project_root) / ".forge" / "pending" / f"{run_id}.yaml"
+            data = yaml.safe_load(path.read_text())
+            seen["options"] = data["options"]
+            seen["advisory"] = data.get("advisory")
+            seen["decision_required"] = data.get("decision_required")
+            return "redirect", "2026-07-16T00:00:00Z"
+
+        with patch("theforge.pending.poll_pending", side_effect=fake_poll):
+            with patch("theforge.notify_backends.send_notifications"):
+                decision = _pending_escalate_gate(
+                    state,
+                    task,
+                    config,
+                    state.error,
+                    {"reviewer-a": "REQUEST_CHANGES"},
+                    "PASS",
+                    run_id="run-1",
+                    advisory=report,
+                )
+
+        assert decision == "redirect"
+        assert seen["options"] == list(rp.ACTION_TAXONOMY)
+        assert seen["advisory"]["recommendation"] == "redirect"
+        assert seen["decision_required"] is True
+
+    def test_timeout_returns_timeout_not_reject(self, tmp_path):
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+        state.advisory_packet = {"cycles": []}
+        report = _canned_report("redirect")
+
+        with patch("theforge.pending.poll_pending", return_value=("timeout", None)):
+            with patch("theforge.notify_backends.send_notifications"):
+                decision = _pending_escalate_gate(
+                    state,
+                    task,
+                    config,
+                    state.error,
+                    {"reviewer-a": "REQUEST_CHANGES"},
+                    None,
+                    run_id="run-2",
+                    advisory=report,
+                )
+        assert decision == "timeout"
+
+
+# ── _run_escalate_gate: disposition normalisation ─────────────────────────────
+
+
+class TestRunEscalateGateDispositions:
+    def _call(self, tmp_path, monkeypatch, gate_decision, *, report=None):
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+
+        # Fresh advisor + pending decision are both stubbed so we exercise the
+        # normalisation logic in _run_escalate_gate deterministically.
+        monkeypatch.setattr(
+            rp, "run_escalation_advisor", lambda *a, **k: report or _canned_report("redirect")
+        )
+        monkeypatch.setattr(rp, "_pending_escalate_gate", lambda *a, **k: gate_decision)
+        # Approve path calls _finalize_approve — stub it to a DONE result.
+        monkeypatch.setattr(
+            rp,
+            "_finalize_approve",
+            lambda *a, **k: CoordinatorResult(
+                success=True, phase=Phase.DONE, state=state, message="approved"
+            ),
+        )
+        monkeypatch.setattr(rp, "_append_cycle_history", lambda *a, **k: None)
+        monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
+
+        return state, _run_escalate_gate(
+            state,
+            config,
+            task,
+            tmp_path / "ws",
+            "forge/test",
+            0.0,
+            auto_merge=False,
+            notify=True,
+            logger=None,
+            run_id="run-x",
+        )
+
+    def test_accept_maps_to_approve(self, tmp_path, monkeypatch):
+        state, result = self._call(
+            tmp_path, monkeypatch, "accept", report=_canned_report("accept")
+        )
+        assert result is not None and result.success is True
+        assert result.phase == Phase.DONE
+        assert state.escalate_selected_action == "accept"
+
+    def test_defer_or_abandon_maps_to_reject(self, tmp_path, monkeypatch):
+        state, result = self._call(tmp_path, monkeypatch, "defer_or_abandon")
+        assert result is not None and result.success is False
+        assert state.escalate_decision == "reject"
+        assert state.escalate_selected_action == "defer_or_abandon"
+
+    def test_redirect_maps_to_named_preserve(self, tmp_path, monkeypatch):
+        state, result = self._call(tmp_path, monkeypatch, "redirect")
+        assert result is not None and result.success is False
+        # Named action preserves the worktree and records the taxonomy action —
+        # it is NOT a plain reject that discards the work.
+        assert state.escalate_decision == "redirect"
+        assert state.escalate_selected_action == "redirect"
+        assert "re-run with constraint" in result.message
+
+    def test_elevate_maps_to_named_preserve(self, tmp_path, monkeypatch):
+        state, result = self._call(
+            tmp_path, monkeypatch, "elevate", report=_canned_report("elevate")
+        )
+        assert result.success is False
+        assert state.escalate_decision == "elevate"
+        assert "bump" in result.message
+
+    def test_timeout_does_not_auto_reject(self, tmp_path, monkeypatch):
+        state, result = self._call(tmp_path, monkeypatch, "timeout")
+        assert result is not None and result.success is False
+        # Contract change: timeout preserves rather than auto-rejecting.
+        assert state.escalate_decision == "advisory_pending"
+        assert state.escalate_decision != "reject"
+
+    def test_reject_policy_still_short_circuits_without_advisor(self, tmp_path, monkeypatch):
+        # escalate_policy=reject must not even generate an advisory.
+        config = _pending_config(tmp_path)
+        config = dataclasses.replace(
+            config, retry=dataclasses.replace(config.retry, escalate_policy="reject")
+        )
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+        called = {"advisor": False}
+
+        def _should_not_run(*a, **k):
+            called["advisor"] = True
+            return _canned_report()
+
+        monkeypatch.setattr(rp, "run_escalation_advisor", _should_not_run)
+        monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
+
+        result = _run_escalate_gate(
+            state,
+            config,
+            task,
+            tmp_path / "ws",
+            "forge/test",
+            0.0,
+            auto_merge=False,
+            notify=True,
+            logger=None,
+            run_id="run-r",
+        )
+        assert result is not None and result.success is False
+        assert state.escalate_decision == "reject"
+        assert called["advisor"] is False

--- a/tests/test_escalation_advisor.py
+++ b/tests/test_escalation_advisor.py
@@ -402,3 +402,26 @@ options:
             parse_errors=[],
         )
         assert report.ok
+
+    def test_prompt_construction_exercises_1365_packet(self):
+        # Exercise the #1365 evidence packet through prompt construction (not just
+        # a prewritten report): the fresh-advisor prompt must carry the full
+        # taxonomy AND the per-cycle churn signal so a fresh model can surface the
+        # blocklist-vs-invariant framing.
+        from theforge.task.advisor_prompts import build_advisor_prompt
+
+        packet = self._packet_1365()
+        prompt = build_advisor_prompt(packet)
+
+        # The constrained taxonomy is presented to the advisor.
+        for action in ACTION_TAXONOMY:
+            assert f"`{action}`" in prompt
+        # The churn pattern (each cycle's bypass finding) is in the packet section.
+        assert "force-push" in prompt
+        assert "case-varied alias" in prompt
+        assert "Cycle 5" in prompt
+        # The end-state invariant framing from the issue body is present.
+        assert "end-state invariant" in prompt
+        # The required constrained-output contract is spelled out.
+        assert "recommendation" in prompt
+        assert "<advisory_report>" in prompt

--- a/tests/test_escalation_advisor.py
+++ b/tests/test_escalation_advisor.py
@@ -1,0 +1,404 @@
+"""Tests for the escalation advisor: taxonomy, packet, and report schema boundary.
+
+Covers the pure-data module (``theforge.escalation_advisor``) plus the
+evidence-packet builder in ``escalation_advisor_flow``. The fresh-context agent
+invocation is exercised in ``test_coord_escalation_advisor.py``; here we validate
+the deterministic pipeline: packet assembly → schema validation → rendering, and
+the #1365 worked-example check that a well-formed report surfaces the
+blocklist-vs-invariant framing as a Redirect/Elevate option.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.escalation_advisor_flow import (
+    _extract_acceptance_criteria,
+    build_evidence_packet,
+)
+from theforge.coordinator.state import CoordinatorState, CycleHistory
+from theforge.escalation_advisor import (
+    ACTION_TAXONOMY,
+    AdvisoryReport,
+    EvidencePacket,
+    action_disposition,
+    parse_advisory_report,
+    render_advisory_for_pending,
+)
+from theforge.review import ReviewFinding, ReviewResult
+from theforge.task import TaskStory
+
+
+def _config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+            base_branch="main",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        preflight_fallback_profile=None,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _finding(desc: str) -> ReviewFinding:
+    return ReviewFinding(
+        severity="P1",
+        file="src/guard.py",
+        line=10,
+        observed=desc,
+        suggestion=None,
+    )
+
+
+def _review(verdict: str, summary: str, findings: list[str]) -> ReviewResult:
+    return ReviewResult(
+        verdict=verdict,
+        summary=summary,
+        findings=[_finding(f) for f in findings],
+        story_matches=False,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+# ── Taxonomy + dispositions ───────────────────────────────────────────────────
+
+
+class TestTaxonomy:
+    def test_taxonomy_values(self):
+        assert ACTION_TAXONOMY == (
+            "accept",
+            "land_core_defer_edges",
+            "redirect",
+            "decompose",
+            "elevate",
+            "defer_or_abandon",
+        )
+
+    def test_dispositions(self):
+        assert action_disposition("accept") == "approve"
+        assert action_disposition("defer_or_abandon") == "reject"
+        for named in ("land_core_defer_edges", "redirect", "decompose", "elevate"):
+            assert action_disposition(named) == "named"
+
+    def test_unknown_action_fails_closed_to_reject(self):
+        assert action_disposition("merge_it_all") == "reject"
+        assert action_disposition("") == "reject"
+
+
+# ── Schema boundary ───────────────────────────────────────────────────────────
+
+
+class TestParseAdvisoryReport:
+    def _valid_block(self, recommendation: str = "redirect") -> str:
+        return f"""
+Prose the advisor may emit before the block is ignored.
+<advisory_report>
+recommendation: {recommendation}
+rationale: The blocklist cannot be complete; the issue named an end-state invariant.
+options:
+  - action: redirect
+    evidence: Cycles 1-5 each found a new git-guard bypass.
+    forge_operation: re-run with constraint
+    risk: The corrected framing may still be under-specified.
+    consequence: Dev re-runs against the end-state invariant.
+  - action: elevate
+    evidence: The blocklist-vs-invariant choice is an unmade architecture decision.
+    forge_operation: bump
+    risk: Adds a human round-trip.
+    consequence: A human picks the enforcement architecture.
+</advisory_report>
+"""
+
+    def test_valid_report_parses(self):
+        report = parse_advisory_report(self._valid_block())
+        assert report.ok
+        assert report.recommendation == "redirect"
+        assert {o.action for o in report.options} == {"redirect", "elevate"}
+        rec = report.recommended_option()
+        assert rec is not None and rec.action == "redirect"
+
+    def test_missing_block_is_error(self):
+        report = parse_advisory_report("no structured output here")
+        assert not report.ok
+        assert any("no <advisory_report>" in e for e in report.parse_errors)
+
+    def test_recommendation_outside_taxonomy_rejected(self):
+        block = self._valid_block(recommendation="ship_it")
+        report = parse_advisory_report(block)
+        assert not report.ok
+        assert any("recommendation must be one of" in e for e in report.parse_errors)
+
+    def test_recommendation_must_be_among_options(self):
+        block = """
+<advisory_report>
+recommendation: decompose
+options:
+  - action: accept
+    evidence: e
+    risk: r
+    consequence: c
+</advisory_report>
+"""
+        report = parse_advisory_report(block)
+        assert not report.ok
+        assert any("not present among the options" in e for e in report.parse_errors)
+
+    def test_option_missing_required_field_rejected(self):
+        block = """
+<advisory_report>
+recommendation: accept
+options:
+  - action: accept
+    evidence: e
+    risk: r
+</advisory_report>
+"""
+        report = parse_advisory_report(block)
+        assert not report.ok
+        assert any("missing consequence" in e for e in report.parse_errors)
+
+    def test_option_action_outside_taxonomy_rejected(self):
+        block = """
+<advisory_report>
+recommendation: accept
+options:
+  - action: accept
+    evidence: e
+    risk: r
+    consequence: c
+  - action: rewrite_everything
+    evidence: e
+    risk: r
+    consequence: c
+</advisory_report>
+"""
+        report = parse_advisory_report(block)
+        assert not report.ok
+        assert any("action must be one of" in e for e in report.parse_errors)
+
+    def test_malformed_yaml_is_error_not_exception(self):
+        block = "<advisory_report>\nrecommendation: : : {[}\n</advisory_report>"
+        report = parse_advisory_report(block)
+        assert not report.ok
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+
+class TestRendering:
+    def test_render_lists_all_options_and_marks_recommended(self):
+        report = parse_advisory_report(
+            """
+<advisory_report>
+recommendation: elevate
+rationale: unmade design decision
+options:
+  - action: redirect
+    evidence: churn evidence
+    forge_operation: re-run with constraint
+    risk: rr
+    consequence: cc
+  - action: elevate
+    evidence: architecture decision
+    forge_operation: bump
+    risk: rr2
+    consequence: cc2
+</advisory_report>
+"""
+        )
+        packet = EvidencePacket(
+            story_name="git-guard",
+            issue_ref="#1365",
+            issue_body="body",
+            acceptance_criteria=["ac1"],
+            cycles=[],
+            reviewer_verdicts={},
+            final_verdict="REQUEST_CHANGES",
+            dev_diff="",
+            test_failures="",
+            escalation_reason="max cycles exhausted",
+        )
+        text = render_advisory_for_pending(report, packet)
+        assert "RECOMMENDED ACTION: Elevate" in text
+        assert "Redirect" in text and "Elevate" in text
+        assert "← recommended" in text
+        assert "max cycles exhausted" in text
+
+
+# ── Evidence packet builder ───────────────────────────────────────────────────
+
+
+class TestBuildEvidencePacket:
+    def test_extract_acceptance_criteria(self):
+        body = (
+            "# Story\n\nSome intro.\n\n"
+            "## Acceptance criteria\n\n"
+            "- first observable outcome\n"
+            "- second observable outcome\n\n"
+            "## Notes\n\n- not an AC\n"
+        )
+        acs = _extract_acceptance_criteria(body)
+        assert acs == ["first observable outcome", "second observable outcome"]
+
+    def test_packet_pulls_cycle_history_and_verdicts(self, tmp_path):
+        config = _config(tmp_path)
+        task = TaskStory(name="Guard", slug="issue-1365", github_issue=1365)
+        state = CoordinatorState()
+        state.story_content = (
+            "Enforce the git guard.\n\n## Acceptance criteria\n\n- guard cannot be bypassed\n"
+        )
+        state.cycle_history = [
+            CycleHistory(
+                cycle=1,
+                verdict="REQUEST_CHANGES",
+                summary="missing pull",
+                p1_findings=["pull bypass"],
+            ),
+            CycleHistory(
+                cycle=2,
+                verdict="REQUEST_CHANGES",
+                summary="force-push",
+                p1_findings=["+refspec bypass"],
+            ),
+        ]
+        state.review_results = [_review("REQUEST_CHANGES", "still bypassable", ["alias bypass"])]
+        state.last_cycle_reviewer_results = [("reviewer-a", state.review_results[-1])]
+        state.error = "Review requested changes after 5 cycles. Max cycles (5) exhausted."
+
+        packet = build_evidence_packet(state, task, config, tmp_path / "nonexistent")
+        assert packet.issue_ref == "#1365"
+        assert packet.acceptance_criteria == ["guard cannot be bypassed"]
+        assert [c.cycle for c in packet.cycles] == [1, 2]
+        assert packet.reviewer_verdicts == {"reviewer-a": "REQUEST_CHANGES"}
+        assert "Max cycles" in packet.escalation_reason
+        # Serialisable for the audit trail.
+        assert packet.to_dict()["issue_ref"] == "#1365"
+
+    def test_packet_falls_back_to_review_results_when_no_cycle_history(self, tmp_path):
+        config = _config(tmp_path)
+        task = TaskStory(name="Guard", slug="issue-1365", github_issue=1365)
+        state = CoordinatorState()
+        state.story_content = "body"
+        state.review_results = [
+            _review("REQUEST_CHANGES", "cycle one", ["f1"]),
+            _review("REQUEST_CHANGES", "cycle two", ["f2"]),
+        ]
+        packet = build_evidence_packet(state, task, config, tmp_path / "nope")
+        assert [c.cycle for c in packet.cycles] == [1, 2]
+        assert packet.cycles[0].findings == ["f1"]
+
+
+# ── Worked-example check (AC 5) ───────────────────────────────────────────────
+
+
+class TestWorkedExample1365:
+    """Given #1365's evidence packet, a well-formed advisory surfaces the
+    invocation-blocklist-vs-end-state-invariant framing as Redirect or Elevate
+    with cited evidence."""
+
+    def _packet_1365(self) -> EvidencePacket:
+        bypasses = [
+            "missing `pull` in the git-guard shim",
+            "`+refspec` force-push bypass",
+            "inline alias bypass",
+            "case-varied alias bypass",
+            "`-C` worktree alias bypass",
+        ]
+        from theforge.escalation_advisor import CycleEvidence
+
+        cycles = [
+            CycleEvidence(
+                cycle=i + 1,
+                verdict="REQUEST_CHANGES",
+                summary=f"reviewer found {b}",
+                findings=[b],
+            )
+            for i, b in enumerate(bypasses)
+        ]
+        return EvidencePacket(
+            story_name="git-guard end-state invariant",
+            issue_ref="#1365",
+            issue_body=(
+                "Enforce that the dev phase cannot mutate git history. The issue "
+                "specifies an end-state invariant at the dev-phase boundary."
+            ),
+            acceptance_criteria=["the dev phase boundary enforces an end-state invariant"],
+            cycles=cycles,
+            reviewer_verdicts={"reviewer-a": "REQUEST_CHANGES"},
+            final_verdict="REQUEST_CHANGES",
+            dev_diff="a git-subcommand blocklist shim",
+            test_failures="",
+            escalation_reason="Review requested changes after 5 cycles. Max cycles (5) exhausted.",
+        )
+
+    def test_redirect_or_elevate_surfaced_with_cited_evidence(self):
+        # A representative advisor output for the #1365 packet. This validates the
+        # end-to-end plumbing/schema deterministically (the LLM quality itself is
+        # not asserted here — only that a well-formed report routes to the right
+        # taxonomy actions with evidence citing the packet).
+        advisor_output = """
+<advisory_report>
+recommendation: redirect
+rationale: >-
+  Five cycles each found a different bypass of a git-subcommand blocklist; the
+  enforcement approach cannot be complete, while the issue already named a
+  winnable end-state invariant.
+options:
+  - action: redirect
+    evidence: >-
+      Cycles 1-5 each surfaced a new bypass (missing pull, +refspec force-push,
+      inline/case-varied/-C alias variants) — whack-a-mole on an unbounded space.
+    forge_operation: re-run with constraint (enforce the end-state invariant)
+    risk: The invariant framing must be specified precisely or dev drifts again.
+    consequence: Dev re-runs against the end-state invariant, not the blocklist.
+  - action: elevate
+    evidence: >-
+      Choosing an end-state invariant over a subcommand blocklist is an unmade
+      architecture decision the issue implies but never fixed.
+    forge_operation: bump (route the enforcement-architecture choice to a human)
+    risk: Adds a human round-trip before code changes.
+    consequence: A human fixes the enforcement architecture; the story re-enters.
+</advisory_report>
+"""
+        report = parse_advisory_report(advisor_output)
+        assert report.ok
+        assert report.recommendation in ("redirect", "elevate")
+        actions = {o.action for o in report.options}
+        assert "redirect" in actions or "elevate" in actions
+        rec_opt = report.recommended_option()
+        assert rec_opt is not None
+        # Evidence cites the churn pattern from the packet.
+        assert "bypass" in rec_opt.evidence.lower() or "invariant" in rec_opt.evidence.lower()
+
+    def test_report_is_advisory_report_dataclass(self):
+        report = AdvisoryReport(
+            recommendation="elevate",
+            rationale="x",
+            options=[],
+            parse_errors=[],
+        )
+        assert report.ok


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 is fixed; timeout now preserves a selectable pending checkpoint, and no blocking regressions were found. | [google-gemini-3.5-flash] The escalation advisor implementation is fully verified, and the prior P1 timeout-deletion bug is successfully resolved. | [claude-sonnet] Iteration 1 correctly fixes the Cycle 1 P1 (pending file no longer deleted on timeout — it's rewritten in place with a timed_out_awaiting_decision marker, taxonomy options, and advisory payload, verified by a new resolve-after-timeout regression test) and both prior P2s (preserve message now varies on state.advisory_generated; state.py comment documents the taxonomy). No regressions found in the touched files; full suite (4925 tests) passes.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $16.90
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Escalation Advisor: fresh-context advisory with evidence-backed action choices replaces max-cycles auto-reject (GitHub Issue #1664)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1664