### PR TITLE
Review-parse-retry prompt + schema cross-validations create an oscillation trap when reviewer drops fields to dodge syntax issues

### DIFF
--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -125,6 +125,8 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
                     "p2_count": sum(1 for f in r.findings if f.severity == "P2"),
                     "findings": findings_list,
                     "ac_verification": ac_verification_list,
+                    "criteria_enumerable": r.criteria_enumerable,
+                    "criteria_enumerable_rationale": (r.criteria_enumerable_rationale or None),
                     "parse_errors": parse_errors_list,
                 }
             )

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -75,6 +75,81 @@ def _is_transient_review_failure(result: Any, config: ForgeConfig) -> bool:
     return any(pattern in lower for pattern in config.retry.review_transient_output_patterns)
 
 
+# Corrective YAML structure appended to every review-retry prompt. Every field
+# the reviewer emitted originally appears here so "reformat" never reads as
+# "drop the sections that are hard to encode".
+_CORRECTIVE_YAML_STRUCTURE = (
+    "verdict: APPROVE | REQUEST_CHANGES\n"
+    'summary: "one-line summary"\n'
+    "findings:\n"
+    "  - severity: P1 | P2\n"
+    '    file: "path"   # null for architectural findings\n'
+    "    line: <number or null>   # null for file-scope findings "
+    "(file existence, whole-file state, structural hygiene)\n"
+    '    observed: "what is wrong"\n'
+    '    expected: "category-level rule that generalises"\n'
+    '    evidence: "file path, line, or anchor"\n'
+    '    suggestion: "how to fix (optional)"\n'
+    "story_compliance:\n"
+    "  matches_spec: true | false\n"
+    "  mismatches: []\n"
+    "test_coverage:\n"
+    "  adequate: true | false\n"
+    "  gaps: []\n"
+    "ac_verification:\n"
+    "  - criterion: \"verbatim AC text, or 'Symptom resolution: ...' for bugs\"\n"
+    "    status: VERIFIED | PARTIAL | NOT_VERIFIED\n"
+    '    evidence: "file:line diff hunks (VERIFIED) or reason (otherwise)"\n'
+    "criteria_enumerable: true   # false ONLY if the issue has no enumerable AC\n"
+    'criteria_enumerable_rationale: ""   # required (non-empty) when '
+    "criteria_enumerable is false\n"
+    "Do not drop a P1 finding to satisfy a line-number requirement: "
+    "line: null is valid when the defect is the existence, absence, mode, "
+    "or whole-file state of the path.\n"
+)
+
+
+def _build_review_retry_prompt(error_desc: str, original_output: str) -> str:
+    """Build a corrective retry prompt that anchors the reviewer's prior content.
+
+    A retry prompt that asks an agent to fix formatting must communicate that the
+    *content* of the previous output is correct and only the *encoding* needs
+    repair. Reviewers are unreliable at distinguishing "fix the quoting of this
+    value" from "emit a different value that won't have the same problem" — the
+    latter (dropping ac_verification to dodge the APPROVE-needs-verified-AC rule,
+    or flipping the verdict to dodge a cross-validation) produces an oscillation
+    trap. This prompt pins the prior output as the anchor and names dropping a
+    field as an explicitly wrong response, removing that move from the reachable
+    space. ``original_output`` is the reviewer's verbatim prior emission.
+    """
+    return (
+        "Your previous review output failed schema/parse validation:\n" + error_desc + "\n\n"
+        "The CONTENT of your previous review is correct — your verdict, your "
+        "findings, and your ac_verification entries are what you meant to say. "
+        "ONLY the ENCODING (YAML formatting) is broken. Re-emit the SAME review "
+        "with the formatting error fixed.\n\n"
+        "Preserve your previous output verbatim:\n"
+        "  - Keep the SAME verdict. Do NOT switch APPROVE <-> REQUEST_CHANGES.\n"
+        "  - Keep EVERY finding. Do NOT drop, merge, or downgrade a finding.\n"
+        "  - Keep EVERY ac_verification entry, with the same criterion, status, "
+        "and evidence.\n\n"
+        "Dropping or altering a field to make a validation error go away is a "
+        "WRONG response. If a value failed to parse, fix the QUOTING/ESCAPING of "
+        "that value — do NOT delete the value, and do NOT change the verdict to "
+        "sidestep a cross-validation rule. If your verdict is APPROVE and your "
+        "ac_verification keeps failing to encode, that is a formatting problem to "
+        "solve; it is NOT a reason to empty the table or switch to "
+        "REQUEST_CHANGES. (If the issue genuinely has no enumerable acceptance "
+        "criteria, set criteria_enumerable: false with a rationale rather than "
+        "dropping the table.)\n\n"
+        "Do NOT re-review the code.\n\n"
+        "Required YAML structure:\n"
+        + _CORRECTIVE_YAML_STRUCTURE
+        + "\n\nYour previous output (fix its formatting, keep its content):\n"
+        + original_output
+    )
+
+
 # Failure codes marking a reviewer that completed its turn without delivering a
 # verdict (no submit call). These are infrastructure/behavioral failures, not
 # review outcomes, and must not be able to kill a story on their own.
@@ -636,28 +711,6 @@ def _run_review_pool(
     # prompt via run_agent up to max_review_parse_retries times.
     # meta.parse_retries accumulates the sum of per-reviewer retries attempted.
     _profile_by_name = {p.name: p for p in pool}
-    _corrective_yaml_structure = (
-        "verdict: APPROVE | REQUEST_CHANGES\n"
-        'summary: "one-line summary"\n'
-        "findings:\n"
-        "  - severity: P1 | P2\n"
-        '    file: "path"   # null for architectural findings\n'
-        "    line: <number or null>   # null for file-scope findings "
-        "(file existence, whole-file state, structural hygiene)\n"
-        '    observed: "what is wrong"\n'
-        '    expected: "category-level rule that generalises"\n'
-        '    evidence: "file path, line, or anchor"\n'
-        '    suggestion: "how to fix (optional)"\n'
-        "story_compliance:\n"
-        "  matches_spec: true | false\n"
-        "  mismatches: []\n"
-        "test_coverage:\n"
-        "  adequate: true | false\n"
-        "  gaps: []\n"
-        "Do not drop a P1 finding to satisfy a line-number requirement: "
-        "line: null is valid when the defect is the existence, absence, mode, "
-        "or whole-file state of the path.\n"
-    )
     for i, (name, parsed) in enumerate(zip(names, parsed_results)):
         if not parsed.parse_errors:
             continue
@@ -677,27 +730,13 @@ def _run_review_pool(
                 f"(retry {_retry_num}/{max_review_parse_retries}): "
                 f"{_error_desc[:120]}"
             )
-            # Build corrective prompt — mode-specific to avoid re-review
-            if _prof.mode == "api":
-                # Include original output so the agent can reformat without re-reviewing
-                _original_output = _original_result.output or ""
-                _retry_prompt = (
-                    "Your previous output (reproduced below) had schema/parse errors:\n"
-                    + _error_desc
-                    + "\n\nReformat your output as valid YAML. Do NOT re-review the code.\n\n"
-                    "Required YAML structure:\n"
-                    + _corrective_yaml_structure
-                    + "\n\nYour previous output:\n"
-                    + _original_output
-                )
-            else:
-                # CLI: prompt is simpler — session continuity via session_id handles context
-                _retry_prompt = (
-                    "Your previous review output had schema/parse errors:\n"
-                    + _error_desc
-                    + "\n\nReformat your output as valid YAML. Do NOT re-review the code.\n\n"
-                    "Required YAML structure:\n" + _corrective_yaml_structure
-                )
+            # Build corrective prompt anchored on the reviewer's prior output.
+            # Both modes include the verbatim prior emission so "reformat" cannot
+            # be read as "drop the fields that are hard to encode". CLI mode also
+            # carries session continuity via session_id; the explicit anchor is
+            # more robust than relying on session memory alone.
+            _original_output = _original_result.output or ""
+            _retry_prompt = _build_review_retry_prompt(_error_desc, _original_output)
             _retry_result = run_agent(
                 prompt=_retry_prompt,
                 profile=_prof,

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -120,6 +120,8 @@ def _deserialize_review_result(data: object) -> object | None:
         parse_errors=_deserialize_parse_errors(data.get("parse_errors")),
         raw_yaml=dict(data.get("raw_yaml") or {}),
         ac_verification=tuple(ac_verification),
+        criteria_enumerable=bool(data.get("criteria_enumerable", True)),
+        criteria_enumerable_rationale=data.get("criteria_enumerable_rationale") or "",
         sanitization_audit=dict(data.get("sanitization_audit") or {}),
     )
 

--- a/src/theforge/review.py
+++ b/src/theforge/review.py
@@ -106,6 +106,10 @@ class ReviewResult:
     parse_errors: list[ParseError]  # non-empty if parsing/validation failed
     raw_yaml: dict  # the parsed YAML data
     ac_verification: tuple[ACVerification, ...] = ()  # per-AC verification table
+    # Escape valve: reviewer declares the issue has no enumerable acceptance
+    # criteria. Defaults to True (criteria are enumerable) for backward compat.
+    criteria_enumerable: bool = True
+    criteria_enumerable_rationale: str = ""
     sanitization_audit: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
@@ -268,6 +272,20 @@ def _extract_ac_verification(data: dict) -> tuple[ACVerification, ...]:
     return tuple(out)
 
 
+def _extract_criteria_enumerable(data: dict) -> tuple[bool, str]:
+    """Extract the criteria_enumerable escape-valve flag and its rationale.
+
+    Defaults to ``(True, "")`` — criteria are enumerable — when the field is
+    absent or malformed, matching the validator's default so downstream code
+    and audit see the same value the cross-validation used.
+    """
+    raw = data.get("criteria_enumerable", True)
+    enumerable = raw if isinstance(raw, bool) else True
+    rationale = data.get("criteria_enumerable_rationale")
+    rationale = rationale if isinstance(rationale, str) else ""
+    return enumerable, rationale
+
+
 def parse_review_json(data: dict, reporter: str = "") -> ReviewResult:
     """Parse and validate review JSON from API response.
 
@@ -292,6 +310,7 @@ def parse_review_json(data: dict, reporter: str = "") -> ReviewResult:
     test_adequate = tests.get("adequate", False) if isinstance(tests, dict) else False
     test_gaps = tests.get("gaps", []) if isinstance(tests, dict) else []
 
+    _enumerable, _enum_rationale = _extract_criteria_enumerable(data)
     return ReviewResult(
         verdict=data.get("verdict", "REQUEST_CHANGES"),
         summary=summary,
@@ -303,6 +322,8 @@ def parse_review_json(data: dict, reporter: str = "") -> ReviewResult:
         parse_errors=schema_errors,
         raw_yaml=data,
         ac_verification=_extract_ac_verification(data),
+        criteria_enumerable=_enumerable,
+        criteria_enumerable_rationale=_enum_rationale,
         sanitization_audit=sanitization_audit,
     )
 
@@ -374,6 +395,7 @@ def parse_review_output(agent_output: str, reporter: str = "") -> ReviewResult:
     test_adequate = tests.get("adequate", False) if isinstance(tests, dict) else False
     test_gaps = tests.get("gaps", []) if isinstance(tests, dict) else []
 
+    _enumerable, _enum_rationale = _extract_criteria_enumerable(data)
     return ReviewResult(
         verdict=data.get("verdict", "REQUEST_CHANGES"),
         summary=summary,
@@ -385,6 +407,8 @@ def parse_review_output(agent_output: str, reporter: str = "") -> ReviewResult:
         parse_errors=schema_errors,
         raw_yaml=data,
         ac_verification=_extract_ac_verification(data),
+        criteria_enumerable=_enumerable,
+        criteria_enumerable_rationale=_enum_rationale,
         sanitization_audit=sanitization_audit,
     )
 
@@ -948,6 +972,21 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
         *(r.sanitization_audit for _, r in valid)
     )
 
+    # The merged review can only assert "no enumerable acceptance criteria" if
+    # EVERY valid reviewer said so. A single reviewer that enumerated criteria
+    # keeps the merged flag True (its entries are in the merged table, so the
+    # escape valve is neither needed nor claimed).
+    merged_enumerable = any(r.criteria_enumerable for _, r in valid)
+    merged_enum_rationale = (
+        " | ".join(
+            f"[{name}] {r.criteria_enumerable_rationale}"
+            for name, r in valid
+            if not r.criteria_enumerable and r.criteria_enumerable_rationale.strip()
+        )
+        if not merged_enumerable
+        else ""
+    )
+
     return ReviewResult(
         verdict=verdict,
         summary=summary,
@@ -959,6 +998,8 @@ def merge_review_results(results: list[ReviewResult], names: list[str]) -> Revie
         parse_errors=[],  # valid reviewers had no errors
         raw_yaml={},
         ac_verification=merged_ac,
+        criteria_enumerable=merged_enumerable,
+        criteria_enumerable_rationale=merged_enum_rationale,
         sanitization_audit=merged_sanitization_audit,
     )
 

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -109,6 +109,10 @@ def validate_review_yaml(data: Any) -> list[ParseError]:
     Cross-validation rules:
     - APPROVE + any P1 → error (can't approve with blocking findings)
     - REQUEST_CHANGES + zero P1s → error (must justify the request)
+    - APPROVE + empty ac_verification → error, UNLESS the reviewer declares
+      ``criteria_enumerable: false`` with a non-empty
+      ``criteria_enumerable_rationale`` (escape valve for issues with no
+      enumerable acceptance criteria).
     """
     errors: list[ParseError] = []
 
@@ -232,13 +236,41 @@ def validate_review_yaml(data: Any) -> list[ParseError]:
         if status in ("PARTIAL", "NOT_VERIFIED"):
             non_verified_count += 1
 
+    # ── criteria_enumerable escape valve ──────────────────────────
+    # A reviewer who has reviewed the code, approves, and finds the issue has
+    # no enumerable acceptance criteria (some bug fixes, chores) previously had
+    # no legal move: APPROVE demands a non-empty ac_verification table. Rather
+    # than force the reviewer to manufacture criteria — or oscillate between
+    # APPROVE (empty table) and REQUEST_CHANGES (no P1) to dodge the rules —
+    # this flag lets the reviewer declare the degenerate state explicitly. It
+    # is not a free bypass: criteria_enumerable=false requires a non-empty
+    # rationale so the assertion is deliberate and auditable.
+    criteria_enumerable = data.get("criteria_enumerable", True)
+    if not isinstance(criteria_enumerable, bool):
+        _schema("criteria_enumerable must be a boolean when provided (true/false)")
+        criteria_enumerable = True
+    rationale = data.get("criteria_enumerable_rationale")
+    if rationale is not None and not isinstance(rationale, str):
+        _schema("criteria_enumerable_rationale must be a string when provided")
+        rationale = None
+
     if verdict == "APPROVE":
         if not ac_v:
-            _cross(
-                "verdict is APPROVE but ac_verification is empty — "
-                "reviewers must enumerate each acceptance criterion (or symptom for bugs) "
-                "and mark it VERIFIED with evidence pointers"
-            )
+            if criteria_enumerable is False:
+                # Legal degenerate state — require the reviewer to say why.
+                if not isinstance(rationale, str) or not rationale.strip():
+                    _cross(
+                        "verdict is APPROVE with criteria_enumerable: false but "
+                        "criteria_enumerable_rationale is empty — the reviewer must "
+                        "state why the issue has no enumerable acceptance criteria"
+                    )
+            else:
+                _cross(
+                    "verdict is APPROVE but ac_verification is empty — "
+                    "reviewers must enumerate each acceptance criterion (or symptom for bugs) "
+                    "and mark it VERIFIED with evidence pointers, or set "
+                    "criteria_enumerable: false with a rationale if the issue has none"
+                )
         elif non_verified_count > 0:
             _cross(
                 f"verdict is APPROVE but {non_verified_count} ac_verification entry(ies) "
@@ -395,6 +427,8 @@ def review_json_schema() -> dict:
             "story_compliance",
             "test_coverage",
             "ac_verification",
+            "criteria_enumerable",
+            "criteria_enumerable_rationale",
         ],
         "properties": {
             "verdict": {
@@ -496,6 +530,25 @@ def review_json_schema() -> dict:
                         "evidence": {"type": "string"},
                     },
                 },
+            },
+            "criteria_enumerable": {
+                "type": "boolean",
+                "description": (
+                    "Whether the issue has enumerable acceptance criteria to verify. "
+                    "Set true in the normal case. Set false ONLY when the issue "
+                    "genuinely has none to enumerate (e.g. some bug fixes or chores); "
+                    "then ac_verification may be empty and you MUST supply a non-empty "
+                    "criteria_enumerable_rationale. This is not a shortcut to avoid "
+                    "verifying criteria that do exist."
+                ),
+            },
+            "criteria_enumerable_rationale": {
+                "type": "string",
+                "description": (
+                    "Required (non-empty) when criteria_enumerable is false: one "
+                    "sentence stating why the issue has no enumerable acceptance "
+                    "criteria. Empty string when criteria_enumerable is true."
+                ),
             },
         },
     }

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -125,12 +125,19 @@ def build_synthesis_prompt(
               tests covering the issue's specific failure mode (signature, error
               string, retry context). Pointers must be concrete, not generic.
               For PARTIAL or NOT_VERIFIED: explain what is missing.>
+        criteria_enumerable: true
+        criteria_enumerable_rationale: ""
         ```
 
         ## Rules
 
         - verdict MUST be `APPROVE` if there are zero P1 findings AND every
           ac_verification entry is VERIFIED
+        - If the issue genuinely has NO enumerable acceptance criteria (some bug
+          fixes, chores), you MAY APPROVE with an empty `ac_verification` by
+          setting `criteria_enumerable: false` and giving a one-sentence
+          `criteria_enumerable_rationale`. Use this only when there is truly
+          nothing to enumerate — never to skip verifying criteria that exist.
         - verdict MUST be `REQUEST_CHANGES` if any P1 finding exists OR any
           ac_verification entry is PARTIAL or NOT_VERIFIED
         - Reconcile per-AC verification across reviewers — if any reviewer
@@ -336,7 +343,15 @@ def build_review_prompt(
               tests covering the issue's specific failure mode (signature, error
               string, retry context). Pointers must be concrete, not generic.
               For PARTIAL or NOT_VERIFIED: explain what is missing.>
+        criteria_enumerable: true
+        criteria_enumerable_rationale: ""
         ```
+
+        If the issue genuinely has NO enumerable acceptance criteria (some bug
+        fixes, chores), you MAY APPROVE with an empty `ac_verification` by setting
+        `criteria_enumerable: false` and a one-sentence
+        `criteria_enumerable_rationale`. Use this only when there is truly nothing
+        to enumerate — never to skip verifying criteria that exist.
     """)
     if mode == "api":
         output_format_section = dedent("""\
@@ -528,7 +543,9 @@ def build_review_prompt(
         - **Cross-validation enforced**: APPROVE with any PARTIAL or
           NOT_VERIFIED ac_verification entry will be rejected by the schema
           validator and your review will be discarded — do not produce that
-          combination.
+          combination. APPROVE with an empty ac_verification is also rejected
+          UNLESS you set `criteria_enumerable: false` with a rationale (only
+          legitimate when the issue has no enumerable criteria).
         - **YAML safety**: In `description` and `suggestion` fields, do NOT use
           backslashes or double-quote characters inside double-quoted strings —
           they break YAML parsing. Use single quotes or paraphrase instead.

--- a/tests/test_coord_review_phase_pool.py
+++ b/tests/test_coord_review_phase_pool.py
@@ -925,3 +925,91 @@ class TestReviewPoolResilience:
         # Best individual is reviewer-a's APPROVE → task succeeds
         assert result.success is True
         assert result.phase == Phase.DONE
+
+
+_ESCAPE_VALVE_APPROVE = (
+    "```yaml\n"
+    "verdict: APPROVE\n"
+    'summary: "Dependency bump, nothing to enumerate"\n'
+    "findings: []\n"
+    "story_compliance:\n"
+    "  matches_spec: true\n"
+    "  mismatches: []\n"
+    "test_coverage:\n"
+    "  adequate: true\n"
+    "  gaps: []\n"
+    "ac_verification: []\n"
+    "criteria_enumerable: false\n"
+    'criteria_enumerable_rationale: "Chore with no acceptance criteria."\n'
+    "```\n"
+)
+
+
+class TestCriteriaEnumerableEscapeValveSeam:
+    """Seam-level: the escape valve is review-phase output data that flows to
+    gating and the audit trail. Verify APPROVE-with-empty-AC passes the review
+    phase (no oscillation retry) and the flag reaches the audit."""
+
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_escape_valve_approve_passes_without_retry(
+        self, mock_shell, mock_engine_agent, mock_preflight, mock_pool, mock_review_agent, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_engine_agent.return_value = _make_agent_result()
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=_ESCAPE_VALVE_APPROVE, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+        audit = generate_audit_log(config, task, result)
+
+        assert result.success is True
+        assert result.state.review_cycle == 1
+        # No oscillation retry — the escape valve made APPROVE-with-empty-AC legal.
+        assert result.state.review_cycle_metadata[0].parse_retries == 0
+        # The reviewer's retry entrypoint was never called.
+        mock_review_agent.assert_not_called()
+        # The flag is surfaced in the audit trail.
+        assert audit["reviews"][0]["criteria_enumerable"] is False
+
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_retry_prompt_anchors_prior_content(
+        self, mock_shell, mock_engine_agent, mock_preflight, mock_pool, mock_review_agent, tmp_path
+    ):
+        """When a reviewer output needs a parse retry, the corrective prompt sent
+        to run_agent must anchor the prior output and forbid dropping fields."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_engine_agent.return_value = _make_agent_result()
+
+        broken = _make_agent_result(success=True, output=PARSE_ERROR_OUTPUT, profile_name="review")
+        mock_pool.return_value = [broken]
+        mock_review_agent.return_value = _make_agent_result(output=APPROVE_REVIEW)
+
+        run_task(config, task)
+
+        assert mock_review_agent.called
+        retry_prompt = mock_review_agent.call_args.kwargs["prompt"]
+        # Anchors prior content and forecloses the field-dropping interpretation.
+        assert "CONTENT" in retry_prompt and "ENCODING" in retry_prompt
+        assert "WRONG" in retry_prompt
+        assert PARSE_ERROR_OUTPUT in retry_prompt

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1017,3 +1017,90 @@ class TestParseReviewOutputStringLine:
         assert len(result.findings) == 1
         assert result.findings[0].line == 42
         assert isinstance(result.findings[0].line, int)
+
+
+APPROVE_NO_ENUMERABLE_AC = """\
+```yaml
+verdict: APPROVE
+summary: "Chore fix, nothing to enumerate"
+findings: []
+story_compliance:
+  matches_spec: true
+  mismatches: []
+test_coverage:
+  adequate: true
+  gaps: []
+ac_verification: []
+criteria_enumerable: false
+criteria_enumerable_rationale: "Dependency bump with no acceptance criteria."
+```
+"""
+
+
+class TestCriteriaEnumerableParsing:
+    def test_escape_valve_parses_without_errors(self):
+        result = parse_review_output(APPROVE_NO_ENUMERABLE_AC)
+        assert result.parse_errors == []
+        assert result.verdict == "APPROVE"
+        assert result.criteria_enumerable is False
+        assert "Dependency bump" in result.criteria_enumerable_rationale
+
+    def test_defaults_true_when_field_absent(self):
+        result = parse_review_output(VALID_APPROVE_YAML)
+        assert result.criteria_enumerable is True
+        assert result.criteria_enumerable_rationale == ""
+
+    def test_json_path_carries_escape_valve(self):
+        data = {
+            "verdict": "APPROVE",
+            "summary": "ok",
+            "findings": [],
+            "story_compliance": {"matches_spec": True, "mismatches": []},
+            "test_coverage": {"adequate": True, "gaps": []},
+            "ac_verification": [],
+            "criteria_enumerable": False,
+            "criteria_enumerable_rationale": "no enumerable AC",
+        }
+        result = parse_review_json(data)
+        assert result.parse_errors == []
+        assert result.criteria_enumerable is False
+
+
+class TestCriteriaEnumerableMerge:
+    def _reviewer(self, *, enumerable, rationale=""):
+        return ReviewResult(
+            verdict="APPROVE",
+            summary="ok",
+            findings=[],
+            story_matches=True,
+            story_mismatches=[],
+            test_adequate=True,
+            test_gaps=[],
+            parse_errors=[],
+            raw_yaml={},
+            criteria_enumerable=enumerable,
+            criteria_enumerable_rationale=rationale,
+        )
+
+    def test_all_false_merges_false(self):
+        merged = merge_review_results(
+            [
+                self._reviewer(enumerable=False, rationale="chore"),
+                self._reviewer(enumerable=False, rationale="no ACs"),
+            ],
+            ["a", "b"],
+        )
+        assert merged.criteria_enumerable is False
+        assert "chore" in merged.criteria_enumerable_rationale
+        assert "no ACs" in merged.criteria_enumerable_rationale
+
+    def test_any_enumerable_keeps_true(self):
+        merged = merge_review_results(
+            [
+                self._reviewer(enumerable=False, rationale="chore"),
+                self._reviewer(enumerable=True),
+            ],
+            ["a", "b"],
+        )
+        assert merged.criteria_enumerable is True
+        assert merged.criteria_enumerable_rationale == ""

--- a/tests/test_review_retry_prompt.py
+++ b/tests/test_review_retry_prompt.py
@@ -1,0 +1,59 @@
+"""Tests for the review-retry corrective prompt.
+
+The retry prompt must anchor the reviewer's prior content and foreclose the
+field-dropping interpretation that produces the APPROVE-empty-AC ↔
+REQUEST_CHANGES-no-P1 oscillation trap (issue #1546).
+"""
+
+from theforge.coordinator.review_pool import (
+    _CORRECTIVE_YAML_STRUCTURE,
+    _build_review_retry_prompt,
+)
+
+_PRIOR_OUTPUT = """\
+verdict: APPROVE
+summary: "Looks good"
+ac_verification:
+  - criterion: "Handles the retry's failure mode"
+    status: VERIFIED
+    evidence: "src/x.py:10"
+"""
+
+
+class TestBuildReviewRetryPrompt:
+    def test_includes_prior_output_verbatim(self):
+        prompt = _build_review_retry_prompt("YAML syntax error", _PRIOR_OUTPUT)
+        assert _PRIOR_OUTPUT in prompt
+
+    def test_includes_error_description(self):
+        prompt = _build_review_retry_prompt("apostrophe in single-quote", _PRIOR_OUTPUT)
+        assert "apostrophe in single-quote" in prompt
+
+    def test_names_dropping_a_field_as_wrong(self):
+        prompt = _build_review_retry_prompt("err", _PRIOR_OUTPUT).lower()
+        assert "wrong" in prompt
+        assert "drop" in prompt
+
+    def test_forbids_verdict_flip(self):
+        prompt = _build_review_retry_prompt("err", _PRIOR_OUTPUT)
+        assert "APPROVE" in prompt and "REQUEST_CHANGES" in prompt
+        # The prompt must instruct keeping the same verdict.
+        assert "SAME verdict" in prompt
+
+    def test_anchors_content_as_correct(self):
+        prompt = _build_review_retry_prompt("err", _PRIOR_OUTPUT)
+        assert "CONTENT" in prompt and "ENCODING" in prompt
+
+    def test_points_to_escape_valve_instead_of_dropping(self):
+        prompt = _build_review_retry_prompt("err", _PRIOR_OUTPUT)
+        assert "criteria_enumerable" in prompt
+
+    def test_still_says_do_not_re_review(self):
+        prompt = _build_review_retry_prompt("err", _PRIOR_OUTPUT)
+        assert "Do NOT re-review" in prompt
+
+    def test_corrective_structure_lists_ac_verification(self):
+        # The required-structure block must not omit ac_verification — omitting
+        # it is itself an inducement to drop the field.
+        assert "ac_verification:" in _CORRECTIVE_YAML_STRUCTURE
+        assert "criteria_enumerable" in _CORRECTIVE_YAML_STRUCTURE

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -195,6 +195,53 @@ class TestValidateReviewYaml:
         errors = validate_review_yaml(data)
         assert any("APPROVE" in e and "ac_verification" in e for e in errors)
 
+    def test_approve_empty_ac_with_criteria_enumerable_false_is_valid(self):
+        """Escape valve: APPROVE + empty ac_verification is legal when the
+        reviewer declares no enumerable criteria and gives a rationale."""
+        data = _valid_review()
+        data["ac_verification"] = []
+        data["criteria_enumerable"] = False
+        data["criteria_enumerable_rationale"] = (
+            "Chore-style fix with no acceptance criteria to enumerate."
+        )
+        errors = validate_review_yaml(data)
+        assert errors == []
+
+    def test_approve_criteria_enumerable_false_without_rationale_is_error(self):
+        """The escape valve is not a free bypass — it requires a rationale."""
+        data = _valid_review()
+        data["ac_verification"] = []
+        data["criteria_enumerable"] = False
+        data["criteria_enumerable_rationale"] = ""
+        errors = validate_review_yaml(data)
+        assert any("criteria_enumerable" in e and "rationale" in e for e in errors)
+
+    def test_approve_empty_ac_default_enumerable_still_errors(self):
+        """Without the flag, APPROVE + empty ac_verification stays an error
+        (default criteria_enumerable is True)."""
+        data = _valid_review()
+        data["ac_verification"] = []
+        errors = validate_review_yaml(data)
+        assert any("APPROVE" in e and "ac_verification" in e for e in errors)
+
+    def test_criteria_enumerable_non_bool_is_error(self):
+        data = _valid_review()
+        data["criteria_enumerable"] = "false"
+        errors = validate_review_yaml(data)
+        assert any("criteria_enumerable" in e and "boolean" in e for e in errors)
+
+    def test_criteria_enumerable_false_does_not_bypass_non_verified(self):
+        """The flag only rescues the empty-table case — a populated table with a
+        NOT_VERIFIED entry still fails even with criteria_enumerable false."""
+        data = _valid_review()
+        data["criteria_enumerable"] = False
+        data["criteria_enumerable_rationale"] = "n/a"
+        data["ac_verification"] = [
+            {"criterion": "Foo", "status": "NOT_VERIFIED", "evidence": "missing"},
+        ]
+        errors = validate_review_yaml(data)
+        assert any("APPROVE" in e and "NOT_VERIFIED" in e for e in errors)
+
     def test_approve_with_partial_ac_is_error(self):
         """APPROVE with any PARTIAL entry fails — silent contract swap guard."""
         data = _valid_review()
@@ -383,3 +430,23 @@ class TestRepairReviewYaml:
         errors = validate_review_yaml(data)
         assert any("APPROVE" in error and "P1" in error for error in errors)
         assert data["verdict"] == "APPROVE"
+
+
+class TestReviewJsonSchemaEscapeValve:
+    """The exported strict JSON schema must expose the escape-valve fields so
+    API (forced-tool) reviewers can reach the same degenerate state as CLI ones."""
+
+    def test_schema_declares_criteria_enumerable_fields(self):
+        from theforge.schemas import review_json_schema
+
+        schema = review_json_schema()
+        props = schema["properties"]
+        assert props["criteria_enumerable"]["type"] == "boolean"
+        assert props["criteria_enumerable_rationale"]["type"] == "string"
+
+    def test_strict_schema_lists_new_fields_as_required(self):
+        """OpenAI strict mode requires every property in `required`."""
+        from theforge.schemas import review_json_schema
+
+        schema = review_json_schema()
+        assert set(schema["properties"]) == set(schema["required"])


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The retry prompt is anchored, the schema has an auditable escape valve, and the touched seams are covered. | [google-gemini-3.5-flash] The review-retry oscillation trap has been successfully resolved with a robust corrective prompt and a criteria_enumerable escape valve.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $5.71
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Review-parse-retry prompt + schema cross-validations create an oscillation trap when reviewer drops fields to dodge syntax issues (GitHub Issue #1546)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1546