### PR TITLE
Preflight: preserve partial evidence from failed runs

### DIFF
--- a/docs/reference/preflight-partial-evidence.md
+++ b/docs/reference/preflight-partial-evidence.md
@@ -8,9 +8,13 @@ crashing; that exploration correctly identified the relevant files, and it was
 thrown away. The **partial-evidence artifact** preserves that exploration so the
 PLAN phase can consume it instead of starting from scratch.
 
-This artifact is produced *only* on a failed preflight run (`success is False`).
-A successful preflight already surfaces its analysis through `preflight_output`
-and `likely_files`; this artifact fills the gap the failure path left open.
+This artifact is produced on any *failed* preflight run. A failure is either a
+hard failure (`success is False` — timeout, crash, non-zero exit) or a clean
+exit that emits unparseable / non-YAML output (`success is True` but the verdict
+does not parse, the `parse_error` degrade path). Both discard the run's verdict,
+so both salvage the exploration. A preflight that parses a valid verdict already
+surfaces its analysis through `preflight_output` and `likely_files`; this
+artifact fills the gap the failure paths left open.
 
 ## Where it lives
 

--- a/docs/reference/preflight-partial-evidence.md
+++ b/docs/reference/preflight-partial-evidence.md
@@ -1,0 +1,89 @@
+# Preflight partial-evidence artifact
+
+When the preflight agent fails — timeout, crash (SIGKILL), stuck-pattern
+termination, or a non-zero exit with no structured verdict — the exploration it
+already performed is not zero-value work. In the motivating incident (#332) a
+preflight agent spent $2.54 reading adapter files and tracing a code path before
+crashing; that exploration correctly identified the relevant files, and it was
+thrown away. The **partial-evidence artifact** preserves that exploration so the
+PLAN phase can consume it instead of starting from scratch.
+
+This artifact is produced *only* on a failed preflight run (`success is False`).
+A successful preflight already surfaces its analysis through `preflight_output`
+and `likely_files`; this artifact fills the gap the failure path left open.
+
+## Where it lives
+
+The artifact is stored in three places, mirroring the existing preflight
+failure fields (`degraded` / `degraded_reason` / `failure_action`):
+
+1. **On run state** — `CoordinatorState.preflight_partial_evidence` (the
+   serialized dict, or `None` when preflight succeeded / the failed run left
+   nothing observable).
+2. **In the audit trail** — under the audit record's `preflight` block as
+   `partial_evidence`, alongside the failure fields it accompanies. It rides in
+   the record's `raw_json`; no audit-record schema bump is required.
+3. **As a per-run log artifact** — `.forge/logs/.../preflight-partial-evidence.yaml`
+   (written next to `preflight.yaml` / `preflight-raw.log`), and inline inside
+   `preflight.yaml` under the `partial_evidence` key.
+
+## Contract
+
+Defined by `PreflightPartialEvidence` in
+`src/theforge/coordinator/preflight_evidence.py`. Serialized form:
+
+```yaml
+partial_evidence:
+  files_inspected:            # list[str] — unique file paths the agent read/edited
+    - src/theforge/runners/adapters/anthropic.py
+    - src/theforge/coordinator/plan_flow.py
+  tool_calls:                 # list — ordered tool activity
+    - tool: Read
+      target: src/theforge/runners/adapters/anthropic.py
+    - tool: Grep
+      target: plan_review
+    - tool: Read
+      target: null            # a tool call whose target could not be determined
+  partial_conclusion: >-      # str | null — last substantive agent text, if captured
+    The adapter path routes through _resolve_model_info; the plan-review
+    tracing pointed at ...
+  failure_reason: "TIMEOUT: Agent exceeded 300s limit"  # str | null — result.output marker
+  failure_code: timeout       # str | null — stable identifier (timeout, stuck_pattern, ...)
+  exit_code: -9               # int | null
+  cost_usd: 2.54              # float | null — money already spent
+  duration_s: 301.2           # float | null — wall-clock before failure
+```
+
+### Field semantics
+
+| Field | Meaning |
+| --- | --- |
+| `files_inspected` | Unique, de-duplicated file paths the agent actually read or edited. Derived from `tool_calls` where the tool is a file-inspection tool (Read/Edit/Write/NotebookEdit/…). Search patterns (Grep/Glob) are excluded here — they still appear in `tool_calls`. |
+| `tool_calls` | The ordered sequence of observed tool calls, each `{tool, target}`. `target` is the file path or search pattern, or `null` when it could not be determined. |
+| `partial_conclusion` | The last substantive text the agent emitted before dying (truncated). `null` when none was captured. |
+| `failure_reason` | The failure marker on the result's `output` (e.g. the timeout/stuck marker), truncated. |
+| `failure_code` | Machine-readable failure identifier from the runner (`timeout`, `stuck_pattern`, …), or `null`. |
+| `exit_code` / `cost_usd` / `duration_s` | Failure metadata: raw exit code, money spent, wall-clock elapsed. |
+
+The artifact is **omitted** (`None`) when it would be empty — i.e. the agent
+died before making any observable tool call *and* left no partial conclusion.
+
+## Provider coverage
+
+Tool-trace capture depends on the runner streaming tool activity. The Claude
+runner streams `tool_use` events and retains them on every exit path (success,
+timeout, stuck, no-result), so `files_inspected` / `tool_calls` are populated
+for Claude preflight runs. Single-shot CLIs that do not stream (Gemini, Codex)
+leave `tool_trace` empty; for those providers the artifact still captures the
+failure metadata and any `partial_conclusion` recoverable from `output`, but not
+the file/tool list. Extending capture to streaming Gemini/Codex is a follow-on.
+
+## Consumption by the PLAN phase
+
+When `state.preflight_partial_evidence` is present, `build_plan_prompt` receives
+a pre-rendered markdown block (via `render_partial_evidence`) as a
+`## Partial Evidence from a Failed Preflight` section. It lists the files already
+inspected, the tool calls made, and any partial conclusion, with an explicit
+instruction to verify anything relied upon since the exploration is incomplete.
+This is advisory — the plan agent is free to ignore it — and independent of the
+success-path `## Preflight Analysis` section.

--- a/src/theforge/agent_types.py
+++ b/src/theforge/agent_types.py
@@ -45,3 +45,14 @@ class AgentResult:
     transport_fallback_fired: bool = False  # invocation switched transport mid-attempt
     transport_fallback_reason: str | None = None  # classifier reason that triggered fallback
     transport_used: str | None = None  # transport that actually ran last: "cli" or "api"
+    # Best-effort observed tool calls, retained even when the run crashes/times
+    # out so downstream phases can salvage the exploration a failed agent did.
+    # Each entry is {"tool": <name>, "target": <path/pattern or None>}. Empty
+    # for providers/paths that do not stream tool activity (e.g. single-shot
+    # CLIs). Consumed by the preflight partial-evidence artifact (issue #706).
+    tool_trace: tuple[dict[str, Any], ...] = ()
+    # Last substantive agent text captured from a killed/crashed run whose
+    # ``output`` field holds only a failure marker (timeout/stuck/no-result).
+    # None on clean successes (``output`` already carries the text) and on
+    # providers that do not stream partial output.
+    partial_output: str | None = None

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -621,6 +621,9 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "degraded_reason": state.preflight_degraded_reason,
                 "risk_signals": list(state.preflight_risk_signals),
                 "failure_action": state.preflight_failure_action,
+                # Exploration salvaged from a failed preflight run (#706): files
+                # inspected, tool calls, partial conclusion. None on success.
+                "partial_evidence": state.preflight_partial_evidence,
                 "attempts": (
                     list(state.preflight_result.raw.get("attempts", []))
                     if state.preflight_result is not None

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -62,6 +62,7 @@ from .plan_trajectory import (
     record_plan_attempt,
 )
 from .preflight import _escalate_dev_model, _find_registry_key_for_profile
+from .preflight_evidence import render_partial_evidence
 from .remote_gates import _plan_review_remote
 from .state import CoordinatorResult, CoordinatorState, Phase, PlanFindingRecord
 from .util import _fmt_cost, _fmt_duration, _log_phase, resolve_timeout_with_active
@@ -642,6 +643,7 @@ def _run_plan_phase(
         preflight_output=(
             preflight_result.output if preflight_result and preflight_result.success else None
         ),
+        partial_preflight_evidence=render_partial_evidence(state.preflight_partial_evidence),
         assembled_context=plan_context,
         conventions=config.conventions_soft,
         work_type=state.preflight_work_type,

--- a/src/theforge/coordinator/preflight_evidence.py
+++ b/src/theforge/coordinator/preflight_evidence.py
@@ -1,0 +1,193 @@
+"""Partial-evidence artifact for failed preflight runs (issue #706).
+
+When the preflight agent crashes, times out, or is killed mid-exploration, the
+work it already did — the files it inspected and the tool calls it made — is
+real, paid-for signal. This module defines the artifact that preserves that
+exploration so the PLAN phase can consume it instead of starting from scratch.
+
+The artifact is intentionally provider-neutral and pure-data (stdlib only): it
+is built from an ``AgentResult``'s best-effort ``tool_trace`` / ``partial_output``
+fields, serialized into the audit trail alongside the existing preflight
+failure fields (``degraded`` / ``degraded_reason`` / ``failure_action``), and
+rendered into a compact markdown block for the plan prompt.
+
+Artifact contract — see also ``docs/reference/preflight-partial-evidence.md``::
+
+    files_inspected:  tuple[str, ...]   # unique file paths the agent read/edited
+    tool_calls:       tuple[dict, ...]  # ordered [{"tool": str, "target": str|None}]
+    partial_conclusion: str | None      # last substantive agent text, if captured
+    failure_reason:   str | None        # the failure marker on result.output
+    failure_code:     str | None        # stable machine identifier (timeout, ...)
+    exit_code:        int | None
+    cost_usd:         float | None
+    duration_s:       float | None
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Tools whose target argument names a file the agent actually inspected or
+# touched. Search tools (Grep/Glob) are excluded from files_inspected because
+# their target is a pattern/directory, not a concrete file read — they still
+# appear in tool_calls.
+_FILE_INSPECTION_TOOLS = frozenset(
+    {"Read", "Edit", "Write", "NotebookEdit", "MultiEdit", "View", "Cat"}
+)
+
+# Bound the free-text fields so a runaway agent transcript cannot bloat the
+# audit record or the plan prompt.
+_MAX_CONCLUSION_CHARS = 4000
+_MAX_REASON_CHARS = 1000
+_MAX_RENDERED_FILES = 40
+_MAX_RENDERED_CALLS = 60
+
+
+def _truncate(text: str | None, limit: int) -> str | None:
+    if text is None:
+        return None
+    text = text.strip()
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+@dataclass(frozen=True)
+class PreflightPartialEvidence:
+    """Exploration salvaged from a failed preflight run.
+
+    ``is_empty()`` is True when the agent died before doing any observable
+    work AND left no partial conclusion — in that case there is nothing worth
+    surfacing to the plan phase.
+    """
+
+    files_inspected: tuple[str, ...] = ()
+    tool_calls: tuple[dict[str, Any], ...] = ()
+    partial_conclusion: str | None = None
+    failure_reason: str | None = None
+    failure_code: str | None = None
+    exit_code: int | None = None
+    cost_usd: float | None = None
+    duration_s: float | None = None
+
+    def is_empty(self) -> bool:
+        return not (self.files_inspected or self.tool_calls or self.partial_conclusion)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict for the audit trail / YAML artifact."""
+        return {
+            "files_inspected": list(self.files_inspected),
+            "tool_calls": [dict(call) for call in self.tool_calls],
+            "partial_conclusion": self.partial_conclusion,
+            "failure_reason": self.failure_reason,
+            "failure_code": self.failure_code,
+            "exit_code": self.exit_code,
+            "cost_usd": self.cost_usd,
+            "duration_s": self.duration_s,
+        }
+
+    def render_for_plan(self) -> str:
+        """Render a compact markdown block for injection into the plan prompt.
+
+        Returns "" when empty so callers can treat it as an optional section.
+        """
+        if self.is_empty():
+            return ""
+        lines: list[str] = [
+            "A previous preflight run failed before finishing, but it had "
+            "already explored the codebase. Use this to avoid re-reading the "
+            "same files — verify anything you rely on, as the exploration is "
+            "incomplete.",
+        ]
+        if self.failure_code or self.failure_reason:
+            marker = self.failure_code or (self.failure_reason or "").strip()
+            lines.append(f"\nFailure: {marker}")
+        if self.files_inspected:
+            shown = list(self.files_inspected[:_MAX_RENDERED_FILES])
+            lines.append("\nFiles already inspected:")
+            lines.extend(f"- {path}" for path in shown)
+            extra = len(self.files_inspected) - len(shown)
+            if extra > 0:
+                lines.append(f"- … and {extra} more")
+        if self.tool_calls:
+            shown_calls = list(self.tool_calls[:_MAX_RENDERED_CALLS])
+            lines.append("\nTool calls made:")
+            for call in shown_calls:
+                target = call.get("target")
+                suffix = f" {target}" if target else ""
+                lines.append(f"- {call.get('tool', '?')}{suffix}")
+            extra_calls = len(self.tool_calls) - len(shown_calls)
+            if extra_calls > 0:
+                lines.append(f"- … and {extra_calls} more")
+        if self.partial_conclusion:
+            lines.append("\nPartial conclusion reached before the crash:")
+            lines.append(self.partial_conclusion)
+        return "\n".join(lines)
+
+
+def build_partial_evidence(
+    result: Any,
+    *,
+    duration_s: float | None = None,
+) -> PreflightPartialEvidence:
+    """Build a :class:`PreflightPartialEvidence` from a failed ``AgentResult``.
+
+    Duck-typed on ``result`` so this module stays stdlib-only and decoupled
+    from the runners package. Reads ``tool_trace`` and ``partial_output`` when
+    present (Claude streaming path); degrades to failure metadata only for
+    providers that do not stream tool activity.
+    """
+    raw_trace = getattr(result, "tool_trace", ()) or ()
+    tool_calls: list[dict[str, Any]] = []
+    files: list[str] = []
+    seen_files: set[str] = set()
+    for entry in raw_trace:
+        if not isinstance(entry, dict):
+            continue
+        tool = str(entry.get("tool", "?"))
+        target = entry.get("target")
+        target = target if isinstance(target, str) and target.strip() else None
+        tool_calls.append({"tool": tool, "target": target})
+        if tool in _FILE_INSPECTION_TOOLS and target and target not in seen_files:
+            seen_files.add(target)
+            files.append(target)
+
+    partial_conclusion = _truncate(getattr(result, "partial_output", None), _MAX_CONCLUSION_CHARS)
+    failure_reason = _truncate(getattr(result, "output", None), _MAX_REASON_CHARS)
+
+    return PreflightPartialEvidence(
+        files_inspected=tuple(files),
+        tool_calls=tuple(tool_calls),
+        partial_conclusion=partial_conclusion,
+        failure_reason=failure_reason,
+        failure_code=getattr(result, "failure_code", None),
+        exit_code=getattr(result, "exit_code", None),
+        cost_usd=getattr(result, "cost_usd", None),
+        duration_s=duration_s,
+    )
+
+
+def render_partial_evidence(evidence: dict[str, Any] | None) -> str | None:
+    """Render a stored partial-evidence dict into a plan-prompt markdown block.
+
+    Accepts the ``to_dict()`` form persisted on ``CoordinatorState`` /
+    the audit trail. Returns None when there is nothing worth surfacing so the
+    plan call site can pass through cleanly.
+    """
+    if not evidence:
+        return None
+    reconstructed = PreflightPartialEvidence(
+        files_inspected=tuple(evidence.get("files_inspected") or ()),
+        tool_calls=tuple(evidence.get("tool_calls") or ()),
+        partial_conclusion=evidence.get("partial_conclusion"),
+        failure_reason=evidence.get("failure_reason"),
+        failure_code=evidence.get("failure_code"),
+        exit_code=evidence.get("exit_code"),
+        cost_usd=evidence.get("cost_usd"),
+        duration_s=evidence.get("duration_s"),
+    )
+    rendered = reconstructed.render_for_plan()
+    return rendered or None

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -52,6 +52,7 @@ from .preflight import (
     score_to_band,
 )
 from .preflight_cache import capture_preflight_cache_snapshot
+from .preflight_evidence import build_partial_evidence
 from .state import CoordinatorResult, CoordinatorState, Phase
 from .util import _fmt_duration, _log_phase
 from .validation_complexity import (
@@ -339,8 +340,21 @@ def _run_preflight_phase(
             state.preflight_degraded_reason = "parse_error"
             _log("  ⚠ PREFLIGHT output malformed — fallback PROCEED (degraded)")
     else:
-        # Preflight agent failed (timeout, SIGKILL, non-zero exit). Whether
-        # it is safe to fall through to a conservative PROCEED depends on
+        # Preflight agent failed (timeout, SIGKILL, non-zero exit). Preserve
+        # whatever exploration it managed before dying — files inspected, tool
+        # calls, any partial conclusion — as an audit artifact the plan phase
+        # can consume instead of re-reading the same files (issue #706).
+        _partial_evidence = build_partial_evidence(
+            preflight_result, duration_s=round(_preflight_elapsed, 2)
+        )
+        if not _partial_evidence.is_empty():
+            state.preflight_partial_evidence = _partial_evidence.to_dict()
+            _log(
+                "  ⓘ PREFLIGHT partial evidence preserved: "
+                f"{len(_partial_evidence.files_inspected)} file(s) inspected, "
+                f"{len(_partial_evidence.tool_calls)} tool call(s)"
+            )
+        # Whether it is safe to fall through to a conservative PROCEED depends on
         # whether preflight was a confidence boost or the load-bearing check
         # that catches contract drift. Detect risk signals deterministically
         # from local state — no extra agent calls — and escalate when any
@@ -810,6 +824,7 @@ def _run_preflight_phase(
         "degraded_reason": state.preflight_degraded_reason,
         "risk_signals": list(state.preflight_risk_signals),
         "failure_action": state.preflight_failure_action,
+        "partial_evidence": state.preflight_partial_evidence,
         "attempts": attempts,
     }
     state.preflight_cache_snapshot = dict(_preflight_artifact["cache_snapshot"])
@@ -819,6 +834,16 @@ def _run_preflight_phase(
         "preflight.yaml",
         yaml.dump(_preflight_artifact, default_flow_style=False, allow_unicode=True),
     )
+    if state.preflight_partial_evidence is not None:
+        _write_log_artifact(
+            state.log_dir,
+            "preflight-partial-evidence.yaml",
+            yaml.dump(
+                state.preflight_partial_evidence,
+                default_flow_style=False,
+                allow_unicode=True,
+            ),
+        )
 
     # ── stop_phase gate ────────────────────────────────────────────────
     if stop_phase is not None and stop_phase == Phase.PREFLIGHT:

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -333,17 +333,13 @@ def _run_preflight_phase(
         **{**preflight_result.__dict__, "raw": preflight_raw}
     )
 
-    if preflight_result.success:
-        verdict, reason, _parse_degraded = _parse_preflight_verdict(preflight_result.output)
-        if _parse_degraded:
-            state.preflight_degraded = True
-            state.preflight_degraded_reason = "parse_error"
-            _log("  ⚠ PREFLIGHT output malformed — fallback PROCEED (degraded)")
-    else:
-        # Preflight agent failed (timeout, SIGKILL, non-zero exit). Preserve
-        # whatever exploration it managed before dying — files inspected, tool
-        # calls, any partial conclusion — as an audit artifact the plan phase
-        # can consume instead of re-reading the same files (issue #706).
+    def _preserve_partial_evidence() -> None:
+        # Preserve whatever exploration the preflight agent managed — files
+        # inspected, tool calls, any partial conclusion — as an audit artifact
+        # the plan phase can consume instead of re-reading the same files
+        # (issue #706). Applies both when the agent dies (timeout/SIGKILL) and
+        # when it exits cleanly but emits unparseable output: in both cases the
+        # tool trace it left behind is real, paid-for signal.
         _partial_evidence = build_partial_evidence(
             preflight_result, duration_s=round(_preflight_elapsed, 2)
         )
@@ -354,6 +350,19 @@ def _run_preflight_phase(
                 f"{len(_partial_evidence.files_inspected)} file(s) inspected, "
                 f"{len(_partial_evidence.tool_calls)} tool call(s)"
             )
+
+    if preflight_result.success:
+        verdict, reason, _parse_degraded = _parse_preflight_verdict(preflight_result.output)
+        if _parse_degraded:
+            state.preflight_degraded = True
+            state.preflight_degraded_reason = "parse_error"
+            # A clean exit with malformed output is still a failed preflight —
+            # salvage the exploration the same way as a crashed run.
+            _preserve_partial_evidence()
+            _log("  ⚠ PREFLIGHT output malformed — fallback PROCEED (degraded)")
+    else:
+        # Preflight agent failed (timeout, SIGKILL, non-zero exit).
+        _preserve_partial_evidence()
         # Whether it is safe to fall through to a conservative PROCEED depends on
         # whether preflight was a confidence boost or the load-bearing check
         # that catches contract drift. Detect risk signals deterministically

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -381,6 +381,12 @@ class CoordinatorState:
     # conservative PROCEED) or "escalate" (risk signals present → BLOCKED).
     # None when preflight did not fail.
     preflight_failure_action: str | None = None
+    # Partial-evidence artifact salvaged from a failed preflight run (#706):
+    # files inspected, tool calls, and any partial conclusion the agent reached
+    # before crashing/timing out. The serialized (to_dict) form; None when
+    # preflight succeeded or the failed run left nothing observable. Consumed by
+    # the PLAN phase to avoid re-reading the same files.
+    preflight_partial_evidence: dict | None = None
     plan_results: list[AgentResult] = field(default_factory=list)
     plan_output: str | None = (
         None  # contents of the worktree plan file, passed to dev (raw string for audit)

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -503,6 +503,57 @@ def _extract_stream_output(lines: list[str]) -> str | None:
     return "".join(lines).strip() or None
 
 
+def _tool_call_target(inp: dict[str, Any]) -> str | None:
+    """Return the file/path/pattern a tool call operated on, or None.
+
+    Prefers the concrete file argument shared by the read/edit/write tools,
+    then falls back to search targets (``path``/``pattern``). Kept
+    stack-neutral so it works for any tool the agent happens to invoke.
+    """
+    if not isinstance(inp, dict):
+        return None
+    for key in ("file_path", "notebook_path", "path", "pattern"):
+        value = inp.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def extract_tool_trace(lines: list[str]) -> tuple[dict[str, Any], ...]:
+    """Extract observed tool calls from accumulated Claude stream-json lines.
+
+    Claude emits ``assistant`` events whose ``message.content`` holds one or
+    more ``tool_use`` items (``name`` + ``input``). This retains the ordered
+    sequence of calls — ``{"tool": <name>, "target": <path/pattern or None>}``
+    — so a crashed run's exploration is not lost. Best-effort: malformed lines
+    are skipped, never raising.
+    """
+    trace: list[dict[str, Any]] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(event, dict) or event.get("type") != "assistant":
+            continue
+        message = event.get("message", {})
+        content = message.get("content", []) if isinstance(message, dict) else []
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "tool_use":
+                trace.append(
+                    {
+                        "tool": str(item.get("name", "?")),
+                        "target": _tool_call_target(item.get("input", {})),
+                    }
+                )
+    return tuple(trace)
+
+
 def _build_no_text_marker(reason: str, *, subtype: str | None = None) -> str:
     """Return a machine-readable marker for streams that contained no text output."""
     marker = f"CLAUDE_STREAM_NO_TEXT: reason={reason}"
@@ -717,6 +768,8 @@ def _run_claude(
             model_usage=_stuck_usage,
             failure_code="stuck_pattern",
             dev_handoff=_try_parse_handoff(partial_output),
+            tool_trace=extract_tool_trace(lines),
+            partial_output=_extract_stream_output(lines),
         )
 
     if timed_out or (time.monotonic() - start) >= profile.timeout_seconds * 1.05:
@@ -744,6 +797,8 @@ def _run_claude(
             model_usage=_timeout_usage,
             failure_code="timeout",
             dev_handoff=_try_parse_handoff(partial_output),
+            tool_trace=extract_tool_trace(lines),
+            partial_output=_extract_stream_output(lines),
         )
 
     elapsed = time.monotonic() - start
@@ -793,6 +848,8 @@ def _run_claude(
             profile_name=profile.name,
             model_usage=_noresult_usage,
             dev_handoff=_try_parse_handoff(_noresult_output),
+            tool_trace=extract_tool_trace(lines),
+            partial_output=None if proc.returncode == 0 else _extract_stream_output(lines),
         )
 
     try:
@@ -816,4 +873,5 @@ def _run_claude(
         profile_name=profile.name,
         model_usage=_parse_model_usage(result_json),
         dev_handoff=_try_parse_handoff(_success_output),
+        tool_trace=extract_tool_trace(lines),
     )

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -516,6 +516,7 @@ def build_plan_prompt(
     *,
     story_content: str,
     preflight_output: str | None = None,
+    partial_preflight_evidence: str | None = None,
     assembled_context: ContextPack | None = None,
     conventions: list[str] | None = None,
     work_type: str | None = None,
@@ -524,6 +525,12 @@ def build_plan_prompt(
 
     The planning agent reads the story and produces a structured YAML plan.
     It does NOT write code.
+
+    ``partial_preflight_evidence`` is an optional pre-rendered markdown block
+    salvaged from a *failed* preflight run (issue #706) — files it already
+    inspected, tool calls, any partial conclusion — surfaced so the planner
+    can skip re-reading the same files. It is mutually informative with, and
+    independent of, ``preflight_output`` (which is only present on success).
 
     Output is ONLY the plan document in YAML format.
     """
@@ -536,6 +543,15 @@ def build_plan_prompt(
             The preflight agent already analysed the codebase:
 
             {preflight_output}
+        """)
+
+    partial_evidence_section = ""
+    if partial_preflight_evidence:
+        partial_evidence_section = dedent(f"""\
+
+            ## Partial Evidence from a Failed Preflight
+
+            {partial_preflight_evidence}
         """)
 
     work_type_instruction = ""
@@ -572,7 +588,7 @@ def build_plan_prompt(
         ## Spec
 
         {story_content}
-        {preflight_section}{context_section}{work_type_instruction}
+        {preflight_section}{partial_evidence_section}{context_section}{work_type_instruction}
         ## Output Format
 
         You MUST output ONLY a YAML block. No prose before or after.

--- a/tests/test_coord_preflight_partial_evidence_seam.py
+++ b/tests/test_coord_preflight_partial_evidence_seam.py
@@ -100,6 +100,73 @@ def test_failed_preflight_evidence_reaches_plan_prompt(tmp_path):
     assert "The adapter path routes plan review through _resolve_model_info." in plan_prompt
 
 
+# A preflight run that exited cleanly (success=True, exit 0) but emitted
+# unparseable, non-YAML output after inspecting two files — the parse_error
+# degrade path. The tool trace it left behind is still real, paid-for signal.
+_MALFORMED_PREFLIGHT = AgentResult(
+    success=True,
+    output="I looked at the adapters but I'm not sure — no YAML block here, sorry.",
+    session_id=None,
+    cost_usd=1.87,
+    exit_code=0,
+    raw={},
+    profile_name="preflight",
+    tool_trace=(
+        {"tool": "Read", "target": "src/theforge/runners/adapters/anthropic.py"},
+        {"tool": "Grep", "target": "plan_review"},
+        {"tool": "Read", "target": "src/theforge/coordinator/plan_flow.py"},
+    ),
+)
+
+
+def test_malformed_preflight_evidence_reaches_plan_prompt(tmp_path):
+    """A clean exit with unparseable output still salvages partial evidence."""
+    config = _make_plan_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+
+    captured: dict[str, str | None] = {}
+
+    def _plan_side_effect(**kwargs):
+        captured["prompt"] = kwargs.get("prompt")
+        return _make_agent_result(success=True, output="Implemented.")
+
+    with (
+        patch("theforge.coordinator.util._run_shell") as mock_shell,
+        patch("theforge.coordinator.dev_phase.run_agent") as mock_dev,
+        patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+        patch("theforge.coordinator.plan_flow.run_agent") as mock_plan_agent,
+        patch("theforge.coordinator.review_pool.run_agent_pool") as mock_pool,
+    ):
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _MALFORMED_PREFLIGHT
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = _plan_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+    # The malformed run degraded on parse_error but its exploration survived.
+    assert result.state.preflight_degraded is True
+    assert result.state.preflight_degraded_reason == "parse_error"
+    evidence = result.state.preflight_partial_evidence
+    assert evidence is not None
+    assert evidence["files_inspected"] == [
+        "src/theforge/runners/adapters/anthropic.py",
+        "src/theforge/coordinator/plan_flow.py",
+    ]
+    assert evidence["cost_usd"] == 1.87
+
+    # And it is surfaced into the plan prompt so planning skips the re-read.
+    assert "prompt" in captured, "plan agent was not invoked"
+    plan_prompt = captured["prompt"] or ""
+    assert "Partial Evidence from a Failed Preflight" in plan_prompt
+    assert "src/theforge/runners/adapters/anthropic.py" in plan_prompt
+
+
 def test_successful_preflight_leaves_no_partial_evidence(tmp_path):
     """A clean preflight must not produce a partial-evidence artifact."""
     config = _make_plan_config(tmp_path)

--- a/tests/test_coord_preflight_partial_evidence_seam.py
+++ b/tests/test_coord_preflight_partial_evidence_seam.py
@@ -1,0 +1,152 @@
+"""Seam test: failed-preflight partial evidence flows into the PLAN phase (#706).
+
+Covers the preflight -> plan state handoff (CONVENTIONS.md §8): a preflight run
+that fails after inspecting files must (a) persist a partial-evidence artifact on
+run state and (b) surface it into the plan agent's prompt so planning doesn't
+re-read the same files. Exercised end-to-end through run_task with the runner
+boundary mocked, so no provider SDK is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_plan_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import Phase
+from theforge.runners import AgentResult
+
+# A preflight run that crashed on a wall-clock timeout after inspecting two
+# files and running a search — carrying the best-effort tool trace + partial
+# conclusion the Claude runner now retains on kill paths.
+_FAILED_PREFLIGHT = AgentResult(
+    success=False,
+    output="TIMEOUT: Agent exceeded 300s limit",
+    session_id=None,
+    cost_usd=2.54,
+    exit_code=-9,
+    raw={},
+    profile_name="preflight",
+    failure_code="timeout",
+    tool_trace=(
+        {"tool": "Read", "target": "src/theforge/runners/adapters/anthropic.py"},
+        {"tool": "Grep", "target": "plan_review"},
+        {"tool": "Read", "target": "src/theforge/coordinator/plan_flow.py"},
+    ),
+    partial_output="The adapter path routes plan review through _resolve_model_info.",
+)
+
+
+def test_failed_preflight_evidence_reaches_plan_prompt(tmp_path):
+    config = _make_plan_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+
+    captured: dict[str, str | None] = {}
+
+    def _plan_side_effect(**kwargs):
+        captured["prompt"] = kwargs.get("prompt")
+        return _make_agent_result(success=True, output="Implemented.")
+
+    with (
+        patch("theforge.coordinator.util._run_shell") as mock_shell,
+        patch("theforge.coordinator.dev_phase.run_agent") as mock_dev,
+        patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+        patch("theforge.coordinator.plan_flow.run_agent") as mock_plan_agent,
+        patch("theforge.coordinator.review_pool.run_agent_pool") as mock_pool,
+    ):
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _FAILED_PREFLIGHT
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = _plan_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+    # (a) Artifact persisted on run state.
+    evidence = result.state.preflight_partial_evidence
+    assert evidence is not None
+    assert evidence["files_inspected"] == [
+        "src/theforge/runners/adapters/anthropic.py",
+        "src/theforge/coordinator/plan_flow.py",
+    ]
+    assert evidence["failure_code"] == "timeout"
+    assert evidence["cost_usd"] == 2.54
+    assert (
+        evidence["partial_conclusion"]
+        == "The adapter path routes plan review through _resolve_model_info."
+    )
+
+    # A failed preflight with no risk signals falls through to a conservative
+    # (degraded) PROCEED and still runs planning.
+    assert result.state.preflight_verdict == "PROCEED"
+    assert result.state.preflight_degraded is True
+
+    # (b) The evidence is surfaced into the plan agent's prompt.
+    assert "prompt" in captured, "plan agent was not invoked"
+    plan_prompt = captured["prompt"] or ""
+    assert "Partial Evidence from a Failed Preflight" in plan_prompt
+    assert "src/theforge/runners/adapters/anthropic.py" in plan_prompt
+    assert "The adapter path routes plan review through _resolve_model_info." in plan_prompt
+
+
+def test_successful_preflight_leaves_no_partial_evidence(tmp_path):
+    """A clean preflight must not produce a partial-evidence artifact."""
+    config = _make_plan_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+
+    preflight_ok = """\
+```yaml
+verdict: PROCEED
+reason: "Needs implementation."
+complexity: medium
+sufficiency: needs_planning
+work_type: feature
+criteria_checked:
+  - criterion: "Feature X"
+    satisfied: false
+    evidence: "Not found"
+```
+"""
+
+    captured: dict[str, str | None] = {}
+
+    def _plan_side_effect(**kwargs):
+        captured["prompt"] = kwargs.get("prompt")
+        return _make_agent_result(success=True, output="Implemented.")
+
+    with (
+        patch("theforge.coordinator.util._run_shell") as mock_shell,
+        patch("theforge.coordinator.dev_phase.run_agent") as mock_dev,
+        patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+        patch("theforge.coordinator.plan_flow.run_agent") as mock_plan_agent,
+        patch("theforge.coordinator.review_pool.run_agent_pool") as mock_pool,
+    ):
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=preflight_ok, cost_usd=0.10, profile_name="preflight"
+        )
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = _plan_side_effect
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+    assert result.phase == Phase.DONE
+    assert result.state.preflight_partial_evidence is None
+    plan_prompt = captured.get("prompt") or ""
+    assert "Partial Evidence from a Failed Preflight" not in plan_prompt

--- a/tests/test_preflight_partial_evidence.py
+++ b/tests/test_preflight_partial_evidence.py
@@ -1,0 +1,195 @@
+"""Unit tests for the preflight partial-evidence artifact (issue #706).
+
+Covers three layers:
+  - runner_claude.extract_tool_trace: parsing tool calls from stream-json lines
+  - preflight_evidence.build_partial_evidence: AgentResult -> artifact
+  - preflight_evidence.render_partial_evidence: stored dict -> plan-prompt block
+
+None of these exercise a real provider CLI — extract_tool_trace is a pure parse
+of accumulated JSONL strings, and the evidence builder is duck-typed on a stub
+result — so the suite runs with or without provider SDKs installed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from theforge.coordinator.preflight_evidence import (
+    PreflightPartialEvidence,
+    build_partial_evidence,
+    render_partial_evidence,
+)
+from theforge.runners.runner_claude import extract_tool_trace
+
+
+def _assistant_line(*tool_uses: tuple[str, dict]) -> str:
+    content = [{"type": "tool_use", "name": name, "input": inp} for name, inp in tool_uses]
+    return json.dumps({"type": "assistant", "message": {"content": content}})
+
+
+@dataclass
+class _StubResult:
+    """Duck-typed stand-in for AgentResult (build_partial_evidence uses getattr)."""
+
+    tool_trace: tuple = ()
+    partial_output: str | None = None
+    output: str = ""
+    failure_code: str | None = None
+    exit_code: int | None = None
+    cost_usd: float | None = None
+
+
+# ── extract_tool_trace ───────────────────────────────────────────────────────
+
+
+class TestExtractToolTrace:
+    def test_extracts_tool_name_and_file_target(self):
+        lines = [
+            _assistant_line(("Read", {"file_path": "src/a.py"})),
+            _assistant_line(("Grep", {"pattern": "def foo", "path": "src"})),
+        ]
+        trace = extract_tool_trace(lines)
+        assert trace == (
+            {"tool": "Read", "target": "src/a.py"},
+            {"tool": "Grep", "target": "src"},
+        )
+
+    def test_pattern_target_when_no_path(self):
+        lines = [_assistant_line(("Glob", {"pattern": "**/*.py"}))]
+        assert extract_tool_trace(lines) == ({"tool": "Glob", "target": "**/*.py"},)
+
+    def test_multiple_tool_uses_in_one_event_preserve_order(self):
+        lines = [
+            _assistant_line(
+                ("Read", {"file_path": "a.py"}),
+                ("Read", {"file_path": "b.py"}),
+            )
+        ]
+        trace = extract_tool_trace(lines)
+        assert [t["target"] for t in trace] == ["a.py", "b.py"]
+
+    def test_target_none_when_no_recognized_arg(self):
+        lines = [_assistant_line(("Bash", {"command": "ls -la"}))]
+        assert extract_tool_trace(lines) == ({"tool": "Bash", "target": None},)
+
+    def test_ignores_non_assistant_and_malformed_lines(self):
+        lines = [
+            "not json at all",
+            json.dumps({"type": "result", "result": "done"}),
+            "",
+            _assistant_line(("Read", {"file_path": "src/keep.py"})),
+        ]
+        assert extract_tool_trace(lines) == ({"tool": "Read", "target": "src/keep.py"},)
+
+    def test_empty_lines_yield_empty_trace(self):
+        assert extract_tool_trace([]) == ()
+
+
+# ── build_partial_evidence ───────────────────────────────────────────────────
+
+
+class TestBuildPartialEvidence:
+    def test_derives_unique_files_inspected_from_file_tools_only(self):
+        result = _StubResult(
+            tool_trace=(
+                {"tool": "Read", "target": "src/a.py"},
+                {"tool": "Read", "target": "src/a.py"},  # duplicate
+                {"tool": "Edit", "target": "src/b.py"},
+                {"tool": "Grep", "target": "src"},  # search tool excluded
+            ),
+            output="TIMEOUT: Agent exceeded 300s limit",
+            failure_code="timeout",
+            exit_code=-9,
+            cost_usd=2.54,
+        )
+        ev = build_partial_evidence(result, duration_s=301.2)
+        assert ev.files_inspected == ("src/a.py", "src/b.py")
+        # all calls (including the search) are retained in tool_calls
+        assert len(ev.tool_calls) == 4
+        assert ev.failure_code == "timeout"
+        assert ev.exit_code == -9
+        assert ev.cost_usd == 2.54
+        assert ev.duration_s == 301.2
+        assert ev.failure_reason == "TIMEOUT: Agent exceeded 300s limit"
+
+    def test_partial_conclusion_from_partial_output(self):
+        result = _StubResult(
+            tool_trace=({"tool": "Read", "target": "a.py"},),
+            partial_output="  The adapter routes through _resolve.  ",
+            output="TIMEOUT",
+        )
+        ev = build_partial_evidence(result)
+        assert ev.partial_conclusion == "The adapter routes through _resolve."
+
+    def test_is_empty_when_no_observable_work(self):
+        result = _StubResult(output="TIMEOUT", failure_code="timeout")
+        ev = build_partial_evidence(result)
+        assert ev.is_empty() is True
+
+    def test_not_empty_with_partial_conclusion_only(self):
+        result = _StubResult(partial_output="I concluded X", output="TIMEOUT")
+        ev = build_partial_evidence(result)
+        assert ev.is_empty() is False
+
+    def test_to_dict_roundtrips_fields(self):
+        result = _StubResult(
+            tool_trace=({"tool": "Read", "target": "a.py"},),
+            partial_output="conclusion",
+            output="TIMEOUT",
+            failure_code="timeout",
+            exit_code=-9,
+            cost_usd=1.0,
+        )
+        d = build_partial_evidence(result, duration_s=10.0).to_dict()
+        assert d["files_inspected"] == ["a.py"]
+        assert d["tool_calls"] == [{"tool": "Read", "target": "a.py"}]
+        assert d["partial_conclusion"] == "conclusion"
+        assert d["failure_code"] == "timeout"
+        assert d["duration_s"] == 10.0
+
+    def test_truncates_overlong_conclusion(self):
+        result = _StubResult(partial_output="x" * 9000, output="TIMEOUT")
+        ev = build_partial_evidence(result)
+        assert ev.partial_conclusion is not None
+        assert len(ev.partial_conclusion) <= 4000
+        assert ev.partial_conclusion.endswith("…")
+
+    def test_ignores_malformed_trace_entries(self):
+        result = _StubResult(
+            tool_trace=("not a dict", {"tool": "Read", "target": "a.py"}, 42),
+            output="TIMEOUT",
+        )
+        ev = build_partial_evidence(result)
+        assert ev.tool_calls == ({"tool": "Read", "target": "a.py"},)
+
+
+# ── render_partial_evidence ──────────────────────────────────────────────────
+
+
+class TestRenderPartialEvidence:
+    def test_none_and_empty_return_none(self):
+        assert render_partial_evidence(None) is None
+        assert render_partial_evidence({}) is None
+        assert render_partial_evidence({"files_inspected": [], "tool_calls": []}) is None
+
+    def test_renders_files_calls_and_conclusion(self):
+        evidence = PreflightPartialEvidence(
+            files_inspected=("src/a.py", "src/b.py"),
+            tool_calls=(
+                {"tool": "Read", "target": "src/a.py"},
+                {"tool": "Grep", "target": "foo"},
+            ),
+            partial_conclusion="It routes through X.",
+            failure_code="timeout",
+        ).to_dict()
+        rendered = render_partial_evidence(evidence)
+        assert rendered is not None
+        assert "src/a.py" in rendered
+        assert "src/b.py" in rendered
+        assert "Read src/a.py" in rendered
+        assert "It routes through X." in rendered
+        assert "timeout" in rendered
+
+    def test_render_for_plan_empty_is_blank(self):
+        assert PreflightPartialEvidence().render_for_plan() == ""


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior parse_error preservation bug is fixed, and I found no blocking regressions in the latest iteration. | [google-gemini-3.5-flash] The implementation of preserving partial evidence from failed preflight runs is fully verified, including the parse_error path, with excellent test coverage and documentation.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $1.97
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight: preserve partial evidence from failed runs (GitHub Issue #706)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #706