### PR TITLE
forge run/sprint: print config warnings at startup

### DIFF
--- a/src/theforge/cli/run.py
+++ b/src/theforge/cli/run.py
@@ -17,6 +17,7 @@ from theforge.cli.shared import (
     _find_config,
     _write_audit,
     check_run_preconditions,
+    load_config_checked,
 )
 from theforge.config import load_config
 from theforge.coordinator.engine import (
@@ -69,7 +70,8 @@ def cmd_run(args: "argparse.Namespace") -> int:
         return 1
 
     config = apply_base_branch_override(
-        load_config(config_path), getattr(args, "base_branch", None)
+        load_config_checked(config_path, loader=load_config),
+        getattr(args, "base_branch", None),
     )
 
     # --dev-model override: provider/model@base_url

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import yaml
@@ -16,7 +18,10 @@ from theforge.artifacts import (
 from theforge.config import (
     ForgeConfig,
     _validate_plan_provider,
+    load_config,
 )
+from theforge.config.auth import check_agent_auth
+from theforge.config.types import ModelProfile
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.audit_substrate import CURRENT_RECORD_SCHEMA_VERSION
 from theforge.coordinator.redact import redact
@@ -138,6 +143,94 @@ def _find_config(start: Path | None = None) -> Path | None:
         if candidate.exists():
             return candidate
     return None
+
+
+def _iter_config_profiles(config: ForgeConfig) -> Iterator[tuple[str, ModelProfile]]:
+    """Yield ``(role_label, profile)`` for every ModelProfile a run/sprint uses.
+
+    Covers the dev profile, preflight (+ optional fallback), every reviewer in
+    the pool, the optional synthesis profile, and every agent-pool entry (each
+    projected to a ModelProfile). Plan/plan-review configs are validated
+    separately at load time and are not ModelProfiles, so they are not included.
+    """
+    yield ("dev", config.dev_profile)
+    yield ("preflight", config.preflight_profile)
+    if config.preflight_fallback_profile is not None:
+        yield ("preflight-fallback", config.preflight_fallback_profile)
+    for profile in config.review_pool:
+        yield ("review", profile)
+    if config.synthesis_profile is not None:
+        yield ("synthesis", config.synthesis_profile)
+    for agent in config.agents:
+        yield ("agent-pool", agent.to_model_profile())
+
+
+def _print_startup_auth_warnings(config: ForgeConfig) -> None:
+    """Print a stderr warning for every configured profile missing credentials.
+
+    Runs ``check_agent_auth`` on each profile after ``load_config`` succeeds so
+    the operator learns about a missing API key or CLI binary before the state
+    machine spends money. These are warnings only — they never block the run.
+    Sandbox readiness is intentionally excluded; this surface is about config
+    credentials, not the host environment.
+
+    Computing the warnings is itself best-effort: a profile that
+    ``check_agent_auth`` cannot classify is skipped rather than aborting the
+    run, since a genuinely malformed profile is already rejected by
+    ``load_config`` before this point. "Warnings don't block" applies to the
+    computation as much as the result.
+    """
+    try:
+        profiles = list(_iter_config_profiles(config))
+    except Exception:
+        return
+
+    seen: set[tuple[str, str]] = set()
+    for label, profile in profiles:
+        try:
+            ready, reason = check_agent_auth(
+                profile, config.secrets, include_sandbox_readiness=False
+            )
+        except Exception:
+            continue
+        if ready:
+            continue
+        dedup_key = (profile.name, reason)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+        print(
+            f"⚠ config: {label} profile {profile.name!r} — {reason}",
+            file=sys.stderr,
+        )
+
+
+def load_config_checked(
+    config_path: Path,
+    *,
+    loader: Callable[[Path], ForgeConfig] | None = None,
+) -> ForgeConfig:
+    """Load config for a run/sprint entrypoint, enforcing startup contracts.
+
+    - A structural config error — a ``ValueError`` raised while ``load_config``
+      parses/validates ``forge.yaml`` — exits with code 2 instead of bubbling
+      up as a generic exit-1 crash.
+    - After a successful load, every configured profile is auth-checked and any
+      missing-credential / missing-binary warnings print to stderr before the
+      caller enters the coordinator state machine. Warnings never block.
+
+    ``loader`` lets callers pass their own module-level ``load_config`` reference
+    so it stays patchable at the call-site module (e.g. tests that mock
+    ``theforge.cli.run.load_config``). Defaults to this module's ``load_config``.
+    """
+    load = loader or load_config
+    try:
+        config = load(config_path)
+    except ValueError as exc:
+        print(f"✗ forge.yaml is invalid: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    _print_startup_auth_warnings(config)
+    return config
 
 
 def _parse_story_frontmatter(story_path: Path) -> dict:

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 from theforge.cli.overrides import apply_base_branch_override
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.config import load_config
 from theforge.coordinator.util import set_log_level as coordinator_set_log_level
 from theforge.runners import LogLevel
@@ -89,7 +89,8 @@ def cmd_sprint(args: object) -> int:
         return 1
 
     config = apply_base_branch_override(
-        load_config(config_path), getattr(args, "base_branch", None)
+        load_config_checked(config_path, loader=load_config),
+        getattr(args, "base_branch", None),
     )
 
     # ── Detach BEFORE any subprocess/gh work ─────────────────────────────

--- a/tests/test_cli_startup_config_warnings.py
+++ b/tests/test_cli_startup_config_warnings.py
@@ -1,0 +1,208 @@
+"""Tests for startup config warnings + structural-error exit code.
+
+Covers ``theforge.cli.shared.load_config_checked`` and its helpers, which run
+after ``load_config`` succeeds to (a) surface per-profile auth warnings on
+stderr before the coordinator state machine starts and (b) convert structural
+config errors into exit code 2 rather than a generic exit-1 crash.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from theforge.cli import shared
+from theforge.config import ModelProfile
+
+
+def _api_profile(name: str, provider: str = "anthropic") -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        cli=None,
+        provider=provider,
+        model="model-x",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+
+
+def _cli_profile(name: str, cli: str = "claude") -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        cli=cli,
+        provider=None,
+        model="sonnet",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+
+
+def _fake_config(**overrides) -> SimpleNamespace:
+    """A minimal stand-in exposing only the attributes the warning code reads."""
+    base = dict(
+        dev_profile=_api_profile("dev"),
+        preflight_profile=_api_profile("preflight"),
+        preflight_fallback_profile=None,
+        review_pool=[_api_profile("review")],
+        synthesis_profile=None,
+        agents=[],
+        secrets={},
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ── Startup auth warnings ───────────────────────────────────────────────
+
+
+def test_missing_api_key_emits_warning_per_profile(monkeypatch, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    config = _fake_config()
+
+    shared._print_startup_auth_warnings(config)
+
+    err = capsys.readouterr().err
+    assert "ANTHROPIC_API_KEY not set" in err
+    # dev, preflight, and review are all anthropic API profiles missing the key.
+    assert err.count("ANTHROPIC_API_KEY not set") == 3
+    assert "dev profile 'dev'" in err
+    assert "preflight profile 'preflight'" in err
+    assert "review profile 'review'" in err
+
+
+def test_ready_profiles_emit_no_warning(monkeypatch, capsys):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-present")
+    config = _fake_config()
+
+    shared._print_startup_auth_warnings(config)
+
+    assert capsys.readouterr().err == ""
+
+
+def test_secrets_dict_resolves_credentials(monkeypatch, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    config = _fake_config(secrets={"ANTHROPIC_API_KEY": "sk-from-secrets"})
+
+    shared._print_startup_auth_warnings(config)
+
+    assert capsys.readouterr().err == ""
+
+
+def test_duplicate_name_and_reason_deduped(monkeypatch, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # Two reviewers sharing the same name+reason should warn only once.
+    config = _fake_config(review_pool=[_api_profile("rev"), _api_profile("rev")])
+
+    shared._print_startup_auth_warnings(config)
+
+    err = capsys.readouterr().err
+    assert err.count("profile 'rev'") == 1
+
+
+def test_agent_pool_and_synthesis_profiles_checked(monkeypatch, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "")  # ensure unset for openai agent
+
+    agent = SimpleNamespace(to_model_profile=lambda: _api_profile("pool-a", provider="openai"))
+    config = _fake_config(
+        synthesis_profile=_api_profile("synth"),
+        agents=[agent],
+    )
+
+    shared._print_startup_auth_warnings(config)
+
+    err = capsys.readouterr().err
+    assert "synthesis profile 'synth'" in err
+    assert "agent-pool profile 'pool-a'" in err
+    assert "OPENAI_API_KEY not set" in err
+
+
+def test_sandbox_readiness_excluded(monkeypatch, capsys):
+    """Only credential/binary readiness is reported — not host sandbox state."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-present")
+    # An API profile that is auth-ready must not warn even if the host lacks a
+    # workspace sandbox; the warning surface passes include_sandbox_readiness=False.
+    config = _fake_config(
+        dev_profile=_api_profile("dev"),
+        preflight_profile=_api_profile("preflight"),
+        review_pool=[_api_profile("review")],
+    )
+
+    with patch("theforge.cli.shared.check_agent_auth") as mock_check:
+        mock_check.return_value = (True, "")
+        shared._print_startup_auth_warnings(config)
+
+    # Every call must opt out of sandbox readiness.
+    assert mock_check.call_count > 0
+    for call in mock_check.call_args_list:
+        assert call.kwargs["include_sandbox_readiness"] is False
+    assert capsys.readouterr().err == ""
+
+
+# ── load_config_checked: structural errors + non-blocking warnings ──────
+
+
+def test_structural_error_exits_code_2(capsys):
+    with patch("theforge.cli.shared.load_config", side_effect=ValueError("bad key")):
+        with pytest.raises(SystemExit) as exc_info:
+            shared.load_config_checked("/nonexistent/forge.yaml")
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "forge.yaml is invalid" in err
+    assert "bad key" in err
+
+
+def test_unclassifiable_profile_is_skipped_not_fatal(monkeypatch, capsys):
+    # A profile with neither cli nor provider makes check_agent_auth raise
+    # ValueError. Because a genuinely malformed profile is already rejected by
+    # load_config, the warning pass treats this as best-effort: the bad profile
+    # is skipped, well-formed profiles are still checked, and the run proceeds.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    bad = ModelProfile(
+        name="bad",
+        cli=None,
+        provider=None,
+        model="x",
+        budget_usd=0.0,
+        timeout_seconds=0,
+        allowed_tools=(),
+    )
+    config = _fake_config(dev_profile=bad)
+
+    with patch("theforge.cli.shared.load_config", return_value=config):
+        result = shared.load_config_checked("/some/forge.yaml")
+
+    assert result is config
+    err = capsys.readouterr().err
+    # The bad profile did not crash the run; the well-formed review profile is
+    # still auth-checked and reported.
+    assert "review profile 'review'" in err
+    assert "profile 'bad'" not in err
+
+
+def test_warnings_do_not_block_load(monkeypatch, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    config = _fake_config()
+
+    with patch("theforge.cli.shared.load_config", return_value=config):
+        result = shared.load_config_checked("/some/forge.yaml")
+
+    # Config is still returned despite the missing-credential warnings.
+    assert result is config
+    assert "ANTHROPIC_API_KEY not set" in capsys.readouterr().err
+
+
+def test_success_no_warnings_returns_config(monkeypatch, capsys):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-present")
+    config = _fake_config()
+
+    with patch("theforge.cli.shared.load_config", return_value=config):
+        result = shared.load_config_checked("/some/forge.yaml")
+
+    assert result is config
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

The run and sprint startup paths now load config through the checked wrapper, emit non-blocking auth warnings, and convert structural config errors to exit 2.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $4.90
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge run/sprint: print config warnings at startup (GitHub Issue #219)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #219