### PR TITLE
Plan-review parse failure is fatal with no reviewer retry — flaky reviewer output kills stories

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -681,6 +681,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         max_plan_review_transport_retries=int(
             retry_data.get("max_plan_review_transport_retries", 2)
         ),
+        max_plan_review_parse_retries=int(retry_data.get("max_plan_review_parse_retries", 2)),
         max_review_transport_retries=int(retry_data.get("max_review_transport_retries", 2)),
         review_transport_retry_backoff_seconds=float(
             retry_data.get("review_transport_retry_backoff_seconds", 8.0)

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -261,6 +261,10 @@ class RetryPolicy:
     max_plan_review_transport_retries: int = (
         2  # per-reviewer retries on transient plan-review transport/provider failure
     )
+    max_plan_review_parse_retries: int = (
+        2  # per-reviewer fresh-session retries when a plan reviewer completes but
+        # emits unparseable output (prose / non-mapping YAML root); 0 disables
+    )
     # Per-reviewer retries on transient review-pool transport/provider failure.
     max_review_transport_retries: int = 2
     # Initial backoff (seconds) for review-pool transient retry; doubled per retry.

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -163,8 +163,11 @@ def _build_plan_review_per_reviewer(state: CoordinatorState, config: ForgeConfig
             for result in state.plan_review_results
         ]
 
+    # Both retry paths append a pre-retry result to state.plan_review_results per
+    # retry, so the per-attempt chunk size in plan_review_results is
+    # pool_size + transport_retries + parse_retries for that attempt.
     retry_counts_by_attempt: dict[int, int] = {}
-    for event in state.plan_review_transport_retries:
+    for event in (*state.plan_review_transport_retries, *state.plan_review_parse_retries):
         attempt = event.get("attempt")
         if isinstance(attempt, int):
             retry_counts_by_attempt[attempt] = retry_counts_by_attempt.get(attempt, 0) + 1
@@ -664,6 +667,11 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 **(
                     {"transport_retries": state.plan_review_transport_retries}
                     if state.plan_review_transport_retries
+                    else {}
+                ),
+                **(
+                    {"parse_retries": state.plan_review_parse_retries}
+                    if state.plan_review_parse_retries
                     else {}
                 ),
                 **(

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -205,6 +205,99 @@ def _retry_transient_plan_review_failures(
     return retried_results, retry_events
 
 
+def _plan_review_parse_errors(result: "AgentResult") -> list[str]:
+    """Return parse-error strings for a reviewer completion, or [] if it parses.
+
+    Only successful-at-transport completions are eligible: transport failures are
+    owned by _retry_transient_plan_review_failures and must not be double-counted
+    here as parse failures.
+    """
+    if not result.success:
+        return []
+    parsed = parse_plan_review_output(result.output or "")
+    return [str(e) for e in parsed.parse_errors]
+
+
+def _retry_parse_failed_plan_reviews(
+    *,
+    prompt: str,
+    profiles: list[ModelProfile],
+    results: list["AgentResult"],
+    state: CoordinatorState,
+    config: ForgeConfig,
+    workspace_path: Path,
+    attempt: int,
+) -> tuple[list["AgentResult"], list[dict]]:
+    """Retry plan reviewers whose completion succeeded but produced unparseable output.
+
+    A reviewer that returns success at the transport level but emits prose or a
+    non-mapping YAML root is a transient *agent* failure, not a story failure. The
+    transport-retry path (_retry_transient_plan_review_failures) never reaches these
+    because it gates on result.success == False. Mirror it for the success-but-
+    unparseable case: re-invoke that specific reviewer in a fresh session (a stale
+    session anchors on its own bad output) up to max_plan_review_parse_retries times
+    before the minimum-reviewers gate is evaluated.
+
+    Each pre-retry result is appended to state.plan_review_results so cost and the
+    per-reviewer audit reconstruction stay consistent with the transport path.
+    """
+    max_retries = config.retry.max_plan_review_parse_retries
+    if max_retries <= 0:
+        return results, []
+
+    retried_results = list(results)
+    retry_events: list[dict] = []
+
+    for index, (profile, result) in enumerate(zip(profiles, retried_results)):
+        errors = _plan_review_parse_errors(result)
+        if not errors:
+            continue
+
+        retry_count = 0
+        current = result
+        while retry_count < max_retries and errors:
+            state.plan_review_results.append(current)
+            retry_count += 1
+            _log(
+                f"  ↻ PLAN_REVIEW   {profile.name} unparseable output "
+                f"(parse retry {retry_count}/{max_retries}): {'; '.join(errors)[:120]}"
+            )
+            retried = run_agent(
+                prompt=prompt,
+                profile=profile,
+                working_dir=workspace_path,
+                quiet=True,
+                secrets=config.secrets,
+                session_id=None,  # fresh session — prior anchors on its own bad output
+            )
+            if retried.session_id:
+                state.plan_review_session_ids[profile.name] = retried.session_id
+            _write_log_artifact(
+                state.log_dir,
+                f"plan-review/attempt-{attempt}/{profile.name}-parse-retry{retry_count}.yaml",
+                retried.output or "",
+            )
+            retry_events.append(
+                {
+                    "attempt": attempt,
+                    "reviewer": profile.name,
+                    "retry": retry_count,
+                    "errors": list(errors),
+                }
+            )
+            current = retried
+            errors = _plan_review_parse_errors(current)
+
+        if retry_count:
+            if errors:
+                _log(f"  ✗ PLAN_REVIEW   {profile.name} parse retries exhausted")
+            else:
+                _log(f"  ✓ PLAN_REVIEW   {profile.name} parse retry {retry_count} succeeded")
+        retried_results[index] = current
+
+    return retried_results, retry_events
+
+
 def _clean_stale_plan_files(workspace_path: Path) -> None:
     """Remove stale plan artifacts before starting a fresh PLAN phase."""
     for plan_path in plan_paths(workspace_path):
@@ -638,6 +731,16 @@ def _run_plan_agent_review(
             attempt=_attempt,
         )
         state.plan_review_transport_retries.extend(_transport_retry_events)
+        pr_results, _parse_retry_events = _retry_parse_failed_plan_reviews(
+            prompt=pr_prompt,
+            profiles=par_profiles,
+            results=pr_results,
+            state=state,
+            config=config,
+            workspace_path=workspace_path,
+            attempt=_attempt,
+        )
+        state.plan_review_parse_retries.extend(_parse_retry_events)
         _pr_elapsed = time.monotonic() - _pr_start
         state.plan_review_durations.append(_pr_elapsed)
 
@@ -685,7 +788,7 @@ def _run_plan_agent_review(
                     _failure_kind = _res.failure_code or "generic"
                 _retry_count = sum(
                     1
-                    for _event in _transport_retry_events
+                    for _event in (*_transport_retry_events, *_parse_retry_events)
                     if _event["attempt"] == _attempt and _event["reviewer"] == _prof.name
                 )
                 _log(

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -369,6 +369,10 @@ class CoordinatorState:
     plan_review_transport_retries: list[dict] = field(
         default_factory=list
     )  # per-retry audit trail: {"attempt": int, "reviewer": str, "retry": int, "error": str}
+    plan_review_parse_retries: list[dict] = field(
+        default_factory=list
+    )  # per-retry audit for successful-but-unparseable reviewer re-invocations:
+    # {"attempt": int, "reviewer": str, "retry": int, "errors": list[str]}
     plan_review_failures: list[dict] = field(
         default_factory=list
     )  # per-reviewer failures: {"attempt": int, "reviewer": str, "errors": list[str], ...}

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -139,6 +139,16 @@ class TestLoadConfig:
         assert "rate_limit" in config.retry.review_transient_failure_codes
         assert any("rate limit" in p for p in config.retry.review_transient_output_patterns)
 
+    def test_plan_review_parse_retries_default(self, tmp_path):
+        config_path = _write_config({"retry": {}}, tmp_path)
+        config = load_config(config_path)
+        assert config.retry.max_plan_review_parse_retries == 2
+
+    def test_plan_review_parse_retries_override(self, tmp_path):
+        config_path = _write_config({"retry": {"max_plan_review_parse_retries": 0}}, tmp_path)
+        config = load_config(config_path)
+        assert config.retry.max_plan_review_parse_retries == 0
+
     def test_auto_model_escalation_defaults_false(self, tmp_path):
         config_path = _write_config({"retry": {}}, tmp_path)
         config = load_config(config_path)

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -105,7 +105,14 @@ def _make_plan_agent_review_config(tmp_path: Path, *, dual_reviewer: bool = Fals
         preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
         review_pool=[DEFAULT_REVIEW_PROFILE],
         synthesis_profile=None,
-        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        retry=RetryPolicy(
+            max_dev_iterations=2,
+            max_review_cycles=2,
+            # Default this helper to no parse retries so the many gate/recording
+            # tests built on it exercise the escalation path in isolation; the
+            # parse-retry tests opt in with an explicit positive value.
+            max_plan_review_parse_retries=0,
+        ),
         plan=PlanConfig(enabled=True, budget_usd=0.50, timeout=300, validate_spec=False),
         plan_agent_review=par_config,
         log=LogConfig(enabled=False),
@@ -682,7 +689,10 @@ findings:
         config = dataclasses.replace(
             _make_plan_agent_review_config(tmp_path),
             retry=RetryPolicy(
-                max_dev_iterations=2, max_review_cycles=2, max_plan_regen_attempts=1
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_regen_attempts=1,
+                max_plan_review_parse_retries=0,
             ),
         )
         task = _make_task(tmp_path)
@@ -1319,7 +1329,10 @@ class TestPlanReviewerFailureAudit:
         config = dataclasses.replace(
             _make_plan_agent_review_config(tmp_path),
             retry=RetryPolicy(
-                max_dev_iterations=2, max_review_cycles=2, max_plan_regen_attempts=0
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_regen_attempts=0,
+                max_plan_review_parse_retries=0,
             ),
         )
         task = _make_task(tmp_path)
@@ -1371,7 +1384,10 @@ class TestPlanReviewerFailureAudit:
         pool_config = dataclasses.replace(
             _make_plan_agent_review_config(tmp_path),
             retry=RetryPolicy(
-                max_dev_iterations=2, max_review_cycles=2, max_plan_regen_attempts=0
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_regen_attempts=0,
+                max_plan_review_parse_retries=0,
             ),
             plan_agent_review=PlanAgentReviewConfig(
                 enabled=True,
@@ -1949,3 +1965,196 @@ class TestPlanReviewerFailureAudit:
 
         assert result.success is True
         assert "reviewer_failures" not in audit["plan_review"]
+
+
+# ── TestPlanReviewParseRetry ──────────────────────────────────────────
+
+# Prose emitted by a reviewer that stalled instead of producing contract output
+# (mirrors issue-75: "Waiting on the verification agent's results before I
+# finalize the review.").  Parses to a non-mapping YAML root → parse error.
+PLAN_REVIEW_PROSE = "Waiting on the verification agent's results before I finalize the review."
+
+
+class TestPlanReviewParseRetry:
+    """A reviewer completion that succeeds at transport level but emits unparseable
+    output is a transient agent failure — it must be re-invoked (fresh session) up
+    to max_plan_review_parse_retries times before the min-reviewers gate escalates
+    the story (issue-1667)."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_parse_failure_retried_then_succeeds(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_plan_pool,
+        mock_human_review,
+        mock_code_pool,
+        tmp_path,
+    ):
+        """Single reviewer emits prose → retried once → parses → story proceeds to DONE."""
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_regen_attempts=0,
+                max_plan_review_parse_retries=2,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        # run_agent sequence: PLAN → plan-review parse retry (now valid) → DEV
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nA plan.", cost_usd=0.10),
+            _make_agent_result(
+                success=True,
+                output=PLAN_AGENT_APPROVE,
+                cost_usd=0.06,
+                profile_name="plan-review",
+            ),
+            _make_agent_result(success=True, output="Implemented."),
+        ]
+        # Initial pool completion succeeds at transport level but is unparseable prose.
+        mock_plan_pool.side_effect = [
+            [
+                _make_agent_result(
+                    success=True,
+                    output=PLAN_REVIEW_PROSE,
+                    cost_usd=0.08,
+                    profile_name="plan-review",
+                )
+            ]
+        ]
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.plan_review_decision == "approve"
+        # Reviewer recovered on retry → no residual parse failure recorded.
+        assert result.state.plan_review_failures == []
+        assert len(result.state.plan_review_parse_retries) == 1
+        retry = result.state.plan_review_parse_retries[0]
+        assert retry["attempt"] == 0
+        assert retry["reviewer"] == "plan-review"
+        assert retry["retry"] == 1
+        assert retry["errors"]
+        # Both the prose completion and the successful retry are cost-tracked.
+        assert len(result.state.plan_review_results) == 2
+        assert result.state.total_plan_review_cost == pytest.approx(0.14)
+        # Fresh session on retry (session_id=None passed to run_agent). The retry
+        # is the last plan_flow.run_agent call (PLAN is the first).
+        assert mock_plan_agent.call_args_list[-1].kwargs["session_id"] is None
+
+        audit = generate_audit_log(config, task, result)
+        assert audit["plan_review"]["parse_retries"] == result.state.plan_review_parse_retries
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_parse_failure_exhausts_retries_then_escalates(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_plan_pool,
+        mock_human_review,
+        mock_code_pool,
+        tmp_path,
+    ):
+        """Prose on every attempt → parse retries exhausted → min-reviewers gate escalates."""
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_regen_attempts=0,
+                max_plan_review_parse_retries=2,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        # run_agent sequence: PLAN → two parse retries, both still unparseable prose.
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nA plan.", cost_usd=0.10),
+            _make_agent_result(
+                success=True, output=PLAN_REVIEW_PROSE, cost_usd=0.06, profile_name="plan-review"
+            ),
+            _make_agent_result(
+                success=True, output=PLAN_REVIEW_PROSE, cost_usd=0.06, profile_name="plan-review"
+            ),
+        ]
+        mock_plan_pool.side_effect = [
+            [
+                _make_agent_result(
+                    success=True,
+                    output=PLAN_REVIEW_PROSE,
+                    cost_usd=0.08,
+                    profile_name="plan-review",
+                )
+            ]
+        ]
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.plan_review_decision == "reject"
+        assert "minimum required is 1" in (result.message or "")
+        # Two fresh-session retries attempted before escalating.
+        assert len(result.state.plan_review_parse_retries) == 2
+        # Prose completion + two prose retries are all cost-tracked.
+        assert len(result.state.plan_review_results) == 3
+        assert result.state.total_plan_review_cost == pytest.approx(0.20)
+        assert len(result.state.plan_review_failures) == 1
+        failure = result.state.plan_review_failures[0]
+        assert failure["reviewer"] == "plan-review"
+        assert failure["failure_kind"] == "parse"
+        assert failure["retryable"] is False
+        # retry_count reflects the exhausted parse-retry budget, not a first-attempt fluke.
+        assert failure["retry_count"] == 2
+
+        audit = generate_audit_log(config, task, result)
+        assert audit["plan_review"]["parse_retries"] == result.state.plan_review_parse_retries
+        # Per-reviewer reconstruction stays aligned despite the extra retry results.
+        assert audit["plan_review"]["per_reviewer"] == [
+            {
+                "attempt": 0,
+                "profile": "plan-review",
+                "verdict": "PARSE_ERROR",
+                "cost_usd": pytest.approx(0.06),
+            }
+        ]


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the plan-review parse retry requirements and the focused regression tests pass. | [google-gemini-3.5-flash] The implementation successfully resolves the plan-review parse-failure retry gap with robust fresh-session retries and comprehensive audit trail tracking.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $6.33
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Plan-review parse failure is fatal with no reviewer retry — flaky reviewer output kills stories (GitHub Issue #1667)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1667