### PR TITLE
Sprint postmortem and audit substrate distinguish shape-gate skip categories so repeated-block patterns become visible from output rather than operator memory

### DIFF
--- a/src/theforge/cli/audits.py
+++ b/src/theforge/cli/audits.py
@@ -18,8 +18,113 @@ def cmd_audits(args: object) -> int:
         return _cmd_audits_export_assignment_history(args)
     if sub == "show":
         return _cmd_audits_show(args)
+    if sub == "skips":
+        return _cmd_audits_skips(args)
     print(f"forge audits: unknown subcommand {sub!r}", file=sys.stderr)
     return 2
+
+
+def _cmd_audits_skips(args: object) -> int:
+    """Query shape-gate skip events from the audit substrate (issue #1453).
+
+    Answers "show me all sprints in date range D where skip code C fired" — the
+    question that took manual log-walking this week — as a one-line query. With
+    ``--stuck`` it instead lists repeated-block patterns: issues blocked by the
+    same code ``>= threshold`` times across runs.
+    """
+    config_path = _find_config(Path(args.config).resolve() if args.config else None)
+    if config_path is None:
+        print(
+            "[forge] forge.yaml not found. Run from a forge project root.",
+            file=sys.stderr,
+        )
+        return 1
+    project_root = config_path.parent
+    sub_path = audit_substrate.substrate_path(project_root)
+    if not sub_path.exists():
+        print(
+            f"[forge] audit substrate not found at {sub_path}. "
+            f"Run `forge audits rebuild` to create it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = audit_substrate.create_or_open(project_root)
+    try:
+        if getattr(args, "stuck", False):
+            threshold = int(getattr(args, "threshold", None) or 3)
+            rows = audit_substrate.repeated_shape_skip_blocks(
+                conn,
+                threshold=threshold,
+                since=getattr(args, "since", None),
+                until=getattr(args, "until", None),
+            )
+            if not rows:
+                print(f"[forge] no issues blocked >= {threshold} time(s) by the same skip code.")
+                return 0
+            header = ("issue", "code", "blocks", "first_seen", "last_seen", "runs")
+            fmt_rows: list[tuple[str, ...]] = [header]
+            for r in rows:
+                fmt_rows.append(
+                    (
+                        f"#{r['issue_id']}",
+                        _fmt(r["reason_code"]),
+                        str(r["block_count"]),
+                        _fmt((r.get("first_seen") or "")[:19]),
+                        _fmt((r.get("last_seen") or "")[:19]),
+                        str(len(r.get("run_ids") or [])),
+                    )
+                )
+            _print_table(fmt_rows)
+            print(f"\n{len(rows)} stuck pattern(s) (threshold={threshold})")
+            return 0
+
+        events = list(
+            audit_substrate.iter_shape_skip_events(
+                conn,
+                issue_id=getattr(args, "issue", None),
+                reason_code=getattr(args, "code", None),
+                category=getattr(args, "category", None),
+                since=getattr(args, "since", None),
+                until=getattr(args, "until", None),
+            )
+        )
+    finally:
+        conn.close()
+
+    if not events:
+        print("[forge] no shape-gate skip events matched.")
+        return 0
+
+    header = ("issue", "code", "category", "severity", "source", "prior", "emitted_at")
+    fmt_rows = [header]
+    for e in events:
+        fmt_rows.append(
+            (
+                f"#{e.get('issue_id')}",
+                _fmt(e.get("reason_code")),
+                _fmt(e.get("category")),
+                _fmt(e.get("severity")),
+                _fmt(e.get("source")),
+                str(e.get("prior_block_count", 0)),
+                _fmt(str(e.get("emitted_at") or "")[:19]),
+            )
+        )
+    _print_table(fmt_rows)
+    print(f"\n{len(events)} skip event(s) shown")
+    return 0
+
+
+def _print_table(fmt_rows: list[tuple[str, ...]]) -> None:
+    """Render header + separator + rows as an aligned text table."""
+    if not fmt_rows:
+        return
+    ncols = len(fmt_rows[0])
+    widths = [max(len(r[i]) for r in fmt_rows) for i in range(ncols)]
+    for i, row in enumerate(fmt_rows):
+        print("  ".join(cell.ljust(widths[c]) for c, cell in enumerate(row)))
+        if i == 0:
+            print("  ".join("-" * w for w in widths))
 
 
 def _cmd_audits_show(args: object) -> int:
@@ -367,6 +472,35 @@ def register_parser(subparsers: object) -> None:
         help="Maximum rows to render (default: 20)",
     )
     show_parser.add_argument(
+        "--config",
+        help="Path to forge.yaml (default: auto-detect)",
+    )
+
+    skips_parser = audits_sub.add_parser(
+        "skips",
+        help="Query shape-gate skip events (by code, issue, date range) or stuck patterns",
+    )
+    skips_parser.add_argument("--code", help="Filter to a single skip reason code")
+    skips_parser.add_argument("--issue", help="Filter to a single issue id (e.g. 1135)")
+    skips_parser.add_argument("--category", help="Filter to a taxonomy category")
+    skips_parser.add_argument(
+        "--since", help="Only events with emitted_at >= this ISO-8601 timestamp"
+    )
+    skips_parser.add_argument(
+        "--until", help="Only events with emitted_at <= this ISO-8601 timestamp"
+    )
+    skips_parser.add_argument(
+        "--stuck",
+        action="store_true",
+        help="List repeated-block patterns (issues blocked by the same code >= threshold times)",
+    )
+    skips_parser.add_argument(
+        "--threshold",
+        type=int,
+        default=3,
+        help="Stuck-pattern threshold when --stuck is set (default: 3)",
+    )
+    skips_parser.add_argument(
         "--config",
         help="Path to forge.yaml (default: auto-detect)",
     )

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -502,6 +502,52 @@ def _remediate_shape_gate_skips(
     return new_runnable, new_skipped
 
 
+def _emit_shape_skip_events(
+    *,
+    config: object,
+    run_id: str | None,
+    sprint_name: str | None,
+    milestone: str | None,
+    original_skips: list,
+    original_advisories: list,
+    intake_outcomes: "dict | None" = None,
+) -> None:
+    """Record shape-gate skip classification events into the audit substrate.
+
+    Derives the per-issue remediation outcome from ``intake_outcomes`` (an issue
+    the entry-intake gate REMEDIATED vs. one it declined) and hands the gate's
+    original skip/advisory partition to :func:`emit_shape_skip_events`.
+    Best-effort — the helper swallows substrate failures internally.
+    """
+    from theforge.intake import IntakeOutcomeKind
+    from theforge.sprint.skip_report import emit_shape_skip_events
+
+    intake_outcomes = intake_outcomes or {}
+    remediated: set[int] = set()
+    declined: set[int] = set()
+    for num, outcome in intake_outcomes.items():
+        kind = getattr(outcome, "kind", None)
+        if kind is IntakeOutcomeKind.REMEDIATED:
+            remediated.add(int(num))
+        elif kind is IntakeOutcomeKind.DROPPED_SHAPE:
+            audit = getattr(outcome, "audit", None) or {}
+            if isinstance(audit, dict) and audit.get("remediation_source") == "declined":
+                declined.add(int(num))
+    try:
+        emit_shape_skip_events(
+            config.project_root,
+            run_id=run_id,
+            sprint_name=sprint_name,
+            milestone=milestone,
+            skipped=original_skips,
+            advisories=original_advisories,
+            remediated_numbers=remediated,
+            declined_numbers=declined,
+        )
+    except Exception as exc:  # noqa: BLE001 — observability, never gating
+        print(f"[forge] Warning: shape-skip emission failed: {exc}", file=sys.stderr)
+
+
 def _emit_all_skipped_audit(
     *,
     config: object,
@@ -509,6 +555,7 @@ def _emit_all_skipped_audit(
     budget_usd: float,
     skipped_issues: list,
     intake_outcomes: "dict | None" = None,
+    run_id: str | None = None,
 ) -> None:
     """Write sprint-audit.yaml and sprint-summary.yaml when every issue was
     gated out. Without this, an all-skipped sprint leaves no machine-readable
@@ -613,6 +660,7 @@ def _emit_all_skipped_audit(
             duration=0.0,
             project_root=config.project_root,
             skipped_issues=skipped_issues,
+            run_id=run_id,
         )
         log_dir = config.project_root / ".forge" / "logs" / sprint_name
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -626,6 +674,8 @@ def _emit_all_skipped_audit(
             sprint_log_dir=log_dir,
             skipped_issues=skipped_issues,
             story_state=story_state,
+            run_id=run_id,
+            project_root=config.project_root,
         )
     except Exception as exc:
         print(
@@ -768,6 +818,12 @@ def _run_query_mode(
             emit_verdict=_emit_shape_verdict,
             intake_remediated_numbers=carried_remediated_numbers or None,
         )
+        # Capture the gate's original skip/advisory partition before the
+        # remediation passes below mutate ``skipped_issues`` — the shape-skip
+        # substrate emission (issue #1453) classifies every gate skip, including
+        # the ones remediation later moves back to runnable.
+        original_gate_skips = list(gate_result.skipped)
+        original_gate_advisories = list(gate_result.advisories)
         if gate_result.skipped:
             warning = format_skipped_warning(gate_result.skipped)
             if force:
@@ -841,6 +897,23 @@ def _run_query_mode(
                 config=config,
             )
 
+        # Shape-gate skip observability (issue #1453): record every gate skip
+        # (and advisory) with its taxonomy category into the audit substrate,
+        # tagging remediation outcomes so the postmortem can separate
+        # remediated-and-proceeded from declined-by-remediation from
+        # still-blocked. Runs after remediation settles; correlates by
+        # gate_run_id with the sprint's downstream rows. Observability only —
+        # failures are swallowed inside the helper.
+        _emit_shape_skip_events(
+            config=config,
+            run_id=gate_run_id,
+            sprint_name=gate_sprint_name,
+            milestone=milestone,
+            original_skips=original_gate_skips,
+            original_advisories=original_gate_advisories,
+            intake_outcomes=entry_intake_outcomes,
+        )
+
         if not issues:
             print(
                 f"[forge] All {len(skipped_issues)} issue(s) skipped by shape gate "
@@ -856,6 +929,7 @@ def _run_query_mode(
                 budget_usd=budget_usd,
                 skipped_issues=skipped_issues,
                 intake_outcomes=entry_intake_outcomes,
+                run_id=gate_run_id,
             )
             return 0
 

--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -102,6 +102,12 @@ def display_sprint_digest(run_id: str, project_root: Path) -> int:
     _print_header(sprint_block, run_id)
     _print_landed(landed, len(stories))
 
+    # Shape-gate skip categories (issue #1453) are independent of story
+    # outcomes: a sprint can land every runnable story yet still have skipped a
+    # batch of issues at the gate. Render before the all-DONE early return so
+    # those skips (and any stuck-issue patterns) are never hidden.
+    _print_shape_gate_skips(summary)
+
     # All-DONE sprint: tighter LANDED-only digest, no recovery sections.
     if not non_done:
         return 0
@@ -150,6 +156,63 @@ def _print_landed(landed: list[dict], total: int) -> None:
         return
     for story in landed:
         print(f"  ✓ {_story_row(story)}")
+
+
+def _print_shape_gate_skips(summary: dict) -> None:
+    """Render the shape-gate skip categories + stuck-issue patterns.
+
+    Reads the ``shape_gate_skips`` block the sprint summary writer persisted
+    (sourced from the audit substrate). Groups skipped issues by taxonomy
+    category — cheapest-to-recover first — so an operator distinguishes a
+    stale-label block they fix in seconds from a semantic gate that needs a
+    producer from a genuine structural failure. Repeated-block ("stuck") issues
+    are flagged prominently: the pattern that surfaced #1135 and #1405 only via
+    manual log-walking.
+    """
+    block = summary.get("shape_gate_skips")
+    if not isinstance(block, dict):
+        return
+    categories = block.get("categories")
+    if not isinstance(categories, dict) or not categories:
+        return
+
+    total = block.get("total")
+    total_str = f" ({total})" if isinstance(total, int) else ""
+    print()
+    print(f"SHAPE-GATE SKIPS{total_str}")
+    for category, rows in categories.items():
+        if not isinstance(rows, list) or not rows:
+            continue
+        label = str(category).replace("_", "-")
+        print(f"  {label} ({len(rows)})")
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            issue = row.get("issue_id")
+            code = row.get("reason_code") or "<no code>"
+            axis = row.get("four_question_axis")
+            axis_str = f"  [{axis}]" if axis else ""
+            print(f"    ⊘ #{issue}  {code}{axis_str}")
+
+    stuck = block.get("stuck_issues")
+    if isinstance(stuck, list) and stuck:
+        threshold = block.get("threshold")
+        window = ""
+        for item in stuck:
+            if not isinstance(item, dict):
+                continue
+            first = item.get("first_seen")
+            last = item.get("last_seen")
+            if first and last:
+                window = f" ({str(first)[:10]} → {str(last)[:10]})"
+            count = item.get("block_count")
+            times = f"{count}×" if isinstance(count, int) else "repeatedly"
+            print(
+                f"  ⚠ STUCK: #{item.get('issue_id')} blocked by "
+                f"{item.get('reason_code')} {times} across runs{window}"
+            )
+        if isinstance(threshold, int):
+            print(f"       (stuck threshold: {threshold})")
 
 
 def _print_failed_by_class(non_done: list[dict], rca_stories: dict) -> None:

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -961,7 +961,21 @@ def load_config(config_path: Path) -> ForgeConfig:
             "forge.yaml 'shape_check.classifier' must be a non-empty string, "
             f"got {shape_check_classifier!r}"
         )
-    shape_check_cfg = ShapeCheckConfig(classifier=shape_check_classifier.strip())
+    shape_check_threshold = shape_check_data.get("stuck_issue_threshold", 3)
+    if isinstance(shape_check_threshold, bool) or not isinstance(shape_check_threshold, int):
+        raise ValueError(
+            "forge.yaml 'shape_check.stuck_issue_threshold' must be an integer, "
+            f"got {shape_check_threshold!r}"
+        )
+    if shape_check_threshold < 1:
+        raise ValueError(
+            "forge.yaml 'shape_check.stuck_issue_threshold' must be >= 1, "
+            f"got {shape_check_threshold!r}"
+        )
+    shape_check_cfg = ShapeCheckConfig(
+        classifier=shape_check_classifier.strip(),
+        stuck_issue_threshold=shape_check_threshold,
+    )
 
     intake_data = raw.get("intake", {}) or {}
     if not isinstance(intake_data, dict):

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -497,9 +497,15 @@ class ShapeCheckConfig:
     when an LLM-assisted classifier should be used. Sprint entry falls back
     to ``heuristic`` when the configured provider is unavailable at sprint
     time (e.g. no credentials, no SDK installed, no network).
+
+    ``stuck_issue_threshold`` is the number of times an issue may be blocked by
+    the same shape-gate skip code across runs before the sprint postmortem flags
+    it as a stuck-issue pattern (issue #1453). Default 3 would have surfaced
+    #1135 and #1405 weeks before manual log-walking did.
     """
 
     classifier: str = "heuristic"
+    stuck_issue_threshold: int = 3
 
 
 @dataclass(frozen=True)

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -222,6 +222,7 @@ CREATE TABLE IF NOT EXISTS shape_skip_events (
     prior_block_count INTEGER NOT NULL DEFAULT 0,
     first_blocked_at TEXT,
     last_blocked_at TEXT,
+    last_status TEXT,
     emitted_at TEXT NOT NULL,
     raw_json TEXT NOT NULL
 );
@@ -250,6 +251,7 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
         "ALTER TABLE audit_records ADD COLUMN verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN staleness_verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN diagnosis_baseline_sha TEXT",
+        "ALTER TABLE shape_skip_events ADD COLUMN last_status TEXT",
     ):
         try:
             conn.execute(stmt)
@@ -944,9 +946,18 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
     readers across normal runtime operations. The legacy import flag
     is also carried forward so a subsequent operator-driven import is
     still considered already-done.
+
+    Shape-gate skip events (``shape_skip_events``, issue #1453) are likewise
+    snapshotted and re-applied. They are the canonical per-skip audit record
+    and are not derivable from the per-run JSON files, so a rebuild that
+    dropped them would lose the very skip history the observability layer
+    exists to expose — including the repeated-block patterns that surfaced
+    #1135 and #1405. Rows are restored verbatim (prior-block counts and
+    computed status preserved) rather than recomputed.
     """
     path = substrate_path(project_root)
     legacy_snapshot: list[tuple[str, str, str | None, float | None]] = []
+    skip_event_snapshot: list[tuple] = []
     legacy_import_done: str | None = None
     if path.exists():
         try:
@@ -969,6 +980,7 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
                             row["source_mtime"],
                         )
                     )
+                skip_event_snapshot = _snapshot_shape_skip_events(existing_conn)
                 legacy_import_done = _meta_get(existing_conn, "legacy_import_done")
             finally:
                 existing_conn.close()
@@ -977,6 +989,7 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
             # must run `forge audits rebuild --include-legacy-history`
             # explicitly to recover legacy data.
             legacy_snapshot = []
+            skip_event_snapshot = []
             legacy_import_done = None
         path.unlink()
     conn = create_or_open(project_root)
@@ -1035,12 +1048,66 @@ def rebuild_from_runs(project_root: Path) -> RebuildSummary:
             )
         except sqlite3.DatabaseError:
             continue
+    # Restore preserved shape-skip events. Re-applied verbatim (no history
+    # recomputation) so counts/status match what was recorded at emit time.
+    _restore_shape_skip_events(conn, skip_event_snapshot)
     if legacy_import_done is not None:
         _meta_set(conn, "legacy_import_done", legacy_import_done)
     _meta_set(conn, "last_rebuild_at", _now_iso())
     conn.commit()
     conn.close()
     return summary
+
+
+# Column order shared by the shape-skip snapshot/restore pair so the two stay in
+# lockstep — a column added to one must be added to the other.
+_SHAPE_SKIP_SNAPSHOT_COLUMNS = (
+    "issue_id",
+    "reason_code",
+    "source",
+    "severity",
+    "category",
+    "four_question_axis",
+    "run_id",
+    "sprint_id",
+    "sprint_name",
+    "milestone",
+    "prior_block_count",
+    "first_blocked_at",
+    "last_blocked_at",
+    "last_status",
+    "emitted_at",
+    "raw_json",
+)
+
+
+def _snapshot_shape_skip_events(conn: sqlite3.Connection) -> list[tuple]:
+    """Return every ``shape_skip_events`` row (sans ``event_id``) for rebuild.
+
+    Ordered by ``emitted_at`` so restore re-inserts them chronologically and any
+    auto-assigned ``event_id`` preserves emission order.
+    """
+    cols = ", ".join(_SHAPE_SKIP_SNAPSHOT_COLUMNS)
+    try:
+        rows = conn.execute(
+            f"SELECT {cols} FROM shape_skip_events ORDER BY emitted_at ASC, event_id ASC"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        # Substrate predates the table — nothing to preserve.
+        return []
+    return [tuple(row) for row in rows]
+
+
+def _restore_shape_skip_events(conn: sqlite3.Connection, rows: list[tuple]) -> None:
+    """Re-insert snapshotted ``shape_skip_events`` rows verbatim after a rebuild."""
+    if not rows:
+        return
+    cols = ", ".join(_SHAPE_SKIP_SNAPSHOT_COLUMNS)
+    placeholders = ", ".join("?" for _ in _SHAPE_SKIP_SNAPSHOT_COLUMNS)
+    conn.executemany(
+        f"INSERT INTO shape_skip_events ({cols}) VALUES ({placeholders})",
+        rows,
+    )
 
 
 def _now_iso() -> str:
@@ -1547,6 +1614,16 @@ def iter_shape_verdict_events(
             continue
 
 
+# Shape-skip prior-status values (issue #1453 AC1: "last unblocked-or-still-blocked
+# status"). ``NO_PRIOR_BLOCK`` — this is the issue's first block on this code.
+# ``UNBLOCKED`` — the issue cleared the gate (a RUNNABLE shape verdict) since the
+# previous block, then tripped this code again. ``STILL_BLOCKED`` — the issue has
+# been continuously blocked since its previous block with no intervening pass.
+SKIP_STATUS_NO_PRIOR = "no_prior_block"
+SKIP_STATUS_UNBLOCKED = "unblocked"
+SKIP_STATUS_STILL_BLOCKED = "still_blocked"
+
+
 def _skip_prior_block_history(
     conn: sqlite3.Connection, issue_id: str, reason_code: str
 ) -> tuple[int, str | None, str | None]:
@@ -1567,6 +1644,36 @@ def _skip_prior_block_history(
         return 0, None, None
     count = int(row[0] or 0)
     return count, row[1], row[2]
+
+
+def _skip_last_status(
+    conn: sqlite3.Connection,
+    issue_id: str,
+    prior_count: int,
+    last_blocked_at: str | None,
+) -> str:
+    """Return the issue's last unblocked-or-still-blocked status for this skip code.
+
+    ``NO_PRIOR_BLOCK`` when this is the first block. Otherwise the issue is
+    ``UNBLOCKED`` when a ``RUNNABLE`` shape-verdict event was emitted after the
+    previous block (the gate cleared it, and it has now tripped again — the shape
+    of #1135/#1405, an issue that repeatedly passes and re-blocks); else
+    ``STILL_BLOCKED`` (continuously blocked since the previous block). A RUNNABLE
+    verdict clears every code, so it is a sound per-code unblock signal.
+    """
+    if prior_count <= 0:
+        return SKIP_STATUS_NO_PRIOR
+    row = conn.execute(
+        "SELECT verdict FROM shape_verdict_events "
+        "WHERE issue_id = ? AND emitted_at > ? "
+        "ORDER BY emitted_at DESC, event_id DESC LIMIT 1",
+        (issue_id, last_blocked_at or ""),
+    ).fetchone()
+    if row is not None:
+        verdict = row[0] if not isinstance(row, sqlite3.Row) else row["verdict"]
+        if str(verdict or "").lower() == "runnable":
+            return SKIP_STATUS_UNBLOCKED
+    return SKIP_STATUS_STILL_BLOCKED
 
 
 def record_shape_skip_event(project_root: Path, event: dict) -> int:
@@ -1594,20 +1701,22 @@ def record_shape_skip_event(project_root: Path, event: dict) -> int:
         prior_count, first_blocked, last_blocked = _skip_prior_block_history(
             conn, issue_id, reason_code
         )
+        last_status = _skip_last_status(conn, issue_id, prior_count, last_blocked)
         # Fold the computed history back into the persisted raw_json so the
         # canonical record and the indexed columns agree.
         enriched = dict(event)
         enriched["prior_block_count"] = prior_count
         enriched["first_blocked_at"] = first_blocked
         enriched["last_blocked_at"] = last_blocked
+        enriched["last_status"] = last_status
         enriched["emitted_at"] = emitted_at
         raw_json = _canonical_json(enriched)
         cur = conn.execute(
             "INSERT INTO shape_skip_events "
             "(issue_id, reason_code, source, severity, category, four_question_axis, "
             "run_id, sprint_id, sprint_name, milestone, prior_block_count, "
-            "first_blocked_at, last_blocked_at, emitted_at, raw_json) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "first_blocked_at, last_blocked_at, last_status, emitted_at, raw_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 issue_id,
                 reason_code,
@@ -1622,6 +1731,7 @@ def record_shape_skip_event(project_root: Path, event: dict) -> int:
                 prior_count,
                 first_blocked,
                 last_blocked,
+                last_status,
                 emitted_at,
                 raw_json,
             ),

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -1651,28 +1651,35 @@ def _skip_last_status(
     issue_id: str,
     prior_count: int,
     last_blocked_at: str | None,
+    current_emitted_at: str,
 ) -> str:
     """Return the issue's last unblocked-or-still-blocked status for this skip code.
 
     ``NO_PRIOR_BLOCK`` when this is the first block. Otherwise the issue is
-    ``UNBLOCKED`` when a ``RUNNABLE`` shape-verdict event was emitted after the
-    previous block (the gate cleared it, and it has now tripped again — the shape
-    of #1135/#1405, an issue that repeatedly passes and re-blocks); else
-    ``STILL_BLOCKED`` (continuously blocked since the previous block). A RUNNABLE
-    verdict clears every code, so it is a sound per-code unblock signal.
+    ``UNBLOCKED`` when *any* ``RUNNABLE`` shape-verdict event was emitted in the
+    open interval ``(last_blocked_at, current_emitted_at)`` — the gate cleared it
+    between the previous block and this one, and it has now tripped again (the
+    #1135/#1405 pass-then-reblock shape); else ``STILL_BLOCKED`` (continuously
+    blocked since the previous block).
+
+    Checking for *any* runnable in the window — not the latest verdict — is what
+    makes the clear-and-reblock case correct: at sprint runtime the current
+    non-runnable verdict is emitted before this skip record, and a later
+    non-runnable verdict must not mask an earlier runnable one. Bounding the
+    upper end at ``current_emitted_at`` excludes the current block's own verdict
+    from the window. A RUNNABLE verdict clears every code, so it is a sound
+    per-code unblock signal.
     """
     if prior_count <= 0:
         return SKIP_STATUS_NO_PRIOR
     row = conn.execute(
-        "SELECT verdict FROM shape_verdict_events "
-        "WHERE issue_id = ? AND emitted_at > ? "
-        "ORDER BY emitted_at DESC, event_id DESC LIMIT 1",
-        (issue_id, last_blocked_at or ""),
+        "SELECT 1 FROM shape_verdict_events "
+        "WHERE issue_id = ? AND emitted_at > ? AND emitted_at < ? "
+        "AND LOWER(verdict) = 'runnable' LIMIT 1",
+        (issue_id, last_blocked_at or "", current_emitted_at),
     ).fetchone()
     if row is not None:
-        verdict = row[0] if not isinstance(row, sqlite3.Row) else row["verdict"]
-        if str(verdict or "").lower() == "runnable":
-            return SKIP_STATUS_UNBLOCKED
+        return SKIP_STATUS_UNBLOCKED
     return SKIP_STATUS_STILL_BLOCKED
 
 
@@ -1701,7 +1708,7 @@ def record_shape_skip_event(project_root: Path, event: dict) -> int:
         prior_count, first_blocked, last_blocked = _skip_prior_block_history(
             conn, issue_id, reason_code
         )
-        last_status = _skip_last_status(conn, issue_id, prior_count, last_blocked)
+        last_status = _skip_last_status(conn, issue_id, prior_count, last_blocked, emitted_at)
         # Fold the computed history back into the persisted raw_json so the
         # canonical record and the indexed columns agree.
         enriched = dict(event)

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -207,6 +207,29 @@ CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_verdict ON shape_verdict_eve
 CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_issue ON shape_verdict_events(issue_id);
 CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_milestone ON shape_verdict_events(milestone);
 CREATE INDEX IF NOT EXISTS idx_shape_verdict_events_run ON shape_verdict_events(run_id);
+CREATE TABLE IF NOT EXISTS shape_skip_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    source TEXT,
+    severity TEXT,
+    category TEXT,
+    four_question_axis TEXT,
+    run_id TEXT,
+    sprint_id TEXT,
+    sprint_name TEXT,
+    milestone TEXT,
+    prior_block_count INTEGER NOT NULL DEFAULT 0,
+    first_blocked_at TEXT,
+    last_blocked_at TEXT,
+    emitted_at TEXT NOT NULL,
+    raw_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_shape_skip_events_issue ON shape_skip_events(issue_id);
+CREATE INDEX IF NOT EXISTS idx_shape_skip_events_code ON shape_skip_events(reason_code);
+CREATE INDEX IF NOT EXISTS idx_shape_skip_events_category ON shape_skip_events(category);
+CREATE INDEX IF NOT EXISTS idx_shape_skip_events_run ON shape_skip_events(run_id);
+CREATE INDEX IF NOT EXISTS idx_shape_skip_events_emitted ON shape_skip_events(emitted_at);
 """
 
 
@@ -1522,6 +1545,199 @@ def iter_shape_verdict_events(
             yield json.loads(raw)
         except json.JSONDecodeError:
             continue
+
+
+def _skip_prior_block_history(
+    conn: sqlite3.Connection, issue_id: str, reason_code: str
+) -> tuple[int, str | None, str | None]:
+    """Return ``(count, first_blocked_at, last_blocked_at)`` for prior blocks.
+
+    Counts only ``severity='blocking'`` rows for this ``(issue_id, reason_code)``
+    pair — advisories are not blocks and must not inflate the stuck-issue count.
+    Used at write time to embed the prior skip history directly into a new
+    record (issue #1453 AC1) so each record is self-describing without a
+    follow-up query.
+    """
+    row = conn.execute(
+        "SELECT COUNT(*), MIN(emitted_at), MAX(emitted_at) FROM shape_skip_events "
+        "WHERE issue_id = ? AND reason_code = ? AND severity = 'blocking'",
+        (issue_id, reason_code),
+    ).fetchone()
+    if row is None:
+        return 0, None, None
+    count = int(row[0] or 0)
+    return count, row[1], row[2]
+
+
+def record_shape_skip_event(project_root: Path, event: dict) -> int:
+    """Insert a per-skip classification row into the audit substrate.
+
+    Each event captures one ``(issue, reason_code)`` skip at sprint entry with
+    its category / four-question axis / severity plus the issue's prior skip
+    history on the same code (issue #1453 AC1). The prior-history fields
+    (``prior_block_count``, ``first_blocked_at``, ``last_blocked_at``) are
+    computed here from existing rows and embedded so the record is
+    self-describing. Returns the inserted row's ``event_id``. Raises
+    :class:`SubstrateError` on missing required keys so callers can decide
+    whether to swallow (the sprint gate treats this as observability, not
+    gating).
+    """
+    required = {"issue_id", "reason_code"}
+    missing = required - set(event)
+    if missing:
+        raise SubstrateError(f"shape skip event missing required keys: {sorted(missing)}")
+    issue_id = str(event["issue_id"])
+    reason_code = str(event["reason_code"])
+    emitted_at = event.get("emitted_at") or _now_iso()
+    conn = create_or_open(project_root)
+    try:
+        prior_count, first_blocked, last_blocked = _skip_prior_block_history(
+            conn, issue_id, reason_code
+        )
+        # Fold the computed history back into the persisted raw_json so the
+        # canonical record and the indexed columns agree.
+        enriched = dict(event)
+        enriched["prior_block_count"] = prior_count
+        enriched["first_blocked_at"] = first_blocked
+        enriched["last_blocked_at"] = last_blocked
+        enriched["emitted_at"] = emitted_at
+        raw_json = _canonical_json(enriched)
+        cur = conn.execute(
+            "INSERT INTO shape_skip_events "
+            "(issue_id, reason_code, source, severity, category, four_question_axis, "
+            "run_id, sprint_id, sprint_name, milestone, prior_block_count, "
+            "first_blocked_at, last_blocked_at, emitted_at, raw_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                issue_id,
+                reason_code,
+                event.get("source"),
+                event.get("severity"),
+                event.get("category"),
+                event.get("four_question_axis"),
+                event.get("run_id"),
+                event.get("sprint_id"),
+                event.get("sprint_name"),
+                event.get("milestone"),
+                prior_count,
+                first_blocked,
+                last_blocked,
+                emitted_at,
+                raw_json,
+            ),
+        )
+        conn.commit()
+        return int(cur.lastrowid or 0)
+    finally:
+        conn.close()
+
+
+def iter_shape_skip_events(
+    conn: sqlite3.Connection,
+    *,
+    issue_id: str | None = None,
+    reason_code: str | None = None,
+    category: str | None = None,
+    run_id: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> Iterable[dict]:
+    """Yield shape-skip event dicts (parsed from raw_json), oldest first.
+
+    Serves the AC6 query surface: filter by ``reason_code`` and an
+    ``[since, until]`` ``emitted_at`` window to answer "all sprints in date
+    range D where skip code C fired" in one call. ``since``/``until`` are
+    inclusive ISO-8601 strings compared lexically (the emitted_at format is
+    zero-padded UTC, so lexical order equals chronological order).
+    """
+    clauses: list[str] = []
+    params: list = []
+    if issue_id is not None:
+        clauses.append("issue_id = ?")
+        params.append(issue_id)
+    if reason_code is not None:
+        clauses.append("reason_code = ?")
+        params.append(reason_code)
+    if category is not None:
+        clauses.append("category = ?")
+        params.append(category)
+    if run_id is not None:
+        clauses.append("run_id = ?")
+        params.append(run_id)
+    if since is not None:
+        clauses.append("emitted_at >= ?")
+        params.append(since)
+    if until is not None:
+        clauses.append("emitted_at <= ?")
+        params.append(until)
+    sql = "SELECT raw_json FROM shape_skip_events"
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    sql += " ORDER BY emitted_at ASC, event_id ASC"
+    for row in conn.execute(sql, tuple(params)):
+        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
+        try:
+            yield json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+
+def repeated_shape_skip_blocks(
+    conn: sqlite3.Connection,
+    *,
+    threshold: int,
+    since: str | None = None,
+    until: str | None = None,
+) -> list[dict]:
+    """Return ``(issue_id, reason_code)`` pairs blocked ``>= threshold`` times.
+
+    This is the stuck-issue detector (issue #1453 AC3): a pattern that surfaced
+    #1135 and #1405 only via manual log-walking becomes a single grouped query.
+    Only ``severity='blocking'`` rows count toward the threshold. Each result
+    carries the block count, first/last block timestamps, and the distinct run
+    ids that hit the block. Ordered by descending block count.
+    """
+    clauses = ["severity = 'blocking'"]
+    params: list = []
+    if since is not None:
+        clauses.append("emitted_at >= ?")
+        params.append(since)
+    if until is not None:
+        clauses.append("emitted_at <= ?")
+        params.append(until)
+    where = " WHERE " + " AND ".join(clauses)
+    sql = (
+        "SELECT issue_id, reason_code, COUNT(*) AS n, "
+        "MIN(emitted_at) AS first_seen, MAX(emitted_at) AS last_seen "
+        "FROM shape_skip_events" + where + " "
+        "GROUP BY issue_id, reason_code HAVING n >= ? "
+        "ORDER BY n DESC, issue_id ASC, reason_code ASC"
+    )
+    out: list[dict] = []
+    for row in conn.execute(sql, tuple(params) + (int(threshold),)):
+        issue_id = row[0] if not isinstance(row, sqlite3.Row) else row["issue_id"]
+        reason_code = row[1] if not isinstance(row, sqlite3.Row) else row["reason_code"]
+        n = row[2] if not isinstance(row, sqlite3.Row) else row["n"]
+        first_seen = row[3] if not isinstance(row, sqlite3.Row) else row["first_seen"]
+        last_seen = row[4] if not isinstance(row, sqlite3.Row) else row["last_seen"]
+        run_rows = conn.execute(
+            "SELECT DISTINCT run_id FROM shape_skip_events "
+            "WHERE issue_id = ? AND reason_code = ? AND severity = 'blocking' "
+            "AND run_id IS NOT NULL ORDER BY run_id",
+            (issue_id, reason_code),
+        ).fetchall()
+        run_ids = [r[0] if not isinstance(r, sqlite3.Row) else r["run_id"] for r in run_rows]
+        out.append(
+            {
+                "issue_id": issue_id,
+                "reason_code": reason_code,
+                "block_count": int(n),
+                "first_seen": first_seen,
+                "last_seen": last_seen,
+                "run_ids": run_ids,
+            }
+        )
+    return out
 
 
 def seed_records(project_root: Path, records: Iterable[dict]) -> None:

--- a/src/theforge/shape_check/__init__.py
+++ b/src/theforge/shape_check/__init__.py
@@ -14,6 +14,16 @@ from theforge.shape_check.check import (
     SEED_VOCABULARY,
     check,
 )
+from theforge.shape_check.skip_taxonomy import (
+    DEFAULT_STUCK_ISSUE_THRESHOLD,
+    FourQuestionAxis,
+    RemediationOutcome,
+    SkipCategory,
+    SkipClassification,
+    SkipSeverity,
+    classify_skip,
+    group_by_category,
+)
 from theforge.shape_check.types import (
     VERDICT_DESCRIPTIONS,
     Reason,
@@ -27,13 +37,21 @@ from theforge.shape_check.types import (
 __all__ = [
     "DEFAULT_CLASSIFIER",
     "DEFAULT_CLUSTER_THRESHOLD",
+    "DEFAULT_STUCK_ISSUE_THRESHOLD",
+    "FourQuestionAxis",
     "Reason",
+    "RemediationOutcome",
     "SEED_VOCABULARY",
     "Severity",
     "Shape",
     "ShapeResult",
     "ShapeVerdict",
+    "SkipCategory",
+    "SkipClassification",
+    "SkipSeverity",
     "SuggestedAction",
     "VERDICT_DESCRIPTIONS",
     "check",
+    "classify_skip",
+    "group_by_category",
 ]

--- a/src/theforge/shape_check/skip_taxonomy.py
+++ b/src/theforge/shape_check/skip_taxonomy.py
@@ -1,0 +1,231 @@
+"""Shape-gate skip taxonomy — pure classification of skip reason codes.
+
+Every shape-gate skip today looks the same in operator-facing output: an opaque
+``reason_codes`` tuple and a single "X issue(s) flagged by shape gate" line. This
+module makes the *kind* of friction visible by tagging each skip along two axes:
+
+* a **category** an operator reads for recovery cost — a stale-label block the
+  operator fixes in seconds vs. a semantic gate no operator can satisfy without
+  invoking a producer vs. a genuine structural failure; and
+* the **four-question framework** from #1450 (what invariant failed / what
+  response is valid / was a response attempted and did the gate still refuse /
+  did verification pass but another gate fire). Tagging v0.11 skip records along
+  this axis is what lets the v0.12 architectural audit ground itself in real
+  data rather than reconstructing intent from log files.
+
+Stdlib-only and side-effect-free: this is the low-dependency pure-data layer the
+substrate writer and the postmortem/RCA renderers all classify through, so the
+taxonomy stays a single discoverable source rather than drifting across
+surfaces. Grep :data:`STALE_LABEL_CODES` / :data:`SEMANTIC_GATE_CODES` /
+:data:`AXIS_BY_CODE` to see everything the classifier knows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+# Default "stuck issue" threshold: when the same issue has been blocked by the
+# same skip code this many times across runs, the postmortem flags it as a
+# repeated-block pattern. #1135 hit ``reopened_stale_contract`` ten times and
+# #1405 three times before manual log-walking surfaced them — a default of 3
+# would have flagged both weeks earlier. Operators may raise it via
+# ``shape_check.stuck_issue_threshold`` in forge.yaml.
+DEFAULT_STUCK_ISSUE_THRESHOLD = 3
+
+
+class SkipCategory(str, Enum):
+    """Operator-facing recovery classes for a shape-gate skip.
+
+    The five values are the minimum grouping the sprint postmortem distinguishes
+    (issue #1453 AC2). ``REMEDIATED_PROCEEDED`` and ``DECLINED_REMEDIATION`` are
+    remediation *outcomes* layered on top of the underlying code class; the other
+    three derive from the reason code + skip source alone.
+    """
+
+    SEMANTIC_GATE = "blocked_by_semantic_gate"
+    STALE_LABEL = "blocked_by_stale_label"
+    REMEDIATED_PROCEEDED = "remediated_and_proceeded"
+    DECLINED_REMEDIATION = "declined_by_remediation"
+    UNRUNNABLE_SHAPE = "unrunnable_by_shape"
+
+
+class FourQuestionAxis(str, Enum):
+    """The #1450 four-question framework, one value per question.
+
+    * ``INVARIANT_VIOLATED`` — the shape gate found a structural invariant the
+      issue simply does not satisfy (missing type, missing AC, ...).
+    * ``RESPONSE_NOT_ATTEMPTED`` — a valid response exists but no producer has
+      run yet (a bug needs diagnosis, a reopen needs its context folded in).
+    * ``RESPONSE_ATTEMPTED_GATE_FAILED`` — remediation ran and the gate still
+      refused the issue.
+    * ``VERIFICATION_PASSED_OTHER_GATE`` — the content check would pass but a
+      separate gate (a stale label) fired anyway.
+    """
+
+    INVARIANT_VIOLATED = "invariant_violated"
+    RESPONSE_NOT_ATTEMPTED = "response_not_yet_attempted"
+    RESPONSE_ATTEMPTED_GATE_FAILED = "response_attempted_gate_verification_failed"
+    VERIFICATION_PASSED_OTHER_GATE = "verification_passed_but_other_gate_fired"
+
+
+class SkipSeverity(str, Enum):
+    """Whether a skip blocks sprint entry or is advisory-only.
+
+    Mirrors the blocking/advisory distinction the shape gate already draws
+    between ``ShapeGateResult.skipped`` and ``ShapeGateResult.advisories``.
+    """
+
+    BLOCKING = "blocking"
+    ADVISORY = "advisory"
+
+
+class RemediationOutcome(str, Enum):
+    """What the intake remediation gate did with a skipped issue.
+
+    ``REMEDIATED`` — the gate auto-fixed the issue and it proceeded to dev.
+    ``DECLINED`` — the gate refused (the skip reason is not body-only fixable).
+    ``NONE`` — remediation did not run or had no verdict for this issue.
+    """
+
+    REMEDIATED = "remediated"
+    DECLINED = "declined"
+    NONE = "none"
+
+
+# ── Reason-code → category / axis mapping (single discoverable location) ──────
+#
+# Codes are the ``Reason.code`` strings emitted by shape_check/heuristics.py plus
+# the gate-local synthetic codes defined in sprint/shape_gate.py. Any code not
+# listed here falls through to the structural / unrunnable class — a new
+# structural check needs no edit here, while a new *semantic* or *stale-label*
+# check must be added explicitly so it is not silently miscategorised as
+# operator-unrunnable.
+
+# The stale ``needs-grooming`` label is the seconds-to-fix class: the local check
+# may already pass, but the async relabeler has not caught up.
+STALE_LABEL_CODES: frozenset[str] = frozenset({"needs_grooming_label"})
+
+# Semantic gates verify content a producer must generate — the operator cannot
+# satisfy them by hand in seconds. These are the codes #1450 wants surfaced as
+# "response not yet attempted" rather than "malformed".
+SEMANTIC_GATE_CODES: frozenset[str] = frozenset(
+    {
+        "needs_diagnosis",
+        "diagnosis_cause_unknown",
+        "reopened_stale_contract",
+        "criterion_needs_live_evidence",
+    }
+)
+
+# Per-code four-question axis. Codes absent from this map are structural
+# invariants → ``INVARIANT_VIOLATED``.
+AXIS_BY_CODE: dict[str, FourQuestionAxis] = {
+    "needs_grooming_label": FourQuestionAxis.VERIFICATION_PASSED_OTHER_GATE,
+    "needs_diagnosis": FourQuestionAxis.RESPONSE_NOT_ATTEMPTED,
+    "diagnosis_cause_unknown": FourQuestionAxis.RESPONSE_NOT_ATTEMPTED,
+    "reopened_stale_contract": FourQuestionAxis.RESPONSE_NOT_ATTEMPTED,
+    "criterion_needs_live_evidence": FourQuestionAxis.RESPONSE_NOT_ATTEMPTED,
+}
+
+
+@dataclass(frozen=True)
+class SkipClassification:
+    """The taxonomy verdict for a single (reason_code, source, remediation) skip."""
+
+    reason_code: str
+    source: str
+    severity: SkipSeverity
+    category: SkipCategory
+    four_question_axis: FourQuestionAxis
+
+    def as_dict(self) -> dict:
+        return {
+            "reason_code": self.reason_code,
+            "source": self.source,
+            "severity": self.severity.value,
+            "category": self.category.value,
+            "four_question_axis": self.four_question_axis.value,
+        }
+
+
+def _base_category(reason_code: str, source: str) -> SkipCategory:
+    """Category from the code + source alone, before remediation is considered."""
+    if reason_code in STALE_LABEL_CODES:
+        return SkipCategory.STALE_LABEL
+    if reason_code in SEMANTIC_GATE_CODES:
+        return SkipCategory.SEMANTIC_GATE
+    return SkipCategory.UNRUNNABLE_SHAPE
+
+
+def classify_skip(
+    reason_code: str,
+    source: str,
+    *,
+    severity: SkipSeverity = SkipSeverity.BLOCKING,
+    remediation: RemediationOutcome = RemediationOutcome.NONE,
+) -> SkipClassification:
+    """Classify one skip into its category + four-question axis.
+
+    ``remediation`` overrides the category: a remediated issue is reported as
+    ``REMEDIATED_PROCEEDED`` and a refused one as ``DECLINED_REMEDIATION`` so the
+    postmortem can separate "the gate fixed it" from "the gate gave up" from "the
+    operator never got a fix attempt". The axis for a declined issue becomes
+    ``RESPONSE_ATTEMPTED_GATE_FAILED`` (a response *was* attempted); otherwise the
+    axis is derived from the reason code.
+    """
+    code = (reason_code or "").strip()
+
+    if remediation is RemediationOutcome.REMEDIATED:
+        category = SkipCategory.REMEDIATED_PROCEEDED
+        axis = AXIS_BY_CODE.get(code, FourQuestionAxis.INVARIANT_VIOLATED)
+    elif remediation is RemediationOutcome.DECLINED:
+        category = SkipCategory.DECLINED_REMEDIATION
+        axis = FourQuestionAxis.RESPONSE_ATTEMPTED_GATE_FAILED
+    else:
+        category = _base_category(code, source)
+        axis = AXIS_BY_CODE.get(code, FourQuestionAxis.INVARIANT_VIOLATED)
+
+    return SkipClassification(
+        reason_code=code,
+        source=source or "",
+        severity=severity,
+        category=category,
+        four_question_axis=axis,
+    )
+
+
+# Deterministic display order for the postmortem — cheapest-to-recover first so
+# the operator sees "you can unblock these in seconds" above "these need a
+# producer" above "these are genuinely malformed".
+CATEGORY_DISPLAY_ORDER: tuple[SkipCategory, ...] = (
+    SkipCategory.STALE_LABEL,
+    SkipCategory.REMEDIATED_PROCEEDED,
+    SkipCategory.SEMANTIC_GATE,
+    SkipCategory.DECLINED_REMEDIATION,
+    SkipCategory.UNRUNNABLE_SHAPE,
+)
+
+
+def group_by_category(events: list[dict]) -> dict[str, list[dict]]:
+    """Group skip-event dicts by their ``category`` field, in display order.
+
+    Events lacking a recognised category fall under ``UNRUNNABLE_SHAPE`` so no
+    event is silently dropped from the postmortem. Returns an insertion-ordered
+    mapping restricted to non-empty categories.
+    """
+    buckets: dict[str, list[dict]] = {}
+    for event in events:
+        raw = str(event.get("category") or SkipCategory.UNRUNNABLE_SHAPE.value)
+        buckets.setdefault(raw, []).append(event)
+
+    ordered: dict[str, list[dict]] = {}
+    for category in CATEGORY_DISPLAY_ORDER:
+        rows = buckets.pop(category.value, None)
+        if rows:
+            ordered[category.value] = rows
+    # Any category value not in the canonical order (forward-compat) trails the
+    # known ones rather than vanishing.
+    for leftover, rows in buckets.items():
+        ordered[leftover] = rows
+    return ordered

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -608,6 +608,19 @@ def _write_sprint_audit(
         "iteration_usage_distribution": usage_distribution,
     }
 
+    # Shape-gate skip classification (issue #1453): project this run's skip
+    # events into a category-grouped block with stuck-issue flags so operators
+    # read gate friction from audit output rather than reconstructing it from
+    # log files. Best-effort — omitted when this run recorded no skip events.
+    from ..shape_check.skip_taxonomy import DEFAULT_STUCK_ISSUE_THRESHOLD
+    from .skip_report import build_shape_gate_skip_block
+
+    skip_block = build_shape_gate_skip_block(
+        project_root, run_id, threshold=DEFAULT_STUCK_ISSUE_THRESHOLD
+    )
+    if skip_block is not None:
+        audit["shape_gate_skips"] = skip_block
+
     audits_dir = project_root / ".forge" / "audits"
     audits_dir.mkdir(parents=True, exist_ok=True)
     audit_path = audits_dir / "sprint-audit.yaml"
@@ -1006,6 +1019,23 @@ def _write_sprint_summary(
         "skipped": [s.as_dict() if hasattr(s, "as_dict") else dict(s) for s in skipped_issues],
         "iteration_usage_distribution": usage_distribution,
     }
+
+    # Shape-gate skip classification (issue #1453). The postmortem digest and
+    # sprint RCA read this block from the summary, so the stuck-issue threshold
+    # honours the operator's ``shape_check.stuck_issue_threshold`` config here
+    # (the audit-YAML copy uses the default). Best-effort — omitted when this
+    # run recorded no skip events.
+    from ..shape_check.skip_taxonomy import DEFAULT_STUCK_ISSUE_THRESHOLD
+    from .skip_report import build_shape_gate_skip_block
+
+    _threshold = DEFAULT_STUCK_ISSUE_THRESHOLD
+    _shape_cfg = getattr(config, "shape_check", None)
+    if _shape_cfg is not None:
+        _threshold = getattr(_shape_cfg, "stuck_issue_threshold", DEFAULT_STUCK_ISSUE_THRESHOLD)
+    if project_root is not None:
+        skip_block = build_shape_gate_skip_block(project_root, run_id, threshold=_threshold)
+        if skip_block is not None:
+            summary["shape_gate_skips"] = skip_block
 
     try:
         sprint_log_dir.mkdir(parents=True, exist_ok=True)

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -287,7 +287,7 @@ def build_sprint_rca(summary_path: Path, *, generated_at: str | None = None) -> 
             story, summary_path, sprint_log_dir, logs_root, run_id
         )
 
-    return {
+    payload = {
         "schema_version": SCHEMA_VERSION,
         "ruleset_version": RULESET_VERSION,
         "sprint_run_id": run_id,
@@ -295,6 +295,17 @@ def build_sprint_rca(summary_path: Path, *, generated_at: str | None = None) -> 
         "generator": "mechanical",
         "stories": story_entries,
     }
+
+    # Attach the shape-gate skip classification context (issue #1453) so an
+    # operator reading the RCA sees whether the sprint was affected by gate
+    # friction and how often. Sourced from the summary the writer already
+    # persisted, so the RCA stays a pure function over on-disk artifacts and the
+    # ``--check`` reproducibility guard still holds.
+    skip_block = summary.get("shape_gate_skips")
+    if isinstance(skip_block, dict) and skip_block:
+        payload["shape_gate_skips"] = skip_block
+
+    return payload
 
 
 def write_sprint_rca(

--- a/src/theforge/sprint/skip_report.py
+++ b/src/theforge/sprint/skip_report.py
@@ -143,6 +143,7 @@ def _slim_event(event: dict) -> dict:
         "category": event.get("category"),
         "four_question_axis": event.get("four_question_axis"),
         "prior_block_count": event.get("prior_block_count", 0),
+        "last_status": event.get("last_status"),
     }
 
 

--- a/src/theforge/sprint/skip_report.py
+++ b/src/theforge/sprint/skip_report.py
@@ -183,9 +183,7 @@ def build_shape_gate_skip_block(
         conn.close()
 
     run_pairs = {(str(e.get("issue_id")), str(e.get("reason_code"))) for e in events}
-    stuck = [
-        s for s in all_stuck if (str(s["issue_id"]), str(s["reason_code"])) in run_pairs
-    ]
+    stuck = [s for s in all_stuck if (str(s["issue_id"]), str(s["reason_code"])) in run_pairs]
 
     categories = {cat: [_slim_event(e) for e in rows] for cat, rows in grouped.items()}
     return {

--- a/src/theforge/sprint/skip_report.py
+++ b/src/theforge/sprint/skip_report.py
@@ -1,0 +1,197 @@
+"""Shape-gate skip observability: emit per-skip records and build the postmortem
+classification block.
+
+This is the seam between the sprint-entry shape gate and the audit substrate for
+issue #1453. Two responsibilities:
+
+* :func:`emit_shape_skip_events` — called from ``cli/sprint.py`` after the gate
+  and intake remediation have settled, so each ``(issue, reason_code)`` skip is
+  recorded with its taxonomy category (including the remediation outcome) into
+  the ``shape_skip_events`` substrate table.
+* :func:`build_shape_gate_skip_block` — called from the sprint summary/audit
+  writers to project this run's skip events into the operator-facing
+  ``shape_gate_skips`` block that the postmortem digest and RCA render. Stuck
+  patterns (an issue blocked by the same code ``>= threshold`` times across
+  runs) are surfaced here rather than reconstructed from log files.
+
+Emission is observability, not gating: a substrate write failure is logged and
+swallowed so the sprint proceeds exactly as before.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, Iterable
+
+from ..shape_check.skip_taxonomy import (
+    RemediationOutcome,
+    SkipSeverity,
+    classify_skip,
+    group_by_category,
+)
+
+_log = logging.getLogger(__name__)
+
+
+def _skip_reason_codes(skip: object) -> list[str]:
+    codes = getattr(skip, "reason_codes", None)
+    if codes is None and isinstance(skip, dict):
+        codes = skip.get("reason_codes")
+    return [str(c) for c in (codes or []) if str(c).strip()]
+
+
+def _skip_number(skip: object) -> int | None:
+    num = getattr(skip, "issue_number", None)
+    if num is None and isinstance(skip, dict):
+        num = skip.get("issue_number")
+    try:
+        return int(num) if num is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _skip_source(skip: object) -> str:
+    src = getattr(skip, "source", None)
+    if src is None and isinstance(skip, dict):
+        src = skip.get("source")
+    return str(src or "")
+
+
+def emit_shape_skip_events(
+    project_root: Path,
+    *,
+    run_id: str | None,
+    sprint_name: str | None = None,
+    sprint_id: str | None = None,
+    milestone: str | None = None,
+    skipped: Iterable[object] = (),
+    advisories: Iterable[object] = (),
+    remediated_numbers: "set[int] | frozenset[int]" = frozenset(),
+    declined_numbers: "set[int] | frozenset[int]" = frozenset(),
+    record: Callable[[Path, dict], int] | None = None,
+) -> int:
+    """Record one substrate skip event per ``(issue, reason_code)``.
+
+    ``skipped`` events are blocking, ``advisories`` are advisory. The
+    remediation outcome for an issue (``remediated_numbers`` /
+    ``declined_numbers``) sets the taxonomy category so the postmortem can
+    separate "the gate fixed it and it ran" from "the gate refused" from "still
+    blocked". Returns the number of events written. All failures are logged at
+    WARNING and swallowed — this is observability, never gating.
+    """
+    if record is None:
+        from ..coordinator.audit_substrate import record_shape_skip_event as record
+
+    written = 0
+    remediated = {int(n) for n in remediated_numbers}
+    declined = {int(n) for n in declined_numbers}
+
+    def _emit(skip: object, severity: SkipSeverity) -> None:
+        nonlocal written
+        number = _skip_number(skip)
+        if number is None:
+            return
+        if number in remediated:
+            remediation = RemediationOutcome.REMEDIATED
+        elif number in declined:
+            remediation = RemediationOutcome.DECLINED
+        else:
+            remediation = RemediationOutcome.NONE
+        source = _skip_source(skip)
+        for code in _skip_reason_codes(skip):
+            classification = classify_skip(
+                code, source, severity=severity, remediation=remediation
+            )
+            event = {
+                "issue_id": str(number),
+                "reason_code": code,
+                "source": source,
+                "severity": classification.severity.value,
+                "category": classification.category.value,
+                "four_question_axis": classification.four_question_axis.value,
+                "run_id": run_id,
+                "sprint_id": sprint_id,
+                "sprint_name": sprint_name,
+                "milestone": milestone,
+            }
+            try:
+                record(project_root, event)
+                written += 1
+            except Exception as exc:  # noqa: BLE001
+                _log.warning(
+                    "shape-gate skip substrate write failed for issue=%s code=%s: %s",
+                    number,
+                    code,
+                    exc,
+                )
+
+    for skip in skipped:
+        _emit(skip, SkipSeverity.BLOCKING)
+    for advisory in advisories:
+        _emit(advisory, SkipSeverity.ADVISORY)
+    return written
+
+
+def _slim_event(event: dict) -> dict:
+    """Project a stored skip event to the fields the postmortem block renders."""
+    return {
+        "issue_id": event.get("issue_id"),
+        "reason_code": event.get("reason_code"),
+        "source": event.get("source"),
+        "severity": event.get("severity"),
+        "category": event.get("category"),
+        "four_question_axis": event.get("four_question_axis"),
+        "prior_block_count": event.get("prior_block_count", 0),
+    }
+
+
+def build_shape_gate_skip_block(
+    project_root: Path,
+    run_id: str | None,
+    *,
+    threshold: int,
+) -> dict | None:
+    """Build the ``shape_gate_skips`` classification block for one sprint run.
+
+    Reads this run's skip events from the substrate, groups them by taxonomy
+    category, and flags stuck-issue patterns — an issue this run skipped that
+    has been blocked by the same code ``>= threshold`` times across all runs.
+    Returns ``None`` when this run recorded no skip events (so the summary/audit
+    omit the block entirely) or when the substrate is unavailable. Never raises:
+    the block is observability layered on top of the canonical summary.
+    """
+    if not run_id:
+        return None
+    try:
+        from ..coordinator import audit_substrate
+
+        conn = audit_substrate.create_or_open(project_root)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("shape-gate skip block: substrate unavailable: %s", exc)
+        return None
+    try:
+        events = list(audit_substrate.iter_shape_skip_events(conn, run_id=run_id))
+        if not events:
+            return None
+        grouped = group_by_category(events)
+        all_stuck = audit_substrate.repeated_shape_skip_blocks(conn, threshold=threshold)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("shape-gate skip block: query failed: %s", exc)
+        return None
+    finally:
+        conn.close()
+
+    run_pairs = {(str(e.get("issue_id")), str(e.get("reason_code"))) for e in events}
+    stuck = [
+        s for s in all_stuck if (str(s["issue_id"]), str(s["reason_code"])) in run_pairs
+    ]
+
+    categories = {cat: [_slim_event(e) for e in rows] for cat, rows in grouped.items()}
+    return {
+        "threshold": threshold,
+        "total": len(events),
+        "category_counts": {cat: len(rows) for cat, rows in categories.items()},
+        "categories": categories,
+        "stuck_issues": stuck,
+    }

--- a/tests/test_audits_skips.py
+++ b/tests/test_audits_skips.py
@@ -1,0 +1,100 @@
+"""Tests for the `forge audits skips` query CLI (issue #1453 AC6).
+
+The command turns "show me all sprints in date range D where skip code C fired"
+— which took manual log-walking this week — into a one-line query, and exposes
+stuck-issue patterns via ``--stuck``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from theforge.cli import audits as audits_cli
+from theforge.coordinator.audit_substrate import record_shape_skip_event
+
+
+def _setup_project(tmp_path: Path) -> Path:
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    return forge_yaml
+
+
+def _emit(tmp_path: Path, issue: str, code: str, run: str, when: str) -> None:
+    record_shape_skip_event(
+        tmp_path,
+        {
+            "issue_id": issue,
+            "reason_code": code,
+            "severity": "blocking",
+            "category": "blocked_by_semantic_gate",
+            "four_question_axis": "response_not_yet_attempted",
+            "source": "local_check",
+            "run_id": run,
+            "emitted_at": when,
+        },
+    )
+
+
+def _args(forge_yaml: Path, **kw) -> SimpleNamespace:
+    base = dict(
+        config=str(forge_yaml),
+        audits_command="skips",
+        code=None,
+        issue=None,
+        category=None,
+        since=None,
+        until=None,
+        stuck=False,
+        threshold=3,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_code_and_date_range_query(tmp_path: Path, capsys) -> None:
+    forge_yaml = _setup_project(tmp_path)
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r1", "2026-05-04T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r2", "2026-05-06T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r3", "2026-05-09T00:00:00Z")
+
+    rc = audits_cli.cmd_audits(
+        _args(
+            forge_yaml,
+            code="reopened_stale_contract",
+            since="2026-05-05T00:00:00Z",
+            until="2026-05-07T00:00:00Z",
+        )
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 skip event(s) shown" in out
+    assert "reopened_stale_contract" in out
+
+
+def test_stuck_query(tmp_path: Path, capsys) -> None:
+    forge_yaml = _setup_project(tmp_path)
+    for i in range(4):
+        _emit(tmp_path, "1135", "reopened_stale_contract", f"r{i}", f"2026-05-0{i + 4}T00:00:00Z")
+    _emit(tmp_path, "7", "needs_grooming_label", "r1", "2026-05-04T00:00:00Z")
+
+    rc = audits_cli.cmd_audits(_args(forge_yaml, stuck=True, threshold=3))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "#1135" in out
+    assert "1 stuck pattern(s)" in out
+
+
+def test_no_matches(tmp_path: Path, capsys) -> None:
+    forge_yaml = _setup_project(tmp_path)
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r1", "2026-05-04T00:00:00Z")
+    rc = audits_cli.cmd_audits(_args(forge_yaml, code="nonexistent_code"))
+    assert rc == 0
+    assert "no shape-gate skip events matched" in capsys.readouterr().out
+
+
+def test_missing_substrate_errors(tmp_path: Path, capsys) -> None:
+    forge_yaml = _setup_project(tmp_path)
+    rc = audits_cli.cmd_audits(_args(forge_yaml))
+    assert rc == 1
+    assert "audit substrate not found" in capsys.readouterr().err

--- a/tests/test_audits_skips.py
+++ b/tests/test_audits_skips.py
@@ -98,3 +98,28 @@ def test_missing_substrate_errors(tmp_path: Path, capsys) -> None:
     rc = audits_cli.cmd_audits(_args(forge_yaml))
     assert rc == 1
     assert "audit substrate not found" in capsys.readouterr().err
+
+
+def test_rebuild_preserves_skip_events_for_query(tmp_path: Path, capsys) -> None:
+    from theforge.coordinator.audit_substrate import runs_dir
+
+    forge_yaml = _setup_project(tmp_path)
+    runs_dir(tmp_path).mkdir(parents=True, exist_ok=True)
+    for i in range(3):
+        _emit(tmp_path, "1135", "reopened_stale_contract", f"r{i}", f"2026-05-0{i + 4}T00:00:00Z")
+
+    rebuild_args = SimpleNamespace(
+        config=str(forge_yaml),
+        audits_command="rebuild",
+        include_legacy_history=False,
+    )
+    assert audits_cli.cmd_audits(rebuild_args) == 0
+    capsys.readouterr()  # discard rebuild noise
+
+    # The stuck pattern must still be queryable after a rebuild — otherwise the
+    # durable query surface silently loses the history it exists to expose.
+    rc = audits_cli.cmd_audits(_args(forge_yaml, stuck=True, threshold=3))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "#1135" in out
+    assert "1 stuck pattern(s)" in out

--- a/tests/test_shape_skip_events.py
+++ b/tests/test_shape_skip_events.py
@@ -12,11 +12,17 @@ from pathlib import Path
 import pytest
 
 from theforge.coordinator.audit_substrate import (
+    SKIP_STATUS_NO_PRIOR,
+    SKIP_STATUS_STILL_BLOCKED,
+    SKIP_STATUS_UNBLOCKED,
     SubstrateError,
     create_or_open,
     iter_shape_skip_events,
+    rebuild_from_runs,
     record_shape_skip_event,
+    record_shape_verdict_event,
     repeated_shape_skip_blocks,
+    runs_dir,
 )
 
 
@@ -131,3 +137,94 @@ def test_repeated_block_threshold_excludes_below(tmp_path: Path) -> None:
     finally:
         conn.close()
     assert stuck == []
+
+
+# ── last_status (AC1: "last unblocked-or-still-blocked status") ────────────────
+
+
+def test_last_status_no_prior_block(tmp_path: Path) -> None:
+    _emit(tmp_path, "1", "c", "r1", "2026-05-01T00:00:00Z")
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, issue_id="1"))
+    finally:
+        conn.close()
+    assert events[0]["last_status"] == SKIP_STATUS_NO_PRIOR
+
+
+def test_last_status_still_blocked_when_never_cleared(tmp_path: Path) -> None:
+    _emit(tmp_path, "1", "c", "r1", "2026-05-01T00:00:00Z")
+    _emit(tmp_path, "1", "c", "r2", "2026-05-02T00:00:00Z")
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, issue_id="1"))
+    finally:
+        conn.close()
+    # No intervening RUNNABLE verdict — the second block is continuous.
+    assert events[-1]["last_status"] == SKIP_STATUS_STILL_BLOCKED
+
+
+def test_last_status_unblocked_after_runnable_verdict(tmp_path: Path) -> None:
+    _emit(tmp_path, "1", "c", "r1", "2026-05-01T00:00:00Z")
+    # The issue cleared the gate between blocks (a RUNNABLE shape verdict).
+    record_shape_verdict_event(
+        tmp_path, {"issue_id": "1", "verdict": "runnable", "emitted_at": "2026-05-02T00:00:00Z"}
+    )
+    _emit(tmp_path, "1", "c", "r3", "2026-05-03T00:00:00Z")
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, issue_id="1"))
+    finally:
+        conn.close()
+    # Cleared then re-blocked — the #1135/#1405 pass/re-block shape.
+    assert events[-1]["last_status"] == SKIP_STATUS_UNBLOCKED
+
+
+def test_last_status_persisted_in_indexed_column(tmp_path: Path) -> None:
+    _emit(tmp_path, "1", "c", "r1", "2026-05-01T00:00:00Z")
+    _emit(tmp_path, "1", "c", "r2", "2026-05-02T00:00:00Z")
+    conn = create_or_open(tmp_path)
+    try:
+        rows = conn.execute(
+            "SELECT last_status FROM shape_skip_events "
+            "WHERE issue_id = '1' ORDER BY emitted_at ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+    # Both the indexed column and raw_json carry the status.
+    assert [r[0] for r in rows] == [SKIP_STATUS_NO_PRIOR, SKIP_STATUS_STILL_BLOCKED]
+
+
+# ── rebuild preservation (AC6: skip history is durable audit output) ──────────
+
+
+def test_rebuild_preserves_shape_skip_events(tmp_path: Path) -> None:
+    runs_dir(tmp_path).mkdir(parents=True, exist_ok=True)  # rebuild scans this dir
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r1", "2026-05-04T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r2", "2026-05-05T00:00:00Z")
+    record_shape_verdict_event(
+        tmp_path,
+        {"issue_id": "1135", "verdict": "runnable", "emitted_at": "2026-05-06T00:00:00Z"},
+    )
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r3", "2026-05-07T00:00:00Z")
+
+    rebuild_from_runs(tmp_path)
+
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, issue_id="1135"))
+        stuck = repeated_shape_skip_blocks(conn, threshold=3)
+    finally:
+        conn.close()
+
+    # All three skip rows survive with their computed history/status intact.
+    assert len(events) == 3
+    assert [e["prior_block_count"] for e in events] == [0, 1, 2]
+    assert [e["last_status"] for e in events] == [
+        SKIP_STATUS_NO_PRIOR,
+        SKIP_STATUS_STILL_BLOCKED,
+        SKIP_STATUS_UNBLOCKED,
+    ]
+    # And the stuck-issue query still fires post-rebuild — the whole point.
+    assert len(stuck) == 1
+    assert stuck[0]["block_count"] == 3

--- a/tests/test_shape_skip_events.py
+++ b/tests/test_shape_skip_events.py
@@ -72,9 +72,7 @@ def test_advisories_do_not_count_as_prior_blocks(tmp_path: Path) -> None:
     conn = create_or_open(tmp_path)
     try:
         blocking = [
-            e
-            for e in iter_shape_skip_events(conn, issue_id="42")
-            if e["severity"] == "blocking"
+            e for e in iter_shape_skip_events(conn, issue_id="42") if e["severity"] == "blocking"
         ]
     finally:
         conn.close()

--- a/tests/test_shape_skip_events.py
+++ b/tests/test_shape_skip_events.py
@@ -180,6 +180,51 @@ def test_last_status_unblocked_after_runnable_verdict(tmp_path: Path) -> None:
     assert events[-1]["last_status"] == SKIP_STATUS_UNBLOCKED
 
 
+def test_last_status_unblocked_despite_later_nonrunnable_verdict(tmp_path: Path) -> None:
+    """Clear-and-reblock: a runnable verdict followed by a later non-runnable one.
+
+    The status must be ``unblocked`` — the issue cleared the gate between blocks —
+    even though the most recent verdict before the new skip is non-runnable.
+    Regression guard for the iter-2 P1: the old "latest verdict" lookup reported
+    ``still_blocked`` here and hid the exact pass/re-block pattern the story wants.
+    """
+    _emit(tmp_path, "1", "c", "r1", "2026-05-01T00:00:00Z")
+    record_shape_verdict_event(
+        tmp_path, {"issue_id": "1", "verdict": "runnable", "emitted_at": "2026-05-02T00:00:00Z"}
+    )
+    record_shape_verdict_event(
+        tmp_path, {"issue_id": "1", "verdict": "needs_type", "emitted_at": "2026-05-03T00:00:00Z"}
+    )
+    _emit(tmp_path, "1", "c", "r4", "2026-05-04T00:00:00Z")
+
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, issue_id="1"))
+    finally:
+        conn.close()
+    assert events[-1]["last_status"] == SKIP_STATUS_UNBLOCKED
+
+
+def test_last_status_ignores_current_run_nonrunnable_verdict(tmp_path: Path) -> None:
+    """Sprint-runtime ordering: the current block's own non-runnable verdict is
+    emitted *before* the skip record. It must not be mistaken for a clear, and —
+    with no prior runnable — the status stays ``still_blocked``.
+    """
+    _emit(tmp_path, "1", "c", "r1", "2026-05-01T00:00:00Z")
+    # Current run: the gate emits the non-runnable verdict, then the skip record.
+    record_shape_verdict_event(
+        tmp_path, {"issue_id": "1", "verdict": "needs_type", "emitted_at": "2026-05-02T00:00:00Z"}
+    )
+    _emit(tmp_path, "1", "c", "r2", "2026-05-02T00:00:01Z")
+
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, issue_id="1"))
+    finally:
+        conn.close()
+    assert events[-1]["last_status"] == SKIP_STATUS_STILL_BLOCKED
+
+
 def test_last_status_persisted_in_indexed_column(tmp_path: Path) -> None:
     _emit(tmp_path, "1", "c", "r1", "2026-05-01T00:00:00Z")
     _emit(tmp_path, "1", "c", "r2", "2026-05-02T00:00:00Z")

--- a/tests/test_shape_skip_events.py
+++ b/tests/test_shape_skip_events.py
@@ -1,0 +1,135 @@
+"""Substrate coverage for shape-gate skip events (issue #1453 AC1/AC3/AC6).
+
+The ``shape_skip_events`` table is the canonical per-skip record. These tests
+pin: prior-skip-history embedding at write time (AC1), the date-range/code query
+surface (AC6), and stuck-issue detection (AC3).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from theforge.coordinator.audit_substrate import (
+    SubstrateError,
+    create_or_open,
+    iter_shape_skip_events,
+    record_shape_skip_event,
+    repeated_shape_skip_blocks,
+)
+
+
+def _emit(project_root: Path, issue_id: str, code: str, run: str, when: str, **extra) -> None:
+    event = {
+        "issue_id": issue_id,
+        "reason_code": code,
+        "severity": "blocking",
+        "source": "local_check",
+        "run_id": run,
+        "emitted_at": when,
+    }
+    event.update(extra)
+    record_shape_skip_event(project_root, event)
+
+
+def test_missing_required_keys_raises(tmp_path: Path) -> None:
+    with pytest.raises(SubstrateError):
+        record_shape_skip_event(tmp_path, {"issue_id": "1"})
+    with pytest.raises(SubstrateError):
+        record_shape_skip_event(tmp_path, {"reason_code": "x"})
+
+
+def test_prior_block_history_embedded_at_write_time(tmp_path: Path) -> None:
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r1", "2026-05-04T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r2", "2026-05-05T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r3", "2026-05-06T00:00:00Z")
+
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, issue_id="1135"))
+    finally:
+        conn.close()
+
+    # Chronological order; each record embeds the count of prior blocks.
+    assert [e["prior_block_count"] for e in events] == [0, 1, 2]
+    assert events[-1]["first_blocked_at"] == "2026-05-04T00:00:00Z"
+    assert events[-1]["last_blocked_at"] == "2026-05-05T00:00:00Z"
+
+
+def test_advisories_do_not_count_as_prior_blocks(tmp_path: Path) -> None:
+    record_shape_skip_event(
+        tmp_path,
+        {
+            "issue_id": "42",
+            "reason_code": "reopened_stale_contract",
+            "severity": "advisory",
+            "emitted_at": "2026-05-04T00:00:00Z",
+        },
+    )
+    _emit(tmp_path, "42", "reopened_stale_contract", "r2", "2026-05-05T00:00:00Z")
+
+    conn = create_or_open(tmp_path)
+    try:
+        blocking = [
+            e
+            for e in iter_shape_skip_events(conn, issue_id="42")
+            if e["severity"] == "blocking"
+        ]
+    finally:
+        conn.close()
+    # The advisory row must not inflate the block count of the later block.
+    assert blocking[0]["prior_block_count"] == 0
+
+
+def test_date_range_and_code_query(tmp_path: Path) -> None:
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r1", "2026-05-04T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r2", "2026-05-06T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r3", "2026-05-09T00:00:00Z")
+    _emit(tmp_path, "7", "needs_grooming_label", "r2", "2026-05-06T00:00:00Z")
+
+    conn = create_or_open(tmp_path)
+    try:
+        rows = list(
+            iter_shape_skip_events(
+                conn,
+                reason_code="reopened_stale_contract",
+                since="2026-05-05T00:00:00Z",
+                until="2026-05-07T00:00:00Z",
+            )
+        )
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == "r2"
+
+
+def test_repeated_block_detection(tmp_path: Path) -> None:
+    for i in range(4):
+        _emit(tmp_path, "1135", "reopened_stale_contract", f"r{i}", f"2026-05-0{i + 4}T00:00:00Z")
+    _emit(tmp_path, "7", "needs_grooming_label", "r1", "2026-05-05T00:00:00Z")
+
+    conn = create_or_open(tmp_path)
+    try:
+        stuck = repeated_shape_skip_blocks(conn, threshold=3)
+    finally:
+        conn.close()
+
+    assert len(stuck) == 1
+    assert stuck[0]["issue_id"] == "1135"
+    assert stuck[0]["reason_code"] == "reopened_stale_contract"
+    assert stuck[0]["block_count"] == 4
+    assert stuck[0]["run_ids"] == ["r0", "r1", "r2", "r3"]
+
+
+def test_repeated_block_threshold_excludes_below(tmp_path: Path) -> None:
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r1", "2026-05-04T00:00:00Z")
+    _emit(tmp_path, "1135", "reopened_stale_contract", "r2", "2026-05-05T00:00:00Z")
+
+    conn = create_or_open(tmp_path)
+    try:
+        stuck = repeated_shape_skip_blocks(conn, threshold=3)
+    finally:
+        conn.close()
+    assert stuck == []

--- a/tests/test_shape_skip_report.py
+++ b/tests/test_shape_skip_report.py
@@ -15,5 +15,211 @@ from theforge.coordinator.audit_substrate import (
     iter_shape_skip_events,
     record_shape_skip_event,
 )
-from theforge.sprint.shape_report import  # noqa: F401  (re-export check below)
-    build_shape_gate_skip_block as _direct_import_guard  # type: ignore  # noqa: E999
+from theforge.sprint.shape_gate import SkippedIssue
+from theforge.sprint.skip_report import (
+    build_shape_gate_skip_block,
+    emit_shape_skip_events,
+)
+
+
+def test_emission_records_category_and_axis(tmp_path: Path) -> None:
+    skipped = [
+        SkippedIssue(
+            issue_number=1135,
+            reason_codes=("reopened_stale_contract",),
+            source="local_check",
+        ),
+        SkippedIssue(
+            issue_number=7,
+            reason_codes=("needs_grooming_label",),
+            source="label",
+        ),
+    ]
+    written = emit_shape_skip_events(
+        tmp_path,
+        run_id="run-1",
+        sprint_name="v0.11",
+        skipped=skipped,
+    )
+    assert written == 2
+
+    conn = create_or_open(tmp_path)
+    try:
+        events = {e["issue_id"]: e for e in iter_shape_skip_events(conn, run_id="run-1")}
+    finally:
+        conn.close()
+
+    assert events["1135"]["category"] == "blocked_by_semantic_gate"
+    assert events["1135"]["four_question_axis"] == "response_not_yet_attempted"
+    assert events["7"]["category"] == "blocked_by_stale_label"
+    assert events["7"]["severity"] == "blocking"
+
+
+def test_remediation_outcomes_change_category(tmp_path: Path) -> None:
+    code = ("reopened_stale_contract",)
+    skipped = [
+        SkippedIssue(issue_number=10, reason_codes=code, source="local_check"),
+        SkippedIssue(issue_number=11, reason_codes=code, source="local_check"),
+    ]
+    emit_shape_skip_events(
+        tmp_path,
+        run_id="run-1",
+        skipped=skipped,
+        remediated_numbers={10},
+        declined_numbers={11},
+    )
+
+    conn = create_or_open(tmp_path)
+    try:
+        events = {e["issue_id"]: e for e in iter_shape_skip_events(conn, run_id="run-1")}
+    finally:
+        conn.close()
+
+    assert events["10"]["category"] == "remediated_and_proceeded"
+    assert events["11"]["category"] == "declined_by_remediation"
+    assert events["11"]["four_question_axis"] == "response_attempted_gate_verification_failed"
+
+
+def test_advisories_emitted_with_advisory_severity(tmp_path: Path) -> None:
+    advisories = [
+        SkippedIssue(
+            issue_number=99,
+            reason_codes=("reopened_stale_contract",),
+            source="local_check",
+        )
+    ]
+    emit_shape_skip_events(tmp_path, run_id="run-1", advisories=advisories)
+
+    conn = create_or_open(tmp_path)
+    try:
+        events = list(iter_shape_skip_events(conn, run_id="run-1"))
+    finally:
+        conn.close()
+    assert len(events) == 1
+    assert events[0]["severity"] == "advisory"
+
+
+def test_emission_failure_is_swallowed(tmp_path: Path) -> None:
+    def _boom(_root: Path, _event: dict) -> int:
+        raise RuntimeError("substrate offline")
+
+    skipped = [SkippedIssue(issue_number=1, reason_codes=("missing_type",), source="local_check")]
+    # Must not raise — observability, not gating.
+    written = emit_shape_skip_events(tmp_path, run_id="r", skipped=skipped, record=_boom)
+    assert written == 0
+
+
+def test_build_block_scopes_stuck_to_this_run(tmp_path: Path) -> None:
+    # Four prior blocks across runs, latest in this run.
+    for i in range(3):
+        record_shape_skip_event(
+            tmp_path,
+            {
+                "issue_id": "1135",
+                "reason_code": "reopened_stale_contract",
+                "severity": "blocking",
+                "category": "blocked_by_semantic_gate",
+                "four_question_axis": "response_not_yet_attempted",
+                "source": "local_check",
+                "run_id": f"old-{i}",
+                "emitted_at": f"2026-05-0{i + 4}T00:00:00Z",
+            },
+        )
+    emit_shape_skip_events(
+        tmp_path,
+        run_id="run-now",
+        skipped=[
+            SkippedIssue(
+                issue_number=1135,
+                reason_codes=("reopened_stale_contract",),
+                source="local_check",
+            )
+        ],
+    )
+
+    block = build_shape_gate_skip_block(tmp_path, "run-now", threshold=3)
+    assert block is not None
+    assert block["total"] == 1
+    assert block["threshold"] == 3
+    stuck = block["stuck_issues"]
+    assert len(stuck) == 1
+    assert stuck[0]["issue_id"] == "1135"
+    assert stuck[0]["block_count"] == 4
+
+
+def test_build_block_none_when_no_events(tmp_path: Path) -> None:
+    assert build_shape_gate_skip_block(tmp_path, "absent-run", threshold=3) is None
+
+
+def test_build_block_none_without_run_id(tmp_path: Path) -> None:
+    assert build_shape_gate_skip_block(tmp_path, None, threshold=3) is None
+
+
+def test_summary_writer_embeds_block_from_substrate(tmp_path: Path) -> None:
+    """Seam: emitted skip events → ``_write_sprint_summary`` → summary YAML.
+
+    Exercises the sprint-entry → summary-writer boundary directly: the writer
+    must query the substrate by run_id and embed the ``shape_gate_skips`` block
+    the digest and RCA then read (convention 8 — cross-phase state handoff).
+    """
+    import datetime
+
+    import yaml
+
+    from theforge.sprint.audit import _write_sprint_summary
+    from theforge.sprint.manifest import ResolvedSprint, SprintResult
+    from theforge.sprint.story_state import SprintStoryState, StoryOutcome
+
+    emit_shape_skip_events(
+        tmp_path,
+        run_id="run-seam",
+        sprint_name="v0.11",
+        skipped=[
+            SkippedIssue(
+                issue_number=1135,
+                reason_codes=("reopened_stale_contract",),
+                source="local_check",
+            )
+        ],
+    )
+
+    story_state = SprintStoryState()
+    story_state.register(
+        "issue-1135",
+        "Issue #1135",
+        outcome=StoryOutcome.SKIPPED,
+        reason="shape-gate",
+        canonical_ref="issue:1135",
+    )
+    manifest = ResolvedSprint(name="v0.11", budget_usd=10.0, stories=[], max_parallel=1)
+    result = SprintResult(
+        name="v0.11",
+        specs_total=1,
+        specs_succeeded=0,
+        specs_failed=0,
+        specs_skipped=1,
+        total_cost_usd=0.0,
+        budget_usd=10.0,
+        results=[],
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    log_dir = tmp_path / ".forge" / "logs" / "v0.11"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    _write_sprint_summary(
+        manifest=manifest,
+        result=result,
+        canonical_refs=[],
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        sprint_log_dir=log_dir,
+        skipped_issues=[],
+        story_state=story_state,
+        run_id="run-seam",
+        project_root=tmp_path,
+    )
+
+    summary = yaml.safe_load((log_dir / "sprint-summary.yaml").read_text(encoding="utf-8"))
+    block = summary["shape_gate_skips"]
+    assert block["total"] == 1
+    assert "blocked_by_semantic_gate" in block["categories"]

--- a/tests/test_shape_skip_report.py
+++ b/tests/test_shape_skip_report.py
@@ -1,0 +1,19 @@
+"""Seam coverage for shape-gate skip emission → substrate → postmortem block.
+
+Issue #1453: the gate's skip partition must land in the substrate with taxonomy
+categories (including remediation outcomes), and the summary/RCA block must
+project this run's events with stuck-issue flags. This exercises the full
+emission → query → block seam the sprint entry path relies on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.coordinator.audit_substrate import (
+    create_or_open,
+    iter_shape_skip_events,
+    record_shape_skip_event,
+)
+from theforge.sprint.shape_report import  # noqa: F401  (re-export check below)
+    build_shape_gate_skip_block as _direct_import_guard  # type: ignore  # noqa: E999

--- a/tests/test_skip_taxonomy.py
+++ b/tests/test_skip_taxonomy.py
@@ -1,0 +1,97 @@
+"""Unit coverage for the shape-gate skip taxonomy (issue #1453 AC2/AC5).
+
+The taxonomy is the pure-data layer every observability surface classifies
+through. These tests pin the code → category / four-question-axis mapping and
+the remediation-outcome overrides so a drift in one surface can't diverge from
+another.
+"""
+
+from __future__ import annotations
+
+from theforge.shape_check.skip_taxonomy import (
+    FourQuestionAxis,
+    RemediationOutcome,
+    SkipCategory,
+    SkipSeverity,
+    classify_skip,
+    group_by_category,
+)
+
+
+def test_stale_label_code_is_stale_label_category() -> None:
+    c = classify_skip("needs_grooming_label", "label")
+    assert c.category is SkipCategory.STALE_LABEL
+    # A stale label is the "verification passed but another gate fired" axis.
+    assert c.four_question_axis is FourQuestionAxis.VERIFICATION_PASSED_OTHER_GATE
+
+
+def test_semantic_gate_codes_map_to_response_not_attempted() -> None:
+    for code in ("needs_diagnosis", "diagnosis_cause_unknown", "reopened_stale_contract"):
+        c = classify_skip(code, "local_check")
+        assert c.category is SkipCategory.SEMANTIC_GATE, code
+        assert c.four_question_axis is FourQuestionAxis.RESPONSE_NOT_ATTEMPTED, code
+
+
+def test_structural_code_is_unrunnable_invariant_violated() -> None:
+    c = classify_skip("missing_acceptance_criteria", "local_check")
+    assert c.category is SkipCategory.UNRUNNABLE_SHAPE
+    assert c.four_question_axis is FourQuestionAxis.INVARIANT_VIOLATED
+
+
+def test_unknown_code_defaults_to_unrunnable() -> None:
+    c = classify_skip("brand_new_check_code", "local_check")
+    assert c.category is SkipCategory.UNRUNNABLE_SHAPE
+    assert c.four_question_axis is FourQuestionAxis.INVARIANT_VIOLATED
+
+
+def test_remediated_outcome_overrides_category() -> None:
+    c = classify_skip(
+        "reopened_stale_contract",
+        "local_check",
+        remediation=RemediationOutcome.REMEDIATED,
+    )
+    assert c.category is SkipCategory.REMEDIATED_PROCEEDED
+    # Axis still reflects the underlying invariant that was then fixed.
+    assert c.four_question_axis is FourQuestionAxis.RESPONSE_NOT_ATTEMPTED
+
+
+def test_declined_outcome_is_response_attempted_gate_failed() -> None:
+    c = classify_skip(
+        "reopened_stale_contract",
+        "local_check",
+        remediation=RemediationOutcome.DECLINED,
+    )
+    assert c.category is SkipCategory.DECLINED_REMEDIATION
+    assert c.four_question_axis is FourQuestionAxis.RESPONSE_ATTEMPTED_GATE_FAILED
+
+
+def test_severity_is_carried_through() -> None:
+    c = classify_skip("reopened_stale_contract", "local_check", severity=SkipSeverity.ADVISORY)
+    assert c.severity is SkipSeverity.ADVISORY
+    assert c.as_dict()["severity"] == "advisory"
+
+
+def test_group_by_category_orders_cheapest_first() -> None:
+    events = [
+        {"category": "unrunnable_by_shape", "issue_id": "1"},
+        {"category": "blocked_by_stale_label", "issue_id": "2"},
+        {"category": "blocked_by_semantic_gate", "issue_id": "3"},
+    ]
+    grouped = group_by_category(events)
+    # Stale-label (seconds to fix) must appear before semantic-gate before
+    # unrunnable so the operator reads recovery cost top-down.
+    keys = list(grouped)
+    assert keys.index("blocked_by_stale_label") < keys.index("blocked_by_semantic_gate")
+    assert keys.index("blocked_by_semantic_gate") < keys.index("unrunnable_by_shape")
+
+
+def test_group_by_category_keeps_unknown_categories() -> None:
+    events = [{"category": "some_future_category", "issue_id": "9"}]
+    grouped = group_by_category(events)
+    assert grouped["some_future_category"] == events
+
+
+def test_group_by_category_defaults_missing_category() -> None:
+    events = [{"issue_id": "9"}]
+    grouped = group_by_category(events)
+    assert "unrunnable_by_shape" in grouped

--- a/tests/test_sprint_digest_skip_categories.py
+++ b/tests/test_sprint_digest_skip_categories.py
@@ -1,0 +1,131 @@
+"""Digest coverage for the shape-gate skip categories section (issue #1453 AC2/AC3).
+
+The postmortem digest must distinguish skip categories in operator-facing output
+and flag stuck-issue patterns. These tests exercise the renderer against a
+summary carrying a ``shape_gate_skips`` block.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+
+def _write_summary(tmp_path: Path, run_id: str, *, skip_block: dict | None, stories: list) -> None:
+    log_dir = tmp_path / ".forge" / "logs" / "v0.11"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    data: dict = {
+        "sprint": {
+            "name": "v0.11",
+            "run_id": run_id,
+            "total_cost_usd": 1.0,
+            "duration_seconds": 60.0,
+            "finished_at": "2026-05-08T03:00:00Z",
+        },
+        "stories": stories,
+    }
+    if skip_block is not None:
+        data["shape_gate_skips"] = skip_block
+    (log_dir / "sprint-summary.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _render(tmp_path: Path, run_id: str) -> str:
+    from theforge.cli.sprint_digest import display_sprint_digest
+
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        rc = display_sprint_digest(run_id, tmp_path)
+    assert rc == 0, buf.getvalue()
+    return buf.getvalue()
+
+
+def _landed(num: int) -> dict:
+    return {"slug": f"issue-{num}", "path": f"Issue #{num}", "outcome": "DONE", "cost_usd": 1.0}
+
+
+def test_skip_categories_render_grouped(tmp_path: Path) -> None:
+    block = {
+        "threshold": 3,
+        "total": 2,
+        "category_counts": {"blocked_by_stale_label": 1, "blocked_by_semantic_gate": 1},
+        "categories": {
+            "blocked_by_stale_label": [
+                {
+                    "issue_id": "7",
+                    "reason_code": "needs_grooming_label",
+                    "four_question_axis": "verification_passed_but_other_gate_fired",
+                }
+            ],
+            "blocked_by_semantic_gate": [
+                {
+                    "issue_id": "1135",
+                    "reason_code": "reopened_stale_contract",
+                    "four_question_axis": "response_not_yet_attempted",
+                }
+            ],
+        },
+        "stuck_issues": [],
+    }
+    _write_summary(tmp_path, "run-1", skip_block=block, stories=[_landed(1)])
+    out = _render(tmp_path, "run-1")
+
+    assert "SHAPE-GATE SKIPS (2)" in out
+    assert "blocked-by-stale-label (1)" in out
+    assert "blocked-by-semantic-gate (1)" in out
+    assert "#1135" in out
+    assert "reopened_stale_contract" in out
+    assert "response_not_yet_attempted" in out
+
+
+def test_stuck_issue_flagged(tmp_path: Path) -> None:
+    block = {
+        "threshold": 3,
+        "total": 1,
+        "category_counts": {"blocked_by_semantic_gate": 1},
+        "categories": {
+            "blocked_by_semantic_gate": [
+                {"issue_id": "1135", "reason_code": "reopened_stale_contract"}
+            ]
+        },
+        "stuck_issues": [
+            {
+                "issue_id": "1135",
+                "reason_code": "reopened_stale_contract",
+                "block_count": 4,
+                "first_seen": "2026-05-04T00:00:00Z",
+                "last_seen": "2026-05-08T00:00:00Z",
+                "run_ids": ["a", "b", "c", "d"],
+            }
+        ],
+    }
+    _write_summary(tmp_path, "run-1", skip_block=block, stories=[_landed(1)])
+    out = _render(tmp_path, "run-1")
+
+    assert "STUCK: #1135" in out
+    assert "4×" in out
+    assert "2026-05-04" in out
+
+
+def test_skip_section_renders_for_all_done_sprint(tmp_path: Path) -> None:
+    # Every story landed, but issues were skipped at the gate — the section
+    # must still render (not hidden by the all-DONE early return).
+    block = {
+        "threshold": 3,
+        "total": 1,
+        "category_counts": {"unrunnable_by_shape": 1},
+        "categories": {"unrunnable_by_shape": [{"issue_id": "5", "reason_code": "missing_type"}]},
+        "stuck_issues": [],
+    }
+    _write_summary(tmp_path, "run-1", skip_block=block, stories=[_landed(1)])
+    out = _render(tmp_path, "run-1")
+    assert "SHAPE-GATE SKIPS" in out
+    assert "unrunnable-by-shape" in out
+
+
+def test_no_skip_block_renders_nothing(tmp_path: Path) -> None:
+    _write_summary(tmp_path, "run-1", skip_block=None, stories=[_landed(1)])
+    out = _render(tmp_path, "run-1")
+    assert "SHAPE-GATE SKIPS" not in out

--- a/tests/test_sprint_rca_skip_context.py
+++ b/tests/test_sprint_rca_skip_context.py
@@ -1,0 +1,75 @@
+"""RCA coverage for shape-gate skip context attachment (issue #1453 AC4).
+
+Sprint RCA output must attach the same skip-classification context to its
+narrative so an operator reading an RCA sees whether the sprint was affected by
+gate friction and how often. The engine sources it from the summary, keeping the
+RCA a pure function over on-disk artifacts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from theforge.sprint.rca import build_sprint_rca
+
+
+def _write_summary(tmp_path: Path, *, skip_block: dict | None) -> Path:
+    log_dir = tmp_path / ".forge" / "logs" / "v0.11"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    data: dict = {
+        "sprint": {"name": "v0.11", "run_id": "run-1", "finished_at": "2026-05-08T03:00:00Z"},
+        "stories": [
+            {
+                "slug": "issue-1",
+                "path": "Issue #1",
+                "outcome": "ESCALATE",
+                "error": "review requested changes",
+            }
+        ],
+    }
+    if skip_block is not None:
+        data["shape_gate_skips"] = skip_block
+    summary_path = log_dir / "sprint-summary.yaml"
+    summary_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return summary_path
+
+
+def test_rca_attaches_skip_block(tmp_path: Path) -> None:
+    block = {
+        "threshold": 3,
+        "total": 1,
+        "category_counts": {"blocked_by_semantic_gate": 1},
+        "categories": {
+            "blocked_by_semantic_gate": [
+                {"issue_id": "1135", "reason_code": "reopened_stale_contract"}
+            ]
+        },
+        "stuck_issues": [],
+    }
+    summary_path = _write_summary(tmp_path, skip_block=block)
+    payload = build_sprint_rca(summary_path)
+    assert payload is not None
+    assert payload["shape_gate_skips"] == block
+
+
+def test_rca_omits_skip_block_when_absent(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, skip_block=None)
+    payload = build_sprint_rca(summary_path)
+    assert payload is not None
+    assert "shape_gate_skips" not in payload
+
+
+def test_rca_stays_reproducible_with_skip_block(tmp_path: Path) -> None:
+    block = {
+        "threshold": 3,
+        "total": 1,
+        "category_counts": {"unrunnable_by_shape": 1},
+        "categories": {"unrunnable_by_shape": [{"issue_id": "5", "reason_code": "missing_type"}]},
+        "stuck_issues": [],
+    }
+    summary_path = _write_summary(tmp_path, skip_block=block)
+    # Two builds from the same inputs must be byte-identical (the --check guard
+    # depends on this determinism).
+    assert build_sprint_rca(summary_path) == build_sprint_rca(summary_path)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved in the current tree, the shape-skip observability path is invoked at runtime, and the targeted regression suite passed. | [google-gemini-3.5-flash] All prior P1 findings are fully resolved, and the shape-gate skip observability layer is robustly implemented with comprehensive test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $24.67
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint postmortem and audit substrate distinguish shape-gate skip categories so repeated-block patterns become visible from output rather than operator memory (GitHub Issue #1453)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1453