### PR TITLE
PLAN signals DECOMPOSE_NEEDED — escalate oversized stories before DEV

### DIFF
--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -415,6 +415,55 @@ def _clean_stale_plan_files(workspace_path: Path) -> None:
             stale_trace.unlink()
 
 
+def _maybe_escalate_decompose(
+    state: CoordinatorState,
+    task: TaskStory,
+    plan_result: "AgentResult",
+    plan_elapsed: float,
+    notify: bool,
+    config: ForgeConfig,
+    logger: "StructuredLogger | None",
+) -> CoordinatorResult | None:
+    """Escalate when the planner signalled the story is too large to plan.
+
+    The planner emits ``decompose: true`` (with an optional ``decompose_reason``)
+    when the story bundles independent deliverables that cannot be implemented as
+    a single unit. This escalates the story for a human to split manually — the
+    coordinator does NOT auto-split (auto-decomposition is the separate #28 effort).
+
+    Returns a terminal CoordinatorResult when the signal is present, or None to
+    continue the normal PLAN → PLAN_REVIEW → DEV flow.
+    """
+    if not (state.plan_structured and state.plan_structured.get("decompose") is True):
+        return None
+
+    _reason = str(state.plan_structured.get("decompose_reason") or "").strip()
+    state.phase = Phase.ESCALATE
+    state.escalate_kind = "decompose"
+    state.escalate_reason = (
+        _reason or "Planner signalled the story is too large to plan as one unit."
+    )
+    state.error = (
+        "PLAN signalled DECOMPOSE_NEEDED — the story is too large to plan and "
+        "implement as a single unit. Split it into smaller runnable stories; the "
+        "coordinator does not auto-split."
+    )
+    if _reason:
+        state.error += f" Planner reason: {_reason}"
+    _log(f"  ⚑ PLAN   decompose signalled after {_fmt_duration(plan_elapsed)}")
+    _log(f"✗ ESCALATE   {state.error}")
+    if logger:
+        logger._safe_emit("phase_end", phase="PLAN", outcome="escalate")
+        logger._safe_emit("escalate", reason=state.error, phase="PLAN", escalate_kind="decompose")
+    _escalate_notify(task, state, notify, config)
+    return CoordinatorResult(
+        success=False,
+        phase=state.phase,
+        state=state,
+        message=state.error,
+    )
+
+
 def _run_plan_phase(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -645,6 +694,17 @@ def _run_plan_phase(
         worktree_plan_path.write_text(plan_text, encoding="utf-8")
         state.plan_output = plan_text
         state.plan_structured = parse_plan_output(plan_text)
+
+        # Decompose signal: the planner judged the story too large to implement
+        # as one unit. Escalate for manual splitting — the coordinator does NOT
+        # auto-split (auto-decomposition is the separate #28 effort). This runs
+        # before PLAN_REVIEW/DEV so no dev budget is spent on an oversized story.
+        _decompose_result = _maybe_escalate_decompose(
+            state, task, plan_result, _plan_elapsed, notify, config, logger
+        )
+        if _decompose_result is not None:
+            return _decompose_result
+
         _log(f"  ✓ PLAN   {_fmt_cost(plan_result.cost_usd)}  {_fmt_duration(_plan_elapsed)}")
         if logger:
             logger._safe_emit(

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -196,7 +196,7 @@ def load_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
         ]
     if "surviving_families" in data and isinstance(data["surviving_families"], list):
         state.surviving_families = data["surviving_families"]
-    if data.get("escalate_kind") in ("hygiene", "content"):
+    if data.get("escalate_kind") in ("hygiene", "content", "decompose"):
         state.escalate_kind = data["escalate_kind"]
     if isinstance(data.get("hygiene_escalation_dev_commit_sha"), str):
         state.hygiene_escalation_dev_commit_sha = data["hygiene_escalation_dev_commit_sha"]

--- a/src/theforge/task/plan_parser.py
+++ b/src/theforge/task/plan_parser.py
@@ -29,6 +29,13 @@ class PlanData(_PlanDataRequired, total=False):
 
     criteria_mapping: list[dict]
     risks: list[dict]
+    # Decompose signal: the planner sets decompose=True when the story is too
+    # large to plan and implement as a single unit. The coordinator escalates
+    # for manual splitting rather than auto-decomposing (see #161; auto-split is
+    # the separate, deeper #28 effort). decompose_reason carries the planner's
+    # justification for the audit trail and the operator.
+    decompose: bool
+    decompose_reason: str
 
 
 def _extract_plan_block(text: str) -> str | None:
@@ -83,6 +90,20 @@ def parse_plan_output(text: str) -> PlanData | None:
     plan = data["plan"]
     if not isinstance(plan, dict):
         return None
+
+    # Decompose signal short-circuits the steps requirement: a planner that
+    # judges the story too large is not expected to produce a full step plan.
+    # Surface the signal (and reason) so the coordinator can escalate for manual
+    # splitting instead of proceeding to DEV.
+    if plan.get("decompose") is True:
+        decompose_result: PlanData = {
+            "approach": str(plan.get("approach", "")),
+            "steps": plan["steps"] if isinstance(plan.get("steps"), list) else [],
+            "decompose": True,
+        }
+        if plan.get("decompose_reason") is not None:
+            decompose_result["decompose_reason"] = str(plan["decompose_reason"])
+        return decompose_result
 
     # Validate required top-level keys
     if "approach" not in plan or "steps" not in plan:

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -607,9 +607,31 @@ def build_plan_prompt(
               mitigation: "<how to address it>"
         ```
 
+        ## When the Story Is Too Large
+
+        If — and only if — the story cannot be planned and implemented as a
+        single coherent unit (it bundles multiple independent deliverables that
+        each warrant their own plan and review cycle), do NOT force a plan.
+        Instead, signal that the story must be split, using this schema:
+
+        ```yaml
+        plan:
+          decompose: true
+          decompose_reason: "<why too large; name the independent pieces it should split into>"
+        ```
+
+        When you signal `decompose: true`, omit `steps` — a step plan is not
+        expected. The coordinator will escalate the story for a human to split
+        it manually; it will NOT auto-split. Use this sparingly: most stories,
+        even sizable ones, should be planned normally. Reserve the signal for
+        stories that genuinely bundle separable concerns.
+
         ## Rules
 
         - Do NOT write code. Do NOT modify files.
+        - Do NOT set `decompose: true` merely because the story is non-trivial.
+          Only use it when the story bundles independent deliverables that fight
+          each other in one implementation cycle.
         - Do NOT invent function signatures — cite what exists in the codebase.
         - Do NOT pad the plan with edge case tables or test scenario details
           that the dev agent will derive from the code. Keep it lean.

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -496,6 +496,52 @@ findings:
         # plan review pool called twice; code review never reached
         assert mock_pool.call_count == 2
 
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_plan_decompose_signal_escalates_before_dev(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Planner signals decompose → coordinator escalates before PLAN_REVIEW/DEV.
+
+        Seam-level: verifies the PLAN → (PLAN_REVIEW/DEV) boundary. When the plan
+        agent emits ``decompose: true``, the coordinator must stop at PLAN and
+        escalate for manual splitting — never invoking the plan-review pool or the
+        dev phase, so no dev budget is spent on an oversized story.
+        """
+        config = _make_plan_agent_review_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        _decompose_plan = (
+            "plan:\n"
+            "  decompose: true\n"
+            '  decompose_reason: "Bundles an auth refactor and an unrelated API redesign."\n'
+        )
+        mock_plan_agent.return_value = _make_agent_result(
+            success=True, output=_decompose_plan, cost_usd=0.10
+        )
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert result.state.escalate_kind == "decompose"
+        assert "DECOMPOSE_NEEDED" in result.message
+        assert "auth refactor" in result.state.escalate_reason
+        # Never reached plan review or dev — no auto-split, no dev budget spent.
+        assert mock_pool.call_count == 0
+        assert mock_dev.call_count == 0
+        assert result.state.plan_structured is not None
+        assert result.state.plan_structured.get("decompose") is True
+
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))
     @patch("theforge.coordinator.plan_flow.run_agent_pool")

--- a/tests/test_task_plan.py
+++ b/tests/test_task_plan.py
@@ -209,6 +209,69 @@ plan:
         assert result is not None
 
 
+class TestParsePlanDecomposeSignal:
+    """Tests for the decompose signal in parse_plan_output()."""
+
+    def test_decompose_true_parsed_without_steps(self):
+        text = (
+            'plan:\n  decompose: true\n  decompose_reason: "Bundles two independent features."\n'
+        )
+        result = parse_plan_output(text)
+        assert result is not None
+        assert result["decompose"] is True
+        assert result["decompose_reason"] == "Bundles two independent features."
+        # No steps required when decomposing.
+        assert result["steps"] == []
+
+    def test_decompose_reason_optional(self):
+        text = "plan:\n  decompose: true\n"
+        result = parse_plan_output(text)
+        assert result is not None
+        assert result["decompose"] is True
+        assert "decompose_reason" not in result
+
+    def test_decompose_false_falls_through_to_normal_validation(self):
+        # decompose: false must not short-circuit; a plan without steps is still
+        # rejected as a malformed normal plan.
+        text = "plan:\n  decompose: false\n  approach: do it\n"
+        assert parse_plan_output(text) is None
+
+    def test_decompose_absent_is_normal_plan(self):
+        result = parse_plan_output(_VALID_PLAN_YAML)
+        assert result is not None
+        assert "decompose" not in result
+
+    def test_decompose_preserves_steps_when_present(self):
+        text = (
+            "plan:\n"
+            "  decompose: true\n"
+            '  decompose_reason: "Too big."\n'
+            "  approach: partial\n"
+            "  steps:\n"
+            "    - id: 1\n"
+            "      description: something\n"
+            "      files: [src/foo.py]\n"
+            "      action: modify\n"
+            "      details: detail\n"
+        )
+        result = parse_plan_output(text)
+        assert result is not None
+        assert result["decompose"] is True
+        assert len(result["steps"]) == 1
+
+
+class TestBuildPlanPromptDecompose:
+    """The plan prompt must teach the planner the decompose signal."""
+
+    def test_prompt_documents_decompose_signal(self, tmp_path: Path):
+        from theforge.task import build_plan_prompt
+
+        task = _make_task(tmp_path)
+        prompt = build_plan_prompt(task, story_content="# Spec\n\nHuge story.")
+        assert "decompose: true" in prompt
+        assert "decompose_reason" in prompt
+
+
 class TestBuildDevPromptStructuredPlan:
     """Tests for build_dev_prompt() with PlanData dict as plan_output."""
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the PLAN decompose-signal story and the targeted tests and lint checks pass. | [google-gemini-3.5-flash] The implementation of the PLAN decompose signal is clean, robust, and fully compliant with the specification, featuring excellent unit and seam-level integration tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $3.12
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

PLAN signals DECOMPOSE_NEEDED — escalate oversized stories before DEV (GitHub Issue #161)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #161