### PR TITLE
Resume forge.yaml sync + skip-worktree makes pre-dev rebase abort when base-branch forge.yaml has diverged

### DIFF
--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -263,12 +263,68 @@ def delete_merge_state(workspace_path: Path) -> None:
         _logger.warning("merge_state.yaml: failed to delete (%s) — ignoring", exc)
 
 
+def _detach_skip_worktree_forge_yaml(worktree_path: Path) -> str | None:
+    """Temporarily detach a skip-worktree'd forge.yaml so a rebase can update it.
+
+    _setup_resume_entry syncs the operator's live forge.yaml into the worktree and
+    marks it skip-worktree (issue #1627) so its content never lands in a story
+    commit. skip-worktree hides the working-tree modification from status/diff, but
+    it does NOT protect the path from an incoming rebase/checkout: if the base
+    branch changed forge.yaml, git tries to update the path, detects the divergent
+    working-tree content, and aborts the whole rebase ("local changes ... would be
+    overwritten by checkout") — a conflict forge manufactured against a file the
+    operator never edited in that worktree (issue #1772).
+
+    Preserve the synced content, clear the skip-worktree bit, and reset the working
+    copy to the tracked version so the tree is clean and the rebase can replay
+    freely. Returns the preserved content for _reattach_skip_worktree_forge_yaml,
+    or None when forge.yaml is not skip-worktree here (e.g. the reused-worktree
+    path in workspace.py that never syncs operator config).
+    """
+    ls_ok, ls_out = _cu._run_shell("git ls-files -v forge.yaml", worktree_path)
+    if not ls_ok or not ls_out.strip().startswith("S "):
+        return None
+    forge_yaml = worktree_path / "forge.yaml"
+    try:
+        content = forge_yaml.read_text()
+    except OSError:
+        # Nothing to preserve/restore; leave the bit as-is rather than risk
+        # re-syncing empty content over operator config.
+        return None
+    _cu._run_shell("git update-index --no-skip-worktree forge.yaml", worktree_path)
+    _cu._run_shell("git checkout -- forge.yaml", worktree_path)
+    return content
+
+
+def _reattach_skip_worktree_forge_yaml(worktree_path: Path, content: str | None) -> None:
+    """Re-apply operator forge.yaml content and re-set skip-worktree after rebase.
+
+    Restores the steady state established by _setup_resume_entry (issue #1627): the
+    run executes with operator config in the working tree, but the file stays
+    hidden from status/diff/staging so it never lands in a story commit. Called
+    unconditionally after the rebase (success or failure) to undo the detach.
+    """
+    if content is None:
+        return
+    forge_yaml = worktree_path / "forge.yaml"
+    try:
+        forge_yaml.write_text(content)
+    except OSError:
+        pass
+    _cu._run_shell("git update-index --skip-worktree forge.yaml", worktree_path)
+
+
 def _rebase_onto_main(worktree_path: str, base_branch: str, logger) -> tuple[bool, str]:
     """Fetch and rebase the resumed worktree onto origin/base_branch."""
     git_dir = Path(worktree_path) / ".git"
     if not git_dir.exists():
         return True, ""
 
+    wt = Path(worktree_path)
+    # A synced, skip-worktree'd forge.yaml would abort the rebase if the base
+    # branch diverged on that file; detach it around the rebase and restore it
+    # afterward (issue #1772).
+    _synced_forge_yaml = _detach_skip_worktree_forge_yaml(wt)
     try:
         with FETCH_LOCK:
             fetch_proc = subprocess.run(
@@ -300,6 +356,8 @@ def _rebase_onto_main(worktree_path: str, base_branch: str, logger) -> tuple[boo
         if logger is not None:
             logger.warning("resume rebase step failed: %s", exc)
         return False, str(exc)
+    finally:
+        _reattach_skip_worktree_forge_yaml(wt, _synced_forge_yaml)
 
     return True, ""
 

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -139,6 +139,93 @@ def test_dirty_synced_forge_yaml_excluded_from_story_commit(tmp_path):
     assert _git(workspace, "show", "HEAD:forge.yaml") == committed_forge
 
 
+def test_resume_rebase_succeeds_when_base_forge_yaml_diverged(tmp_path):
+    """Seam regression for issue #1772: a resumed worktree whose committed
+    forge.yaml predates a forge.yaml change on the base branch must complete the
+    pre-dev rebase without ESCALATE, while operator config still never lands in a
+    story commit.
+
+    Drives the real seam — run_setup's sync (which flags the synced file
+    skip-worktree, issue #1627) → _rebase_onto_main's fetch+rebase onto
+    origin/main — over a real git repo with a diverged origin base branch.
+    Without the detach/reattach handling the skip-worktree'd working-tree
+    forge.yaml aborts the rebase ("local changes ... would be overwritten by
+    checkout").
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _init_repo(origin)
+
+    # Baseline on origin/main: the mainline forge.yaml plus a story file.
+    committed_forge = "project: mainline\nmodel_order: [full, mini]\n"
+    (origin / "forge.yaml").write_text(committed_forge, encoding="utf-8")
+    (origin / "story.py").write_text("# story baseline\n", encoding="utf-8")
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-q", "-m", "baseline")
+
+    # The worktree is cloned/branched from this baseline (predates the change).
+    workspace = tmp_path / "workspace"
+    _git(tmp_path, "clone", "-q", str(origin), str(workspace))
+    _git(workspace, "config", "user.email", "test@example.com")
+    _git(workspace, "config", "user.name", "Test")
+    _git(workspace, "checkout", "-q", "-b", "forge/test-task")
+    # Story work that does NOT touch forge.yaml.
+    (workspace / "story.py").write_text("# story in progress\n", encoding="utf-8")
+    _git(workspace, "add", "-A")
+    _git(workspace, "commit", "-q", "-m", "wip story")
+
+    # The base branch then diverges on forge.yaml — an everyday forge-managed change.
+    updated_forge = "project: mainline\nmodel_order: [full, mini, nano]\n"
+    (origin / "forge.yaml").write_text(updated_forge, encoding="utf-8")
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-q", "-m", "bump forge.yaml on main")
+
+    # Operator's live working-tree config at project root — never committed.
+    experiment_forge = "project: mainline\nmodel_order: [mini, full]  # EXPERIMENT\n"
+    (tmp_path / "forge.yaml").write_text(experiment_forge, encoding="utf-8")
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    # Real git runs (no _run_shell mock) so skip-worktree is actually applied.
+    result = _setup_resume_entry(
+        config,
+        task,
+        workspace,
+        initial_phase=Phase.DEV,
+        notify=False,
+        run_id="test-run-id",
+    )
+    assert isinstance(result, tuple)
+
+    # The pre-dev rebase must succeed — no manufactured conflict.
+    from theforge.coordinator.run_setup import _rebase_onto_main
+
+    rebase_ok, rebase_err = _rebase_onto_main(str(workspace), "main", None)
+    assert rebase_ok, rebase_err
+
+    # The base-branch forge.yaml change was applied to the branch tip.
+    assert _git(workspace, "show", "HEAD:forge.yaml") == updated_forge
+    # The story's own work survived the rebase.
+    assert "# story in progress\n" == (workspace / "story.py").read_text(encoding="utf-8")
+
+    # The run still sees operator config in the working tree...
+    assert (workspace / "forge.yaml").read_text(encoding="utf-8") == experiment_forge
+    # ...and it remains hidden from dirty detection (skip-worktree re-set).
+    status = _git(workspace, "status", "--porcelain")
+    assert "forge.yaml" not in _parse_dirty_files(status)
+
+    # A subsequent indiscriminate ``git add -A`` auto-commit omits forge.yaml.
+    (workspace / "story.py").write_text("# story implemented\n", encoding="utf-8")
+    _git(workspace, "add", "-A")
+    _git(workspace, "commit", "-q", "-m", "acceptance_criteria:")
+    committed = _git(workspace, "show", "--name-only", "--pretty=format:", "HEAD").split()
+    assert "story.py" in committed
+    assert "forge.yaml" not in committed
+    # The branch's forge.yaml is the rebased base content, not operator config.
+    assert _git(workspace, "show", "HEAD:forge.yaml") == updated_forge
+
+
 def test_setup_returns_escalate_when_workspace_missing(tmp_path):
     """Returns CoordinatorResult when workspace_path doesn't exist."""
     config = _make_config(tmp_path)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the resume rebase symptom and preserves the skip-worktree guard for operator forge.yaml content. | [google-gemini-3.5-flash] The implementation successfully detaches skip-worktree forge.yaml around resume rebase to prevent self-inflicted rebase aborts, with excellent test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $1.68
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Resume forge.yaml sync + skip-worktree makes pre-dev rebase abort when base-branch forge.yaml has diverged (GitHub Issue #1772)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1772