### PR TITLE
Surface reviewer identity in finding log lines

### DIFF
--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -101,6 +101,7 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                     "line": f.line,
                     "description": f.description,
                     "reviewers": list(f.reviewers),
+                    "reporter": f.reporter,
                 }
                 for f in r.findings
             ]

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -524,22 +524,38 @@ def _apply_review_parse_fallback(
     return None
 
 
+def _story_label(task: TaskStory) -> str:
+    """Human-readable story tag for finding log lines, e.g. ``Add retry backoff (#42)``."""
+    if task.github_issue is not None:
+        return f"{task.name} (#{task.github_issue})"
+    return task.name
+
+
 def _log_review_findings(
     parsed_review: ReviewResult,
     p1_count: int,
     p2_count: int,
     review_cost: float,
     logger: StructuredLogger | None,
+    task: TaskStory,
 ) -> None:
-    """Log review summary and findings grouped by severity; emit structured review_result event."""
+    """Log review summary and findings grouped by severity; emit structured review_result event.
+
+    Each finding line surfaces the reviewer profile that produced it and the story
+    under review so operators can see which model flagged what on which story. The
+    reporter tag is always present — an unattributed finding renders ``[reviewer: ?]``
+    rather than being hidden, so the single-reviewer (no-pool) case still shows a tag.
+    """
     _log(f"  Summary: {parsed_review.summary}")
+    _story_tag = f" [story: {_story_label(task)}]"
     _findings_by_sev: dict[str, list] = {}
     for _f in parsed_review.findings:
         _findings_by_sev.setdefault(_f.severity, []).append(_f)
     for _sev in sorted(_findings_by_sev):
         for _f in _findings_by_sev[_sev]:
             _loc = f" [{_f.file}:{_f.line}]" if _f.file else ""
-            _log(f"  [{_sev}]{_loc} {_f.description}")
+            _reporter_tag = f" [reviewer: {_f.reporter or '?'}]"
+            _log(f"  [{_sev}]{_reporter_tag}{_story_tag}{_loc} {_f.description}")
     if logger:
         logger._safe_emit(
             "review_result",
@@ -1335,7 +1351,7 @@ def _run_review_phase(
         max_iterations=_adaptive_review_max,
     )
 
-    _log_review_findings(parsed_review, _p1_count, _p2_count, _review_cost, logger)
+    _log_review_findings(parsed_review, _p1_count, _p2_count, _review_cost, logger, task)
 
     # ── Early termination: consecutive zero-new-findings cycles ────────
     # Stop the review loop regardless of verdict when the reviewer converges
@@ -1778,7 +1794,7 @@ def _run_review_only_phase(
     _ro_cost = sum(r.cost_usd or 0.0 for r in state.review_agent_results)
     _ro_elapsed = _pool_elapsed
 
-    _log_review_findings(parsed_review, _ro_p1, _ro_p2, _ro_cost, logger)
+    _log_review_findings(parsed_review, _ro_p1, _ro_p2, _ro_cost, logger, task)
 
     if parsed_review.verdict == "APPROVE":
         state.phase = Phase.DONE

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -626,9 +626,9 @@ def _run_review_pool(
     parsed_results: list[ReviewResult] = []
     for r in successful:
         if r.structured_data:
-            parsed_results.append(parse_review_json(r.structured_data))
+            parsed_results.append(parse_review_json(r.structured_data, r.profile_name))
         else:
-            parsed_results.append(parse_review_output(r.output))
+            parsed_results.append(parse_review_output(r.output, r.profile_name))
     names = [r.profile_name for r in successful]
 
     # ── Per-reviewer parse retry (all modes) ─────────────────────────
@@ -713,7 +713,7 @@ def _run_review_pool(
                     f"  {name} retry {_retry_num} agent failed (exit={_retry_result.exit_code})"
                 )
                 break
-            _retried = _try_parse_review(_retry_result.output, _retry_result.structured_data)
+            _retried = _try_parse_review(_retry_result.output, _retry_result.structured_data, name)
             write_trace(
                 workspace_path
                 / ".forge/traces"

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -90,9 +90,12 @@ def _deserialize_review_result(data: object) -> object | None:
                 severity=f.get("severity", "P1"),
                 file=f.get("file", ""),
                 line=f.get("line"),
-                description=f.get("description", ""),
+                observed=f.get("observed", ""),
+                expected=f.get("expected", ""),
+                evidence=f.get("evidence", ""),
                 suggestion=f.get("suggestion"),
                 reviewers=tuple(f.get("reviewers") or ()),
+                reporter=f.get("reporter", ""),
             )
         )
     ac_verification = []

--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -78,6 +78,7 @@ class ReviewFinding:
     expected: str = ""
     evidence: str = ""
     reviewers: tuple[str, ...] = ()  # reviewers who raised this finding (audit attribution)
+    reporter: str = ""  # reviewer profile that produced this finding (surfaced in log lines)
 
     @property
     def description(self) -> str:
@@ -187,8 +188,14 @@ def _merge_sanitization_audits(*audits: dict[str, dict[str, int]]) -> dict[str, 
 
 def _extract_review_payload(
     data: dict,
+    reporter: str = "",
 ) -> tuple[str, list[ReviewFinding], dict[str, dict[str, int]]]:
-    """Extract sanitized summary/findings payload from parsed review data."""
+    """Extract sanitized summary/findings payload from parsed review data.
+
+    ``reporter`` is the reviewer profile name that produced this output; it is
+    stamped onto every extracted finding so attribution flows through parsing to
+    the log line without consulting the finding registry.
+    """
     summary, summary_audit = sanitize_llm_text(
         data.get("summary", "(no summary)"),
         field_name="summary",
@@ -228,6 +235,7 @@ def _extract_review_payload(
                 expected=expected,
                 evidence=evidence,
                 suggestion=suggestion,
+                reporter=reporter,
             )
         )
         sanitization_audit = _merge_sanitization_audits(
@@ -260,18 +268,19 @@ def _extract_ac_verification(data: dict) -> tuple[ACVerification, ...]:
     return tuple(out)
 
 
-def parse_review_json(data: dict) -> ReviewResult:
+def parse_review_json(data: dict, reporter: str = "") -> ReviewResult:
     """Parse and validate review JSON from API response.
 
     This path is used for API-based reviewers that return structured JSON.
-    The cross-validation rules are the same as the YAML path.
+    The cross-validation rules are the same as the YAML path. ``reporter`` is the
+    reviewer profile name, stamped onto each finding for log-line attribution.
     """
     # Best-effort repair before strict validation
     repair_review_yaml(data)
     schema_errors = validate_review_yaml(data)
 
     # Extract findings
-    summary, findings, sanitization_audit = _extract_review_payload(data)
+    summary, findings, sanitization_audit = _extract_review_payload(data, reporter)
 
     # Extract story compliance (accept both story_compliance and spec_compliance for compat)
     spec = data.get("story_compliance") or data.get("spec_compliance") or {}
@@ -298,13 +307,16 @@ def parse_review_json(data: dict) -> ReviewResult:
     )
 
 
-def parse_review_output(agent_output: str) -> ReviewResult:
+def parse_review_output(agent_output: str, reporter: str = "") -> ReviewResult:
     """Extract and parse review YAML from agent output.
 
     Strategy:
     1. Look for ```yaml ... ``` fenced block
     2. Fall back to parsing entire output as YAML
     3. If all parsing fails, return REQUEST_CHANGES with parse errors
+
+    ``reporter`` is the reviewer profile name, stamped onto each finding for
+    log-line attribution.
     """
     # Try to extract YAML from markdown code fences
     yaml_match = re.search(
@@ -350,7 +362,7 @@ def parse_review_output(agent_output: str) -> ReviewResult:
     schema_errors = validate_review_yaml(data)
 
     # Extract findings
-    summary, findings, sanitization_audit = _extract_review_payload(data)
+    summary, findings, sanitization_audit = _extract_review_payload(data, reporter)
 
     # Extract story compliance (accept both story_compliance and spec_compliance for compat)
     spec = data.get("story_compliance") or data.get("spec_compliance") or {}
@@ -377,12 +389,14 @@ def parse_review_output(agent_output: str) -> ReviewResult:
     )
 
 
-def _try_parse_review(output: str, structured_data: dict | None = None) -> ReviewResult | None:
+def _try_parse_review(
+    output: str, structured_data: dict | None = None, reporter: str = ""
+) -> ReviewResult | None:
     """Parse review output; return None if any parse errors occurred."""
     if structured_data:
-        result = parse_review_json(structured_data)
+        result = parse_review_json(structured_data, reporter)
     else:
-        result = parse_review_output(output)
+        result = parse_review_output(output, reporter)
     return None if result.parse_errors else result
 
 
@@ -851,6 +865,7 @@ def _dedup_findings(reviewer_findings: list[tuple[str, ReviewFinding]]) -> list[
                 evidence=finding.evidence,
                 suggestion=finding.suggestion,
                 reviewers=tuple(seen_reviewers[key]),
+                reporter=finding.reporter,
             )
         )
     return result

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -88,6 +88,17 @@ class TestParseReviewOutput:
         assert result.test_adequate is False
         assert len(result.test_gaps) == 1
 
+    def test_reporter_stamped_on_findings(self):
+        """The reviewer profile name flows onto each parsed finding for log attribution."""
+        result = parse_review_output(VALID_REQUEST_CHANGES_YAML, reporter="reviewer-2")
+        assert len(result.findings) == 2
+        assert all(f.reporter == "reviewer-2" for f in result.findings)
+
+    def test_reporter_defaults_to_empty(self):
+        """Omitting reporter leaves the field empty rather than raising."""
+        result = parse_review_output(VALID_REQUEST_CHANGES_YAML)
+        assert all(f.reporter == "" for f in result.findings)
+
     def test_file_scope_p1_with_null_line_parses_cleanly(self):
         """File-scope P1 (file existence) with line: null preserves REQUEST_CHANGES."""
         text = (
@@ -872,6 +883,19 @@ class TestDedupFindings:
         result = _dedup_findings([("r1", f1), ("r2", f2)])
         assert len(result) == 1
         assert set(result[0].reviewers) == {"r1", "r2"}
+
+    def test_reporter_preserved_from_canonical(self):
+        """Dedup keeps the canonical finding's reporter so attribution survives merge."""
+        f = ReviewFinding(
+            severity="P1",
+            file="foo.py",
+            line=1,
+            observed="Bug A",
+            suggestion=None,
+            reporter="reviewer-a",
+        )
+        result = _dedup_findings([("reviewer-a", f)])
+        assert result[0].reporter == "reviewer-a"
 
 
 # ── Tests: merge_review_results deduplication ────────────────────────

--- a/tests/test_review_ac_verification.py
+++ b/tests/test_review_ac_verification.py
@@ -259,6 +259,44 @@ def test_build_reviews_emits_ac_verification_table() -> None:
     ]
 
 
+def test_build_reviews_emits_reporter_per_finding() -> None:
+    """Per-cycle review audit findings carry the reporter profile name so audit
+    consumers reading reviews[].findings can see which profile produced each one."""
+    state = CoordinatorState()
+    state.review_cycle_metadata.append(
+        ReviewCycleMetadata(
+            pool_models=["reviewer-2"],
+            successful=["reviewer-2"],
+            failed=[],
+            synthesized=False,
+        )
+    )
+    state.review_results.append(
+        ReviewResult(
+            verdict="REQUEST_CHANGES",
+            summary="bug",
+            findings=[
+                ReviewFinding(
+                    severity="P1",
+                    file="src/foo.py",
+                    line=10,
+                    observed="bug",
+                    suggestion="fix",
+                    reporter="reviewer-2",
+                )
+            ],
+            story_matches=False,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={},
+        )
+    )
+    reviews = build_reviews(state)
+    assert reviews[0]["findings"][0]["reporter"] == "reviewer-2"
+
+
 def test_build_reviews_emits_empty_ac_verification_when_absent() -> None:
     """REQUEST_CHANGES results may carry no AC table — audit emits []."""
     state = CoordinatorState()

--- a/tests/test_review_finding_log_attribution.py
+++ b/tests/test_review_finding_log_attribution.py
@@ -1,0 +1,74 @@
+"""Seam test: reviewer identity + story context surface in finding log lines.
+
+Covers the flow from ReviewFinding.reporter (populated during parsing) through
+_log_review_findings, the review-phase call site that emits the operator-facing
+`[P1]`/`[P2]` lines. Asserts both the reviewer tag and the story tag appear, and
+that the reporter tag is present even for the single-reviewer (no-pool) case.
+"""
+
+from theforge.coordinator import review_phase as rp
+from theforge.review import ReviewFinding, ReviewResult
+from theforge.task import TaskStory
+
+
+def _finding(reporter: str) -> ReviewFinding:
+    return ReviewFinding(
+        severity="P1",
+        file="src/theforge/coordinator/dev_phase.py",
+        line=112,
+        observed="The review retry path treats X as Y",
+        suggestion=None,
+        reporter=reporter,
+    )
+
+
+def _review(findings: list[ReviewFinding]) -> ReviewResult:
+    return ReviewResult(
+        verdict="REQUEST_CHANGES",
+        summary="something to fix",
+        findings=findings,
+        story_matches=False,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def _capture_findings(monkeypatch, review: ReviewResult, task: TaskStory) -> list[str]:
+    captured: list[str] = []
+    monkeypatch.setattr(rp, "_log", lambda msg: captured.append(msg))
+    rp._log_review_findings(review, 1, 0, 0.0, None, task)
+    return [m for m in captured if m.strip().startswith("[P")]
+
+
+def test_finding_line_includes_reviewer_and_story(monkeypatch):
+    task = TaskStory(name="Add retry backoff", slug="retry-backoff", github_issue=42)
+    lines = _capture_findings(monkeypatch, _review([_finding("reviewer-2")]), task)
+    assert len(lines) == 1
+    line = lines[0]
+    assert "[reviewer: reviewer-2]" in line
+    assert "[story: Add retry backoff (#42)]" in line
+    assert "[src/theforge/coordinator/dev_phase.py:112]" in line
+
+
+def test_story_tag_omits_issue_number_when_absent(monkeypatch):
+    task = TaskStory(name="Local story", slug="local-story", github_issue=None)
+    lines = _capture_findings(monkeypatch, _review([_finding("reviewer-1")]), task)
+    assert "[story: Local story]" in lines[0]
+    assert "(#" not in lines[0]
+
+
+def test_single_reviewer_reporter_tag_present(monkeypatch):
+    """AC: the reporter tag is not conditionally hidden for the no-pool case."""
+    task = TaskStory(name="Solo review", slug="solo", github_issue=7)
+    lines = _capture_findings(monkeypatch, _review([_finding("solo-reviewer")]), task)
+    assert "[reviewer: solo-reviewer]" in lines[0]
+
+
+def test_unattributed_finding_renders_placeholder(monkeypatch):
+    """An empty reporter still emits a tag (never a hidden/missing segment)."""
+    task = TaskStory(name="Solo review", slug="solo", github_issue=7)
+    lines = _capture_findings(monkeypatch, _review([_finding("")]), task)
+    assert "[reviewer: ?]" in lines[0]

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -9,7 +9,11 @@ from coord_test_helpers import _make_config, _make_task
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.coordinator.engine import _run_resume_coordinator
 from theforge.coordinator.gate import _parse_dirty_files
-from theforge.coordinator.run_setup import _setup_resume_entry
+from theforge.coordinator.run_setup import (
+    _deserialize_review_result,
+    _serialize_review_result,
+    _setup_resume_entry,
+)
 from theforge.coordinator.state import CoordinatorResult, Phase
 
 _STRUCTURED_PLAN = """---
@@ -52,6 +56,50 @@ def _call_setup(config, task, workspace_path):
             notify=False,
             run_id="test-run-id",
         )
+
+
+def test_review_result_sidecar_roundtrip_preserves_finding_fields():
+    """Serialize→deserialize of the hygiene-escalation sidecar must reconstruct
+    ReviewFinding faithfully, including reporter attribution and the observed/
+    expected/evidence prose fields (regression: the deserializer previously read a
+    non-existent ``description`` key and dropped reporter)."""
+    from theforge.review import ReviewFinding, ReviewResult
+
+    original = ReviewResult(
+        verdict="REQUEST_CHANGES",
+        summary="needs work",
+        findings=[
+            ReviewFinding(
+                severity="P1",
+                file="src/foo.py",
+                line=12,
+                observed="null deref on retry",
+                expected="runtime paths guard against null",
+                evidence="src/foo.py:12",
+                suggestion="add a guard",
+                reviewers=("reviewer-2",),
+                reporter="reviewer-2",
+            )
+        ],
+        story_matches=False,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+    restored = _deserialize_review_result(_serialize_review_result(original))
+
+    assert restored is not None
+    assert len(restored.findings) == 1
+    f = restored.findings[0]
+    assert f.reporter == "reviewer-2"
+    assert f.observed == "null deref on retry"
+    assert f.expected == "runtime paths guard against null"
+    assert f.evidence == "src/foo.py:12"
+    assert f.reviewers == ("reviewer-2",)
+    assert f.severity == "P1"
 
 
 def test_forge_yaml_synced_from_project_root(tmp_path):


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior per-cycle audit reporter omission is fixed, the reviewed diff satisfies the finding attribution requirements, and the focused test suite passes. | [google-gemini-3.5-flash] All acceptance criteria are fully met, prior P1 findings are resolved, and robust test coverage has been added.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $8.29
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Surface reviewer identity in finding log lines (GitHub Issue #398)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #398