### PR TITLE
Baseline gate runs in a bare worktree — setup_command never runs

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -542,6 +542,28 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
                 ),
             }
 
+        if config.workspace.setup_command:
+            _log(f"Running baseline workspace setup: {config.workspace.setup_command}")
+            setup_ok, setup_out = coordinator_workspace._run_setup_split(
+                config.workspace.setup_command, baseline_worktree
+            )
+            if not setup_ok:
+                duration = time.monotonic() - started_monotonic
+                return {
+                    "status": "error",
+                    "passed": False,
+                    "exit_code": 1,
+                    "duration_seconds": round(duration, 2),
+                    "started_at": baseline_started_at,
+                    "finished_at": datetime.datetime.now(datetime.timezone.utc),
+                    "merge_base": merge_base_ref,
+                    "command": config.validation.gate_command,
+                    "message": (
+                        "Broken baseline: workspace setup command failed in the temporary "
+                        f"baseline worktree for merge base {merge_base_ref}: {setup_out}"
+                    ),
+                }
+
         decision, error, output_tail, resolved_gate_cmd, gate_exit_code = run_gate_full(
             config, baseline_worktree
         )

--- a/tests/test_sprint_baseline_gate.py
+++ b/tests/test_sprint_baseline_gate.py
@@ -143,6 +143,48 @@ def test_baseline_gate_preserves_actual_gate_exit_code(tmp_path: Path) -> None:
     assert "boom" in str(baseline.get("output_tail", ""))
 
 
+def test_baseline_gate_runs_setup_command_before_gate(tmp_path: Path) -> None:
+    config, resolved, base_commit = _init_repo(tmp_path)
+    # setup_command bootstraps a marker the gate depends on; the merge base has
+    # no such marker, so the gate can only pass if setup runs first inside the
+    # temporary baseline worktree.
+    config = replace(
+        config,
+        workspace=replace(config.workspace, setup_command="echo READY > toolchain.txt"),
+        validation=replace(
+            config.validation,
+            gate_command=(
+                'python -c "import pathlib; '
+                "print(pathlib.Path('toolchain.txt').read_text().strip())\""
+            ),
+        ),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is True
+    assert baseline["status"] == "pass"
+    assert baseline["merge_base"] == base_commit
+    assert "READY" in str(baseline.get("output_tail", ""))
+    # The setup marker must not leak into the project root checkout.
+    assert not (tmp_path / "toolchain.txt").exists()
+
+
+def test_baseline_gate_reports_setup_command_failure(tmp_path: Path) -> None:
+    config, resolved, base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        workspace=replace(config.workspace, setup_command="exit 3"),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is False
+    assert baseline["status"] == "error"
+    assert baseline["merge_base"] == base_commit
+    assert "workspace setup command failed" in str(baseline["message"]).lower()
+
+
 def test_baseline_gate_accepts_symlinked_project_root(tmp_path: Path) -> None:
     real_root = tmp_path / "real-root"
     real_root.mkdir()


### PR DESCRIPTION
## Summary

The change runs setup_command in the temporary baseline worktree before the gate and adds focused regression coverage; no blocking issues found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $1.06
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Baseline gate runs in a bare worktree — setup_command never runs (GitHub Issue #1605)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1605