### PR TITLE
Preflight returns conversational prose (sonnet delegating to a non-existent 'investigation agent') → parse_error → silent PROCEED with all metadata None, no retry

### DIFF
--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -79,6 +79,16 @@ _AMBIGUITY_TOKENS = (
     "measurable",
 )
 
+# Number of same-profile re-requests to attempt when preflight exits cleanly
+# but emits output the parser cannot read (parse_error). A clean exit with
+# unparseable output means preflight did not actually run — the model narrated
+# (e.g. a hand-off to a non-existent "investigation agent", issue #1773)
+# instead of producing the structured dict. A transient narration is cheap to
+# re-request against the same output contract and expensive to proceed past, so
+# retry the same profile before consulting any fallback profile or falling
+# through to a degraded PROCEED.
+_PREFLIGHT_PARSE_RETRY_ATTEMPTS = 1
+
 
 def _evidence_is_too_thin(evidence: str) -> bool:
     """Return True when evidence is too short to justify ALREADY_DONE."""
@@ -288,24 +298,60 @@ def _run_preflight_phase(
         log_agent_result(result, f"PREFLIGHT[{label}]")
         return result, elapsed
 
-    def _attempt_failed(result: object) -> bool:
+    def _is_parse_degraded(result: object) -> bool:
+        """True when the agent exited cleanly but emitted unparseable output.
+
+        Distinct from a crashed run (``success=False``): this is the
+        parse_error case where preflight narrated instead of producing the
+        structured dict, and re-requesting the same output contract is worth a
+        cheap retry.
+        """
         if not result.success:
-            return True
+            return False
         _verdict, _reason, parse_degraded = _parse_preflight_verdict(result.output)
         return parse_degraded
 
+    def _attempt_failed(result: object) -> bool:
+        if not result.success:
+            return True
+        return _is_parse_degraded(result)
+
     attempts: list[dict[str, object]] = []
+
+    def _record_attempt(profile: ModelProfile, result: object, elapsed: float) -> None:
+        attempts.append(
+            {
+                "profile_name": profile.name,
+                "model": profile.model,
+                "cost_usd": result.cost_usd,
+                "duration_s": round(elapsed, 2),
+                "success": result.success,
+                "exit_code": result.exit_code,
+            }
+        )
+
     preflight_result, _preflight_elapsed = _invoke_preflight(preflight_profile, "primary")
-    attempts.append(
-        {
-            "profile_name": preflight_profile.name,
-            "model": preflight_profile.model,
-            "cost_usd": preflight_result.cost_usd,
-            "duration_s": round(_preflight_elapsed, 2),
-            "success": preflight_result.success,
-            "exit_code": preflight_result.exit_code,
-        }
-    )
+    _record_attempt(preflight_profile, preflight_result, _preflight_elapsed)
+
+    # ── Same-profile parse-error retry ──────────────────────────────────
+    # A clean exit with unparseable output has not produced a preflight result;
+    # re-issue the identical output contract to the same profile before any
+    # fallback so a one-off narration does not silently discard all agent-derived
+    # metadata (issue #1773). Only fires on parse_error (success=True but
+    # malformed) — a crashed agent is handled by the risk-signal path below.
+    parse_retry = 0
+    while parse_retry < _PREFLIGHT_PARSE_RETRY_ATTEMPTS and _is_parse_degraded(preflight_result):
+        parse_retry += 1
+        _log(
+            "  ⚠ PREFLIGHT output malformed (parse_error) — retrying same profile "
+            f"{preflight_profile.model} (attempt {parse_retry}/{_PREFLIGHT_PARSE_RETRY_ATTEMPTS})"
+        )
+        retry_result, retry_elapsed = _invoke_preflight(
+            preflight_profile, f"parse-retry-{parse_retry}"
+        )
+        _record_attempt(preflight_profile, retry_result, retry_elapsed)
+        preflight_result = retry_result
+        _preflight_elapsed += retry_elapsed
 
     fallback_profile = config.preflight_fallback_profile
     if fallback_profile is not None and _attempt_failed(preflight_result):
@@ -313,16 +359,7 @@ def _run_preflight_phase(
             f"  ⚠ PREFLIGHT primary failed — retrying with fallback model {fallback_profile.model}"
         )
         fallback_result, fallback_elapsed = _invoke_preflight(fallback_profile, "fallback")
-        attempts.append(
-            {
-                "profile_name": fallback_profile.name,
-                "model": fallback_profile.model,
-                "cost_usd": fallback_result.cost_usd,
-                "duration_s": round(fallback_elapsed, 2),
-                "success": fallback_result.success,
-                "exit_code": fallback_result.exit_code,
-            }
-        )
+        _record_attempt(fallback_profile, fallback_result, fallback_elapsed)
         preflight_result = fallback_result
         _preflight_elapsed += fallback_elapsed
 

--- a/tests/test_coord_preflight_parse_error.py
+++ b/tests/test_coord_preflight_parse_error.py
@@ -170,6 +170,13 @@ class TestPreflightParseErrorIntegration:
         assert result.state.preflight_degraded_reason == "parse_error"
         assert result.phase == Phase.DONE
         assert result.success is True
+        # #1773: an unparseable first output is re-requested against the same
+        # profile before falling through to degraded PROCEED.
+        assert mock_preflight.call_count == 2
+        assert [c.kwargs["profile"].name for c in mock_preflight.call_args_list] == [
+            config.preflight_profile.name,
+            config.preflight_profile.name,
+        ]
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
@@ -200,5 +207,167 @@ class TestPreflightParseErrorIntegration:
         assert result.state.preflight_verdict == "PROCEED"
         assert result.state.preflight_degraded is True
         assert result.state.preflight_degraded_reason == "parse_error"
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+
+# ── Same-profile parse-error retry (#1773) ─────────────────────────────────────
+
+# The conversational narration observed in #1453 / #1735: sonnet narrated a
+# hand-off to a non-existent "investigation agent" in place of the structured
+# dict. yaml.safe_load parses this scalar prose to a string, so the parser
+# reports parse_error.
+PREFLIGHT_NARRATION = "I'll pause here until the investigation agent's findings come back."
+
+PREFLIGHT_PROCEED_WITH_FILES = """\
+```yaml
+verdict: PROCEED
+reason: "Needs implementation."
+complexity: medium
+sufficiency: needs_planning
+work_type: feature
+likely_files:
+  - "src/theforge/coordinator/preflight_flow.py"
+```
+"""
+
+
+class TestPreflightParseErrorRetry:
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_parse_error_retried_same_profile_recovers_metadata(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """First output is narration (parse_error); same-profile retry recovers a
+        structured result, so the run is NOT degraded and agent-derived metadata
+        (likely_files) is preserved."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.side_effect = [
+            _make_agent_result(success=True, output=PREFLIGHT_NARRATION, cost_usd=0.05),
+            _make_agent_result(success=True, output=PREFLIGHT_PROCEED_WITH_FILES, cost_usd=0.05),
+        ]
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert mock_preflight.call_count == 2
+        # Both attempts used the SAME (primary) profile — no fallback involved.
+        assert [c.kwargs["profile"].name for c in mock_preflight.call_args_list] == [
+            config.preflight_profile.name,
+            config.preflight_profile.name,
+        ]
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is False
+        assert result.state.preflight_degraded_reason is None
+        # Recovered structured metadata — not the silent-None of a discarded run.
+        assert result.state.preflight_likely_files == [
+            "src/theforge/coordinator/preflight_flow.py"
+        ]
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_parse_error_retry_exhausted_marks_degraded(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """When the same-profile retry is also unparseable, the run is marked
+        degraded (parse_error) with None likely_files so collision serialization
+        treats the footprint as unknown-and-risky, not known-empty."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.side_effect = [
+            _make_agent_result(success=True, output=PREFLIGHT_NARRATION, cost_usd=0.05),
+            _make_agent_result(success=True, output=PREFLIGHT_NARRATION, cost_usd=0.05),
+        ]
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert mock_preflight.call_count == 2
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is True
+        assert result.state.preflight_degraded_reason == "parse_error"
+        assert result.state.preflight_likely_files is None
+        # Both attempts recorded in the audit trail for traceability.
+        assert len(result.state.preflight_result.raw["attempts"]) == 2
+        assert result.phase == Phase.DONE
+        assert result.success is True
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch("theforge.coordinator.util._run_shell")
+    def test_parse_error_retry_precedes_fallback_profile(
+        self, mock_shell, mock_dev, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """With a fallback profile configured, the same-profile retry fires FIRST;
+        only when it is still unparseable does the fallback profile run."""
+        from theforge.config.types import ModelProfile
+
+        config = _make_config(tmp_path)
+        fallback = ModelProfile(
+            name="preflight_fallback",
+            cli="gemini",
+            model="gemini-2.5-pro",
+            budget_usd=1.0,
+            timeout_seconds=300,
+            allowed_tools=("Read", "Bash", "Glob", "Grep"),
+            phase="preflight",
+        )
+        config = config.__class__(**{**config.__dict__, "preflight_fallback_profile": fallback})
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.side_effect = [
+            _make_agent_result(success=True, output=PREFLIGHT_NARRATION, cost_usd=0.05),
+            _make_agent_result(success=True, output=PREFLIGHT_NARRATION, cost_usd=0.05),
+            _make_agent_result(success=True, output=PREFLIGHT_PROCEED_WITH_FILES, cost_usd=0.05),
+        ]
+        mock_dev.return_value = _make_agent_result(success=True, output="Implemented.")
+        mock_plan_agent.side_effect = mock_dev
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert mock_preflight.call_count == 3
+        assert [c.kwargs["profile"].name for c in mock_preflight.call_args_list] == [
+            config.preflight_profile.name,
+            config.preflight_profile.name,
+            "preflight_fallback",
+        ]
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_degraded is False
+        assert result.state.preflight_likely_files == [
+            "src/theforge/coordinator/preflight_flow.py"
+        ]
         assert result.phase == Phase.DONE
         assert result.success is True


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] No blocking findings; the parse-error retry path and degraded fallback behavior are covered by focused tests. | [google-gemini-3.5-flash] The implementation successfully adds a same-profile retry loop for preflight parse errors before fallback or degraded PROCEED, and correctly marks the state as degraded when retries are exhausted.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.99
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight returns conversational prose (sonnet delegating to a non-existent 'investigation agent') → parse_error → silent PROCEED with all metadata None, no retry (GitHub Issue #1773)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1773