### PR TITLE
Review classifier suppresses a correct P1 via keyword-matched gate_contradicted — story with matches_spec=false reaches DONE instead of escalating

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -800,6 +800,12 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
             }
             for r in state.finding_registry
         ],
+        # Non-blocking / suppressed P1s: findings that were set aside without
+        # blocking approval. Both net_new (latent, single-reviewer) and
+        # gate_contradicted (mechanically disproven by a PASS gate) belong here so
+        # a reader can see which P1s were waived and on what basis — a suppression
+        # that leaves no trace here is invisible where waived findings are looked
+        # for. The real disposition is preserved rather than flattened to net_new.
         "non_blocking_p1s": [
             {
                 "finding_id": r.finding_id,
@@ -808,10 +814,10 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "line": r.line,
                 "description": r.description,
                 "reporter": r.reporter,
-                "disposition": "net_new",
+                "disposition": r.disposition,
             }
             for r in state.finding_registry
-            if r.severity == "P1" and r.disposition == "net_new"
+            if r.severity == "P1" and r.disposition in ("net_new", "gate_contradicted")
         ],
         "conventions": {"soft": config.conventions_soft} if config.conventions_soft else None,
         **_build_phases_block(state, config),

--- a/src/theforge/coordinator/gate_contradiction.py
+++ b/src/theforge/coordinator/gate_contradiction.py
@@ -1,0 +1,136 @@
+"""Assertion-based gate-contradiction classification for review findings.
+
+Pure Python, stdlib-only.  Consumed by ``review_phase`` to decide whether a
+passing gate mechanically contradicts a P1 finding.
+
+The distinction this module enforces is between what a finding is *about* and
+what it *asserts*.  A passing gate contradicts exactly one class of claim: that
+tests / build / lint are currently *failing*.  It has no bearing on a claim that
+coverage is inadequate, that acceptance evidence was never produced, or that a
+criterion remains undemonstrated — all of which are entirely consistent with a
+green gate.  Matching a finding's subject matter (any mention of "tests") rather
+than its assertion is what allowed a correct "acceptance evidence is missing" P1
+to be suppressed on the authority of a gate that had no bearing on it.
+
+``asserts_gate_verifiable_failure`` therefore returns True only when a finding
+positively asserts a gate-verifiable *failure* and carries no signal that it is
+in fact an inadequacy / absence claim or an indictment of the gate itself.  It
+fails closed: when the assertion cannot be positively established, the finding is
+treated as non-contradicted and keeps blocking.
+"""
+
+from __future__ import annotations
+
+# ── Positive failure assertions ──────────────────────────────────────────────
+# Phrases that assert a gate-verifiable signal (tests, build, lint, compile) is
+# currently FAILING — the only claim a PASS gate mechanically disproves.  Each is
+# a subject bound to a failure predicate; a bare subject ("test suite") is not
+# here, because a green gate says nothing about a finding that merely discusses
+# tests.
+_GATE_FAILURE_ASSERTIONS: tuple[str, ...] = (
+    "test fail",
+    "tests fail",
+    "test failure",
+    "tests are failing",
+    "failing test",
+    "test is failing",
+    "tests failing",
+    "build fail",
+    "build error",
+    "build is broken",
+    "broken build",
+    "does not compile",
+    "doesn't compile",
+    "will not compile",
+    "won't compile",
+    "compilation fail",
+    "compilation error",
+    "compile fail",
+    "compile error",
+    "lint fail",
+    "lint error",
+    "linter fail",
+    "linter error",
+    "import error",
+    "syntax error",
+    "0 passed",
+    "0 tests pass",
+    "zero tests pass",
+)
+
+# ── Suppression vetoes ────────────────────────────────────────────────────────
+# Signals that a finding — even one that mentions tests or failures — is NOT a
+# claim a green gate can contradict.  Two families:
+#   1. Inadequacy / absence / insufficiency of coverage or acceptance evidence.
+#      A passing gate is entirely consistent with all of these.
+#   2. Indictment of the gate/validation mechanism itself.  A finding arguing the
+#      oracle is wrong must never be dismissed on the oracle's authority.
+# Presence of any veto term forces the fail-closed path (finding keeps blocking).
+_SUPPRESSION_VETO: tuple[str, ...] = (
+    # inadequacy / absence / insufficiency of coverage
+    "inadequate",
+    "insufficient",
+    "not demonstrated",
+    "undemonstrated",
+    "never demonstrated",
+    "not shown",
+    "never shown",
+    "not exercised",
+    "does not exercise",
+    "doesn't exercise",
+    "only exercises",
+    "only exercise",
+    "only tests",
+    "only test",
+    "mocked",
+    "mock",
+    "stubbed",
+    "stub",
+    "patched out",
+    "patches out",
+    "coverage",
+    "missing test",
+    "no test",
+    "without test",
+    "lacks test",
+    "does not cover",
+    "doesn't cover",
+    "not covered",
+    "fails to demonstrate",
+    "fails to show",
+    "not validated",
+    "not verified",
+    "acceptance",
+    "criterion",
+    "criteria",
+    "within budget",
+    # indictment of the gate / validation mechanism itself
+    "gate",
+    "validation",
+    "validate",
+    "false pass",
+    "reports pass",
+    "report pass",
+    "reported pass",
+    "would pass",
+    "still pass",
+    "substring",
+    "0 failed",
+)
+
+
+def asserts_gate_verifiable_failure(description: str) -> bool:
+    """Return True only when *description* asserts a gate-verifiable failure.
+
+    A gate-verifiable failure is a claim that tests, the build, or lint are
+    currently failing — the one class of claim a PASS gate mechanically
+    contradicts.
+
+    Fails closed: any inadequacy / absence / gate-indictment signal, or the
+    absence of a positive failure assertion, yields False, and the caller keeps
+    the finding blocking.
+    """
+    d = description.lower()
+    if any(veto in d for veto in _SUPPRESSION_VETO):
+        return False
+    return any(assertion in d for assertion in _GATE_FAILURE_ASSERTIONS)

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -29,6 +29,7 @@ from theforge.task import ContextAssembler, TaskStory, build_review_prompt
 from .commit_guard import _has_commits_ahead_of_base
 from .completion import _append_cycle_history, _finalize_approve
 from .escalation_advisor_flow import run_escalation_advisor
+from .gate_contradiction import asserts_gate_verifiable_failure
 from .logging import StructuredLogger
 from .notify import (
     _escalate_gate_interactive,
@@ -1176,53 +1177,66 @@ def _run_review_phase(
     _allow_net_new_bypass = config.finding_classifier.allow_net_new_bypass
     _log(f"  [finding_classifier] allow_net_new_bypass={_allow_net_new_bypass}")
 
-    # ── Gate-contradiction downgrade ──────────────────────────────────────────
-    # If the most recent gate decision was PASS, any P1 finding whose description
-    # matches a gate-verifiable pattern (test failures, build errors, lint failures)
-    # is mechanically contradicted. Such findings are downgraded in-place to
-    # disposition gate_contradicted so they do not block approval.
-    # Pattern matching is keyword-based (conservative). False negatives are
-    # acceptable — the P1 remains blocking if no pattern matches.
+    # ── Gate-contradiction downgrade (assertion-based) ────────────────────────
+    # A PASS gate mechanically contradicts exactly one class of P1: a claim that
+    # tests/build/lint are currently FAILING.  It has no bearing on a claim that
+    # coverage is inadequate, that acceptance evidence was never produced, or that
+    # a criterion remains undemonstrated — all of which are entirely consistent
+    # with a green gate.  Suppression is therefore derived from what a finding
+    # *asserts* (asserts_gate_verifiable_failure), not from its subject matter,
+    # and it fails closed: a finding whose assertion is not established as a
+    # gate-verifiable failure keeps blocking.
     # No downgrade occurs when the gate decision is FAIL, BLOCKED, or absent.
-    _GATE_VERIFIABLE_PATTERNS = (
-        "test fail",
-        "tests fail",
-        "test failure",
-        "failing test",
-        "build fail",
-        "build error",
-        "lint fail",
-        "lint error",
-        "compilation fail",
-        "compile fail",
-        "import error",
-        "syntax error",
-        " failures",
-        "0 passed",
-        "test suite",
-        "broken build",
-        "does not compile",
-    )
     _last_gate = state.gate_decisions[-1] if state.gate_decisions else None
     if _last_gate == "PASS":
         for _rec in _classified:
             if _rec.severity != "P1":
                 continue
-            _desc_lower = _rec.description.lower()
-            _matched = next((p for p in _GATE_VERIFIABLE_PATTERNS if p in _desc_lower), None)
-            if _matched is not None:
+            if asserts_gate_verifiable_failure(_rec.description):
                 _log(
                     f"  ↷ gate_contradicted: P1 downgraded"
-                    f" (gate={_last_gate}, pattern={_matched!r}):"
+                    f" (gate={_last_gate}, asserts gate-verifiable failure):"
                     f" {_rec.description[:80]}"
                 )
                 _rec.disposition = "gate_contradicted"  # type: ignore[assignment]
+
+    # ── AC-violation override (runs after every disposition assignment) ───────
+    # A reviewer that returned matches_spec=false asserts the story was not
+    # completed correctly.  Any P1 from that reviewer must block — even one a
+    # mechanical signal downgraded to gate_contradicted, since a green gate cannot
+    # contradict a claim that acceptance evidence is missing.  This override runs
+    # AFTER the gate-contradiction downgrade and inspects P1s regardless of their
+    # current disposition, so no suppression can run ahead of the guard written to
+    # catch exactly this error, whatever order dispositions were assigned in.
+    _ac_failing_reporters = {
+        name for name, rr in state.last_cycle_reviewer_results if not rr.story_matches
+    }
+    _ac_reblocked = [
+        _rec
+        for _rec in _classified
+        if _rec.severity == "P1"
+        and _rec.reporter in _ac_failing_reporters
+        and _rec.disposition in ("net_new", "gate_contradicted")
+    ]
+    if _ac_reblocked:
+        # Persist the AC-blocking classification so the audit trail records these
+        # findings as ac_blocking rather than net_new/gate_contradicted.
+        for _rec in _ac_reblocked:
+            _rec.disposition = "ac_blocking"  # type: ignore[assignment]
+        _ac_descs = "; ".join(r.description[:80] for r in _ac_reblocked)
+        _log(
+            f"  ✗ {len(_ac_reblocked)} P1(s) blocked"
+            f" (AC-blocking: reviewer indicated matches_spec=false): {_ac_descs}"
+        )
 
     if state.review_cycle >= 2:
         # has_blocking_p1 / net_new_p1s inlined to avoid importing theforge.finding_classifier.
         # Logic is identical to the functions in finding_classifier.py.
         # gate_contradicted is intentionally excluded: these findings are mechanically
-        # disproven by a PASS gate and must not block approval.
+        # disproven by a PASS gate and must not block approval.  The AC-violation
+        # override above has already re-blocked any gate_contradicted P1 from a
+        # matches_spec=false reviewer, so only genuinely test-failure-asserting
+        # findings remain gate_contradicted here.
         _BLOCKING_DISPOSITIONS = {"unresolved", "regression", "corroborated_new", "ac_blocking"}
         _blocking_p1 = any(
             r.severity == "P1" and r.disposition in _BLOCKING_DISPOSITIONS for r in _classified
@@ -1233,30 +1247,6 @@ def _run_review_phase(
         _gate_contradicted_p1s = [
             r for r in _classified if r.severity == "P1" and r.disposition == "gate_contradicted"
         ]
-        # AC-violation override: a net-new P1 from a reviewer who also flagged
-        # matches_spec=false is not speculative — it asserts the story was not completed
-        # correctly and must block regardless of its disposition classification.
-        # Conservative rule: if *any* reviewer in the pool returned matches_spec=false,
-        # all net-new P1s from that reviewer are treated as AC-blocking.
-        _ac_failing_reporters = {
-            name for name, rr in state.last_cycle_reviewer_results if not rr.story_matches
-        }
-        if _ac_failing_reporters:
-            _ac_blocking_p1s = [r for r in _nonblocking_p1s if r.reporter in _ac_failing_reporters]
-            _nonblocking_p1s = [
-                r for r in _nonblocking_p1s if r.reporter not in _ac_failing_reporters
-            ]
-            if _ac_blocking_p1s:
-                _blocking_p1 = True
-                # Persist the AC-blocking classification so the audit trail records
-                # these findings as ac_blocking rather than net_new.
-                for _rec in _ac_blocking_p1s:
-                    _rec.disposition = "ac_blocking"  # type: ignore[assignment]
-                _ac_descs = "; ".join(r.description[:80] for r in _ac_blocking_p1s)
-                _log(
-                    f"  ✗ {len(_ac_blocking_p1s)} net-new P1(s) blocked"
-                    f" (AC-blocking: reviewer indicated matches_spec=false): {_ac_descs}"
-                )
         # When allow_net_new_bypass is disabled, net-new P1s are treated as blocking.
         # Persist the disposition change so the audit trail records these as blocking,
         # not as net_new (which audit.py would serialize under non_blocking_p1s).

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1410,9 +1410,35 @@ def _run_review_phase(
     # If the synthesized verdict is REQUEST_CHANGES but all P1s are net_new (single-reviewer,
     # not in changed files, not previously raised), we treat the cycle as passing.
     # Net-new P1s are recorded in the audit trail but do not block.
-    _effective_approve = parsed_review.verdict == "APPROVE" or (
-        parsed_review.verdict == "REQUEST_CHANGES" and not _blocking_p1
+    #
+    # An unsatisfied acceptance criterion blocks on its own, independent of P1
+    # count or disposition. A review can be schema-legal with verdict APPROVE (or
+    # REQUEST_CHANGES with every P1 suppressed) and still report matches_spec=false
+    # while carrying zero blocking P1s — nothing in cross-validation forbids it.
+    # Relying only on the AC-violation override (which re-blocks P1s that exist)
+    # lets that shape reach DONE, the exact class of bug this path guards. Treat a
+    # matches_spec=false verdict as its own blocking signal so the story cannot be
+    # approved on the strength of a suppressed or absent finding.
+    #
+    # Use the merged review's story_matches (computed over valid reviewers via
+    # all(); False if any valid reviewer dissents) rather than the raw
+    # last_cycle_reviewer_results set — the latter includes parse-failed reviewers,
+    # which default story_matches=False and would spuriously block an otherwise
+    # clean fallback approval.
+    _story_criterion_unsatisfied = not parsed_review.story_matches
+    _effective_approve = not _story_criterion_unsatisfied and (
+        parsed_review.verdict == "APPROVE"
+        or (parsed_review.verdict == "REQUEST_CHANGES" and not _blocking_p1)
     )
+    if _story_criterion_unsatisfied and not _blocking_p1:
+        # No blocking P1 carried the signal (e.g. APPROVE + matches_spec=false +
+        # zero P1s): the unsatisfied criterion itself blocks. Mark it so the audit
+        # trail and downstream routing see a blocking decision, not a silent pass.
+        _blocking_p1 = True
+        _log(
+            "  ✗ REVIEW   matches_spec=false with no blocking P1 — story does not "
+            "match spec; blocking on the unsatisfied criterion itself"
+        )
 
     # ── Empty-diff guard ────────────────────────────────────────────
     # APPROVE on a branch with zero commits ahead of base is a workflow failure,

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1282,6 +1282,24 @@ def _run_review_phase(
             _blocking_p1 = _p1_count > 0
         _nonblocking_p1s = []
 
+    # ── Unsatisfied-criterion → blocking (single source of truth) ──────────────
+    # A merged story_matches=false is blocking on its own, independent of P1 count
+    # or disposition. Fold it into _blocking_p1 HERE — before trajectory /
+    # early-termination / effective-approve — so every DONE-exit path keys on one
+    # blocking signal instead of each re-deriving the criterion check. A review can
+    # be schema-legal with verdict APPROVE (or REQUEST_CHANGES with every P1
+    # suppressed) and still report matches_spec=false with zero blocking P1s;
+    # deriving the check only at the effective-approve step let the zero-findings
+    # early-termination branch finalize DONE ahead of it. Merged story_matches is
+    # all()-over-valid-reviewers, so parse-failed reviewers (which default
+    # story_matches=False) do not spuriously block a clean fallback approval.
+    if not parsed_review.story_matches and not _blocking_p1:
+        _blocking_p1 = True
+        _log(
+            "  ✗ REVIEW   matches_spec=false — story does not match spec; blocking "
+            "approval on the unsatisfied criterion (independent of P1 count)"
+        )
+
     # ── Trajectory classification (in-process) ─────────────────────────────
     # Runs for EVERY successfully merged parsed_review (APPROVE, exhausted, retry).
     # Uses a dedicated monotonic counter (trajectory_cycle) that is never reset
@@ -1406,39 +1424,15 @@ def _run_review_phase(
             )
 
     # ── APPROVE (or disposition-gated pass) ─────────────────────────
-    # The coordinator makes the blocking decision independently of the synthesized verdict.
-    # If the synthesized verdict is REQUEST_CHANGES but all P1s are net_new (single-reviewer,
-    # not in changed files, not previously raised), we treat the cycle as passing.
-    # Net-new P1s are recorded in the audit trail but do not block.
-    #
-    # An unsatisfied acceptance criterion blocks on its own, independent of P1
-    # count or disposition. A review can be schema-legal with verdict APPROVE (or
-    # REQUEST_CHANGES with every P1 suppressed) and still report matches_spec=false
-    # while carrying zero blocking P1s — nothing in cross-validation forbids it.
-    # Relying only on the AC-violation override (which re-blocks P1s that exist)
-    # lets that shape reach DONE, the exact class of bug this path guards. Treat a
-    # matches_spec=false verdict as its own blocking signal so the story cannot be
-    # approved on the strength of a suppressed or absent finding.
-    #
-    # Use the merged review's story_matches (computed over valid reviewers via
-    # all(); False if any valid reviewer dissents) rather than the raw
-    # last_cycle_reviewer_results set — the latter includes parse-failed reviewers,
-    # which default story_matches=False and would spuriously block an otherwise
-    # clean fallback approval.
-    _story_criterion_unsatisfied = not parsed_review.story_matches
-    _effective_approve = not _story_criterion_unsatisfied and (
-        parsed_review.verdict == "APPROVE"
-        or (parsed_review.verdict == "REQUEST_CHANGES" and not _blocking_p1)
-    )
-    if _story_criterion_unsatisfied and not _blocking_p1:
-        # No blocking P1 carried the signal (e.g. APPROVE + matches_spec=false +
-        # zero P1s): the unsatisfied criterion itself blocks. Mark it so the audit
-        # trail and downstream routing see a blocking decision, not a silent pass.
-        _blocking_p1 = True
-        _log(
-            "  ✗ REVIEW   matches_spec=false with no blocking P1 — story does not "
-            "match spec; blocking on the unsatisfied criterion itself"
-        )
+    # _blocking_p1 is the single source of truth for whether this cycle may pass:
+    # it already folds in blocking P1 dispositions, the net-new/AC-blocking
+    # overrides, and (above) the unsatisfied-criterion signal. A cycle is
+    # approve-equivalent exactly when nothing blocks — this covers both a genuine
+    # APPROVE verdict and a REQUEST_CHANGES verdict whose P1s are all non-blocking
+    # net_new (net_new_pass). Cross-validation forbids APPROVE with P1 findings, so
+    # the only way an APPROVE verdict carries _blocking_p1 is the matches_spec=false
+    # fold — which must correctly deny approval.
+    _effective_approve = not _blocking_p1
 
     # ── Empty-diff guard ────────────────────────────────────────────
     # APPROVE on a branch with zero commits ahead of base is a workflow failure,

--- a/tests/test_coord_review_ac_blocking.py
+++ b/tests/test_coord_review_ac_blocking.py
@@ -95,6 +95,32 @@ test_coverage:
 """
 
 
+# Schema-legal review that reaches DONE only if matches_spec=false is ignored:
+# verdict APPROVE with all ac_verification entries VERIFIED (so no P1 is required
+# or present), yet story_compliance.matches_spec=false. Nothing in
+# cross-validation ties story_compliance.matches_spec to the verdict or to
+# ac_verification, so this shape is legal.
+_APPROVE_MATCHES_SPEC_FALSE_NO_P1 = """\
+```yaml
+verdict: APPROVE
+summary: "Code is clean but the story is not fully implemented."
+findings: []
+story_compliance:
+  matches_spec: false
+  mismatches:
+    - "AC3: live sparse-body diagnose run never demonstrated"
+test_coverage:
+  adequate: false
+  gaps:
+    - "acceptance criterion never exercised"
+ac_verification:
+  - criterion: "Implementation satisfies the spec"
+    status: VERIFIED
+    evidence: "diff hunks present and tests cover the failure mode (test fixture default)"
+```
+"""
+
+
 def _in_process_worktree_eval(
     workspace_path: Path, command: str, payload: dict, timeout: int = 120
 ) -> dict:
@@ -361,3 +387,49 @@ class TestNetNewAcBlocking:
         ]
         assert len(ac_records) == 1
         assert ac_records[0].disposition == "fixed"
+
+    @patch("theforge.coordinator.util._run_worktree_eval", side_effect=_in_process_worktree_eval)
+    @patch("theforge.finding_classifier._get_changed_files")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_approve_with_matches_spec_false_and_no_p1_does_not_reach_done(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_changed_files,
+        mock_eval,
+        tmp_path,
+    ):
+        """verdict=APPROVE + matches_spec=false + zero P1 findings must not reach DONE.
+
+        The unsatisfied criterion blocks on its own; there is no P1 for the
+        AC-violation override to re-block, so approval must be refused on the
+        matches_spec=false signal directly."""
+        base = _make_config(tmp_path)
+        # Single review cycle so one REQUEST_CHANGES-equivalent exhausts the budget.
+        config = dataclasses.replace(
+            base, retry=dataclasses.replace(base.retry, max_review_cycles=1)
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_changed_files.return_value = frozenset(["src/changed.py"])
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Fixed.")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_pool.return_value = [
+            _make_agent_result(
+                success=True, output=_APPROVE_MATCHES_SPEC_FALSE_NO_P1, profile_name="review"
+            )
+        ]
+
+        result = run_from_review(config, task, workspace)
+
+        # Must NOT be approved to DONE despite the APPROVE verdict.
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE

--- a/tests/test_coord_review_ac_blocking.py
+++ b/tests/test_coord_review_ac_blocking.py
@@ -433,3 +433,54 @@ class TestNetNewAcBlocking:
         # Must NOT be approved to DONE despite the APPROVE verdict.
         assert result.success is False
         assert result.phase == Phase.ESCALATE
+
+    @patch("theforge.coordinator.util._run_worktree_eval", side_effect=_in_process_worktree_eval)
+    @patch("theforge.finding_classifier._get_changed_files")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_matches_spec_false_blocks_even_via_zero_findings_early_termination(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_changed_files,
+        mock_eval,
+        tmp_path,
+    ):
+        """The zero-findings early-termination branch must not finalize DONE when the
+        merged review reports matches_spec=false. The unsatisfied criterion is folded
+        into _blocking_p1 before the early-termination check, so convergence with an
+        unsatisfied criterion escalates rather than passing."""
+        base = _make_config(tmp_path)
+        config = dataclasses.replace(
+            base,
+            retry=dataclasses.replace(
+                base.retry, max_review_cycles=4, review_zero_findings_stop=2
+            ),
+            review_pool=[_make_review_profile("review", budget_usd=2.0)],
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_changed_files.return_value = frozenset(["src/changed.py"])
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Fixed.")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        # Every cycle: APPROVE + matches_spec=false + zero findings → zero new
+        # findings each cycle → early-termination fires on cycle 2.
+        mock_pool.return_value = [
+            _make_agent_result(
+                success=True, output=_APPROVE_MATCHES_SPEC_FALSE_NO_P1, profile_name="review"
+            )
+        ]
+
+        result = run_from_review(config, task, workspace)
+
+        # Early termination converged, but the unsatisfied criterion blocks → ESCALATE.
+        assert result.state.review_early_terminated is True
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE

--- a/tests/test_coord_review_gate_contradiction.py
+++ b/tests/test_coord_review_gate_contradiction.py
@@ -157,6 +157,59 @@ test_coverage:
 ```
 """
 
+# Observed trail (story #1425): the finding mentions "test suite" — a substring the
+# old keyword list would downgrade on — but asserts that acceptance evidence was
+# never produced (inadequate coverage), which a green gate cannot contradict.
+# The reviewer also returned matches_spec=false.
+_CYCLE2_INADEQUATE_ACCEPTANCE_AC_FALSE = """\
+```yaml
+verdict: REQUEST_CHANGES
+summary: "Acceptance evidence missing."
+findings:
+  - severity: P1
+    file: src/unchanged.py
+    line: 438
+    observed: "test suite only exercises mocked diagnose output; no run shown within budget"
+    expected: "Behaviour conforms to project contract for this category of inputs."
+    evidence: "(test fixture evidence)"
+    suggestion: "Demonstrate a live diagnose run"
+story_compliance:
+  matches_spec: false
+  mismatches:
+    - "AC3: live sparse-body diagnose run never demonstrated"
+test_coverage:
+  adequate: false
+  gaps:
+    - "no live diagnose run exercised"
+```
+"""
+
+# Same inadequate-coverage finding, but the reviewer returned matches_spec=true.
+# The old keyword list ("test suite") would still have downgraded this to
+# gate_contradicted → net_new_pass → DONE. Assertion-based classification must
+# refuse the downgrade so it keeps blocking on its own merits.
+_CYCLE2_INADEQUATE_ACCEPTANCE_AC_TRUE = """\
+```yaml
+verdict: REQUEST_CHANGES
+summary: "Acceptance evidence missing."
+findings:
+  - severity: P1
+    file: src/unchanged.py
+    line: 438
+    observed: "test suite only exercises mocked diagnose output; no run shown within budget"
+    expected: "Behaviour conforms to project contract for this category of inputs."
+    evidence: "(test fixture evidence)"
+    suggestion: "Demonstrate a live diagnose run"
+story_compliance:
+  matches_spec: true
+  mismatches: []
+test_coverage:
+  adequate: false
+  gaps:
+    - "no live diagnose run exercised"
+```
+"""
+
 
 def _in_process_worktree_eval(
     workspace_path: Path, command: str, payload: dict, timeout: int = 120
@@ -307,7 +360,7 @@ class TestGateContradiction:
         mock_eval,
         tmp_path,
     ):
-        """gate_contradicted findings appear in finding_registry at original P1 severity."""
+        """gate_contradicted findings appear in finding_registry and are legible as suppressed."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
@@ -330,10 +383,13 @@ class TestGateContradiction:
         assert downgraded[0]["severity"] == "P1"
         assert "test failure" in downgraded[0]["description"].lower()
 
-        # Must NOT appear in non_blocking_p1s (which only lists net_new disposition)
+        # Suppression must be legible in the audit trail: the gate_contradicted P1
+        # appears in non_blocking_p1s (where waived findings are looked for) with
+        # its real disposition preserved, not flattened to net_new or omitted.
         non_blocking = audit["non_blocking_p1s"]
-        non_blocking_ids = {r["finding_id"] for r in non_blocking}
-        assert downgraded[0]["finding_id"] not in non_blocking_ids
+        suppressed = [r for r in non_blocking if r["finding_id"] == downgraded[0]["finding_id"]]
+        assert len(suppressed) == 1
+        assert suppressed[0]["disposition"] == "gate_contradicted"
 
     @patch("theforge.coordinator.util._run_worktree_eval", side_effect=_in_process_worktree_eval)
     @patch("theforge.finding_classifier._get_changed_files")
@@ -421,3 +477,85 @@ class TestGateContradiction:
             r for r in result.state.finding_registry if r.disposition == "gate_contradicted"
         ]
         assert len(contradicted) == 0
+
+    @patch("theforge.coordinator.util._run_worktree_eval", side_effect=_in_process_worktree_eval)
+    @patch("theforge.finding_classifier._get_changed_files")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_inadequate_acceptance_p1_blocks_despite_gate_pass_and_keyword(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_changed_files,
+        mock_eval,
+        tmp_path,
+    ):
+        """Replay of the observed trail: a P1 mentioning "test suite" but asserting
+        inadequate acceptance evidence, with reviewer matches_spec=false and a PASS
+        gate, must NOT be suppressed — it blocks and the story escalates, not DONE."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_changed_files.return_value = frozenset(["src/changed.py"])
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Fixed.")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_pool.side_effect = self._two_cycle_pool(_CYCLE2_INADEQUATE_ACCEPTANCE_AC_FALSE)
+
+        result = run_from_review(config, task, workspace)
+
+        # The finding is not gate-contradictable: story must escalate, not reach DONE.
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.review_cycle == 2
+
+        # The finding must be recorded as blocking (ac_blocking), never gate_contradicted.
+        recs = [r for r in result.state.finding_registry if "test suite" in r.description]
+        assert len(recs) == 1
+        assert recs[0].disposition == "ac_blocking"
+
+    @patch("theforge.coordinator.util._run_worktree_eval", side_effect=_in_process_worktree_eval)
+    @patch("theforge.finding_classifier._get_changed_files")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_inadequate_acceptance_keyword_not_downgraded_even_when_ac_true(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_changed_files,
+        mock_eval,
+        tmp_path,
+    ):
+        """Even with matches_spec=true, a "test suite"-mentioning inadequate-coverage
+        P1 must not be downgraded to gate_contradicted on a PASS gate. It keeps
+        blocking on its own merits (net-new bypass disabled by default)."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_changed_files.return_value = frozenset(["src/changed.py"])
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Fixed.")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_pool.side_effect = self._two_cycle_pool(_CYCLE2_INADEQUATE_ACCEPTANCE_AC_TRUE)
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+
+        # The keyword-matching finding must NOT be suppressed as gate_contradicted.
+        recs = [r for r in result.state.finding_registry if "test suite" in r.description]
+        assert len(recs) == 1
+        assert recs[0].disposition != "gate_contradicted"

--- a/tests/test_gate_contradiction_assertion.py
+++ b/tests/test_gate_contradiction_assertion.py
@@ -1,0 +1,67 @@
+"""Unit tests for assertion-based gate-contradiction classification.
+
+A PASS gate contradicts exactly one class of claim: that tests/build/lint are
+currently FAILING. It has no bearing on a claim that coverage is inadequate,
+that acceptance evidence was never produced, or that a criterion remains
+undemonstrated. ``asserts_gate_verifiable_failure`` must distinguish what a
+finding *asserts* from what it is *about*, and fail closed.
+"""
+
+from __future__ import annotations
+
+from theforge.coordinator.gate_contradiction import asserts_gate_verifiable_failure
+
+
+class TestAssertsGateVerifiableFailure:
+    """Only positive failure assertions are gate-contradictable; everything else blocks."""
+
+    def test_positive_test_failure_assertion(self):
+        assert asserts_gate_verifiable_failure("Test failure: 435 tests fail with ReferenceError")
+
+    def test_positive_build_error_assertion(self):
+        assert asserts_gate_verifiable_failure("Build error in compilation step prevents deploy")
+
+    def test_positive_lint_failure_assertion(self):
+        assert asserts_gate_verifiable_failure("Lint fail: unused import in module")
+
+    def test_positive_does_not_compile(self):
+        assert asserts_gate_verifiable_failure("The module does not compile after this change")
+
+    def test_observed_inadequate_coverage_is_not_contradictable(self):
+        """The exact shape that was wrongly suppressed: mentions tests, asserts inadequacy."""
+        desc = (
+            "The changed test suite only exercises mocked diagnose output and prompt "
+            "string contents, so no sparse-body diagnose run on a representative "
+            "landing-failure bug is shown to complete within budget."
+        )
+        assert not asserts_gate_verifiable_failure(desc)
+
+    def test_missing_acceptance_evidence_is_not_contradictable(self):
+        desc = "The third acceptance criterion is never demonstrated by any test."
+        assert not asserts_gate_verifiable_failure(desc)
+
+    def test_inadequate_coverage_wording_is_not_contradictable(self):
+        desc = "Test coverage is inadequate; the new branch is not exercised."
+        assert not asserts_gate_verifiable_failure(desc)
+
+    def test_gate_self_indictment_is_not_contradictable(self):
+        """A finding indicting the gate must never be dismissed on the gate's authority."""
+        desc = (
+            "Gate success detection substring-matches '0 failed' and would report PASS "
+            "while ten or more tests fail."
+        )
+        assert not asserts_gate_verifiable_failure(desc)
+
+    def test_test_double_detection_indictment_is_not_contradictable(self):
+        desc = "The validation gate branches its behavior on test-double detection."
+        assert not asserts_gate_verifiable_failure(desc)
+
+    def test_subject_only_mention_is_not_contradictable(self):
+        """Bare subject matter ('test suite') with no failure predicate keeps blocking."""
+        assert not asserts_gate_verifiable_failure("The test suite covers the handler path.")
+
+    def test_design_finding_unrelated_to_tests(self):
+        assert not asserts_gate_verifiable_failure("Missing validation in the data pipeline.")
+
+    def test_fails_closed_on_empty_description(self):
+        assert not asserts_gate_verifiable_failure("")


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved: matches_spec=false is folded into the blocking signal before all DONE exits, and the observed gate_contradicted suppression path now remains blocking and audited. | [google-gemini-3.5-flash] The implementation of assertion-based gate-contradiction classification and the matches_spec=false blocking logic is exceptionally clean, robust, and fully compliant with all acceptance criteria. | [claude-sonnet] Both prior-cycle P1s are resolved. Commit 8f1e3ac closed the zero-P1 APPROVE+matches_spec=false gap; commit b3af3d2 fixes the newly-surfaced regression where the zero-findings early-termination branch could finalize DONE ahead of the criterion check, by folding the unsatisfied-criterion signal into _blocking_p1 as the single approval gate before trajectory classification and early termination. _effective_approve is now reduced to not _blocking_p1, so no DONE-exit path can re-derive the check independently. Full review/audit/gate-contradiction suite (1000 tests) passes; no regressions found in the touched files.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $23.38
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Review classifier suppresses a correct P1 via keyword-matched gate_contradicted — story with matches_spec=false reaches DONE instead of escalating (GitHub Issue #1734)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1734