### PR TITLE
Baseline gate does not substitute {test_target} — literal placeholder reaches the shell

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -225,6 +225,7 @@ validation:
   gate_debug_timeout: ~                # seconds; default: same resolved value as gate_timeout
   test_command: ~                      # optional command agents may run during dev
   pre_validate_command: ~              # optional: run before dirty check
+  default_test_target: "."             # {test_target} substitution when no story test_target applies (e.g. baseline gate)
 
 # ── Retry policy ───────────────────────────────────────────
 retry:

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -545,6 +545,9 @@ def load_config(config_path: Path) -> ForgeConfig:
         pre_validate_command=val_data.get("pre_validate_command"),
         gate_cpu_cores=val_data.get("gate_cpu_cores"),
         gate_timeout_scale=str(val_data.get("gate_timeout_scale", "adaptive")),
+        default_test_target=str(
+            val_data.get("default_test_target", DEFAULT_VALIDATION.default_test_target)
+        ),
     )
 
     # ── v0.8 models: key ──────────────────────────────────────────────

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -235,6 +235,9 @@ class ValidationConfig:
     )
     gate_debug_timeout: int | None = None  # seconds; None = same resolved value as gate_timeout
     test_command: str | None = None  # canonical command for intermediate test runs in dev loop
+    # Substituted for {test_target} when no task is available (baseline gate) or
+    # when a task has no test_target of its own.
+    default_test_target: str = "."
     pre_validate_command: str | None = None  # optional command run before dirty check
     # Adaptive gate-timeout scaling under sprint --parallel N. The baseline
     # gate_timeout above is the alone-time budget. When mode == "adaptive"

--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -85,10 +85,11 @@ def run_gate_full(
         gate_cmd = task.gate_override  # type: ignore[union-attr]
     else:
         gate_cmd = config.validation.gate_command
-        if task is not None:
-            test_target = task.test_target or "."
-            gate_cmd = gate_cmd.replace("{test_target}", test_target)
-            gate_cmd = gate_cmd.replace("{slug}", task.slug)
+        default_target = config.validation.default_test_target or "."
+        test_target = (task.test_target if task is not None else None) or default_target
+        slug = task.slug if task is not None else "baseline"
+        gate_cmd = gate_cmd.replace("{test_target}", test_target)
+        gate_cmd = gate_cmd.replace("{slug}", slug)
 
     _cu._log_verbose(f"Running gate: {gate_cmd}")
     gate_timeout = config.validation.gate_timeout or 600

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1001,6 +1001,31 @@ class TestValidationTestCommand:
         with pytest.raises(ValueError, match="v0.8"):
             load_config(config_path)
 
+    def test_default_test_target_parsed_when_present(self, tmp_path):
+        config_path = _write_config(
+            {
+                "validation": {
+                    "gate_command": "make gate",
+                    "default_test_target": "tests/",
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.validation.default_test_target == "tests/"
+
+    def test_default_test_target_defaults_to_dot_when_absent(self, tmp_path):
+        config_path = _write_config(
+            {
+                "validation": {
+                    "gate_command": "make gate",
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.validation.default_test_target == "."
+
 
 class TestCliPoolCrossProviderRotation:
     """Issue #1468 — a CLI-only models: pool (claude/codex/gemini) loaded via

--- a/tests/test_gate_test_target_substitution.py
+++ b/tests/test_gate_test_target_substitution.py
@@ -1,0 +1,74 @@
+"""run_gate_full must substitute {test_target}/{slug} even when no task is
+supplied (the baseline gate path), instead of leaking the literal
+placeholder text into the shell command."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from coord_test_helpers import _make_config
+
+from theforge.coordinator.gate import run_gate_full
+from theforge.task import TaskStory
+
+
+def test_no_task_substitutes_default_test_target_and_slug(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    config = replace(
+        config,
+        validation=replace(config.validation, gate_command="echo {test_target} {slug}"),
+    )
+
+    _decision, _error, _output_tail, resolved_gate_cmd, _exit_code = run_gate_full(
+        config, tmp_path, task=None
+    )
+
+    assert "{test_target}" not in resolved_gate_cmd
+    assert "{slug}" not in resolved_gate_cmd
+    assert "." in resolved_gate_cmd
+    assert "baseline" in resolved_gate_cmd
+
+
+def test_no_task_uses_configured_default_test_target(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command="echo {test_target}",
+            default_test_target="tests/",
+        ),
+    )
+
+    _decision, _error, _output_tail, resolved_gate_cmd, _exit_code = run_gate_full(
+        config, tmp_path, task=None
+    )
+
+    assert resolved_gate_cmd == "echo tests/"
+
+
+def test_task_test_target_still_takes_precedence_over_default(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command="echo {test_target} {slug}",
+            default_test_target="tests/",
+        ),
+    )
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Test Spec\n", encoding="utf-8")
+    task = TaskStory(
+        name="Test Task",
+        story_path=spec,
+        slug="my-slug",
+        test_target="tests/test_foo.py",
+    )
+
+    _decision, _error, _output_tail, resolved_gate_cmd, _exit_code = run_gate_full(
+        config, tmp_path, task=task
+    )
+
+    assert resolved_gate_cmd == "echo tests/test_foo.py my-slug"

--- a/tests/test_sprint_baseline_gate.py
+++ b/tests/test_sprint_baseline_gate.py
@@ -143,6 +143,28 @@ def test_baseline_gate_preserves_actual_gate_exit_code(tmp_path: Path) -> None:
     assert "boom" in str(baseline.get("output_tail", ""))
 
 
+def test_baseline_gate_substitutes_test_target_placeholder(tmp_path: Path) -> None:
+    # A gate_command that uses {test_target}/{slug} (as HDP's did) must not
+    # leak the literal placeholder text into the baseline gate's shell
+    # command, since the baseline gate has no TaskStory to source them from.
+    config, resolved, base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command="echo {test_target} {slug}",
+        ),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is True
+    assert baseline["merge_base"] == base_commit
+    resolved_cmd = baseline["command"]
+    assert "{test_target}" not in resolved_cmd
+    assert "{slug}" not in resolved_cmd
+
+
 def test_baseline_gate_runs_setup_command_before_gate(tmp_path: Path) -> None:
     config, resolved, base_commit = _init_repo(tmp_path)
     # setup_command bootstraps a marker the gate depends on; the merge base has


### PR DESCRIPTION
## Summary

Prior P1 (default_test_target never parsed from forge.yaml) is resolved in commit e7f1035; load.py now reads the key with DEFAULT_VALIDATION fallback and two load_config-level tests cover present/absent cases. No regressions introduced.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $3.09
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Baseline gate does not substitute {test_target} — literal placeholder reaches the shell (GitHub Issue #1608)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1608