### PR TITLE
Dev-iteration timeout is terminal: story escalates with unused iterations and reports 'exit=-9', discarding the runner's TIMEOUT message

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -825,7 +825,10 @@ def _run_dev_phase(
         if any(result.cost_usd is not None for result in _dev_results_this_iteration)
         else "unknown"
     )
-    _log(f"  ✓ DEV   {_dev_cost_str}  {_fmt_duration(_dev_elapsed)}")
+    # Glyph reflects the actual outcome: a killed or crashed iteration must not
+    # be rendered with the success glyph one line above the failure it caused.
+    _dev_glyph = "✓" if dev_result.success else "✗"
+    _log(f"  {_dev_glyph} DEV   {_dev_cost_str}  {_fmt_duration(_dev_elapsed)}")
     if logger:
         logger._safe_emit(
             "phase_end",
@@ -934,7 +937,56 @@ def _run_dev_phase(
             )
 
     if not dev_result.success:
-        _log_verbose(f"Dev agent failed (exit={dev_result.exit_code})")
+        _is_timeout = dev_result.failure_code == "timeout"
+        # The signal number records only what was done to the process, not what
+        # went wrong. When the runner already explained the failure in words
+        # (e.g. "TIMEOUT: Agent exceeded 900s limit"), surface that instead of
+        # the raw exit code so the operator is not left to reconstruct a fact
+        # the system already had.
+        _failure_detail = (
+            dev_result.output.strip()
+            if _is_timeout and dev_result.output and dev_result.output.strip()
+            else f"exit={dev_result.exit_code}"
+        )
+        _log_verbose(f"Dev agent failed ({_failure_detail})")
+        # ── Timeout retry (iterations remaining) ─────────────────────────
+        # A per-iteration timeout is a retryable failure, not a terminal
+        # escalation. Running out of time is not the same event as crashing or
+        # producing wrong work: it is ordinarily retryable and arrives with its
+        # own explanation. Where dev iterations remain, spend one and re-enter
+        # dev with the timeout and its limit stated in context rather than
+        # ending the story with unused budget. The empty-diff guard's job is to
+        # keep a zero-commit run from reaching APPROVE — it must not also become
+        # the thing that declares a story terminal while a safe outcome (another
+        # attempt) remained available. #1216 established this for the gate; it
+        # applies equally to the dev phase.
+        if _is_timeout and not state.budget.is_exhausted():
+            state.retry_reason = RetryReason.TIMEOUT_RESUME
+            state.human_feedback = (
+                f"Your previous dev iteration was cut off by a timeout: {_failure_detail}. "
+                "Continue from where you left off. Commit the work you already have "
+                "before doing anything else, then narrow the remaining scope so you "
+                "finish within the time limit."
+            )
+            record_dev_iteration_telemetry(
+                state,
+                workspace_path,
+                max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
+                gate_result="DEV_TIMEOUT",
+                is_timeout=True,
+            )
+            _log(
+                f"  ✗ DEV   TIMEOUT  (iter={state.dev_iteration} → retrying dev; "
+                f"{state.budget.remaining()} iteration(s) remaining)"
+            )
+            if logger:
+                logger._safe_emit(
+                    "phase_end",
+                    phase="DEV",
+                    outcome="timeout_retry",
+                    iteration=state.dev_iteration,
+                )
+            return None
         # ── Zero-commit guard (any failed dev iteration) ─────────────────
         # If the dev agent exited with failure (non-zero or signal-killed) and
         # the worktree has no new commits ahead of base, escalate immediately
@@ -942,7 +994,7 @@ def _run_dev_phase(
         if not _has_commits_ahead_of_base(workspace_path, config.workspace.base_branch):
             state.phase = Phase.ESCALATE
             state.error = (
-                f"Dev agent failed (exit={dev_result.exit_code}) and produced no commits "
+                f"Dev agent failed ({_failure_detail}) and produced no commits "
                 "ahead of base — escalating to avoid an empty-diff APPROVE"
             )
             record_dev_iteration_telemetry(

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -456,7 +456,14 @@ def _coordinator_loop(
                     message=state.error,
                 )
 
-            if state.retry_reason == RetryReason.MAX_ITERATIONS_NO_SUBMIT:
+            # A dev-phase timeout retry (iterations remaining) re-enters DEV
+            # directly rather than routing through VALIDATE — the timed-out
+            # iteration may have produced no commits, and validating an
+            # unchanged worktree is pointless. Mirror the MAX_ITERATIONS retry.
+            if state.retry_reason in (
+                RetryReason.MAX_ITERATIONS_NO_SUBMIT,
+                RetryReason.TIMEOUT_RESUME,
+            ):
                 continue
 
             # ── Scrub forge-artifact commits from branch history ──

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -616,6 +616,11 @@ class AgentLoopManager:
         failure_code = None
         if reason.startswith("Agent loop terminated: max iterations reached"):
             failure_code = "max_iterations_reached"
+        elif reason.startswith("Agent loop terminated: wall-clock timeout"):
+            # Running out of wall-clock time is a distinct, retryable failure
+            # kind — classified so the coordinator hands back to dev with the
+            # remaining iteration budget rather than escalating terminally.
+            failure_code = "timeout"
         elif reason.startswith("Agent finished without calling submit tool"):
             # The agent completed its turn cleanly but delivered no verdict —
             # a non-verdict/behavioral completion, distinct from a transport

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -103,6 +103,9 @@ def _handle_exception(
             exit_code=-1,
             raw={},
             profile_name=profile.name,
+            # A timeout is a distinct, retryable failure kind — classify it so
+            # the coordinator can hand back to dev instead of escalating.
+            failure_code="timeout",
         )
     if isinstance(exc, FileNotFoundError):
         return AgentResult(

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -742,6 +742,7 @@ def _run_claude(
             raw={},
             profile_name=profile.name,
             model_usage=_timeout_usage,
+            failure_code="timeout",
             dev_handoff=_try_parse_handoff(partial_output),
         )
 

--- a/tests/test_coord_dev_timeout_retry.py
+++ b/tests/test_coord_dev_timeout_retry.py
@@ -16,27 +16,40 @@ from __future__ import annotations
 
 import contextlib
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from theforge.config import (
+sys.path.insert(0, str(Path(__file__).parent))
+
+from coord_test_helpers import (  # noqa: E402
+    _PREFLIGHT_RESULT,
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.config import (  # noqa: E402
     DEFAULT_DEV_PROFILE,
     DEFAULT_PREFLIGHT_PROFILE,
     DEFAULT_REVIEW_PROFILE,
     DEFAULT_VALIDATION,
     ForgeConfig,
     LogConfig,
+    ModelProfile,
     RetryPolicy,
     WorkspaceConfig,
 )
-from theforge.coordinator.state import (
+from theforge.coordinator.engine import run_task  # noqa: E402
+from theforge.coordinator.state import (  # noqa: E402
     CoordinatorResult,
     CoordinatorState,
     Phase,
     RetryReason,
 )
-from theforge.runners import AgentResult
-from theforge.task import TaskStory
+from theforge.runners import AgentResult  # noqa: E402
+from theforge.task import TaskStory  # noqa: E402
 
 _TIMEOUT_OUTPUT = "TIMEOUT: Agent exceeded 900s limit"
 
@@ -203,3 +216,114 @@ def test_killed_iteration_not_rendered_with_success_glyph(tmp_path: Path) -> Non
     phase_line = next(m for m in dev_lines if "m " in m or "s" in m)
     assert "✓ DEV" not in phase_line
     assert "✗ DEV" in phase_line
+
+
+# ── Seam test: timeout retry through the engine loop into a 2nd DEV ──────
+
+
+def _make_seam_config(tmp_path: Path) -> ForgeConfig:
+    dev_profile = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=30.0,
+        timeout_seconds=900,
+        timeout_medium_seconds=1200,
+        timeout_large_seconds=1800,
+        allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
+    )
+    review_profile = ModelProfile(
+        name="claude-opus",
+        cli="claude",
+        model="opus",
+        budget_usd=10.0,
+        timeout_seconds=300,
+        allowed_tools=("Read", "Bash", "Glob", "Grep"),
+    )
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev_profile,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[review_profile],
+        synthesis_profile=None,
+        retry=RetryPolicy(
+            max_dev_iterations=3,
+            max_review_cycles=2,
+            auto_model_escalation=True,
+        ),
+        models=["claude/sonnet", "claude/opus"],
+    )
+
+
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.dev_phase.run_agent")
+@patch("theforge.coordinator.util._run_shell")
+def test_timeout_retry_reenters_dev_through_engine_loop(
+    mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+) -> None:
+    """Full DEV→(retry)→DEV seam: a dev timeout on the first call re-enters DEV
+    directly (skipping VALIDATE) and the second DEV prompt carries the timeout
+    text and its limit.
+
+    This is the engine-level regression the unit tests above cannot cover: the
+    timeout must flow through run_task's coordinator loop into a *second* DEV
+    invocation, not merely be handled at the dev-phase boundary in isolation.
+    """
+    config = _make_seam_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir()
+
+    # The retry path skips VALIDATE after the timeout, so the gate only runs
+    # once — after the second (successful) DEV call.
+    mock_shell.side_effect = _shell_with_gate(workspace, ["PASS"])
+
+    dev_calls: list[dict] = []
+
+    def dev_side_effect(**kwargs):
+        dev_calls.append({"prompt": kwargs.get("prompt"), "profile": kwargs.get("profile")})
+        if len(dev_calls) == 1:
+            # First call: killed at its per-iteration timeout (SIGKILL, exit -9).
+            return AgentResult(
+                success=False,
+                output=_TIMEOUT_OUTPUT,
+                session_id="sess-1",
+                cost_usd=0.10,
+                exit_code=-9,
+                raw={},
+                profile_name="dev",
+                failure_code="timeout",
+            )
+        # Second call: continues from the timeout and succeeds.
+        return _make_agent_result(success=True, output="Done.", session_id="sess-1")
+
+    mock_preflight.return_value = _PREFLIGHT_RESULT
+    mock_dev.side_effect = dev_side_effect
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+    ]
+
+    result = run_task(config, task)
+
+    # ── Boundary: the run continues rather than ending on the timeout ──
+    assert result.success is True, f"Expected success, got: {result.message}"
+
+    # ── Boundary: exactly two DEV invocations occurred ─────────────────
+    assert len(dev_calls) == 2, f"Expected 2 dev calls, got {len(dev_calls)}"
+
+    # ── Boundary: the timeout and its limit reach the 2nd DEV prompt ───
+    second_prompt = dev_calls[1]["prompt"] or ""
+    assert "TIMEOUT" in second_prompt
+    assert "900s" in second_prompt
+
+    # ── Boundary: this was the dev-phase timeout retry, NOT the VALIDATE
+    # model-escalation path — no model escalation should have fired. ───
+    assert result.state.timeout_escalation_used is False

--- a/tests/test_coord_dev_timeout_retry.py
+++ b/tests/test_coord_dev_timeout_retry.py
@@ -1,0 +1,205 @@
+"""Tests for the DEV-phase timeout-retry seam.
+
+A dev iteration killed at its per-iteration timeout is a *retryable* failure,
+not a terminal escalation. While dev iterations remain, the coordinator must
+spend one and re-enter DEV with the timeout and its limit stated in context,
+rather than letting the zero-commit guard declare the story terminal with
+unused budget (issue #1745). Only once the iteration budget is exhausted does a
+timeout escalate — and the recorded error then names the timeout and its limit
+rather than the raw signal number.
+
+The empty-diff guard's job (keep a zero-commit run from reaching APPROVE) is
+preserved: a terminal timeout with no commits still escalates.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import (
+    CoordinatorResult,
+    CoordinatorState,
+    Phase,
+    RetryReason,
+)
+from theforge.runners import AgentResult
+from theforge.task import TaskStory
+
+_TIMEOUT_OUTPUT = "TIMEOUT: Agent exceeded 900s limit"
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+            base_branch="main",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        preflight_fallback_profile=None,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=3, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _timeout_agent_result() -> AgentResult:
+    """A dev agent killed at its per-iteration timeout (SIGKILL, exit -9)."""
+    return AgentResult(
+        success=False,
+        output=_TIMEOUT_OUTPUT,
+        session_id="sess-abc",
+        cost_usd=0.5,
+        exit_code=-9,
+        raw={},
+        profile_name="dev",
+        failure_code="timeout",
+    )
+
+
+def _crash_agent_result() -> AgentResult:
+    """A dev agent that crashed (non-timeout failure)."""
+    return AgentResult(
+        success=False,
+        output="",
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=-2,
+        raw={},
+        profile_name="dev",
+    )
+
+
+def _setup(tmp_path: Path) -> tuple[ForgeConfig, TaskStory, CoordinatorState]:
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    spec = tmp_path / "specs" / "t.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# t\n", encoding="utf-8")
+    state = CoordinatorState()
+    state.adaptive_dev_max = 3
+    return config, task, state
+
+
+def _run_dev(config, task, state, tmp_path, agent_result, captured_logs=None):
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", return_value=agent_result)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        if captured_logs is not None:
+            stack.enter_context(
+                patch(
+                    "theforge.coordinator.dev_phase._log",
+                    new=lambda msg: captured_logs.append(msg),
+                )
+            )
+        return _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+
+
+def test_timeout_with_iterations_remaining_retries_not_escalates(tmp_path: Path) -> None:
+    """A timeout with budget remaining consumes one iteration and re-enters DEV."""
+    config, task, state = _setup(tmp_path)
+    # Budget for 3 dev iterations; this is the first — two remain after it.
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    result = _run_dev(config, task, state, tmp_path, _timeout_agent_result())
+
+    # Signals the engine loop to re-enter DEV rather than ending the story.
+    assert result is None
+    assert state.phase != Phase.ESCALATE
+    assert state.retry_reason == RetryReason.TIMEOUT_RESUME
+    # The timeout and its limit reach the next dev iteration's context.
+    assert "TIMEOUT" in (state.human_feedback or "")
+    assert "900s" in (state.human_feedback or "")
+    # The killed iteration is counted as spent.
+    assert len(state.dev_iteration_telemetry) == 1
+    assert state.dev_iteration_telemetry[-1].is_timeout is True
+
+
+def test_timeout_when_iterations_exhausted_escalates_naming_timeout(tmp_path: Path) -> None:
+    """A timeout with no budget left escalates, naming the timeout not the signal."""
+    config, task, state = _setup(tmp_path)
+    # Only one iteration allowed; consuming it exhausts the budget.
+    state.budget.max_iterations = 1
+    state.budget.consume(review_cycle=0)
+
+    result = _run_dev(config, task, state, tmp_path, _timeout_agent_result())
+
+    assert isinstance(result, CoordinatorResult)
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    # Empty-diff guard still blocks a zero-commit run from reaching APPROVE.
+    assert "no commits ahead of base" in (state.error or "")
+    # The recorded error names the timeout and its limit, not the signal number.
+    assert _TIMEOUT_OUTPUT in (state.error or "")
+    assert "exit=-9" not in (state.error or "")
+
+
+def test_non_timeout_failure_escalates_even_with_iterations_remaining(tmp_path: Path) -> None:
+    """Only timeouts retry; a crash with no commits still escalates immediately."""
+    config, task, state = _setup(tmp_path)
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    result = _run_dev(config, task, state, tmp_path, _crash_agent_result())
+
+    assert isinstance(result, CoordinatorResult)
+    assert state.phase == Phase.ESCALATE
+    assert state.retry_reason != RetryReason.TIMEOUT_RESUME
+    assert "no commits ahead of base" in (state.error or "")
+    # A crash carries no runner explanation, so the exit code is the best signal.
+    assert "exit=-2" in (state.error or "")
+
+
+def test_killed_iteration_not_rendered_with_success_glyph(tmp_path: Path) -> None:
+    """The DEV phase-line glyph reflects the actual outcome of a killed run."""
+    config, task, state = _setup(tmp_path)
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+    logs: list[str] = []
+
+    _run_dev(config, task, state, tmp_path, _timeout_agent_result(), captured_logs=logs)
+
+    dev_lines = [m for m in logs if "DEV" in m and ("✓" in m or "✗" in m)]
+    assert dev_lines, "expected a DEV phase-line to be logged"
+    phase_line = next(m for m in dev_lines if "m " in m or "s" in m)
+    assert "✓ DEV" not in phase_line
+    assert "✗ DEV" in phase_line

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -356,6 +356,10 @@ class TestRunAgentClaude:
         assert result.success is False
         assert "TIMEOUT" in result.output
         assert result.exit_code == -9
+        # A timeout is a distinct, retryable failure kind — not an
+        # undifferentiated crash. The coordinator keys its retry decision off
+        # failure_code, so the runner must classify it.
+        assert result.failure_code == "timeout"
 
     def test_timeout_returns_session_id(self, tmp_path: Path) -> None:
         profile = ModelProfile(


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 is resolved: the new engine-level seam test drives a dev timeout through run_task into a second DEV prompt carrying TIMEOUT/900s, and I found no blocking regressions. | [google-gemini-3.5-flash] The dev-iteration timeout retry logic is fully implemented, and the prior P1 finding is resolved with a robust engine-level seam integration test.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $6.33
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Dev-iteration timeout is terminal: story escalates with unused iterations and reports 'exit=-9', discarding the runner's TIMEOUT message (GitHub Issue #1745)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1745