### PR TITLE
Flake discipline: make-deterministic + visible flake register (not retry-on-flake)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -589,6 +589,27 @@ land in `.forge/worktrees/<slug>/` on branch `feat/<slug>`.
   seconds. A hanging test kills the entire gate run for every story in the sprint.
 - **Never import optional provider SDKs unconditionally in tests.** Tests must pass whether the environment has `.[dev]` or `.[all,dev]` installed. Mock or stub provider SDK boundaries.
 
+### Flake discipline
+
+A flaky gate is a trust violation: a red-when-it-should-be-green (or the reverse)
+gate is the gate lying, and combined with auto-merge a lucky re-run can land
+unreviewed code (this happened — see [`docs/flake-register.md`](docs/flake-register.md)).
+The rules:
+
+- **Fix flakes by removing nondeterminism, not by retrying.** Retrying a flaky
+  test masks it and trains everyone to ignore red — worse than the flake. Remove
+  the timing/ordering assumption: synchronize on the actual condition (poll the
+  observed state with a bounded timeout), not on a `sleep`, a schedule, or an
+  assumed ordering. Do **not** add retry-on-flake and do **not** widen a timeout
+  to chase a contention flake — a wider window hides the race instead of removing
+  it.
+- **A green-on-re-run after a same-SHA red is a flake signal, not a pass.** If the
+  gate goes red and a plain re-run of the *same commit* goes green, treat the test
+  that flipped as flaky. Do not merge on the green — register the flake first.
+- **Track every known flake in [`docs/flake-register.md`](docs/flake-register.md)**
+  (test id, symptom, suspected cause, owning issue) so it is burned down, never
+  silently retried into invisibility. A flake that isn't tracked rots.
+
 ## Cutting a Release
 
 The full release process is documented in [`RELEASING.md`](RELEASING.md). Use the

--- a/docs/flake-register.md
+++ b/docs/flake-register.md
@@ -1,0 +1,86 @@
+# Flake Register
+
+A flaky gate is a direct trust violation for a project whose thesis is
+trustworthy gates. A red-when-it-should-be-green (or green-when-it-should-be-red)
+gate is the gate lying, and it has teeth: on 2026-07-17 a flaky `gate (3.13)`
+failure blocked a PR, a re-run passed, and armed auto-merge then landed
+out-of-scope code (#1717) — flake + auto-merge turned "blocked pending decision"
+into "merged on the second coin flip."
+
+This register is the visible ledger of every known-flaky test. **The point is
+burndown, not tolerance.** A flake that isn't tracked rots; a flake that is
+retried into invisibility trains everyone to ignore red. See
+[the flake discipline in CONVENTIONS.md](../CONVENTIONS.md#flake-discipline)
+for the rules that govern entries here.
+
+## How this register works
+
+- **A flake is fixed by removing nondeterminism, not by retrying.** Retrying a
+  flaky test masks it and is worse than the flake itself.
+- **Every known flake lives here** with a test id, symptom, suspected cause, and
+  an owning issue, until it has a determinism fix or is deliberately retired.
+- **A green-on-re-run after a same-SHA red is a flake signal, not a pass.** When
+  a gate goes red and a plain re-run of the same commit goes green, the test that
+  flipped is a flake candidate — add it here rather than merging on the green.
+
+## Status legend
+
+- **fixed** — nondeterminism removed; kept in the register for provenance until
+  a clean burndown window confirms it stays green.
+- **open** — reproduces or can reproduce; has an owning issue and awaits a
+  determinism fix.
+- **absent** — the flaky code is not currently in the tree (e.g. reverted); the
+  entry is a forward-looking guard so the flake is re-registered, not
+  rediscovered, if the code returns.
+
+## Register
+
+### 1. `test_process_group.py::test_kill_process_group_reaps_the_whole_tree`
+
+- **Status:** absent
+- **Symptom:** Process-reap timing race — the test asserts the whole process
+  tree is reaped, but the reap has not always completed when the assertion runs,
+  producing intermittent `gate (3.13)` failures.
+- **Suspected cause:** The test synchronizes on a schedule/timing assumption
+  rather than on the actual "all descendants are gone" condition, so under load
+  (notably 3.13 in the CI matrix) the reap lags the assertion.
+- **Owning issue:** #1649 (process-group isolation, held for v0.12).
+- **Notes:** The `process_group.py` implementation and this test were reverted
+  by #1719 as out-of-scope for rc1, so neither is in the tree today. When #1649
+  reintroduces subprocess isolation, the reaper test **must synchronize on the
+  observed absence of every child PID** (poll until no descendant remains, with
+  a bounded timeout) instead of sleeping or assuming the reap has finished.
+
+### 2. `test_apply_branch_protection.py` — fake-`gh` SIGPIPE race
+
+- **Status:** open
+- **Symptom:** Intermittent failure of the branch-protection tests when the
+  script under test pipes the protection body into the PATH-mocked `gh`.
+- **Suspected cause:** SIGPIPE race between the writer (`echo "$BODY" | gh`) and
+  the fake `gh` — exit paths in the fake that do not drain stdin can leave the
+  writing side of the pipe receiving SIGPIPE, and `set -o pipefail` then fails
+  the pipeline nondeterministically.
+- **Owning issue:** #1722 (this register); burndown tracked here.
+- **Determinism fix applied:** The fake `gh` now drains stdin on **every** exit
+  path (`tests/test_apply_branch_protection.py`), so the writer never races a
+  reader that exits without reading. This removes the SIGPIPE window rather than
+  papering over it with a gate-timeout bump.
+
+### 3. Gate-timeout contention under `--parallel 3`
+
+- **Status:** open
+- **Symptom:** `make gate` occasionally times out under `forge sprint --parallel 3`
+  on a 10-core host, then passes instantly when the same commit is resumed solo
+  (observed for #1243, twice; worked around by bumping `gate_timeout` 45 → 60 in
+  `forge.yaml`).
+- **Suspected cause:** Aggregate gate CPU demand exceeds host capacity when three
+  gates run concurrently on ~10 cores, so wall-clock gate time crosses the
+  timeout even though the tests themselves are green. This is a scheduling
+  race, not a per-test race — the "flake" is the timeout, not an assertion.
+- **Owning issue:** #1722 (this register); burndown tracked here.
+- **Notes:** The current mitigation (`gate_timeout: 60`) is a timeout bump, not a
+  determinism fix. A real fix removes the contention rather than widening the
+  window: cap concurrent gate CPU (e.g. bound `-n auto` worker count per gate, or
+  scale `--parallel` to `cores / gate_worker_budget`) so N parallel gates cannot
+  oversubscribe the host. Until then, do **not** raise `gate_timeout` further to
+  chase this — a wider timeout hides the contention instead of removing it.

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -33,6 +33,11 @@ def _write_fake_gh(bin_dir: Path, *, put_exit: int) -> Path:
     """
     log = bin_dir / "gh.log"
     fake = bin_dir / "gh"
+    # Drain stdin on EVERY exit path. The script under test writes the protection
+    # body via `echo "$BODY" | gh ...` under `set -o pipefail`; if this fake exits
+    # without reading stdin the writer can receive SIGPIPE and pipefail fails the
+    # pipeline nondeterministically. Reading stdin to a file (PUT) or /dev/null
+    # (non-PUT) before exiting removes that race — see docs/flake-register.md #2.
     fake.write_text(
         "#!/usr/bin/env bash\n"
         f'echo "$@" >> "{log}"\n'
@@ -44,6 +49,7 @@ def _write_fake_gh(bin_dir: Path, *, put_exit: int) -> Path:
         f'    cat > "{bin_dir}/gh.put_body.json"\n'
         f"    exit {put_exit}\n"
         "else\n"
+        "    cat > /dev/null\n"
         "    exit 3\n"
         "fi\n"
     )


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The flake register and flake-discipline guidance satisfy the stated acceptance criteria, and the targeted branch-protection tests plus startup-warning tests pass locally. | [google-gemini-3.5-flash] The flake discipline and register have been successfully implemented, and the fake-gh SIGPIPE race has been resolved deterministically. | [claude-sonnet] Flake register + make-deterministic discipline is documented accurately, cross-links resolve, the SIGPIPE determinism fix is verified correct, and tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $1.65
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Flake discipline: make-deterministic + visible flake register (not retry-on-flake) (GitHub Issue #1722)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1722