### PR TITLE
Collision DAG gives zero protection to a story with empty likely_files — additive same-file collision races to MERGE_FAILED (no conservative or merge-time fallback)

### DIFF
--- a/src/theforge/sprint/collision.py
+++ b/src/theforge/sprint/collision.py
@@ -230,8 +230,19 @@ def compute_synthetic_edges(
     deps: dict[str, set[str]] = {task.slug: set(task.depends_on) for task in tasks}
     synthetic: dict[str, set[str]] = {}
 
+    # A story whose preflight_likely_files is None (preflight failed/excluded) or
+    # empty ([]) has an *unknown* footprint. Absence of evidence is not evidence
+    # of no collision: such a story could touch any file, so it must serialize
+    # conservatively against every other story rather than silently race them to
+    # a merge-time conflict. Stories with a known, non-empty footprint continue
+    # to serialize only on an actual file intersection, so genuinely disjoint
+    # work still runs in parallel.
+    unknown_slugs: list[str] = []
     for slug, state in preflight_states.items():
-        if state.preflight_likely_files is None:
+        if slug not in task_by_slug:
+            continue
+        if not state.preflight_likely_files:
+            unknown_slugs.append(slug)
             continue
         for path in state.preflight_likely_files:
             file_to_slugs.setdefault(path, []).append(slug)
@@ -253,6 +264,17 @@ def compute_synthetic_edges(
             stack.extend(deps.get(slug, set()) - seen)
         return False
 
+    def _serialize(prev: str, curr: str) -> str | None:
+        """Inject a serialize edge (curr depends_on prev). Returns a skip reason
+        if the edge already exists or would cycle, else None (edge injected)."""
+        if _has_dependency_path(curr, prev):
+            return f"{curr} already depends_on {prev}"
+        if _has_dependency_path(prev, curr):
+            return f"{curr} depends_on {prev} would cycle"
+        synthetic.setdefault(curr, set()).add(prev)
+        deps.setdefault(curr, set()).add(prev)
+        return None
+
     for path, slugs in sorted(file_to_slugs.items()):
         unique_slugs = sorted(set(slugs), key=_sort_key)
         if len(unique_slugs) <= 1:
@@ -260,16 +282,57 @@ def compute_synthetic_edges(
         injected: list[str] = []
         skipped: list[str] = []
         for prev, curr in zip(unique_slugs, unique_slugs[1:], strict=False):
-            if _has_dependency_path(curr, prev):
-                skipped.append(f"{curr} already depends_on {prev}")
-                continue
-            if _has_dependency_path(prev, curr):
-                skipped.append(f"{curr} depends_on {prev} would cycle")
-                continue
-            synthetic.setdefault(curr, set()).add(prev)
-            deps.setdefault(curr, set()).add(prev)
-            injected.append(f"{curr} depends_on {prev}")
+            reason = _serialize(prev, curr)
+            if reason is None:
+                injected.append(f"{curr} depends_on {prev}")
+            else:
+                skipped.append(reason)
         detail = f"Collision detected for {path}: stories={unique_slugs}; injected={injected}"
+        if skipped:
+            detail += f"; skipped={skipped}"
+        _log(detail)
+
+    # Conservative fallback for unknown footprints. A story with a known,
+    # non-empty likely_files set makes a concrete claim about which files it
+    # touches; an unknown-footprint sibling cannot be proven disjoint from that
+    # claim, so it is serialized against it rather than left to race to a
+    # merge-time conflict. Edges are pairwise (not a chain), so known, disjoint
+    # siblings are not serialized against each other as a side effect — only the
+    # unknown story is pinned relative to each concrete claim.
+    #
+    # Two prediction-less stories are deliberately NOT serialized against each
+    # other: there is no concrete file claim on either side and no evidence of
+    # overlap, so chaining every prediction-less story would collapse all
+    # parallelism on zero signal (e.g. a fully offline sprint where preflight
+    # could not run at all). That residual overlap is left to the integration
+    # step to detect and recover.
+    known_slugs = sorted(
+        (
+            slug
+            for slug, state in preflight_states.items()
+            if state.preflight_likely_files and slug in task_by_slug
+        ),
+        key=_sort_key,
+    )
+    for unknown in sorted(set(unknown_slugs), key=_sort_key):
+        injected = []
+        skipped = []
+        for known in known_slugs:
+            if known == unknown:
+                continue
+            prev, curr = sorted((unknown, known), key=_sort_key)
+            reason = _serialize(prev, curr)
+            if reason is None:
+                injected.append(f"{curr} depends_on {prev}")
+            else:
+                skipped.append(reason)
+        if not injected and not skipped:
+            continue
+        detail = (
+            f"Unknown footprint for {unknown} (empty/None likely_files): "
+            f"serializing conservatively against known-footprint siblings; "
+            f"injected={injected}"
+        )
         if skipped:
             detail += f"; skipped={skipped}"
         _log(detail)

--- a/tests/test_sprint_collision.py
+++ b/tests/test_sprint_collision.py
@@ -56,11 +56,67 @@ def test_inject_synthetic_deps_writes_to_collision_deps() -> None:
     assert augmented[1].collision_deps == ["extra", "story-12"]
 
 
-def test_compute_synthetic_edges_ignores_missing_likely_files() -> None:
+def test_compute_synthetic_edges_serializes_empty_likely_files_conservatively() -> None:
+    """An empty likely_files ([]) is an *unknown* footprint, not proof of no
+    collision. The regression from #1771: story-12 emitted [] while story-15
+    correctly predicted a shared file; the empty side contributed nothing to the
+    intersection so no edge formed and both raced to a merge conflict. Now the
+    unknown-footprint story is serialized conservatively against its siblings."""
     tasks = [_task("story-12", 12), _task("story-15", 15)]
     states = {
         "story-12": CoordinatorState(preflight_likely_files=[]),
         "story-15": CoordinatorState(preflight_likely_files=["a.py"]),
+    }
+
+    assert compute_synthetic_edges(states, tasks) == {"story-15": ["story-12"]}
+
+
+def test_compute_synthetic_edges_serializes_none_likely_files_conservatively() -> None:
+    """A None footprint (preflight failed/excluded) is also unknown and must be
+    serialized conservatively rather than silently granted zero protection."""
+    tasks = [_task("story-12", 12), _task("story-15", 15)]
+    states = {
+        "story-12": CoordinatorState(preflight_likely_files=None),
+        "story-15": CoordinatorState(preflight_likely_files=["a.py"]),
+    }
+
+    assert compute_synthetic_edges(states, tasks) == {"story-15": ["story-12"]}
+
+
+def test_compute_synthetic_edges_unknown_footprint_does_not_serialize_disjoint_siblings() -> None:
+    """The unknown story pins itself against every sibling, but known, disjoint
+    siblings must still run in parallel relative to each other (no blanket
+    over-serialization)."""
+    tasks = [_task("story-12", 12), _task("story-15", 15), _task("story-25", 25)]
+    states = {
+        # Unknown footprint — must serialize against both others.
+        "story-12": CoordinatorState(preflight_likely_files=[]),
+        # Known and disjoint — parallel to each other, after story-12.
+        "story-15": CoordinatorState(preflight_likely_files=["a.py"]),
+        "story-25": CoordinatorState(preflight_likely_files=["b.py"]),
+    }
+
+    synthetic = compute_synthetic_edges(states, tasks)
+
+    assert synthetic == {
+        "story-15": ["story-12"],
+        "story-25": ["story-12"],
+    }
+    # story-15 and story-25 do not depend on each other — disjoint work stays parallel.
+    build_dag(inject_synthetic_deps(tasks, synthetic))
+
+
+def test_compute_synthetic_edges_two_unknown_footprints_not_serialized() -> None:
+    """Two prediction-less stories are NOT serialized against each other: there
+    is no concrete file claim on either side and no evidence of overlap, so
+    chaining every prediction-less story would collapse all parallelism on zero
+    signal (e.g. a fully offline sprint where preflight could not run). That
+    residual overlap is left to the integration step. Conservative serialization
+    only fires against a sibling that made a concrete, non-empty file claim."""
+    tasks = [_task("story-12", 12), _task("story-15", 15)]
+    states = {
+        "story-12": CoordinatorState(preflight_likely_files=[]),
+        "story-15": CoordinatorState(preflight_likely_files=None),
     }
 
     assert compute_synthetic_edges(states, tasks) == {}


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The conservative serialization path is implemented on the live sprint DAG path and covered for the reported empty-likely-files failure mode. | [google-gemini-3.5-flash] The conservative-serialization fix for unknown-footprint stories is robust, correctly implemented, and fully tested.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.07
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Collision DAG gives zero protection to a story with empty likely_files — additive same-file collision races to MERGE_FAILED (no conservative or merge-time fallback) (GitHub Issue #1771)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1771