### PR TITLE
PLAN runner: API connection-closed produces empty plan with no retry; 900s plan timeout not enforced (observed 3h47m)

### DIFF
--- a/src/theforge/config/defaults.py
+++ b/src/theforge/config/defaults.py
@@ -93,6 +93,7 @@ budget_usd: 50.0
 retry:
   max_dev_iterations: 3    # retries within a review cycle
   max_dev_transport_retries: 1  # retry one transient dev provider failure
+  max_plan_transport_retries: 2  # retry transient plan draft/regen provider failures
   max_review_cycles: 2     # full dev→review loops before escalation
 
 context:

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -676,6 +676,7 @@ def load_config(config_path: Path) -> ForgeConfig:
     retry = RetryPolicy(
         max_dev_iterations=int(retry_data.get("max_dev_iterations", 3)),
         max_dev_transport_retries=int(retry_data.get("max_dev_transport_retries", 1)),
+        max_plan_transport_retries=int(retry_data.get("max_plan_transport_retries", 2)),
         max_review_cycles=int(retry_data.get("max_review_cycles", 2)),
         max_review_parse_retries=int(retry_data.get("max_review_parse_retries", 2)),
         max_plan_review_transport_retries=int(

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -256,6 +256,9 @@ class RetryPolicy:
     max_dev_transport_retries: int = (
         1  # per-iteration retries on transient dev transport/provider failure
     )
+    max_plan_transport_retries: int = (
+        2  # per-attempt retries on transient plan draft/regen transport/provider failure
+    )
     max_review_cycles: int = 2  # full dev->review loops
     max_review_parse_retries: int = 2  # reviewer retries on parse/schema error per cycle
     max_plan_review_transport_retries: int = (

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -221,6 +221,11 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
             "attempt_plans": [
                 {"attempt": i, "plan": p} for i, p in enumerate(state.plan_attempt_plans)
             ],
+            **(
+                {"transport_retries": state.plan_transport_retries}
+                if state.plan_transport_retries
+                else {}
+            ),
         }
 
     # ── plan_review ───────────────────────────────────────────────────────────

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -101,6 +101,28 @@ _TRANSIENT_PLAN_REVIEW_ERROR_PATTERNS = (
     "timeout awaiting headers",
 )
 
+# Transient signatures for the PLAN draft/regen agent call. Extends the
+# plan-review set with connection-closed/mid-stream-disconnect wordings — the
+# exact failure that killed sprint 065a91f3caf1 was an empty plan output whose
+# only line was "API Error: Connection closed mid-response. The response above
+# may be incomplete." (#1672), which none of the review patterns above match.
+_TRANSIENT_PLAN_ERROR_PATTERNS = (
+    *_TRANSIENT_PLAN_REVIEW_ERROR_PATTERNS,
+    "connection closed",
+    "connection-closed",
+    "closed mid-response",
+    "response above may be incomplete",
+    "response may be incomplete",
+    "mid-stream disconnect",
+    "stream disconnected",
+    "stream idle timeout",
+    "partial response received",
+)
+
+# Initial backoff (seconds) before a transient plan retry; doubled per retry.
+_PLAN_TRANSPORT_RETRY_BACKOFF_BASE_SECONDS = 2
+
+
 # ── Lazy runner slots ─────────────────────────────────────────────────
 # None until first call; tests may replace before calling run_task.
 # Patch targets:
@@ -142,6 +164,89 @@ def _summarize_plan_review_failure(result: "AgentResult") -> str:
     if output:
         parts.append(output[:200])
     return ": ".join((parts[0], " | ".join(parts[1:]))) if len(parts) > 1 else parts[0]
+
+
+def _is_transient_plan_failure(result: "AgentResult") -> bool:
+    """Return True when a failed PLAN draft/regen invocation looks transient/retryable.
+
+    A connection-closed / empty-output transport failure (exit!=0 with the error
+    banner as the only content) is retryable; a genuine planning failure or a
+    startup failure (CLI missing) is not.
+    """
+    if result.success:
+        return False
+    if getattr(result, "startup_failure", False):
+        return False
+    failure_code = (result.failure_code or "").lower()
+    if failure_code in {"rate_limit", "provider_internal_error", "connection_reset"}:
+        return True
+    output = (result.output or "").lower()
+    return any(pattern in output for pattern in _TRANSIENT_PLAN_ERROR_PATTERNS)
+
+
+def _plan_transport_retry_backoff_seconds(retry_count: int) -> int:
+    """Return the backoff delay before the next transient plan retry."""
+    return _PLAN_TRANSPORT_RETRY_BACKOFF_BASE_SECONDS * (2 ** max(retry_count - 1, 0))
+
+
+def _run_plan_agent_with_retry(
+    *,
+    prompt: str,
+    profile: ModelProfile,
+    workspace_path: Path,
+    config: ForgeConfig,
+    state: CoordinatorState,
+    phase_label: str,
+    attempt: int,
+    session_id: str | None = None,
+) -> "AgentResult":
+    """Invoke the plan agent, retrying bounded times on transient transport failures.
+
+    Mirrors the DEV (_is_transient_dev_failure) and PLAN_REVIEW
+    (_retry_transient_plan_review_failures) resilience: a single connection-closed
+    / empty-output transport error must not escalate the story. Retries use a
+    fresh session — a resumed session anchors on its own truncated/empty output —
+    with exponential backoff, and each retry is recorded in
+    state.plan_transport_retries for the audit trail.
+
+    phase_label is "PLAN" (initial draft) or "PLAN_REGEN" (post-review regen);
+    it is used only for logging and audit provenance.
+    """
+    max_retries = max(0, config.retry.max_plan_transport_retries)
+    result = run_agent(
+        prompt=prompt,
+        profile=profile,
+        working_dir=workspace_path,
+        session_id=session_id,
+        secrets=config.secrets,
+    )
+    retry_count = 0
+    while retry_count < max_retries and _is_transient_plan_failure(result):
+        retry_count += 1
+        _summary = _summarize_plan_review_failure(result)
+        state.plan_transport_retries.append(
+            {
+                "phase": phase_label,
+                "attempt": attempt,
+                "retry": retry_count,
+                "error": _summary,
+            }
+        )
+        _log(
+            f"  ↻ {phase_label}   transient transport failure "
+            f"(retry {retry_count}/{max_retries}): {_summary}"
+        )
+        _backoff_s = _plan_transport_retry_backoff_seconds(retry_count)
+        _log_verbose(f"  {phase_label} retry backoff: {_backoff_s}s")
+        time.sleep(_backoff_s)
+        result = run_agent(
+            prompt=prompt,
+            profile=profile,
+            working_dir=workspace_path,
+            session_id=None,  # fresh session — prior anchors on its own bad/empty output
+            secrets=config.secrets,
+        )
+    return result
 
 
 def _retry_transient_plan_review_failures(
@@ -500,11 +605,14 @@ def _run_plan_phase(
 
     _plan_hygiene_before = snapshot_porcelain(workspace_path)
     _plan_start = time.monotonic()
-    plan_result = run_agent(
+    plan_result = _run_plan_agent_with_retry(
         prompt=plan_prompt,
         profile=plan_profile,
-        working_dir=workspace_path,
-        secrets=config.secrets,
+        workspace_path=workspace_path,
+        config=config,
+        state=state,
+        phase_label="PLAN",
+        attempt=0,
     )
     _plan_elapsed = time.monotonic() - _plan_start
     _plan_ok, _plan_diag, _plan_offending = check_phase_no_mutation(
@@ -1188,12 +1296,15 @@ def _run_plan_agent_review(
 
         _plan_start = time.monotonic()
         _log(f"  Starting plan regen (model={plan_profile.model}, new session)...")
-        plan_result = run_agent(
+        plan_result = _run_plan_agent_with_retry(
             prompt=regen_prompt,
             profile=plan_profile,
-            working_dir=workspace_path,
+            workspace_path=workspace_path,
+            config=config,
+            state=state,
+            phase_label="PLAN_REGEN",
+            attempt=state.plan_regen_count,
             session_id=None,  # fresh session — prior session anchors on its own wrong output
-            secrets=config.secrets,
         )
         _plan_elapsed = time.monotonic() - _plan_start
         state.plan_durations.append(_plan_elapsed)
@@ -1373,12 +1484,15 @@ def _run_human_plan_review(
                 regen_plan_prompt = plan_prompt
 
             _plan_start = time.monotonic()
-            plan_result = run_agent(
+            plan_result = _run_plan_agent_with_retry(
                 prompt=regen_plan_prompt,
                 profile=plan_profile,
-                working_dir=workspace_path,
+                workspace_path=workspace_path,
+                config=config,
+                state=state,
+                phase_label="PLAN_REGEN",
+                attempt=state.plan_regen_count,
                 session_id=state.plan_session_id,
-                secrets=config.secrets,
             )
             _plan_elapsed = time.monotonic() - _plan_start
             state.plan_durations.append(_plan_elapsed)

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -373,6 +373,10 @@ class CoordinatorState:
         default_factory=list
     )  # per-retry audit for successful-but-unparseable reviewer re-invocations:
     # {"attempt": int, "reviewer": str, "retry": int, "errors": list[str]}
+    plan_transport_retries: list[dict] = field(
+        default_factory=list
+    )  # per-retry audit for transient plan draft/regen re-invocations:
+    # {"phase": "PLAN"|"PLAN_REGEN", "attempt": int, "retry": int, "error": str}
     plan_review_failures: list[dict] = field(
         default_factory=list
     )  # per-reviewer failures: {"attempt": int, "reviewer": str, "errors": list[str], ...}

--- a/src/theforge/runners/process_group.py
+++ b/src/theforge/runners/process_group.py
@@ -1,0 +1,61 @@
+"""Process-group isolation and reaping for agent subprocesses.
+
+Agent CLIs (claude, codex, gemini) spawn descendant processes through their
+tool layer — the Bash tool, in particular, forks arbitrary shell commands. A
+plain ``proc.kill()`` SIGKILLs only the immediate agent process; a descendant
+can inherit the agent's stdout pipe write-end and hold it open after the agent
+itself is dead. The parent's blocking read (``for line in proc.stdout``) then
+never sees EOF and hangs indefinitely — long past the configured timeout
+(observed: a 900s plan timeout that ran 3h47m before the orphan finally
+exited; #1672).
+
+The fix is to launch the agent as its own process-group leader
+(``start_new_session=True``) and, at kill time, signal the *whole group* with
+``os.killpg`` instead of the single process. Killing the group closes every
+inherited fd — including the orphan's copy of the stdout write-end — which
+delivers EOF and unblocks the read within the timeout window.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+
+# Passed to subprocess.Popen/subprocess.run for agent invocations. On POSIX
+# this makes the child a session (and process-group) leader whose PGID equals
+# its PID, so os.killpg(pid, ...) targets the child and every descendant it
+# spawns. Empty on platforms without setsid (Windows), where killpg is also
+# unavailable and kill_process_group() falls back to proc.kill().
+NEW_PROCESS_GROUP_KWARGS: dict[str, bool] = (
+    {"start_new_session": True} if hasattr(os, "setsid") else {}
+)
+
+
+def kill_process_group(proc: "subprocess.Popen") -> None:
+    """SIGKILL ``proc`` and every descendant sharing its process group.
+
+    ``proc`` MUST have been started with ``start_new_session=True`` (see
+    ``NEW_PROCESS_GROUP_KWARGS``) so that its PGID equals its PID; otherwise
+    the process group would be the parent's and killing it would take down the
+    orchestrator itself. Call this *before* ``proc.wait()`` so the leader is
+    still a resolvable (zombie) process and its PGID is intact.
+
+    Falls back to ``proc.kill()`` when ``os.killpg`` is unavailable (non-POSIX)
+    or the group has already been reaped.
+    """
+    killpg = getattr(os, "killpg", None)
+    pid = proc.pid
+    if killpg is not None and isinstance(pid, int):
+        try:
+            # start_new_session=True guarantees PGID == PID for the leader.
+            killpg(pid, signal.SIGKILL)
+            return
+        except (ProcessLookupError, PermissionError, OSError):
+            # Group already gone, or we lack permission — fall through to the
+            # single-process kill, which is a strict subset of what killpg does.
+            pass
+    try:
+        proc.kill()
+    except (ProcessLookupError, OSError):
+        pass

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from theforge.agent_types import AgentResult, ModelUsage
 from theforge.log_util import _log_line
+from theforge.runners.process_group import NEW_PROCESS_GROUP_KWARGS, kill_process_group
 from theforge.runners.stuck_detection import StuckTracker, build_observation
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
 from theforge.workspace_env import build_workspace_env
@@ -604,6 +605,10 @@ def _run_claude(
             text=True,
             cwd=str(working_dir),
             env=env,
+            # Own process group so timeout/stop kills reach Bash-tool-spawned
+            # descendants that would otherwise inherit stdout and hang the read
+            # past the deadline (#1672).
+            **NEW_PROCESS_GROUP_KWARGS,
         )
         assert proc.stdin is not None
         # Send the initial prompt as a stream-json user message. stdin is kept
@@ -625,12 +630,11 @@ def _run_claude(
                 if proc.poll() is not None:
                     return
                 if stop_event is not None and stop_event.is_set():
-                    proc.kill()
+                    kill_process_group(proc)
                     return
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    if proc.poll() is None:
-                        proc.kill()
+                    kill_process_group(proc)
                     return
                 time.sleep(min(0.5, remaining))
 
@@ -653,14 +657,14 @@ def _run_claude(
                     f"{stuck_monitor.iteration_count} iterations: "
                     f"{stuck_monitor.terminate_pattern}"
                 )
-                proc.kill()
+                kill_process_group(proc)
                 break
             if stop_event is not None and stop_event.is_set():
-                proc.kill()
+                kill_process_group(proc)
                 timed_out = True
                 break
             if time.monotonic() > deadline:
-                proc.kill()
+                kill_process_group(proc)
                 timed_out = True
                 break
             # Break as soon as the result event arrives — the stream is complete.

--- a/tests/test_plan_transport_retry.py
+++ b/tests/test_plan_transport_retry.py
@@ -1,0 +1,124 @@
+"""Seam-level tests for transient-transport retry of the PLAN agent call (#1672).
+
+Sprint 065a91f3caf1 escalated two stories at PLAN because a single
+connection-closed transport error produced an empty plan and the coordinator
+escalated immediately with no retry — unlike DEV and PLAN_REVIEW, which both
+retry transient failures. These tests exercise the coordinator PREFLIGHT→PLAN
+seam and assert the draft call now retries a transient failure before
+escalating, records the retry in the audit trail, and still escalates a genuine
+(non-transient) planning failure.
+"""
+
+import dataclasses
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    PREFLIGHT_PROCEED_MEDIUM,
+    _make_agent_result,
+    _make_plan_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import Phase
+
+_CONNECTION_CLOSED = (
+    "API Error: Connection closed mid-response. The response above may be incomplete."
+)
+
+
+def _prep(mock_validate_story, mock_shell, mock_preflight, tmp_path):
+    from theforge.story_validator import StoryValidationResult
+
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+    mock_validate_story.return_value = StoryValidationResult(verdict="PASS")
+    mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+    mock_preflight.return_value = _make_agent_result(
+        success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+    )
+    return task
+
+
+@patch("theforge.coordinator.plan_flow.time.sleep", lambda *_a, **_k: None)
+@patch("theforge.coordinator.plan_flow.run_agent")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+@patch("theforge.story_validator.validate_story")
+def test_plan_draft_retries_transient_connection_closed(
+    mock_validate_story, mock_shell, mock_preflight, mock_plan_agent, tmp_path
+):
+    """A connection-closed draft failure is retried, not escalated."""
+    config = _make_plan_config(tmp_path)
+    task = _prep(mock_validate_story, mock_shell, mock_preflight, tmp_path)
+
+    mock_plan_agent.side_effect = [
+        _make_agent_result(success=False, output=_CONNECTION_CLOSED, cost_usd=0.0),
+        _make_agent_result(success=True, output="# Plan\n\n- step 1", cost_usd=0.10),
+    ]
+
+    result = run_task(config, task, stop_phase=Phase.PLAN)
+
+    assert result.success is True
+    assert mock_plan_agent.call_count == 2  # retried once instead of escalating
+    retries = result.state.plan_transport_retries
+    assert len(retries) == 1
+    assert retries[0]["phase"] == "PLAN"
+    assert retries[0]["retry"] == 1
+
+
+@patch("theforge.coordinator.plan_flow.time.sleep", lambda *_a, **_k: None)
+@patch("theforge.coordinator.plan_flow.run_agent")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+@patch("theforge.story_validator.validate_story")
+def test_plan_draft_escalates_after_retries_exhausted(
+    mock_validate_story, mock_shell, mock_preflight, mock_plan_agent, tmp_path
+):
+    """When every attempt hits the transient error, escalate after the bound."""
+    base = _make_plan_config(tmp_path)
+    config = dataclasses.replace(
+        base, retry=dataclasses.replace(base.retry, max_plan_transport_retries=1)
+    )
+    task = _prep(mock_validate_story, mock_shell, mock_preflight, tmp_path)
+
+    mock_plan_agent.side_effect = [
+        _make_agent_result(success=False, output=_CONNECTION_CLOSED, cost_usd=0.0),
+        _make_agent_result(success=False, output=_CONNECTION_CLOSED, cost_usd=0.0),
+    ]
+
+    result = run_task(config, task, stop_phase=Phase.PLAN)
+
+    assert result.success is False
+    assert result.phase == Phase.ESCALATE
+    assert mock_plan_agent.call_count == 2  # 1 initial + 1 retry, then escalate
+    assert len(result.state.plan_transport_retries) == 1
+
+
+@patch("theforge.coordinator.plan_flow.time.sleep", lambda *_a, **_k: None)
+@patch("theforge.coordinator.plan_flow.run_agent")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+@patch("theforge.story_validator.validate_story")
+def test_plan_draft_genuine_failure_does_not_retry(
+    mock_validate_story, mock_shell, mock_preflight, mock_plan_agent, tmp_path
+):
+    """A non-transient planning failure escalates immediately with no retry."""
+    config = _make_plan_config(tmp_path)
+    task = _prep(mock_validate_story, mock_shell, mock_preflight, tmp_path)
+
+    mock_plan_agent.side_effect = [
+        _make_agent_result(
+            success=False, output="I could not decompose this story.", cost_usd=0.02
+        ),
+        _make_agent_result(success=True, output="# Plan\n\n- step 1", cost_usd=0.10),
+    ]
+
+    result = run_task(config, task, stop_phase=Phase.PLAN)
+
+    assert result.success is False
+    assert result.phase == Phase.ESCALATE
+    assert mock_plan_agent.call_count == 1  # no retry on a genuine failure
+    assert result.state.plan_transport_retries == []

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -1,0 +1,95 @@
+"""Tests for process-group isolation and reaping of agent subprocesses (#1672).
+
+The PLAN runner hung for 3h47m against a 900s timeout because a Bash-tool
+descendant inherited the agent's stdout pipe and held it open after the parent
+`claude` process was SIGKILLed — so the coordinator's blocking
+`for line in proc.stdout` read never saw EOF. Launching the agent in its own
+process group and killing the whole group at the deadline reaps such orphans
+and delivers EOF promptly.
+"""
+
+import os
+import subprocess
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from theforge.runners.process_group import NEW_PROCESS_GROUP_KWARGS, kill_process_group
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="POSIX process groups only")
+def test_kill_process_group_unblocks_read_held_open_by_descendant() -> None:
+    # The shell forks a background `sleep` that inherits stdout and keeps the
+    # pipe's write end open, then the shell itself exits. A plain kill of the
+    # shell would leave `sleep` holding stdout, so reading to EOF blocks for the
+    # full sleep. kill_process_group must take the descendant down too.
+    proc = subprocess.Popen(
+        ["/bin/sh", "-c", "sleep 60 & echo parent-done"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        **NEW_PROCESS_GROUP_KWARGS,
+    )
+    assert proc.stdout is not None
+
+    # Let the background child start and inherit the stdout fd.
+    time.sleep(0.5)
+
+    captured: dict[str, str] = {}
+
+    def _read() -> None:
+        captured["data"] = proc.stdout.read()  # blocks until every writer closes
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+
+    # The read must still be blocked: the `sleep 60` descendant holds stdout.
+    reader.join(timeout=1.0)
+    assert reader.is_alive(), "stdout hit EOF before the descendant was killed"
+
+    kill_process_group(proc)
+    proc.wait(timeout=5)
+
+    # Killing the group closed the descendant's fd → EOF → read returns promptly.
+    reader.join(timeout=5.0)
+    assert not reader.is_alive(), "kill_process_group did not unblock the stdout read"
+    assert "parent-done" in captured["data"]
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="POSIX process groups only")
+def test_kill_process_group_reaps_the_whole_tree() -> None:
+    # Capture a marker file the descendant would write if it survived past the
+    # kill; its absence proves the descendant was reaped, not just the parent.
+    proc = subprocess.Popen(
+        ["/bin/sh", "-c", "sleep 30 & echo started; wait"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        **NEW_PROCESS_GROUP_KWARGS,
+    )
+    time.sleep(0.5)
+    child_pgid = os.getpgid(proc.pid)
+
+    kill_process_group(proc)
+    proc.wait(timeout=5)
+
+    # The group must be gone: signalling it with 0 raises ProcessLookupError.
+    with pytest.raises(ProcessLookupError):
+        os.killpg(child_pgid, 0)
+
+
+def test_kill_process_group_tolerates_non_int_pid() -> None:
+    # A MagicMock proc (pid is not an int) must not raise; it falls back to
+    # proc.kill(). Guards the runner's existing MagicMock-based timeout tests.
+    mock_proc = MagicMock()
+    kill_process_group(mock_proc)
+    mock_proc.kill.assert_called_once()
+
+
+def test_new_process_group_kwargs_requests_new_session_on_posix() -> None:
+    if hasattr(os, "setsid"):
+        assert NEW_PROCESS_GROUP_KWARGS == {"start_new_session": True}
+    else:
+        assert NEW_PROCESS_GROUP_KWARGS == {}


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the PLAN transport retry and claude-runner timeout requirements; targeted retry/process-group tests pass. | [google-gemini-3.5-flash] Successfully implemented transient-transport retry for PLAN draft/regen calls and process-group isolation for the Claude runner to enforce timeouts. | [claude-sonnet] Both defects are fixed with correct logic, matching tests (7/7 passing) verifying the exact observed symptom, and the full test suite (4835 tests) plus ruff lint/format pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $6.97
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

PLAN runner: API connection-closed produces empty plan with no retry; 900s plan timeout not enforced (observed 3h47m) (GitHub Issue #1672)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1672