### PR TITLE
Shape-gate diagnosis requirements become a single published spec consumed by validator, remediation prompt, findings, and skeleton

### DIFF
--- a/docs/reference/bug-shape.md
+++ b/docs/reference/bug-shape.md
@@ -1,0 +1,61 @@
+# Bug shape reference
+
+> Generated from `theforge.shape_check.diagnosis_spec`. Do not edit by hand —
+> run the shape-reference generator (or the test that regenerates it) instead.
+
+A bug-typed issue is *fix-ready* when its body carries a complete
+`## Diagnosis` section. The shape gate refuses symptom-only bug bodies;
+an honest non-assertion confirmed cause (`unknown`, `not yet identified`,
+`pending investigation`, `TBD`) is admissible and marks the bug
+investigation-ready rather than implementation-ready.
+
+## Required components
+
+Each component is written as a bolded bullet lead-in under the
+`## Diagnosis` heading. The gate matches the **label** literally (case-insensitive).
+
+### Observed symptom
+
+- Satisfies: bolded bullet lead-in or heading inside "## Diagnosis"
+- Example: - **Observed symptom:** sprint resume false-skips zero-delta APPROVE stories, reporting them merged when no commit landed.
+
+### Evidence
+
+- Satisfies: bolded bullet lead-in or heading inside "## Diagnosis"
+- Example: - **Evidence:** run id `1ff6b0bb7992`, story #1102 — resume log shows the false skip.
+
+### Ruled out
+
+- Satisfies: bolded bullet lead-in or heading listing eliminated hypotheses
+- Example: - **Ruled out:** workspace creation actually succeeds (verified in logs) — not the cause.
+
+### Confirmed cause
+
+- Satisfies: bolded bullet lead-in or heading; its value may be a specific claim or an honest non-assertion ("unknown", "not yet identified")
+- Example: - **Confirmed cause:** `_is_already_merged` requires at least one commit ahead, so a zero-delta APPROVE is misclassified as unmerged.
+
+### Affected code path
+
+- Satisfies: bolded bullet lead-in or heading naming the module/function
+- Example: - **Affected code path:** `sprint.runner._is_already_merged`.
+
+### Fix-success criterion
+
+- Satisfies: bolded bullet lead-in or heading stating the observable pass condition
+- Example: - **Fix-success criterion:** resume identifies a zero-delta APPROVE story as already merged.
+
+## Fileable skeleton
+
+Copy this into a bug issue body and replace each example value. A body
+that starts from this skeleton passes the shape gate by construction.
+
+```markdown
+## Diagnosis
+
+- **Observed symptom:** sprint resume false-skips zero-delta APPROVE stories, reporting them merged when no commit landed.
+- **Evidence:** run id `1ff6b0bb7992`, story #1102 — resume log shows the false skip.
+- **Ruled out:** workspace creation actually succeeds (verified in logs) — not the cause.
+- **Confirmed cause:** `_is_already_merged` requires at least one commit ahead, so a zero-delta APPROVE is misclassified as unmerged.
+- **Affected code path:** `sprint.runner._is_already_merged`.
+- **Fix-success criterion:** resume identifies a zero-delta APPROVE story as already merged.
+```

--- a/src/theforge/intake/agent_rewrite.py
+++ b/src/theforge/intake/agent_rewrite.py
@@ -9,9 +9,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..shape_check.diagnosis_spec import render_diagnosis_requirements_block
 from .findings import IntakeFinding
 
 _NO_REMEDIATION_PREFIX = "NO_REMEDIATION:"
+
+# Finding codes whose remediation requires a complete bug Diagnosis section.
+# When present, the prompt embeds the diagnosis spec's labels + examples so the
+# agent aims at exactly the target the validator checks (#1629).
+_DIAGNOSIS_FINDING_CODES: frozenset[str] = frozenset({"needs_diagnosis"})
 
 
 @dataclass(frozen=True)
@@ -56,6 +62,14 @@ def build_agent_rewrite_prompt(
     ]
     for finding in findings:
         lines.append(f"- `{finding.code}` at `{finding.location}`: {finding.problem}")
+    if any(finding.code in _DIAGNOSIS_FINDING_CODES for finding in findings):
+        lines.extend(
+            [
+                "",
+                "Diagnosis section requirements:",
+                render_diagnosis_requirements_block(),
+            ]
+        )
     lines.extend(
         [
             "",

--- a/src/theforge/intake/remediation.py
+++ b/src/theforge/intake/remediation.py
@@ -418,9 +418,18 @@ def _remediate_one(
     if auto_fix_mode == "edit":
         if rerun_blocking:
             # Don't edit a body that still fails — but do not silently discard
-            # the candidate either. Post the proposed replacement plus the
-            # remaining blocking findings as a comment so the operator can
-            # continue from the candidate instead of redoing the rewrite.
+            # the candidate either. Always persist the rejected rewrite and the
+            # specific unmet components to a durable audit artifact so the
+            # refusal is inspectable after the sprint (#1629 AC5 — #1627 dropped
+            # a rewrite that could never be re-examined). Also post the
+            # candidate as an issue comment when possible so the operator finds
+            # it on the thread.
+            artifact_path = _write_candidate_artifact(
+                issue_number=issue_number,
+                candidate_body=proposed_body,
+                findings=rerun_blocking,
+                project_root=project_root,
+            )
             salvage_comment = _format_remediation_comment(
                 rerun_blocking,
                 proposed_body,
@@ -432,22 +441,15 @@ def _remediate_one(
                 ),
             )
             posted = post_comment(issue_number, salvage_comment, project_root)
-            artifact_path: str | None = None
-            if not posted:
-                # Fallback persistence: comment post failed, so the operator
-                # cannot find the candidate on the issue thread. Write a
-                # durable artifact instead so proposed_replacement is never
-                # silently lost.
-                artifact_path = _write_candidate_artifact(
-                    issue_number=issue_number,
-                    candidate_body=proposed_body,
-                    findings=rerun_blocking,
-                    project_root=project_root,
+            if posted and artifact_path is not None:
+                detail = (
+                    "rerun gate still failing; candidate posted as issue comment and "
+                    f"persisted to {artifact_path} for operator review"
                 )
-            if posted:
+            elif posted:
                 detail = (
                     "rerun gate still failing; candidate posted as issue comment "
-                    "for operator review"
+                    "for operator review (artifact write failed)"
                 )
             elif artifact_path is not None:
                 detail = (
@@ -510,21 +512,32 @@ def _remediate_one(
     comment = _format_remediation_comment(blocking, proposed_body)
     posted = post_comment(issue_number, comment, project_root)
     if rerun_blocking:
+        # Persist the rejected rewrite + unmet components as a durable audit
+        # artifact so the refusal is inspectable regardless of comment I/O
+        # (#1629 AC5).
+        artifact_path = _write_candidate_artifact(
+            issue_number=issue_number,
+            candidate_body=proposed_body,
+            findings=rerun_blocking,
+            project_root=project_root,
+        )
+        detail = "comment mode: posted replacement; rerun gate still failing"
+        if artifact_path is not None:
+            detail += f"; candidate persisted to {artifact_path}"
+        detail += _grooming_divergence_suffix(rerun_blocking)
         return IntakeOutcome(
             slug=slug,
             kind=IntakeOutcomeKind.DROPPED_AFTER_FIX,
             findings=tuple(rerun_blocking),
             proposed_replacement=proposed_body,
-            detail=(
-                "comment mode: posted replacement; rerun gate still failing"
-                + _grooming_divergence_suffix(rerun_blocking)
-            ),
+            detail=detail,
             audit=_build_audit(
                 consumed=_consumed,
                 semantic_remaining=semantic_remaining,
                 agent=agent_result,
                 remediation_source=("agent" if agent_result is not None else "mechanical"),
                 comment_posted=posted,
+                candidate_artifact_path=artifact_path,
             ),
         )
     return IntakeOutcome(

--- a/src/theforge/shape_check/diagnosis_spec.py
+++ b/src/theforge/shape_check/diagnosis_spec.py
@@ -1,0 +1,243 @@
+"""Declarative spec for the bug Diagnosis section the shape gate requires.
+
+Single source of truth for the components a well-formed ``## Diagnosis`` section
+must contain. Four consumers derive from this list rather than restating it:
+
+- the shape-gate validator
+  (:func:`theforge.shape_check.heuristics.diagnosis_completeness`),
+- the shape-gate finding messages
+  (:func:`theforge.shape_check.heuristics.check_bug_missing_diagnosis`),
+- the intake remediation prompt
+  (:func:`theforge.intake.agent_rewrite.build_agent_rewrite_prompt`), and
+- the fileable skeleton (:func:`render_bug_shape_reference`, published as
+  ``docs/reference/bug-shape.md``).
+
+Deriving producers and validator from one spec is the fix for the
+producer/validator drift documented in #1629 — five fully-diagnosed bugs were
+refused because a component's *label* did not match the validator's private
+token list, while the requirement was never published anywhere a producer could
+read. It is the same shape as #1546's review-parse oscillation trap, applied to
+the intake gate: a rewrite agent now aims at exactly the labels the validator
+checks, and a filing that starts from the skeleton passes by construction.
+
+Stdlib only — pure-data types in a low-dependency module (project convention 4).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+#: Repo-relative path of the published shape reference derived from this spec.
+BUG_SHAPE_REFERENCE_PATH = "docs/reference/bug-shape.md"
+
+#: The heading a bug's diagnosis lives under.
+DIAGNOSIS_HEADING = "## Diagnosis"
+
+
+@dataclass(frozen=True)
+class DiagnosisComponent:
+    """One required component of a bug's Diagnosis section.
+
+    Attributes:
+        key: stable machine identifier.
+        label: the bolded label an operator writes as the bullet lead-in
+            (e.g. ``"Confirmed cause"``). The validator matches it
+            case-insensitively; the finding message, remediation prompt, and
+            skeleton all quote it verbatim. The lowercased label is also the
+            substring the validator scans for — see :attr:`token`.
+        satisfies: human description of what content satisfies the component.
+        example: a concrete example value, quoted verbatim into the finding
+            message, the remediation prompt, and the skeleton.
+    """
+
+    key: str
+    label: str
+    satisfies: str
+    example: str
+
+    @property
+    def token(self) -> str:
+        """The lowercased substring the validator scans the section for.
+
+        Kept identical to ``label.lower()`` so a skeleton bullet built from
+        :meth:`bullet` always contains the token the validator matches — the
+        drift the spec exists to eliminate.
+        """
+        return self.label.lower()
+
+    def bullet(self) -> str:
+        """Render the component as a skeleton bullet: ``- **Label:** example``."""
+        return f"- **{self.label}:** {self.example}"
+
+
+REQUIRED_DIAGNOSIS_COMPONENTS: tuple[DiagnosisComponent, ...] = (
+    DiagnosisComponent(
+        key="observed_symptom",
+        label="Observed symptom",
+        satisfies='bolded bullet lead-in or heading inside "## Diagnosis"',
+        example=(
+            "sprint resume false-skips zero-delta APPROVE stories, reporting them "
+            "merged when no commit landed."
+        ),
+    ),
+    DiagnosisComponent(
+        key="evidence",
+        label="Evidence",
+        satisfies='bolded bullet lead-in or heading inside "## Diagnosis"',
+        example="run id `1ff6b0bb7992`, story #1102 — resume log shows the false skip.",
+    ),
+    DiagnosisComponent(
+        key="ruled_out",
+        label="Ruled out",
+        satisfies="bolded bullet lead-in or heading listing eliminated hypotheses",
+        example="workspace creation actually succeeds (verified in logs) — not the cause.",
+    ),
+    DiagnosisComponent(
+        key="confirmed_cause",
+        label="Confirmed cause",
+        satisfies=(
+            "bolded bullet lead-in or heading; its value may be a specific claim "
+            'or an honest non-assertion ("unknown", "not yet identified")'
+        ),
+        example=(
+            "`_is_already_merged` requires at least one commit ahead, so a "
+            "zero-delta APPROVE is misclassified as unmerged."
+        ),
+    ),
+    DiagnosisComponent(
+        key="affected_code_path",
+        label="Affected code path",
+        satisfies="bolded bullet lead-in or heading naming the module/function",
+        example="`sprint.runner._is_already_merged`.",
+    ),
+    DiagnosisComponent(
+        key="fix_success_criterion",
+        label="Fix-success criterion",
+        satisfies="bolded bullet lead-in or heading stating the observable pass condition",
+        example="resume identifies a zero-delta APPROVE story as already merged.",
+    ),
+)
+
+
+def required_diagnosis_tokens() -> tuple[str, ...]:
+    """The substring tokens the validator scans a Diagnosis section for.
+
+    Derived from :data:`REQUIRED_DIAGNOSIS_COMPONENTS` — the validator must not
+    carry its own independent list.
+    """
+    return tuple(component.token for component in REQUIRED_DIAGNOSIS_COMPONENTS)
+
+
+def component_for_token(token: str) -> DiagnosisComponent | None:
+    """Return the component whose token matches, or ``None``."""
+    for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+        if component.token == token:
+            return component
+    return None
+
+
+def describe_missing(tokens: Iterable[str]) -> str:
+    """Render the operator-facing description of missing components.
+
+    Each missing component is named by its exact literal label and paired with
+    its example, so a finding message quotes the target a producer must hit
+    rather than a bare component name (#1629 AC3).
+    """
+    parts: list[str] = []
+    for token in tokens:
+        component = component_for_token(token)
+        if component is None:
+            # Forward-compat: an unrecognized token still surfaces literally.
+            parts.append(f'"{token}"')
+            continue
+        parts.append(
+            f'a "**{component.label}:**" bullet under {DIAGNOSIS_HEADING} '
+            f'(example: "{component.bullet()}")'
+        )
+    return "; ".join(parts)
+
+
+def render_diagnosis_requirements_block() -> str:
+    """Render the spec as prompt instructions embedding labels + examples.
+
+    Consumed verbatim by the intake remediation prompt so a rewrite agent aims
+    at exactly the labels the validator checks (#1629 AC2).
+    """
+    lines = [
+        f"The bug body must contain a {DIAGNOSIS_HEADING} section with all of the",
+        "components below, each written as a bolded bullet lead-in. Use these exact",
+        "labels — the shape gate matches them literally:",
+        "",
+    ]
+    for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+        lines.append(f"- **{component.label}:** {component.satisfies}")
+        lines.append(f"  Example — {component.bullet()}")
+    lines.extend(
+        [
+            "",
+            f"Full shape reference: {BUG_SHAPE_REFERENCE_PATH}",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_bug_skeleton_body() -> str:
+    """Render a fileable ``## Diagnosis`` skeleton from the spec.
+
+    A bug body that starts from this skeleton passes the shape gate by
+    construction: every component's bullet contains its own token, and the
+    confirmed-cause example is a specific claim (implementation-ready).
+    """
+    lines = [DIAGNOSIS_HEADING, ""]
+    for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+        lines.append(component.bullet())
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_bug_shape_reference() -> str:
+    """Render the full ``docs/reference/bug-shape.md`` document from the spec.
+
+    The on-disk doc is checked against this output by a test, so the published
+    reference can never drift from what the validator enforces (#1629 AC4).
+    """
+    lines = [
+        "# Bug shape reference",
+        "",
+        "> Generated from `theforge.shape_check.diagnosis_spec`. Do not edit by hand —",
+        "> run the shape-reference generator (or the test that regenerates it) instead.",
+        "",
+        "A bug-typed issue is *fix-ready* when its body carries a complete",
+        f"`{DIAGNOSIS_HEADING}` section. The shape gate refuses symptom-only bug bodies;",
+        "an honest non-assertion confirmed cause (`unknown`, `not yet identified`,",
+        "`pending investigation`, `TBD`) is admissible and marks the bug",
+        "investigation-ready rather than implementation-ready.",
+        "",
+        "## Required components",
+        "",
+        "Each component is written as a bolded bullet lead-in under the",
+        f"`{DIAGNOSIS_HEADING}` heading. The gate matches the **label** literally"
+        " (case-insensitive).",
+        "",
+    ]
+    for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+        lines.append(f"### {component.label}")
+        lines.append("")
+        lines.append(f"- Satisfies: {component.satisfies}")
+        lines.append(f"- Example: {component.bullet()}")
+        lines.append("")
+    lines.extend(
+        [
+            "## Fileable skeleton",
+            "",
+            "Copy this into a bug issue body and replace each example value. A body",
+            "that starts from this skeleton passes the shape gate by construction.",
+            "",
+            "```markdown",
+            render_bug_skeleton_body().rstrip("\n"),
+            "```",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -501,13 +501,17 @@ def check_bug_missing_diagnosis(title: str, body: str, labels: Iterable[str]) ->
             severity=Severity.BLOCKING,
             detail=(
                 "Bug has no Diagnosis section — not fix-ready. Add a '## Diagnosis' "
-                "section containing observed symptom, evidence, ruled-out hypotheses, "
-                "confirmed cause, affected code path, and fix-success criterion before "
-                "sprinting (or run `forge diagnose` when available). The confirmed-cause "
-                "value may be a specific claim or a non-assertion phrase such as "
-                "'unknown', 'not yet identified', 'pending investigation', or 'TBD' — "
-                "investigation-ready bugs are admissible; only symptom-only bodies are "
-                "refused."
+                "section containing "
+                # Derive the full required-component list from the single spec so
+                # the no-section message quotes the same literal labels + examples
+                # the validator checks (#1629), not a hand-maintained name list.
+                f"{describe_missing(required_diagnosis_tokens())} "
+                "before sprinting (or run `forge diagnose` when available). The "
+                "confirmed-cause value may be a specific claim or a non-assertion "
+                "phrase such as 'unknown', 'not yet identified', 'pending "
+                "investigation', or 'TBD' — investigation-ready bugs are admissible; "
+                "only symptom-only bodies are refused. "
+                f"Full shape reference: {BUG_SHAPE_REFERENCE_PATH}"
             ),
         )
     if _diagnosis_cause_unknown(body):

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -9,6 +9,11 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable
 
+from theforge.shape_check.diagnosis_spec import (
+    BUG_SHAPE_REFERENCE_PATH,
+    describe_missing,
+    required_diagnosis_tokens,
+)
 from theforge.shape_check.parsing import (
     extract_ac_section,
     extract_bullets,
@@ -210,14 +215,12 @@ def _find_tracking_body_declaration(body: str) -> tuple[str, str] | None:
 
 
 DIAGNOSIS_HEADING_PATTERN = r"diagnosis"
-REQUIRED_DIAGNOSIS_TOKENS: tuple[str, ...] = (
-    "observed symptom",
-    "evidence",
-    "ruled out",
-    "confirmed cause",
-    "affected code path",
-    "fix-success criterion",
-)
+
+# Derived from the single declarative spec (diagnosis_spec.py) — this module
+# must not carry its own independent list of required components. Kept as a
+# module-level name for backward-compatible imports; the spec is the source of
+# truth (#1629).
+REQUIRED_DIAGNOSIS_TOKENS: tuple[str, ...] = required_diagnosis_tokens()
 
 # Non-assertion vocabulary admissible as the value of the "confirmed cause" field.
 # A bug whose Diagnosis section has every other component but states the cause is
@@ -520,8 +523,9 @@ def check_bug_missing_diagnosis(title: str, body: str, labels: Iterable[str]) ->
         code="needs_diagnosis",
         severity=Severity.BLOCKING,
         detail=(
-            "Bug Diagnosis section is incomplete — missing required component(s): "
-            f"{', '.join(missing)}."
+            "Bug Diagnosis section is incomplete — missing "
+            f"{describe_missing(missing)}. "
+            f"Full shape reference: {BUG_SHAPE_REFERENCE_PATH}"
         ),
     )
 

--- a/tests/test_diagnosis_spec.py
+++ b/tests/test_diagnosis_spec.py
@@ -1,0 +1,152 @@
+"""Tests for the single declarative Diagnosis spec and its consumers (#1629).
+
+The bug-shape gate's required Diagnosis components live in one declarative spec
+(``theforge.shape_check.diagnosis_spec``); the validator, the gate finding
+message, the intake remediation prompt, and the published skeleton all derive
+from it. These tests pin that every consumer stays derived from the spec so the
+producer/validator drift of #1629 cannot recur.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from theforge.intake.agent_rewrite import build_agent_rewrite_prompt
+from theforge.intake.findings import IntakeFinding, IntakeSeverity
+from theforge.shape_check import Shape, check
+from theforge.shape_check.diagnosis_spec import (
+    BUG_SHAPE_REFERENCE_PATH,
+    REQUIRED_DIAGNOSIS_COMPONENTS,
+    render_bug_shape_reference,
+    render_bug_skeleton_body,
+    required_diagnosis_tokens,
+)
+from theforge.shape_check.heuristics import (
+    REQUIRED_DIAGNOSIS_TOKENS,
+    check_bug_missing_diagnosis,
+)
+
+# Repo root: tests/ -> project root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# A compliant, implementation-ready bug body (shape of #1609/#1598).
+_COMPLIANT_BODY = textwrap.dedent(
+    """\
+    ## Diagnosis
+
+    - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
+    - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
+    - **Ruled out.** Workspace creation actually succeeds (verified in logs).
+    - **Confirmed cause.** `_is_already_merged` requires at least one commit ahead.
+    - **Affected code path.** sprint.runner._is_already_merged.
+    - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.
+    """
+)
+
+# The content is all present, but the confirmed-cause component is written under
+# a different label ("Root cause") than the one the validator matches. This is
+# exactly the #1629 failure mode: complete RCA, mismatched label.
+_LABEL_MISMATCH_BODY = textwrap.dedent(
+    """\
+    ## Diagnosis
+
+    - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
+    - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
+    - **Ruled out.** Workspace creation actually succeeds (verified in logs).
+    - **Root cause.** `_is_already_merged` requires at least one commit ahead.
+    - **Affected code path.** sprint.runner._is_already_merged.
+    - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.
+    """
+)
+
+
+class TestSpecIsSingleSource:
+    def test_validator_tokens_derive_from_spec(self) -> None:
+        # The heuristics module must not carry an independent list (#1629 AC1).
+        assert REQUIRED_DIAGNOSIS_TOKENS == required_diagnosis_tokens()
+        assert REQUIRED_DIAGNOSIS_TOKENS == tuple(c.token for c in REQUIRED_DIAGNOSIS_COMPONENTS)
+
+    def test_every_component_bullet_contains_its_own_token(self) -> None:
+        # Guarantees a skeleton bullet always satisfies the validator match.
+        for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+            assert component.token in component.bullet().lower()
+
+
+class TestSkeletonPassesByConstruction:
+    def test_skeleton_body_passes_shape_gate(self) -> None:
+        # AC4: a filing that starts from the skeleton passes by construction.
+        result = check("Bug: something", render_bug_skeleton_body(), ["bug"])
+        assert result.shape is Shape.RUNNABLE
+        assert result.reasons == ()
+
+    def test_skeleton_has_all_labels(self) -> None:
+        skeleton = render_bug_skeleton_body()
+        for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+            assert f"**{component.label}:**" in skeleton
+
+
+class TestPublishedReferenceMatchesSpec:
+    def test_doc_on_disk_matches_generator(self) -> None:
+        # AC4: the published reference is checked against the same spec, so it
+        # cannot drift from what the validator enforces.
+        doc_path = _REPO_ROOT / BUG_SHAPE_REFERENCE_PATH
+        assert doc_path.exists(), f"{BUG_SHAPE_REFERENCE_PATH} must exist"
+        on_disk = doc_path.read_text(encoding="utf-8")
+        assert on_disk == render_bug_shape_reference(), (
+            "docs/reference/bug-shape.md is stale — regenerate it from "
+            "theforge.shape_check.diagnosis_spec.render_bug_shape_reference()"
+        )
+
+
+class TestRemediationPromptEmbedsSpec:
+    def test_prompt_embeds_labels_and_examples_verbatim(self) -> None:
+        # AC2: the remediation agent aims at the same target the validator checks.
+        finding = IntakeFinding(
+            code="needs_diagnosis",
+            severity=IntakeSeverity.BLOCK,
+            location="body",
+            problem="Bug Diagnosis section is incomplete.",
+        )
+        prompt = build_agent_rewrite_prompt("## What\nprose", [finding])
+        for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+            assert f"**{component.label}:**" in prompt
+            assert component.example in prompt
+        assert BUG_SHAPE_REFERENCE_PATH in prompt
+
+    def test_prompt_omits_spec_when_no_diagnosis_finding(self) -> None:
+        finding = IntakeFinding(
+            code="missing_example",
+            severity=IntakeSeverity.BLOCK,
+            location="examples",
+            problem="No example.",
+        )
+        prompt = build_agent_rewrite_prompt("## What\nprose", [finding])
+        assert "Diagnosis section requirements:" not in prompt
+
+
+class TestFindingMessageQuotesLiteralLabel:
+    def test_compliant_body_passes(self) -> None:
+        # AC6: existing well-formed bodies (e.g. #1609, #1598) pass unchanged.
+        assert check_bug_missing_diagnosis("T", _COMPLIANT_BODY, ["bug"]) is None
+
+    def test_label_mismatch_message_quotes_missing_literal_label(self) -> None:
+        # AC6: the finding message quotes the exact literal label the producer
+        # must hit, plus its example and the shape reference.
+        reason = check_bug_missing_diagnosis("T", _LABEL_MISMATCH_BODY, ["bug"])
+        assert reason is not None
+        assert reason.code == "needs_diagnosis"
+        assert '"**Confirmed cause:**"' in reason.detail
+        # The example for the missing component is quoted so the target is
+        # unambiguous — not merely the component name.
+        confirmed = next(c for c in REQUIRED_DIAGNOSIS_COMPONENTS if c.key == "confirmed_cause")
+        assert confirmed.example in reason.detail
+        assert BUG_SHAPE_REFERENCE_PATH in reason.detail
+        # Components that ARE present must not be reported as missing.
+        assert "**Observed symptom:**" not in reason.detail
+
+    def test_pipeline_flags_label_mismatch(self) -> None:
+        result = check("Bug: foo", _LABEL_MISMATCH_BODY, ["bug"])
+        assert result.shape is Shape.NEEDS_GROOMING
+        assert any(r.code == "needs_diagnosis" for r in result.reasons)

--- a/tests/test_diagnosis_spec.py
+++ b/tests/test_diagnosis_spec.py
@@ -150,3 +150,15 @@ class TestFindingMessageQuotesLiteralLabel:
         result = check("Bug: foo", _LABEL_MISMATCH_BODY, ["bug"])
         assert result.shape is Shape.NEEDS_GROOMING
         assert any(r.code == "needs_diagnosis" for r in result.reasons)
+
+    def test_no_section_message_quotes_every_literal_label_and_example(self) -> None:
+        # AC3: the completely-absent-section branch must also quote the literal
+        # labels + examples from the spec, not bare component names — the
+        # producer must see the same target the validator checks (iter 1 P1).
+        reason = check_bug_missing_diagnosis("T", "## What\nprose only", ["bug"])
+        assert reason is not None
+        assert reason.code == "needs_diagnosis"
+        for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+            assert f'"**{component.label}:**"' in reason.detail
+            assert component.example in reason.detail
+        assert BUG_SHAPE_REFERENCE_PATH in reason.detail

--- a/tests/test_fix_readiness.py
+++ b/tests/test_fix_readiness.py
@@ -90,10 +90,12 @@ class TestCheckBugMissingDiagnosis:
         partial = "## Diagnosis\n- Observed symptom: x.\n"
         reason = check_bug_missing_diagnosis("T", partial, ["bug"])
         assert reason is not None
-        # Missing component names should appear in the operator-facing detail
-        assert "missing required component" in reason.detail
-        for tok in ("ruled out", "confirmed cause", "affected code path"):
-            assert tok in reason.detail
+        # The detail now names the exact literal labels a producer must hit,
+        # each with its example, and links the full shape reference (#1629 AC3).
+        assert "**Ruled out:**" in reason.detail
+        assert "**Confirmed cause:**" in reason.detail
+        assert "**Affected code path:**" in reason.detail
+        assert "docs/reference/bug-shape.md" in reason.detail
 
     def test_check_pipeline_blocks_undiagnosed_bug(self) -> None:
         result = check("Bug: foo", "## What\nprose only", ["bug"])

--- a/tests/test_intake/test_remediation.py
+++ b/tests/test_intake/test_remediation.py
@@ -158,7 +158,7 @@ def test_auto_fix_edit_mode_updates_body_and_remediates():
     assert post_calls == []
 
 
-def test_auto_fix_edit_mode_keeps_failing_body_off_issue():
+def test_auto_fix_edit_mode_keeps_failing_body_off_issue(tmp_path):
     task = _make_task()
     post_comment, _ = _record_calls()
     edit_body, edit_calls = _record_calls()
@@ -168,7 +168,7 @@ def test_auto_fix_edit_mode_keeps_failing_body_off_issue():
 
     outcomes = run_intake_remediation(
         [task],
-        None,
+        tmp_path,
         grooming_enabled=True,
         auto_fix_enabled=True,
         auto_fix_mode="edit",
@@ -182,7 +182,7 @@ def test_auto_fix_edit_mode_keeps_failing_body_off_issue():
     assert edit_calls == []  # never wrote a still-failing body
 
 
-def test_grooming_only_drop_surfaces_shape_check_divergence():
+def test_grooming_only_drop_surfaces_shape_check_divergence(tmp_path):
     """When a rerun drop is driven solely by the grooming gate (groom_* codes),
     the outcome detail must state that this is NOT corroborated by the
     shape-check gate — otherwise the shape-check Action ('runnable') and the
@@ -199,7 +199,7 @@ def test_grooming_only_drop_surfaces_shape_check_divergence():
 
     outcomes = run_intake_remediation(
         [task],
-        None,
+        tmp_path,
         grooming_enabled=True,
         auto_fix_enabled=True,
         auto_fix_mode="edit",
@@ -219,7 +219,7 @@ def test_grooming_only_drop_surfaces_shape_check_divergence():
     assert "shape-check" in out.detail
 
 
-def test_shape_backed_drop_does_not_claim_divergence():
+def test_shape_backed_drop_does_not_claim_divergence(tmp_path):
     """A drop whose rerun findings include a shape-check code IS corroborated by
     the shape-check gate, so the divergence note must NOT be attached."""
     task = _make_task()
@@ -232,7 +232,7 @@ def test_shape_backed_drop_does_not_claim_divergence():
 
     outcomes = run_intake_remediation(
         [task],
-        None,
+        tmp_path,
         grooming_enabled=True,
         auto_fix_enabled=True,
         auto_fix_mode="edit",
@@ -333,10 +333,11 @@ def test_mechanical_only_remediation_is_distinguished_from_agent_flow():
     assert post_calls
 
 
-def test_edit_mode_rerun_failure_persists_candidate_as_comment():
+def test_edit_mode_rerun_failure_persists_candidate_as_comment(tmp_path):
     """When the edit-mode rerun gate still fails, the candidate body must not
     be silently discarded — it must be posted as an issue comment with the
-    remaining blocking findings so the operator can act on it.
+    remaining blocking findings AND persisted to a durable audit artifact so
+    the refusal is inspectable after the sprint (#1629 AC5).
     """
     task = _make_task()
     post_comment, post_calls = _record_calls()
@@ -349,7 +350,7 @@ def test_edit_mode_rerun_failure_persists_candidate_as_comment():
 
     outcomes = run_intake_remediation(
         [task],
-        None,
+        tmp_path,
         grooming_enabled=True,
         auto_fix_enabled=True,
         auto_fix_mode="edit",
@@ -369,6 +370,17 @@ def test_edit_mode_rerun_failure_persists_candidate_as_comment():
     assert "Remaining blocking findings" in posted_body
     assert out.audit["comment_posted"] is True
     assert "candidate posted" in out.detail
+    # The rejected rewrite + unmet components are also persisted durably, even
+    # though the comment post succeeded (#1629 AC5).
+    artifact_path = out.audit["candidate_artifact_path"]
+    assert artifact_path is not None
+    from pathlib import Path
+
+    artifact = Path(artifact_path)
+    assert artifact.exists()
+    contents = artifact.read_text(encoding="utf-8")
+    assert candidate in contents
+    assert "Remaining blocking findings" in contents
 
 
 def test_edit_mode_rerun_failure_falls_back_to_artifact_when_post_fails(tmp_path):

--- a/tests/test_intake/test_remediation.py
+++ b/tests/test_intake/test_remediation.py
@@ -131,6 +131,43 @@ def test_auto_fix_comment_mode_posts_replacement_and_drops():
     assert edit_calls == []
 
 
+def test_comment_mode_rerun_failure_persists_candidate_artifact(tmp_path):
+    """Comment mode: when the agent's rewrite still fails the rerun gate, the
+    rejected rewrite + unmet components must be persisted to a durable audit
+    artifact so the refusal is inspectable (#1629 AC5)."""
+    task = _make_task()
+    post_comment, post_calls = _record_calls()
+
+    candidate = "## What\n\nstill not enough\n"
+
+    def agent(body, findings, comments=()):
+        return AgentRewriteResult(replacement=candidate, detail="agent produced replacement")
+
+    outcomes = run_intake_remediation(
+        [task],
+        tmp_path,
+        grooming_enabled=True,
+        auto_fix_enabled=True,
+        auto_fix_mode="comment",
+        agent_caller=agent,
+        fetch_detail=_make_fetch({"title": "T", "body": _FAILING_BODY, "labels": ["enhancement"]}),
+        post_comment=post_comment,
+    )
+    out = outcomes[task.slug]
+    assert out.kind is IntakeOutcomeKind.DROPPED_AFTER_FIX
+    assert out.proposed_replacement == candidate
+    artifact_path = out.audit["candidate_artifact_path"]
+    assert artifact_path is not None
+    from pathlib import Path
+
+    artifact = Path(artifact_path)
+    assert artifact.exists()
+    contents = artifact.read_text(encoding="utf-8")
+    assert candidate in contents
+    assert "Remaining blocking findings" in contents
+    assert artifact_path in out.detail
+
+
 def test_auto_fix_edit_mode_updates_body_and_remediates():
     task = _make_task()
     post_comment, post_calls = _record_calls()


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior no-Diagnosis-section P1 is fixed, the shared Diagnosis spec is consumed by the validator, prompt, messages, skeleton, and remediation audit path, and the focused regression tests pass. | [google-gemini-3.5-flash] The implementation successfully unifies the required Diagnosis components into a single declarative spec and resolves the prior P1 finding.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $7.06
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Shape-gate diagnosis requirements become a single published spec consumed by validator, remediation prompt, findings, and skeleton (GitHub Issue #1629)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1629