### PR TITLE
feat(intake): opt-in inline remediation posture, training-wheels WARNING, audit emission (#1513)

### DIFF
--- a/docs/guides/authoring.md
+++ b/docs/guides/authoring.md
@@ -27,6 +27,19 @@ never auto-invoked — you run it.
 Once `forge shape` has put the issue in a typed bucket, the per-use-case
 rules below apply.
 
+### Groom before the sprint, not during it
+
+Making a typed issue shape-gate-clean is the job of **`forge groom <issue>`**,
+run *before* sprint selection. Sprint entry is the final readiness *check*, not
+the place readiness gets created.
+
+Inline remediation is the fallback when pre-sprint grooming was skipped, not the
+primary workflow. The `intake.grooming` flag (disabled by default) exists as an
+opt-in safety net for incident-time pressure; when it fires it warns you to run
+`forge groom` next time. Do not treat it as a substitute for grooming. See
+[ADR-0001](../adr/0001-intake-readiness-workflow.md) and the
+[`intake.grooming` reference](inputs-reference.md#inline-intake-remediation-intakegrooming).
+
 ## Storage: GitHub issue vs local story file
 
 TheForge accepts the same content in two storage backends:

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -368,6 +368,13 @@ notifications:
     priority: high
     # url resolved from NTFY_URL in .forge/.env
 
+# ── Inline intake remediation (optional, opt-in fallback) ──
+# Defaults to disabled. See "Inline intake remediation" below.
+intake:
+  grooming: false             # opt-in inline shape/grooming repair at sprint entry
+  auto_fix: false             # allow a single agent rewrite pass on failure
+  auto_fix_mode: comment      # "comment" (post + drop) | "edit" (rewrite body, rerun once)
+
 # ── Secrets (optional) ────────────────────────────────────
 # API keys are read from .forge/.env (run `forge secrets-init` to create)
 ```
@@ -382,6 +389,40 @@ notifications:
 | When to use | Dev agent (needs full editor access) | Reviewers (read-only analysis) |
 | `allowed_tools` | Forwarded to CLI as flags | TheForge executes tools locally |
 | Cost tracking | Parsed from CLI output | Calculated from token usage |
+
+### Inline intake remediation (`intake.grooming`)
+
+`intake.grooming` is an **opt-in fallback**, not the primary readiness workflow.
+It is disabled by default (`grooming: false` in the schema), and the recommended
+path is to make an issue shape-gate-clean with **`forge groom <issue>` before
+sprint selection**.
+
+When enabled, an issue that fails the shape gate at sprint entry gets an inline
+remediation pass instead of being dropped immediately. Each time it fires, the
+daemon emits a WARNING naming `forge groom` as the intended path:
+
+```
+[forge] Inline intake remediation ran at sprint entry for #1497.
+[forge] Intended workflow: run `forge groom 1497` before sprint selection.
+```
+
+Treat this as training wheels for the operator who skipped pre-sprint grooming
+(e.g. incident-time pressure) — not as a reason to skip it routinely. Every
+firing is also recorded in the SQLite audit substrate
+(`inline_remediation_events`) with the issue id, sprint id, triggering
+shape-gate verdict, action taken, success, and the time/cost spent, so the
+remediation-to-runnable cost ratio is queryable per milestone.
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `intake.grooming` | `false` | Enable the opt-in inline shape/grooming repair pass at sprint entry. |
+| `intake.auto_fix` | `false` | Allow a single agent rewrite pass when the gate fails. |
+| `intake.auto_fix_mode` | `comment` | `comment` posts the candidate and drops the story; `edit` rewrites the issue body in place and reruns the gate once. |
+
+Canonical design: **ADR-0001 — Intake Readiness Workflow**
+(`docs/adr/0001-intake-readiness-workflow.md`), "Inline intake remediation
+posture". `forge init` and generated templates emit no `intake.grooming` line
+(so it resolves to `false`); there is no migration path.
 
 ---
 

--- a/forge.yaml
+++ b/forge.yaml
@@ -59,10 +59,10 @@ provider_fallbacks:
 
 budget_usd: 50.0
 
-intake:
-  grooming: true
-  auto_fix: true
-  auto_fix_mode: edit
+# Inline intake remediation (intake.grooming) is intentionally left at the
+# schema default (false) — see ADR-0001 "Inline intake remediation posture".
+# This repo runs `forge groom` as the primary pre-sprint readiness path, so no
+# dogfood override is set here; the repo behaves like any fresh consumer.
 
 workspace:
   create_command: "git worktree add .forge/worktrees/{slug} -b feat/{slug} {base_branch}"

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -858,6 +858,8 @@ def _run_query_mode(
                 remediation_targets,
                 config=config,
                 log=lambda m: print(f"[forge] {m}", file=sys.stderr),
+                sprint_id=gate_run_id,
+                milestone=milestone,
             )
 
         # Re-add successfully remediated issues so the sprint continues without

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-SUBSTRATE_SCHEMA_VERSION = 3
+SUBSTRATE_SCHEMA_VERSION = 4
 # Current per-record schema version. Records pre-dating the indexed-dimensions
 # slice (#1522) are treated as version 1. The reader-side migration helper
 # (`_migrate_record`) is the seam future breaking changes hang off — a version
@@ -231,6 +231,25 @@ CREATE INDEX IF NOT EXISTS idx_shape_skip_events_code ON shape_skip_events(reaso
 CREATE INDEX IF NOT EXISTS idx_shape_skip_events_category ON shape_skip_events(category);
 CREATE INDEX IF NOT EXISTS idx_shape_skip_events_run ON shape_skip_events(run_id);
 CREATE INDEX IF NOT EXISTS idx_shape_skip_events_emitted ON shape_skip_events(emitted_at);
+CREATE TABLE IF NOT EXISTS inline_remediation_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id TEXT NOT NULL,
+    sprint_id TEXT,
+    milestone TEXT,
+    shape_verdict TEXT,
+    action TEXT NOT NULL,
+    succeeded INTEGER NOT NULL,
+    cost_usd REAL,
+    duration_seconds REAL,
+    emitted_at TEXT NOT NULL,
+    raw_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_inline_remediation_events_milestone
+    ON inline_remediation_events(milestone);
+CREATE INDEX IF NOT EXISTS idx_inline_remediation_events_issue
+    ON inline_remediation_events(issue_id);
+CREATE INDEX IF NOT EXISTS idx_inline_remediation_events_action
+    ON inline_remediation_events(action);
 """
 
 
@@ -1869,6 +1888,110 @@ def repeated_shape_skip_blocks(
                 "run_ids": run_ids,
             }
         )
+    return out
+
+
+def record_inline_remediation_event(project_root: Path, event: dict) -> int:
+    """Insert an inline-remediation event row into the audit substrate.
+
+    Inline intake remediation is the opt-in ``intake.grooming`` fallback that
+    fires at sprint entry when pre-sprint ``forge groom`` was skipped
+    (ADR-0001, "Inline intake remediation posture"). Each firing writes one
+    structured record here so the refusal-economics metric — the
+    remediation-to-runnable cost ratio — can be queried from a single table
+    rather than reconstructed from scattered WARNING logs.
+
+    The ``milestone`` and ``cost_usd`` columns are indexed/summable so
+    ``count(inline_remediation_events) per milestone`` and
+    ``total_cost(inline_remediation_events) per milestone`` are direct SQL
+    (see :func:`inline_remediation_rollup_by_milestone`).
+
+    Required keys: ``issue_id``, ``action``. ``succeeded`` is coerced to a
+    0/1 integer. Returns the inserted row's ``event_id``. Raises
+    :class:`SubstrateError` on missing required keys or I/O failure so the
+    caller can decide whether to swallow (sprint treats this as
+    observability, not gating).
+    """
+    required = {"issue_id", "action"}
+    missing = required - set(event)
+    if missing:
+        raise SubstrateError(f"inline remediation event missing required keys: {sorted(missing)}")
+    raw_json = _canonical_json(event)
+    emitted_at = event.get("emitted_at") or _now_iso()
+    raw_cost = event.get("cost_usd")
+    try:
+        cost_usd = float(raw_cost) if raw_cost is not None else None
+    except (TypeError, ValueError):
+        cost_usd = None
+    raw_duration = event.get("duration_seconds")
+    try:
+        duration_seconds = float(raw_duration) if raw_duration is not None else None
+    except (TypeError, ValueError):
+        duration_seconds = None
+    conn = create_or_open(project_root)
+    try:
+        cur = conn.execute(
+            "INSERT INTO inline_remediation_events "
+            "(issue_id, sprint_id, milestone, shape_verdict, action, succeeded, "
+            "cost_usd, duration_seconds, emitted_at, raw_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(event["issue_id"]),
+                event.get("sprint_id"),
+                event.get("milestone"),
+                event.get("shape_verdict"),
+                str(event["action"]),
+                1 if event.get("succeeded") else 0,
+                cost_usd,
+                duration_seconds,
+                emitted_at,
+                raw_json,
+            ),
+        )
+        conn.commit()
+        return int(cur.lastrowid or 0)
+    finally:
+        conn.close()
+
+
+def iter_inline_remediation_events(
+    conn: sqlite3.Connection,
+    *,
+    milestone: str | None = None,
+) -> Iterable[dict]:
+    """Yield inline-remediation event dicts (parsed from raw_json), oldest first."""
+    sql = "SELECT raw_json FROM inline_remediation_events"
+    params: tuple = ()
+    if milestone is not None:
+        sql += " WHERE milestone = ?"
+        params = (milestone,)
+    sql += " ORDER BY emitted_at ASC, event_id ASC"
+    for row in conn.execute(sql, params):
+        raw = row[0] if not isinstance(row, sqlite3.Row) else row["raw_json"]
+        try:
+            yield json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+
+def inline_remediation_rollup_by_milestone(conn: sqlite3.Connection) -> dict[str, dict]:
+    """Return ``{milestone: {"count": int, "total_cost_usd": float}}``.
+
+    The postmortem refusal-economics numerator: how many inline-remediation
+    events fired per milestone and what they cost. A ``None`` milestone is
+    keyed under the empty string so callers can still surface un-milestoned
+    events. Costs recorded as NULL contribute 0.0.
+    """
+    rows = conn.execute(
+        "SELECT COALESCE(milestone, ''), COUNT(*), COALESCE(SUM(cost_usd), 0.0) "
+        "FROM inline_remediation_events GROUP BY milestone"
+    ).fetchall()
+    out: dict[str, dict] = {}
+    for milestone, count, total_cost in rows:
+        out[str(milestone)] = {
+            "count": int(count),
+            "total_cost_usd": float(total_cost),
+        }
     return out
 
 

--- a/src/theforge/sprint/entry_intake.py
+++ b/src/theforge/sprint/entry_intake.py
@@ -98,6 +98,25 @@ def remediate_entry_skipped_issues(
                     "shape_gate_detail": sk.detail,
                 },
             )
+            # The pass loop only fires on non-PASSED outcomes, so it skipped
+            # this issue while the body check was still PASSED. Now that the
+            # bridge has converted it to a declined DROPPED_SHAPE, emit the
+            # training-wheels WARNING + audit row here so the decline is not
+            # silent. Gated on grooming (the opt-in fallback this posture is
+            # about); auto_fix-only runs never emit the grooming memo.
+            if grooming_enabled:
+                from .runner import emit_inline_remediation_event  # noqa: PLC0415
+
+                emit_inline_remediation_event(
+                    config=config,
+                    issue=issue_num,
+                    slug=slug,
+                    outcome=outcome,
+                    log=log,
+                    sprint_id=sprint_id,
+                    milestone=milestone,
+                    duration_seconds=0.0,
+                )
         outcomes[issue_num] = outcome
         log(
             f"Entry shape-gate skip remediation: issue #{issue_num} "

--- a/src/theforge/sprint/entry_intake.py
+++ b/src/theforge/sprint/entry_intake.py
@@ -25,6 +25,8 @@ def remediate_entry_skipped_issues(
     *,
     config: "ForgeConfig",
     log: Callable[[str], None],
+    sprint_id: str | None = None,
+    milestone: str | None = None,
 ) -> dict[int, IntakeOutcome]:
     """Run the intake remediation gate over entry-skipped issues.
 
@@ -68,6 +70,8 @@ def remediate_entry_skipped_issues(
         config=config,
         tasks=tasks,
         log=log,
+        sprint_id=sprint_id,
+        milestone=milestone,
     )
 
     outcomes: dict[int, IntakeOutcome] = {}

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import os
 import shutil
 import subprocess
@@ -173,12 +174,22 @@ def _run_intake_remediation_pass(
     tasks: list[TaskStory],
     log: Callable[[str], None],
     force: bool = False,
+    sprint_id: str | None = None,
+    milestone: str | None = None,
 ) -> dict[str, IntakeOutcome]:
     """Run the intake remediation pass on the normalized task list.
 
     Returns an empty dict when intake is fully disabled (grooming + auto_fix
     both False) — the runner skips the dropped/remediated bookkeeping in
     that case, preserving today's behavior exactly.
+
+    When ``intake.grooming`` is enabled and remediation actually fires for an
+    issue (a non-PASSED outcome), each firing emits the ADR-0001 training-
+    wheels WARNING naming ``forge groom`` and writes a structured record to
+    the audit substrate (``inline_remediation_events``). ``sprint_id`` and
+    ``milestone`` label those records for per-milestone refusal-economics
+    rollups; both default to ``None`` for the entry-shape-gate bridge path,
+    which has no sprint id in scope.
     """
     intake_cfg = getattr(config, "intake", None)
     grooming_raw = getattr(intake_cfg, "grooming", False)
@@ -207,7 +218,8 @@ def _run_intake_remediation_pass(
             config=config,
             log=log,
         )
-    return run_intake_remediation(
+    _remediation_started = time.monotonic()
+    outcomes = run_intake_remediation(
         tasks,
         config.project_root,
         grooming_enabled=grooming_enabled,
@@ -217,6 +229,89 @@ def _run_intake_remediation_pass(
         missing_agent_detail=missing_agent_detail,
         force=force,
     )
+    _remediation_duration = time.monotonic() - _remediation_started
+    # Training-wheels posture (ADR-0001): when the opt-in grooming fallback
+    # fires inline, tell the operator the intended pre-sprint path and record
+    # the event for refusal-economics rollups. Gated on grooming_enabled so
+    # auto_fix-only runs (a distinct opt-in) don't emit the grooming memo.
+    if grooming_enabled:
+        _emit_inline_remediation_events(
+            config=config,
+            tasks=tasks,
+            outcomes=outcomes,
+            log=log,
+            sprint_id=sprint_id,
+            milestone=milestone,
+            duration_seconds=_remediation_duration,
+        )
+    return outcomes
+
+
+def _emit_inline_remediation_events(
+    *,
+    config: ForgeConfig,
+    tasks: list[TaskStory],
+    outcomes: dict[str, IntakeOutcome],
+    log: Callable[[str], None],
+    sprint_id: str | None,
+    milestone: str | None,
+    duration_seconds: float,
+) -> None:
+    """Emit the ADR-0001 training-wheels WARNING + audit record per firing.
+
+    "Firing" = a non-PASSED outcome (blocking findings triggered remediation).
+    PASSED outcomes did nothing, so they neither warn nor record. Substrate
+    write failures are observability-only: they log a WARNING and never abort
+    the sprint.
+    """
+    from ..coordinator.audit_substrate import (  # noqa: PLC0415
+        SubstrateError,
+        record_inline_remediation_event,
+    )
+
+    logger = logging.getLogger("theforge.intake")
+    slug_to_issue = {t.slug: getattr(t, "github_issue", None) for t in tasks}
+    for slug, outcome in outcomes.items():
+        # Production outcomes are always IntakeOutcome; guard so a caller that
+        # passes a stub/placeholder (only tests do) never trips substrate I/O.
+        if not isinstance(outcome, IntakeOutcome):
+            continue
+        if outcome.kind is IntakeOutcomeKind.PASSED:
+            continue
+        issue = slug_to_issue.get(slug)
+        issue_ref = f"#{issue}" if issue is not None else slug
+        groom_ref = str(issue) if issue is not None else slug
+        line1 = f"Inline intake remediation ran at sprint entry for {issue_ref}."
+        line2 = f"Intended workflow: run `forge groom {groom_ref}` before sprint selection."
+        # Operator-facing sprint log (matches the ADR `[forge]` example) …
+        log(line1)
+        log(line2)
+        # … and a WARNING-level record so the message carries severity.
+        logger.warning("%s %s", line1, line2)
+
+        codes = _intake_finding_codes(outcome)
+        remediation_source = (
+            outcome.audit.get("remediation_source") if isinstance(outcome.audit, dict) else None
+        )
+        event = {
+            "issue_id": str(issue) if issue is not None else slug,
+            "sprint_id": sprint_id,
+            "milestone": milestone,
+            "shape_verdict": codes[0] if codes else outcome.kind.value,
+            "shape_verdict_codes": codes,
+            "action": outcome.kind.value,
+            "succeeded": outcome.kind is IntakeOutcomeKind.REMEDIATED,
+            "cost_usd": _intake_outcome_cost(outcome),
+            "duration_seconds": duration_seconds,
+            "remediation_source": remediation_source,
+            "detail": outcome.detail,
+        }
+        try:
+            record_inline_remediation_event(config.project_root, event)
+        except SubstrateError as exc:
+            msg = f"inline-remediation substrate write failed (continuing): {exc}"
+            log(f"WARNING: {msg}")
+            logger.warning(msg)
 
 
 def _intake_outcome_cost(outcome: IntakeOutcome) -> float:
@@ -1915,6 +2010,7 @@ def run_sprint(
         tasks=dispatch_tasks,
         log=_log,
         force=force,
+        sprint_id=_sprint_id,
     )
     # Intake remediation agent spend (auto_fix LLM rewrites) must roll up
     # into the sprint total. Without this, sprint.total_cost_usd silently

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -264,12 +264,6 @@ def _emit_inline_remediation_events(
     write failures are observability-only: they log a WARNING and never abort
     the sprint.
     """
-    from ..coordinator.audit_substrate import (  # noqa: PLC0415
-        SubstrateError,
-        record_inline_remediation_event,
-    )
-
-    logger = logging.getLogger("theforge.intake")
     slug_to_issue = {t.slug: getattr(t, "github_issue", None) for t in tasks}
     for slug, outcome in outcomes.items():
         # Production outcomes are always IntakeOutcome; guard so a caller that
@@ -278,40 +272,85 @@ def _emit_inline_remediation_events(
             continue
         if outcome.kind is IntakeOutcomeKind.PASSED:
             continue
-        issue = slug_to_issue.get(slug)
-        issue_ref = f"#{issue}" if issue is not None else slug
-        groom_ref = str(issue) if issue is not None else slug
-        line1 = f"Inline intake remediation ran at sprint entry for {issue_ref}."
-        line2 = f"Intended workflow: run `forge groom {groom_ref}` before sprint selection."
-        # Operator-facing sprint log (matches the ADR `[forge]` example) …
-        log(line1)
-        log(line2)
-        # … and a WARNING-level record so the message carries severity.
-        logger.warning("%s %s", line1, line2)
-
-        codes = _intake_finding_codes(outcome)
-        remediation_source = (
-            outcome.audit.get("remediation_source") if isinstance(outcome.audit, dict) else None
+        emit_inline_remediation_event(
+            config=config,
+            issue=slug_to_issue.get(slug),
+            slug=slug,
+            outcome=outcome,
+            log=log,
+            sprint_id=sprint_id,
+            milestone=milestone,
+            duration_seconds=duration_seconds,
         )
-        event = {
-            "issue_id": str(issue) if issue is not None else slug,
-            "sprint_id": sprint_id,
-            "milestone": milestone,
-            "shape_verdict": codes[0] if codes else outcome.kind.value,
-            "shape_verdict_codes": codes,
-            "action": outcome.kind.value,
-            "succeeded": outcome.kind is IntakeOutcomeKind.REMEDIATED,
-            "cost_usd": _intake_outcome_cost(outcome),
-            "duration_seconds": duration_seconds,
-            "remediation_source": remediation_source,
-            "detail": outcome.detail,
-        }
-        try:
-            record_inline_remediation_event(config.project_root, event)
-        except SubstrateError as exc:
-            msg = f"inline-remediation substrate write failed (continuing): {exc}"
-            log(f"WARNING: {msg}")
-            logger.warning(msg)
+
+
+def emit_inline_remediation_event(
+    *,
+    config: ForgeConfig,
+    issue: int | None,
+    slug: str,
+    outcome: IntakeOutcome,
+    log: Callable[[str], None],
+    sprint_id: str | None,
+    milestone: str | None,
+    duration_seconds: float,
+) -> None:
+    """Emit the ADR-0001 training-wheels WARNING + one audit record for a firing.
+
+    A single inline-remediation firing (one issue). Shared by the in-pass loop
+    and the entry-shape-gate bridge, which converts a body-PASSED outcome into
+    a ``declined`` DROPPED_SHAPE *after* the pass loop has skipped it (that
+    conversion path has no other firing hook). The ``remediation_source`` in
+    the outcome's audit block drives the recorded ``action``: a ``declined``
+    source records ``action="declined"`` and takes the triggering verdict from
+    the shape-gate reason codes the bridge stashed in ``audit`` (the body
+    checks produced no findings). Substrate write failures are
+    observability-only.
+    """
+    from ..coordinator.audit_substrate import (  # noqa: PLC0415
+        SubstrateError,
+        record_inline_remediation_event,
+    )
+
+    logger = logging.getLogger("theforge.intake")
+    issue_ref = f"#{issue}" if issue is not None else slug
+    groom_ref = str(issue) if issue is not None else slug
+    line1 = f"Inline intake remediation ran at sprint entry for {issue_ref}."
+    line2 = f"Intended workflow: run `forge groom {groom_ref}` before sprint selection."
+    # Operator-facing sprint log (matches the ADR `[forge]` example) …
+    log(line1)
+    log(line2)
+    # … and a WARNING-level record so the message carries severity.
+    logger.warning("%s %s", line1, line2)
+
+    audit = outcome.audit if isinstance(outcome.audit, dict) else {}
+    remediation_source = audit.get("remediation_source")
+    codes = _intake_finding_codes(outcome)
+    if not codes:
+        shape_gate_codes = audit.get("shape_gate_codes")
+        if isinstance(shape_gate_codes, list) and shape_gate_codes:
+            codes = [str(c) for c in shape_gate_codes]
+    declined = remediation_source == "declined"
+    action = "declined" if declined else outcome.kind.value
+    event = {
+        "issue_id": str(issue) if issue is not None else slug,
+        "sprint_id": sprint_id,
+        "milestone": milestone,
+        "shape_verdict": codes[0] if codes else outcome.kind.value,
+        "shape_verdict_codes": codes,
+        "action": action,
+        "succeeded": outcome.kind is IntakeOutcomeKind.REMEDIATED,
+        "cost_usd": _intake_outcome_cost(outcome),
+        "duration_seconds": duration_seconds,
+        "remediation_source": remediation_source,
+        "detail": outcome.detail,
+    }
+    try:
+        record_inline_remediation_event(config.project_root, event)
+    except SubstrateError as exc:
+        msg = f"inline-remediation substrate write failed (continuing): {exc}"
+        log(f"WARNING: {msg}")
+        logger.warning(msg)
 
 
 def _intake_outcome_cost(outcome: IntakeOutcome) -> float:

--- a/tests/test_inline_remediation_emission.py
+++ b/tests/test_inline_remediation_emission.py
@@ -1,0 +1,252 @@
+"""Inline intake remediation: training-wheels WARNING + audit-substrate emission.
+
+Issue #1513 / ADR-0001 "Inline intake remediation posture". When the opt-in
+``intake.grooming`` fallback fires at sprint entry, the daemon must (a) emit a
+two-line WARNING naming ``forge groom`` as the intended primary path and (b)
+write a structured record to the SQLite audit substrate so the
+remediation-to-runnable cost ratio is queryable per milestone.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from theforge.config.types import IntakeConfig
+from theforge.coordinator.audit_substrate import (
+    SubstrateError,
+    inline_remediation_rollup_by_milestone,
+    iter_inline_remediation_events,
+    record_inline_remediation_event,
+    substrate_path,
+)
+from theforge.intake import IntakeOutcome, IntakeOutcomeKind
+from theforge.intake.findings import FixType, IntakeFinding, IntakeSeverity
+from theforge.sprint.runner import _run_intake_remediation_pass
+from theforge.task import TaskStory
+
+# ── Substrate unit coverage ──────────────────────────────────────────────
+
+
+def test_record_and_iter_inline_remediation_event(tmp_path: Path) -> None:
+    event = {
+        "issue_id": "1497",
+        "sprint_id": "sprint-abc",
+        "milestone": "v0.11.0",
+        "shape_verdict": "needs_grooming_missing_ac",
+        "action": "dropped_shape",
+        "succeeded": False,
+        "cost_usd": 0.42,
+        "duration_seconds": 3.1,
+    }
+    event_id = record_inline_remediation_event(tmp_path, event)
+    assert event_id > 0
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        events = list(iter_inline_remediation_events(conn))
+    finally:
+        conn.close()
+    assert len(events) == 1
+    assert events[0]["issue_id"] == "1497"
+    assert events[0]["action"] == "dropped_shape"
+    assert events[0]["milestone"] == "v0.11.0"
+
+
+def test_record_inline_remediation_requires_issue_id_and_action(tmp_path: Path) -> None:
+    with pytest.raises(SubstrateError):
+        record_inline_remediation_event(tmp_path, {"action": "dropped_shape"})
+    with pytest.raises(SubstrateError):
+        record_inline_remediation_event(tmp_path, {"issue_id": "1"})
+
+
+def test_rollup_by_milestone_counts_and_sums_cost(tmp_path: Path) -> None:
+    for issue, cost in (("1", 0.10), ("2", 0.25)):
+        record_inline_remediation_event(
+            tmp_path,
+            {
+                "issue_id": issue,
+                "action": "dropped_shape",
+                "succeeded": False,
+                "milestone": "v0.11.0",
+                "cost_usd": cost,
+            },
+        )
+    record_inline_remediation_event(
+        tmp_path,
+        {
+            "issue_id": "3",
+            "action": "remediated",
+            "succeeded": True,
+            "milestone": "v0.12.0",
+            "cost_usd": 1.00,
+        },
+    )
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        rollup = inline_remediation_rollup_by_milestone(conn)
+        # Raw SQL per the AC (count / total_cost per milestone) also works.
+        raw = dict(
+            conn.execute(
+                "SELECT milestone, COUNT(*) FROM inline_remediation_events GROUP BY milestone"
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+    assert rollup["v0.11.0"]["count"] == 2
+    assert rollup["v0.11.0"]["total_cost_usd"] == pytest.approx(0.35)
+    assert rollup["v0.12.0"]["count"] == 1
+    assert rollup["v0.12.0"]["total_cost_usd"] == pytest.approx(1.00)
+    assert raw["v0.11.0"] == 2
+
+
+def test_null_cost_contributes_zero(tmp_path: Path) -> None:
+    record_inline_remediation_event(
+        tmp_path,
+        {"issue_id": "9", "action": "dropped_shape", "milestone": "v0.11.0"},
+    )
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        rollup = inline_remediation_rollup_by_milestone(conn)
+    finally:
+        conn.close()
+    assert rollup["v0.11.0"]["total_cost_usd"] == 0.0
+
+
+# ── Seam coverage: runner pass → WARNING + substrate row ─────────────────
+
+
+def _dropped_outcome(slug: str) -> IntakeOutcome:
+    finding = IntakeFinding(
+        code="needs_grooming_missing_ac",
+        severity=IntakeSeverity.BLOCK,
+        location="acceptance_criteria",
+        problem="no acceptance criteria section",
+        fix_type=FixType.SEMANTIC,
+    )
+    return IntakeOutcome(
+        slug=slug,
+        kind=IntakeOutcomeKind.DROPPED_SHAPE,
+        findings=(finding,),
+        detail="auto-fix disabled",
+        audit={"remediation_source": "none", "agent": {"cost_usd": 0.0}},
+    )
+
+
+def _grooming_config(tmp_path: Path) -> types.SimpleNamespace:
+    # _run_intake_remediation_pass only reads config.intake and
+    # config.project_root when grooming is enabled and auto_fix is off.
+    return types.SimpleNamespace(
+        intake=IntakeConfig(grooming=True, auto_fix=False),
+        project_root=tmp_path,
+    )
+
+
+def test_grooming_firing_warns_and_records(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _grooming_config(tmp_path)
+    task = TaskStory(name="Issue #1497", slug="issue-1497", github_issue=1497)
+    logs: list[str] = []
+
+    def _fake_remediation(tasks, project_root, **_kwargs):  # noqa: ARG001
+        return {t.slug: _dropped_outcome(t.slug) for t in tasks}
+
+    with (
+        patch("theforge.sprint.runner.run_intake_remediation", side_effect=_fake_remediation),
+        caplog.at_level(logging.WARNING, logger="theforge.intake"),
+    ):
+        outcomes = _run_intake_remediation_pass(
+            config=config,
+            tasks=[task],
+            log=logs.append,
+            sprint_id="sprint-xyz",
+            milestone="v0.11.0",
+        )
+
+    assert outcomes["issue-1497"].kind is IntakeOutcomeKind.DROPPED_SHAPE
+
+    # Two-line operator log naming forge groom (matches the ADR example).
+    joined = "\n".join(logs)
+    assert "Inline intake remediation ran at sprint entry for #1497." in joined
+    assert "run `forge groom 1497` before sprint selection." in joined
+
+    # WARNING-level severity carried by the intake logger.
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("forge groom 1497" in m for m in warnings)
+
+    # Structured audit record with the required fields.
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        events = list(iter_inline_remediation_events(conn, milestone="v0.11.0"))
+    finally:
+        conn.close()
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["issue_id"] == "1497"
+    assert ev["sprint_id"] == "sprint-xyz"
+    assert ev["milestone"] == "v0.11.0"
+    assert ev["shape_verdict"] == "needs_grooming_missing_ac"
+    assert ev["action"] == "dropped_shape"
+    assert ev["succeeded"] is False
+    assert "duration_seconds" in ev
+    assert "cost_usd" in ev
+
+
+def test_passed_outcome_does_not_warn_or_record(tmp_path: Path) -> None:
+    config = _grooming_config(tmp_path)
+    task = TaskStory(name="Issue #200", slug="issue-200", github_issue=200)
+    logs: list[str] = []
+
+    def _fake_remediation(tasks, project_root, **_kwargs):  # noqa: ARG001
+        return {t.slug: IntakeOutcome(slug=t.slug, kind=IntakeOutcomeKind.PASSED) for t in tasks}
+
+    with patch("theforge.sprint.runner.run_intake_remediation", side_effect=_fake_remediation):
+        _run_intake_remediation_pass(config=config, tasks=[task], log=logs.append)
+
+    assert not any("forge groom" in line for line in logs)
+    assert not substrate_path(tmp_path).exists() or _count_events(tmp_path) == 0
+
+
+def test_remediated_outcome_records_success(tmp_path: Path) -> None:
+    config = _grooming_config(tmp_path)
+    task = TaskStory(name="Issue #55", slug="issue-55", github_issue=55)
+
+    def _fake_remediation(tasks, project_root, **_kwargs):  # noqa: ARG001
+        return {
+            t.slug: IntakeOutcome(
+                slug=t.slug,
+                kind=IntakeOutcomeKind.REMEDIATED,
+                audit={"remediation_source": "agent", "agent": {"cost_usd": 0.9}},
+            )
+            for t in tasks
+        }
+
+    with patch("theforge.sprint.runner.run_intake_remediation", side_effect=_fake_remediation):
+        _run_intake_remediation_pass(config=config, tasks=[task], log=lambda _m: None)
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        events = list(iter_inline_remediation_events(conn))
+    finally:
+        conn.close()
+    assert len(events) == 1
+    assert events[0]["action"] == "remediated"
+    assert events[0]["succeeded"] is True
+    assert events[0]["cost_usd"] == pytest.approx(0.9)
+
+
+def _count_events(project_root: Path) -> int:
+    conn = sqlite3.connect(str(substrate_path(project_root)))
+    try:
+        return conn.execute("SELECT COUNT(*) FROM inline_remediation_events").fetchone()[0]
+    finally:
+        conn.close()

--- a/tests/test_sprint_entry_intake.py
+++ b/tests/test_sprint_entry_intake.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+import sqlite3
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from theforge.config import (
     DEFAULT_VALIDATION,
@@ -15,6 +19,10 @@ from theforge.config import (
     WorkspaceConfig,
 )
 from theforge.config.types import IntakeConfig
+from theforge.coordinator.audit_substrate import (
+    iter_inline_remediation_events,
+    substrate_path,
+)
 from theforge.intake import IntakeOutcome, IntakeOutcomeKind
 from theforge.sprint.entry_intake import remediate_entry_skipped_issues
 from theforge.sprint.shape_gate import SkippedIssue
@@ -113,6 +121,80 @@ def test_passing_body_with_entry_skip_records_declined(tmp_path: Path) -> None:
     assert outcome.audit["shape_gate_codes"] == ["reopened_stale_contract"]
     # Operator-visible log line ensures non-silence.
     assert any("issue #1135" in line for line in logs)
+
+
+def test_declined_entry_skip_emits_warning_and_records(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A body-PASSED outcome converted to a declined DROPPED_SHAPE must still
+    emit the training-wheels WARNING and write an inline_remediation_events
+    row with action='declined' — the pass loop skipped it while PASSED."""
+    config = _make_config(
+        tmp_path,
+        intake=IntakeConfig(grooming=True, auto_fix=False, auto_fix_mode="comment"),
+    )
+
+    def fake_pass(*, config, tasks, log, **_kwargs):  # noqa: ARG001
+        return {t.slug: IntakeOutcome(slug=t.slug, kind=IntakeOutcomeKind.PASSED) for t in tasks}
+
+    logs: list[str] = []
+    with (
+        patch("theforge.sprint.runner._run_intake_remediation_pass", side_effect=fake_pass),
+        caplog.at_level(logging.WARNING, logger="theforge.intake"),
+    ):
+        outcomes = remediate_entry_skipped_issues(
+            [_skipped(1135, "reopened_stale_contract")],
+            config=config,
+            log=logs.append,
+            sprint_id="sprint-decl",
+            milestone="v0.11.0",
+        )
+
+    assert outcomes[1135].kind is IntakeOutcomeKind.DROPPED_SHAPE
+
+    joined = "\n".join(logs)
+    assert "Inline intake remediation ran at sprint entry for #1135." in joined
+    assert "run `forge groom 1135` before sprint selection." in joined
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("forge groom 1135" in m for m in warnings)
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        events = list(iter_inline_remediation_events(conn, milestone="v0.11.0"))
+    finally:
+        conn.close()
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["issue_id"] == "1135"
+    assert ev["sprint_id"] == "sprint-decl"
+    assert ev["action"] == "declined"
+    assert ev["shape_verdict"] == "reopened_stale_contract"
+    assert ev["succeeded"] is False
+
+
+def test_declined_entry_skip_no_emit_when_grooming_disabled(tmp_path: Path) -> None:
+    """auto_fix-only runs (grooming off) still record the declined outcome but
+    do not emit the grooming training-wheels WARNING or an audit row."""
+    config = _make_config(
+        tmp_path,
+        intake=IntakeConfig(grooming=False, auto_fix=True, auto_fix_mode="comment"),
+    )
+
+    def fake_pass(*, config, tasks, log, **_kwargs):  # noqa: ARG001
+        return {t.slug: IntakeOutcome(slug=t.slug, kind=IntakeOutcomeKind.PASSED) for t in tasks}
+
+    logs: list[str] = []
+    with patch("theforge.sprint.runner._run_intake_remediation_pass", side_effect=fake_pass):
+        outcomes = remediate_entry_skipped_issues(
+            [_skipped(1136, "reopened_stale_contract")],
+            config=config,
+            log=logs.append,
+        )
+
+    assert outcomes[1136].kind is IntakeOutcomeKind.DROPPED_SHAPE
+    assert not any("forge groom" in line for line in logs)
+    assert not substrate_path(tmp_path).exists()
 
 
 def test_remediation_outcome_passes_through(tmp_path: Path) -> None:

--- a/tests/test_sprint_entry_intake.py
+++ b/tests/test_sprint_entry_intake.py
@@ -93,7 +93,7 @@ def test_passing_body_with_entry_skip_records_declined(tmp_path: Path) -> None:
         intake=IntakeConfig(grooming=True, auto_fix=False, auto_fix_mode="comment"),
     )
 
-    def fake_pass(*, config, tasks, log):  # noqa: ARG001
+    def fake_pass(*, config, tasks, log, **_kwargs):  # noqa: ARG001
         return {t.slug: IntakeOutcome(slug=t.slug, kind=IntakeOutcomeKind.PASSED) for t in tasks}
 
     logs: list[str] = []
@@ -122,7 +122,7 @@ def test_remediation_outcome_passes_through(tmp_path: Path) -> None:
         intake=IntakeConfig(grooming=True, auto_fix=True, auto_fix_mode="comment"),
     )
 
-    def fake_pass(*, config, tasks, log):  # noqa: ARG001
+    def fake_pass(*, config, tasks, log, **_kwargs):  # noqa: ARG001
         return {
             tasks[0].slug: IntakeOutcome(
                 slug=tasks[0].slug,


### PR DESCRIPTION
Recovers the approved-but-unmerged #1513 (sprint run `8019a5f6af18`, MERGE_FAILED).

The story was reviewed APPROVE but failed to land: it collided with #1453 on `audit_substrate.py` — both added a new events table (shape_skip_events / inline_remediation_events) and both added iterator/rollup functions at the same locations. The collision DAG didn't serialize them because #1513's preflight didn't predict audit_substrate.py.

Resolution: additive union. Took main's audit_substrate.py (with #1453's shape_skip additions, schema v3) and re-applied #1513's three additions exactly — inline_remediation_events table, the three record/iter/rollup functions, and the clean schema bump 3→4 (no version collision; #1453 didn't bump). Full suite green (5228 passed) with both features' tables and functions coexisting.

Closes #1513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)