### PR TITLE
Timeout-only overrides.dev block silently disables adaptive dev-model routing — static fallback downgrades dev to the cheapest model

### DIFF
--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -280,11 +280,19 @@ def _format_complexity_aware_section(
     budget_usd: float,
     overrides: dict | None,
     registry: dict | None = None,
+    *,
+    dev_routing_active: bool = True,
 ) -> list[str]:
     """Build the DERIVED ROLES section for v0.8 simple-mode configs.
 
     Calls derive_roles() at each complexity level and renders the tier×complexity
     routing table so the operator can verify complexity-aware routing at a glance.
+
+    ``dev_routing_active`` reflects the effective runtime state
+    (``ForgeConfig.dev_profile_is_default``): when an ``overrides.dev`` block pins
+    the model, complexity-aware dev routing is disabled and the same model runs at
+    every complexity. Surfacing this here makes the coupling visible at
+    config-check time rather than only through changed runtime behavior. See #1764.
     """
     _ov = overrides or {}
     ra_low = derive_roles(models, _ov, budget_usd=budget_usd, complexity="LOW", registry=registry)
@@ -330,6 +338,17 @@ def _format_complexity_aware_section(
     dl, dm, dh = _dev_label(ra_low), _dev_label(ra_mid), _dev_label(ra_high)
     dev_parts = _collapse_complexity_labels({"LOW": dl, "MEDIUM": dm, "HIGH": dh})
     lines.append(f"  {'dev:':<14}{dev_parts}")
+    # Surface routing state whenever an overrides.dev block exists so the operator
+    # can see whether their override left complexity-aware routing active (a
+    # resource-only override such as a timeout) or pinned it (a model override).
+    # Emitted on its own line so it stays visible even when dev_parts wraps across
+    # complexity levels. See #1764.
+    if (_ov or {}).get("dev"):
+        if dev_routing_active:
+            dev_note = "complexity-aware routing active — overrides.dev tunes limits only"
+        else:
+            dev_note = "routing disabled — pinned by overrides.dev"
+        lines.append(f"  {'':<14}({dev_note})")
 
     # Review pool: show pool size + synthesis info per complexity
     def _review_label(ra) -> str:  # type: ignore[no-untyped-def]
@@ -452,6 +471,7 @@ def _format_config(
             config.models_budget_usd,
             overrides=config.models_overrides,
             registry=config.model_registry,
+            dev_routing_active=config.dev_profile_is_default,
         )
         lines.extend(derived_lines)
         lines.append("")

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -42,6 +42,7 @@ from .profiles import (
     _apply_profile_overrides,
     _apply_provider_fallback,
     _parse_provider_fallbacks,
+    override_constrains_model,
 )
 from .role_derivation import derive_roles
 from .secrets import _parse_notifications
@@ -659,8 +660,11 @@ def load_config(config_path: Path) -> ForgeConfig:
             provider_fallbacks = {**auto_provider_fallbacks, **provider_fallbacks}
         # Track which roles were auto-derived vs explicitly overridden. Complexity-aware
         # adaptation (preflight._apply_complexity_adaptation) only rewrites auto-derived
-        # roles so explicit overrides bypass routing.
-        _dev_profile_is_default = "dev" not in overrides
+        # roles so explicit overrides bypass routing. A dev override that only tunes
+        # resource limits (timeouts, budget) expresses a preference about budgets, not
+        # model selection, and must leave routing active — only a model-constraining
+        # override pins the role. See #1764.
+        _dev_profile_is_default = not override_constrains_model(overrides.get("dev"))
         _review_pool_is_default = "review_pool" not in overrides
 
     else:

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -121,6 +121,31 @@ def _parse_model_spec(
 _VALID_SANDBOX_MODES = {"workspace-write", "read-only", "none"}
 
 
+# Override keys that select or constrain which model runs. When a role override
+# contains any of these, the operator has expressed a preference about model
+# identity/transport, so complexity-aware routing must not overwrite it.
+# Resource-only keys (timeout*, budget) express a preference about limits, not
+# model choice, and must leave routing active. See #1764.
+_MODEL_SELECTION_KEYS: frozenset[str] = frozenset(
+    {"model", "models", "fallback_models", "provider", "cli"}
+)
+
+
+def override_constrains_model(data: dict[str, Any] | None) -> bool:
+    """Return True if a role-override block pins/constrains model identity.
+
+    An override that touches only resource limits (``timeout_seconds``,
+    ``timeout_medium_seconds``, ``timeout_large_seconds``, ``budget_usd``) or
+    other non-model fields expresses a preference about budgets, not model
+    selection, so it must not suppress complexity-aware model routing. Only an
+    override that names a model, model list, fallbacks, provider, or cli pins
+    the role. See #1764.
+    """
+    if not isinstance(data, dict):
+        return False
+    return any(key in _MODEL_SELECTION_KEYS for key in data)
+
+
 def _apply_profile_overrides(base: ModelProfile, data: dict[str, Any]) -> ModelProfile:
     """Apply partial forge.yaml profile overrides on top of an auto-assigned profile.
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -624,7 +624,10 @@ class ForgeConfig:
     review_pool_is_default: bool = False  # True when review_pool was not explicitly configured
     plan_model_is_default: bool = False  # True when plan.cli/model were not explicitly configured
     dev_profile_is_default: bool = (
-        False  # True when dev_profile was auto-derived from models: (no overrides.dev)
+        # True when dev routing is active: dev_profile was auto-derived from
+        # models: and no model-constraining overrides.dev pinned it. A
+        # resource-only overrides.dev (timeouts/budget) leaves this True. See #1764.
+        False
     )
     conventions_hard: HardConventionsConfig | None = None  # None = no section = no checks
     conventions_soft: list[str] = field(default_factory=list)  # [] = no soft conventions

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -986,6 +986,55 @@ class TestComplexityAwareDisplay:
         assert "plan:" in out
         assert "code_review:" in out
 
+    def test_timeout_only_dev_override_shows_routing_active(self, tmp_path: Path, capsys) -> None:
+        """#1764: a resource-only overrides.dev is surfaced as routing-active."""
+        config = self._make_v08_forge_config(tmp_path)
+        config = replace(
+            config,
+            models_overrides={"dev": {"timeout_large_seconds": 3600}},
+            dev_profile_is_default=True,
+        )
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        assert "complexity-aware routing active" in out
+        assert "routing disabled" not in out
+
+    def test_model_dev_override_shows_routing_disabled(self, tmp_path: Path, capsys) -> None:
+        """#1764: a model-pinning overrides.dev is surfaced as routing-disabled."""
+        config = self._make_v08_forge_config(tmp_path)
+        config = replace(
+            config,
+            models_overrides={"dev": {"model": "opus"}},
+            dev_profile_is_default=False,
+        )
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        assert "routing disabled" in out
+        assert "pinned by overrides.dev" in out
+
+    def test_no_dev_override_shows_no_routing_note(self, tmp_path: Path, capsys) -> None:
+        """Without an overrides.dev block, no routing annotation is added."""
+        config = self._make_v08_forge_config(tmp_path)
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        assert "routing disabled" not in out
+        assert "routing active" not in out
+
     def test_mode_simple_shown_in_header(self, tmp_path: Path, capsys) -> None:
         config = self._make_v08_forge_config(tmp_path)
         with (

--- a/tests/test_config_v08_loader.py
+++ b/tests/test_config_v08_loader.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from theforge.config import load_config
+from theforge.config.profiles import override_constrains_model
 from theforge.coordinator.preflight import _apply_preflight_config
 from theforge.coordinator.state import CoordinatorState
 
@@ -124,6 +125,40 @@ plan_agent_review:
     assert profiles[0].model == "sonnet"
 
 
+# ── override_constrains_model ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"timeout_seconds": 1200},
+        {"timeout_medium_seconds": 1800, "timeout_large_seconds": 3600},
+        {"budget_usd": 20.0},
+        {"sandbox_mode": "read-only"},
+        {"allowed_tools": ["Read"]},
+        {},
+        None,
+    ],
+)
+def test_override_constrains_model_false_for_non_model_keys(data):
+    assert override_constrains_model(data) is False
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"model": "opus"},
+        {"models": ["opus", "sonnet"]},
+        {"fallback_models": ["sonnet"]},
+        {"provider": "anthropic"},
+        {"cli": "codex"},
+        {"timeout_seconds": 1200, "model": "opus"},
+    ],
+)
+def test_override_constrains_model_true_for_model_keys(data):
+    assert override_constrains_model(data) is True
+
+
 # ── Simple mode + overrides ───────────────────────────────────────────────────
 
 
@@ -143,6 +178,110 @@ overrides:
         cfg = load_config(cfg_path)
 
     assert cfg.dev_profile.timeout_seconds == 1200
+
+
+def test_v08_timeout_only_dev_override_keeps_routing_active(tmp_path):
+    """A resource-only overrides.dev (timeouts) must not pin the dev model.
+
+    Regression for #1764: raising the dev timeout is a statement about budgets,
+    not model selection, so complexity-aware dev routing stays active.
+    """
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+  - claude/opus
+overrides:
+  dev:
+    timeout_medium_seconds: 1800
+    timeout_large_seconds: 3600
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile_is_default is True
+    # Operator's timeout override is still applied to the derived dev profile.
+    assert cfg.dev_profile.timeout_medium_seconds == 1800
+    assert cfg.dev_profile.timeout_large_seconds == 3600
+
+
+def test_v08_model_dev_override_pins_routing(tmp_path):
+    """A model-constraining overrides.dev pins the role and disables routing."""
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+  - claude/opus
+overrides:
+  dev:
+    model: opus
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    assert cfg.dev_profile_is_default is False
+    assert cfg.dev_profile.model == "opus"
+
+
+def test_v08_timeout_only_dev_override_routes_and_preserves_timeout_seam(tmp_path):
+    """Seam: load → complexity adaptation with a timeout-only dev override.
+
+    A large story must route dev to the strong model (routing active) while the
+    operator's timeout override survives the model reassignment (#1764).
+    """
+    from theforge.coordinator.preflight import _apply_complexity_adaptation
+
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+  - claude/opus
+overrides:
+  dev:
+    timeout_large_seconds: 3600
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    # Static derivation picks the cheapest dev-capable model.
+    assert cfg.dev_profile.model == "sonnet"
+
+    updated = _apply_complexity_adaptation(cfg, "large", complexity_score=10)
+
+    # Routing stayed active → hardest story routes to the strong model...
+    assert updated.dev_profile.model == "opus"
+    # ...and the operator's timeout override is preserved across the swap.
+    assert updated.dev_profile.timeout_large_seconds == 3600
+
+
+def test_v08_model_dev_override_bypasses_routing_seam(tmp_path):
+    """Seam: a pinned dev model is not rewritten by complexity adaptation."""
+    from theforge.coordinator.preflight import _apply_complexity_adaptation
+
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - claude/sonnet
+  - claude/opus
+overrides:
+  dev:
+    model: sonnet
+""",
+    )
+    with _auth_ok:
+        cfg = load_config(cfg_path)
+
+    updated = _apply_complexity_adaptation(cfg, "large", complexity_score=10)
+
+    # Pinned model survives — routing did not upgrade it to opus.
+    assert updated.dev_profile.model == "sonnet"
 
 
 def test_v08_overrides_preflight_timeout(tmp_path):


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the timeout-only routing fix, preserves pinned-model bypass behavior, and exposes the routing state in check-config. | [google-gemini-3.5-flash] Successfully resolved the issue where timeout-only overrides.dev silently disabled adaptive dev-model routing by introducing a model-constraining key check and updating check-config to display the routing state.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $3.67
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Timeout-only overrides.dev block silently disables adaptive dev-model routing — static fallback downgrades dev to the cheapest model (GitHub Issue #1764)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1764