### PR TITLE
Harness-imposed kills are recorded as model failures — starved runs poison success_rate, avg_iterations, and routing

### DIFF
--- a/src/theforge/cli/profiles.py
+++ b/src/theforge/cli/profiles.py
@@ -94,7 +94,7 @@ def cmd_profiles_list(args: argparse.Namespace) -> int:
     rows = _profile_rows(data, model=args.model, role=args.role)
 
     if not rows:
-        print("canonical_id              role       complexity  runs  successes  rate")
+        print("canonical_id              role       complexity  runs  successes  rate  terminated")
         return 0
 
     widths = {
@@ -104,6 +104,7 @@ def cmd_profiles_list(args: argparse.Namespace) -> int:
         "runs": max(len("runs"), *(len(str(row["runs"])) for row in rows)),
         "successes": max(len("successes"), *(len(str(row["successes"])) for row in rows)),
         "rate": max(len("rate"), *(len(str(row["rate"])) for row in rows)),
+        "terminated": max(len("terminated"), *(len(str(row["terminated"])) for row in rows)),
     }
     print(
         f"{'canonical_id':<{widths['canonical_id']}}  "
@@ -111,7 +112,8 @@ def cmd_profiles_list(args: argparse.Namespace) -> int:
         f"{'complexity':<{widths['complexity']}}  "
         f"{'runs':>{widths['runs']}}  "
         f"{'successes':>{widths['successes']}}  "
-        f"{'rate':>{widths['rate']}}"
+        f"{'rate':>{widths['rate']}}  "
+        f"{'terminated':>{widths['terminated']}}"
     )
     for row in rows:
         print(
@@ -120,7 +122,8 @@ def cmd_profiles_list(args: argparse.Namespace) -> int:
             f"{row['complexity']:<{widths['complexity']}}  "
             f"{row['runs']:>{widths['runs']}}  "
             f"{row['successes']:>{widths['successes']}}  "
-            f"{row['rate']:>{widths['rate']}}"
+            f"{row['rate']:>{widths['rate']}}  "
+            f"{row['terminated']:>{widths['terminated']}}"
         )
     return 0
 
@@ -225,6 +228,10 @@ def _entry_rows(
                             bucket.get("runs", 0),
                             bucket.get("success_rate", 0.0),
                         ),
+                        # Harness-imposed terminations (deadline kill / stuck-
+                        # pattern terminate) are recorded but excluded from runs/
+                        # rate (#1763), so surface the tally separately here.
+                        "terminated": int((bucket.get("harness_terminated") or {}).get("runs", 0)),
                     }
                 )
             continue
@@ -239,6 +246,7 @@ def _entry_rows(
                 "runs": runs,
                 "successes": "—",
                 "rate": "—",
+                "terminated": "—",
             }
         )
     return rows

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -1049,6 +1049,14 @@ def _run_dev_phase(
             # execution fall through (#1754). model_profiles_bridge reads this to
             # segregate the run as a censored observation for the kill floor.
             state.dev_process_timeout_killed = True
+        if dev_result.failure_code == "stuck_pattern":
+            # Record the stuck-pattern terminate on state immediately, before any
+            # retry/escalate/fall-through decision runs — same rationale as the
+            # timeout flag above (#1754 lets execution fall through, overwriting
+            # the terminated iteration's telemetry). model_profiles_bridge reads
+            # this to segregate the run as a harness-imposed termination that must
+            # not contaminate the model's capability statistics.
+            state.dev_process_stuck_terminated = True
         # The signal number records only what was done to the process, not what
         # went wrong. When the runner already explained the failure in words
         # (e.g. "TIMEOUT: Agent exceeded 900s limit"), surface that instead of

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -63,6 +63,16 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
     dev_timeout_limit_s = (
         int(state.adaptive_dev_timeout_seconds) if state.adaptive_dev_timeout_seconds else None
     )
+    # Termination-cause taxonomy: why the harness ended the dev process, if it
+    # did. A harness-imposed ending (a deadline kill or a stuck-pattern terminate)
+    # is evidence about the budget or the harness, not about the model, so the
+    # aggregator segregates these runs out of the capability statistics. Timeout
+    # takes precedence when both flags happen to be set.
+    dev_termination_cause = (
+        "timeout"
+        if state.dev_process_timeout_killed
+        else ("stuck_pattern" if state.dev_process_stuck_terminated else None)
+    )
     return RunOutcome(
         complexity=complexity,
         complexity_score=state.preflight_complexity_score,
@@ -75,6 +85,7 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         dev_duration_s=dev_duration_s,
         dev_timeout_killed=dev_timeout_killed,
         dev_timeout_limit_s=dev_timeout_limit_s,
+        dev_termination_cause=dev_termination_cause,
         # Pass the cost-unknown signal through (None) instead of coercing to
         # $0.00, so unmeasured CLI-transport runs are recorded as unmeasured.
         dev_cost_usd=state.total_dev_cost_measured,

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -320,6 +320,14 @@ class CoordinatorState:
     # is distinct from a VALIDATE gate/test-command timeout (a different failure
     # class carried on DevIterationTelemetry.is_timeout).
     dev_process_timeout_killed: bool = False
+    # Sticky "the dev process was terminated by stuck-pattern detection at least
+    # once" flag. Set once at kill time in dev_phase (never cleared), mirroring
+    # dev_process_timeout_killed: the terminated iteration's telemetry can be
+    # overwritten by a later VALIDATE-phase write once checkpoint-committed work
+    # (#1754) lets execution fall through, so the last telemetry entry is not a
+    # reliable signal. This is the reliable signal that the dev process was ended
+    # by stuck-pattern detection (runner failure_code == 'stuck_pattern').
+    dev_process_stuck_terminated: bool = False
     review_agent_results: list[AgentResult] = field(default_factory=list)
     review_durations: list[float] = field(
         default_factory=list

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -80,6 +80,13 @@ class RunOutcome:
     dev_timeout_killed: bool = False
     # The granted per-story timeout (seconds) at which a killed run was terminated.
     dev_timeout_limit_s: int | None = None
+    # Why the harness ended the dev process, if it did: ``"timeout"`` (deadline
+    # kill) or ``"stuck_pattern"`` (stuck-pattern terminate); ``None`` for a run
+    # the model itself finished (success or genuine failure). A harness-imposed
+    # ending is evidence about the budget or the harness, not the model, so the
+    # aggregator segregates these runs into a visible ``harness_terminated``
+    # sub-dict and keeps them out of success_rate/avg_iterations/avg_cost stats.
+    dev_termination_cause: str | None = None
     preflight_model: str | None = None
     dev_actual_model: str | None = None
     dev_provider: str | None = None
@@ -297,6 +304,61 @@ def _fold_duration(
         )
 
 
+def _fold_harness_terminated(bucket: dict, cause: str | None, cost_usd: float | None) -> None:
+    """Record a harness-imposed termination in ``bucket['harness_terminated']``.
+
+    Harness-terminated runs (deadline kill, stuck-pattern terminate) are kept out
+    of the capability accumulators (``runs``/``_successes``/``_iterations_sum`` →
+    ``success_rate``/``avg_iterations``) entirely so the orchestrator can never
+    steer away from a model because it starved the run (#1763). They are instead
+    tallied here — visibly, with a per-cause breakdown — and their spend is folded
+    against this sub-dict so killed-run cost stays on the ledger without diluting
+    the capability ``avg_cost_usd``.
+    """
+    ht = bucket.setdefault("harness_terminated", {})
+    ht["runs"] = int(ht.get("runs", 0)) + 1
+    by_cause = ht.setdefault("by_cause", {})
+    if cause is not None:
+        by_cause[cause] = int(by_cause.get(cause, 0)) + 1
+    _fold_cost(ht, cost_usd)
+
+
+def _fold_dev_bucket(
+    bucket: dict,
+    success: bool,
+    iterations: int,
+    cost_usd: float | None,
+    duration_s: float | None,
+    timeout_killed: bool,
+    timeout_limit_s: int | None,
+    termination_cause: str | None,
+) -> None:
+    """Fold one dev run into a single dev bucket (top-level / band / score).
+
+    A harness-terminated run bypasses the capability accumulators and cost fold
+    entirely (recorded via :func:`_fold_harness_terminated`); only the duration
+    fold still runs with ``duration_s=None`` so a timeout kill can raise
+    ``max_killed_timeout_s`` without touching completed-run duration stats.
+    """
+    if termination_cause is not None:
+        _fold_harness_terminated(bucket, termination_cause, cost_usd)
+        # duration_s=None: skip the completed-duration branch for BOTH timeout and
+        # stuck; the killed/limit branch still raises max_killed_timeout_s for a
+        # timeout (timeout_killed=True carries the kill floor).
+        _fold_duration(bucket, None, timeout_killed, timeout_limit_s)
+        return
+    runs = int(bucket.get("runs", 0)) + 1
+    successes = int(bucket.get("_successes", 0)) + (1 if success else 0)
+    iter_sum = float(bucket.get("_iterations_sum", 0.0)) + float(iterations)
+    bucket["runs"] = runs
+    bucket["_successes"] = successes
+    bucket["_iterations_sum"] = iter_sum
+    bucket["success_rate"] = round(successes / runs, 4)
+    bucket["avg_iterations"] = round(iter_sum / runs, 4)
+    _fold_cost(bucket, cost_usd)
+    _fold_duration(bucket, duration_s, timeout_killed, timeout_limit_s)
+
+
 def _update_dev(
     entry: dict,
     complexity: str,
@@ -307,6 +369,7 @@ def _update_dev(
     duration_s: float | None = None,
     timeout_killed: bool = False,
     timeout_limit_s: int | None = None,
+    termination_cause: str | None = None,
 ) -> None:
     if cost_usd is None:
         log.warning(
@@ -316,44 +379,44 @@ def _update_dev(
             complexity,
         )
     dev = entry.setdefault("dev", {})
-    runs = int(dev.get("runs", 0)) + 1
-    successes = int(dev.get("_successes", 0)) + (1 if success else 0)
-    iter_sum = float(dev.get("_iterations_sum", 0.0)) + float(iterations)
-    dev["runs"] = runs
-    dev["_successes"] = successes
-    dev["_iterations_sum"] = iter_sum
-    dev["success_rate"] = round(successes / runs, 4)
-    dev["avg_iterations"] = round(iter_sum / runs, 4)
-    _fold_cost(dev, cost_usd)
-    _fold_duration(dev, duration_s, timeout_killed, timeout_limit_s)
+    _fold_dev_bucket(
+        dev,
+        success,
+        iterations,
+        cost_usd,
+        duration_s,
+        timeout_killed,
+        timeout_limit_s,
+        termination_cause,
+    )
 
     by = dev.setdefault("by_complexity", {})
     bc = by.setdefault(complexity, {})
-    bc_runs = int(bc.get("runs", 0)) + 1
-    bc_successes = int(bc.get("_successes", 0)) + (1 if success else 0)
-    bc_iter_sum = float(bc.get("_iterations_sum", 0.0)) + float(iterations)
-    bc["runs"] = bc_runs
-    bc["_successes"] = bc_successes
-    bc["_iterations_sum"] = bc_iter_sum
-    bc["success_rate"] = round(bc_successes / bc_runs, 4)
-    bc["avg_iterations"] = round(bc_iter_sum / bc_runs, 4)
-    _fold_cost(bc, cost_usd)
-    _fold_duration(bc, duration_s, timeout_killed, timeout_limit_s)
+    _fold_dev_bucket(
+        bc,
+        success,
+        iterations,
+        cost_usd,
+        duration_s,
+        timeout_killed,
+        timeout_limit_s,
+        termination_cause,
+    )
 
     if complexity_score is not None:
         score_key = str(int(complexity_score))
         by_score = dev.setdefault("by_complexity_score", {})
         sc = by_score.setdefault(score_key, {})
-        sc_runs = int(sc.get("runs", 0)) + 1
-        sc_successes = int(sc.get("_successes", 0)) + (1 if success else 0)
-        sc_iter_sum = float(sc.get("_iterations_sum", 0.0)) + float(iterations)
-        sc["runs"] = sc_runs
-        sc["_successes"] = sc_successes
-        sc["_iterations_sum"] = sc_iter_sum
-        sc["success_rate"] = round(sc_successes / sc_runs, 4)
-        sc["avg_iterations"] = round(sc_iter_sum / sc_runs, 4)
-        _fold_cost(sc, cost_usd)
-        _fold_duration(sc, duration_s, timeout_killed, timeout_limit_s)
+        _fold_dev_bucket(
+            sc,
+            success,
+            iterations,
+            cost_usd,
+            duration_s,
+            timeout_killed,
+            timeout_limit_s,
+            termination_cause,
+        )
 
 
 def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float | None) -> None:
@@ -402,6 +465,13 @@ def _zero_dev_bucket(bucket: dict) -> None:
     bucket["avg_duration_s"] = 0.0
     bucket["max_duration_s"] = 0.0
     bucket["max_killed_timeout_s"] = 0.0
+    bucket["harness_terminated"] = {
+        "runs": 0,
+        "by_cause": {},
+        "_cost_sum": 0.0,
+        "_cost_unknown_runs": 0,
+        "avg_cost_usd": 0.0,
+    }
 
 
 def _zero_review_section(section: dict) -> None:
@@ -431,6 +501,10 @@ def _recompute_dev_section(section: dict) -> None:
     duration_runs = 0
     max_duration = 0.0
     max_killed_timeout = 0.0
+    ht_runs = 0
+    ht_by_cause: dict[str, int] = {}
+    ht_cost_sum = 0.0
+    ht_cost_unknown = 0
     for band in COMPLEXITY_BANDS:
         bucket = by.setdefault(band, {})
         runs += int(bucket.get("runs", 0))
@@ -444,6 +518,13 @@ def _recompute_dev_section(section: dict) -> None:
         max_killed_timeout = max(
             max_killed_timeout, float(bucket.get("max_killed_timeout_s", 0.0))
         )
+        ht = bucket.get("harness_terminated") or {}
+        if isinstance(ht, dict):
+            ht_runs += int(ht.get("runs", 0))
+            ht_cost_sum += float(ht.get("_cost_sum", 0.0))
+            ht_cost_unknown += int(ht.get("_cost_unknown_runs", 0))
+            for cause, count in (ht.get("by_cause") or {}).items():
+                ht_by_cause[cause] = ht_by_cause.get(cause, 0) + int(count)
     section["runs"] = runs
     section["_successes"] = successes
     section["_iterations_sum"] = iterations
@@ -460,6 +541,14 @@ def _recompute_dev_section(section: dict) -> None:
     )
     section["max_duration_s"] = max_duration
     section["max_killed_timeout_s"] = max_killed_timeout
+    ht_measured = ht_runs - ht_cost_unknown
+    section["harness_terminated"] = {
+        "runs": ht_runs,
+        "by_cause": ht_by_cause,
+        "_cost_sum": ht_cost_sum,
+        "_cost_unknown_runs": ht_cost_unknown,
+        "avg_cost_usd": round(ht_cost_sum / ht_measured, 6) if ht_measured > 0 else 0.0,
+    }
 
 
 def apply_run(data: dict, outcome: RunOutcome) -> dict:
@@ -482,6 +571,7 @@ def apply_run(data: dict, outcome: RunOutcome) -> dict:
         duration_s=outcome.dev_duration_s,
         timeout_killed=outcome.dev_timeout_killed,
         timeout_limit_s=outcome.dev_timeout_limit_s,
+        termination_cause=outcome.dev_termination_cause,
     )
     if outcome.preflight_model:
         pf_entry = _ensure_model(
@@ -1122,6 +1212,40 @@ def _merge_duration(target: dict, src: dict) -> None:
     )
 
 
+def _merge_harness_terminated(target: dict, src: dict) -> None:
+    """Combine the ``harness_terminated`` sub-dicts of two dev buckets.
+
+    Sums the run tally, the per-cause counts, and the segregated cost ledger.
+    Legacy entries predating #1763 lack the sub-dict entirely, so every read
+    tolerates absence — a merge from such a ``src`` is a no-op.
+    """
+    src_ht = src.get("harness_terminated")
+    if not isinstance(src_ht, dict):
+        return
+    tgt_ht = target.setdefault(
+        "harness_terminated",
+        {
+            "runs": 0,
+            "by_cause": {},
+            "_cost_sum": 0.0,
+            "_cost_unknown_runs": 0,
+            "avg_cost_usd": 0.0,
+        },
+    )
+    tgt_ht["runs"] = int(tgt_ht.get("runs", 0)) + int(src_ht.get("runs", 0))
+    tgt_by_cause = tgt_ht.setdefault("by_cause", {})
+    for cause, count in (src_ht.get("by_cause") or {}).items():
+        tgt_by_cause[cause] = int(tgt_by_cause.get(cause, 0)) + int(count)
+    cost_sum = float(tgt_ht.get("_cost_sum", 0.0)) + float(src_ht.get("_cost_sum", 0.0))
+    cost_unknown = int(tgt_ht.get("_cost_unknown_runs", 0)) + int(
+        src_ht.get("_cost_unknown_runs", 0)
+    )
+    tgt_ht["_cost_sum"] = cost_sum
+    tgt_ht["_cost_unknown_runs"] = cost_unknown
+    measured = int(tgt_ht.get("runs", 0)) - cost_unknown
+    tgt_ht["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
+
+
 def _merge_dev(target: dict, src: dict) -> None:
     runs = int(target.get("runs", 0)) + int(src.get("runs", 0))
     successes = int(target.get("_successes", 0)) + int(src.get("_successes", 0))
@@ -1163,6 +1287,7 @@ def _merge_dev(target: dict, src: dict) -> None:
         measured = runs - cost_unknown
         target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
     _merge_duration(target, src)
+    _merge_harness_terminated(target, src)
 
     src_by = src.get("by_complexity") or {}
     if src_by:
@@ -1206,6 +1331,7 @@ def _merge_dev(target: dict, src: dict) -> None:
                     round(bc_cost / bc_measured, 6) if bc_measured > 0 else 0.0
                 )
             _merge_duration(bc_target, bc_src)
+            _merge_harness_terminated(bc_target, bc_src)
 
     src_by_score = src.get("by_complexity_score") or {}
     if src_by_score:
@@ -1249,6 +1375,7 @@ def _merge_dev(target: dict, src: dict) -> None:
                     round(sc_cost / sc_measured, 6) if sc_measured > 0 else 0.0
                 )
             _merge_duration(sc_target, sc_src)
+            _merge_harness_terminated(sc_target, sc_src)
 
 
 def _merge_review(target: dict, src: dict) -> None:

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -454,7 +454,8 @@ class AgentLoopManager:
                 )
                 return self._failure_result(
                     f"Agent loop terminated: {stuck_terminate} "
-                    f"(at iteration {iterations}, {self._total_tool_calls} tool calls)"
+                    f"(at iteration {iterations}, {self._total_tool_calls} tool calls)",
+                    failure_code_override="stuck_pattern",
                 )
             if stuck_nudge is not None:
                 messages = list(messages)
@@ -610,11 +611,15 @@ class AgentLoopManager:
             structured_data=structured_data,
         )
 
-    def _failure_result(self, reason: str) -> AgentResult:
+    def _failure_result(
+        self, reason: str, *, failure_code_override: str | None = None
+    ) -> AgentResult:
         usage = self._usage.to_model_usage(self._profile.model, self._provider)
         usage, cost = self._zero_cost_if_local(usage)
-        failure_code = None
-        if reason.startswith("Agent loop terminated: max iterations reached"):
+        failure_code = failure_code_override
+        if failure_code is not None:
+            pass
+        elif reason.startswith("Agent loop terminated: max iterations reached"):
             failure_code = "max_iterations_reached"
         elif reason.startswith("Agent loop terminated: wall-clock timeout"):
             # Running out of wall-clock time is a distinct, retryable failure

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -805,3 +805,89 @@ def test_apply_preflight_skips_warning_when_cap_unset(tmp_path, monkeypatch):
     assert state._adaptive_decision.dev.model == "opus"
     assert state._adaptive_decision.budget_audit["target_usd"] is None
     assert state._adaptive_decision.budget_audit["downgraded"] is False
+
+
+def _dev_state_medium() -> CoordinatorState:
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 5
+    state.dev_trace_count = 3
+    state.dev_durations = [40.0, 40.0, 40.0]
+    return state
+
+
+def _apply(config, state, success):
+    """Seam: bridge.build_run_outcome → model_profiles.apply_run."""
+    from theforge.coordinator.model_profiles_bridge import build_run_outcome
+    from theforge.model_profiles import apply_run
+
+    data: dict = {"models": {}}
+    outcome = build_run_outcome(config, state, success=success)
+    return apply_run(data, outcome), outcome
+
+
+def test_seam_harness_kill_does_not_contaminate_capability_stats(tmp_path):
+    """Seam (dev_phase flag → bridge → aggregator): a harness-imposed kill set on
+    CoordinatorState must not move the dev bucket's success_rate/avg_iterations/
+    _successes/runs versus a baseline with no kill — it is recorded separately in
+    harness_terminated instead (#1763)."""
+    from dataclasses import replace as _replace
+
+    config = _replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="claude-sonnet",
+                provider=None,
+                model="sonnet",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="cheap",
+                cli="claude",
+            )
+        ],
+    )
+
+    def _dev_section(data):
+        entry = next(m for m in data["models"].values() if "dev" in m)
+        return entry["dev"]
+
+    # Baseline: a single clean completed run.
+    baseline_state = _dev_state_medium()
+    baseline_data, _ = _apply(config, baseline_state, success=True)
+    base_dev = _dev_section(baseline_data)
+
+    # Timeout kill: dev_phase set the sticky flag before falling through.
+    killed_state = _dev_state_medium()
+    killed_state.adaptive_dev_timeout_seconds = 900
+    killed_state.dev_process_timeout_killed = True
+    killed_data, killed_outcome = _apply(config, killed_state, success=False)
+    killed_dev = _dev_section(killed_data)
+
+    # The bridge carried the taxonomy across the seam.
+    assert killed_outcome.dev_termination_cause == "timeout"
+
+    # Capability stats: the kill starts from an empty profile, so a contaminated
+    # fold would show runs=1/success_rate=0.0. Segregation keeps them at zero.
+    assert killed_dev.get("runs", 0) == 0
+    assert killed_dev.get("_successes", 0) == 0
+    assert killed_dev.get("success_rate", 0.0) == 0.0
+    assert killed_dev.get("avg_iterations", 0.0) == 0.0
+    # ...while the clean baseline recorded a real success.
+    assert base_dev["runs"] == 1 and base_dev["success_rate"] == 1.0
+
+    # The kill is recorded, and the timeout floor still moves.
+    bc = killed_dev["by_complexity"]["medium"]
+    assert bc["harness_terminated"]["runs"] == 1
+    assert bc["harness_terminated"]["by_cause"] == {"timeout": 1}
+    assert bc["max_killed_timeout_s"] == 900.0
+
+    # Stuck-terminate flows through the same seam under its own cause, with no floor.
+    stuck_state = _dev_state_medium()
+    stuck_state.dev_process_stuck_terminated = True
+    stuck_data, stuck_outcome = _apply(config, stuck_state, success=False)
+    assert stuck_outcome.dev_termination_cause == "stuck_pattern"
+    stuck_bc = _dev_section(stuck_data)["by_complexity"]["medium"]
+    assert stuck_bc["harness_terminated"]["by_cause"] == {"stuck_pattern": 1}
+    assert stuck_bc.get("runs", 0) == 0
+    assert stuck_bc.get("max_killed_timeout_s", 0.0) == 0.0

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -792,3 +792,266 @@ def test_merge_tolerates_legacy_entry_without_duration_keys():
     _merge_dev(target, legacy_src)
     assert target["max_duration_s"] == 350.0  # target's learned value preserved
     assert target["_duration_runs"] == 1  # legacy src contributes 0 duration runs
+
+
+# ── Harness-terminated segregation (#1763) ────────────────────────────────
+
+
+def _baseline_medium_run(data: dict, *, success: bool = True) -> None:
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=success,
+            dev_iterations=3,
+            dev_cost_usd=1.0,
+            dev_duration_s=120.0,
+        ),
+    )
+
+
+def test_harness_timeout_kill_does_not_touch_capability_stats():
+    """A deadline kill must not fold into success_rate/avg_iterations/_successes:
+    those must equal a baseline with no killed run at all (#1763)."""
+    baseline: dict = {"models": {}}
+    _baseline_medium_run(baseline)
+
+    contaminated: dict = {"models": {}}
+    _baseline_medium_run(contaminated)
+    # Interleave a harness-killed run — it must be segregated, not counted.
+    apply_run(
+        contaminated,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_duration_s=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=900,
+            dev_termination_cause="timeout",
+        ),
+    )
+
+    for scope in ("dev",):
+        b = baseline["models"]["sonnet"][scope]
+        c = contaminated["models"]["sonnet"][scope]
+        assert c["runs"] == b["runs"]
+        assert c["_successes"] == b["_successes"]
+        assert c["_iterations_sum"] == b["_iterations_sum"]
+        assert c["success_rate"] == b["success_rate"]
+        assert c["avg_iterations"] == b["avg_iterations"]
+
+    bc_b = baseline["models"]["sonnet"]["dev"]["by_complexity"]["medium"]
+    bc_c = contaminated["models"]["sonnet"]["dev"]["by_complexity"]["medium"]
+    assert bc_c["runs"] == bc_b["runs"]
+    assert bc_c["success_rate"] == bc_b["success_rate"]
+    assert bc_c["avg_iterations"] == bc_b["avg_iterations"]
+
+    # ...but the kill IS visibly recorded and the timeout floor still moves.
+    ht = bc_c["harness_terminated"]
+    assert ht["runs"] == 1
+    assert ht["by_cause"] == {"timeout": 1}
+    assert bc_c["max_killed_timeout_s"] == 900.0
+    # Completed-run duration stats are untouched by the kill.
+    assert bc_c["_duration_runs"] == bc_b["_duration_runs"] == 1
+    assert bc_c["avg_duration_s"] == 120.0
+    # Top-level dev section aggregates the tally too.
+    assert contaminated["models"]["sonnet"]["dev"]["harness_terminated"]["runs"] == 1
+
+
+def test_harness_stuck_terminate_segregated_and_no_kill_floor():
+    """A stuck-pattern terminate is segregated like a timeout, but — not being a
+    deadline kill — it must NOT raise max_killed_timeout_s."""
+    data: dict = {"models": {}}
+    _baseline_medium_run(data)
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_duration_s=None,
+            dev_timeout_killed=False,
+            dev_timeout_limit_s=None,
+            dev_termination_cause="stuck_pattern",
+        ),
+    )
+    bc = data["models"]["sonnet"]["dev"]["by_complexity"]["medium"]
+    assert bc["runs"] == 1  # only the completed baseline run
+    assert bc["success_rate"] == 1.0
+    ht = bc["harness_terminated"]
+    assert ht["runs"] == 1
+    assert ht["by_cause"] == {"stuck_pattern": 1}
+    assert bc.get("max_killed_timeout_s", 0.0) == 0.0  # stuck is not a kill floor
+
+
+def test_harness_terminated_cost_segregated_from_capability_avg_cost():
+    """Killed-run spend stays visible under harness_terminated without diluting
+    the capability avg_cost_usd."""
+    data: dict = {"models": {}}
+    _baseline_medium_run(data)  # cost 1.0
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=0.50,  # killed run still spent money
+            dev_duration_s=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=900,
+            dev_termination_cause="timeout",
+        ),
+    )
+    bc = data["models"]["sonnet"]["dev"]["by_complexity"]["medium"]
+    assert bc["avg_cost_usd"] == 1.0  # only the completed run's cost
+    assert bc["harness_terminated"]["_cost_sum"] == 0.5
+    assert bc["harness_terminated"]["avg_cost_usd"] == 0.5
+
+
+def test_get_dev_success_rate_unchanged_by_interleaved_kill():
+    """Regression: get_dev_success_rate returns the same value with and without an
+    interleaved harness-killed run."""
+    clean: dict = {"models": {}}
+    dirty: dict = {"models": {}}
+    for _ in range(3):
+        _baseline_medium_run(clean, success=True)
+        _baseline_medium_run(dirty, success=True)
+    apply_run(
+        dirty,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=900,
+            dev_termination_cause="timeout",
+        ),
+    )
+    rate_clean = get_dev_success_rate(clean, "sonnet", "medium", min_runs=1)
+    rate_dirty = get_dev_success_rate(dirty, "sonnet", "medium", min_runs=1)
+    assert rate_clean == rate_dirty == 1.0
+
+
+def test_zero_dev_bucket_resets_harness_terminated():
+    from theforge.model_profiles import reset_profile_data
+
+    data: dict = {"models": {}}
+    _baseline_medium_run(data)
+    apply_run(
+        data,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=900,
+            dev_termination_cause="timeout",
+        ),
+    )
+    updated, _ = reset_profile_data(data, "sonnet", role="dev", complexity="medium")
+    bc = updated["models"]["sonnet"]["dev"]["by_complexity"]["medium"]
+    assert bc["harness_terminated"]["runs"] == 0
+    assert bc["harness_terminated"]["by_cause"] == {}
+
+
+def test_recompute_dev_section_aggregates_harness_terminated():
+    from theforge.model_profiles import _recompute_dev_section
+
+    section = {
+        "by_complexity": {
+            "small": {"runs": 1, "harness_terminated": {"runs": 1, "by_cause": {"timeout": 1}}},
+            "medium": {
+                "runs": 2,
+                "harness_terminated": {"runs": 2, "by_cause": {"timeout": 1, "stuck_pattern": 1}},
+            },
+            "large": {"runs": 0},
+        }
+    }
+    _recompute_dev_section(section)
+    ht = section["harness_terminated"]
+    assert ht["runs"] == 3
+    assert ht["by_cause"] == {"timeout": 2, "stuck_pattern": 1}
+
+
+def test_merge_dev_sums_harness_terminated():
+    from theforge.model_profiles import _merge_dev
+
+    src_a: dict = {"models": {}}
+    _baseline_medium_run(src_a)
+    apply_run(
+        src_a,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=900,
+            dev_termination_cause="timeout",
+        ),
+    )
+    src_b: dict = {"models": {}}
+    _baseline_medium_run(src_b)
+    apply_run(
+        src_b,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_termination_cause="stuck_pattern",
+        ),
+    )
+    target = src_a["models"]["sonnet"]["dev"]
+    _merge_dev(target, src_b["models"]["sonnet"]["dev"])
+    assert target["harness_terminated"]["runs"] == 2
+    assert target["harness_terminated"]["by_cause"] == {"timeout": 1, "stuck_pattern": 1}
+    bc = target["by_complexity"]["medium"]
+    assert bc["harness_terminated"]["runs"] == 2
+
+
+def test_merge_dev_tolerates_legacy_src_without_harness_terminated():
+    from theforge.model_profiles import _merge_dev
+
+    holder: dict = {"models": {}}
+    _baseline_medium_run(holder)
+    apply_run(
+        holder,
+        RunOutcome(
+            complexity="medium",
+            complexity_score=5,
+            dev_model="sonnet",
+            dev_success=False,
+            dev_iterations=1,
+            dev_cost_usd=None,
+            dev_timeout_killed=True,
+            dev_timeout_limit_s=900,
+            dev_termination_cause="timeout",
+        ),
+    )
+    target = holder["models"]["sonnet"]["dev"]
+    legacy_src = {"runs": 2, "success_rate": 1.0, "avg_iterations": 3.0, "avg_cost_usd": 1.0}
+    _merge_dev(target, legacy_src)
+    # Target's own tally survives a legacy merge (no harness_terminated on src).
+    assert target["harness_terminated"]["runs"] == 1

--- a/tests/test_model_profiles_bridge.py
+++ b/tests/test_model_profiles_bridge.py
@@ -259,3 +259,38 @@ def test_build_run_outcome_no_kill_flag_is_not_killed_despite_stale_timeout_tail
     state.dev_iteration_telemetry = [_dev_telemetry(is_timeout=True)]
     outcome = build_run_outcome(_Cfg(), state, success=True)
     assert outcome.dev_timeout_killed is False
+
+
+def test_build_run_outcome_termination_cause_timeout():
+    """A timeout kill sets dev_termination_cause='timeout' so the aggregator can
+    segregate the run out of capability stats (#1763)."""
+    state = _state_with_dev_costs([0.30])
+    state.adaptive_dev_timeout_seconds = 1350
+    state.dev_process_timeout_killed = True
+    outcome = build_run_outcome(_Cfg(), state, success=False)
+    assert outcome.dev_termination_cause == "timeout"
+
+
+def test_build_run_outcome_termination_cause_stuck():
+    """A stuck-pattern terminate sets dev_termination_cause='stuck_pattern'."""
+    state = _state_with_dev_costs([0.30])
+    state.dev_process_stuck_terminated = True
+    outcome = build_run_outcome(_Cfg(), state, success=False)
+    assert outcome.dev_termination_cause == "stuck_pattern"
+    assert outcome.dev_timeout_killed is False
+
+
+def test_build_run_outcome_termination_cause_timeout_precedence():
+    """When both flags are set, timeout takes precedence over stuck."""
+    state = _state_with_dev_costs([0.30])
+    state.dev_process_timeout_killed = True
+    state.dev_process_stuck_terminated = True
+    outcome = build_run_outcome(_Cfg(), state, success=False)
+    assert outcome.dev_termination_cause == "timeout"
+
+
+def test_build_run_outcome_no_termination_cause_on_clean_run():
+    """A run the model finished (no harness kill) carries no termination cause."""
+    state = _state_with_dev_costs([0.30])
+    outcome = build_run_outcome(_Cfg(), state, success=True)
+    assert outcome.dev_termination_cause is None

--- a/tests/test_profiles_reset.py
+++ b/tests/test_profiles_reset.py
@@ -295,3 +295,35 @@ def test_profiles_list_shows_zeroed_bucket_after_reset(capsys, tmp_path):
     assert "small" in stdout
     assert "anthropic/sonnet/cli  dev   small" in stdout
     assert "0          0     —" in stdout
+
+
+def test_profiles_list_shows_harness_terminated_column(capsys, tmp_path):
+    """The dev-role table surfaces a per-band harness-terminated tally so an
+    operator can see kills are recorded but excluded from `rate` (#1763)."""
+    fixture = _profiles_fixture()
+    fixture["models"][CANONICAL_ID]["dev"]["by_complexity"]["medium"]["harness_terminated"] = {
+        "runs": 2,
+        "by_cause": {"timeout": 2},
+    }
+    project_root = _write_profiles(tmp_path, fixture)
+
+    parser = build_parser()
+    list_args = parser.parse_args(
+        [
+            "profiles",
+            "list",
+            "--project-root",
+            str(project_root),
+            "--model",
+            CANONICAL_ID,
+            "--role",
+            "dev",
+        ]
+    )
+    assert cmd_profiles(list_args) == 0
+
+    stdout = capsys.readouterr().out
+    assert "terminated" in stdout  # header rendered
+    # The medium band shows its 2 terminations; capability rate is unchanged.
+    lines = [ln for ln in stdout.splitlines() if "medium" in ln]
+    assert lines and lines[0].rstrip().endswith("2")


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change segregates deadline and stuck-pattern dev terminations from capability statistics, and the targeted profile tests pass. | [google-gemini-3.5-flash] The implementation successfully segregates harness-imposed terminations from model capability statistics, preventing routing contamination.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $6.08
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Harness-imposed kills are recorded as model failures — starved runs poison success_rate, avg_iterations, and routing (GitHub Issue #1763)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1763