### PR TITLE
conventions: hard checks hardcode src/theforge/ package root — no-op silently for consumer projects

### DIFF
--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -122,6 +122,37 @@ def _format_audit_storage(
     return lines, errors, warnings
 
 
+def _format_conventions(
+    config: ForgeConfig,
+) -> tuple[list[str], list[str]]:
+    """Build the CONVENTIONS (hard) section for check-config output.
+
+    Returns ``(lines, warnings)``. Prints the effective package roots the
+    circular-import, test-mirror, and line-count checks scan so an operator
+    can confirm a consumer layout is covered rather than silently no-oping.
+    A configured root that doesn't exist becomes a warning (bumps exit to 1).
+    """
+    hard = config.conventions_hard
+    if hard is None:
+        return [], []
+
+    lines: list[str] = ["CONVENTIONS (hard)"]
+    warnings: list[str] = []
+
+    if hard.package_roots:
+        lines.append(f"  {'package_roots:':<16}{', '.join(hard.package_roots)}")
+        for root in hard.package_roots:
+            if not (config.project_root / root).exists():
+                warnings.append(
+                    f"conventions.hard.package_roots entry '{root}' does not exist "
+                    "under the project root — its checks will find nothing"
+                )
+    else:
+        lines.append(f"  {'package_roots:':<16}src/theforge (default scope)")
+
+    return lines, warnings
+
+
 class _CapturingHandler(logging.Handler):
     """Logging handler that captures WARNING+ records into a list."""
 
@@ -507,6 +538,13 @@ def _format_config(
             if not ready:
                 warnings_list.append(f"{agent.name}: {reason} — will be skipped at runtime")
         lines.append("")
+
+    # ── CONVENTIONS (hard) ───────────────────────────────────────────────
+    conv_lines, conv_warnings = _format_conventions(config)
+    if conv_lines:
+        lines.extend(conv_lines)
+        lines.append("")
+        warnings_list.extend(conv_warnings)
 
     # ── AUDIT STORAGE ────────────────────────────────────────────────────
     audit_lines, audit_errors, audit_warnings = _format_audit_storage(config.project_root)

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -1000,6 +1000,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         _no_scratch = conventions_hard_raw.get("no_scratch_files", True)
         _stack = conventions_hard_raw.get("stack", [])
         _allowed_root_files = conventions_hard_raw.get("allowed_root_files", [])
+        _package_roots = conventions_hard_raw.get("package_roots", [])
         if not isinstance(_max_module, int):
             raise ValueError(
                 "forge.yaml 'conventions.hard.max_module_lines' must be an int,"
@@ -1041,6 +1042,20 @@ def load_config(config_path: Path) -> ForgeConfig:
                 "forge.yaml 'conventions.hard.allowed_root_files' must be a list of strings,"
                 f" got {_allowed_root_files!r}"
             )
+        if not isinstance(_package_roots, list) or not all(
+            isinstance(item, str) for item in _package_roots
+        ):
+            raise ValueError(
+                "forge.yaml 'conventions.hard.package_roots' must be a list of strings,"
+                f" got {_package_roots!r}"
+            )
+        for _root in _package_roots:
+            if not (project_root / _root).exists():
+                log.warning(
+                    "forge.yaml 'conventions.hard.package_roots' entry %r does not exist "
+                    "under the project root — its checks will find nothing",
+                    _root,
+                )
         conventions_hard_cfg = HardConventionsConfig(
             max_module_lines=_max_module,
             max_test_file_lines=_max_test,
@@ -1049,6 +1064,7 @@ def load_config(config_path: Path) -> ForgeConfig:
             no_scratch_files=_no_scratch,
             stack=normalize_root_file_stacks(_stack_items),
             allowed_root_files=tuple(_allowed_root_files),
+            package_roots=tuple(_package_roots),
         )
 
     conventions_advisory_raw = conventions_raw.get("advisory", {})

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -510,6 +510,11 @@ class HardConventionsConfig:
     no_scratch_files: bool = True
     stack: tuple[str, ...] = ()
     allowed_root_files: tuple[str, ...] = ()
+    # Repo-relative package directories scanned by the circular-import,
+    # test-mirror, and line-count checks. Empty preserves the legacy
+    # src/theforge scope; consumer projects list their own package roots
+    # (e.g. ("src/pipeline", "analysis", "api")).
+    package_roots: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/theforge/conventions.py
+++ b/src/theforge/conventions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import io
+import logging
 import re
 import subprocess
 import tempfile
@@ -16,6 +17,44 @@ from theforge.root_file_conventions import (
     DEFAULT_ALLOWED_ROOT_FILES,
     resolve_root_file_allowances,
 )
+
+log = logging.getLogger(__name__)
+
+# Legacy default scope when no package_roots are configured: theforge's own
+# package. Preserves historical behavior for repos that don't set the field.
+_DEFAULT_PACKAGE_ROOT = "src/theforge"
+
+
+def _resolve_package_dirs(
+    project_root: Path, package_roots: tuple[str, ...] | list[str]
+) -> list[tuple[Path, Path]]:
+    """Return ``(package_dir, import_root)`` pairs for the configured roots.
+
+    ``package_dir`` is the directory scanned for ``*.py`` files; ``import_root``
+    is the directory dotted module names are resolved against (the package's
+    parent, mirroring how Python resolves imports). An empty ``package_roots``
+    falls back to the legacy ``src/theforge`` scope so existing repos are
+    unaffected.
+
+    Configured roots that don't exist are logged (not silently dropped) so
+    enabling a check against a missing root surfaces a warning instead of a
+    no-op.
+    """
+    roots = list(package_roots) if package_roots else [_DEFAULT_PACKAGE_ROOT]
+    pairs: list[tuple[Path, Path]] = []
+    for rel in roots:
+        pkg_dir = project_root / rel
+        if not pkg_dir.exists():
+            if package_roots:
+                log.warning(
+                    "conventions: configured package_root %r does not exist under %s "
+                    "— nothing to check",
+                    rel,
+                    project_root,
+                )
+            continue
+        pairs.append((pkg_dir, pkg_dir.parent))
+    return pairs
 
 
 @dataclass
@@ -33,9 +72,9 @@ def check_hard_conventions(
     violations: list[ConventionViolation] = []
     violations.extend(_check_line_counts(config, project_root))
     if config.no_circular_imports:
-        violations.extend(_check_circular_imports(project_root))
+        violations.extend(_check_circular_imports(project_root, config.package_roots))
     if config.test_mirrors_source:
-        violations.extend(_check_test_mirrors(project_root))
+        violations.extend(_check_test_mirrors(project_root, config.package_roots))
     if config.no_scratch_files:
         violations.extend(
             _check_no_scratch_files(
@@ -106,21 +145,36 @@ def _check_line_counts(
 ) -> list[ConventionViolation]:
     violations: list[ConventionViolation] = []
 
-    src_root = project_root / "src"
     tests_root = project_root / "tests"
 
-    for py_file in sorted(src_root.rglob("*.py")):
-        line_count = len(py_file.read_text(encoding="utf-8", errors="replace").splitlines())
-        if line_count > config.max_module_lines:
-            rel = str(py_file.relative_to(project_root))
-            violations.append(
-                ConventionViolation(
-                    rule="max_module_lines",
-                    file=rel,
-                    detail=f"{rel} has {line_count} lines (limit {config.max_module_lines})",
-                    blocking=False,
+    # Module scan roots: configured package_roots (which may live outside src/),
+    # else the legacy src/** scope. Dedup by resolved path so overlapping roots
+    # (e.g. "src" and "src/pipeline") don't double-report a file.
+    if config.package_roots:
+        module_roots = [project_root / rel for rel in config.package_roots]
+    else:
+        module_roots = [project_root / "src"]
+
+    seen: set[Path] = set()
+    for module_root in module_roots:
+        if not module_root.exists():
+            continue
+        for py_file in sorted(module_root.rglob("*.py")):
+            resolved = py_file.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            line_count = len(py_file.read_text(encoding="utf-8", errors="replace").splitlines())
+            if line_count > config.max_module_lines:
+                rel = str(py_file.relative_to(project_root))
+                violations.append(
+                    ConventionViolation(
+                        rule="max_module_lines",
+                        file=rel,
+                        detail=f"{rel} has {line_count} lines (limit {config.max_module_lines})",
+                        blocking=False,
+                    )
                 )
-            )
 
     for py_file in sorted(tests_root.rglob("*.py")):
         line_count = len(py_file.read_text(encoding="utf-8", errors="replace").splitlines())
@@ -206,22 +260,24 @@ def _collect_imports(py_file: Path, src_root: Path) -> list[str]:
     return imports
 
 
-def _check_circular_imports(project_root: Path) -> list[ConventionViolation]:
-    # Spec scopes this check to src/theforge only
-    theforge_src = project_root / "src" / "theforge"
-    src_root = project_root / "src"
-    if not theforge_src.exists():
+def _check_circular_imports(
+    project_root: Path, package_roots: tuple[str, ...] | list[str] = ()
+) -> list[ConventionViolation]:
+    pairs = _resolve_package_dirs(project_root, package_roots)
+    if not pairs:
         return []
 
-    # Build adjacency: module → set of imported modules
+    # Build adjacency: module → set of imported modules. Modules from every
+    # configured root share one graph, so cycles that span roots are caught.
     adjacency: dict[str, list[str]] = {}
     file_map: dict[str, Path] = {}
 
-    for py_file in sorted(theforge_src.rglob("*.py")):
-        mod = _module_name(py_file, src_root)
-        imports = _collect_imports(py_file, src_root)
-        adjacency[mod] = imports
-        file_map[mod] = py_file
+    for pkg_dir, import_root in pairs:
+        for py_file in sorted(pkg_dir.rglob("*.py")):
+            mod = _module_name(py_file, import_root)
+            imports = _collect_imports(py_file, import_root)
+            adjacency[mod] = imports
+            file_map[mod] = py_file
 
     # DFS-based cycle detection
     visited: set[str] = set()
@@ -339,48 +395,54 @@ def _check_no_scratch_files(
 # ── Test mirror check ─────────────────────────────────────────────────
 
 
-def _check_test_mirrors(project_root: Path) -> list[ConventionViolation]:
-    src_pkg = project_root / "src" / "theforge"
+def _check_test_mirrors(
+    project_root: Path, package_roots: tuple[str, ...] | list[str] = ()
+) -> list[ConventionViolation]:
     tests_root = project_root / "tests"
-    if not src_pkg.exists() or not tests_root.exists():
+    if not tests_root.exists():
+        return []
+
+    pkg_dirs = [pkg_dir for pkg_dir, _ in _resolve_package_dirs(project_root, package_roots)]
+    if not pkg_dirs:
         return []
 
     violations: list[ConventionViolation] = []
 
-    for item in sorted(src_pkg.iterdir()):
-        if item.name == "__init__.py" or item.name == "__pycache__":
-            continue
+    for src_pkg in pkg_dirs:
+        for item in sorted(src_pkg.iterdir()):
+            if item.name == "__init__.py" or item.name == "__pycache__":
+                continue
 
-        if item.is_file() and item.suffix == ".py":
-            # src/theforge/foo.py → tests/test_foo.py
-            expected = tests_root / f"test_{item.stem}.py"
-            if not expected.exists():
-                rel = str(item.relative_to(project_root))
-                expected_rel = expected.relative_to(project_root)
-                violations.append(
-                    ConventionViolation(
-                        rule="test_mirrors_source",
-                        file=rel,
-                        detail=f"No test mirror found for {rel} (expected {expected_rel})",
+            if item.is_file() and item.suffix == ".py":
+                # <root>/foo.py → tests/test_foo.py
+                expected = tests_root / f"test_{item.stem}.py"
+                if not expected.exists():
+                    rel = str(item.relative_to(project_root))
+                    expected_rel = expected.relative_to(project_root)
+                    violations.append(
+                        ConventionViolation(
+                            rule="test_mirrors_source",
+                            file=rel,
+                            detail=f"No test mirror found for {rel} (expected {expected_rel})",
+                        )
                     )
-                )
-        elif item.is_dir():
-            # src/theforge/foo/ → tests/test_foo_*.py OR tests/test_foo/
-            pkg_name = item.name
-            mirror_dir = tests_root / f"test_{pkg_name}"
-            mirror_glob = list(tests_root.glob(f"test_{pkg_name}_*.py"))
-            if not mirror_dir.exists() and not mirror_glob:
-                rel = str(item.relative_to(project_root))
-                violations.append(
-                    ConventionViolation(
-                        rule="test_mirrors_source",
-                        file=rel,
-                        detail=(
-                            f"No test mirror found for package {rel} "
-                            f"(expected tests/test_{pkg_name}_*.py or tests/test_{pkg_name}/)"
-                        ),
+            elif item.is_dir():
+                # <root>/foo/ → tests/test_foo_*.py OR tests/test_foo/
+                pkg_name = item.name
+                mirror_dir = tests_root / f"test_{pkg_name}"
+                mirror_glob = list(tests_root.glob(f"test_{pkg_name}_*.py"))
+                if not mirror_dir.exists() and not mirror_glob:
+                    rel = str(item.relative_to(project_root))
+                    violations.append(
+                        ConventionViolation(
+                            rule="test_mirrors_source",
+                            file=rel,
+                            detail=(
+                                f"No test mirror found for package {rel} "
+                                f"(expected tests/test_{pkg_name}_*.py or tests/test_{pkg_name}/)"
+                            ),
+                        )
                     )
-                )
 
     return violations
 

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -178,6 +178,52 @@ class TestCheckConfigHappyPath:
         assert "forge init-hooks" in out
         assert "--update" not in out
 
+    def test_package_roots_printed_and_pass(self, tmp_path: Path, capsys) -> None:
+        """check-config prints effective package_roots and exits 0 when they exist (AC1)."""
+        from theforge.config.types import HardConventionsConfig
+
+        (tmp_path / "src" / "pipeline").mkdir(parents=True)
+        (tmp_path / "analysis").mkdir(parents=True)
+        (tmp_path / "api").mkdir(parents=True)
+        config = replace(
+            _make_forge_config(tmp_path),
+            conventions_hard=HardConventionsConfig(
+                package_roots=("src/pipeline", "analysis", "api")
+            ),
+        )
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            exit_code = cmd_check_config(_make_args())
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "CONVENTIONS (hard)" in out
+        assert "src/pipeline, analysis, api" in out
+        assert "WARNINGS" not in out
+
+    def test_missing_package_root_warns(self, tmp_path: Path, capsys) -> None:
+        """A configured package_root that doesn't exist surfaces a warning (exit 1)."""
+        from theforge.config.types import HardConventionsConfig
+
+        (tmp_path / "src" / "pipeline").mkdir(parents=True)
+        config = replace(
+            _make_forge_config(tmp_path),
+            conventions_hard=HardConventionsConfig(package_roots=("src/pipeline", "api")),
+        )
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            exit_code = cmd_check_config(_make_args())
+        assert exit_code == 1
+        out = capsys.readouterr().out
+        assert "CONVENTIONS (hard)" in out
+        assert "WARNINGS" in out
+        assert "'api' does not exist" in out
+
     def test_sections_present(self, tmp_path: Path, capsys) -> None:
         config = _make_forge_config(tmp_path)
         with (

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -798,6 +798,41 @@ class TestConventionsConfig:
         assert config.conventions_hard.stack == ("python", "javascript")
         assert config.conventions_hard.allowed_root_files == ("my-project-config.yaml",)
 
+    def test_conventions_hard_package_roots_parsed(self, tmp_path):
+        """conventions.hard.package_roots parses into a tuple of strings."""
+        (tmp_path / "src" / "pipeline").mkdir(parents=True)
+        (tmp_path / "analysis").mkdir(parents=True)
+        (tmp_path / "api").mkdir(parents=True)
+        config_path = _write_config(
+            {
+                "conventions": {
+                    "hard": {
+                        "package_roots": ["src/pipeline", "analysis", "api"],
+                    }
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.conventions_hard is not None
+        assert config.conventions_hard.package_roots == ("src/pipeline", "analysis", "api")
+
+    def test_conventions_hard_package_roots_default_empty(self, tmp_path):
+        """Omitting package_roots yields an empty tuple (legacy scope preserved)."""
+        config_path = _write_config({"conventions": {"hard": {}}}, tmp_path)
+        config = load_config(config_path)
+        assert config.conventions_hard is not None
+        assert config.conventions_hard.package_roots == ()
+
+    def test_conventions_hard_package_roots_invalid_type_raises(self, tmp_path):
+        """package_roots that isn't a list of strings raises ValueError."""
+        config_path = _write_config(
+            {"conventions": {"hard": {"package_roots": "src/pipeline"}}},
+            tmp_path,
+        )
+        with pytest.raises(ValueError, match="package_roots"):
+            load_config(config_path)
+
     def test_conventions_absent_is_none(self, tmp_path):
         """forge.yaml without conventions section yields conventions_hard=None."""
         config_path = _write_config({}, tmp_path)

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -86,6 +86,25 @@ class TestLineCountCheck:
         violations = _check_line_counts(cfg, tmp_path)
         assert violations == []
 
+    def test_line_count_under_configured_root_outside_src(self, tmp_path):
+        """Oversized file under a configured root outside src/ is reported (AC3)."""
+        py_file = tmp_path / "analysis" / "big.py"
+        _write(py_file, "\n" * 501)
+        cfg = _make_config(max_module_lines=500, package_roots=("analysis",))
+        violations = _check_line_counts(cfg, tmp_path)
+        assert any(
+            v.rule == "max_module_lines" and "analysis/big.py" in v.file for v in violations
+        )
+
+    def test_line_count_configured_roots_no_double_report(self, tmp_path):
+        """Overlapping configured roots don't report the same file twice."""
+        py_file = tmp_path / "src" / "pipeline" / "big.py"
+        _write(py_file, "\n" * 501)
+        cfg = _make_config(max_module_lines=500, package_roots=("src", "src/pipeline"))
+        violations = _check_line_counts(cfg, tmp_path)
+        matches = [v for v in violations if v.rule == "max_module_lines" and "big.py" in v.file]
+        assert len(matches) == 1
+
 
 # ── Circular import tests ─────────────────────────────────────────────
 
@@ -162,6 +181,42 @@ class TestCircularImportCheck:
         violations = _check_circular_imports(tmp_path)
         assert not any(v.rule == "no_circular_imports" for v in violations)
 
+    def test_cycle_under_configured_non_default_root(self, tmp_path):
+        """A cycle under a configured non-default root is reported (AC2)."""
+        # Consumer layout: top-level 'analysis' package, not src/theforge.
+        pkg = tmp_path / "analysis"
+        pkg.mkdir(parents=True)
+        _write(pkg / "a.py", "from analysis import b\n")
+        _write(pkg / "b.py", "from analysis import a\n")
+        # No src/theforge exists — the default scope would find nothing.
+        violations = _check_circular_imports(tmp_path, ("analysis",))
+        assert any(v.rule == "no_circular_imports" for v in violations)
+
+    def test_cycle_under_configured_src_subpackage(self, tmp_path):
+        """A cycle under a configured src/ subpackage root resolves module names."""
+        pkg = tmp_path / "src" / "pipeline"
+        pkg.mkdir(parents=True)
+        _write(pkg / "a.py", "from pipeline import b\n")
+        _write(pkg / "b.py", "from pipeline import a\n")
+        violations = _check_circular_imports(tmp_path, ("src/pipeline",))
+        assert any(v.rule == "no_circular_imports" for v in violations)
+
+    def test_cycle_across_configured_roots(self, tmp_path):
+        """A cycle spanning two configured roots is caught in one shared graph."""
+        analysis = tmp_path / "analysis"
+        api = tmp_path / "api"
+        analysis.mkdir(parents=True)
+        api.mkdir(parents=True)
+        _write(analysis / "a.py", "from api import b\n")
+        _write(api / "b.py", "from analysis import a\n")
+        violations = _check_circular_imports(tmp_path, ("analysis", "api"))
+        assert any(v.rule == "no_circular_imports" for v in violations)
+
+    def test_missing_configured_root_no_crash(self, tmp_path):
+        """A configured root that doesn't exist is skipped without crashing."""
+        violations = _check_circular_imports(tmp_path, ("does/not/exist",))
+        assert violations == []
+
 
 # ── Test mirror tests ─────────────────────────────────────────────────
 
@@ -225,6 +280,20 @@ class TestTestMirrorCheck:
         """Missing src or tests dir → no crash, no violations."""
         violations = _check_test_mirrors(tmp_path)
         assert violations == []
+
+    def test_missing_mirror_under_configured_root(self, tmp_path):
+        """A module under a configured non-default root needs a test mirror."""
+        _write(tmp_path / "analysis" / "bar.py", "# module\n")
+        (tmp_path / "tests").mkdir(parents=True)
+        violations = _check_test_mirrors(tmp_path, ("analysis",))
+        assert any(v.rule == "test_mirrors_source" and "bar.py" in v.file for v in violations)
+
+    def test_mirror_ok_under_configured_root(self, tmp_path):
+        """Mirror present for a module under a configured root → no violation."""
+        _write(tmp_path / "analysis" / "bar.py", "# module\n")
+        _write(tmp_path / "tests" / "test_bar.py", "# tests\n")
+        violations = _check_test_mirrors(tmp_path, ("analysis",))
+        assert not any(v.rule == "test_mirrors_source" and "bar.py" in v.file for v in violations)
 
 
 # ── check_hard_conventions integration ───────────────────────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the package_roots acceptance criteria with focused runtime coverage. | [google-gemini-3.5-flash] The package_roots configuration successfully un-hardcodes the hard-check scope for circular-import, test-mirror, and line-count checks with full backward compatibility.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $3.84
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

conventions: hard checks hardcode src/theforge/ package root — no-op silently for consumer projects (GitHub Issue #1704)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1704