### PR TITLE
forge diagnose absorbs adjacent problems into the confirmed cause — over-scopes the fix beyond the stated symptom

### DIFF
--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -526,6 +526,9 @@ def _artifact_to_dict(artifact: DiagnosisArtifact) -> dict:
         "premise_anchors": [
             {"file": a.file, "pattern": a.pattern} for a in artifact.premise_anchors
         ],
+        "related_findings": [
+            {"summary": r.summary, "related": r.related} for r in artifact.related_findings
+        ],
     }
 
 

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -78,6 +78,28 @@ class PremiseAnchor:
 
 
 @dataclass(frozen=True)
+class RelatedFinding:
+    """A real defect noticed in adjacent code that is *not* the cause of the
+    issue's stated symptom.
+
+    The diagnose flow must scope its ``confirmed_cause`` to the symptom of the
+    issue under investigation.  When the agent notices a separate, genuine
+    problem in nearby code — one that belongs to a different issue or domain —
+    it records it here instead of folding it into ``confirmed_cause``.  This
+    keeps the diagnosis boundary aligned with the issue boundary so a
+    downstream dev does not implement an adjacent problem as part of this
+    issue's fix (the #1672 scope-creep failure mode).
+
+    ``summary`` is a one-line description of the adjacent defect.  ``related``
+    is an optional pointer to the owning/related issue (e.g. ``"#1649"``) or
+    domain so the finding can be triaged separately rather than built here.
+    """
+
+    summary: str
+    related: str = ""
+
+
+@dataclass(frozen=True)
 class AbsentPremise:
     """A cited premise reference that no longer exists in the baseline.
 
@@ -123,6 +145,10 @@ class DiagnosisArtifact:
     baseline_captured_at: str = ""
     inspected_files: tuple[InspectedFile, ...] = ()
     premise_anchors: tuple[PremiseAnchor, ...] = ()
+    # Adjacent-but-unrelated defects the agent noticed in nearby code. These
+    # are surfaced as separate linked findings and MUST NOT be folded into
+    # confirmed_cause — they are not the cause of this issue's stated symptom.
+    related_findings: tuple[RelatedFinding, ...] = ()
 
     def is_complete(self) -> bool:
         """Return True only when every required field is non-empty."""
@@ -294,6 +320,28 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
             "",
         ]
     )
+    if artifact.related_findings:
+        lines.extend(
+            [
+                "### Related findings (out of scope)",
+                "",
+                (
+                    "> These are adjacent problems noticed during investigation. "
+                    "They are **not** the cause of this issue's symptom and are "
+                    "**out of scope for this fix** — triage them separately under "
+                    "the linked issue. Do not implement them as part of this issue."
+                ),
+                "",
+            ]
+        )
+        for finding in artifact.related_findings:
+            summary = finding.summary.strip()
+            ref = finding.related.strip()
+            if ref:
+                lines.append(f"- {summary} (related: {ref})")
+            else:
+                lines.append(f"- {summary}")
+        lines.append("")
     if artifact.notes.strip():
         lines.extend(["### Notes", "", artifact.notes.strip(), ""])
     return "\n".join(lines)

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -14,6 +14,7 @@ from theforge.diagnose_types import (
     Hypothesis,
     InspectedFile,
     PremiseAnchor,
+    RelatedFinding,
 )
 
 _DIAGNOSE_PROMPT_TEMPLATE = """\
@@ -50,6 +51,19 @@ Mode: {mode}
    you finish: if a cited file or pattern is absent from the baseline, the run
    is reported as "already resolved" rather than landed as a live diagnosis.
    Do NOT emit a confirmed cause for code that no longer exists.
+6. **Scope the confirmed cause to THIS issue's stated symptom — nothing more.**
+   The diagnosis boundary must match the issue boundary.  While investigating
+   you may notice other real defects in nearby code that are NOT the cause of
+   this issue's symptom (a different bug, another issue's domain, a latent
+   problem you happened to see).  Do NOT fold those into ``confirmed_cause`` or
+   ``affected_code_path`` — a downstream dev implements the confirmed cause
+   verbatim, so anything you put there becomes part of THIS issue's fix and
+   over-scopes it.  Instead, record each such adjacent problem as a separate
+   entry in ``related_findings``, naming the owning/related issue if you know
+   it (e.g. ``"#1649"``).  Ask of every claim you put in ``confirmed_cause``:
+   "is this the cause of the *stated* symptom?"  If it is a neighboring problem
+   rather than the cause of what the issue reports, it belongs in
+   ``related_findings``, not in the fix scope.
 
 == OUTPUT FORMAT ==
 
@@ -95,6 +109,14 @@ premise_anchors:
   # resolved" (premise removed) instead of landed as a live confirmed cause.
   - file: "<repo-relative path the bug lives in>"
     pattern: "<exact code substring that must exist for the bug to be live>"
+related_findings:
+  # OPTIONAL. Adjacent, real defects you noticed in nearby code that are NOT
+  # the cause of THIS issue's stated symptom. Recording them here keeps them
+  # OUT of the fix scope (confirmed_cause) so the dev does not build them as
+  # part of this issue. Name the owning/related issue in `related` when known.
+  # Omit or leave empty if you noticed no separate adjacent problems.
+  - summary: "<one-line description of a separate adjacent defect>"
+    related: "<owning/related issue ref, e.g. '#1649', or empty>"
 ```
 """
 
@@ -213,6 +235,27 @@ def parse_diagnose_output(
             seen_anchors.add(key)
             anchors.append(PremiseAnchor(file=file, pattern=pattern))
 
+    raw_related = parsed.get("related_findings") or []
+    related: list[RelatedFinding] = []
+    if isinstance(raw_related, list):
+        seen_related: set[tuple[str, str]] = set()
+        for entry in raw_related:
+            if isinstance(entry, str):
+                summary = entry.strip()
+                ref = ""
+            elif isinstance(entry, dict):
+                summary = str(entry.get("summary", "")).strip()
+                ref = str(entry.get("related", "")).strip()
+            else:
+                continue
+            if not summary:
+                continue
+            key = (summary, ref)
+            if key in seen_related:
+                continue
+            seen_related.add(key)
+            related.append(RelatedFinding(summary=summary, related=ref))
+
     return DiagnosisArtifact(
         issue_number=issue_number,
         observed_symptom=str(parsed.get("observed_symptom", "")).strip(),
@@ -225,4 +268,5 @@ def parse_diagnose_output(
         notes=str(parsed.get("notes", "")).strip(),
         inspected_files=tuple(inspected),
         premise_anchors=tuple(anchors),
+        related_findings=tuple(related),
     )

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -199,6 +199,16 @@ class TestPromptBuilder:
         # Diagnose != fix; the prompt must not instruct the agent to modify code.
         assert "Do not modify any files" in prompt
 
+    def test_prompt_instructs_scope_boundary_discipline(self):
+        # The prompt must tell the agent to scope confirmed_cause to the stated
+        # symptom and surface adjacent defects as separate related_findings —
+        # the #1672 scope-creep guard.
+        prompt = build_diagnose_prompt(issue_number=1, title="t", body="b", mode="autonomous")
+        lower = prompt.lower()
+        assert "related_findings" in prompt
+        assert "boundary" in lower
+        assert "scope" in lower
+
 
 # ── State machine / flow tests ────────────────────────────────────────
 
@@ -1180,3 +1190,61 @@ class TestParsePremiseAnchors:
         artifact = parse_diagnose_output(_agent_yaml_output(), issue_number=1)
         assert artifact is not None
         assert artifact.premise_anchors == ()
+
+
+class TestParseRelatedFindings:
+    def test_parses_related_findings_out_of_confirmed_cause(self):
+        # Boundary discipline: an adjacent defect is surfaced as a separate
+        # related finding, NOT folded into confirmed_cause.
+        payload = (
+            "observed_symptom: s\nreproduction_or_evidence: r\n"
+            "hypotheses:\n  - statement: a\n    status: confirmed\n    evidence: e\n"
+            "confirmed_cause: the retry is missing\naffected_code_path: p\n"
+            "fix_success_criterion: f\n"
+            "related_findings:\n"
+            "  - summary: no process-group isolation on subprocess kill\n"
+            "    related: '#1649'\n"
+            "  - summary: a second adjacent problem\n"
+        )
+        artifact = parse_diagnose_output(payload, issue_number=1672)
+        assert artifact is not None
+        assert len(artifact.related_findings) == 2
+        assert artifact.related_findings[0].related == "#1649"
+        assert "process-group" in artifact.related_findings[0].summary
+        assert artifact.related_findings[1].related == ""
+        # The adjacent problem must not have leaked into the fix scope.
+        assert "process-group" not in artifact.confirmed_cause
+        assert artifact.confirmed_cause == "the retry is missing"
+
+    def test_related_findings_accepts_bare_string_entries(self):
+        payload = (
+            "observed_symptom: s\nreproduction_or_evidence: r\n"
+            "hypotheses:\n  - statement: a\n    status: confirmed\n    evidence: e\n"
+            "confirmed_cause: c\naffected_code_path: p\nfix_success_criterion: f\n"
+            "related_findings:\n  - just a bare string finding\n"
+        )
+        artifact = parse_diagnose_output(payload, issue_number=1)
+        assert artifact is not None
+        assert len(artifact.related_findings) == 1
+        assert artifact.related_findings[0].summary == "just a bare string finding"
+        assert artifact.related_findings[0].related == ""
+
+    def test_missing_related_findings_is_empty_tuple(self):
+        artifact = parse_diagnose_output(_agent_yaml_output(), issue_number=1)
+        assert artifact is not None
+        assert artifact.related_findings == ()
+
+    def test_blank_related_summaries_dropped_and_deduped(self):
+        payload = (
+            "observed_symptom: s\nreproduction_or_evidence: r\n"
+            "hypotheses:\n  - statement: a\n    status: confirmed\n    evidence: e\n"
+            "confirmed_cause: c\naffected_code_path: p\nfix_success_criterion: f\n"
+            "related_findings:\n"
+            "  - summary: '   '\n    related: '#9'\n"
+            "  - summary: dup\n    related: '#1'\n"
+            "  - summary: dup\n    related: '#1'\n"
+        )
+        artifact = parse_diagnose_output(payload, issue_number=1)
+        assert artifact is not None
+        assert len(artifact.related_findings) == 1
+        assert artifact.related_findings[0].summary == "dup"

--- a/tests/test_diagnose_types.py
+++ b/tests/test_diagnose_types.py
@@ -18,6 +18,7 @@ from theforge.diagnose_types import (
     DiagnosisArtifact,
     Hypothesis,
     PremiseAnchor,
+    RelatedFinding,
     render_already_resolved_markdown,
     render_artifact_markdown,
     upsert_diagnosis_section,
@@ -106,6 +107,73 @@ class TestPremiseAnchorField:
         assert artifact.premise_anchors[0].file == "a.py"
         # Optional metadata: does not affect completeness.
         assert artifact.is_complete()
+
+
+class TestRelatedFindingsField:
+    def _make(self, **overrides) -> DiagnosisArtifact:
+        defaults = dict(
+            issue_number=1672,
+            observed_symptom="empty plan on connection close",
+            reproduction_or_evidence="audit YAML shows empty plan",
+            hypotheses=(Hypothesis("missing retry", "confirmed", "no retry wrapper"),),
+            confirmed_cause="PLAN runner does not retry on connection-closed",
+            affected_code_path="runner_claude.py",
+            fix_success_criterion="connection-closed retries and yields a plan",
+        )
+        defaults.update(overrides)
+        return DiagnosisArtifact(**defaults)
+
+    def test_artifact_carries_related_findings(self):
+        artifact = self._make(
+            related_findings=(
+                RelatedFinding(summary="no process-group isolation", related="#1649"),
+            ),
+        )
+        assert artifact.related_findings[0].related == "#1649"
+        # Optional metadata: does not affect completeness.
+        assert artifact.is_complete()
+
+    def test_related_findings_default_empty(self):
+        assert self._make().related_findings == ()
+
+    def test_related_findings_do_not_count_as_substantive_content(self):
+        # A run that produced only adjacent findings but no diagnosis of the
+        # stated symptom has diagnosed nothing — related findings alone must not
+        # clear the content floor (mirrors the notes exclusion).
+        empty = self._make(
+            observed_symptom="",
+            reproduction_or_evidence="",
+            hypotheses=(),
+            confirmed_cause="",
+            affected_code_path="",
+            fix_success_criterion="",
+            related_findings=(RelatedFinding(summary="adjacent bug", related="#1649"),),
+        )
+        assert not empty.has_substantive_content()
+
+    def test_render_surfaces_related_findings_as_out_of_scope_section(self):
+        artifact = self._make(
+            related_findings=(
+                RelatedFinding(summary="no process-group isolation", related="#1649"),
+                RelatedFinding(summary="an unlinked adjacent defect", related=""),
+            ),
+        )
+        md = render_artifact_markdown(artifact)
+        assert "### Related findings (out of scope)" in md
+        assert "out of scope for this fix" in md.lower()
+        assert "no process-group isolation (related: #1649)" in md
+        assert "- an unlinked adjacent defect" in md
+        # The out-of-scope material must live in its own section, not inside the
+        # confirmed-cause block that a dev implements.
+        cause_idx = md.index("### Confirmed cause")
+        related_idx = md.index("### Related findings")
+        assert related_idx > cause_idx
+        confirmed_block = md[cause_idx:related_idx]
+        assert "process-group" not in confirmed_block
+
+    def test_no_related_section_when_empty(self):
+        md = render_artifact_markdown(self._make())
+        assert "### Related findings" not in md
 
 
 class TestDiagnoseOutputDestinations:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change adds a runtime-consumed related_findings channel, keeps it out of the confirmed-cause scope, instruments it in audit output, and covers the #1672/#1649 failure mode. | [google-gemini-3.5-flash] The implementation successfully introduces a related_findings channel to isolate adjacent defects from the confirmed cause, preventing scope creep.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.16
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose absorbs adjacent problems into the confirmed cause — over-scopes the fix beyond the stated symptom (GitHub Issue #1721)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1721