### PR TITLE
Gate FAIL/ESCALATE outcome records only 'Gate returned FAIL after N attempts' — evidence already captured is never carried to the surfaces where the escalation is read

### DIFF
--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -135,6 +135,39 @@ def run_gate_full(
     return decision, None, output_tail, gate_cmd, exit_code
 
 
+def format_gate_failure_summary(
+    header: str,
+    *,
+    exit_code: int | None,
+    output_tail: str,
+    tail_chars: int,
+    trace_path: str | None = None,
+) -> str:
+    """Attach gate triage evidence to a terminal gate-failure outcome string.
+
+    ``header`` is the verdict phrase (e.g. "Gate returned FAIL after 3
+    attempts"). The gate exit code and output tail are appended verbatim so a
+    reader of ``forge status`` detail or the escalation issue comment can tell a
+    compile error from a flake from an infrastructure failure without opening
+    the run log — the evidence travels with the verdict rather than sitting in a
+    file the outcome never references. When a full-output trace was written its
+    path is named too (it survives worktree cleanup only for preserved ESCALATE
+    worktrees, so the tail is always carried inline as well). Nothing here
+    interprets the output; it is copied as-is, so the summary is independent of
+    the gate command, language, and toolchain.
+    """
+    header_line = header if exit_code is None else f"{header} (gate exit code {exit_code})"
+    parts = [header_line]
+    tail = (output_tail or "").strip()
+    if tail:
+        parts.append(f"Gate output tail (last {tail_chars} chars):\n{tail}")
+    else:
+        parts.append("Gate captured no output.")
+    if trace_path:
+        parts.append(f"Full gate output trace: {trace_path}")
+    return "\n".join(parts)
+
+
 def _run_gate_debug_command(
     config: ForgeConfig,
     workspace_path: Path,
@@ -174,22 +207,6 @@ def _run_gate_debug_command(
         output_tail=output_tail,
         output_truncated=len(output) > len(output_tail),
     )
-
-
-def _run_gate_full(
-    config: ForgeConfig,
-    workspace_path: Path,
-    task: TaskStory | None = None,
-    iter_num: int | None = None,
-) -> tuple[str | None, str | None, str, str]:
-    """Backward-compatible wrapper for callers that do not need exit_code."""
-    decision, error, output_tail, resolved_gate_cmd, _exit_code = run_gate_full(
-        config,
-        workspace_path,
-        task,
-        iter_num,
-    )
-    return decision, error, output_tail, resolved_gate_cmd
 
 
 def _run_gate(

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -20,7 +20,13 @@ from theforge.task import TaskStory
 from . import util as _cu
 from .commit_guard import _commits_exist_strict, _has_commits_ahead_of_base
 from .dev_phase import _extract_failed_tests, record_dev_iteration_telemetry
-from .gate import _is_gate_skip, _parse_dirty_files, _run_gate_debug_command, _run_gate_full
+from .gate import (
+    _is_gate_skip,
+    _parse_dirty_files,
+    _run_gate_debug_command,
+    format_gate_failure_summary,
+    run_gate_full,
+)
 from .logging import StructuredLogger
 from .notify import _escalate_notify
 from .review_context import (
@@ -145,6 +151,21 @@ def _is_identical_failure(telemetry: list[DevIterationTelemetry]) -> bool:
     if curr.failed_tests and set(curr.failed_tests) == set(prev.failed_tests):
         return True
     return False
+
+
+def _gate_trace_path(iter_num: int | None) -> str | None:
+    """Return the worktree-relative gate trace path written for this iteration.
+
+    Mirrors ``run_gate_full``'s trace-write gate: a trace is persisted only when
+    ``iter_num is not None``. Baseline gate runs (``iter_num is None``) produce
+    no trace, so no artifact is named and the terminal outcome falls back to its
+    inline tail. The path is relative to the worktree root
+    (``.forge/traces/{iter}-gate.txt``); ESCALATE worktrees are preserved, so it
+    remains resolvable for the surfaces that read an escalation.
+    """
+    if iter_num is None:
+        return None
+    return f".forge/traces/{iter_num}-gate.txt"
 
 
 def _test_file_exists_in_head(workspace_path: Path, test_file: str) -> bool:
@@ -381,6 +402,7 @@ def _run_validate_phase(
     _gate_start = time.monotonic()
     gate_override = task.gate_override
     gate_output_tail: str = ""
+    gate_exit_code: int | None = None
     gate_result_for_telemetry: str | None = None
     if _is_gate_skip(gate_override):
         _log_phase(state.phase, "skipped (gate: none)")
@@ -394,8 +416,8 @@ def _run_validate_phase(
             _log(f"  Gate: {gate_override} (story override)")
         else:
             _log_phase(state.phase, "running gate...")
-        gate_decision, gate_err, gate_output_tail, resolved_gate_cmd = _run_gate_full(
-            config, workspace_path, task=task, iter_num=state.dev_iteration
+        gate_decision, gate_err, gate_output_tail, resolved_gate_cmd, gate_exit_code = (
+            run_gate_full(config, workspace_path, task=task, iter_num=state.dev_iteration)
         )
         gate_result_for_telemetry = gate_decision or "ERROR"
     _gate_elapsed = time.monotonic() - _gate_start
@@ -670,7 +692,13 @@ def _run_validate_phase(
     elif gate_decision in ("FAIL", "BLOCKED"):
         if state.budget.is_exhausted():
             state.phase = Phase.ESCALATE
-            state.error = f"Gate returned {gate_decision} after {state.dev_iteration} attempts"
+            state.error = format_gate_failure_summary(
+                f"Gate returned {gate_decision} after {state.dev_iteration} attempts",
+                exit_code=gate_exit_code,
+                output_tail=gate_output_tail,
+                tail_chars=config.validation.gate_output_tail_chars,
+                trace_path=_gate_trace_path(state.dev_iteration),
+            )
             _log(f"✗ ESCALATE   {state.error}")
             record_dev_iteration_telemetry(
                 state,
@@ -718,10 +746,14 @@ def _run_validate_phase(
             )
         if _is_identical_failure(state.dev_iteration_telemetry):
             state.phase = Phase.ESCALATE
-            state.error = (
+            state.error = format_gate_failure_summary(
                 f"Identical gate failure on consecutive iterations"
                 f" (iteration {state.dev_iteration}): gate returned {gate_decision}."
-                f" Remaining retry budget: {state.budget.remaining()}."
+                f" Remaining retry budget: {state.budget.remaining()}.",
+                exit_code=gate_exit_code,
+                output_tail=gate_output_tail,
+                tail_chars=config.validation.gate_output_tail_chars,
+                trace_path=_gate_trace_path(state.dev_iteration),
             )
             _log(f"✗ ESCALATE   {state.error}")
             if logger:

--- a/tests/test_coord_convention_parallel.py
+++ b/tests/test_coord_convention_parallel.py
@@ -34,7 +34,7 @@ class TestConventionParallelCheck:
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._get_handoff_content")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase.run_gate_full")
     def test_gate_fail_includes_convention_violations(
         self,
         mock_gate,
@@ -55,7 +55,7 @@ class TestConventionParallelCheck:
 
         viol = _make_violation()
         state.budget.max_iterations = config.retry.max_dev_iterations
-        mock_gate.return_value = ("FAIL", None, "test output: 1 failed", "make gate")
+        mock_gate.return_value = ("FAIL", None, "test output: 1 failed", "make gate", 1)
         mock_cv.return_value = ([viol], [viol])
         mock_handoff.return_value = "handoff content"
 
@@ -84,7 +84,7 @@ class TestConventionParallelCheck:
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase.run_gate_full")
     @patch("theforge.coordinator.validate_phase._cu._run_shell")
     @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
     def test_gate_pass_convention_violation_still_blocks(
@@ -108,7 +108,7 @@ class TestConventionParallelCheck:
 
         viol = _make_violation(blocking=True)
         state.budget.max_iterations = config.retry.max_dev_iterations
-        mock_gate.return_value = ("PASS", None, "", "make gate")
+        mock_gate.return_value = ("PASS", None, "", "make gate", 0)
         mock_cv.return_value = ([viol], [viol])
         mock_shell.return_value = (True, "")  # clean worktree
 
@@ -131,7 +131,7 @@ class TestConventionParallelCheck:
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase.update_advisory_violations")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase.run_gate_full")
     @patch("theforge.coordinator.validate_phase._cu._run_shell")
     @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
     def test_gate_pass_followup_only_violations_proceed_to_pass(
@@ -157,7 +157,7 @@ class TestConventionParallelCheck:
         # LOC violations are non-blocking follow-ups
         viol = _make_violation(rule="max_module_lines", blocking=False)
         state.budget.max_iterations = config.retry.max_dev_iterations
-        mock_gate.return_value = ("PASS", None, "", "make gate")
+        mock_gate.return_value = ("PASS", None, "", "make gate", 0)
         mock_cv.return_value = ([viol], [viol])
         mock_shell.return_value = (True, "")  # clean worktree
         mock_update_advisory.return_value = {
@@ -200,7 +200,7 @@ class TestConventionParallelCheck:
 
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase.run_gate_full")
     @patch("theforge.coordinator.validate_phase._cu._run_shell")
     @patch("theforge.coordinator.validate_phase._deindex_forge_artifacts")
     def test_gate_pass_mixed_violations_blocks_on_blocking_only(
@@ -225,7 +225,7 @@ class TestConventionParallelCheck:
         blocking_viol = _make_violation(rule="no_circular_imports", file="src/a.py", blocking=True)
         followup_viol = _make_violation(rule="max_module_lines", file="src/big.py", blocking=False)
         state.budget.max_iterations = config.retry.max_dev_iterations
-        mock_gate.return_value = ("PASS", None, "", "make gate")
+        mock_gate.return_value = ("PASS", None, "", "make gate", 0)
         mock_cv.return_value = ([blocking_viol, followup_viol], [blocking_viol, followup_viol])
         mock_shell.return_value = (True, "")  # clean worktree
 
@@ -254,7 +254,7 @@ class TestConventionParallelCheck:
     @patch("theforge.coordinator.validate_phase.record_dev_iteration_telemetry")
     @patch("theforge.coordinator.validate_phase._get_handoff_content")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase.run_gate_full")
     def test_no_conventions_configured_unchanged(
         self,
         mock_gate,
@@ -271,7 +271,7 @@ class TestConventionParallelCheck:
         state = _make_state()
 
         state.budget.max_iterations = config.retry.max_dev_iterations
-        mock_gate.return_value = ("FAIL", None, "1 failed", "make gate")
+        mock_gate.return_value = ("FAIL", None, "1 failed", "make gate", 1)
         mock_cv.return_value = None  # None because conventions_hard is None
         mock_handoff.return_value = "handoff"
 

--- a/tests/test_coord_gate_contradiction_exit.py
+++ b/tests/test_coord_gate_contradiction_exit.py
@@ -17,7 +17,7 @@ from coord_test_helpers import (
     _write_handoff,
 )
 
-from theforge.coordinator.gate import _run_gate_full
+from theforge.coordinator.gate import run_gate_full
 from theforge.coordinator.state import CoordinatorState, Phase
 from theforge.coordinator.validate_phase import _run_validate_phase, _ValidateOutcome
 
@@ -25,7 +25,7 @@ from theforge.coordinator.validate_phase import _run_validate_phase, _ValidateOu
 
 
 class TestGateDecision:
-    """_run_gate_full trusts exit code as sole gate signal."""
+    """run_gate_full trusts exit code as sole gate signal."""
 
     def test_gate_plain_fail_unchanged(self, tmp_path: Path):
         """Exit non-zero with genuine failure output → FAIL."""
@@ -37,7 +37,7 @@ class TestGateDecision:
         with patch("theforge.coordinator.gate._cu._run_shell") as mock_shell:
             mock_shell.return_value = (False, "2 failed, 1 passed\nERROR: test_foo")
             with patch("theforge.coordinator.gate._cu._log"):
-                decision, error, _tail, _cmd = _run_gate_full(config, workspace)
+                decision, error, _tail, _cmd, _exit = run_gate_full(config, workspace)
 
         assert decision == "FAIL"
         assert error is None
@@ -52,7 +52,7 @@ class TestGateDecision:
         with patch("theforge.coordinator.gate._cu._run_shell") as mock_shell:
             mock_shell.return_value = (True, "All checks passed!")
             with patch("theforge.coordinator.gate._cu._log"):
-                decision, error, _tail, _cmd = _run_gate_full(config, workspace)
+                decision, error, _tail, _cmd, _exit = run_gate_full(config, workspace)
 
         assert decision == "PASS"
         assert error is None
@@ -75,7 +75,7 @@ class TestGateDecision:
                 "All checks passed!\n2 failed, 3 passed\nFAILED tests/test_foo.py::test_bar",
             )
             with patch("theforge.coordinator.gate._cu._log"):
-                decision, error, _tail, _cmd = _run_gate_full(config, workspace)
+                decision, error, _tail, _cmd, _exit = run_gate_full(config, workspace)
 
         assert decision == "FAIL"
         assert error is None
@@ -95,7 +95,7 @@ def _make_state(config) -> CoordinatorState:
 class TestValidatePhaseFailRetries:
     """Validate phase retries dev on FAIL."""
 
-    @patch("theforge.coordinator.validate_phase._run_gate_full")
+    @patch("theforge.coordinator.validate_phase.run_gate_full")
     @patch("theforge.coordinator.validate_phase._check_conventions_parallel")
     @patch("theforge.coordinator.validate_phase._escalate_notify")
     def test_plain_fail_still_retries(
@@ -108,7 +108,7 @@ class TestValidatePhaseFailRetries:
         workspace.mkdir()
         _write_handoff(workspace, "FAIL")
 
-        mock_gate.return_value = ("FAIL", None, "2 failed, 1 passed", "make gate")
+        mock_gate.return_value = ("FAIL", None, "2 failed, 1 passed", "make gate", 1)
         mock_conventions.return_value = None
 
         state = _make_state(config)

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -9,8 +9,10 @@ from unittest.mock import patch
 
 from coord_test_helpers import _make_agent_result, _make_config, _make_task
 
+from theforge.coordinator.gate import format_gate_failure_summary
 from theforge.coordinator.state import CoordinatorState, DevIterationTelemetry
 from theforge.coordinator.validate_phase import (
+    _gate_trace_path,
     _get_convention_baseline_ref,
     _is_identical_failure,
     _run_validate_phase,
@@ -64,8 +66,14 @@ def test_run_validate_phase_records_failed_gate_iteration_telemetry(tmp_path: Pa
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=("FAIL", None, "FAILED tests/test_alpha.py::test_one", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=(
+                "FAIL",
+                None,
+                "FAILED tests/test_alpha.py::test_one",
+                "pytest tests/",
+                1,
+            ),
         ),
         patch(
             "theforge.coordinator.validate_phase._get_handoff_content",
@@ -115,8 +123,8 @@ def test_run_validate_phase_records_dirty_pass_iteration_once(tmp_path: Path) ->
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=("PASS", None, "OK", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/", 0),
         ),
         patch(
             "theforge.coordinator.validate_phase._get_raw_dev_notes",
@@ -161,8 +169,8 @@ def test_run_validate_phase_records_gate_error_escalation_once(tmp_path: Path) -
     )
 
     with patch(
-        "theforge.coordinator.validate_phase._run_gate_full",
-        return_value=(None, "gate crashed", "traceback tail", "pytest tests/"),
+        "theforge.coordinator.validate_phase.run_gate_full",
+        return_value=(None, "gate crashed", "traceback tail", "pytest tests/", None),
     ):
         outcome, result = _run_validate_phase(
             state,
@@ -210,12 +218,13 @@ def test_run_validate_phase_runs_gate_debug_command_on_timeout(tmp_path: Path) -
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
+            "theforge.coordinator.validate_phase.run_gate_full",
             return_value=(
                 None,
                 "Gate timed out after 120s",
                 "TIMEOUT after 120s: pytest tests/",
                 "pytest tests/",
+                None,
             ),
         ),
         patch("theforge.coordinator.util._run_shell_detailed", side_effect=shell_side_effect),
@@ -257,8 +266,8 @@ def test_run_validate_phase_timeout_without_gate_debug_command_is_unchanged(
     state.last_dev_start_commit = "HEAD"
 
     with patch(
-        "theforge.coordinator.validate_phase._run_gate_full",
-        return_value=(None, "Gate timed out after 120s", "", "pytest tests/"),
+        "theforge.coordinator.validate_phase.run_gate_full",
+        return_value=(None, "Gate timed out after 120s", "", "pytest tests/", None),
     ):
         outcome, result = _run_validate_phase(
             state,
@@ -289,12 +298,13 @@ def test_run_validate_phase_timeout_with_commits_routes_to_dev_retry(tmp_path: P
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
+            "theforge.coordinator.validate_phase.run_gate_full",
             return_value=(
                 None,
                 "Gate timed out after 45s",
                 "TIMEOUT after 45s: pytest tests/test_hang.py",
                 "make gate",
+                None,
             ),
         ),
         patch(
@@ -376,12 +386,13 @@ def test_run_validate_phase_timeout_rca_packet_falls_back_to_stderr(
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
+            "theforge.coordinator.validate_phase.run_gate_full",
             return_value=(
                 None,
                 "Gate timed out after 45s: FATAL pytest internal error, exit code 3",
                 "",
                 "make gate",
+                None,
             ),
         ),
         patch(
@@ -439,8 +450,8 @@ def test_run_validate_phase_timeout_without_commits_still_escalates(tmp_path: Pa
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=(None, "Gate timed out after 45s", "", "make gate"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=(None, "Gate timed out after 45s", "", "make gate", None),
         ),
         patch(
             "theforge.coordinator.validate_phase._commits_exist_strict",
@@ -477,8 +488,8 @@ def test_run_validate_phase_timeout_with_commits_but_budget_exhausted_escalates(
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=(None, "Gate timed out after 45s", "", "make gate"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=(None, "Gate timed out after 45s", "", "make gate", None),
         ),
         patch(
             "theforge.coordinator.validate_phase._commits_exist_strict",
@@ -557,8 +568,8 @@ def test_run_validate_phase_already_complete_when_handoff_documents_work_done(
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=("PASS", None, "OK", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/", 0),
         ),
         patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
         # _check_conventions_parallel runs in a thread; stub it out so the test
@@ -611,8 +622,8 @@ def test_run_validate_phase_empty_worktree_without_handoff_still_escalates(
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=("PASS", None, "OK", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/", 0),
         ),
         patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
         patch(
@@ -685,8 +696,8 @@ def test_run_validate_phase_empty_worktree_handoff_partial_ac_escalates(
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=("PASS", None, "OK", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/", 0),
         ),
         patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
         patch(
@@ -752,8 +763,8 @@ def test_run_validate_phase_empty_worktree_handoff_unverifiable_sha_escalates(
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=("PASS", None, "OK", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/", 0),
         ),
         patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
         patch(
@@ -831,8 +842,8 @@ def test_run_validate_phase_empty_worktree_handoff_off_branch_sha_escalates(
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=("PASS", None, "OK", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=("PASS", None, "OK", "pytest tests/", 0),
         ),
         patch("theforge.coordinator.validate_phase._deindex_forge_artifacts"),
         patch(
@@ -909,13 +920,14 @@ def test_run_validate_phase_retry_feedback_includes_extracted_failures(tmp_path:
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
+            "theforge.coordinator.validate_phase.run_gate_full",
             return_value=(
                 "FAIL",
                 None,
                 "FAILED tests/test_existing.py::test_breaks\n"
                 "FAILED generated/test_new.py::test_agent",
                 "pytest tests/",
+                1,
             ),
         ),
         patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
@@ -1066,12 +1078,13 @@ def test_run_validate_phase_escalates_on_identical_gate_fail(tmp_path: Path) -> 
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
+            "theforge.coordinator.validate_phase.run_gate_full",
             return_value=(
                 "FAIL",
                 None,
                 "FAILED tests/test_alpha.py::test_one",
                 "pytest tests/",
+                1,
             ),
         ),
         patch(
@@ -1096,6 +1109,99 @@ def test_run_validate_phase_escalates_on_identical_gate_fail(tmp_path: Path) -> 
     assert "Remaining retry budget:" in result.message
 
 
+def test_format_gate_failure_summary_carries_exit_code_tail_and_trace() -> None:
+    """The summary attaches the exit code, output tail, and trace to the verdict phrase."""
+    summary = format_gate_failure_summary(
+        "Gate returned FAIL after 3 attempts",
+        exit_code=65,
+        output_tail="** TEST FAILED **\nmake[2]: *** [test-ios] Error 65",
+        tail_chars=2000,
+        trace_path=".forge/traces/3-gate.txt",
+    )
+    assert "Gate returned FAIL after 3 attempts (gate exit code 65)" in summary
+    assert "Gate output tail (last 2000 chars):" in summary
+    assert "** TEST FAILED **" in summary
+    assert "make[2]: *** [test-ios] Error 65" in summary
+    assert ".forge/traces/3-gate.txt" in summary
+
+
+def test_format_gate_failure_summary_baseline_without_exit_code_or_trace() -> None:
+    """A None exit code / trace (baseline gate, iter_num None) still carries the tail inline."""
+    summary = format_gate_failure_summary(
+        "Gate returned FAIL after 1 attempts",
+        exit_code=None,
+        output_tail="",
+        tail_chars=2000,
+        trace_path=None,
+    )
+    # No exit-code parenthetical, no trace line, but the outcome is still explicit.
+    assert summary == "Gate returned FAIL after 1 attempts\nGate captured no output."
+
+
+def test_gate_trace_path_none_for_baseline_run() -> None:
+    """No trace artifact is named when the gate ran without an iteration number."""
+    assert _gate_trace_path(None) is None
+    assert _gate_trace_path(2) == ".forge/traces/2-gate.txt"
+
+
+def test_run_validate_phase_gate_fail_escalation_carries_evidence(tmp_path: Path) -> None:
+    """Budget-exhausted gate FAIL escalation carries exit code, output tail, and trace.
+
+    Regression for issue #1736: the terminal outcome recorded only 'Gate
+    returned FAIL after N attempts' with no reference to the exit code, output
+    tail, or trace the gate already captured, so an operator reading `forge
+    status` detail or the escalation issue comment could not tell a compile
+    error from a flake from an infrastructure failure.
+    """
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=2)
+    state.budget.max_iterations = config.retry.max_dev_iterations  # 2 → exhausted
+    state.dev_results.append(_make_agent_result())
+    state.dev_durations.append(1.5)
+    state.last_dev_start_commit = "HEAD"
+
+    gate_tail = (
+        "HealthKitSyncServiceTests.swift:126:10: note: add '@MainActor'\n"
+        "Testing failed:\n** TEST FAILED **\nmake[2]: *** [test-ios] Error 65"
+    )
+
+    with (
+        patch(
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=("FAIL", None, gate_tail, "make gate", 65),
+        ),
+        patch(
+            "theforge.coordinator.validate_phase._get_handoff_content",
+            return_value="summary: pending",
+        ),
+        patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
+    ):
+        outcome, result = _run_validate_phase(
+            state,
+            config,
+            task,
+            tmp_path,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ValidateOutcome.ESCALATE
+    assert result is not None
+    assert result.success is False
+    # The record consumed by forge status / the escalation comment is state.error.
+    assert result.message == state.error
+    # Verdict phrase preserved for existing readers.
+    assert "Gate returned FAIL after 2 attempts" in state.error
+    # Exit code travels with the verdict.
+    assert "gate exit code 65" in state.error
+    # Output tail carried inline — a compile error is identifiable without the run log.
+    assert "** TEST FAILED **" in state.error
+    assert "make[2]: *** [test-ios] Error 65" in state.error
+    # The full-output trace is named as the artifact holding the complete output.
+    assert ".forge/traces/2-gate.txt" in state.error
+
+
 def test_run_validate_phase_escalates_on_consecutive_timeouts(tmp_path: Path) -> None:
     """Circuit breaker escalates when two consecutive gate errors are both timeouts."""
     config = _make_config(tmp_path)
@@ -1118,8 +1224,8 @@ def test_run_validate_phase_escalates_on_consecutive_timeouts(tmp_path: Path) ->
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
-            return_value=(None, "gate timed out after 120s", "", "pytest tests/"),
+            "theforge.coordinator.validate_phase.run_gate_full",
+            return_value=(None, "gate timed out after 120s", "", "pytest tests/", None),
         ),
         patch("theforge.coordinator.util._run_shell", return_value=(True, "")),
     ):
@@ -1163,12 +1269,13 @@ def test_run_validate_phase_retries_when_failures_differ(tmp_path: Path) -> None
 
     with (
         patch(
-            "theforge.coordinator.validate_phase._run_gate_full",
+            "theforge.coordinator.validate_phase.run_gate_full",
             return_value=(
                 "FAIL",
                 None,
                 "FAILED tests/test_alpha.py::test_two",
                 "pytest tests/",
+                1,
             ),
         ),
         patch(


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The terminal gate-FAIL outcome now carries the captured exit code, output tail, and trace reference through the validate-phase state.error path, with focused regression coverage. | [google-gemini-3.5-flash] The implementation successfully carries the gate exit code, output tail, and trace path into terminal gate-FAIL outcome records, resolving the triage visibility gap.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $8.15
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Gate FAIL/ESCALATE outcome records only 'Gate returned FAIL after N attempts' — evidence already captured is never carried to the surfaces where the escalation is read (GitHub Issue #1736)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1736