### PR TITLE
forge diagnose shows no output while model is working

### DIFF
--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -23,6 +23,7 @@ import os
 import re
 import subprocess
 import tempfile
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,6 +31,7 @@ from pathlib import Path
 import yaml
 
 from theforge.config import ForgeConfig, ModelProfile
+from theforge.coordinator.util import _log as _progress_log
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
     AbsentPremise,
@@ -554,6 +556,68 @@ def _build_diagnose_profile(config: ForgeConfig) -> ModelProfile:
     )
 
 
+# ── Progress heartbeat ────────────────────────────────────────────────
+#
+# Interval between diagnose progress heartbeats. The investigative agent can
+# run for the full diagnose timeout (default 600s); ``run_agent`` blocks for
+# that whole window and the diagnose flow otherwise emits nothing to the
+# console between the runner's "Starting diagnose" line and the result. That
+# silence makes a live run indistinguishable from a hang, so we emit an
+# elapsed-time line at PROGRESS level every interval.
+_DIAGNOSE_HEARTBEAT_INTERVAL_S = 30.0
+
+
+def _run_agent_with_heartbeat(
+    *,
+    prompt: str,
+    profile: ModelProfile,
+    working_dir: Path,
+    secrets: dict[str, str] | None,
+    heartbeat_interval_s: float | None = None,
+) -> "object":
+    """Run the investigative agent, emitting a periodic progress heartbeat.
+
+    ``run_agent`` blocks for the entire model run. We run it on a background
+    thread and emit an elapsed-time line every ``heartbeat_interval_s`` seconds
+    (always shown, not verbose-gated) so the operator can see the agent is still
+    working rather than staring at a silent console for up to the full timeout.
+
+    Any exception raised inside the agent thread is re-raised to the caller so
+    the existing INVESTIGATE error handling is unchanged. Returns the
+    ``AgentResult`` produced by ``run_agent``.
+    """
+    if heartbeat_interval_s is None:
+        heartbeat_interval_s = _DIAGNOSE_HEARTBEAT_INTERVAL_S
+    box: dict[str, object] = {}
+
+    def _run() -> None:
+        try:
+            box["result"] = run_agent(
+                prompt=prompt,
+                profile=profile,
+                working_dir=working_dir,
+                secrets=secrets,
+            )
+        except BaseException as exc:  # noqa: BLE001 — re-raised in caller thread
+            box["exc"] = exc
+
+    start = time.monotonic()
+    thread = threading.Thread(target=_run, name="diagnose-agent", daemon=True)
+    thread.start()
+    while thread.is_alive():
+        thread.join(timeout=heartbeat_interval_s)
+        if thread.is_alive():
+            elapsed = int(time.monotonic() - start)
+            _progress_log(
+                f"  [diagnose] still investigating "
+                f"({elapsed}s elapsed, timeout {int(profile.timeout_seconds)}s)"
+            )
+
+    if "exc" in box:
+        raise box["exc"]  # type: ignore[misc]
+    return box["result"]
+
+
 # ── Landing strategies ────────────────────────────────────────────────
 
 
@@ -687,7 +751,7 @@ def run_diagnose_flow(
 
     t0 = time.monotonic()
     try:
-        agent_result = run_agent(
+        agent_result = _run_agent_with_heartbeat(
             prompt=prompt,
             profile=profile,
             working_dir=project_root,

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -1248,3 +1248,125 @@ class TestParseRelatedFindings:
         assert artifact is not None
         assert len(artifact.related_findings) == 1
         assert artifact.related_findings[0].summary == "dup"
+
+
+class TestDiagnoseHeartbeat:
+    """The investigative agent runs for up to the diagnose timeout; the flow must
+    emit periodic progress so a live run is distinguishable from a hang."""
+
+    def test_heartbeat_emitted_while_agent_runs(self, tmp_path):
+        import time as _time
+
+        from theforge.coordinator import diagnose_flow
+
+        profile = diagnose_flow._build_diagnose_profile(_make_config(tmp_path))
+
+        def _slow_agent(**_kwargs):
+            _time.sleep(0.18)
+            return _fake_agent_result(_agent_yaml_output())
+
+        with (
+            patch.object(diagnose_flow, "run_agent", _slow_agent),
+            patch.object(diagnose_flow, "_progress_log") as mock_log,
+        ):
+            result = diagnose_flow._run_agent_with_heartbeat(
+                prompt="p",
+                profile=profile,
+                working_dir=tmp_path,
+                secrets=None,
+                heartbeat_interval_s=0.05,
+            )
+
+        assert result is not None
+        heartbeats = [c.args[0] for c in mock_log.call_args_list]
+        assert heartbeats, "expected at least one heartbeat line"
+        assert all("still investigating" in line for line in heartbeats)
+        assert any("elapsed" in line for line in heartbeats)
+
+    def test_no_heartbeat_when_agent_returns_fast(self, tmp_path):
+        from theforge.coordinator import diagnose_flow
+
+        profile = diagnose_flow._build_diagnose_profile(_make_config(tmp_path))
+
+        def _fast_agent(**_kwargs):
+            return _fake_agent_result(_agent_yaml_output())
+
+        with (
+            patch.object(diagnose_flow, "run_agent", _fast_agent),
+            patch.object(diagnose_flow, "_progress_log") as mock_log,
+        ):
+            diagnose_flow._run_agent_with_heartbeat(
+                prompt="p",
+                profile=profile,
+                working_dir=tmp_path,
+                secrets=None,
+                heartbeat_interval_s=5.0,
+            )
+
+        assert not mock_log.called
+
+    def test_agent_exception_is_reraised(self, tmp_path):
+        from theforge.coordinator import diagnose_flow
+
+        profile = diagnose_flow._build_diagnose_profile(_make_config(tmp_path))
+
+        def _boom(**_kwargs):
+            raise RuntimeError("agent blew up")
+
+        with patch.object(diagnose_flow, "run_agent", _boom):
+            try:
+                diagnose_flow._run_agent_with_heartbeat(
+                    prompt="p",
+                    profile=profile,
+                    working_dir=tmp_path,
+                    secrets=None,
+                    heartbeat_interval_s=0.05,
+                )
+            except RuntimeError as exc:
+                assert "agent blew up" in str(exc)
+            else:
+                raise AssertionError("expected RuntimeError to propagate")
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_flow_emits_heartbeat_during_investigate(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        """Seam test: a full diagnose run whose INVESTIGATE agent is slow must
+        surface heartbeat lines between the runner's start line and the result."""
+        import time as _time
+
+        from theforge.coordinator import diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 1421,
+            "title": "silent diagnose",
+            "body": "no output while model works",
+            "state": "OPEN",
+        }
+        mock_post.return_value = "https://example/comment"
+
+        def _slow_agent(**_kwargs):
+            _time.sleep(0.18)
+            return _fake_agent_result(_agent_yaml_output())
+
+        mock_agent.side_effect = _slow_agent
+
+        with (
+            patch.object(diagnose_flow, "_DIAGNOSE_HEARTBEAT_INTERVAL_S", 0.05),
+            patch.object(diagnose_flow, "_progress_log") as mock_log,
+        ):
+            result = diagnose_flow.run_diagnose_flow(
+                issue_number=1421,
+                config=config,
+                project_root=tmp_path,
+                output_destination="comment",
+            )
+
+        assert result.success
+        heartbeats = [
+            c.args[0] for c in mock_log.call_args_list if "still investigating" in c.args[0]
+        ]
+        assert heartbeats, "expected heartbeat lines during INVESTIGATE"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change adds an invoked diagnose heartbeat path with focused unit and seam coverage; no blocking issues found. | [google-gemini-3.5-flash] The implementation successfully introduces a background thread to emit periodic progress heartbeats during the investigative agent run, resolving the silence issue. | [claude-sonnet] Heartbeat wrapper correctly fills the silent gap during INVESTIGATE, is thread-safe and exception-safe, and is covered by both unit and seam-level tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $3.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose shows no output while model is working (GitHub Issue #1421)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1421