### PR TITLE
Coordinator should checkpoint-commit a killed/failed dev iteration's worktree before escalating — work stranded as uncommitted state is invisible to every commit-based mechanism

### DIFF
--- a/src/theforge/coordinator/commit_guard.py
+++ b/src/theforge/coordinator/commit_guard.py
@@ -4,12 +4,22 @@ A dev iteration that produces zero commits ahead of the base branch must not
 flow through to APPROVE/DONE. The guards in this module are invoked at the
 DEV → VALIDATE, VALIDATE → REVIEW, and REVIEW → DONE seams to escalate empty
 runs early instead of letting integration silently skip PR creation.
+
+This module also owns the checkpoint-commit that preserves a killed/failed dev
+iteration's uncommitted work before those guards run: work stranded as
+working-tree state is invisible to every commit-reasoning mechanism, so the
+coordinator commits it first (the agent may be gone — SIGKILL — but the
+coordinator owns the worktree).
 """
 
 from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+
+# Fixed subject marking a coordinator checkpoint commit. Kept distinct from any
+# normal dev commit message so the commit is identifiable in history and audit.
+CHECKPOINT_COMMIT_SUBJECT = "chore(checkpoint): coordinator-preserved dev iteration work"
 
 
 def _has_commits_ahead_of_base(workspace_path: Path, base_branch: str) -> bool:
@@ -66,3 +76,89 @@ def _commits_exist_strict(workspace_path: Path, base_branch: str) -> bool:
         except ValueError:
             continue
     return False
+
+
+def _worktree_has_changes(workspace_path: Path) -> bool:
+    """Return True if the worktree has any uncommitted changes.
+
+    Covers tracked edits, staged content, and untracked files (anything
+    ``git status --porcelain`` reports). Fail-closed: returns False on any git
+    error. A checkpoint commit is only worth attempting when the worktree is
+    positively confirmed dirty; if status cannot be read there is nothing safe
+    to preserve, and returning False leaves the existing empty-diff guard's
+    behaviour unchanged.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(workspace_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    if proc.returncode != 0:
+        return False
+    return bool(proc.stdout.strip())
+
+
+def _checkpoint_commit(workspace_path: Path, reason: str) -> bool:
+    """Commit the worktree's uncommitted changes as a coordinator checkpoint.
+
+    Preserves whatever a killed or failed dev iteration produced as a real
+    commit on the story branch, so every commit-reasoning mechanism — the
+    zero-commit guard, the next iteration, integration, and the audit trail —
+    can see it. The commit is authored by the coordinator process; a
+    SIGKILLed agent cannot commit its own work.
+
+    The entire transient ``.forge`` directory (traces, quarantine, handoff,
+    sessions) is unstaged after staging so the checkpoint captures only real
+    work. A commit is created only when there is staged content after that: a
+    truly empty iteration produces no commit and this returns False, leaving the
+    empty-diff guard to escalate as before. The subject is the fixed
+    :data:`CHECKPOINT_COMMIT_SUBJECT` marker so the commit is distinguishable
+    from a normal dev commit; ``reason`` (the failure detail) is recorded in the
+    commit body. Returns True iff a commit was made.
+    """
+    try:
+        add = subprocess.run(
+            ["git", "add", "-A"],
+            cwd=str(workspace_path),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if add.returncode != 0:
+            return False
+        # Unstage the whole transient .forge directory (traces, quarantine,
+        # handoff, sessions) that `git add -A` may have picked up when it is not
+        # gitignored, so no forge state enters the checkpoint. No-op when
+        # nothing under .forge is staged.
+        subprocess.run(
+            ["git", "reset", "-q", "--", ".forge"],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=10,
+        )
+        # Nothing staged after excluding .forge → no real work to preserve; do
+        # not create an empty commit.
+        staged = subprocess.run(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=10,
+        )
+        if staged.returncode == 0:
+            return False
+        body = (reason or "").strip()[:2000] or "no failure detail available"
+        commit = subprocess.run(
+            ["git", "commit", "-m", CHECKPOINT_COMMIT_SUBJECT, "-m", body],
+            cwd=str(workspace_path),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return commit.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -21,7 +21,12 @@ from theforge.sessions import save_sessions
 from theforge.task import ContextAssembler, TaskStory, build_dev_prompt, build_fix_prompt
 from theforge.traces import write_trace
 
-from .commit_guard import _commits_exist_strict, _has_commits_ahead_of_base
+from .commit_guard import (
+    _checkpoint_commit,
+    _commits_exist_strict,
+    _has_commits_ahead_of_base,
+    _worktree_has_changes,
+)
 from .gate import _is_gate_skip
 from .logging import StructuredLogger
 from .notify import _escalate_notify
@@ -949,6 +954,31 @@ def _run_dev_phase(
             else f"exit={dev_result.exit_code}"
         )
         _log_verbose(f"Dev agent failed ({_failure_detail})")
+        # ── Checkpoint-commit stranded work (#1746) ──────────────────────
+        # A killed/failed dev iteration may leave correct work as uncommitted
+        # working-tree state that every commit-reasoning mechanism below is
+        # blind to: the timeout-retry (which would restart from an empty
+        # base), the zero-commit guard (which would escalate on a diff that is
+        # not actually empty), integration, and the audit trail. The agent may
+        # already be gone (SIGKILL); the coordinator owns the worktree and is
+        # the only party still alive able to commit. Preserve whatever was
+        # produced as a checkpoint commit BEFORE any retry/escalate decision
+        # runs. Committing only happens when the worktree is genuinely dirty,
+        # so a truly empty iteration still escalates as before.
+        if _worktree_has_changes(workspace_path):
+            _checkpointed = _checkpoint_commit(workspace_path, _failure_detail)
+            if _checkpointed:
+                _log(
+                    f"  ⎇ DEV   checkpoint-committed stranded work before "
+                    f"failure handling ({_failure_detail})"
+                )
+                if logger:
+                    logger._safe_emit(
+                        "dev_checkpoint_commit",
+                        phase="DEV",
+                        iteration=state.dev_iteration,
+                        reason=_failure_detail,
+                    )
         # ── Timeout retry (iterations remaining) ─────────────────────────
         # A per-iteration timeout is a retryable failure, not a terminal
         # escalation. Running out of time is not the same event as crashing or
@@ -964,9 +994,10 @@ def _run_dev_phase(
             state.retry_reason = RetryReason.TIMEOUT_RESUME
             state.human_feedback = (
                 f"Your previous dev iteration was cut off by a timeout: {_failure_detail}. "
-                "Continue from where you left off. Commit the work you already have "
-                "before doing anything else, then narrow the remaining scope so you "
-                "finish within the time limit."
+                "Any work you had already produced was checkpoint-committed for you, so "
+                "the branch already contains it — continue from that committed state rather "
+                "than redoing it. Narrow the remaining scope so you finish within the time "
+                "limit."
             )
             record_dev_iteration_telemetry(
                 state,

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -911,6 +911,28 @@ def _run_dev_phase(
                 "the same exploratory loop. Narrow scope, stabilize the worktree, and submit a "
                 "structured result promptly."
             )
+            # Preserve any partial edits before retrying (#1746). Like the
+            # timeout resume below, this is another retry-with-possibly-dirty-
+            # worktree case: the agent burned its internal iteration budget
+            # without committing, so whatever it produced is uncommitted
+            # working-tree state the next attempt would otherwise branch from as
+            # if empty. Checkpoint it so the retry continues from committed work.
+            if _worktree_has_changes(workspace_path):
+                _checkpointed = _checkpoint_commit(
+                    workspace_path, "max_iterations_reached without submit"
+                )
+                if _checkpointed:
+                    _log(
+                        "  ⎇ DEV   checkpoint-committed stranded work before "
+                        "max-iterations retry"
+                    )
+                    if logger:
+                        logger._safe_emit(
+                            "dev_checkpoint_commit",
+                            phase="DEV",
+                            iteration=state.dev_iteration,
+                            reason="max_iterations_reached",
+                        )
             return None
 
     if (

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -923,8 +923,7 @@ def _run_dev_phase(
                 )
                 if _checkpointed:
                     _log(
-                        "  ⎇ DEV   checkpoint-committed stranded work before "
-                        "max-iterations retry"
+                        "  ⎇ DEV   checkpoint-committed stranded work before max-iterations retry"
                     )
                     if logger:
                         logger._safe_emit(

--- a/tests/test_coord_commit_guard.py
+++ b/tests/test_coord_commit_guard.py
@@ -397,6 +397,71 @@ def test_dev_phase_timeout_retry_starts_from_checkpointed_work(tmp_path: Path) -
     assert _has_commits_ahead_of_base(tmp_path, "main") is True
 
 
+def _make_max_iterations_agent_result() -> AgentResult:
+    """Simulate a dev agent that exhausted its internal iteration budget without
+    ever calling submit — no structured handoff, partial edits left uncommitted."""
+    return AgentResult(
+        success=False,
+        output="ran out of iterations",
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=1,
+        raw={},
+        profile_name="dev",
+        failure_code="max_iterations_reached",
+        dev_handoff=None,
+    )
+
+
+def test_dev_phase_checkpoints_max_iterations_no_submit_before_retry(tmp_path: Path) -> None:
+    """A max_iterations-without-submit iteration retries via return None; its
+    partial edits must be checkpoint-committed first so the retry continues from
+    committed work rather than branching from a falsely-empty base."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+    state.budget.max_iterations = 2
+
+    spec = tmp_path / "specs" / "t.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# t\n", encoding="utf-8")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+    from theforge.coordinator.state import RetryReason
+
+    def _burn_budget_after_editing(*_args, **_kwargs):
+        (tmp_path / "partial_fix.py").write_text("def half_done():\n    return None\n")
+        return _make_max_iterations_agent_result()
+
+    with (
+        patch(
+            "theforge.coordinator.dev_phase.run_agent",
+            side_effect=_burn_budget_after_editing,
+        ),
+        patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock()),
+    ):
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+
+    assert result is None  # retry, not terminal
+    assert state.retry_reason == RetryReason.MAX_ITERATIONS_NO_SUBMIT
+    # The partial work was checkpoint-committed before the retry.
+    assert _last_commit_subject(tmp_path) == CHECKPOINT_COMMIT_SUBJECT
+    assert _has_commits_ahead_of_base(tmp_path, "main") is True
+    files = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "partial_fix.py" in files
+
+
 def test_dev_phase_empty_killed_iteration_still_escalates(tmp_path: Path) -> None:
     """A genuinely empty killed iteration (no worktree changes) creates no
     checkpoint commit and still escalates on the zero-commit guard — the guard's

--- a/tests/test_coord_commit_guard.py
+++ b/tests/test_coord_commit_guard.py
@@ -25,7 +25,12 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
-from theforge.coordinator.commit_guard import _has_commits_ahead_of_base
+from theforge.coordinator.commit_guard import (
+    CHECKPOINT_COMMIT_SUBJECT,
+    _checkpoint_commit,
+    _has_commits_ahead_of_base,
+    _worktree_has_changes,
+)
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.coordinator.validate_phase import _run_validate_phase, _ValidateOutcome
 from theforge.runners import AgentResult
@@ -179,6 +184,253 @@ def test_dev_phase_escalates_on_failed_agent_with_no_commits(tmp_path: Path) -> 
     assert result.success is False
     assert state.phase == Phase.ESCALATE
     assert "no commits ahead of base" in (state.error or "")
+
+
+# ── Checkpoint-commit helpers (#1746) ────────────────────────────────
+
+
+def _last_commit_subject(path: Path) -> str:
+    out = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def test_worktree_has_changes_detects_dirty_tracked_edit(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "README.md").write_text("edited\n")
+    assert _worktree_has_changes(tmp_path) is True
+
+
+def test_worktree_has_changes_detects_untracked_file(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "brand_new.py").write_text("x = 1\n")
+    assert _worktree_has_changes(tmp_path) is True
+
+
+def test_worktree_has_changes_false_when_clean(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    assert _worktree_has_changes(tmp_path) is False
+
+
+def test_worktree_has_changes_fails_closed_when_not_a_repo(tmp_path: Path) -> None:
+    """Not a git repo — return False so no spurious checkpoint is attempted and
+    the empty-diff guard's behaviour is left unchanged."""
+    assert _worktree_has_changes(tmp_path) is False
+
+
+def test_checkpoint_commit_creates_identifiable_commit(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    # Simulate a killed iteration: production edit + a new (untracked) file.
+    (tmp_path / "README.md").write_text("fix applied\n")
+    (tmp_path / "new_module.py").write_text("def f():\n    return 1\n")
+
+    assert _checkpoint_commit(tmp_path, "exit=-9") is True
+    # Distinguishable from a normal dev commit by its fixed subject marker.
+    assert _last_commit_subject(tmp_path) == CHECKPOINT_COMMIT_SUBJECT
+    # Branch is now non-empty ahead of base — the zero-commit guard will pass.
+    assert _has_commits_ahead_of_base(tmp_path, "main") is True
+    # The reason is recorded in the commit body for audit.
+    body = subprocess.run(
+        ["git", "log", "-1", "--format=%b"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "exit=-9" in body
+    # Both the edit and the new file are captured.
+    files = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "README.md" in files
+    assert "new_module.py" in files
+    # Worktree is clean afterwards.
+    assert _worktree_has_changes(tmp_path) is False
+
+
+def test_checkpoint_commit_no_commit_when_clean(tmp_path: Path) -> None:
+    """A truly empty iteration produces no commit (no empty commit, still empty
+    branch) so the empty-diff guard still escalates as before."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    assert _checkpoint_commit(tmp_path, "exit=-9") is False
+    assert _has_commits_ahead_of_base(tmp_path, "main") is False
+
+
+def test_checkpoint_commit_excludes_forge_artifacts(tmp_path: Path) -> None:
+    """Transient .forge artifacts must not enter the checkpoint commit."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    (tmp_path / "real_work.py").write_text("x = 1\n")
+    forge_dir = tmp_path / ".forge"
+    forge_dir.mkdir(exist_ok=True)
+    (forge_dir / "handoff.yaml").write_text("summary: partial\n")
+
+    assert _checkpoint_commit(tmp_path, "exit=-9") is True
+    files = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "real_work.py" in files
+    assert ".forge/handoff.yaml" not in files
+
+
+def test_checkpoint_commit_no_commit_for_forge_only_churn(tmp_path: Path) -> None:
+    """If the only dirty content is a forge artifact, no checkpoint is made."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    forge_dir = tmp_path / ".forge"
+    forge_dir.mkdir(exist_ok=True)
+    (forge_dir / "handoff.yaml").write_text("summary: partial\n")
+    assert _checkpoint_commit(tmp_path, "exit=-9") is False
+    assert _has_commits_ahead_of_base(tmp_path, "main") is False
+
+
+# ── DEV-phase seam: killed iteration is checkpointed before the guard ─
+
+
+def _make_killed_agent_result() -> AgentResult:
+    """Simulate a dev agent SIGKILLed at its per-iteration timeout (#1737)."""
+    return AgentResult(
+        success=False,
+        output="TIMEOUT: Agent exceeded 900s limit",
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=-9,
+        raw={},
+        profile_name="dev",
+        failure_code="timeout",
+    )
+
+
+def _run_failed_dev_with_uncommitted_work(tmp_path: Path, *, max_iterations: int) -> object:
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+    state.budget.max_iterations = max_iterations
+
+    spec = tmp_path / "specs" / "t.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# t\n", encoding="utf-8")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    def _kill_after_editing(*_args, **_kwargs):
+        # The agent completes the production fix + starts migrating tests, then
+        # is SIGKILLed mid-edit — leaving all of it uncommitted in the worktree.
+        (tmp_path / "prod_fix.py").write_text("def fix():\n    return True\n")
+        (tmp_path / "README.md").write_text("seed\nfix applied\n")
+        return _make_killed_agent_result()
+
+    with (
+        patch("theforge.coordinator.dev_phase.run_agent", side_effect=_kill_after_editing),
+        patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock()),
+    ):
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+    return result, state
+
+
+def test_dev_phase_checkpoints_killed_iteration_before_guard(tmp_path: Path) -> None:
+    """#1737 replay: a SIGKILLed iteration's uncommitted edits are committed to
+    the branch before the zero-commit guard runs, so the guard sees a non-empty
+    diff and does not escalate on a falsely-empty branch. Budget exhausted here
+    so the timeout-retry path is not taken and the guard is actually reached."""
+    result, state = _run_failed_dev_with_uncommitted_work(tmp_path, max_iterations=0)
+
+    # A checkpoint commit exists, identifiable by its subject.
+    assert _last_commit_subject(tmp_path) == CHECKPOINT_COMMIT_SUBJECT
+    # The killed work is preserved on the branch.
+    assert _has_commits_ahead_of_base(tmp_path, "main") is True
+    files = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "prod_fix.py" in files
+    # The empty-diff guard did NOT escalate — the branch is genuinely non-empty.
+    assert state.phase != Phase.ESCALATE
+    assert "no commits ahead of base" not in (state.error or "")
+    # The tracked worktree is clean — the killed work is committed, not stranded.
+    # (Only transient .forge/ quarantine state remains, which is excluded by
+    # design and gitignored in real worktrees.)
+    tracked_dirty = subprocess.run(
+        ["git", "diff", "--name-only"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert tracked_dirty == ""
+
+
+def test_dev_phase_timeout_retry_starts_from_checkpointed_work(tmp_path: Path) -> None:
+    """With iterations remaining, the timeout retry re-enters DEV over the
+    checkpoint commit rather than an empty base."""
+    result, state = _run_failed_dev_with_uncommitted_work(tmp_path, max_iterations=2)
+
+    from theforge.coordinator.state import RetryReason
+
+    assert result is None  # retry, not a terminal result
+    assert state.retry_reason == RetryReason.TIMEOUT_RESUME
+    # The killed iteration's work was committed before the retry decision.
+    assert _last_commit_subject(tmp_path) == CHECKPOINT_COMMIT_SUBJECT
+    assert _has_commits_ahead_of_base(tmp_path, "main") is True
+
+
+def test_dev_phase_empty_killed_iteration_still_escalates(tmp_path: Path) -> None:
+    """A genuinely empty killed iteration (no worktree changes) creates no
+    checkpoint commit and still escalates on the zero-commit guard — the guard's
+    protection is unchanged for truly-empty runs."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+    state.budget.max_iterations = 0  # exhausted → reach the guard
+
+    spec = tmp_path / "specs" / "t.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# t\n", encoding="utf-8")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with (
+        patch(
+            "theforge.coordinator.dev_phase.run_agent",
+            return_value=_make_killed_agent_result(),
+        ),
+        patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock()),
+    ):
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+
+    assert isinstance(result, CoordinatorResult)
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    assert "no commits ahead of base" in (state.error or "")
+    assert _has_commits_ahead_of_base(tmp_path, "main") is False
 
 
 # ── REVIEW-phase guard: documented via helper behaviour ─────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Targeted review found the checkpoint path implemented before retry/escalation decisions, with seam coverage for killed, retrying, and empty iterations; targeted tests pass. | [google-gemini-3.5-flash] The checkpoint-commit logic for killed/failed dev iterations is fully implemented, robustly tested, and free of regressions. | [claude-sonnet] Cycle-2 fix correctly routes the max_iterations-no-submit retry through the same checkpoint-commit call before its return None, closing the previously-flagged gap; the iter-3 change is a pure ruff-format collapse with no behavior difference. No regressions found in either commit.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $8.55
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Coordinator should checkpoint-commit a killed/failed dev iteration's worktree before escalating — work stranded as uncommitted state is invisible to every commit-based mechanism (GitHub Issue #1746)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1746