### PR TITLE
Intake accepts acceptance criteria the dev loop has no mechanism to satisfy

### DIFF
--- a/src/theforge/shape_check/_mapping.py
+++ b/src/theforge/shape_check/_mapping.py
@@ -13,6 +13,10 @@ def map_shape(reasons: tuple[Reason, ...]) -> tuple[Shape, SuggestedAction]:
         return Shape.TRACKING_ONLY, SuggestedAction.REMOVE_FROM_SPRINT
     if "untriaged_finding" in codes:
         return Shape.NEEDS_GROOMING, SuggestedAction.CLARIFY
+    if "criterion_needs_live_evidence" in codes:
+        # Split the live-run criterion out; the satisfiable remainder is
+        # dispatchable on its own.
+        return Shape.NEEDS_GROOMING, SuggestedAction.SPLIT
     if "too_many_behavioral_clusters" in codes:
         return Shape.NEEDS_GROOMING, SuggestedAction.SPLIT
     blocking = [r for r in reasons if r.severity is Severity.BLOCKING]

--- a/src/theforge/shape_check/check.py
+++ b/src/theforge/shape_check/check.py
@@ -10,6 +10,7 @@ from theforge.shape_check.heuristics import (
     DEFAULT_CLUSTER_THRESHOLD,
     SEED_VOCABULARY,
     check_bug_missing_diagnosis,
+    check_criterion_needs_live_evidence,
     check_epic_or_tracking,
     check_implementation_design_dump,
     check_implementation_plan_in_body,
@@ -61,6 +62,7 @@ def check(
         check_missing_acceptance_criteria,
         check_missing_example,
         check_no_observable_done_state,
+        check_criterion_needs_live_evidence,
         check_implementation_design_dump,
         check_implementation_plan_in_body,
     ):

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -852,6 +852,155 @@ def check_no_observable_done_state(title: str, body: str, labels: Iterable[str])
     )
 
 
+# --- live-run evidence detection (#1735) ------------------------------------
+#
+# Some acceptance criteria are satisfiable only by the *recorded outcome of a
+# live run* — its dollar cost, its wall-clock duration, its budget consumption,
+# or whether the artifact an agent produced during that run was complete. The
+# dev loop produces exactly one class of evidence: source changes, deterministic
+# tests, and a gate exit code, and a reviewer only ever sees the diff. A
+# criterion in the live-run class therefore cannot be satisfied by any diff the
+# loop can produce; discovering that through iteration exhaustion is the
+# expensive way to learn what the story text says for free (#1425, run
+# 0f519b0b845b: dev spent its whole iteration budget on such a criterion).
+#
+# Detection requires TWO independent signals in the *same* criterion:
+#   1. a live-run scope — the criterion is about an actual execution instance
+#      ("a diagnose run", "running the pipeline", "a live agent run"), and
+#   2. a recorded-outcome assertion — a property observable only by performing
+#      that run (cost, duration, budget consumption, produced-artifact
+#      completeness).
+# The conjunction is deliberate. A criterion that merely *mentions* runs,
+# budgets, agents, or artifacts (e.g. "the report lists each agent's cost",
+# "forge run prints warnings", "the agent produces a diff") describes an
+# inspectable source feature and must not fire (#1735 AC3).
+
+_LIVE_RUN_SCOPE_RES: tuple[re.Pattern[str], ...] = (
+    # "a diagnose run", "the run", "one sprint run" — run as an execution noun.
+    re.compile(
+        r"\b(?:a|an|the|each|one|any|every|another|this|first|second)\s+"
+        r"(?:\w+[- ]){0,3}run\b",
+        re.IGNORECASE,
+    ),
+    # "run on an issue", "run produces", "run completes" — run + outcome verb.
+    re.compile(
+        r"\brun\s+(?:on|against|of|over|produces?|produced|completes?|completed|"
+        r"yields?|results?|takes?|costs?)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\brunning\b", re.IGNORECASE),
+    re.compile(r"\blive\s+(?:run|agent|invocation|execution|dispatch)\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:agent|pipeline|dev|sprint|diagnose|diagnosis|end-to-end|e2e|real|actual)"
+        r"[- ]run\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bactual\s+(?:invocation|execution)\b", re.IGNORECASE),
+    re.compile(r"\bexecuting\b", re.IGNORECASE),
+    re.compile(r"\bon\s+a\s+(?:representative|real|live|sample)\b", re.IGNORECASE),
+)
+
+_LIVE_RUN_OUTCOME_RES: tuple[re.Pattern[str], ...] = (
+    # Budget consumption of an execution.
+    re.compile(r"\bwithin\s+(?:its\s+|the\s+|a\s+)?budget\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:under|over|exceeds?|exhausts?|stays?\s+(?:with)?in|consumes?|spends?)\s+"
+        r"(?:its\s+|the\s+|a\s+)?(?:\w+\s+){0,2}budget\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\biteration\s+budget\b", re.IGNORECASE),
+    re.compile(r"\bhit_limit\b", re.IGNORECASE),
+    # Completeness of an artifact produced by the run.
+    re.compile(r"\bcomplete\s+artifact\b", re.IGNORECASE),
+    re.compile(r"\bproduces?\s+(?:a\s+)?complete\b", re.IGNORECASE),
+    re.compile(r"\bartifact\s+(?:is|was)\s+complete\b", re.IGNORECASE),
+    # Dollar cost and wall-clock duration — only observable by executing.
+    re.compile(r"\$\s*\d"),
+    re.compile(r"\b\d+\s*(?:minutes?|mins?|seconds?|secs?|hours?)\b", re.IGNORECASE),
+    re.compile(r"\bwall[-\s]?clock\b", re.IGNORECASE),
+    re.compile(r"\b(?:run|agent|it)\s+(?:costs?|spent|spends?)\b", re.IGNORECASE),
+)
+
+
+def _truncate_criterion(text: str, max_len: int = 240) -> str:
+    compact = " ".join(text.split())
+    if len(compact) <= max_len:
+        return compact
+    return compact[: max_len - 1].rstrip() + "…"
+
+
+def _criterion_needs_live_evidence(bullet: str) -> bool:
+    """True when a single AC bullet asserts the recorded outcome of a live run."""
+    if not any(p.search(bullet) for p in _LIVE_RUN_SCOPE_RES):
+        return False
+    return any(p.search(bullet) for p in _LIVE_RUN_OUTCOME_RES)
+
+
+def check_criterion_needs_live_evidence(
+    title: str, body: str, labels: Iterable[str]
+) -> Reason | None:
+    """Flag acceptance criteria satisfiable only by a live run's recorded outcome.
+
+    The dev loop produces source changes, deterministic tests, and a gate exit
+    code; the reviewer sees only the resulting diff. A criterion whose
+    satisfaction depends on the cost, duration, budget consumption, or
+    produced-artifact completeness of an actual run cannot be met by any diff —
+    it is knowable from the story text at intake, so refusing here spends no dev
+    budget to learn what iteration exhaustion would otherwise teach expensively.
+
+    Bug-format issues are exempt (they use observed/expected, not acceptance
+    criteria, and their Diagnosis section legitimately references runs and
+    evidence). The check fires only on the conjunction of a live-run scope and a
+    recorded-outcome assertion within the *same* bullet, so a criterion that
+    merely mentions runs, budgets, agents, or artifacts does not trip it.
+
+    When some criteria are satisfiable and others are not, the detail names the
+    flagged criteria and notes the satisfiable remainder, so a partly-dispatchable
+    story stays distinguishable from a wholly-undispatchable one.
+    """
+    if is_bug_format_issue(body, labels):
+        return None
+    ac = extract_ac_section(body)
+    if not ac:
+        return None
+    # Use whole-bullet blocks (continuation prose included): a criterion often
+    # states its live-run scope on the first line and its recorded-outcome
+    # assertion on a wrapped continuation line, and both signals must be seen
+    # together for the conjunction to fire.
+    bullets = extract_top_level_bullet_blocks(ac)
+    if not bullets:
+        return None
+    flagged = [b for b in bullets if _criterion_needs_live_evidence(b)]
+    if not flagged:
+        return None
+
+    satisfiable = len(bullets) - len(flagged)
+    flagged_render = "; ".join(f"'{_truncate_criterion(b)}'" for b in flagged)
+    if satisfiable > 0:
+        mix_note = (
+            f" The other {satisfiable} criterion(s) are satisfiable by ordinary source "
+            "and tests and remain dispatchable once the live-run criterion(s) are split "
+            "out."
+        )
+    else:
+        mix_note = (
+            " Every acceptance criterion here depends on a live-run outcome; the issue "
+            "is wholly undispatchable to the dev loop as written."
+        )
+    return Reason(
+        code="criterion_needs_live_evidence",
+        severity=Severity.BLOCKING,
+        detail=(
+            f"{len(flagged)} of {len(bullets)} acceptance criterion(s) depend on the "
+            "recorded outcome of a live run (cost, duration, budget consumption, or the "
+            "completeness of an agent-produced artifact) rather than on inspectable "
+            "source or deterministic tests. The dev loop emits only source changes, "
+            "deterministic tests, and a gate exit code, and a reviewer sees only the "
+            f"diff — so no diff can satisfy: {flagged_render}." + mix_note
+        ),
+    )
+
+
 _WORD_RE = re.compile(r"[A-Za-z][A-Za-z\-_]+")
 
 

--- a/src/theforge/shape_check/types.py
+++ b/src/theforge/shape_check/types.py
@@ -74,7 +74,8 @@ VERDICT_DESCRIPTIONS: dict[ShapeVerdict, str] = {
         "issue spans too many behavioral clusters; split into smaller issues"
     ),
     ShapeVerdict.NEEDS_OPERATOR_ACTION: (
-        "issue requires operator triage (epic/tracking, untriaged finding, or stale reopen)"
+        "issue requires operator triage (epic/tracking, untriaged finding, stale reopen, "
+        "or an acceptance criterion the dev loop cannot satisfy)"
     ),
     ShapeVerdict.ADR_CANDIDATE: (
         "issue body contains design/implementation content; "

--- a/src/theforge/shape_check/verdict.py
+++ b/src/theforge/shape_check/verdict.py
@@ -17,6 +17,7 @@ _PRECEDENCE: tuple[tuple[str, ShapeVerdict], ...] = (
     ("epic_or_tracking", ShapeVerdict.NEEDS_OPERATOR_ACTION),
     ("untriaged_finding", ShapeVerdict.NEEDS_OPERATOR_ACTION),
     ("reopened_stale_contract", ShapeVerdict.NEEDS_OPERATOR_ACTION),
+    ("criterion_needs_live_evidence", ShapeVerdict.NEEDS_OPERATOR_ACTION),
     ("missing_type", ShapeVerdict.NEEDS_TYPE),
     ("needs_diagnosis", ShapeVerdict.NEEDS_DIAGNOSIS),
     ("diagnosis_cause_unknown", ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN),

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -12,11 +12,13 @@ from theforge.shape_check import (
     Severity,
     Shape,
     ShapeResult,
+    ShapeVerdict,
     SuggestedAction,
     check,
 )
 from theforge.shape_check.classifier import classify
 from theforge.shape_check.heuristics import (
+    check_criterion_needs_live_evidence,
     check_epic_or_tracking,
     check_implementation_design_dump,
     check_implementation_plan_in_body,
@@ -675,6 +677,104 @@ class TestCheckAggregation:
         assert result.shape is Shape.RUNNABLE
         assert result.suggested_action is SuggestedAction.PROCEED
         assert result.reasons == ()
+
+
+# ----- live-run evidence criterion (#1735) ----------------------------------
+
+
+# The three acceptance criteria #1425 carried, verbatim in shape. Only the
+# third depends on the recorded outcome of a live run.
+ISSUE_1425_AC = textwrap.dedent(
+    """\
+    ## What
+    Enrich the diagnose prompt with environment context.
+
+    ## Acceptance criteria
+    - The diagnose prompt includes an environment briefing section describing
+      the runtime, package layout, and available tooling.
+    - The briefing is templated from project structure, not hardcoded.
+    - A diagnose run on an issue with a sparse body (only observed/expected, no
+      evidence pointers) produces a complete artifact within budget on a
+      representative landing-failure bug.
+    """
+)
+
+
+class TestCriterionNeedsLiveEvidence:
+    def _reason(self, body: str, labels=("enhancement",)):
+        return check_criterion_needs_live_evidence("Some feature", body, list(labels))
+
+    def test_flags_live_run_outcome_criterion(self):
+        body = textwrap.dedent(
+            """\
+            ## Acceptance Criteria
+            - A diagnose run produces a complete artifact within budget on a
+              representative landing-failure bug.
+            """
+        )
+        r = self._reason(body)
+        assert r is not None
+        assert r.code == "criterion_needs_live_evidence"
+        assert r.severity is Severity.BLOCKING
+
+    def test_does_not_fire_on_mere_mention_of_runs_budgets_agents_artifacts(self):
+        # Each bullet mentions a trigger noun but describes an inspectable
+        # source feature, not the recorded outcome of a live run (AC3).
+        body = textwrap.dedent(
+            """\
+            ## Acceptance Criteria
+            - `forge run` prints config warnings at startup.
+            - The command respects the `--budget` flag and stops when exceeded.
+            - The report lists each agent's cost and duration.
+            - The dev agent produces a diff and a gate exit code.
+            - Running the test suite passes.
+            """
+        )
+        assert self._reason(body) is None
+
+    def test_1425_replay_flags_only_the_live_run_criterion(self):
+        r = self._reason(ISSUE_1425_AC)
+        assert r is not None
+        # The flagged criterion is named; the two satisfiable ones are not.
+        assert "produces a complete artifact within budget" in r.detail
+        assert "environment briefing section" not in r.detail
+        assert "templated from project structure" not in r.detail
+        assert "1 of 3" in r.detail
+        # A mix stays distinguishable: the satisfiable remainder is called out.
+        assert "remain dispatchable" in r.detail
+
+    def test_wholly_undispatchable_is_distinguishable_from_mix(self):
+        body = textwrap.dedent(
+            """\
+            ## Acceptance Criteria
+            - A diagnose run produces a complete artifact within budget.
+            - A sprint run stays within its iteration budget and costs under $5.
+            """
+        )
+        r = self._reason(body)
+        assert r is not None
+        assert "2 of 2" in r.detail
+        assert "wholly undispatchable" in r.detail
+        assert "remain dispatchable" not in r.detail
+
+    def test_bug_format_issue_is_exempt(self):
+        body = textwrap.dedent(
+            """\
+            ## What happened
+            A diagnose run produced an incomplete artifact within budget.
+
+            ## What was expected
+            The run should complete within budget.
+            """
+        )
+        assert self._reason(body, labels=["bug"]) is None
+
+    def test_check_aggregation_routes_to_split_and_operator_action(self):
+        result = check("Enrich diagnose prompt", ISSUE_1425_AC, ["enhancement"])
+        assert result.shape is Shape.NEEDS_GROOMING
+        assert result.suggested_action is SuggestedAction.SPLIT
+        assert any(r.code == "criterion_needs_live_evidence" for r in result.reasons)
+        assert result.verdict is ShapeVerdict.NEEDS_OPERATOR_ACTION
 
 
 # ----- classifier mode tests ------------------------------------------------

--- a/tests/test_sprint_shape_gate.py
+++ b/tests/test_sprint_shape_gate.py
@@ -35,6 +35,20 @@ Users need a way to bypass the gate.
 
 _BAD_BODY = "just a one-liner, no acceptance criteria, no structure"
 
+# A story whose third acceptance criterion depends on the recorded outcome of a
+# live run — knowable at intake, unsatisfiable by any diff (#1735 / #1425).
+_LIVE_EVIDENCE_BODY = """## What
+
+Enrich the diagnose prompt with environment context.
+
+## Acceptance criteria
+
+- The diagnose prompt includes an environment briefing section.
+- The briefing is templated from project structure, not hardcoded.
+- A diagnose run on a sparse-body issue produces a complete artifact within
+  budget on a representative landing-failure bug.
+"""
+
 
 def _fake_detail(body: str, labels: list[str], title: str = "Some issue"):
     def _fetch(_number, _project_root):
@@ -99,6 +113,36 @@ def test_label_skip_falls_back_to_label_detail_when_live_check_is_runnable(
     assert entry.source == "label"
     assert entry.reason_codes == ("needs_grooming_label",)
     assert entry.detail == "issue carries 'needs-grooming' label"
+
+
+# ── Live-run evidence criterion (#1735) ─────────────────────────────────────
+
+
+def test_live_run_evidence_criterion_is_not_dispatched(tmp_path: Path) -> None:
+    """A story carrying a live-run-outcome criterion must not silently dispatch.
+
+    Seam test across the sprint-entry boundary: the criterion is detectable
+    from the story text, so the gate keeps the issue out of the dev loop and
+    surfaces which criterion the loop cannot satisfy before any dev budget is
+    spent.
+    """
+    issues = [{"number": 1425, "title": "Enrich diagnose prompt"}]
+
+    result = apply_shape_gate(
+        issues,
+        tmp_path,
+        fetch_detail=_fake_detail(_LIVE_EVIDENCE_BODY, ["enhancement"]),
+    )
+
+    assert result.runnable == []
+    assert len(result.skipped) == 1
+    entry = result.skipped[0]
+    assert entry.source == "local_check"
+    assert "criterion_needs_live_evidence" in entry.reason_codes
+    assert entry.verdict == "needs_operator_action"
+    # The operator is told which criterion cannot be satisfied and why.
+    assert "complete artifact within" in entry.detail
+    assert "remain dispatchable" in entry.detail
 
 
 # ── Intake-remediated label suppression (re-exec carry) ─────────────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The #1735 intake check is wired into the runtime shape gate, flags the #1425 live-run criterion, and keeps ordinary source/test criteria actionable. | [google-gemini-3.5-flash] The implementation of the live-run evidence detection heuristic is exceptionally clean, robust, and fully compliant with all acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $4.82
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Intake accepts acceptance criteria the dev loop has no mechanism to satisfy (GitHub Issue #1735)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1735