### PR TITLE
forge diagnose should auto-inject starting evidence when the issue body cites a run/sprint/PR

### DIFF
--- a/src/theforge/coordinator/diagnose_evidence.py
+++ b/src/theforge/coordinator/diagnose_evidence.py
@@ -1,0 +1,417 @@
+"""Auto-inject starting evidence for the diagnose flow.
+
+When an operator files a symptom bug they usually name the concrete artifact
+the symptom lives in — a sprint run id, a sprint id, a branch, a PR/issue
+number, or an audit/log path. The diagnose agent has a fixed budget and a
+600-second wall-clock; making it *rediscover* pointers the operator already
+wrote is wasted budget it could spend on hypothesis-formation instead.
+
+This module is the deterministic, mechanical pre-load step: it scans the issue
+body for recognizable references, loads bounded excerpts of the matching
+log/audit/PR-history, and renders a ``STARTING EVIDENCE`` block the flow embeds
+in the prompt before invoking the agent.
+
+Design constraints:
+
+- **Best-effort.** An issue with no recognizable references (or references that
+  resolve to nothing on disk) produces an empty block — the flow then behaves
+  exactly as it did before this feature existed.
+- **Bounded.** Every excerpt is truncated to a fixed line/char cap, each
+  reference kind is capped in count, and the whole block is capped in total
+  size. The operator can predict the maximum prompt growth from the constants
+  below; nothing an issue body cites can explode the prompt.
+- **Pure orchestrator work.** No LLM calls. Extraction is regex-driven; loading
+  is filesystem reads plus (optional) ``gh`` queries that fail open.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+# ── Bounding constants (the operator-predictable excerpting rules) ─────
+# The maximum size of the injected block is deterministic:
+#   <= _MAX_TOTAL_EVIDENCE_CHARS overall, assembled from at most
+#   _MAX_ITEMS_PER_KIND items of each kind, each <= _MAX_EXCERPT_CHARS.
+_MAX_LOG_TAIL_LINES = 30  # run/sprint logs: last N lines only
+_MAX_FILE_HEAD_LINES = 40  # generic audit/state files: first N lines
+_MAX_EXCERPT_CHARS = 4000  # hard char cap on any single excerpt body
+_MAX_ITEMS_PER_KIND = 5  # cap distinct references loaded per kind
+_MAX_TOTAL_EVIDENCE_CHARS = 20000  # cap on the whole rendered block body
+_MAX_HISTORY_LINE_MATCHES = 2  # history.jsonl lines loaded per run id
+_HISTORY_LINE_CHAR_CAP = 800  # per-line truncation of a history match
+
+# ── Reference-detection patterns ──────────────────────────────────────
+# A run id or sprint id is a 12-hex token (see diagnose_flow._generate_run_id
+# and sprint id generation). The same token is probed against both the run-log
+# glob and the sprint dir, since the two id spaces are indistinguishable by
+# shape alone.
+_HEX_ID_RE = re.compile(r"\b[0-9a-f]{12}\b")
+# Branch names TheForge creates: a conventional-commit-style prefix plus a slug.
+_BRANCH_RE = re.compile(r"\b(?:feat|fix|chore|refactor|docs|test|perf|hotfix)/[A-Za-z0-9._/-]+")
+# PR / issue cross-references.
+_ISSUE_PR_RE = re.compile(r"#(\d{1,7})\b")
+# An explicit ``.forge/...`` file path with an extension (audit, log, jsonl…).
+_FORGE_PATH_RE = re.compile(r"\.forge/[A-Za-z0-9._:,/-]+\.[A-Za-z0-9]+")
+
+
+@dataclass
+class StartingEvidence:
+    """The rendered ``STARTING EVIDENCE`` block plus what fed it.
+
+    ``text`` is the full section (header + items) ready to embed in the prompt,
+    or ``""`` when nothing was found. ``reference_labels`` is the list of short
+    human labels for each excerpt that was loaded — recorded in the audit so an
+    operator can see, deterministically, what the orchestrator handed the agent.
+    """
+
+    text: str = ""
+    reference_labels: list[str] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.text
+
+
+@dataclass
+class _Item:
+    """One loaded excerpt: a short label/header and its (already-bounded) body."""
+
+    label: str
+    header: str
+    body: str
+
+
+# ── Ordered, deduped reference extraction ─────────────────────────────
+
+
+def _ordered_unique(matches: list[str]) -> list[str]:
+    """Return ``matches`` de-duplicated, preserving first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for m in matches:
+        if m in seen:
+            continue
+        seen.add(m)
+        out.append(m)
+    return out
+
+
+def _truncate(text: str, *, max_chars: int = _MAX_EXCERPT_CHARS) -> str:
+    """Clip ``text`` to ``max_chars`` with a visible truncation marker."""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "\n… [truncated]"
+
+
+def _tail_lines(text: str, n: int) -> str:
+    lines = text.splitlines()
+    if len(lines) <= n:
+        return text.rstrip("\n")
+    return "\n".join(lines[-n:])
+
+
+def _head_lines(text: str, n: int) -> str:
+    lines = text.splitlines()
+    if len(lines) <= n:
+        return text.rstrip("\n")
+    return "\n".join(lines[:n])
+
+
+def _read_text(path: Path) -> str | None:
+    """Read a file as UTF-8, returning None on any failure (best-effort)."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+# ── Per-kind loaders (each returns a list of _Item, bounded) ──────────
+
+
+def _load_run_logs(hex_ids: list[str], project_root: Path) -> list[_Item]:
+    """For each hex id that matches a ``run-<id>.log``, load its last lines."""
+    items: list[_Item] = []
+    logs_root = project_root / ".forge" / "logs"
+    for hid in hex_ids:
+        if len(items) >= _MAX_ITEMS_PER_KIND:
+            break
+        matches = sorted(logs_root.glob(f"*/run-{hid}.log"))
+        if not matches:
+            continue
+        log_path = matches[0]
+        text = _read_text(log_path)
+        if not text:
+            continue
+        rel = log_path.relative_to(project_root)
+        body = _truncate(_tail_lines(text, _MAX_LOG_TAIL_LINES))
+        items.append(
+            _Item(
+                label=f"run log {hid}",
+                header=f"Run log {rel} (last {_MAX_LOG_TAIL_LINES} lines):",
+                body=body,
+            )
+        )
+    return items
+
+
+def _load_sprint_states(hex_ids: list[str], project_root: Path) -> list[_Item]:
+    """For each hex id that matches a ``.forge/sprints/<id>/`` dir, load state."""
+    items: list[_Item] = []
+    sprints_root = project_root / ".forge" / "sprints"
+    for hid in hex_ids:
+        if len(items) >= _MAX_ITEMS_PER_KIND:
+            break
+        state_path = sprints_root / hid / "state.yaml"
+        if not state_path.is_file():
+            continue
+        text = _read_text(state_path)
+        if not text:
+            continue
+        rel = state_path.relative_to(project_root)
+        body = _truncate(_head_lines(text, _MAX_FILE_HEAD_LINES))
+        items.append(
+            _Item(
+                label=f"sprint state {hid}",
+                header=f"Sprint state {rel} (first {_MAX_FILE_HEAD_LINES} lines):",
+                body=body,
+            )
+        )
+    return items
+
+
+def _load_history_entries(hex_ids: list[str], project_root: Path) -> list[_Item]:
+    """Load ``history.jsonl`` lines mentioning a cited run/sprint id.
+
+    Streams the file line by line and stops after collecting a bounded number
+    of matches so a large history file cannot blow the budget.
+    """
+    history_path = project_root / ".forge" / "audits" / "history.jsonl"
+    if not hex_ids or not history_path.is_file():
+        return []
+    wanted = set(hex_ids)
+    found: dict[str, list[str]] = {hid: [] for hid in hex_ids}
+    remaining = len(wanted)
+    try:
+        with history_path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if remaining <= 0:
+                    break
+                for hid in list(wanted):
+                    if hid in line:
+                        bucket = found[hid]
+                        if len(bucket) < _MAX_HISTORY_LINE_MATCHES:
+                            bucket.append(line.strip()[:_HISTORY_LINE_CHAR_CAP])
+                        if len(bucket) >= _MAX_HISTORY_LINE_MATCHES:
+                            wanted.discard(hid)
+                            remaining -= 1
+    except OSError:
+        return []
+
+    items: list[_Item] = []
+    for hid in hex_ids:
+        lines = found.get(hid) or []
+        if not lines:
+            continue
+        if len(items) >= _MAX_ITEMS_PER_KIND:
+            break
+        body = _truncate("\n".join(lines))
+        items.append(
+            _Item(
+                label=f"history {hid}",
+                header=f"history.jsonl entries mentioning {hid}:",
+                body=body,
+            )
+        )
+    return items
+
+
+def _load_forge_paths(paths: list[str], project_root: Path) -> list[_Item]:
+    """Load bounded excerpts of explicitly-cited ``.forge/...`` files."""
+    items: list[_Item] = []
+    for rel in paths:
+        if len(items) >= _MAX_ITEMS_PER_KIND:
+            break
+        target = project_root / rel
+        if not target.is_file():
+            continue
+        text = _read_text(target)
+        if not text:
+            continue
+        # A .log path is most useful at its tail; everything else at its head.
+        if rel.endswith(".log"):
+            excerpt = _tail_lines(text, _MAX_LOG_TAIL_LINES)
+            where = f"last {_MAX_LOG_TAIL_LINES} lines"
+        else:
+            excerpt = _head_lines(text, _MAX_FILE_HEAD_LINES)
+            where = f"first {_MAX_FILE_HEAD_LINES} lines"
+        items.append(
+            _Item(
+                label=f"file {rel}",
+                header=f"{rel} ({where}):",
+                body=_truncate(excerpt),
+            )
+        )
+    return items
+
+
+# ── gh-backed loaders (fail open when gh is unavailable) ──────────────
+
+
+def _run_gh(args: list[str], project_root: Path) -> str | None:
+    """Run a ``gh`` query, returning stdout or None on any failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _load_branch_history(branches: list[str], project_root: Path) -> list[_Item]:
+    """For each cited branch, load its PR history via ``gh pr list --head``."""
+    items: list[_Item] = []
+    for branch in branches:
+        if len(items) >= _MAX_ITEMS_PER_KIND:
+            break
+        out = _run_gh(
+            [
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "all",
+                "--json",
+                "number,state,title,mergedAt",
+            ],
+            project_root,
+        )
+        if not out or out == "[]":
+            continue
+        items.append(
+            _Item(
+                label=f"branch {branch}",
+                header=f"PR history for {branch} (gh pr list --head {branch} --state all):",
+                body=_truncate(out),
+            )
+        )
+    return items
+
+
+def _load_pr_issue_refs(
+    numbers: list[str], project_root: Path, *, self_issue_number: int | None
+) -> list[_Item]:
+    """Load a bounded summary for each cited #NNNN (skipping the issue itself)."""
+    items: list[_Item] = []
+    for num in numbers:
+        if len(items) >= _MAX_ITEMS_PER_KIND:
+            break
+        if self_issue_number is not None and num == str(self_issue_number):
+            continue
+        # A #NNNN can be a PR or an issue. Try PR first (richer landing signal),
+        # fall back to the issue view. Both fail open.
+        pr_out = _run_gh(
+            ["pr", "view", num, "--json", "number,state,title,mergedAt,mergeCommit"],
+            project_root,
+        )
+        if pr_out:
+            items.append(
+                _Item(
+                    label=f"PR #{num}",
+                    header=f"PR #{num} (gh pr view {num}):",
+                    body=_truncate(pr_out),
+                )
+            )
+            continue
+        issue_out = _run_gh(
+            ["issue", "view", num, "--json", "number,state,title"],
+            project_root,
+        )
+        if issue_out:
+            items.append(
+                _Item(
+                    label=f"issue #{num}",
+                    header=f"Issue #{num} (gh issue view {num}):",
+                    body=_truncate(issue_out),
+                )
+            )
+    return items
+
+
+# ── Public entry point ────────────────────────────────────────────────
+
+
+def build_starting_evidence(
+    *,
+    issue_body: str,
+    project_root: Path,
+    self_issue_number: int | None = None,
+) -> StartingEvidence:
+    """Scan ``issue_body`` for references and pre-load bounded excerpts.
+
+    Returns a :class:`StartingEvidence` whose ``text`` is the rendered
+    ``== STARTING EVIDENCE (auto-loaded from issue body references) ==``
+    section, or an empty ``StartingEvidence`` when no reference resolves to
+    anything on disk / via ``gh``. The whole block is capped at
+    ``_MAX_TOTAL_EVIDENCE_CHARS``; excess items are dropped (and logged) rather
+    than silently exploding the prompt.
+    """
+    body = issue_body or ""
+
+    hex_ids = _ordered_unique(_HEX_ID_RE.findall(body))
+    branches = _ordered_unique([m.rstrip(".,;:)]}'\"") for m in _BRANCH_RE.findall(body)])
+    pr_issue_numbers = _ordered_unique(_ISSUE_PR_RE.findall(body))
+    forge_paths = _ordered_unique([m.rstrip(".,;:)]}'\"") for m in _FORGE_PATH_RE.findall(body)])
+
+    items: list[_Item] = []
+    items += _load_run_logs(hex_ids, project_root)
+    items += _load_sprint_states(hex_ids, project_root)
+    items += _load_history_entries(hex_ids, project_root)
+    items += _load_forge_paths(forge_paths, project_root)
+    items += _load_branch_history(branches, project_root)
+    items += _load_pr_issue_refs(
+        pr_issue_numbers, project_root, self_issue_number=self_issue_number
+    )
+
+    if not items:
+        return StartingEvidence()
+
+    return _render(items)
+
+
+def _render(items: list[_Item]) -> StartingEvidence:
+    """Assemble loaded items into the bounded STARTING EVIDENCE block."""
+    header = "== STARTING EVIDENCE (auto-loaded from issue body references) =="
+    rendered: list[str] = []
+    labels: list[str] = []
+    total = 0
+    dropped = 0
+    for item in items:
+        block = f"{item.header}\n{item.body}"
+        # +2 accounts for the blank-line separator between items.
+        if total + len(block) + 2 > _MAX_TOTAL_EVIDENCE_CHARS and rendered:
+            dropped += 1
+            continue
+        rendered.append(block)
+        labels.append(item.label)
+        total += len(block) + 2
+
+    if dropped:
+        _log.debug("starting-evidence: dropped %d item(s) over total char cap", dropped)
+        rendered.append(f"[{dropped} further reference excerpt(s) omitted to bound the prompt]")
+
+    text = header + "\n\n" + "\n\n".join(rendered)
+    return StartingEvidence(text=text, reference_labels=labels)

--- a/src/theforge/coordinator/diagnose_evidence.py
+++ b/src/theforge/coordinator/diagnose_evidence.py
@@ -42,6 +42,12 @@ _MAX_LOG_TAIL_LINES = 30  # run/sprint logs: last N lines only
 _MAX_FILE_HEAD_LINES = 40  # generic audit/state files: first N lines
 _MAX_EXCERPT_CHARS = 4000  # hard char cap on any single excerpt body
 _MAX_ITEMS_PER_KIND = 5  # cap distinct references loaded per kind
+# gh-backed loaders cost a subprocess (up to 30s each) per *attempted* reference
+# whether or not it resolves. _MAX_ITEMS_PER_KIND only bounds *successful* loads,
+# so an issue body citing many unresolved branches/#NNNN could still fire one gh
+# call per reference before the agent starts. This caps attempts (resolved or
+# not) so the pre-load step's wall-clock is bounded regardless of body length.
+_MAX_GH_ATTEMPTS_PER_KIND = 5
 _MAX_TOTAL_EVIDENCE_CHARS = 20000  # cap on the whole rendered block body
 _MAX_HISTORY_LINE_MATCHES = 2  # history.jsonl lines loaded per run id
 _HISTORY_LINE_CHAR_CAP = 800  # per-line truncation of a history match
@@ -283,7 +289,10 @@ def _run_gh(args: list[str], project_root: Path) -> str | None:
 def _load_branch_history(branches: list[str], project_root: Path) -> list[_Item]:
     """For each cited branch, load its PR history via ``gh pr list --head``."""
     items: list[_Item] = []
-    for branch in branches:
+    # Bound attempts, not just successes: every iteration fires a gh call
+    # regardless of whether it resolves, so an unresolved-heavy body must not
+    # spend one subprocess timeout per reference.
+    for branch in branches[:_MAX_GH_ATTEMPTS_PER_KIND]:
         if len(items) >= _MAX_ITEMS_PER_KIND:
             break
         out = _run_gh(
@@ -316,11 +325,15 @@ def _load_pr_issue_refs(
 ) -> list[_Item]:
     """Load a bounded summary for each cited #NNNN (skipping the issue itself)."""
     items: list[_Item] = []
-    for num in numbers:
+    # Drop the self-issue first (it costs no gh call), then bound gh *attempts*:
+    # each remaining reference fires 1-2 gh subprocesses whether or not it
+    # resolves, so a body citing many unresolved #NNNN must not spend one
+    # timeout per reference before the agent starts.
+    self_ref = str(self_issue_number) if self_issue_number is not None else None
+    candidates = [num for num in numbers if num != self_ref]
+    for num in candidates[:_MAX_GH_ATTEMPTS_PER_KIND]:
         if len(items) >= _MAX_ITEMS_PER_KIND:
             break
-        if self_issue_number is not None and num == str(self_issue_number):
-            continue
         # A #NNNN can be a PR or an issue. Try PR first (richer landing signal),
         # fall back to the issue view. Both fail open.
         pr_out = _run_gh(

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import yaml
 
 from theforge.config import ForgeConfig, ModelProfile
+from theforge.coordinator.diagnose_evidence import build_starting_evidence
 from theforge.coordinator.util import _log as _progress_log
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
@@ -480,6 +481,10 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
             "location": state.landed_location,
         },
         "sub_investigations": list(state.sub_investigations),
+        "starting_evidence": {
+            "reference_labels": list(state.starting_evidence_labels),
+            "chars": state.starting_evidence_chars,
+        },
         "baseline": {
             "sha": state.baseline_sha,
             "captured_at": state.baseline_captured_at,
@@ -738,6 +743,27 @@ def run_diagnose_flow(
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
+    # ── STARTING EVIDENCE ─────────────────────────────────────────────
+    # Deterministic pre-load: scan the issue body for references the operator
+    # cited (run/sprint ids, branches, PR/issue numbers, audit paths) and hand
+    # the agent bounded excerpts up front, so its budget is spent on
+    # hypothesis-formation rather than rediscovering pointers already in the
+    # body. Best-effort — an issue with no recognizable references yields an
+    # empty block and the prompt is unchanged from pre-feature behavior.
+    evidence = build_starting_evidence(
+        issue_body=state.issue_body,
+        project_root=project_root,
+        self_issue_number=issue_number,
+    )
+    state.starting_evidence_labels = list(evidence.reference_labels)
+    state.starting_evidence_chars = len(evidence.text)
+    if evidence.reference_labels:
+        _progress_log(
+            f"  [diagnose] pre-loaded {len(evidence.reference_labels)} evidence "
+            f"excerpt(s) from issue-body references: "
+            f"{', '.join(evidence.reference_labels)}"
+        )
+
     # ── INVESTIGATE ───────────────────────────────────────────────────
     state.transition(DiagnosePhase.INVESTIGATE, _now_iso())
     profile = _build_diagnose_profile(config)
@@ -747,6 +773,7 @@ def run_diagnose_flow(
         title=state.issue_title,
         body=state.issue_body,
         mode=mode,
+        starting_evidence=evidence.text,
     )
 
     t0 = time.monotonic()

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -224,6 +224,12 @@ class DiagnoseState:
     already_resolved: bool = False
     absent_premises: tuple[AbsentPremise, ...] = ()
     # Set when the premise check finds the cited code was removed from baseline.
+    starting_evidence_labels: list[str] = field(default_factory=list)
+    # Short labels for each excerpt auto-loaded from issue-body references and
+    # injected into the prompt as STARTING EVIDENCE. Empty when the body cited
+    # nothing recognizable. Recorded so the audit shows exactly what the
+    # orchestrator handed the agent (convention: instrument cross-phase data).
+    starting_evidence_chars: int = 0
 
     def transition(self, new_phase: DiagnosePhase, when: str) -> None:
         self.phase = new_phase

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -28,7 +28,7 @@ Mode: {mode}
 == ISSUE #{issue_number}: {title} ==
 
 {body}
-
+{starting_evidence}
 {environment}
 
 == INSTRUCTIONS ==
@@ -206,6 +206,7 @@ def build_diagnose_prompt(
     title: str,
     body: str,
     mode: str = "autonomous",
+    starting_evidence: str = "",
 ) -> str:
     """Return the diagnose-agent prompt for one issue.
 
@@ -213,15 +214,25 @@ def build_diagnose_prompt(
     it can adjust verbosity (interactive runs may benefit from richer notes
     explaining intermediate steps).
 
+    ``starting_evidence`` is an optional, already-rendered STARTING EVIDENCE
+    block (see :func:`theforge.coordinator.diagnose_evidence.build_starting_evidence`)
+    pre-loaded from references the operator cited in the issue body. It is
+    embedded verbatim right after the issue block so the agent does not spend
+    budget rediscovering pointers the operator already provided. When empty,
+    the prompt is byte-for-byte what it was before auto-injection existed
+    (best-effort: no references → no change).
+
     The prompt embeds an environment briefing (see
     :func:`build_environment_briefing`) so the agent starts from TheForge's
     known audit/log layout instead of burning its budget rediscovering it.
     """
+    evidence_block = f"\n{starting_evidence}\n" if starting_evidence else ""
     return _DIAGNOSE_PROMPT_TEMPLATE.format(
         issue_number=issue_number,
         title=title or f"Issue #{issue_number}",
         body=body or "(issue body is empty)",
         mode=mode,
+        starting_evidence=evidence_block,
         environment=build_environment_briefing(),
     )
 

--- a/tests/test_diagnose_evidence.py
+++ b/tests/test_diagnose_evidence.py
@@ -1,0 +1,232 @@
+"""Tests for diagnose starting-evidence auto-injection.
+
+Covers:
+- reference detection (run/sprint ids, branches, PR/issue numbers, audit paths)
+- bounded excerpting (line/char/count caps)
+- best-effort no-op when nothing is recognizable
+- fixture comparison: an issue citing a run_id pre-loads the run-log excerpt
+  the agent would otherwise have had to discover, vs. an issue with no
+  references (which gets no injected section at all)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from theforge.coordinator.diagnose_evidence import (
+    _MAX_LOG_TAIL_LINES,
+    _MAX_TOTAL_EVIDENCE_CHARS,
+    build_starting_evidence,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestNoReferences:
+    def test_empty_body_yields_empty_evidence(self, tmp_path):
+        ev = build_starting_evidence(issue_body="", project_root=tmp_path)
+        assert ev.is_empty
+        assert ev.text == ""
+        assert ev.reference_labels == []
+
+    def test_body_with_no_recognizable_refs_is_noop(self, tmp_path):
+        ev = build_starting_evidence(
+            issue_body="Something is broken when I run the thing twice.",
+            project_root=tmp_path,
+        )
+        assert ev.is_empty
+
+    def test_reference_that_resolves_to_nothing_is_noop(self, tmp_path):
+        # A well-formed run id that has no matching log on disk → best-effort
+        # produces no section (behaves the same as today).
+        ev = build_starting_evidence(
+            issue_body="Sprint run 7cf3f238d8d8 failed to land.",
+            project_root=tmp_path,
+        )
+        assert ev.is_empty
+
+
+class TestRunLogEvidence:
+    def test_run_id_preloads_log_tail(self, tmp_path):
+        run_id = "7cf3f238d8d8"
+        lines = "\n".join(f"[forge] line {i}" for i in range(100))
+        _write(tmp_path / ".forge" / "logs" / "issues-1135,1409" / f"run-{run_id}.log", lines)
+
+        ev = build_starting_evidence(
+            issue_body=f"Sprint run {run_id} (issues-1135,1409): issue-1135 reached APPROVE",
+            project_root=tmp_path,
+        )
+        assert not ev.is_empty
+        assert "== STARTING EVIDENCE" in ev.text
+        assert f"run-{run_id}.log" in ev.text
+        assert "line 99" in ev.text  # tail present
+        assert "line 0" not in ev.text  # head dropped by the tail bound
+        assert any("run log" in lbl for lbl in ev.reference_labels)
+
+    def test_run_log_tail_is_bounded_to_max_lines(self, tmp_path):
+        run_id = "abcabcabcabc"
+        lines = "\n".join(f"row{i}" for i in range(500))
+        _write(tmp_path / ".forge" / "logs" / "sprintX" / f"run-{run_id}.log", lines)
+
+        ev = build_starting_evidence(issue_body=f"run {run_id}", project_root=tmp_path)
+        # Only the last _MAX_LOG_TAIL_LINES rows appear.
+        assert f"row{500 - _MAX_LOG_TAIL_LINES}" in ev.text
+        assert f"row{500 - _MAX_LOG_TAIL_LINES - 1}" not in ev.text
+
+
+class TestSprintStateEvidence:
+    def test_sprint_id_preloads_state(self, tmp_path):
+        sprint_id = "00f8b889f953"
+        _write(
+            tmp_path / ".forge" / "sprints" / sprint_id / "state.yaml",
+            "sprint_id: 00f8b889f953\nissues: [1, 2, 3]\nstatus: running\n",
+        )
+        ev = build_starting_evidence(
+            issue_body=f"See sprint {sprint_id} state.", project_root=tmp_path
+        )
+        assert not ev.is_empty
+        assert "state.yaml" in ev.text
+        assert "status: running" in ev.text
+
+
+class TestHistoryEvidence:
+    def test_history_lines_mentioning_run_id_are_loaded(self, tmp_path):
+        run_id = "deadbeef0000"
+        history = (
+            '{"run": "other", "outcome": "DONE"}\n'
+            f'{{"run": "{run_id}", "landing_status": "landed"}}\n'
+            '{"run": "unrelated"}\n'
+        )
+        _write(tmp_path / ".forge" / "audits" / "history.jsonl", history)
+        ev = build_starting_evidence(
+            issue_body=f"history.jsonl audit for {run_id} shows landing_status",
+            project_root=tmp_path,
+        )
+        assert "history.jsonl" in ev.text
+        assert "landing_status" in ev.text
+
+
+class TestForgePathEvidence:
+    def test_explicit_forge_path_is_loaded(self, tmp_path):
+        _write(
+            tmp_path / ".forge" / "audits" / "sprint-audit.yaml",
+            "kind: sprint\nsucceeded: 2\nfailed: 0\n",
+        )
+        ev = build_starting_evidence(
+            issue_body="The .forge/audits/sprint-audit.yaml shows the wrong count.",
+            project_root=tmp_path,
+        )
+        assert "sprint-audit.yaml" in ev.text
+        assert "succeeded: 2" in ev.text
+
+
+class TestGhBackedEvidence:
+    def test_branch_reference_loads_pr_history(self, tmp_path):
+        pr_json = '[{"number": 1143, "state": "MERGED", "title": "x", "mergedAt": "2026-04-30"}]'
+
+        def fake_run_gh(args, project_root):
+            assert args[:2] == ["pr", "list"]
+            assert "feat/issue-1135" in args
+            return pr_json
+
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
+            ev = build_starting_evidence(
+                issue_body="Branch feat/issue-1135 never shipped.",
+                project_root=tmp_path,
+            )
+        assert "feat/issue-1135" in ev.text
+        assert "1143" in ev.text
+
+    def test_pr_number_loads_view_and_skips_self_issue(self, tmp_path):
+        calls = []
+
+        def fake_run_gh(args, project_root):
+            calls.append(args)
+            if args[:2] == ["pr", "view"] and args[2] == "1143":
+                return '{"number": 1143, "state": "MERGED"}'
+            return None
+
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
+            ev = build_starting_evidence(
+                issue_body="Related to #1143 but this is issue #1420.",
+                project_root=tmp_path,
+                self_issue_number=1420,
+            )
+        assert "1143" in ev.text
+        # The self-issue (#1420) must not be queried.
+        assert not any(a[:2] == ["pr", "view"] and a[2] == "1420" for a in calls)
+
+    def test_gh_failure_fails_open(self, tmp_path):
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", return_value=None):
+            ev = build_starting_evidence(
+                issue_body="Branch feat/issue-9 and PR #99.",
+                project_root=tmp_path,
+            )
+        assert ev.is_empty
+
+
+class TestBounding:
+    def test_total_block_is_capped(self, tmp_path):
+        # Many run logs, each large, must not produce an unbounded block.
+        body_refs = []
+        for i in range(8):
+            rid = format(0xA0000000000 + i, "012x")  # distinct 12-char hex ids
+            body_refs.append(rid)
+            _write(
+                tmp_path / ".forge" / "logs" / f"s{i}" / f"run-{rid}.log",
+                "\n".join("X" * 200 for _ in range(50)),
+            )
+        ev = build_starting_evidence(issue_body=" ".join(body_refs), project_root=tmp_path)
+        assert len(ev.text) <= _MAX_TOTAL_EVIDENCE_CHARS + 500  # header + marker slack
+
+
+class TestFixtureComparison:
+    """AC: a diagnose run whose body cites a run_id reaches confirmed-cause with
+    less discovery work than one with no auto-injection. Operationalized as a
+    fixture comparison of the built prompt: with the reference, the run-log
+    excerpt is present in the prompt (zero tool calls needed to see it); with no
+    reference, the prompt carries no STARTING EVIDENCE section at all."""
+
+    def test_cited_run_id_preloads_evidence_absent_without_citation(self, tmp_path):
+        from theforge.task.diagnose_prompts import build_diagnose_prompt
+
+        run_id = "7cf3f238d8d8"
+        marker = "issue-1135 reached APPROVE 0 P1 0 P2"
+        _write(
+            tmp_path / ".forge" / "logs" / "issues-1135" / f"run-{run_id}.log",
+            f"[forge] earlier\n[forge] {marker}\n[sprint] Sprint complete\n",
+        )
+
+        with_ref = build_starting_evidence(
+            issue_body=f"Sprint run {run_id}: landing_status wrong",
+            project_root=tmp_path,
+        )
+        without_ref = build_starting_evidence(
+            issue_body="Landing status looks wrong, unclear where.",
+            project_root=tmp_path,
+        )
+
+        prompt_with = build_diagnose_prompt(
+            issue_number=1420,
+            title="landing bug",
+            body=f"Sprint run {run_id}: landing_status wrong",
+            starting_evidence=with_ref.text,
+        )
+        prompt_without = build_diagnose_prompt(
+            issue_number=1420,
+            title="landing bug",
+            body="Landing status looks wrong, unclear where.",
+            starting_evidence=without_ref.text,
+        )
+
+        # With the citation: the log excerpt the agent would otherwise have to
+        # fetch is already in the prompt.
+        assert "== STARTING EVIDENCE" in prompt_with
+        assert marker in prompt_with
+        # Without it: no injected section, unchanged from pre-feature behavior.
+        assert "== STARTING EVIDENCE" not in prompt_without
+        assert marker not in prompt_without

--- a/tests/test_diagnose_evidence.py
+++ b/tests/test_diagnose_evidence.py
@@ -168,6 +168,34 @@ class TestGhBackedEvidence:
             )
         assert ev.is_empty
 
+    def test_many_unresolved_refs_are_gh_call_bounded(self, tmp_path):
+        # A body citing far more branches and #NNNN than the attempt cap must
+        # not fire an unbounded number of (up-to-30s) gh subprocesses before the
+        # agent starts. All unresolved → gh returns None every time.
+        from theforge.coordinator.diagnose_evidence import _MAX_GH_ATTEMPTS_PER_KIND
+
+        branches = " ".join(f"feat/issue-{i}" for i in range(40))
+        prs = " ".join(f"#{2000 + i}" for i in range(40))
+        calls = []
+
+        def fake_run_gh(args, project_root):
+            calls.append(args)
+            return None  # every reference unresolved
+
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
+            ev = build_starting_evidence(
+                issue_body=f"{branches}\n{prs}",
+                project_root=tmp_path,
+            )
+        assert ev.is_empty
+        branch_calls = [a for a in calls if a[:2] == ["pr", "list"]]
+        # A #NNNN attempt is a PR view then (on failure) an issue view: 2 gh calls.
+        pr_calls = [a for a in calls if a[:2] == ["pr", "view"]]
+        issue_calls = [a for a in calls if a[:2] == ["issue", "view"]]
+        assert len(branch_calls) == _MAX_GH_ATTEMPTS_PER_KIND
+        assert len(pr_calls) == _MAX_GH_ATTEMPTS_PER_KIND
+        assert len(issue_calls) == _MAX_GH_ATTEMPTS_PER_KIND
+
 
 class TestBounding:
     def test_total_block_is_capped(self, tmp_path):

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -688,6 +688,89 @@ class TestDiagnoseFlow:
         assert "Partial diagnosis landed" not in result.message
 
 
+class TestStartingEvidenceInjection:
+    """Seam test for the FETCH→INVESTIGATE boundary: when the issue body cites a
+    run id whose log exists on disk, the flow pre-loads a STARTING EVIDENCE block
+    into the prompt handed to the agent and records what it injected in the
+    audit. An issue with no recognizable references leaves the prompt unchanged."""
+
+    def _write_run_log(self, tmp_path: Path, run_id: str, marker: str) -> None:
+        log = tmp_path / ".forge" / "logs" / "issues-1135" / f"run-{run_id}.log"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(f"[forge] earlier\n[forge] {marker}\n", encoding="utf-8")
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_cited_run_id_injects_evidence_and_records_audit(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        run_id = "7cf3f238d8d8"
+        marker = "issue-1135 reached APPROVE"
+        self._write_run_log(tmp_path, run_id, marker)
+        mock_fetch.return_value = {
+            "number": 1420,
+            "title": "landing bug",
+            "body": f"Sprint run {run_id}: landing_status wrong",
+            "state": "OPEN",
+        }
+        mock_agent.return_value = _fake_agent_result(_agent_yaml_output())
+        mock_post.return_value = "https://example/comment"
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1420,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert result.success
+        # The prompt actually handed to the agent carried the pre-loaded excerpt.
+        sent_prompt = mock_agent.call_args.kwargs["prompt"]
+        assert "== STARTING EVIDENCE" in sent_prompt
+        assert marker in sent_prompt
+        # Audit records what was injected (instrumented cross-phase data).
+        audit = tmp_path / ".forge" / "audits" / f"diagnose-issue-1420-{result.state.run_id}.yaml"
+        loaded = yaml.safe_load(audit.read_text())
+        assert loaded["starting_evidence"]["reference_labels"]
+        assert loaded["starting_evidence"]["chars"] > 0
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_no_references_leaves_prompt_and_audit_clean(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 1,
+            "title": "x",
+            "body": "Something is broken but I don't know where.",
+            "state": "OPEN",
+        }
+        mock_agent.return_value = _fake_agent_result(_agent_yaml_output())
+        mock_post.return_value = "https://example/comment"
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=1,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        sent_prompt = mock_agent.call_args.kwargs["prompt"]
+        assert "== STARTING EVIDENCE" not in sent_prompt
+        audit = tmp_path / ".forge" / "audits" / f"diagnose-issue-1-{result.state.run_id}.yaml"
+        loaded = yaml.safe_load(audit.read_text())
+        assert loaded["starting_evidence"]["reference_labels"] == []
+        assert loaded["starting_evidence"]["chars"] == 0
+
+
 # ── dry-run stdout tests ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The cycle-1 gh-attempt bounding issue is fixed, and I found no blocking regressions in the latest iteration. | [google-gemini-3.5-flash] Deterministic starting-evidence auto-injection is fully implemented, bounded, and the prior P1 regarding unbounded gh calls is resolved.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $5.26
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose should auto-inject starting evidence when the issue body cites a run/sprint/PR (GitHub Issue #1426)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1426