### PR TITLE
fix(coordinator): exclude forge's own .forge/ artifacts from hygiene gate (#1699)

### DIFF
--- a/src/theforge/coordinator/workspace_hygiene.py
+++ b/src/theforge/coordinator/workspace_hygiene.py
@@ -9,8 +9,10 @@ fail loudly with the offending paths.
 Three layers:
 
 1. ``check_phase_no_mutation``: invoked around PLAN / PLAN_REVIEW. Any change
-   to the porcelain set fails the phase. ``.forge/`` is gitignored, so
-   coordinator-driven artifact writes are naturally excluded.
+   to the porcelain set fails the phase. Paths under forge's own runtime
+   directory (``.forge/``) are excluded mechanically by ``snapshot_porcelain``
+   — regardless of the consumer repo's gitignore state — so coordinator-driven
+   artifact writes never register as mutations.
 
 2. ``enforce_pre_dev_hygiene`` / ``enforce_pre_review_hygiene``: invoked
    symmetrically before DEV iteration 1 and before each REVIEW cycle.
@@ -35,8 +37,8 @@ Three layers:
    (issue #1499) still has a real failsafe to ride on.
 
 Sanctioned scratch space (``.forge/tmp/<run-id>/``) is provisioned by
-``ensure_scratch_dir``; ``.forge/`` is already gitignored so the directory is
-invisible to git.
+``ensure_scratch_dir``; it lives under ``.forge/``, which the snapshot
+mechanically excludes, so the directory never registers with the gate.
 """
 
 from __future__ import annotations
@@ -49,14 +51,39 @@ from pathlib import Path
 # Restrict to operator-facing work artifacts; everything else is quarantined.
 _ALLOWED_ROOT_UNTRACKED: frozenset[str] = frozenset()
 
+# Forge's own runtime directory. Everything under it is coordinator-written
+# bookkeeping (quarantine dir, escalation markers, scratch, tmp) — never
+# operator contamination. Historically the gate relied on the consumer repo
+# gitignoring ``.forge/`` to keep these out of its porcelain snapshots, but
+# that assumption was unenforced: a repo that only ignores the specific
+# ``.forge/`` files known to an older forge version (or none at all) exposed
+# forge's own output as untracked "contamination", tripping quarantine and
+# escalating on artifacts forge itself wrote (hdp #183, TheForge #1699). The
+# exclusion is now mechanical and independent of gitignore state.
+_FORGE_RUNTIME_DIR = ".forge"
+_FORGE_RUNTIME_PREFIX = ".forge/"
+
+
+def _is_forge_runtime_path(path: str) -> bool:
+    """True if ``path`` (workspace-relative) is under forge's runtime dir.
+
+    Matches the directory itself and anything beneath it, so ``.forge``,
+    ``.forge/quarantine`` and ``.forge/escalated`` are all recognised as
+    forge-owned regardless of the consumer repo's gitignore contents.
+    """
+    return path == _FORGE_RUNTIME_DIR or path.startswith(_FORGE_RUNTIME_PREFIX)
+
 
 def snapshot_porcelain(workspace_path: Path) -> set[str]:
     """Return the porcelain entry set for ``workspace_path``.
 
     Each entry is the raw two-character status code plus the path
-    (``"?? foo.py"``, ``" M src/x.py"``, ...). ``.forge/`` is gitignored so
-    Forge-managed artifacts do not appear. On git failure returns an empty
-    set; callers treat that as "no snapshot" rather than crashing.
+    (``"?? foo.py"``, ``" M src/x.py"``, ...). Entries under forge's own
+    runtime directory (``.forge/``) are filtered out mechanically — they are
+    coordinator-written artifacts, never operator contamination — so the gate
+    is correct even in a consumer repo that does not gitignore ``.forge/``. On
+    git failure returns an empty set; callers treat that as "no snapshot"
+    rather than crashing.
     """
     try:
         proc = subprocess.run(
@@ -74,7 +101,9 @@ def snapshot_porcelain(workspace_path: Path) -> set[str]:
     if not raw:
         return set()
     # -z entries are NUL-terminated; renames split across two NUL fields.
-    return {entry for entry in raw.split("\0") if entry}
+    return {
+        entry for entry in raw.split("\0") if entry and not _is_forge_runtime_path(_path_of(entry))
+    }
 
 
 def _path_of(entry: str) -> str:
@@ -116,8 +145,9 @@ def check_phase_no_mutation(
 def ensure_scratch_dir(workspace_path: Path, run_id: str) -> Path:
     """Create ``.forge/tmp/<run-id>/`` and return it.
 
-    ``.forge/`` is already gitignored, so the directory is invisible to git
-    and safe for agents to use as exploratory scratch space.
+    The directory lives under ``.forge/``, which ``snapshot_porcelain``
+    excludes mechanically, so it is safe for agents to use as exploratory
+    scratch space without tripping the hygiene gate.
     """
     scratch = workspace_path / ".forge" / "tmp" / run_id
     scratch.mkdir(parents=True, exist_ok=True)
@@ -138,11 +168,22 @@ def quarantine_paths(
     Returns ``(moved, failed)``. Moves preserve the relative tree so the
     operator can locate originals. ``shutil.move`` is used so cross-device
     moves degrade to copy+delete cleanly.
+
+    Paths under forge's own runtime directory (``.forge/``) are skipped
+    outright: the quarantine root itself lives at ``.forge/quarantine/...``, so
+    remediation must never target its own bookkeeping location. Moving
+    ``.forge/quarantine`` into a subdirectory of itself is a move-into-own-
+    subtree ``OSError`` that would otherwise surface as a spurious quarantine
+    failure and escalate the phase (hdp #183, TheForge #1699). Such paths are
+    reported as neither moved nor failed — there is nothing to remediate.
     """
     quarantine_root.mkdir(parents=True, exist_ok=True)
     moved: list[str] = []
     failed: list[str] = []
     for rel_path in paths:
+        if _is_forge_runtime_path(rel_path):
+            # Never remediate forge's own runtime artifacts (see docstring).
+            continue
         src = workspace_path / rel_path
         if not src.exists() and not src.is_symlink():
             # Path appeared in porcelain but is gone now (race or untracked dir

--- a/tests/test_coord_workspace_hygiene.py
+++ b/tests/test_coord_workspace_hygiene.py
@@ -38,6 +38,21 @@ def _init_repo(path: Path) -> None:
     subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
 
 
+def _init_repo_no_forge_ignore(path: Path) -> None:
+    """Init a consumer repo that does NOT gitignore ``.forge/`` at all.
+
+    Reproduces the hdp #183 field condition: the gate must classify forge's
+    own runtime output correctly even when nothing in the repo's gitignore
+    covers ``.forge/`` (TheForge #1699).
+    """
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+
+
 # ── snapshot_porcelain ────────────────────────────────────────────────
 
 
@@ -64,6 +79,23 @@ def test_snapshot_porcelain_excludes_gitignored_forge_dir(tmp_path: Path) -> Non
 
 def test_snapshot_porcelain_returns_empty_on_non_repo(tmp_path: Path) -> None:
     assert snapshot_porcelain(tmp_path) == set()
+
+
+def test_snapshot_porcelain_excludes_forge_dir_without_gitignore(tmp_path: Path) -> None:
+    """The #1699 core defect: even with NO ``.forge/`` gitignore entry, forge's
+    own runtime artifacts must not appear in the porcelain snapshot."""
+    _init_repo_no_forge_ignore(tmp_path)
+    (tmp_path / ".forge" / "quarantine").mkdir(parents=True)
+    (tmp_path / ".forge" / "quarantine" / "keep").write_text("x\n", encoding="utf-8")
+    (tmp_path / ".forge" / "escalated").write_text("marker\n", encoding="utf-8")
+    # A genuinely stray operator file at root still shows up.
+    (tmp_path / "stray.txt").write_text("oops\n", encoding="utf-8")
+
+    snap = snapshot_porcelain(tmp_path)
+    paths = {entry[3:] for entry in snap}
+
+    assert all(not p.startswith(".forge") for p in paths)
+    assert "stray.txt" in paths
 
 
 # ── unexpected_entries ────────────────────────────────────────────────
@@ -719,3 +751,93 @@ def test_run_review_phase_reverts_reviewer_tracked_mutation(
     assert outcome != _ReviewOutcome.ESCALATE or state.escalate_kind != "hygiene"
     # Suppress unused-variable warning from outcome capture.
     _ = outcome
+
+
+# ── self-artifact-proofing: forge's own .forge/ output is never contamination
+#    (issue #1699, hdp field incident #183) ─────────────────────────────────
+
+
+def test_quarantine_paths_skips_forge_runtime_paths(tmp_path: Path) -> None:
+    """The remediation machinery must never move its own bookkeeping location.
+
+    Moving ``.forge/quarantine`` into a subdirectory of itself is a
+    move-into-own-subtree OSError; the guard skips such paths so they are
+    reported as neither moved nor failed."""
+    from theforge.coordinator.workspace_hygiene import quarantine_paths  # noqa: PLC0415
+
+    _init_repo_no_forge_ignore(tmp_path)
+    (tmp_path / ".forge" / "quarantine").mkdir(parents=True)
+    (tmp_path / ".forge" / "quarantine" / "keep").write_text("x\n", encoding="utf-8")
+
+    quarantine_root = tmp_path / ".forge" / "quarantine" / "run-1" / "iter-0"
+    moved, failed = quarantine_paths(
+        tmp_path, [".forge/quarantine", ".forge/escalated"], quarantine_root
+    )
+
+    assert moved == []
+    assert failed == []
+    # The bookkeeping location is untouched — not moved into itself.
+    assert (tmp_path / ".forge" / "quarantine" / "keep").read_text() == "x\n"
+
+
+def test_enforce_pre_review_hygiene_ignores_forge_artifacts_without_gitignore(
+    tmp_path: Path,
+) -> None:
+    """Fix-success criterion: in a repo with NO ``.forge/`` gitignore entry, a
+    run that writes ``.forge/quarantine/`` and ``.forge/escalated`` passes the
+    pre-review hygiene checkpoint without quarantining or escalating."""
+    _init_repo_no_forge_ignore(tmp_path)
+    (tmp_path / ".forge" / "quarantine").mkdir(parents=True)
+    (tmp_path / ".forge" / "quarantine" / "prior").write_text("x\n", encoding="utf-8")
+    (tmp_path / ".forge" / "escalated").write_text("marker\n", encoding="utf-8")
+
+    ok, diag, audit = enforce_pre_review_hygiene(tmp_path, "run-1", cycle=1)
+
+    assert ok is True
+    assert diag is None
+    assert audit["quarantined"] == []
+    assert audit["modified"] == []
+    # Forge's own artifacts are left exactly where forge wrote them.
+    assert (tmp_path / ".forge" / "quarantine" / "prior").read_text() == "x\n"
+    assert (tmp_path / ".forge" / "escalated").read_text() == "marker\n"
+
+
+def test_enforce_pre_dev_hygiene_ignores_forge_artifacts_without_gitignore(
+    tmp_path: Path,
+) -> None:
+    """Symmetric pre-DEV counterpart: forge's own runtime output never trips
+    the DEV-entry gate, regardless of gitignore state."""
+    _init_repo_no_forge_ignore(tmp_path)
+    (tmp_path / ".forge").mkdir()
+    (tmp_path / ".forge" / "escalated").write_text("marker\n", encoding="utf-8")
+
+    ok, diag, audit = enforce_pre_dev_hygiene(tmp_path, "run-1", iteration=1)
+
+    assert ok is True
+    assert diag is None
+    assert audit["quarantined"] == []
+    assert (tmp_path / ".forge" / "escalated").read_text() == "marker\n"
+
+
+def test_reconcile_post_review_ignores_forge_artifacts_without_gitignore(
+    tmp_path: Path,
+) -> None:
+    """Post-review reconciliation excludes forge's own runtime output too, so a
+    run that wrote ``.forge/`` artifacts during REVIEW is not escalated on
+    them even absent a ``.forge/`` gitignore entry."""
+    _init_repo_no_forge_ignore(tmp_path)
+    before = snapshot_porcelain(tmp_path)
+    (tmp_path / ".forge" / "quarantine").mkdir(parents=True)
+    (tmp_path / ".forge" / "quarantine" / "new").write_text("x\n", encoding="utf-8")
+    (tmp_path / ".forge" / "escalated").write_text("marker\n", encoding="utf-8")
+
+    ok, diag, offending, audit = reconcile_post_review_mutations(
+        tmp_path, before, "run-1", cycle=0
+    )
+
+    assert ok is True
+    assert diag is None
+    assert offending == []
+    assert audit["quarantined"] == []
+    assert audit["tracked_changes"] == []
+    assert (tmp_path / ".forge" / "quarantine" / "new").read_text() == "x\n"


### PR DESCRIPTION
Closes #1699. Recovery of the sprint-approved fix (run 3f45b08c6129) whose integration rebase failed — the story worktree got branched from a **stale local release/v0.11 ref** (session-start), whose history diverged from origin via squash-merged PRs, so the rebase replayed 23 old commits and conflicted. This is a clean cherry-pick of the approved dev commit (3230eb0) onto current release/v0.11.

The fix itself: forge's own `.forge/` runtime output (quarantine dir, escalated marker) was being treated as untracked contamination by the pre-phase hygiene gate when the consumer repo didn't gitignore it — quarantine_paths then tried to move .forge/quarantine into itself, raising OSError mid-story (hdp #183). Now .forge/ paths are filtered mechanically in snapshot_porcelain regardless of gitignore state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)