### PR TITLE
forge diagnose runs issues serially — add --parallel (per-issue diagnosis is independent)

### DIFF
--- a/src/theforge/cli/diagnose.py
+++ b/src/theforge/cli/diagnose.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
 from theforge.coordinator.diagnose_flow import run_diagnose_flow
+from theforge.coordinator.log_tee import set_worker_slug
 from theforge.coordinator.util import set_log_level as coordinator_set_log_level
 from theforge.diagnose_types import DIAGNOSE_OUTPUT_DESTINATIONS
 from theforge.runners import LogLevel
@@ -79,8 +80,29 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
     else:
         interactive = not config.diagnose.autonomous_default
 
-    overall_ok = True
-    for number in issues:
+    # ── Concurrency ────────────────────────────────────────────────────
+    # Per-issue diagnosis is independent (fresh-context investigative agent,
+    # no shared mutable state), so it parallelizes cleanly under a worker cap
+    # that mirrors ``forge sprint --parallel``. Default (no flag) stays serial.
+    max_parallel: int | None = getattr(args, "parallel", None)
+    if max_parallel is not None and max_parallel < 1:
+        print(f"--parallel: must be >= 1, got {max_parallel}", file=sys.stderr)
+        return 1
+    effective_parallel = 1 if max_parallel is None else max_parallel
+    # Interactive mode confirms each landing on stdin; concurrent stdin prompts
+    # would interleave unreadably, so it always runs serially.
+    if interactive and effective_parallel > 1:
+        print(
+            "[forge] diagnose: --parallel is ignored in interactive mode; running issues serially",
+            file=sys.stderr,
+        )
+        effective_parallel = 1
+
+    def _diagnose_one(number: int, *, tagged: bool) -> bool:
+        # Tag every log line from this worker with its issue number so
+        # interleaved parallel output stays attributable.
+        if tagged:
+            set_worker_slug(f"#{number}")
         print(f"[forge] diagnose: starting issue #{number}", file=sys.stderr)
         result = run_diagnose_flow(
             issue_number=number,
@@ -99,10 +121,45 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
             f"duration={result.state.agent_duration_s:.1f}s)",
             file=sys.stderr,
         )
-        if not result.success:
-            overall_ok = False
+        return result.success
 
+    overall_ok = _run_diagnoses(issues, _diagnose_one, effective_parallel)
     return 0 if overall_ok else 1
+
+
+def _run_diagnoses(
+    issues: list[int],
+    diagnose_one: "callable",
+    effective_parallel: int,
+) -> bool:
+    """Run ``diagnose_one(number, tagged=...)`` for each issue; return overall OK.
+
+    Serial when ``effective_parallel <= 1`` (preserving pre-feature behavior,
+    output untagged); otherwise a bounded ``ThreadPoolExecutor`` runs up to
+    ``effective_parallel`` investigations concurrently with per-issue log tags.
+    """
+    if effective_parallel <= 1 or len(issues) <= 1:
+        overall_ok = True
+        for number in issues:
+            if not diagnose_one(number, tagged=False):
+                overall_ok = False
+        return overall_ok
+
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    overall_ok = True
+    max_workers = min(effective_parallel, len(issues))
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(diagnose_one, number, tagged=True): number for number in issues}
+        for future in as_completed(futures):
+            number = futures[future]
+            try:
+                if not future.result():
+                    overall_ok = False
+            except Exception as exc:  # noqa: BLE001 — surface, don't abort the batch
+                print(f"[forge] ✗ #{number}: diagnose crashed: {exc}", file=sys.stderr)
+                overall_ok = False
+    return overall_ok
 
 
 def register_parser(subparsers: object) -> None:
@@ -139,6 +196,13 @@ def register_parser(subparsers: object) -> None:
         action="store_true",
         default=False,
         help="Land the artifact without operator confirmation (overrides config default)",
+    )
+    p.add_argument(
+        "--parallel",
+        metavar="N",
+        type=int,
+        default=None,
+        help="Maximum concurrent issue diagnoses (default: serial)",
     )
     p.add_argument(
         "--dry-run",

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -32,7 +32,7 @@ import yaml
 
 from theforge.config import ForgeConfig, ModelProfile
 from theforge.coordinator.diagnose_evidence import build_starting_evidence
-from theforge.coordinator.log_tee import get_worker_slug
+from theforge.coordinator.log_tee import get_worker_slug, set_worker_slug
 from theforge.coordinator.util import _log as _progress_log
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
@@ -596,7 +596,14 @@ def _run_agent_with_heartbeat(
         heartbeat_interval_s = _DIAGNOSE_HEARTBEAT_INTERVAL_S
     box: dict[str, object] = {}
 
+    # The worker slug is thread-local; propagate it into the nested agent
+    # thread so runner progress lines under ``forge diagnose --parallel`` stay
+    # attributed to the same issue as the caller's heartbeat lines.
+    caller_slug = get_worker_slug()
+
     def _run() -> None:
+        if caller_slug:
+            set_worker_slug(caller_slug)
         try:
             box["result"] = run_agent(
                 prompt=prompt,

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -32,6 +32,7 @@ import yaml
 
 from theforge.config import ForgeConfig, ModelProfile
 from theforge.coordinator.diagnose_evidence import build_starting_evidence
+from theforge.coordinator.log_tee import get_worker_slug
 from theforge.coordinator.util import _log as _progress_log
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
@@ -626,6 +627,22 @@ def _run_agent_with_heartbeat(
 # ── Landing strategies ────────────────────────────────────────────────
 
 
+def _emit_dry_run(text: str) -> None:
+    """Print operator-facing dry-run markdown to stdout.
+
+    When a worker slug is set (``forge diagnose --parallel``), every line is
+    prefixed with the slug so concurrent multi-line output stays attributable
+    to its issue. Serial runs (no slug) print the text verbatim, unchanged from
+    pre-parallel behavior.
+    """
+    slug = get_worker_slug()
+    if not slug:
+        print(text)
+        return
+    prefix = f"[{slug}] "
+    print("\n".join(prefix + line for line in text.splitlines()))
+
+
 def _land_artifact(
     state: DiagnoseState,
     artifact: DiagnosisArtifact,
@@ -644,13 +661,13 @@ def _land_artifact(
 
     if destination == "comment":
         if dry_run:
-            print(section)
+            _emit_dry_run(section)
             return "<dry-run: comment>"
         return _gh_post_comment(state.issue_number, section, project_root)
 
     if destination == "body_section":
         if dry_run:
-            print(section)
+            _emit_dry_run(section)
             return "<dry-run: body_section>"
         new_body = upsert_diagnosis_section(state.issue_body, section)
         _gh_edit_body(state.issue_number, new_body, project_root)
@@ -662,7 +679,7 @@ def _land_artifact(
     out_dir = project_root / ".forge" / "diagnoses"
     out_path = out_dir / f"issue-{state.issue_number}.md"
     if dry_run:
-        print(section)
+        _emit_dry_run(section)
         return str(out_path)
     out_dir.mkdir(parents=True, exist_ok=True)
     full = (
@@ -881,7 +898,7 @@ def run_diagnose_flow(
             absent=verdict.absent,
         )
         if dry_run:
-            print(report)
+            _emit_dry_run(report)
         first = verdict.absent[0]
         extra = f" (+{len(verdict.absent) - 1} more)" if len(verdict.absent) > 1 else ""
         target = f"{first.file}" + (f":{first.pattern}" if first.pattern else "")

--- a/src/theforge/coordinator/log_tee.py
+++ b/src/theforge/coordinator/log_tee.py
@@ -7,20 +7,17 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+# The worker-slug thread-local now lives in the stdlib-only leaf module
+# ``theforge.log_util`` so the shared log-line emitter can prefix every line
+# (coordinator *and* runner) with it. Re-exported here for backward
+# compatibility with existing importers.
+from theforge.log_util import get_worker_slug as get_worker_slug
+from theforge.log_util import set_worker_slug as set_worker_slug
+
 if TYPE_CHECKING:
     from theforge.config import ForgeConfig
 
     from .logging import StructuredLogger
-
-_worker_ctx = threading.local()
-
-
-def set_worker_slug(slug: str) -> None:
-    _worker_ctx.slug = slug
-
-
-def get_worker_slug() -> str:
-    return getattr(_worker_ctx, "slug", "")
 
 
 def _safe_signal(signum, handler):

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -14,7 +14,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-from theforge.coordinator.log_tee import get_worker_slug
 from theforge.log_level import LogLevel
 from theforge.log_util import _log_line
 from theforge.workspace_env import build_workspace_env
@@ -63,17 +62,15 @@ def _fmt_duration(seconds: float) -> str:
 
 def _log(msg: str) -> None:
     """Print coordinator status to stderr (always shown)."""
-    slug = get_worker_slug()
-    prefix = f"[{slug}] " if slug else ""
-    _log_line("[forge]", f"{prefix}{msg}")
+    # The worker-slug prefix (parallel attribution) is applied centrally by
+    # ``_log_line``; do not prepend it here or it would double-tag.
+    _log_line("[forge]", msg)
 
 
 def _log_verbose(msg: str) -> None:
     """Print coordinator detail to stderr (verbose mode only)."""
     if _LOG_LEVEL >= LogLevel.VERBOSE:
-        slug = get_worker_slug()
-        prefix = f"[{slug}] " if slug else ""
-        _log_line("[forge]", f"{prefix}{msg}")
+        _log_line("[forge]", msg)
 
 
 def _fmt_cost(cost: float | None) -> str:

--- a/src/theforge/log_util.py
+++ b/src/theforge/log_util.py
@@ -2,19 +2,45 @@
 
 All modules with a local ``_log`` or ``_log_verbose`` wrapper delegate here
 so every line written to stderr carries a consistent timestamp prefix.
+
+This module also owns the thread-local *worker slug* — a short tag (e.g. an
+issue number under ``forge diagnose --parallel`` or a story slug under
+``forge sprint --parallel``) that every emitted line is prefixed with, so
+concurrent workers' interleaved output stays attributable to its source.
+Owning it here (a stdlib-only leaf module) lets both the coordinator and the
+lower-level runners tag their lines through the shared emitter without an
+upward dependency; ``coordinator.log_tee`` re-exports the accessors for
+backward compatibility.
 """
 
 from __future__ import annotations
 
 import sys
+import threading
 from datetime import datetime
+
+_worker_ctx = threading.local()
+
+
+def set_worker_slug(slug: str) -> None:
+    """Set the current thread's worker slug (empty string clears it)."""
+    _worker_ctx.slug = slug
+
+
+def get_worker_slug() -> str:
+    """Return the current thread's worker slug, or ``""`` if unset."""
+    return getattr(_worker_ctx, "slug", "")
 
 
 def _log_line(tag: str, msg: str) -> None:
     """Emit a single tagged log line to stderr with a millisecond timestamp.
 
-    Format: ``<tag> HH:MM:SS.mmm <msg>``
+    Format: ``<tag> HH:MM:SS.mmm [<slug>] <msg>`` — the ``[<slug>]`` segment is
+    present only when the current thread has a worker slug set, so parallel
+    workers' lines are attributable to their issue/story.
     """
     now = datetime.now()
     ts = now.strftime("%H:%M:%S.") + f"{now.microsecond // 1000:03d}"
-    print(f"{tag} {ts} {msg}", file=sys.stderr, flush=True)
+    slug = get_worker_slug()
+    prefix = f"[{slug}] " if slug else ""
+    print(f"{tag} {ts} {prefix}{msg}", file=sys.stderr, flush=True)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -22,7 +22,7 @@ from ..config.auth import check_agent_auth
 from ..coordinator import workspace as coordinator_workspace
 from ..coordinator.engine import run_from_dev, run_from_review, run_task
 from ..coordinator.gate import run_gate_full
-from ..coordinator.log_tee import _make_story_log_dir, get_worker_slug, set_worker_slug
+from ..coordinator.log_tee import _make_story_log_dir, set_worker_slug
 from ..coordinator.logging import StructuredLogger
 from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
@@ -84,9 +84,9 @@ log_agent_result = None
 
 
 def _log(msg: str) -> None:
-    slug = get_worker_slug()
-    prefix = f"[{slug}] " if slug else ""
-    _log_line("[sprint]", f"{prefix}{msg}")
+    # Worker-slug prefixing (parallel attribution) is applied centrally by
+    # ``_log_line``; do not prepend it here or it would double-tag.
+    _log_line("[sprint]", msg)
 
 
 def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:

--- a/tests/test_cli_diagnose_parallel.py
+++ b/tests/test_cli_diagnose_parallel.py
@@ -128,13 +128,17 @@ class TestRunDiagnoses:
 
 
 class TestAgentThreadSlug:
-    def _run(self) -> str:
+    def _run(self) -> tuple[str, str]:
+        # fake_run_agent stands in for the real runner: it emits a progress line
+        # through the actual runner log emitter from inside the nested
+        # diagnose-agent thread, exactly where real runner logs originate.
+        from theforge.runners.cli import _log as runner_log
+
         captured: dict[str, str] = {}
 
         def fake_run_agent(*, prompt, profile, working_dir, secrets):
-            # Read the slug from inside the nested diagnose-agent thread, the
-            # thread that emits runner progress lines.
             captured["slug"] = get_worker_slug()
+            runner_log("investigating step 1")
             return SimpleNamespace(output="done")
 
         with patch.object(diagnose_flow, "run_agent", fake_run_agent):
@@ -146,16 +150,25 @@ class TestAgentThreadSlug:
             )
         return captured["slug"]
 
-    def test_nested_agent_thread_inherits_worker_slug(self):
+    def test_nested_agent_thread_inherits_worker_slug(self, capsys):
         try:
             set_worker_slug("#77")
-            assert self._run() == "#77"
+            slug = self._run()
         finally:
             set_worker_slug("")
+        assert slug == "#77"
+        # The runner progress line emitted from the nested thread must carry
+        # the issue slug so it is attributable under --parallel.
+        err = capsys.readouterr().err
+        assert "[#77] investigating step 1" in err
 
-    def test_no_slug_leaves_nested_thread_untagged(self):
+    def test_no_slug_leaves_nested_thread_untagged(self, capsys):
         set_worker_slug("")
-        assert self._run() == ""
+        slug = self._run()
+        assert slug == ""
+        err = capsys.readouterr().err
+        assert "investigating step 1" in err
+        assert "[#" not in err
 
 
 # ── Dry-run output tagging ────────────────────────────────────────────

--- a/tests/test_cli_diagnose_parallel.py
+++ b/tests/test_cli_diagnose_parallel.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 import argparse
 import threading
 import time
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from theforge.cli.diagnose import _run_diagnoses, cmd_diagnose, register_parser
-from theforge.coordinator.diagnose_flow import _emit_dry_run
+from theforge.coordinator import diagnose_flow
+from theforge.coordinator.diagnose_flow import _emit_dry_run, _run_agent_with_heartbeat
 from theforge.coordinator.log_tee import get_worker_slug, set_worker_slug
 from theforge.diagnose_types import DiagnosePhase, DiagnoseResult, DiagnoseState
 
@@ -119,6 +122,40 @@ class TestRunDiagnoses:
         _run_diagnoses([100, 101], worker, effective_parallel=2)
         assert slugs[100] == "#100"
         assert slugs[101] == "#101"
+
+
+# ── Nested agent-thread slug propagation ──────────────────────────────
+
+
+class TestAgentThreadSlug:
+    def _run(self) -> str:
+        captured: dict[str, str] = {}
+
+        def fake_run_agent(*, prompt, profile, working_dir, secrets):
+            # Read the slug from inside the nested diagnose-agent thread, the
+            # thread that emits runner progress lines.
+            captured["slug"] = get_worker_slug()
+            return SimpleNamespace(output="done")
+
+        with patch.object(diagnose_flow, "run_agent", fake_run_agent):
+            _run_agent_with_heartbeat(
+                prompt="p",
+                profile=SimpleNamespace(timeout_seconds=1),
+                working_dir=Path("."),
+                secrets=None,
+            )
+        return captured["slug"]
+
+    def test_nested_agent_thread_inherits_worker_slug(self):
+        try:
+            set_worker_slug("#77")
+            assert self._run() == "#77"
+        finally:
+            set_worker_slug("")
+
+    def test_no_slug_leaves_nested_thread_untagged(self):
+        set_worker_slug("")
+        assert self._run() == ""
 
 
 # ── Dry-run output tagging ────────────────────────────────────────────

--- a/tests/test_cli_diagnose_parallel.py
+++ b/tests/test_cli_diagnose_parallel.py
@@ -15,7 +15,8 @@ import time
 from unittest.mock import patch
 
 from theforge.cli.diagnose import _run_diagnoses, cmd_diagnose, register_parser
-from theforge.coordinator.log_tee import get_worker_slug
+from theforge.coordinator.diagnose_flow import _emit_dry_run
+from theforge.coordinator.log_tee import get_worker_slug, set_worker_slug
 from theforge.diagnose_types import DiagnosePhase, DiagnoseResult, DiagnoseState
 
 
@@ -120,6 +121,28 @@ class TestRunDiagnoses:
         assert slugs[101] == "#101"
 
 
+# ── Dry-run output tagging ────────────────────────────────────────────
+
+
+class TestEmitDryRun:
+    def test_no_slug_prints_verbatim(self, capsys):
+        try:
+            set_worker_slug("")
+            _emit_dry_run("line one\nline two")
+        finally:
+            set_worker_slug("")
+        assert capsys.readouterr().out == "line one\nline two\n"
+
+    def test_slug_prefixes_every_line(self, capsys):
+        try:
+            set_worker_slug("#42")
+            _emit_dry_run("## Diagnosis\n\nconfirmed cause")
+        finally:
+            set_worker_slug("")
+        out = capsys.readouterr().out
+        assert out == "[#42] ## Diagnosis\n[#42] \n[#42] confirmed cause\n"
+
+
 # ── CLI wiring ────────────────────────────────────────────────────────
 
 
@@ -199,6 +222,36 @@ class TestCmdDiagnose:
             rc = cmd_diagnose(self._args(parallel=0))
         assert rc == 1
         flow.assert_not_called()
+
+    def test_dry_run_parallel_tags_multiline_output(self, tmp_path, capsys):
+        # The dry-run markdown each worker prints must be attributable per issue
+        # under --parallel; every emitted line carries its issue's worker slug.
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("x")
+
+        def fake_flow(*, issue_number, dry_run, **_):
+            assert dry_run is True
+            # Mirror _land_artifact's dry-run path: the worker slug is live here.
+            _emit_dry_run(f"## Diagnosis #{issue_number}\n\nbody line")
+            return _result(issue_number)
+
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", return_value=self._patched_config()),
+            patch("theforge.cli.diagnose.run_diagnose_flow", side_effect=fake_flow),
+        ):
+            rc = cmd_diagnose(self._args(dry_run=True, parallel=3))
+
+        assert rc == 0
+        out_lines = capsys.readouterr().out.splitlines()
+        # Every non-empty dry-run line is prefixed with some issue's slug.
+        content_lines = [ln for ln in out_lines if ln.strip("[]# ")]
+        assert content_lines, "expected dry-run markdown on stdout"
+        for ln in content_lines:
+            assert ln.startswith("[#1] ") or ln.startswith("[#2] ") or ln.startswith("[#3] ")
+        # Each issue's own section is present and self-tagged.
+        for n in (1, 2, 3):
+            assert f"[#{n}] ## Diagnosis #{n}" in out_lines
 
     def test_interactive_parallel_downgrades_to_serial(self, tmp_path, capsys):
         cfg_path = tmp_path / "forge.yaml"

--- a/tests/test_cli_diagnose_parallel.py
+++ b/tests/test_cli_diagnose_parallel.py
@@ -1,0 +1,220 @@
+"""Tests for ``forge diagnose --parallel`` concurrency.
+
+Covers:
+- ``_run_diagnoses`` serial vs. parallel dispatch and overall-OK aggregation
+- worker-cap discipline (bounded concurrency, no unbounded spawn)
+- per-issue log tagging via the thread-local worker slug
+- CLI arg wiring and interactive-mode downgrade to serial
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+import time
+from unittest.mock import patch
+
+from theforge.cli.diagnose import _run_diagnoses, cmd_diagnose, register_parser
+from theforge.coordinator.log_tee import get_worker_slug
+from theforge.diagnose_types import DiagnosePhase, DiagnoseResult, DiagnoseState
+
+
+def _result(number: int, *, success: bool = True) -> DiagnoseResult:
+    state = DiagnoseState(issue_number=number, phase=DiagnosePhase.DONE)
+    state.agent_cost_usd = 0.0
+    state.agent_duration_s = 0.1
+    return DiagnoseResult(success=success, state=state, message="ok")
+
+
+# ── _run_diagnoses dispatcher ─────────────────────────────────────────
+
+
+class TestRunDiagnoses:
+    def test_serial_processes_every_issue_in_order(self):
+        seen: list[int] = []
+
+        def worker(number: int, *, tagged: bool) -> bool:
+            assert tagged is False  # serial path never tags
+            seen.append(number)
+            return True
+
+        ok = _run_diagnoses([1, 2, 3], worker, effective_parallel=1)
+        assert ok is True
+        assert seen == [1, 2, 3]
+
+    def test_single_issue_stays_serial_even_with_parallel(self):
+        def worker(number: int, *, tagged: bool) -> bool:
+            assert tagged is False
+            return True
+
+        assert _run_diagnoses([7], worker, effective_parallel=4) is True
+
+    def test_overall_ok_false_when_any_issue_fails(self):
+        def worker(number: int, *, tagged: bool) -> bool:
+            return number != 2
+
+        assert _run_diagnoses([1, 2, 3], worker, effective_parallel=1) is False
+
+    def test_parallel_processes_every_issue(self):
+        seen: set[int] = set()
+        lock = threading.Lock()
+
+        def worker(number: int, *, tagged: bool) -> bool:
+            assert tagged is True  # parallel path tags each worker
+            with lock:
+                seen.add(number)
+            return True
+
+        ok = _run_diagnoses([10, 11, 12, 13], worker, effective_parallel=3)
+        assert ok is True
+        assert seen == {10, 11, 12, 13}
+
+    def test_parallel_respects_worker_cap(self):
+        active = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def worker(number: int, *, tagged: bool) -> bool:
+            nonlocal active, peak
+            with lock:
+                active += 1
+                peak = max(peak, active)
+            time.sleep(0.05)
+            with lock:
+                active -= 1
+            return True
+
+        _run_diagnoses([1, 2, 3, 4, 5, 6], worker, effective_parallel=2)
+        assert peak <= 2
+
+    def test_parallel_worker_exception_marks_failure_not_abort(self):
+        completed: set[int] = set()
+        lock = threading.Lock()
+
+        def worker(number: int, *, tagged: bool) -> bool:
+            if number == 2:
+                raise RuntimeError("boom")
+            with lock:
+                completed.add(number)
+            return True
+
+        ok = _run_diagnoses([1, 2, 3], worker, effective_parallel=3)
+        assert ok is False
+        # The crash of #2 must not prevent #1 and #3 from finishing.
+        assert completed == {1, 3}
+
+    def test_parallel_worker_sets_thread_local_slug(self):
+        slugs: dict[int, str] = {}
+
+        def worker(number: int, *, tagged: bool) -> bool:
+            # Mirror what _diagnose_one does so we exercise the real tagging path.
+            from theforge.coordinator.log_tee import set_worker_slug
+
+            if tagged:
+                set_worker_slug(f"#{number}")
+            slugs[number] = get_worker_slug()
+            return True
+
+        _run_diagnoses([100, 101], worker, effective_parallel=2)
+        assert slugs[100] == "#100"
+        assert slugs[101] == "#101"
+
+
+# ── CLI wiring ────────────────────────────────────────────────────────
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    register_parser(sub)
+    return parser.parse_args(["diagnose", *argv])
+
+
+class TestParserArg:
+    def test_parallel_defaults_to_none(self):
+        args = _parse(["--issue", "1"])
+        assert args.parallel is None
+
+    def test_parallel_parsed_as_int(self):
+        args = _parse(["--issue", "1", "--parallel", "3"])
+        assert args.parallel == 3
+
+
+class TestCmdDiagnose:
+    def _args(self, **over) -> argparse.Namespace:
+        base = dict(
+            issue=["1,2,3"],
+            config=None,
+            output_destination=None,
+            interactive=False,
+            autonomous=True,
+            dry_run=False,
+            parallel=None,
+            verbose=False,
+        )
+        base.update(over)
+        return argparse.Namespace(**base)
+
+    def _patched_config(self):
+        class _Diag:
+            output_destination = "body_section"
+            autonomous_default = True
+
+        class _Cfg:
+            project_root = "/tmp/x"
+            diagnose = _Diag()
+
+        return _Cfg()
+
+    def test_parallel_diagnoses_all_issues(self, tmp_path):
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("x")
+        calls: list[int] = []
+        lock = threading.Lock()
+
+        def fake_flow(*, issue_number, **_):
+            with lock:
+                calls.append(issue_number)
+            return _result(issue_number)
+
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", return_value=self._patched_config()),
+            patch("theforge.cli.diagnose.run_diagnose_flow", side_effect=fake_flow) as flow,
+        ):
+            rc = cmd_diagnose(self._args(parallel=3))
+
+        assert rc == 0
+        assert flow.call_count == 3
+        assert sorted(calls) == [1, 2, 3]
+
+    def test_invalid_parallel_returns_error(self, tmp_path):
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("x")
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", return_value=self._patched_config()),
+            patch("theforge.cli.diagnose.run_diagnose_flow") as flow,
+        ):
+            rc = cmd_diagnose(self._args(parallel=0))
+        assert rc == 1
+        flow.assert_not_called()
+
+    def test_interactive_parallel_downgrades_to_serial(self, tmp_path, capsys):
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("x")
+
+        def fake_flow(*, issue_number, **_):
+            # In serial mode the worker slug is never set.
+            assert get_worker_slug() == ""
+            return _result(issue_number)
+
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", return_value=self._patched_config()),
+            patch("theforge.cli.diagnose.run_diagnose_flow", side_effect=fake_flow),
+        ):
+            rc = cmd_diagnose(self._args(interactive=True, autonomous=False, parallel=4))
+
+        assert rc == 0
+        assert "ignored in interactive mode" in capsys.readouterr().err

--- a/tests/test_coord_logging.py
+++ b/tests/test_coord_logging.py
@@ -742,24 +742,32 @@ class TestWorkerSlugContext:
 
         assert results == {"a": "issue-99", "b": ""}
 
-    def test_runner_log_includes_slug(self, monkeypatch, capsys) -> None:
+    def test_runner_log_includes_slug(self, capsys) -> None:
         import re
 
+        from theforge.coordinator.log_tee import set_worker_slug
         from theforge.sprint import runner
 
-        monkeypatch.setattr(runner, "get_worker_slug", lambda: "my-story")
-        runner._log("hello")
+        try:
+            set_worker_slug("my-story")
+            runner._log("hello")
+        finally:
+            set_worker_slug("")
 
         err = capsys.readouterr().err
         assert re.search(r"\[sprint\] \d{2}:\d{2}:\d{2}\.\d{3} \[my-story\] hello", err)
 
-    def test_util_log_includes_slug(self, monkeypatch, capsys) -> None:
+    def test_util_log_includes_slug(self, capsys) -> None:
         import re
 
         from theforge.coordinator import util
+        from theforge.coordinator.log_tee import set_worker_slug
 
-        monkeypatch.setattr(util, "get_worker_slug", lambda: "my-story")
-        util._log("hello")
+        try:
+            set_worker_slug("my-story")
+            util._log("hello")
+        finally:
+            set_worker_slug("")
 
         err = capsys.readouterr().err
         assert re.search(r"\[forge\] \d{2}:\d{2}:\d{2}\.\d{3} \[my-story\] hello", err)

--- a/tests/test_log_util.py
+++ b/tests/test_log_util.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from theforge.log_util import _log_line
+from theforge.log_util import _log_line, get_worker_slug, set_worker_slug
 
 _TS_RE = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{3}")
 
@@ -49,3 +49,25 @@ def test_message_with_spaces(capsys: object) -> None:
     captured = capsys.readouterr()  # type: ignore[union-attr]
     line = captured.err.rstrip("\n")
     assert line.endswith("a message with spaces"), f"Full message not preserved: {line!r}"
+
+
+def test_no_slug_by_default(capsys: object) -> None:
+    assert get_worker_slug() == ""
+    _log_line("[forge]", "hello")
+    line = capsys.readouterr().err.rstrip("\n")  # type: ignore[union-attr]
+    assert "[#" not in line
+    assert line.endswith("hello")
+
+
+def test_worker_slug_prefixes_message(capsys: object) -> None:
+    try:
+        set_worker_slug("#42")
+        _log_line("[forge]", "hello")
+    finally:
+        set_worker_slug("")
+    line = capsys.readouterr().err.rstrip("\n")  # type: ignore[union-attr]
+    # Format: [forge] <ts> [#42] hello — tag first, then timestamp, then slug.
+    parts = line.split(" ", 2)
+    assert parts[0] == "[forge]"
+    assert _TS_RE.fullmatch(parts[1])
+    assert parts[2] == "[#42] hello"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior stdout and nested-runner attribution fixes are verified, and I found no blocking regressions in the latest logging changes. | [google-gemini-3.5-flash] The parallel diagnosis feature is fully verified, and all prior logging attribution issues are resolved. | [claude-sonnet] Cycle-3 P1 (unprefixed nested-thread runner progress lines) is fixed by centralizing slug prefixing in the shared _log_line emitter; full test suite (5032 tests) passes with no regressions in the refactored logging path.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $12.46
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose runs issues serially — add --parallel (per-issue diagnosis is independent) (GitHub Issue #1707)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1707