### PR TITLE
forge logs --story: drill into a specific story's log during a sprint

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -307,6 +307,17 @@ Tail the log file for a running detached run.
 forge logs <run-id>
 ```
 
+During a sprint, drill into a single story instead of the interleaved
+sprint-level log:
+
+```bash
+forge logs <run-id> --story <slug>   # tail one story's run log
+forge logs <run-id> --story          # list the sprint's stories + current phase
+```
+
+`--story` with no argument prints each story slug alongside its current phase,
+so you can pick a slug without hunting for the nested log path yourself.
+
 ---
 
 ## `forge stop`

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -570,6 +570,53 @@ def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:
         print("\nPending decisions: (none)")
 
 
+def _find_story_log_path(project_root: Path, slug: str, sprint_name: str | None) -> Path | None:
+    """Locate the most recent per-story run log for ``slug``.
+
+    Prefers the nested sprint layout ``.forge/logs/<sprint_name>/<slug>/run-*.log``.
+    Falls back to any log directory named ``<slug>`` so standalone runs and
+    unknown sprint names still resolve. Returns the newest matching file, or
+    ``None`` if the story has no run log yet.
+    """
+    logs_dir = project_root / ".forge" / "logs"
+    if not logs_dir.exists():
+        return None
+
+    candidates: list[Path] = []
+    if sprint_name:
+        story_dir = logs_dir / sprint_name / slug
+        if story_dir.is_dir():
+            candidates = list(story_dir.glob("run-*.log"))
+    if not candidates:
+        candidates = [p for p in logs_dir.rglob("run-*.log") if p.parent.name == slug]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _list_sprint_stories(run_id: str, project_root: Path) -> int:
+    """Print each sprint story slug and its current phase for ``forge logs --story``."""
+    from theforge.sprint.status_reader import read_live_status
+
+    entries = read_live_status(run_id, project_root)
+    if not entries:
+        print(f"No live sprint stories found for run {run_id}", file=sys.stderr)
+        return 1
+
+    slug_width = max((len(e.slug) for e in entries if e.slug), default=0)
+    print(f"Stories for run {run_id}:")
+    for entry in entries:
+        if not entry.slug:
+            continue
+        phase = entry.phase or entry.status or "—"
+        print(f"  {entry.slug.ljust(slug_width)}  [{phase}]")
+    print(
+        f"\nTail a single story with: forge logs {run_id} --story <slug>",
+        file=sys.stderr,
+    )
+    return 0
+
+
 def cmd_logs(args: object) -> int:
     """Tail the log file for a running forge process."""
     from theforge import detach as _detach
@@ -581,6 +628,32 @@ def cmd_logs(args: object) -> int:
     config = load_config(config_path)
     project_root = config.project_root
     run_id = args.run_id
+
+    story_arg = getattr(args, "story", None)
+    if story_arg is not None:
+        from theforge.sprint.status_reader import read_live_sprint_name
+
+        if story_arg == "":
+            return _list_sprint_stories(run_id, project_root)
+
+        sprint_name = read_live_sprint_name(run_id, project_root)
+        story_log = _find_story_log_path(project_root, story_arg, sprint_name)
+        if story_log is None or not story_log.exists():
+            print(
+                f"No log found for story '{story_arg}' in run {run_id}",
+                file=sys.stderr,
+            )
+            print(
+                f"List available stories with: forge logs {run_id} --story",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"[forge] Tailing {story_log} — Ctrl+C to stop", file=sys.stderr)
+        try:
+            _follow_log_with_redirect(story_log, run_id)
+        except KeyboardInterrupt:
+            pass
+        return 0
 
     # Find slug from PID file
     pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
@@ -921,6 +994,18 @@ def register_parsers(subparsers: object) -> None:
         help="Tail the log file for a running forge process",
     )
     logs_parser.add_argument("run_id", help="Run ID to follow logs for")
+    logs_parser.add_argument(
+        "--story",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="SLUG",
+        help=(
+            "Drill into a single sprint story. With a SLUG, tail that story's "
+            "run log instead of the interleaved sprint log. With no argument, "
+            "list the sprint's stories and each story's current phase."
+        ),
+    )
 
     # forge stop
     stop_parser = subparsers.add_parser(

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -84,6 +84,27 @@ def find_live_state_path(run_id: str, project_root: Path) -> Path | None:
     return None
 
 
+def read_live_sprint_name(run_id: str, project_root: Path) -> str | None:
+    """Return the ``sprint_name`` recorded in the live state for ``run_id``.
+
+    Returns ``None`` if no live state file exists or it records no sprint name.
+    Used to resolve the nested per-story log directory
+    (``.forge/logs/<sprint_name>/<slug>/``) for ``forge logs --story``.
+    """
+    state_path = find_live_state_path(run_id, project_root)
+    if state_path is None:
+        return None
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    name = data.get("sprint_name")
+    return name if isinstance(name, str) and name else None
+
+
 def find_sprint_summary(run_id: str, project_root: Path) -> Path | None:
     """Scan .forge/logs/*/sprint-summary.yaml for the file containing run_id.
 

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -322,6 +322,177 @@ class TestCmdLogs:
         assert "legitimate output" in captured.out
         assert "Run re-exec'd" not in captured.err
 
+    def test_story_tail_reads_nested_sprint_log(self, tmp_path, capsys):
+        """forge logs <run> --story <slug> tails that story's nested run log."""
+        from theforge.cli import cmd_logs
+        from theforge.cli.status import _SENTINEL_EOF
+
+        run_id = "sprintrun01"
+        sprint_name = "my-sprint"
+        slug = "story-a"
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.state").write_text(
+            f"sprint_name: {sprint_name}\n"
+            "sprint_id: sid1\n"
+            "stories:\n"
+            f"  - slug: {slug}\n"
+            "    status: running\n"
+            "    phase: DEV\n",
+            encoding="utf-8",
+        )
+
+        story_dir = tmp_path / ".forge" / "logs" / sprint_name / slug
+        story_dir.mkdir(parents=True)
+        (story_dir / f"run-{run_id}.log").write_text(
+            f"story-a dev output\n{_SENTINEL_EOF}\n", encoding="utf-8"
+        )
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, story=slug)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "story-a dev output" in captured.out
+        assert slug in captured.err  # "Tailing .../story-a/run-...log"
+
+    def test_story_tail_picks_most_recent_log(self, tmp_path, capsys):
+        """Across re-exec generations, --story tails the newest run log."""
+        import os
+
+        from theforge.cli import cmd_logs
+        from theforge.cli.status import _SENTINEL_EOF
+
+        run_id = "sprintrun01"
+        sprint_name = "my-sprint"
+        slug = "story-a"
+
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.state").write_text(
+            f"sprint_name: {sprint_name}\nstories:\n  - slug: {slug}\n",
+            encoding="utf-8",
+        )
+
+        story_dir = tmp_path / ".forge" / "logs" / sprint_name / slug
+        story_dir.mkdir(parents=True)
+        old_log = story_dir / "run-oldgen.log"
+        old_log.write_text(f"old generation\n{_SENTINEL_EOF}\n", encoding="utf-8")
+        new_log = story_dir / "run-newgen.log"
+        new_log.write_text(f"new generation\n{_SENTINEL_EOF}\n", encoding="utf-8")
+        # Make new_log clearly newer than old_log.
+        os.utime(old_log, (1_000_000, 1_000_000))
+        os.utime(new_log, (2_000_000, 2_000_000))
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, story=slug)
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "new generation" in captured.out
+        assert "old generation" not in captured.out
+
+    def test_story_tail_missing_log_returns_error(self, tmp_path, capsys):
+        """--story with a slug that has no run log yet returns an error hint."""
+        from theforge.cli import cmd_logs
+
+        run_id = "sprintrun01"
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.state").write_text(
+            "sprint_name: my-sprint\nstories:\n  - slug: story-a\n",
+            encoding="utf-8",
+        )
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id=run_id, story="never-ran")
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "never-ran" in captured.err
+
+    def test_story_list_mode_shows_slugs_and_phases(self, tmp_path, capsys):
+        """forge logs <run> --story (no arg) lists stories with their phases."""
+        from theforge.cli import cmd_logs
+
+        run_id = "sprintrun01"
+        runs_dir = tmp_path / ".forge" / "runs"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / f"{run_id}.state").write_text(
+            "sprint_name: my-sprint\n"
+            "stories:\n"
+            "  - slug: story-a\n"
+            "    status: running\n"
+            "    phase: DEV\n"
+            "  - slug: story-b\n"
+            "    status: running\n"
+            "    phase: REVIEW\n",
+            encoding="utf-8",
+        )
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        # const="" — argparse yields "" when --story is passed with no value.
+        args = argparse.Namespace(run_id=run_id, story="")
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "story-a" in captured.out
+        assert "DEV" in captured.out
+        assert "story-b" in captured.out
+        assert "REVIEW" in captured.out
+
+    def test_story_list_mode_no_live_stories_errors(self, tmp_path, capsys):
+        """--story listing returns error when there is no live sprint state."""
+        from theforge.cli import cmd_logs
+
+        forge_yaml = tmp_path / "forge.yaml"
+        forge_yaml.write_text("project:\n  root: .\n")
+        config = _make_forge_config(tmp_path)
+        args = argparse.Namespace(run_id="nostate", story="")
+
+        with (
+            patch("theforge.cli.status._find_config", return_value=forge_yaml),
+            patch("theforge.cli.status.load_config", return_value=config),
+        ):
+            result = cmd_logs(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "No live sprint stories" in captured.err
+
     def test_reflexive_redirect_does_not_emit_reexec_notice(self, tmp_path, capsys):
         """A redirect file pointing to the current run id must not trigger a re-exec notice.
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation satisfies the story drill-down and list-mode requirements, and the focused CLI log tests pass. | [google-gemini-3.5-flash] The implementation of forge logs --story is clean, robust, fully compliant with the spec, and backed by comprehensive tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.10
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge logs --story: drill into a specific story's log during a sprint (GitHub Issue #216)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #216