### PR TITLE
Adaptive dev timeout derives from learned iteration count, not observed duration — low-iteration history shrinks the timeout until runs starve

### DIFF
--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -278,19 +278,60 @@ def derive_limits(
         raw_dev = profile_stats["avg_iterations"] * _HEADROOM_FACTOR
         chosen_dev = max(floor_dev, min(cap_dev, _ceil_int(raw_dev)))
         timeout_per_iteration = base_timeout_seconds / max(static_dev_max, 1)
-        chosen_timeout = _ceil_int(chosen_dev * timeout_per_iteration)
+        iteration_timeout = _ceil_int(chosen_dev * timeout_per_iteration)
+        # An adaptively-learned wall-clock limit must follow from observations of
+        # the wall-clock it bounds, not from an iteration count scaled by a static
+        # per-iteration baseline. Floor the iteration-derived value by:
+        #   - observed completed-run duration + headroom (success must never make
+        #     the granted time shrink below what success was observed to need), and
+        #   - the max limit that killed comparable runs (a censored observation
+        #     can never drive the limit below the value at which it was killed), and
+        #   - the operator-configured base timeout (now a hard floor).
+        observed_floor = _ceil_int(profile_stats.get("max_duration_s", 0.0) * _HEADROOM_FACTOR)
+        kill_floor = _ceil_int(profile_stats.get("max_killed_timeout_s", 0.0))
+        # ``_ceil_int`` floors at 1; a genuine no-data signal is 0, so drop the
+        # floor to 0 when the underlying observation is absent.
+        if not profile_stats.get("max_duration_s", 0.0):
+            observed_floor = 0
+        if not profile_stats.get("max_killed_timeout_s", 0.0):
+            kill_floor = 0
+        chosen_timeout = max(iteration_timeout, observed_floor, kill_floor, base_timeout_seconds)
         _estimate_headroom = _ESTIMATE_HEADROOM_BY_BAND.get(
             (complexity_band or "").lower(), _HEADROOM_FACTOR
         )
         chosen_estimate = _round_money(profile_stats["avg_cost_usd"] * _estimate_headroom)
         audit["profile_raw_dev_max"] = round(raw_dev, 4)
         audit["estimate_headroom_factor"] = _estimate_headroom
+        audit["iteration_derived_timeout_seconds"] = iteration_timeout
+        audit["profile_max_duration_s"] = round(float(profile_stats.get("max_duration_s", 0.0)), 4)
+        audit["profile_max_killed_timeout_s"] = round(
+            float(profile_stats.get("max_killed_timeout_s", 0.0)), 4
+        )
+        audit["duration_floor_seconds"] = observed_floor
+        audit["kill_floor_seconds"] = kill_floor
+        floored_on_duration = observed_floor > iteration_timeout and observed_floor >= kill_floor
+        floored_on_kill = kill_floor > iteration_timeout and kill_floor > observed_floor
+        audit["timeout_floored_on_observation"] = chosen_timeout > iteration_timeout
         dev_rationale = (
             f"derived dev limits from {profile_runs} "
             f"{complexity_band or 'unknown'}-band profile runs with "
             f"{_HEADROOM_FACTOR}x iteration headroom and {_estimate_headroom}x "
-            "cost-estimate headroom; timeout scaled from static per-iteration baseline."
+            "cost-estimate headroom"
         )
+        if floored_on_kill:
+            dev_rationale += (
+                f"; timeout floored on the {kill_floor}s limit that killed comparable runs."
+            )
+        elif floored_on_duration:
+            dev_rationale += (
+                f"; timeout floored on observed run duration+headroom ({observed_floor}s)."
+            )
+        elif chosen_timeout > iteration_timeout:
+            dev_rationale += (
+                f"; timeout floored on the operator-configured base ({base_timeout_seconds}s)."
+            )
+        else:
+            dev_rationale += "; timeout scaled from static per-iteration baseline."
     audit["chosen_dev_max"] = chosen_dev
     audit["chosen_dev_timeout_seconds"] = chosen_timeout
     audit["chosen_dev_cost_estimate_usd"] = round(chosen_estimate, 4)

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -1040,6 +1040,15 @@ def _run_dev_phase(
 
     if not dev_result.success:
         _is_timeout = dev_result.failure_code == "timeout"
+        if _is_timeout:
+            # Record the wall-clock kill on state immediately, before any
+            # retry/escalate/fall-through decision runs. This is the only
+            # reliable signal that the dev process was harness-killed at its
+            # timeout: the killed iteration's telemetry entry can be overwritten
+            # by a later VALIDATE-phase write once checkpoint-committed work lets
+            # execution fall through (#1754). model_profiles_bridge reads this to
+            # segregate the run as a censored observation for the kill floor.
+            state.dev_process_timeout_killed = True
         # The signal number records only what was done to the process, not what
         # went wrong. When the runner already explained the failure in words
         # (e.g. "TIMEOUT: Agent exceeded 900s limit"), surface that instead of

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -49,6 +49,18 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
     # ``dev_trace_count`` is the only monotonic dev-iteration counter (never reset
     # on cycle boundaries) so it captures total dev attempts across the run.
     dev_iterations = max(int(state.dev_trace_count or 0), 1)
+    # Observed wall-clock of the dev phase (sum of per-call durations). None when
+    # nothing was recorded so learning never treats "unknown" as a $0-style zero.
+    dev_duration_s = round(sum(state.dev_durations), 2) if state.dev_durations else None
+    # A harness kill at the timeout is a censored observation: the last dev
+    # iteration's ``is_timeout`` flag marks it, and the granted timeout is the
+    # limit that terminated it — a floor the next timeout can never fall below.
+    dev_timeout_killed = bool(
+        state.dev_iteration_telemetry and state.dev_iteration_telemetry[-1].is_timeout
+    )
+    dev_timeout_limit_s = (
+        int(state.adaptive_dev_timeout_seconds) if state.adaptive_dev_timeout_seconds else None
+    )
     return RunOutcome(
         complexity=complexity,
         complexity_score=state.preflight_complexity_score,
@@ -58,6 +70,9 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         dev_cli=getattr(config.dev_profile, "cli", None),
         dev_success=bool(success),
         dev_iterations=dev_iterations,
+        dev_duration_s=dev_duration_s,
+        dev_timeout_killed=dev_timeout_killed,
+        dev_timeout_limit_s=dev_timeout_limit_s,
         # Pass the cost-unknown signal through (None) instead of coercing to
         # $0.00, so unmeasured CLI-transport runs are recorded as unmeasured.
         dev_cost_usd=state.total_dev_cost_measured,

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -52,12 +52,14 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
     # Observed wall-clock of the dev phase (sum of per-call durations). None when
     # nothing was recorded so learning never treats "unknown" as a $0-style zero.
     dev_duration_s = round(sum(state.dev_durations), 2) if state.dev_durations else None
-    # A harness kill at the timeout is a censored observation: the last dev
-    # iteration's ``is_timeout`` flag marks it, and the granted timeout is the
-    # limit that terminated it — a floor the next timeout can never fall below.
-    dev_timeout_killed = bool(
-        state.dev_iteration_telemetry and state.dev_iteration_telemetry[-1].is_timeout
-    )
+    # A harness kill at the timeout is a censored observation, and the granted
+    # timeout is the limit that terminated it — a floor the next timeout can
+    # never fall below. Read the sticky ``dev_process_timeout_killed`` flag set
+    # at kill time in dev_phase: the killed iteration's telemetry entry is NOT a
+    # reliable signal because a later VALIDATE-phase telemetry write overwrites
+    # the last entry once checkpoint-committed work (#1754) lets execution fall
+    # through the terminal-kill path without recording is_timeout on the tail.
+    dev_timeout_killed = bool(state.dev_process_timeout_killed)
     dev_timeout_limit_s = (
         int(state.adaptive_dev_timeout_seconds) if state.adaptive_dev_timeout_seconds else None
     )

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -312,6 +312,14 @@ class CoordinatorState:
     dev_trace_count: int = 0  # monotonically increasing across all cycles; never reset
     dev_results: list[AgentResult] = field(default_factory=list)
     dev_durations: list[float] = field(default_factory=list)  # wall-clock seconds per dev call
+    # Sticky "the dev process was killed by its wall-clock timeout at least once"
+    # flag. Set once at kill time in dev_phase (never cleared), because the
+    # killed iteration's telemetry can be overwritten by a later VALIDATE-phase
+    # telemetry write once checkpoint-committed work lets execution fall through
+    # (#1754) — so the last telemetry entry is not a reliable kill signal. This
+    # is distinct from a VALIDATE gate/test-command timeout (a different failure
+    # class carried on DevIterationTelemetry.is_timeout).
+    dev_process_timeout_killed: bool = False
     review_agent_results: list[AgentResult] = field(default_factory=list)
     review_durations: list[float] = field(
         default_factory=list

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -71,6 +71,15 @@ class RunOutcome:
     dev_iterations: int
     dev_cost_usd: float | None  # None = the transport could not measure cost
     complexity_score: int | None = None
+    # Observed wall-clock of the completed dev phase (seconds); None when unknown
+    # or when the run was harness-killed (a kill's true duration is unknown).
+    dev_duration_s: float | None = None
+    # True when the harness terminated the dev phase at its timeout limit. Such a
+    # run is a censored observation: its duration only bounds the timeout from
+    # below and must never lower learned duration.
+    dev_timeout_killed: bool = False
+    # The granted per-story timeout (seconds) at which a killed run was terminated.
+    dev_timeout_limit_s: int | None = None
     preflight_model: str | None = None
     dev_actual_model: str | None = None
     dev_provider: str | None = None
@@ -256,6 +265,38 @@ def _fold_cost(bucket: dict, cost_usd: float | None, *, unknown_count: int = 1) 
     bucket["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
 
 
+def _fold_duration(
+    bucket: dict,
+    duration_s: float | None,
+    killed: bool,
+    limit_s: int | None,
+) -> None:
+    """Fold one dev run's wall-clock signal into ``bucket``.
+
+    Two disjoint cases, kept segregated so harness-killed runs never contaminate
+    learned completed-run duration (see #1763):
+
+    - A COMPLETED run (``not killed``) with a known ``duration_s`` accumulates
+      into ``_duration_sum``/``_duration_runs`` (→ ``avg_duration_s``) and raises
+      ``max_duration_s``.
+    - A harness-KILLED run only raises ``max_killed_timeout_s`` (the limit that
+      terminated it). Its true duration is unknown and only bounds the timeout
+      from below — it never touches the duration accumulators, so a kill can
+      never lower learned duration.
+    """
+    if not killed and duration_s is not None:
+        dur_sum = float(bucket.get("_duration_sum", 0.0)) + float(duration_s)
+        dur_runs = int(bucket.get("_duration_runs", 0)) + 1
+        bucket["_duration_sum"] = dur_sum
+        bucket["_duration_runs"] = dur_runs
+        bucket["avg_duration_s"] = round(dur_sum / dur_runs, 4) if dur_runs > 0 else 0.0
+        bucket["max_duration_s"] = max(float(bucket.get("max_duration_s", 0.0)), float(duration_s))
+    if killed and limit_s is not None:
+        bucket["max_killed_timeout_s"] = max(
+            float(bucket.get("max_killed_timeout_s", 0.0)), float(limit_s)
+        )
+
+
 def _update_dev(
     entry: dict,
     complexity: str,
@@ -263,6 +304,9 @@ def _update_dev(
     iterations: int,
     cost_usd: float | None,
     complexity_score: int | None = None,
+    duration_s: float | None = None,
+    timeout_killed: bool = False,
+    timeout_limit_s: int | None = None,
 ) -> None:
     if cost_usd is None:
         log.warning(
@@ -281,6 +325,7 @@ def _update_dev(
     dev["success_rate"] = round(successes / runs, 4)
     dev["avg_iterations"] = round(iter_sum / runs, 4)
     _fold_cost(dev, cost_usd)
+    _fold_duration(dev, duration_s, timeout_killed, timeout_limit_s)
 
     by = dev.setdefault("by_complexity", {})
     bc = by.setdefault(complexity, {})
@@ -293,6 +338,7 @@ def _update_dev(
     bc["success_rate"] = round(bc_successes / bc_runs, 4)
     bc["avg_iterations"] = round(bc_iter_sum / bc_runs, 4)
     _fold_cost(bc, cost_usd)
+    _fold_duration(bc, duration_s, timeout_killed, timeout_limit_s)
 
     if complexity_score is not None:
         score_key = str(int(complexity_score))
@@ -307,6 +353,7 @@ def _update_dev(
         sc["success_rate"] = round(sc_successes / sc_runs, 4)
         sc["avg_iterations"] = round(sc_iter_sum / sc_runs, 4)
         _fold_cost(sc, cost_usd)
+        _fold_duration(sc, duration_s, timeout_killed, timeout_limit_s)
 
 
 def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float | None) -> None:
@@ -350,6 +397,11 @@ def _zero_dev_bucket(bucket: dict) -> None:
     bucket["success_rate"] = 0.0
     bucket["avg_iterations"] = 0.0
     bucket["avg_cost_usd"] = 0.0
+    bucket["_duration_sum"] = 0.0
+    bucket["_duration_runs"] = 0
+    bucket["avg_duration_s"] = 0.0
+    bucket["max_duration_s"] = 0.0
+    bucket["max_killed_timeout_s"] = 0.0
 
 
 def _zero_review_section(section: dict) -> None:
@@ -375,6 +427,10 @@ def _recompute_dev_section(section: dict) -> None:
     iterations = 0.0
     cost = 0.0
     cost_unknown = 0
+    duration_sum = 0.0
+    duration_runs = 0
+    max_duration = 0.0
+    max_killed_timeout = 0.0
     for band in COMPLEXITY_BANDS:
         bucket = by.setdefault(band, {})
         runs += int(bucket.get("runs", 0))
@@ -382,6 +438,12 @@ def _recompute_dev_section(section: dict) -> None:
         iterations += float(bucket.get("_iterations_sum", 0.0))
         cost += float(bucket.get("_cost_sum", 0.0))
         cost_unknown += int(bucket.get("_cost_unknown_runs", 0))
+        duration_sum += float(bucket.get("_duration_sum", 0.0))
+        duration_runs += int(bucket.get("_duration_runs", 0))
+        max_duration = max(max_duration, float(bucket.get("max_duration_s", 0.0)))
+        max_killed_timeout = max(
+            max_killed_timeout, float(bucket.get("max_killed_timeout_s", 0.0))
+        )
     section["runs"] = runs
     section["_successes"] = successes
     section["_iterations_sum"] = iterations
@@ -391,6 +453,13 @@ def _recompute_dev_section(section: dict) -> None:
     section["avg_iterations"] = round(iterations / runs, 4) if runs > 0 else 0.0
     measured = runs - cost_unknown
     section["avg_cost_usd"] = round(cost / measured, 6) if measured > 0 else 0.0
+    section["_duration_sum"] = duration_sum
+    section["_duration_runs"] = duration_runs
+    section["avg_duration_s"] = (
+        round(duration_sum / duration_runs, 4) if duration_runs > 0 else 0.0
+    )
+    section["max_duration_s"] = max_duration
+    section["max_killed_timeout_s"] = max_killed_timeout
 
 
 def apply_run(data: dict, outcome: RunOutcome) -> dict:
@@ -410,6 +479,9 @@ def apply_run(data: dict, outcome: RunOutcome) -> dict:
         outcome.dev_iterations,
         outcome.dev_cost_usd,
         complexity_score=outcome.complexity_score,
+        duration_s=outcome.dev_duration_s,
+        timeout_killed=outcome.dev_timeout_killed,
+        timeout_limit_s=outcome.dev_timeout_limit_s,
     )
     if outcome.preflight_model:
         pf_entry = _ensure_model(
@@ -561,6 +633,9 @@ def get_dev_complexity_stats(
     measured_runs = 0
     iterations_sum = 0.0
     cost_sum = 0.0
+    duration_runs = 0
+    max_duration_s = 0.0
+    max_killed_timeout_s = 0.0
     for _, entry in matching:
         dev = entry.get("dev")
         if not isinstance(dev, dict):
@@ -581,12 +656,22 @@ def get_dev_complexity_stats(
         measured_runs += entry_runs - int(bc.get("_cost_unknown_runs", 0))
         iterations_sum += entry_iterations
         cost_sum += entry_cost
+        # Duration/kill floors: legacy profiles predate these fields, so a missing
+        # key defaults to 0 rather than voiding the whole (iteration) result.
+        duration_runs += int(bc.get("_duration_runs", 0))
+        max_duration_s = max(max_duration_s, float(bc.get("max_duration_s", 0.0)))
+        max_killed_timeout_s = max(
+            max_killed_timeout_s, float(bc.get("max_killed_timeout_s", 0.0))
+        )
     if runs < min_runs or runs <= 0:
         return None
     return {
         "runs": float(runs),
         "avg_iterations": round(iterations_sum / runs, 4),
         "avg_cost_usd": round(cost_sum / measured_runs, 6) if measured_runs > 0 else 0.0,
+        "max_duration_s": round(max_duration_s, 4),
+        "duration_runs": float(duration_runs),
+        "max_killed_timeout_s": round(max_killed_timeout_s, 4),
     }
 
 
@@ -1016,6 +1101,27 @@ def _bucket_summary(entry: dict) -> dict[str, float | int]:
     }
 
 
+def _merge_duration(target: dict, src: dict) -> None:
+    """Combine the duration/kill accumulators of two dev buckets.
+
+    Sums the completed-run accumulators, maxes the maxima, and recomputes
+    ``avg_duration_s``. Legacy entries predating these fields lack the keys, so
+    every read tolerates absence via ``.get(..., 0)``.
+    """
+    dur_sum = float(target.get("_duration_sum", 0.0)) + float(src.get("_duration_sum", 0.0))
+    dur_runs = int(target.get("_duration_runs", 0)) + int(src.get("_duration_runs", 0))
+    target["_duration_sum"] = dur_sum
+    target["_duration_runs"] = dur_runs
+    target["avg_duration_s"] = round(dur_sum / dur_runs, 4) if dur_runs > 0 else 0.0
+    target["max_duration_s"] = max(
+        float(target.get("max_duration_s", 0.0)), float(src.get("max_duration_s", 0.0))
+    )
+    target["max_killed_timeout_s"] = max(
+        float(target.get("max_killed_timeout_s", 0.0)),
+        float(src.get("max_killed_timeout_s", 0.0)),
+    )
+
+
 def _merge_dev(target: dict, src: dict) -> None:
     runs = int(target.get("runs", 0)) + int(src.get("runs", 0))
     successes = int(target.get("_successes", 0)) + int(src.get("_successes", 0))
@@ -1056,6 +1162,7 @@ def _merge_dev(target: dict, src: dict) -> None:
         target["avg_iterations"] = round(iter_sum / runs, 4)
         measured = runs - cost_unknown
         target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
+    _merge_duration(target, src)
 
     src_by = src.get("by_complexity") or {}
     if src_by:
@@ -1098,6 +1205,7 @@ def _merge_dev(target: dict, src: dict) -> None:
                 bc_target["avg_cost_usd"] = (
                     round(bc_cost / bc_measured, 6) if bc_measured > 0 else 0.0
                 )
+            _merge_duration(bc_target, bc_src)
 
     src_by_score = src.get("by_complexity_score") or {}
     if src_by_score:
@@ -1140,6 +1248,7 @@ def _merge_dev(target: dict, src: dict) -> None:
                 sc_target["avg_cost_usd"] = (
                     round(sc_cost / sc_measured, 6) if sc_measured > 0 else 0.0
                 )
+            _merge_duration(sc_target, sc_src)
 
 
 def _merge_review(target: dict, src: dict) -> None:

--- a/tests/test_adaptive_iterations.py
+++ b/tests/test_adaptive_iterations.py
@@ -397,6 +397,109 @@ def test_read_history_tail_returns_empty_for_truly_fresh_repo(tmp_path: Path):
     assert _read_history_tail(tmp_path) == []
 
 
+# ── Duration-aware timeout floor (issue #1762) ────────────────────────────
+
+
+def _profiles_with_duration(
+    *,
+    band: str = "medium",
+    runs: int = 7,
+    avg_iterations: float = 1.0,
+    avg_cost: float = 1.0,
+    max_duration_s: float = 0.0,
+    duration_runs: int = 0,
+    max_killed_timeout_s: float = 0.0,
+):
+    return {
+        "models": {
+            "dev": {
+                "dev": {
+                    "by_complexity": {
+                        band: {
+                            "runs": runs,
+                            "avg_iterations": avg_iterations,
+                            "avg_cost_usd": avg_cost,
+                            "_duration_runs": duration_runs,
+                            "max_duration_s": max_duration_s,
+                            "max_killed_timeout_s": max_killed_timeout_s,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_timeout_floored_by_observed_duration_for_fast_converging_runs(tmp_path: Path):
+    """Fast-converging (low-iteration) runs whose observed durations approach a
+    large value must not shrink the timeout below observed duration + headroom."""
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(max_dev_iterations=1, max_dev_iterations_cap=6),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles_with_duration(
+            avg_iterations=1.0, max_duration_s=1207.0, duration_runs=7
+        ),
+    )
+    # avg_iterations=1.0 → iteration-derived timeout would be ~600s; the observed
+    # duration floor (1207 * 1.5 = 1811) dominates.
+    assert result.dev_timeout_seconds >= 1207
+    assert result.dev_timeout_seconds == 1811
+    assert result.audit["timeout_floored_on_observation"] is True
+    assert result.audit["duration_floor_seconds"] == 1811
+    assert result.audit["profile_max_duration_s"] == 1207.0
+    assert "observed run duration" in result.audit["rationale"]
+
+
+def test_timeout_never_below_kill_limit(tmp_path: Path):
+    """A profile containing a timeout-killed run yields a timeout >= the kill
+    limit — a censored observation can never drive the limit below where it died."""
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(max_dev_iterations=1, max_dev_iterations_cap=6),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles_with_duration(
+            avg_iterations=1.0,
+            max_duration_s=200.0,
+            duration_runs=6,
+            max_killed_timeout_s=1350.0,
+        ),
+    )
+    assert result.dev_timeout_seconds >= 1350
+    assert result.audit["kill_floor_seconds"] == 1350
+    assert result.audit["profile_max_killed_timeout_s"] == 1350.0
+    assert "killed comparable runs" in result.audit["rationale"]
+
+
+def test_timeout_never_below_base_timeout(tmp_path: Path):
+    """chosen_timeout is floored by the operator-configured base timeout."""
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(max_dev_iterations=1, max_dev_iterations_cap=6),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles_with_duration(
+            avg_iterations=1.0, max_duration_s=50.0, duration_runs=6
+        ),
+    )
+    # Iteration-derived (~600) and duration floor (~75) both below base 900.
+    assert result.dev_timeout_seconds == 900
+
+
 def test_read_history_tail_reads_native_substrate_rows(tmp_path: Path):
     """Substrate-only fixture: native rows surface as story-level history records."""
     from theforge.coordinator import audit_substrate

--- a/tests/test_coord_dev_timeout_retry.py
+++ b/tests/test_coord_dev_timeout_retry.py
@@ -41,6 +41,7 @@ from theforge.config import (  # noqa: E402
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.coordinator.commit_guard import _has_commits_ahead_of_base  # noqa: E402
 from theforge.coordinator.engine import run_task  # noqa: E402
 from theforge.coordinator.state import (  # noqa: E402
     CoordinatorResult,
@@ -165,6 +166,60 @@ def test_timeout_with_iterations_remaining_retries_not_escalates(tmp_path: Path)
     # The killed iteration is counted as spent.
     assert len(state.dev_iteration_telemetry) == 1
     assert state.dev_iteration_telemetry[-1].is_timeout is True
+
+
+def test_timeout_kill_sets_sticky_state_flag_on_retry_path(tmp_path: Path) -> None:
+    """A dev wall-clock timeout sets state.dev_process_timeout_killed at kill time,
+    independent of which downstream branch (retry here) runs. This is the signal
+    model_profiles_bridge reads to segregate the run as a censored observation."""
+    config, task, state = _setup(tmp_path)
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    assert state.dev_process_timeout_killed is False
+    _run_dev(config, task, state, tmp_path, _timeout_agent_result())
+
+    assert state.dev_process_timeout_killed is True
+
+
+def test_terminal_timeout_with_checkpointed_work_sets_kill_flag_and_falls_through(
+    tmp_path: Path,
+) -> None:
+    """The exact reported scenario (#1754): a dev iteration is killed at its
+    timeout with the budget exhausted AND checkpoint-committed work present, so
+    neither the timeout-retry branch nor the zero-commit guard fires and
+    execution falls through to VALIDATE. No telemetry entry with is_timeout=True
+    is recorded for the killed iteration, yet the sticky state flag must still
+    mark the kill so max_killed_timeout_s is populated for this run."""
+    config, task, state = _setup(tmp_path)
+    state.adaptive_dev_timeout_seconds = 900
+    # Exhaust the budget so the timeout-retry branch is skipped (terminal kill).
+    state.budget.max_iterations = 1
+    state.budget.consume(review_cycle=0)
+    # Stranded work in the worktree → checkpoint-commit salvages it, so the run
+    # HAS commits ahead of base and the zero-commit guard does not fire. Use a
+    # tracked-file edit (an untracked stray file would be quarantined first).
+    (tmp_path / "README.md").write_text("seed\nsalvaged work\n", encoding="utf-8")
+
+    result = _run_dev(config, task, state, tmp_path, _timeout_agent_result())
+
+    # Fell through to VALIDATE (no terminal escalation).
+    assert result is None
+    assert state.phase != Phase.ESCALATE
+    # The checkpoint commit put real work ahead of base.
+    assert _has_commits_ahead_of_base(tmp_path, "main") is True
+    # No dev telemetry entry recorded is_timeout=True on this fall-through path...
+    assert not any(t.is_timeout for t in state.dev_iteration_telemetry)
+    # ...but the sticky kill flag still marks the wall-clock kill.
+    assert state.dev_process_timeout_killed is True
+
+    # And the bridge turns that into a censored-observation RunOutcome with the
+    # granted timeout as the kill limit.
+    from theforge.coordinator.model_profiles_bridge import build_run_outcome
+
+    outcome = build_run_outcome(config, state, success=False)
+    assert outcome.dev_timeout_killed is True
+    assert outcome.dev_timeout_limit_s == 900
 
 
 def test_timeout_when_iterations_exhausted_escalates_naming_timeout(tmp_path: Path) -> None:

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -483,6 +483,9 @@ def test_get_dev_complexity_stats_requires_band_averages():
         "runs": 3.0,
         "avg_iterations": 2.5,
         "avg_cost_usd": 1.25,
+        "max_duration_s": 0.0,
+        "duration_runs": 0.0,
+        "max_killed_timeout_s": 0.0,
     }
 
 
@@ -524,6 +527,9 @@ def test_get_dev_complexity_stats_aggregates_fragmented_aliases():
         "runs": 5.0,
         "avg_iterations": 4.2,
         "avg_cost_usd": 1.6,
+        "max_duration_s": 0.0,
+        "duration_runs": 0.0,
+        "max_killed_timeout_s": 0.0,
     }
 
 
@@ -548,3 +554,241 @@ def test_get_dev_complexity_stats_returns_none_under_min_runs():
 
 def test_complexity_bands_constant():
     assert COMPLEXITY_BANDS == ("small", "medium", "large")
+
+
+# ── Duration aggregation + censored-kill floor ────────────────────────────
+
+
+def test_completed_run_records_duration():
+    """A completed run folds its wall-clock into avg/max duration accumulators."""
+    data: dict = {"models": {}}
+    for dur in (100.0, 300.0):
+        apply_run(
+            data,
+            RunOutcome(
+                complexity="medium",
+                dev_model="sonnet",
+                dev_success=True,
+                dev_iterations=1,
+                dev_cost_usd=1.0,
+                dev_duration_s=dur,
+            ),
+        )
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev["_duration_runs"] == 2
+    assert dev["_duration_sum"] == 400.0
+    assert dev["avg_duration_s"] == 200.0
+    assert dev["max_duration_s"] == 300.0
+    # No kill occurred, so the kill-floor key is never written (lazy schema).
+    assert dev.get("max_killed_timeout_s", 0.0) == 0.0
+    bc = dev["by_complexity"]["medium"]
+    assert bc["_duration_runs"] == 2
+    assert bc["avg_duration_s"] == 200.0
+    assert bc["max_duration_s"] == 300.0
+
+
+def test_killed_run_raises_kill_limit_without_touching_duration():
+    """A harness-killed run is a censored observation: it only raises
+    max_killed_timeout_s and never lowers learned duration."""
+    data: dict = {"models": {}}
+    # A fast completed run establishes a low learned duration.
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=1.0,
+            dev_duration_s=120.0,
+        ),
+    )
+    # A run killed at a 1350s limit: duration unknown, only the floor moves.
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_duration_s=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=1350,
+        ),
+    )
+    bc = data["models"]["sonnet"]["dev"]["by_complexity"]["medium"]
+    # Duration learning untouched by the kill.
+    assert bc["_duration_runs"] == 1
+    assert bc["avg_duration_s"] == 120.0
+    assert bc["max_duration_s"] == 120.0
+    # The kill only bounds the timeout from below.
+    assert bc["max_killed_timeout_s"] == 1350.0
+
+
+def test_get_dev_complexity_stats_surfaces_duration_and_kill_floor():
+    data: dict = {"models": {}}
+    for dur in (100.0, 400.0, 250.0):
+        apply_run(
+            data,
+            RunOutcome(
+                complexity="medium",
+                dev_model="sonnet",
+                dev_success=True,
+                dev_iterations=1,
+                dev_cost_usd=1.0,
+                dev_duration_s=dur,
+            ),
+        )
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=900,
+        ),
+    )
+    stats = get_dev_complexity_stats(data, "sonnet", "medium", min_runs=1)
+    assert stats is not None
+    assert stats["max_duration_s"] == 400.0
+    assert stats["duration_runs"] == 3.0
+    assert stats["max_killed_timeout_s"] == 900.0
+
+
+def test_legacy_profile_without_duration_still_yields_iteration_stats():
+    """Profiles predating the duration fields must still return iteration stats
+    (duration/kill floors default to 0.0, they do not void the result)."""
+    profiles = {
+        "models": {
+            "sonnet": {
+                "dev": {
+                    "by_complexity": {
+                        "medium": {
+                            "runs": 4,
+                            "avg_iterations": 3.0,
+                            "avg_cost_usd": 1.0,
+                        }
+                    }
+                }
+            }
+        }
+    }
+    stats = get_dev_complexity_stats(profiles, "sonnet", "medium", min_runs=1)
+    assert stats is not None
+    assert stats["avg_iterations"] == 3.0
+    assert stats["max_duration_s"] == 0.0
+    assert stats["duration_runs"] == 0.0
+    assert stats["max_killed_timeout_s"] == 0.0
+
+
+def test_reset_zeros_duration_fields():
+    from theforge.model_profiles import reset_profile_data
+
+    data: dict = {"models": {}}
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=1.0,
+            dev_duration_s=300.0,
+        ),
+    )
+    updated, _ = reset_profile_data(data, "sonnet", role="dev", complexity="medium")
+    bc = updated["models"]["sonnet"]["dev"]["by_complexity"]["medium"]
+    assert bc["_duration_runs"] == 0
+    assert bc["_duration_sum"] == 0.0
+    assert bc["avg_duration_s"] == 0.0
+    assert bc["max_duration_s"] == 0.0
+    assert bc["max_killed_timeout_s"] == 0.0
+    # Recomputed dev section reflects the zeroed band.
+    assert updated["models"]["sonnet"]["dev"]["max_duration_s"] == 0.0
+
+
+def test_merge_preserves_duration_and_kill_floor():
+    """Merging two dev sections sums duration runs and maxes the maxima."""
+    from theforge.model_profiles import _merge_dev
+
+    src_a: dict = {"models": {}}
+    apply_run(
+        src_a,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=1.0,
+            dev_duration_s=200.0,
+        ),
+    )
+    apply_run(
+        src_a,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=800,
+        ),
+    )
+    src_b: dict = {"models": {}}
+    apply_run(
+        src_b,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=1.0,
+            dev_duration_s=500.0,
+        ),
+    )
+    target = src_a["models"]["sonnet"]["dev"]
+    _merge_dev(target, src_b["models"]["sonnet"]["dev"])
+    assert target["_duration_runs"] == 2  # two completed runs (kill excluded)
+    assert target["max_duration_s"] == 500.0
+    assert target["max_killed_timeout_s"] == 800.0
+    bc = target["by_complexity"]["medium"]
+    assert bc["_duration_runs"] == 2
+    assert bc["max_duration_s"] == 500.0
+    assert bc["max_killed_timeout_s"] == 800.0
+
+
+def test_merge_tolerates_legacy_entry_without_duration_keys():
+    """A legacy src dev section lacking the new keys merges cleanly (keys default
+    to 0) without erasing the target's learned duration."""
+    from theforge.model_profiles import _merge_dev
+
+    holder: dict = {"models": {}}
+    apply_run(
+        holder,
+        RunOutcome(
+            complexity="medium",
+            dev_model="sonnet",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=1.0,
+            dev_duration_s=350.0,
+        ),
+    )
+    target = holder["models"]["sonnet"]["dev"]
+    legacy_src = {
+        "runs": 2,
+        "success_rate": 1.0,
+        "avg_iterations": 3.0,
+        "avg_cost_usd": 1.0,
+        "by_complexity": {
+            "medium": {"runs": 2, "avg_iterations": 3.0, "avg_cost_usd": 1.0},
+        },
+    }
+    _merge_dev(target, legacy_src)
+    assert target["max_duration_s"] == 350.0  # target's learned value preserved
+    assert target["_duration_runs"] == 1  # legacy src contributes 0 duration runs

--- a/tests/test_model_profiles_bridge.py
+++ b/tests/test_model_profiles_bridge.py
@@ -210,7 +210,7 @@ def test_build_run_outcome_populates_duration_from_dev_durations():
     state.dev_durations = [120.5, 200.25]
     outcome = build_run_outcome(_Cfg(), state, success=True)
     assert outcome.dev_duration_s == 320.75
-    # No timeout telemetry → not a censored kill.
+    # No timeout kill flag → not a censored kill.
     assert outcome.dev_timeout_killed is False
 
 
@@ -225,18 +225,37 @@ def test_build_run_outcome_marks_timeout_killed_and_limit():
     state = _state_with_dev_costs([0.30])
     state.dev_durations = [1349.9]
     state.adaptive_dev_timeout_seconds = 1350
-    state.dev_iteration_telemetry = [_dev_telemetry(is_timeout=True)]
+    state.dev_process_timeout_killed = True
     outcome = build_run_outcome(_Cfg(), state, success=False)
     assert outcome.dev_timeout_killed is True
     assert outcome.dev_timeout_limit_s == 1350
 
 
-def test_build_run_outcome_last_iteration_not_timeout_is_not_killed():
+def test_build_run_outcome_reads_sticky_kill_flag_not_last_telemetry():
+    """The censored-kill signal is the sticky state flag set at kill time, NOT
+    the is_timeout of whichever telemetry entry happens to be last. A later
+    VALIDATE-phase telemetry write (no is_timeout) must not erase the kill —
+    the checkpoint-commit terminal-kill scenario from the spec (#1754)."""
     state = _state_with_dev_costs([0.30])
+    state.adaptive_dev_timeout_seconds = 1350
+    # Dev was killed at its timeout (flag set in dev_phase)...
+    state.dev_process_timeout_killed = True
+    # ...but execution fell through to VALIDATE, whose telemetry entry (no
+    # is_timeout) is now the tail of dev_iteration_telemetry.
     state.dev_iteration_telemetry = [
         _dev_telemetry(is_timeout=True),
         _dev_telemetry(is_timeout=False),
     ]
     outcome = build_run_outcome(_Cfg(), state, success=True)
-    # Only the LAST iteration's is_timeout marks a censored kill.
+    assert outcome.dev_timeout_killed is True
+    assert outcome.dev_timeout_limit_s == 1350
+
+
+def test_build_run_outcome_no_kill_flag_is_not_killed_despite_stale_timeout_tail():
+    """Absent the sticky flag, a stale is_timeout on the last telemetry entry
+    (e.g. a VALIDATE gate/test-command timeout) does not mark a censored kill."""
+    state = _state_with_dev_costs([0.30])
+    state.dev_process_timeout_killed = False
+    state.dev_iteration_telemetry = [_dev_telemetry(is_timeout=True)]
+    outcome = build_run_outcome(_Cfg(), state, success=True)
     assert outcome.dev_timeout_killed is False

--- a/tests/test_model_profiles_bridge.py
+++ b/tests/test_model_profiles_bridge.py
@@ -191,3 +191,52 @@ def test_mixed_measured_and_unmeasured_dev_costs_are_unknown_aggregate():
     state = _state_with_dev_costs([0.30, None])
     outcome = build_run_outcome(_Cfg(), state, success=True)
     assert outcome.dev_cost_usd is None
+
+
+def _dev_telemetry(*, is_timeout: bool):
+    from theforge.coordinator.state import DevIterationTelemetry
+
+    return DevIterationTelemetry(
+        iteration=1,
+        max_iterations=3,
+        cost_usd=0.10,
+        duration_s=42.0,
+        is_timeout=is_timeout,
+    )
+
+
+def test_build_run_outcome_populates_duration_from_dev_durations():
+    state = _state_with_dev_costs([0.30])
+    state.dev_durations = [120.5, 200.25]
+    outcome = build_run_outcome(_Cfg(), state, success=True)
+    assert outcome.dev_duration_s == 320.75
+    # No timeout telemetry → not a censored kill.
+    assert outcome.dev_timeout_killed is False
+
+
+def test_build_run_outcome_no_durations_yields_none():
+    state = _state_with_dev_costs([0.30])
+    assert state.dev_durations == []
+    outcome = build_run_outcome(_Cfg(), state, success=True)
+    assert outcome.dev_duration_s is None
+
+
+def test_build_run_outcome_marks_timeout_killed_and_limit():
+    state = _state_with_dev_costs([0.30])
+    state.dev_durations = [1349.9]
+    state.adaptive_dev_timeout_seconds = 1350
+    state.dev_iteration_telemetry = [_dev_telemetry(is_timeout=True)]
+    outcome = build_run_outcome(_Cfg(), state, success=False)
+    assert outcome.dev_timeout_killed is True
+    assert outcome.dev_timeout_limit_s == 1350
+
+
+def test_build_run_outcome_last_iteration_not_timeout_is_not_killed():
+    state = _state_with_dev_costs([0.30])
+    state.dev_iteration_telemetry = [
+        _dev_telemetry(is_timeout=True),
+        _dev_telemetry(is_timeout=False),
+    ]
+    outcome = build_run_outcome(_Cfg(), state, success=True)
+    # Only the LAST iteration's is_timeout marks a censored kill.
+    assert outcome.dev_timeout_killed is False


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 is resolved; the sticky dev timeout-kill signal is set at kill time, consumed by profile persistence, and covered by the checkpointed-work fall-through test. | [google-gemini-3.5-flash] The adaptive dev-timeout derivation and sticky timeout-kill detection are correctly implemented and fully verified. | [claude-sonnet] Cycle-1 P1 (unreliable kill detection via last-telemetry-entry) is fixed with a sticky state.dev_process_timeout_killed flag set at kill time in dev_phase.py, verified by a real seam test exercising the exact checkpoint-commit fall-through scenario; no regressions found in the touched files.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $11.58
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Adaptive dev timeout derives from learned iteration count, not observed duration — low-iteration history shrinks the timeout until runs starve (GitHub Issue #1762)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1762