### PR TITLE
Runtime precondition checks in forge run

### DIFF
--- a/src/theforge/cli/run.py
+++ b/src/theforge/cli/run.py
@@ -4,20 +4,19 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import subprocess
 import sys
 from pathlib import Path
 
 from theforge.artifacts import PLAN_PATH, resolve_plan_path
 from theforge.cli.overrides import apply_base_branch_override
 from theforge.cli.shared import (
-    _SECRETS_FILE,
     _apply_dev_model_override,
     _apply_plan_model_override,
     _build_task,
     _cmd_dry_run,
     _find_config,
     _write_audit,
+    check_run_preconditions,
 )
 from theforge.config import load_config
 from theforge.coordinator.engine import (
@@ -56,20 +55,18 @@ def cmd_run(args: "argparse.Namespace") -> int:
         )
         return 1
 
-    # AC-5: warn if .forge/secrets.yaml is tracked by git (not gitignored)
-    try:
-        tracked = subprocess.run(
-            ["git", "ls-files", "--error-unmatch", _SECRETS_FILE],
-            cwd=str(config_path.parent),
-            capture_output=True,
-        )
-        if tracked.returncode == 0:
-            print(
-                f"⚠ {_SECRETS_FILE} is not gitignored — run 'forge secrets-init' to fix",
-                file=sys.stderr,
-            )
-    except (OSError, FileNotFoundError):
-        pass  # not a git repo or git not installed — ignore
+    # Runtime precondition guards: fail fast when catastrophic machine-local
+    # state is tracked in git; warn (but proceed) on noise paths. This runs
+    # before any agent invocation, workspace mutation, detach/daemonize, or
+    # lock acquisition — see docs/plans/forge-storage-layout.md.
+    blockers, warnings = check_run_preconditions(config_path.parent)
+    for warning in warnings:
+        print(f"⚠ {warning}", file=sys.stderr)
+    if blockers:
+        print("✗ forge run aborted — catastrophic paths are tracked in git:", file=sys.stderr)
+        for blocker in blockers:
+            print(f"  ✗ {blocker}", file=sys.stderr)
+        return 1
 
     config = apply_base_branch_override(
         load_config(config_path), getattr(args, "base_branch", None)

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -31,6 +32,102 @@ from theforge.task import (
 )
 
 _SECRETS_FILE = ".forge/.env"
+
+# ── forge run precondition guards ──────────────────────────────────────────
+# Some machine-local state under .forge/ is catastrophic to track in git.
+# Committing worktree bookkeeping, lock files, daemon state, or pending-run
+# state assumes single-machine locality: parallel machines get false-positive
+# lock errors, nested git repos break checkout, and committed secrets leak.
+# `forge run` fails fast on these before doing any work. Noise paths (logs,
+# derived views, the SQLite index) surface a warning but do not block.
+#
+# Each entry is (display_path, is_dir). Directory entries end in "/" and match
+# any tracked file beneath them; file entries match an exact tracked path.
+_RUN_BLOCKER_PATHS: list[tuple[str, bool]] = [
+    (".forge/worktrees/", True),
+    (".forge/locks/", True),
+    (".forge/merge.lock", False),
+    (".forge/daemon.json", False),
+    (".forge/pending/", True),
+    (".forge/runs/", True),
+    (".forge/.env", False),
+    (".forge/secrets.yaml", False),
+    ("handoff.yaml", False),
+]
+
+_RUN_WARNING_PATHS: list[tuple[str, bool]] = [
+    (".forge/logs/", True),
+    # history.jsonl becomes a derived-local file after the Phase C migration;
+    # warning on it now is harmless (a warning never blocks a run) and matches
+    # the AC. If it is still legitimately tracked pre-migration the operator can
+    # ignore the notice.
+    (".forge/audits/history.jsonl", False),
+    (".forge/audits/index.sqlite", False),
+    (".forge/assignment_history.yaml", False),
+]
+
+
+def _rm_cached_command(display: str, is_dir: bool) -> str:
+    """Build the `git rm --cached` command that stops tracking a path."""
+    flag = "-r " if is_dir else ""
+    return f"git rm --cached {flag}{display}"
+
+
+def _tracked_files(project_root: Path) -> list[str] | None:
+    """Return the list of git-tracked paths under project_root.
+
+    Returns None when the directory is not a git repository or git is
+    unavailable — in that case there is nothing to guard against.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _path_is_tracked(tracked: list[str], display: str, is_dir: bool) -> bool:
+    """Report whether any tracked path matches the guarded path."""
+    if is_dir:
+        prefix = display if display.endswith("/") else display + "/"
+        return any(f.startswith(prefix) for f in tracked)
+    return display in tracked
+
+
+def check_run_preconditions(project_root: Path) -> tuple[list[str], list[str]]:
+    """Return (blocker_messages, warning_messages) for tracked catastrophic paths.
+
+    Blockers must fail the run fast; warnings surface but allow it to proceed.
+    Each message names the exact `git rm --cached` command to resolve it.
+    """
+    tracked = _tracked_files(project_root)
+    if tracked is None:
+        return [], []
+
+    blockers: list[str] = []
+    for display, is_dir in _RUN_BLOCKER_PATHS:
+        if _path_is_tracked(tracked, display, is_dir):
+            blockers.append(
+                f"{display} is tracked in git. "
+                f"Run `{_rm_cached_command(display, is_dir)}` and commit, then retry."
+            )
+
+    warnings: list[str] = []
+    for display, is_dir in _RUN_WARNING_PATHS:
+        if _path_is_tracked(tracked, display, is_dir):
+            warnings.append(
+                f"{display} is tracked in git. "
+                f"Run `{_rm_cached_command(display, is_dir)}` and commit to stop tracking it."
+            )
+
+    return blockers, warnings
 
 
 def _find_config(start: Path | None = None) -> Path | None:

--- a/tests/test_detach_reexec_seam.py
+++ b/tests/test_detach_reexec_seam.py
@@ -116,7 +116,6 @@ def test_cmd_run_detached_child_skips_daemonize(tmp_path, monkeypatch):
         patch("theforge.detach.install_cleanup_handler"),
         patch("theforge.detach.write_run_ended"),
         patch("theforge.detach.remove_pid"),
-        patch("theforge.cli.run.subprocess.run", return_value=MagicMock(returncode=1)),
     ):
         rc = run_cli.cmd_run(args)
 

--- a/tests/test_run_preconditions.py
+++ b/tests/test_run_preconditions.py
@@ -1,0 +1,224 @@
+"""Tests for forge run precondition guards (issue #795).
+
+Covers the pure ``check_run_preconditions`` helper over a real git repo and the
+``cmd_run`` fail-fast / warn-but-proceed behaviour wired on top of it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config
+
+from theforge.cli.run import cmd_run
+from theforge.cli.shared import check_run_preconditions
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _init_repo(path: Path) -> None:
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+
+
+def _track(root: Path, rel: str, content: str = "x\n") -> None:
+    """Create and git-add a file at ``root/rel`` (no .gitignore in the way)."""
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    _git(root, "add", "-f", rel)
+
+
+def _stub_result() -> CoordinatorResult:
+    return CoordinatorResult(
+        success=True, phase=Phase.DONE, state=CoordinatorState(), message="ok"
+    )
+
+
+# ── check_run_preconditions: pure helper ───────────────────────────────────
+
+
+def test_no_git_repo_returns_no_findings(tmp_path: Path) -> None:
+    """A directory that is not a git repo yields no blockers or warnings."""
+    blockers, warnings = check_run_preconditions(tmp_path)
+    assert blockers == []
+    assert warnings == []
+
+
+def test_clean_repo_returns_no_findings(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _track(tmp_path, "src/app.py")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+
+    blockers, warnings = check_run_preconditions(tmp_path)
+    assert blockers == []
+    assert warnings == []
+
+
+def test_tracked_worktrees_dir_is_a_blocker(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _track(tmp_path, ".forge/worktrees/issue-1/foo.py")
+
+    blockers, warnings = check_run_preconditions(tmp_path)
+    assert warnings == []
+    assert len(blockers) == 1
+    assert ".forge/worktrees/ is tracked in git." in blockers[0]
+    assert "git rm --cached -r .forge/worktrees/" in blockers[0]
+    assert "then retry" in blockers[0]
+
+
+def test_tracked_merge_lock_file_is_a_blocker(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _track(tmp_path, ".forge/merge.lock")
+
+    blockers, _ = check_run_preconditions(tmp_path)
+    assert len(blockers) == 1
+    # File blocker: no -r flag.
+    assert "git rm --cached .forge/merge.lock" in blockers[0]
+    assert "-r" not in blockers[0]
+
+
+def test_all_blocker_paths_detected(tmp_path: Path) -> None:
+    """Every catastrophic path in the design doc trips a blocker."""
+    _init_repo(tmp_path)
+    _track(tmp_path, ".forge/worktrees/w/a.py")
+    _track(tmp_path, ".forge/locks/run.lock")
+    _track(tmp_path, ".forge/merge.lock")
+    _track(tmp_path, ".forge/daemon.json")
+    _track(tmp_path, ".forge/pending/p.json")
+    _track(tmp_path, ".forge/runs/r.json")
+    _track(tmp_path, ".forge/.env")
+    _track(tmp_path, ".forge/secrets.yaml")
+    _track(tmp_path, "handoff.yaml")
+
+    blockers, warnings = check_run_preconditions(tmp_path)
+    assert warnings == []
+    assert len(blockers) == 9
+    for display in (
+        ".forge/worktrees/",
+        ".forge/locks/",
+        ".forge/merge.lock",
+        ".forge/daemon.json",
+        ".forge/pending/",
+        ".forge/runs/",
+        ".forge/.env",
+        ".forge/secrets.yaml",
+        "handoff.yaml",
+    ):
+        assert any(b.startswith(f"{display} is tracked in git.") for b in blockers), display
+
+
+def test_noise_paths_are_warnings_not_blockers(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _track(tmp_path, ".forge/logs/run.log")
+    _track(tmp_path, ".forge/audits/history.jsonl")
+    _track(tmp_path, ".forge/audits/index.sqlite")
+    _track(tmp_path, ".forge/assignment_history.yaml")
+
+    blockers, warnings = check_run_preconditions(tmp_path)
+    assert blockers == []
+    assert len(warnings) == 4
+    for display in (
+        ".forge/logs/",
+        ".forge/audits/history.jsonl",
+        ".forge/audits/index.sqlite",
+        ".forge/assignment_history.yaml",
+    ):
+        assert any(w.startswith(f"{display} is tracked in git.") for w in warnings), display
+    # Warnings still name the resolving command.
+    assert any("git rm --cached" in w for w in warnings)
+
+
+def test_audit_runs_dir_is_not_flagged(tmp_path: Path) -> None:
+    """The tracked audit dir (.forge/audits/runs/) is project memory, not a
+    blocker — only the distinct execution-state .forge/runs/ dir is caught."""
+    _init_repo(tmp_path)
+    _track(tmp_path, ".forge/audits/runs/abc.json")
+
+    blockers, warnings = check_run_preconditions(tmp_path)
+    assert blockers == []
+    assert warnings == []
+
+
+# ── cmd_run: fail-fast / warn-but-proceed wiring ────────────────────────────
+
+
+def _run_args(story: Path, forge_yaml: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        story=str(story),
+        slug=None,
+        config=str(forge_yaml),
+        base_branch=None,
+        plan=None,
+        from_phase=None,
+        until=None,
+        reviewers=None,
+        max_cycles=None,
+        resume=False,
+        dev_model=None,
+        plan_model=None,
+        dry_run=False,
+        interactive=False,
+        auto_merge=False,
+        verbose=False,
+        no_notify=True,
+        fg=True,
+        no_pull=False,
+    )
+
+
+def test_cmd_run_aborts_on_tracked_blocker(tmp_path: Path, capsys) -> None:
+    _init_repo(tmp_path)
+    story = tmp_path / "story.md"
+    story.write_text("# Story\n", encoding="utf-8")
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    _track(tmp_path, ".forge/worktrees/w/a.py")
+
+    config = _make_config(tmp_path)
+    args = _run_args(story, forge_yaml)
+
+    with (
+        patch("theforge.cli.run.load_config", return_value=config),
+        patch("theforge.cli.run.run_task", return_value=_stub_result()) as mock_run,
+    ):
+        rc = cmd_run(args)
+
+    assert rc == 1
+    # Precondition check runs before any agent invocation / workspace mutation.
+    mock_run.assert_not_called()
+    err = capsys.readouterr().err
+    assert "git rm --cached -r .forge/worktrees/" in err
+
+
+def test_cmd_run_proceeds_on_warning_only(tmp_path: Path, capsys) -> None:
+    _init_repo(tmp_path)
+    story = tmp_path / "story.md"
+    story.write_text("# Story\n", encoding="utf-8")
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    _track(tmp_path, ".forge/logs/run.log")
+
+    config = _make_config(tmp_path)
+    args = _run_args(story, forge_yaml)
+
+    with (
+        patch("theforge.cli.run.load_config", return_value=config),
+        patch("theforge.cli.run.run_task", return_value=_stub_result()) as mock_run,
+        patch("theforge.cli.run._write_audit", return_value=tmp_path / "audit.json"),
+    ):
+        rc = cmd_run(args)
+
+    assert rc == 0
+    mock_run.assert_called_once()
+    err = capsys.readouterr().err
+    assert ".forge/logs/ is tracked in git." in err


### PR DESCRIPTION
## Summary

The runtime precondition guard is wired before run startup work, covers the specified blocker and warning paths, and has focused tests for fail-fast and warn-proceed behavior.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.34
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Runtime precondition checks in forge run (GitHub Issue #795)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #795