### PR TITLE
Dev handoff reports completion without gate evidence; coordinator catches failures dev should have

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -17,6 +17,7 @@ from theforge.config.auth import sandbox_available_for_profile
 from theforge.config.types import StuckDetectionConfig
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.review import append_convention_retry_findings
+from theforge.schemas import dev_handoff_claims_unproven_completion
 from theforge.sessions import save_sessions
 from theforge.task import ContextAssembler, TaskStory, build_dev_prompt, build_fix_prompt
 from theforge.traces import write_trace
@@ -873,6 +874,37 @@ def _run_dev_phase(
             outcome="success" if dev_result.success else "failure",
             cost_usd=_dev_cost_total if _dev_cost_str != "unknown" else None,
             duration_s=round(_dev_elapsed, 2),
+        )
+
+    # ── Unproven-completion guard (successful dev only) ──────────────
+    # Fail closed at the dev seam: a dev that exits successfully but hands off a
+    # completion claim (an acceptance criterion marked MET) without gate PASS
+    # evidence has reported done without proving the gate ran. Escalate rather
+    # than accept an unverified completion and waste a downstream gate run
+    # rediscovering the failure. This is the coordinator catching what the dev
+    # should have declared as a blocking failure (gate_result: BLOCKED).
+    if dev_result.success and dev_handoff_claims_unproven_completion(dev_result.dev_handoff or {}):
+        state.phase = Phase.ESCALATE
+        state.error = (
+            "Dev handoff claims completion (acceptance criteria MET) without gate PASS "
+            "evidence — the gate was not proven to pass; refusing to accept an "
+            "unverified completion"
+        )
+        record_dev_iteration_telemetry(
+            state,
+            workspace_path,
+            max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
+            gate_result="HANDOFF_NO_GATE_EVIDENCE",
+        )
+        _log(f"✗ ESCALATE   {state.error}")
+        if logger:
+            logger._safe_emit("escalate", reason=state.error, phase="DEV")
+        _escalate_notify(task, state, notify, config)
+        return CoordinatorResult(
+            success=False,
+            phase=state.phase,
+            state=state,
+            message=state.error,
         )
 
     if not dev_result.success:

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -282,7 +282,29 @@ def validate_review_yaml(data: Any) -> list[ParseError]:
 
 
 VALID_AC_STATUSES = ("MET", "PARTIAL", "NOT_MET")
-VALID_GATE_RESULTS = ("PASS", "FAIL")
+VALID_GATE_RESULTS = ("PASS", "FAIL", "BLOCKED")
+
+
+def dev_handoff_claims_unproven_completion(data: dict) -> bool:
+    """Return True when a dev handoff claims completion without gate evidence.
+
+    A completion claim is any acceptance_criteria entry marked ``status: MET``.
+    Such a claim is only proven when ``gate_result`` is exactly ``"PASS"``. A
+    missing gate_result, ``"FAIL"``, or ``"BLOCKED"`` all leave the completion
+    unproven — the gate was never shown to pass, so the claim lacks evidence.
+
+    Handoffs that make no completion claim (all criteria PARTIAL/NOT_MET) never
+    trip this check: gate_result stays optional for them.
+    """
+    if not isinstance(data, dict):
+        return False
+    criteria = data.get("acceptance_criteria")
+    if not isinstance(criteria, list):
+        return False
+    claims_met = any(isinstance(ac, dict) and ac.get("status") == "MET" for ac in criteria)
+    if not claims_met:
+        return False
+    return data.get("gate_result") != "PASS"
 
 
 def validate_dev_handoff(data: Any) -> list[str]:
@@ -353,13 +375,29 @@ def validate_dev_handoff(data: Any) -> list[str]:
             if not isinstance(notes, str) or not notes.strip():
                 errors.append(f"acceptance_criteria[{i}].notes must be a non-empty string")
 
-    # ── gate_result (optional; coordinator is source of truth) ───────
+    # ── gate_result ─────────────────────────────────────────────────
+    # Optional for a non-completion handoff, but load-bearing for a completion
+    # claim: an acceptance criterion marked MET requires gate_result: PASS as
+    # evidence (see the cross-field check below).
     gate_result = data.get("gate_result")
     if gate_result is not None and (
         not isinstance(gate_result, str) or gate_result not in VALID_GATE_RESULTS
     ):
         errors.append(
             f"gate_result must be one of {VALID_GATE_RESULTS} when provided, got: {gate_result!r}"
+        )
+
+    # ── cross-field: completion claim requires gate evidence ─────────
+    # A MET acceptance criterion is a completion claim; it is only proven when
+    # the gate actually passed. Reject a completion claim whose gate_result is
+    # absent, FAIL, or BLOCKED — an unrun or failing gate is a blocking failure,
+    # not completion.
+    if dev_handoff_claims_unproven_completion(data):
+        errors.append(
+            "acceptance_criteria mark MET but gate_result is not PASS — a completion "
+            "claim requires gate evidence (set gate_result: PASS after the gate passes, "
+            "or gate_result: BLOCKED and do not mark criteria MET if the gate could not "
+            "be run)"
         )
 
     # ── story_deviations (accept spec_deviations for backward compat) ─

--- a/src/theforge/task/dev_prompts.py
+++ b/src/theforge/task/dev_prompts.py
@@ -321,6 +321,7 @@ def build_dev_prompt(
              - criterion: "AC text from the spec"
                status: MET | PARTIAL | NOT_MET
                notes: "how it was met, or why not"
+           gate_result: PASS | FAIL | BLOCKED
            story_deviations: none
            deferred_items: none
            </forge_handoff>
@@ -331,6 +332,11 @@ def build_dev_prompt(
            - Content must be valid YAML (no embedded code fences inside the block).
            - `commits` and `acceptance_criteria` must be lists (even if empty: `[]`).
            - `story_deviations` and `deferred_items` may be the word `none` or a list.
+           - Set `gate_result: PASS` only after the gate command actually passed.
+             If you genuinely cannot run the gate, set `gate_result: BLOCKED` and do
+             NOT mark any acceptance criterion `MET` — an unrun or failing gate is a
+             blocking failure, not completion, and must never be reported as done with
+             an environmental excuse attached.
 
         ## Rules
 

--- a/tests/test_coord_dev_unproven_completion.py
+++ b/tests/test_coord_dev_unproven_completion.py
@@ -1,0 +1,135 @@
+"""Seam-level tests for the dev-phase unproven-completion guard (#927).
+
+A dev that exits successfully but hands off a completion claim (an acceptance
+criterion marked MET) without gate PASS evidence must be escalated at the dev
+seam — the coordinator catches what the dev should have declared as a blocking
+failure. A well-formed completion (MET + gate_result PASS) must pass the guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    _PREFLIGHT_RESULT,
+    APPROVE_REVIEW,
+    _make_agent_result,
+    _make_config,
+    _make_task,
+    _shell_with_gate,
+)
+
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import Phase
+
+
+def _completion_handoff(*, gate_result: str | None) -> dict:
+    """A dev handoff that marks its acceptance criterion MET (a completion claim)."""
+    data: dict = {
+        "summary": "Implemented the thing.",
+        "commits": [{"sha": "abc1234", "message": "feat(x): implement"}],
+        "acceptance_criteria": [{"criterion": "It works", "status": "MET", "notes": "tested"}],
+        "story_deviations": "none",
+        "deferred_items": "none",
+    }
+    if gate_result is not None:
+        data["gate_result"] = gate_result
+    return data
+
+
+class TestUnprovenCompletionGuard:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_completion_without_gate_evidence_escalates(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """A successful dev claiming MET with no gate_result → ESCALATE at dev seam."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.return_value = _make_agent_result(
+            success=True,
+            output="Done.",
+            profile_name="dev",
+            dev_handoff=_completion_handoff(gate_result=None),
+        )
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert "without gate PASS evidence" in result.message
+        # Escalated at the dev seam before any review cycle ran.
+        assert mock_pool.call_count == 0
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_completion_with_gate_blocked_escalates(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """MET + gate_result BLOCKED is still an unproven completion → ESCALATE."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.return_value = _make_agent_result(
+            success=True,
+            output="Done.",
+            profile_name="dev",
+            dev_handoff=_completion_handoff(gate_result="BLOCKED"),
+        )
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert "without gate PASS evidence" in result.message
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_well_formed_completion_is_not_escalated(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """MET + gate_result PASS passes the guard and proceeds to review → DONE."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.return_value = _make_agent_result(
+            success=True,
+            output="Done.",
+            profile_name="dev",
+            dev_handoff=_completion_handoff(gate_result="PASS"),
+        )
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.phase != Phase.ESCALATE
+        # The unproven-completion guard did not block the review cycle.
+        assert mock_pool.call_count >= 1

--- a/tests/test_dev_prompts.py
+++ b/tests/test_dev_prompts.py
@@ -256,6 +256,27 @@ def test_dev_prompt_uses_configured_commands_and_no_hardcoded_layout_rule(tmp_pa
     assert "4. Emit a `<forge_handoff>` block in your **final message**" in prompt
 
 
+def test_dev_prompt_requires_honest_gate_result_field(tmp_path):
+    task = _make_task(tmp_path)
+    prompt = build_dev_prompt(
+        task,
+        workspace_path=tmp_path / "ws",
+        branch_name="feat/test",
+        story_content="# Spec",
+        gate_command="make gate",
+    )
+
+    # The handoff block advertises the structured gate_result field...
+    assert "gate_result: PASS | FAIL | BLOCKED" in prompt
+    # ...and forbids claiming completion without gate evidence.
+    assert "Set `gate_result: PASS` only after the gate command actually passed" in prompt
+    assert "set `gate_result: BLOCKED`" in prompt
+    # collapse whitespace to tolerate dedent/wrapping of the multi-line rule
+    _flat = " ".join(prompt.split())
+    assert "do\n" not in _flat  # sanity: flattened
+    assert "NOT mark any acceptance criterion `MET`" in _flat
+
+
 def test_dev_prompt_includes_webfetch_framing_when_tool_allowed(tmp_path):
     task = _make_task(tmp_path)
     prompt = build_dev_prompt(

--- a/tests/test_devhandoff.py
+++ b/tests/test_devhandoff.py
@@ -74,8 +74,24 @@ class TestValidateDevHandoff:
         assert errors == []
 
     def test_valid_gate_result_fail(self):
+        # gate_result FAIL is a valid value on a non-completion handoff
+        # (no acceptance criterion marked MET).
         data = _valid_handoff()
+        data["acceptance_criteria"] = [
+            {"criterion": "Feature X works", "status": "NOT_MET", "notes": "gate failed"}
+        ]
         data["gate_result"] = "FAIL"
+        errors = validate_dev_handoff(data)
+        assert errors == []
+
+    def test_valid_gate_result_blocked(self):
+        # BLOCKED is an accepted gate_result value for a handoff that could not
+        # run the gate — it must not mark any criterion MET.
+        data = _valid_handoff()
+        data["acceptance_criteria"] = [
+            {"criterion": "Feature X works", "status": "PARTIAL", "notes": "gate unrunnable"}
+        ]
+        data["gate_result"] = "BLOCKED"
         errors = validate_dev_handoff(data)
         assert errors == []
 
@@ -171,8 +187,14 @@ class TestValidateDevHandoff:
         errors = validate_dev_handoff(data)
         assert any("mapping" in e for e in errors)
 
-    def test_missing_gate_result(self):
+    def test_missing_gate_result_ok_for_non_completion(self):
+        # gate_result stays optional when the handoff makes no completion claim
+        # (all acceptance criteria PARTIAL/NOT_MET).
         data = _valid_handoff()
+        data["acceptance_criteria"] = [
+            {"criterion": "AC 1", "status": "PARTIAL", "notes": "in progress"},
+            {"criterion": "AC 2", "status": "NOT_MET", "notes": "blocked"},
+        ]
         del data["gate_result"]
         errors = validate_dev_handoff(data)
         assert errors == []
@@ -182,6 +204,42 @@ class TestValidateDevHandoff:
         data["gate_result"] = "SUCCESS"
         errors = validate_dev_handoff(data)
         assert any("gate_result" in e for e in errors)
+
+    # ── cross-field: completion claim requires gate PASS ────────────
+
+    def test_completion_with_gate_pass_is_valid(self):
+        data = _valid_handoff()  # AC MET + gate_result PASS
+        errors = validate_dev_handoff(data)
+        assert errors == []
+
+    def test_completion_missing_gate_result_rejected(self):
+        data = _valid_handoff()  # AC MET
+        del data["gate_result"]
+        errors = validate_dev_handoff(data)
+        assert any("MET but gate_result is not PASS" in e for e in errors)
+
+    def test_completion_gate_fail_rejected(self):
+        data = _valid_handoff()  # AC MET
+        data["gate_result"] = "FAIL"
+        errors = validate_dev_handoff(data)
+        assert any("MET but gate_result is not PASS" in e for e in errors)
+
+    def test_completion_gate_blocked_rejected(self):
+        data = _valid_handoff()  # AC MET
+        data["gate_result"] = "BLOCKED"
+        errors = validate_dev_handoff(data)
+        assert any("MET but gate_result is not PASS" in e for e in errors)
+
+    def test_partial_completion_still_requires_gate(self):
+        # Even one MET criterion among others is a completion claim.
+        data = _valid_handoff()
+        data["acceptance_criteria"] = [
+            {"criterion": "AC 1", "status": "MET", "notes": "done"},
+            {"criterion": "AC 2", "status": "PARTIAL", "notes": "wip"},
+        ]
+        del data["gate_result"]
+        errors = validate_dev_handoff(data)
+        assert any("MET but gate_result is not PASS" in e for e in errors)
 
     def test_missing_story_deviations(self):
         data = _valid_handoff()
@@ -600,8 +658,8 @@ class TestParseDevHandoff:
             '    message: "wip"\n'
             "acceptance_criteria:\n"
             '  - criterion: "AC 1"\n'
-            "    status: MET\n"
-            '    notes: "done"\n'
+            "    status: PARTIAL\n"
+            '    notes: "in progress"\n'
             '  - criterion: "AC 2"\n'
             "    status: NOT_MET\n"
             '    notes: "blocked"\n'
@@ -614,6 +672,42 @@ class TestParseDevHandoff:
         assert result.gate_result == "FAIL"
         assert len(result.acceptance_criteria) == 2
         assert result.acceptance_criteria[1]["status"] == "NOT_MET"
+
+    def test_parse_unproven_completion_populates_errors(self):
+        # A completion claim (AC MET) with no gate_result must surface as a
+        # parse/validation error, not a clean handoff.
+        text = (
+            'summary: "Claims done."\n'
+            "commits:\n"
+            '  - sha: "abc"\n'
+            '    message: "feat: thing"\n'
+            "acceptance_criteria:\n"
+            '  - criterion: "AC 1"\n'
+            "    status: MET\n"
+            '    notes: "done"\n'
+            "spec_deviations: none\n"
+            "deferred_items: none\n"
+        )
+        result = parse_dev_handoff(text)
+        assert any("MET but gate_result is not PASS" in e for e in result.parse_errors)
+
+    def test_parse_gate_result_blocked_round_trips(self):
+        text = (
+            'summary: "Could not run gate."\n'
+            "commits:\n"
+            '  - sha: "abc"\n'
+            '    message: "wip"\n'
+            "acceptance_criteria:\n"
+            '  - criterion: "AC 1"\n'
+            "    status: PARTIAL\n"
+            '    notes: "gate unrunnable"\n'
+            "spec_deviations: none\n"
+            "deferred_items: none\n"
+            "gate_result: BLOCKED\n"
+        )
+        result = parse_dev_handoff(text)
+        assert result.parse_errors == []
+        assert result.gate_result == "BLOCKED"
 
 
 # ── Formatting ────────────────────────────────────────────────────────

--- a/tests/test_devhandoff_gate_result_optional.py
+++ b/tests/test_devhandoff_gate_result_optional.py
@@ -3,21 +3,42 @@ from __future__ import annotations
 from theforge.devhandoff import DevHandoff, dev_handoff_to_reviewer_text, parse_dev_handoff
 from theforge.schemas import validate_dev_handoff
 
-_VALID_YAML = (
-    'summary: "Implemented the thing."\n'
+# gate_result stays optional for a NON-completion handoff (no acceptance
+# criterion marked MET), but a completion claim (any AC MET) now requires
+# gate_result: PASS as evidence. See issue #927.
+
+_NON_COMPLETION_YAML = (
+    'summary: "Work in progress."\n'
     "commits:\n"
     '  - sha: "abc1234"\n'
-    '    message: "feat(x): implement the thing"\n'
+    '    message: "feat(x): partial work"\n'
     "acceptance_criteria:\n"
     '  - criterion: "It works"\n'
-    "    status: MET\n"
-    '    notes: "Tested"\n'
+    "    status: PARTIAL\n"
+    '    notes: "not finished"\n'
     "story_deviations: none\n"
     "deferred_items: none\n"
 )
 
 
-def test_validate_dev_handoff_allows_missing_gate_result() -> None:
+def test_validate_dev_handoff_allows_missing_gate_result_for_non_completion() -> None:
+    # No AC marked MET → no completion claim → gate_result stays optional.
+    data = {
+        "summary": "Work in progress on feature X.",
+        "commits": [{"sha": "abc1234", "message": "feat(x): partial work"}],
+        "acceptance_criteria": [
+            {"criterion": "Feature X works", "status": "PARTIAL", "notes": "still working"}
+        ],
+        "story_deviations": "none",
+        "deferred_items": "none",
+    }
+
+    assert validate_dev_handoff(data) == []
+
+
+def test_validate_dev_handoff_completion_requires_gate_pass() -> None:
+    # An AC marked MET without gate_result: PASS is a completion claim without
+    # evidence and must be rejected.
     data = {
         "summary": "Implemented feature X with tests.",
         "commits": [{"sha": "abc1234", "message": "feat(x): implement feature X"}],
@@ -28,11 +49,27 @@ def test_validate_dev_handoff_allows_missing_gate_result() -> None:
         "deferred_items": "none",
     }
 
+    errors = validate_dev_handoff(data)
+    assert any("MET but gate_result is not PASS" in e for e in errors)
+
+
+def test_validate_dev_handoff_completion_with_gate_pass_is_valid() -> None:
+    data = {
+        "summary": "Implemented feature X with tests.",
+        "commits": [{"sha": "abc1234", "message": "feat(x): implement feature X"}],
+        "acceptance_criteria": [
+            {"criterion": "Feature X works", "status": "MET", "notes": "Tested in test_x.py"}
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "none",
+        "deferred_items": "none",
+    }
+
     assert validate_dev_handoff(data) == []
 
 
-def test_parse_dev_handoff_accepts_missing_gate_result() -> None:
-    result = parse_dev_handoff(_VALID_YAML)
+def test_parse_dev_handoff_accepts_missing_gate_result_for_non_completion() -> None:
+    result = parse_dev_handoff(_NON_COMPLETION_YAML)
 
     assert result.parse_errors == []
     assert result.gate_result is None
@@ -42,7 +79,7 @@ def test_reviewer_text_omits_gate_result_section() -> None:
     handoff = DevHandoff(
         summary="Implemented X.",
         commits=[{"sha": "abc1234", "message": "feat(x): implement X"}],
-        acceptance_criteria=[{"criterion": "X works", "status": "MET", "notes": "Tested"}],
+        acceptance_criteria=[{"criterion": "X works", "status": "PARTIAL", "notes": "wip"}],
         story_deviations=[],
         deferred_items=[],
         gate_result=None,

--- a/tests/test_sprint_pipeline_smoke.py
+++ b/tests/test_sprint_pipeline_smoke.py
@@ -185,6 +185,7 @@ def test_make_gate_covers_mocked_sprint_pipeline_smoke_run(tmp_path: Path) -> No
                         "notes": "Synthetic story",
                     }
                 ],
+                "gate_result": "PASS",
                 "story_deviations": "none",
                 "deferred_items": "none",
             },

--- a/tests/test_validate_phase.py
+++ b/tests/test_validate_phase.py
@@ -546,6 +546,7 @@ def test_run_validate_phase_already_complete_when_handoff_documents_work_done(
         "  - criterion: 'AC2 text from spec'\n"
         "    status: MET\n"
         "    notes: 'satisfied by existing commit'\n"
+        "gate_result: PASS\n"
         "story_deviations: []\n"
         "deferred_items: []\n",
         encoding="utf-8",


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change makes dev completion claims require gate PASS evidence at both the schema boundary and the coordinator dev seam, with focused coverage for the original failure mode. | [google-gemini-3.5-flash] The implementation successfully prevents dev agents from claiming completion without gate PASS evidence by validating the handoff schema and failing closed at the dev phase seam.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $4.52
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Dev handoff reports completion without gate evidence; coordinator catches failures dev should have (GitHub Issue #927)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #927