### PR TITLE
Mid-sprint groom-and-ready workflow — document the ready-label eligibility convention

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -121,6 +121,21 @@ context, but they should not appear in actionable candidate lists.
 
 Source: `feedback_no_closed_issues.md`
 
+### Mid-sprint new bugs are groomed-and-readied for the next sprint, not injected into the running sprint
+
+When a running sprint surfaces a new bug or work item, capture it and bring it to
+a runnable state through the normal intake steps
+(`capture → shape → diagnose → groom`), then apply the `ready` label so ordinary
+sprint selection picks it up in the *next* sprint. Do not modify the running
+sprint's selected work.
+
+There is no `forge queue` command — the `ready` label is the queue-for-next-sprint
+convention, and it carries no ordering or priority semantics. Use
+`forge status --ready [--milestone …]` to see the eligible set. Live injection of
+new work into an in-flight sprint is deliberately out of scope; it belongs to the
+v0.12+ autonomy roadmap. See ADR-0001 and `docs/guides/authoring.md`
+(Mid-sprint workflow).
+
 ## Planning, Review, And Documentation Discipline
 
 ### Capture converged decisions in repo-visible artifacts

--- a/docs/guides/authoring.md
+++ b/docs/guides/authoring.md
@@ -416,6 +416,59 @@ Groom does **not** invoke `forge diagnose` or `forge shape` for you; the
 operator runs them in order (`shape → diagnose → groom`).
 
 ---
+
+## Mid-sprint workflow
+
+When a running sprint surfaces a new bug or work item, you do **not** stop the
+sprint or edit its selected work. You capture the item, bring it to a runnable,
+`ready` state through the normal intake steps, and let the *next* sprint pick it
+up by ordinary selection. The running sprint's topology is never modified.
+
+The canonical step sequence, in order:
+
+1. **Capture** — file the issue (`gh issue create`).
+2. **Shape** — classify it into a typed work object (`forge shape`).
+3. **Diagnose** — for bug-typed items that need root cause (`forge diagnose`).
+4. **Groom** — repair the body to a runnable verdict (`forge groom`).
+5. **Ready** — apply the `ready` label so the next sprint is eligible to select
+   it (`gh issue edit --add-label ready`).
+
+```bash
+gh issue create --label bug --title "..." --body "..."   # capture → returns #1512
+forge shape 1512                                          # classify (often immediate)
+forge diagnose 1512                                       # if bug-typed and needs a cause
+forge groom 1512                                          # repair body → runnable verdict
+gh issue edit 1512 --add-label ready                      # eligible for the next sprint
+```
+
+Not every step applies to every item — a cleanly-captured enhancement may skip
+`forge diagnose`, and `forge shape` may classify immediately. Run the steps the
+item needs; the order above is the pipeline, not a mandatory checklist.
+
+### There is no `forge queue` command
+
+"Queue for next sprint" is a convention, not a command. There is **no
+`forge queue`** and no queue ordering, priority, or cross-sprint dependency
+semantics. The `ready` label *is* the eligibility signal: an open, `ready`-labeled
+issue is what normal sprint selection considers. To see the current eligible set,
+use `forge status --ready` (scope it with `--milestone`):
+
+```
+$ forge status --ready --milestone v0.10.0
+Ready for next sprint in v0.10.0 (2 issues):
+  #1487  bug   ready  status --watch blank during preflight
+  #1512  bug   ready  cut-rc.sh shim wrapper regression
+```
+
+### Live sprint injection is out of scope
+
+Modifying a *running* sprint's selected work — injecting the new item into the
+sprint already in flight — is deliberately **out of scope** here. It belongs to
+the v0.12+ autonomy roadmap, where the orchestrator may re-plan in-flight work.
+Until then, the boundary is firm: mid-sprint discoveries are groomed-and-readied
+for the *next* sprint, never injected into the current one.
+
+---
 ## Operator-action issues
 
 Some work cannot be performed by a dev agent — running real validation

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -297,6 +297,27 @@ Operator-action queue (2 issues):
   blocked  #1480  Cut v0.11.0rc1 (deps: #1450 open, #1469 open - 2 pending)
 ```
 
+### Ready-for-next-sprint set
+
+```bash
+forge status --ready                       # all open `ready`-labeled issues
+forge status --ready --milestone v0.10.0   # scoped to one milestone
+```
+
+Lists open issues carrying the `ready` label — the set eligible for the *next*
+sprint via normal selection. This surfaces the mid-sprint
+[groom-and-ready convention](authoring.md#mid-sprint-workflow) without inventing
+a new command: there is **no `forge queue`**, and this listing adds no ordering
+or priority semantics. It is simply the current eligible set, recomputed from
+GitHub on each invocation.
+
+```
+$ forge status --ready --milestone v0.10.0
+Ready for next sprint in v0.10.0 (2 issues):
+  #1487  bug   ready  status --watch blank during preflight
+  #1512  bug   ready  cut-rc.sh shim wrapper regression
+```
+
 ---
 
 ## `forge logs`
@@ -422,6 +443,27 @@ Every invocation writes a row into the audit substrate's `shape_events`
 table (issue number, input source, classification, confidence, ambiguity
 question count, whether `--apply` mutated the issue).
 
+`forge shape` is the first step of the mid-sprint capture flow — see
+[Mid-sprint workflow](authoring.md#mid-sprint-workflow) for the full
+`capture → shape → diagnose → groom → ready` sequence.
+
+---
+
+## `forge diagnose`
+
+Discover the root cause of a symptom-only bug so it can move from
+investigation-ready to implementation-ready. Bugs without a confirmed cause
+cannot be labeled `ready` (see `forge groom` below).
+
+```bash
+forge diagnose <issue>          # investigate one issue
+forge diagnose <issue> --interactive
+```
+
+`forge diagnose` is the third step of the mid-sprint capture flow — see
+[Mid-sprint workflow](authoring.md#mid-sprint-workflow) for the full
+`capture → shape → diagnose → groom → ready` sequence.
+
 ---
 
 ## `forge groom`
@@ -460,6 +502,10 @@ extension may follow when auto-routing in v0.12+ needs it.
 Every invocation emits a `groom` row to the SQLite audit substrate
 (`.forge/audits/index.sqlite`, table `readiness_events`) so refusal counts
 and investigation-ready piles are queryable.
+
+`forge groom` is the fourth step of the mid-sprint capture flow — see
+[Mid-sprint workflow](authoring.md#mid-sprint-workflow) for the full
+`capture → shape → diagnose → groom → ready` sequence.
 
 ---
 

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -435,10 +435,16 @@ def cmd_status(args: object) -> int:
     watch_interval: int | None = getattr(args, "watch", None)
     no_color: bool = getattr(args, "no_color", False)
     operator_actions: bool = getattr(args, "operator_actions", False)
+    ready: bool = getattr(args, "ready", False)
+    milestone: str | None = getattr(args, "milestone", None)
 
     # ── --operator-actions: readiness queue for operator-owned issues ─────
     if operator_actions:
         return _show_operator_action_queue(project_root)
+
+    # ── --ready: sprint-eligible issues carrying the `ready` label ────────
+    if ready:
+        return _show_ready_queue(project_root, milestone)
 
     if watch_interval is not None and watch_interval <= 0:
         print(
@@ -524,6 +530,15 @@ def _show_operator_action_queue(project_root: Path) -> int:
 
     entries = build_operator_action_queue(project_root)
     print(format_operator_action_queue(entries))
+    return 0
+
+
+def _show_ready_queue(project_root: Path, milestone: str | None) -> int:
+    """Print the ready-labeled, sprint-eligible issue set (milestone-optional)."""
+    from theforge.ready_queue import build_ready_queue, format_ready_queue
+
+    entries = build_ready_queue(project_root, milestone=milestone)
+    print(format_ready_queue(entries, milestone=milestone))
     return 0
 
 
@@ -986,6 +1001,23 @@ def register_parsers(subparsers: object) -> None:
             "List open operator-action issues with a ready/blocked readiness "
             "indicator derived from their depends_on dependency state."
         ),
+    )
+    status_parser.add_argument(
+        "--ready",
+        dest="ready",
+        action="store_true",
+        default=False,
+        help=(
+            "List open issues carrying the `ready` label — the set eligible for "
+            "the next sprint. Combine with --milestone to scope to one milestone."
+        ),
+    )
+    status_parser.add_argument(
+        "--milestone",
+        dest="milestone",
+        default=None,
+        metavar="NAME",
+        help="Scope --ready to open issues in the named GitHub milestone.",
     )
 
     # forge logs

--- a/src/theforge/ready_queue.py
+++ b/src/theforge/ready_queue.py
@@ -1,0 +1,172 @@
+"""Ready-label queue: list sprint-eligible issues carrying the ``ready`` label.
+
+Per ADR-0001, the mid-sprint workflow does **not** introduce a ``forge queue``
+command. "Queue for next sprint" means the ``ready`` label is applied, and
+normal sprint selection picks the issue up. This module surfaces that eligible
+set so the operator can see, at a glance, which open issues are ready for the
+next sprint — optionally scoped to a milestone.
+
+No queue *ordering* or *priority* semantics are added: the list is simply the
+current set of open, ``ready``-labeled issues, recomputed from GitHub on each
+call so it always reflects live label/milestone state.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+READY_LABEL = "ready"
+
+_GH_TIMEOUT_SECONDS = 30
+
+# Dev-runnable and operator work-object type labels, in the order we prefer to
+# report them when an issue carries more than one. This is display-only — it
+# does not gate eligibility (the ``ready`` label alone does that).
+_TYPE_LABELS = (
+    "bug",
+    "enhancement",
+    "task",
+    "documentation",
+    "epic",
+    "operator-action",
+)
+
+
+@dataclass(frozen=True)
+class ReadyEntry:
+    """An open, ``ready``-labeled issue eligible for the next sprint."""
+
+    issue_number: int
+    title: str
+    type_label: str
+
+
+def _issue_type_label(labels: list[str]) -> str:
+    """Return the best display type for an issue from its label set.
+
+    Prefers a known work-object type (bug, enhancement, ...) in a stable order;
+    falls back to ``"—"`` when the issue carries no recognized type label.
+    """
+    label_set = {name.lower() for name in labels}
+    for candidate in _TYPE_LABELS:
+        if candidate in label_set:
+            return candidate
+    return "—"
+
+
+def _gh_list_ready_issues(project_root: Path, milestone: str | None) -> list[dict]:
+    """Return open ``ready``-labeled issues (number/title/labels) via the gh CLI.
+
+    When ``milestone`` is given, the listing is scoped to that GitHub milestone.
+    Best-effort: returns an empty list on any gh failure so the status surface
+    degrades to "no ready issues" rather than crashing.
+    """
+    cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--label",
+        READY_LABEL,
+        "--state",
+        "open",
+        "--limit",
+        "200",
+        "--json",
+        "number,title,labels",
+    ]
+    if milestone:
+        cmd.extend(["--milestone", milestone])
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=_GH_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+
+    if proc.returncode != 0:
+        return []
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict) and "number" in item]
+
+
+def _label_names(issue: dict) -> list[str]:
+    """Extract label names from a gh issue JSON record."""
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return []
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
+def build_ready_queue(
+    project_root: Path,
+    *,
+    milestone: str | None = None,
+    fetch_issues: Callable[[], list[dict]] | None = None,
+) -> list[ReadyEntry]:
+    """Return the ``ready``-labeled, sprint-eligible issue set.
+
+    ``milestone`` optionally scopes the listing to one GitHub milestone.
+    ``fetch_issues`` is an injection seam for testing; it defaults to the
+    gh-backed implementation. Entries are sorted by issue number for stable,
+    tooling-friendly output.
+    """
+    fetch_issues = fetch_issues or (lambda: _gh_list_ready_issues(project_root, milestone))
+
+    issues = fetch_issues()
+    entries: list[ReadyEntry] = []
+    for issue in issues:
+        entries.append(
+            ReadyEntry(
+                issue_number=int(issue["number"]),
+                title=str(issue.get("title", "") or ""),
+                type_label=_issue_type_label(_label_names(issue)),
+            )
+        )
+    entries.sort(key=lambda entry: entry.issue_number)
+    return entries
+
+
+def format_ready_queue(entries: list[ReadyEntry], *, milestone: str | None = None) -> str:
+    """Render the ready-label queue as human- and tooling-parseable text.
+
+    Column order is stable (issue ref, type, ``ready`` marker, title) so adjacent
+    tooling can consume it without breaking on cosmetic changes::
+
+        Ready for next sprint (2 issues):
+          #1487  bug          ready  status --watch blank during preflight
+          #1512  bug          ready  cut-rc.sh shim wrapper regression
+    """
+    scope = f" in {milestone}" if milestone else ""
+    if not entries:
+        return f"Ready for next sprint{scope}: none."
+
+    noun = "issue" if len(entries) == 1 else "issues"
+    lines = [f"Ready for next sprint{scope} ({len(entries)} {noun}):"]
+    type_width = max((len(entry.type_label) for entry in entries), default=0)
+    for entry in entries:
+        lines.append(
+            f"  #{entry.issue_number}  {entry.type_label.ljust(type_width)}  ready  {entry.title}"
+        )
+    return "\n".join(lines)

--- a/tests/test_ready_queue.py
+++ b/tests/test_ready_queue.py
@@ -1,0 +1,246 @@
+"""Tests for the ready-label queue (mid-sprint workflow, issue #1512).
+
+Covers type-label projection, stable rendering, milestone scoping passed through
+to the gh listing, and the ``forge status --ready [--milestone]`` CLI surface.
+The queue carries no ordering/priority semantics — it is simply the set of open,
+``ready``-labeled issues, so tests assert eligibility surfacing, not ranking.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+from theforge.config import (
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.ready_queue import (
+    ReadyEntry,
+    build_ready_queue,
+    format_ready_queue,
+)
+
+
+def _issue(number: int, title: str, labels: list[str]) -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "labels": [{"name": name} for name in labels],
+    }
+
+
+# ── build_ready_queue ──────────────────────────────────────────────────────
+
+
+def test_build_projects_type_label_from_issue_labels(tmp_path: Path) -> None:
+    issues = [_issue(1512, "cut-rc.sh shim regression", ["ready", "bug"])]
+    entries = build_ready_queue(tmp_path, fetch_issues=lambda: issues)
+    assert entries == [ReadyEntry(1512, "cut-rc.sh shim regression", "bug")]
+
+
+def test_build_falls_back_to_dash_when_no_type_label(tmp_path: Path) -> None:
+    issues = [_issue(1600, "untyped but ready", ["ready"])]
+    entries = build_ready_queue(tmp_path, fetch_issues=lambda: issues)
+    assert entries[0].type_label == "—"
+
+
+def test_build_sorts_entries_by_issue_number(tmp_path: Path) -> None:
+    issues = [
+        _issue(1512, "later", ["ready", "bug"]),
+        _issue(1487, "earlier", ["ready", "bug"]),
+    ]
+    entries = build_ready_queue(tmp_path, fetch_issues=lambda: issues)
+    assert [e.issue_number for e in entries] == [1487, 1512]
+
+
+def test_build_empty_when_no_ready_issues(tmp_path: Path) -> None:
+    assert build_ready_queue(tmp_path, fetch_issues=lambda: []) == []
+
+
+def test_build_prefers_first_known_type_when_multiple(tmp_path: Path) -> None:
+    # An issue tagged both bug and enhancement reports the higher-priority type.
+    issues = [_issue(1700, "multi", ["ready", "enhancement", "bug"])]
+    entries = build_ready_queue(tmp_path, fetch_issues=lambda: issues)
+    assert entries[0].type_label == "bug"
+
+
+# ── gh listing wiring: milestone scoping ───────────────────────────────────
+
+
+def test_gh_listing_passes_milestone_flag(tmp_path: Path) -> None:
+    from theforge import ready_queue
+
+    captured_cmd: list[str] = []
+
+    class _Proc:
+        returncode = 0
+        stdout = "[]"
+
+    def _fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        captured_cmd.extend(cmd)
+        return _Proc()
+
+    with patch.object(ready_queue.subprocess, "run", _fake_run):
+        ready_queue._gh_list_ready_issues(tmp_path, "v0.10.0")
+
+    assert "--label" in captured_cmd and "ready" in captured_cmd
+    assert "--milestone" in captured_cmd
+    assert "v0.10.0" in captured_cmd
+
+
+def test_gh_listing_omits_milestone_when_none(tmp_path: Path) -> None:
+    from theforge import ready_queue
+
+    captured_cmd: list[str] = []
+
+    class _Proc:
+        returncode = 0
+        stdout = "[]"
+
+    def _fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        captured_cmd.extend(cmd)
+        return _Proc()
+
+    with patch.object(ready_queue.subprocess, "run", _fake_run):
+        ready_queue._gh_list_ready_issues(tmp_path, None)
+
+    assert "--milestone" not in captured_cmd
+
+
+def test_gh_listing_degrades_to_empty_on_failure(tmp_path: Path) -> None:
+    from theforge import ready_queue
+
+    class _Proc:
+        returncode = 1
+        stdout = ""
+
+    with patch.object(ready_queue.subprocess, "run", lambda *a, **k: _Proc()):
+        assert ready_queue._gh_list_ready_issues(tmp_path, None) == []
+
+
+# ── format_ready_queue ─────────────────────────────────────────────────────
+
+
+def test_format_empty_queue() -> None:
+    assert format_ready_queue([]) == "Ready for next sprint: none."
+
+
+def test_format_empty_queue_names_milestone() -> None:
+    assert format_ready_queue([], milestone="v0.10.0") == (
+        "Ready for next sprint in v0.10.0: none."
+    )
+
+
+def test_format_lists_ready_entries_with_stable_columns() -> None:
+    entries = [
+        ReadyEntry(1487, "status --watch blank during preflight", "bug"),
+        ReadyEntry(1512, "cut-rc.sh shim wrapper regression", "bug"),
+    ]
+    rendered = format_ready_queue(entries, milestone="v0.10.0")
+
+    assert "Ready for next sprint in v0.10.0 (2 issues):" in rendered
+    assert "#1487" in rendered and "#1512" in rendered
+    assert "bug" in rendered
+    assert "ready" in rendered
+    assert "cut-rc.sh shim wrapper regression" in rendered
+
+
+def test_format_single_issue_uses_singular_noun() -> None:
+    rendered = format_ready_queue([ReadyEntry(1512, "one", "bug")])
+    assert "(1 issue):" in rendered
+
+
+# ── CLI: forge status --ready ──────────────────────────────────────────────
+
+
+def _make_forge_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        ),
+        preflight_profile=ModelProfile(
+            name="preflight",
+            cli="claude",
+            model="sonnet",
+            budget_usd=0.5,
+            timeout_seconds=120,
+            allowed_tools=("Read",),
+        ),
+        review_pool=[],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        plan_agent_review=PlanAgentReviewConfig(enabled=False),
+        log=LogConfig(enabled=False),
+    )
+
+
+def test_cmd_status_ready_flag_renders_queue(tmp_path: Path, capsys: object) -> None:
+    from theforge.cli import cmd_status
+
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project:\n  root: .\n")
+    config = _make_forge_config(tmp_path)
+    args = argparse.Namespace(ready=True, milestone="v0.10.0")
+
+    entries = [
+        ReadyEntry(1487, "status --watch blank during preflight", "bug"),
+        ReadyEntry(1512, "cut-rc.sh shim wrapper regression", "bug"),
+    ]
+
+    with (
+        patch("theforge.cli.status._find_config", return_value=forge_yaml),
+        patch("theforge.cli.status.load_config", return_value=config),
+        patch("theforge.ready_queue.build_ready_queue", return_value=entries),
+    ):
+        result = cmd_status(args)
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "Ready for next sprint in v0.10.0 (2 issues):" in captured.out
+    assert "#1487" in captured.out
+    assert "#1512" in captured.out
+
+
+def test_cmd_status_ready_flag_passes_milestone_through(tmp_path: Path) -> None:
+    from theforge.cli import cmd_status
+
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project:\n  root: .\n")
+    config = _make_forge_config(tmp_path)
+    args = argparse.Namespace(ready=True, milestone="v0.11.0")
+
+    seen: dict[str, object] = {}
+
+    def _fake_build(project_root, *, milestone=None, fetch_issues=None):  # noqa: ANN001, ANN003
+        seen["milestone"] = milestone
+        return []
+
+    with (
+        patch("theforge.cli.status._find_config", return_value=forge_yaml),
+        patch("theforge.cli.status.load_config", return_value=config),
+        patch("theforge.ready_queue.build_ready_queue", _fake_build),
+    ):
+        result = cmd_status(args)
+
+    assert result == 0
+    assert seen["milestone"] == "v0.11.0"


### PR DESCRIPTION
## Summary

The change satisfies the documented workflow requirements and the new status surface is wired and covered by targeted tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.51
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Mid-sprint groom-and-ready workflow — document the ready-label eligibility convention (GitHub Issue #1512)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1512