### PR TITLE
bug: sprint death leaks agent subprocess to init — orphaned codex process holds workspace-write sandbox indefinitely

### DIFF
--- a/src/theforge/cli/run.py
+++ b/src/theforge/cli/run.py
@@ -120,6 +120,9 @@ def cmd_run(args: "argparse.Namespace") -> int:
             # daemonize_run never returns in the parent.
     else:
         run_id = _generate_run_id()
+        # --fg / --dry-run stay in the foreground (no setup_detached_child), so
+        # publish the run context here too for agent process-group registration.
+        _detach.export_run_context(run_id, config.project_root)
 
     import theforge
 

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -239,6 +239,15 @@ def cmd_sprint(args: object) -> int:
         run_id = _generate_run_id()
         slug = manifest_path.stem
 
+    # Publish run context for agent process-group registration. setup_detached_child
+    # already exports on the detached path; this covers the --fg path (idempotent).
+    _detach.export_run_context(run_id, config.project_root)
+    # Reap any agent groups orphaned by an abruptly-killed prior sprint before we
+    # launch new work (the guaranteed path for the SIGKILL-parent case).
+    from theforge import process_group as _process_group  # noqa: PLC0415
+
+    _process_group.reap_orphan_agents(config.project_root)
+
     if getattr(args, "detach", False) and _daemon.is_daemon_running(config.project_root):
         release_story_locks(locked_fds)
         sprint_args: dict = {
@@ -792,6 +801,14 @@ def _run_query_mode(
     gate_run_id = (
         (args.__dict__.get("_detached_run_id") or _generate_run_id()) if not dry_run else None
     )
+    if not dry_run and gate_run_id is not None:
+        # Publish run context for agent process-group registration (idempotent with
+        # setup_detached_child) and reap groups orphaned by an abruptly-killed
+        # prior sprint before launching new work.
+        _detach.export_run_context(gate_run_id, config.project_root)
+        from theforge import process_group as _process_group  # noqa: PLC0415
+
+        _process_group.reap_orphan_agents(config.project_root)
     gate_sprint_name = getattr(args, "name", None) or milestone or label or f"issues-{issues_arg}"
     # Carry-across-re-exec: a prior process may have intake-remediated some
     # issues and stashed their numbers in the environment before re-exec.

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -429,6 +429,12 @@ def cmd_status(args: object) -> int:
     config = load_config(config_path)
     project_root = config.project_root
 
+    # Reap agent process groups orphaned by an abruptly-killed sprint. Natural
+    # adjacency to list_active_runs, which already prunes stale PID files.
+    from theforge import process_group as _process_group
+
+    _process_group.reap_orphan_agents(project_root)
+
     recent = getattr(args, "recent", False)
     last = getattr(args, "last", False)
     explicit_run_id: str | None = getattr(args, "run_id", None)
@@ -754,12 +760,16 @@ def _cleanup_stopped_run(
     pid: int | None = None,
 ) -> None:
     from theforge import detach as _detach
+    from theforge import process_group as _process_group
     from theforge.sprint.lock import cleanup_story_locks
 
     lock_slugs = _stopped_run_lock_slugs(run_id, project_root, slug)
     _detach.remove_pid(run_id, project_root)
     _detach.write_run_ended(run_id, project_root, "stopped", force=True)
     cleanup_story_locks(lock_slugs, project_root, pid=pid)
+    # The stopped sprint's own teardown may not have reached its agent groups
+    # (SIGKILL path); reap any now-orphaned groups.
+    _process_group.reap_orphan_agents(project_root)
 
 
 def cmd_stop(args: object) -> int:

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from theforge.log_level import LogLevel
 from theforge.log_util import _log_line
+from theforge.process_group import is_killable_pgid
 from theforge.workspace_env import build_workspace_env
 
 # Stable reference captured at import time so test patches that replace the
@@ -153,12 +154,23 @@ def resolve_timeout_with_active(
 
 
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:
-    """Best-effort kill for a spawned shell process group."""
+    """Best-effort kill for a spawned shell process group.
+
+    Only ``killpg`` a pgid that denotes a real group (``> 1``); a bogus ``<= 1``
+    value would broadcast SIGKILL across the whole session (see
+    ``process_group.is_killable_pgid`` / #1793). Fall back to terminating just the
+    direct child when the group id is unknown or unkillable.
+    """
     try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        return
+        pgid = os.getpgid(proc.pid)
     except OSError:
-        pass
+        pgid = None
+    if is_killable_pgid(pgid):
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+            return
+        except OSError:
+            pass
     try:
         proc.terminate()
     except OSError:

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -24,6 +24,9 @@ from typing import Any
 _DETACHED_ENV = "FORGE_DETACHED"
 _DETACHED_RUN_ID_ENV = "FORGE_DETACHED_RUN_ID"
 _DETACHED_SLUG_ENV = "FORGE_DETACHED_SLUG"
+# Orchestrator project root, published so deep-in-stack runners can locate the
+# .forge/runs/agents sidecar dir for process-group registration.
+_PROJECT_ROOT_ENV = "FORGE_PROJECT_ROOT"
 
 # Module-level list to prevent GC of App Nap activity tokens
 _APP_NAP_ACTIVITIES: list[Any] = []
@@ -364,6 +367,20 @@ def is_detached_child() -> bool:
     return os.environ.get(_DETACHED_ENV) == "1"
 
 
+def export_run_context(run_id: str, project_root: Path) -> None:
+    """Publish (run_id, project_root) into the environment for deep-in-stack code.
+
+    The CLI runners spawn agent subprocesses far below where ``project_root`` is
+    known; they need it to register spawned process groups into the orchestrator's
+    ``.forge/runs/agents`` sidecar dir (see ``theforge.process_group``). Export it
+    here rather than threading it through the runner API. ``FORGE_DETACHED_RUN_ID``
+    is already set on the detached path; set it too so the foreground/``--fg`` path
+    records the run id as well.
+    """
+    os.environ[_PROJECT_ROOT_ENV] = str(project_root)
+    os.environ.setdefault(_DETACHED_RUN_ID_ENV, run_id)
+
+
 def setup_detached_child(
     run_id: str, slug: str, project_root: Path, *, is_sprint: bool = False
 ) -> None:
@@ -377,6 +394,7 @@ def setup_detached_child(
     log_file = project_root / ".forge" / "logs" / slug / f"run-{run_id}.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
+    export_run_context(run_id, project_root)
     write_pid(run_id, slug, project_root)
     if is_sprint:
         write_sprint_marker(run_id, project_root)

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -166,17 +166,18 @@ def unregister_agent_group(pgid: int) -> None:
         pass
 
 
-def _is_killable_pgid(pgid: object) -> bool:
-    """True only for a pgid that can denote a real, spawned agent group.
+def is_killable_pgid(pgid: object) -> bool:
+    """True only for a pgid that can denote a real, spawned process group.
 
-    A group launched via ``start_new_session=True`` is led by its child, so its
-    pgid equals that child's pid and is always ``> 1``. Values ``<= 1`` are never
-    an agent group and are catastrophic as ``killpg`` targets: ``os.killpg(0)``
-    signals the *caller's own* group, and ``os.killpg(1)`` is ``kill(-1, …)`` — a
-    broadcast to every process the user may signal. A non-int (e.g. a test
-    double's unset ``pid`` coerced through ``__index__`` to ``1``) is likewise not
-    a real group. Refusing these keeps a bogus pgid from taking down the process
-    tree (issue #1793).
+    Shared safety rule for every ``killpg`` call site (the agent runners and the
+    coordinator's shell-timeout kill). A group launched via
+    ``start_new_session=True`` is led by its child, so its pgid equals that
+    child's pid and is always ``> 1``. Values ``<= 1`` are never such a group and
+    are catastrophic as ``killpg`` targets: ``os.killpg(0)`` signals the
+    *caller's own* group, and ``os.killpg(1)`` is ``kill(-1, …)`` — a broadcast to
+    every process the user may signal. A non-int (e.g. a test double's unset
+    ``pid`` coerced through ``__index__`` to ``1``) is likewise not a real group.
+    Refusing these keeps a bogus pgid from taking down the process tree (#1793).
     """
     return isinstance(pgid, int) and pgid > 1
 
@@ -189,7 +190,7 @@ def kill_agent_group(pgid: int) -> None:
     SIGKILL that would take down the whole process tree — including sibling test
     workers and the CI runner (issue #1793).
     """
-    if not _is_killable_pgid(pgid):
+    if not is_killable_pgid(pgid):
         return
     try:
         os.killpg(pgid, signal.SIGKILL)

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -1,0 +1,230 @@
+"""Process-group isolation, pgid registry sidecars, and an orphan reaper.
+
+Agent CLI subprocesses (``codex``, ``claude``, …) spawn their own child trees
+(``npm exec`` → ``node`` → the provider binary). When a sprint process dies —
+cleanly, on error, or by an external ``kill -9`` — those trees must die with it.
+Two mechanisms cooperate:
+
+1. **Group-isolated spawn** (`run_in_process_group`) — every agent subprocess is
+   launched with ``start_new_session=True`` so it leads its own process group.
+   On timeout or any teardown the whole group is ``killpg``-ed, so grandchildren
+   (node, the provider leaf binary) die too — a bare ``proc.kill()`` reaches only
+   the direct child.
+2. **Orphan reaper** (`reap_orphan_agents`) — synchronous group-kill cannot run
+   when the parent sprint is ``SIGKILL``-ed, so each spawned group records its
+   pgid + owner pid in a sidecar under ``.forge/runs/agents/``. A later ``forge``
+   invocation (status/stop/sprint-startup) sweeps those sidecars and ``killpg``-s
+   any group whose owner sprint is no longer alive.
+
+Stdlib-only by design (convention 4) so it can be imported by both the runners
+and the CLI without pulling in heavier dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from pathlib import Path
+from typing import Any
+
+# Env seams: register/unregister resolve the orchestrator runs dir from
+# FORGE_PROJECT_ROOT (set at run bootstrap); run_id is the detached run id.
+_PROJECT_ROOT_ENV = "FORGE_PROJECT_ROOT"
+_RUN_ID_ENV = "FORGE_DETACHED_RUN_ID"
+
+
+def _log(msg: str) -> None:
+    # Local import keeps this module stdlib-only at import time.
+    from theforge.log_util import _log_line  # noqa: PLC0415
+
+    _log_line("[forge]", msg)
+
+
+# ── Group-isolated spawn ─────────────────────────────────────────────
+
+
+def run_in_process_group(
+    cmd: list[str],
+    *,
+    timeout: float | None = None,
+    input: str | None = None,
+    capture_output: bool = False,
+    text: bool = False,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+) -> subprocess.CompletedProcess[Any]:
+    """``subprocess.run`` that isolates the child into its own process group.
+
+    Returns a ``subprocess.CompletedProcess`` with the same shape ``subprocess.run``
+    would produce. On ``subprocess.TimeoutExpired`` — or any other ``BaseException``
+    raised while the child runs — the *entire* process group is ``SIGKILL``-ed
+    before the exception is re-raised, so npm→node→leaf grandchildren cannot
+    outlive the call. ``subprocess.run``'s own timeout kill signals only the
+    direct child (``npm exec``), leaving node + the provider leaf alive.
+    """
+    stdout = subprocess.PIPE if capture_output else None
+    stderr = subprocess.PIPE if capture_output else None
+    stdin = subprocess.PIPE if input is not None else None
+
+    proc = subprocess.Popen(  # noqa: S603
+        cmd,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        text=text,
+        env=env,
+        cwd=cwd,
+        start_new_session=True,
+    )
+    # Register the group so the reaper can kill it if the sprint is SIGKILL-ed
+    # while communicate() blocks in its heartbeat thread (no synchronous cleanup
+    # runs in that case). sandbox_dir defaults to cwd — the workspace grant.
+    try:
+        pgid = os.getpgid(proc.pid)
+    except OSError:
+        pgid = None
+    if pgid is not None:
+        register_agent_group(pgid, sandbox_dir=cwd)
+    try:
+        out, err = proc.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _killpg_for(proc.pid)
+        proc.wait()
+        raise
+    except BaseException:
+        _killpg_for(proc.pid)
+        proc.wait()
+        raise
+    finally:
+        if pgid is not None:
+            unregister_agent_group(pgid)
+    return subprocess.CompletedProcess(proc.args, proc.returncode, out, err)
+
+
+def _killpg_for(pid: int) -> None:
+    """Best-effort ``SIGKILL`` of the process group led by *pid*."""
+    try:
+        kill_agent_group(os.getpgid(pid))
+    except OSError:
+        pass
+
+
+# ── pgid registry sidecars ───────────────────────────────────────────
+
+
+def _agents_dir_from_env() -> Path | None:
+    """Resolve ``.forge/runs/agents`` from ``FORGE_PROJECT_ROOT``, or None."""
+    raw = os.environ.get(_PROJECT_ROOT_ENV)
+    if not raw:
+        return None
+    return Path(raw) / ".forge" / "runs" / "agents"
+
+
+def _sidecar_path(agents_dir: Path, owner_pid: int, pgid: int) -> Path:
+    return agents_dir / f"{owner_pid}-{pgid}.json"
+
+
+def register_agent_group(pgid: int, *, sandbox_dir: str | Path | None = None) -> None:
+    """Record a spawned agent group's pgid so a later reaper can kill orphans.
+
+    Writes ``.forge/runs/agents/{owner_pid}-{pgid}.json`` under the orchestrator
+    runs dir, where ``owner_pid`` is the sprint process (``os.getpid()``). Per-pgid
+    files avoid write contention from parallel review pools. No-op when the runs
+    dir is unresolvable (e.g. ``FORGE_PROJECT_ROOT`` unset in tests).
+    """
+    agents_dir = _agents_dir_from_env()
+    if agents_dir is None:
+        return
+    owner_pid = os.getpid()
+    payload = {
+        "owner_pid": owner_pid,
+        "pgid": pgid,
+        "run_id": os.environ.get(_RUN_ID_ENV),
+        "sandbox_dir": str(sandbox_dir) if sandbox_dir is not None else None,
+    }
+    try:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        _sidecar_path(agents_dir, owner_pid, pgid).write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+    except OSError:
+        pass
+
+
+def unregister_agent_group(pgid: int) -> None:
+    """Remove the sidecar for a group that terminated normally."""
+    agents_dir = _agents_dir_from_env()
+    if agents_dir is None:
+        return
+    try:
+        _sidecar_path(agents_dir, os.getpid(), pgid).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+def kill_agent_group(pgid: int) -> None:
+    """Best-effort ``SIGKILL`` of an entire agent process group."""
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except OSError:
+        pass
+
+
+# ── Orphan reaper ────────────────────────────────────────────────────
+
+
+def reap_orphan_agents(project_root: Path) -> int:
+    """Kill agent groups whose owner sprint is dead; return the count reaped.
+
+    Sweeps ``.forge/runs/agents/*.json``. For each sidecar whose ``owner_pid`` is
+    no longer alive, ``killpg`` the recorded group, unlink the sidecar, and log the
+    reaped sandbox path loudly. Groups whose owner is still alive are left intact.
+    This is the guaranteed path for the abrupt-``SIGKILL`` case, where the
+    synchronous group kill in `run_in_process_group` never got to run.
+    """
+    from theforge.detach import _is_pid_alive  # noqa: PLC0415
+
+    agents_dir = project_root / ".forge" / "runs" / "agents"
+    if not agents_dir.exists():
+        return 0
+
+    reaped = 0
+    for sidecar in sorted(agents_dir.glob("*.json")):
+        try:
+            data = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # Corrupt/unreadable sidecar — drop it so it doesn't linger forever.
+            _unlink(sidecar)
+            continue
+
+        owner_pid = data.get("owner_pid")
+        pgid = data.get("pgid")
+        if not isinstance(owner_pid, int) or not isinstance(pgid, int):
+            _unlink(sidecar)
+            continue
+
+        if _is_pid_alive(owner_pid):
+            # Sprint still running — its own teardown owns this group.
+            continue
+
+        sandbox = data.get("sandbox_dir")
+        _log(
+            f"  reaping orphaned agent process group pgid={pgid} "
+            f"(owner sprint pid={owner_pid} is dead, sandbox={sandbox})"
+        )
+        kill_agent_group(pgid)
+        _unlink(sidecar)
+        reaped += 1
+
+    return reaped
+
+
+def _unlink(path: Path) -> None:
+    try:
+        path.unlink()
+    except OSError:
+        pass

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -166,8 +166,31 @@ def unregister_agent_group(pgid: int) -> None:
         pass
 
 
+def _is_killable_pgid(pgid: object) -> bool:
+    """True only for a pgid that can denote a real, spawned agent group.
+
+    A group launched via ``start_new_session=True`` is led by its child, so its
+    pgid equals that child's pid and is always ``> 1``. Values ``<= 1`` are never
+    an agent group and are catastrophic as ``killpg`` targets: ``os.killpg(0)``
+    signals the *caller's own* group, and ``os.killpg(1)`` is ``kill(-1, …)`` — a
+    broadcast to every process the user may signal. A non-int (e.g. a test
+    double's unset ``pid`` coerced through ``__index__`` to ``1``) is likewise not
+    a real group. Refusing these keeps a bogus pgid from taking down the process
+    tree (issue #1793).
+    """
+    return isinstance(pgid, int) and pgid > 1
+
+
 def kill_agent_group(pgid: int) -> None:
-    """Best-effort ``SIGKILL`` of an entire agent process group."""
+    """Best-effort ``SIGKILL`` of an entire agent process group.
+
+    A pgid ``<= 1`` (or a non-int) is treated as "no group to kill" rather than
+    passed to ``killpg``: ``os.killpg(1, …)`` is ``kill(-1, …)``, a broadcast
+    SIGKILL that would take down the whole process tree — including sibling test
+    workers and the CI runner (issue #1793).
+    """
+    if not _is_killable_pgid(pgid):
+        return
     try:
         os.killpg(pgid, signal.SIGKILL)
     except OSError:

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -666,6 +666,36 @@ def _run_claude(
             env=env,
             start_new_session=True,
         )
+    except FileNotFoundError:
+        return AgentResult(
+            success=False,
+            output="ERROR: 'claude' CLI not found. Is it installed?",
+            session_id=None,
+            cost_usd=None,
+            exit_code=-1,
+            raw={},
+            profile_name=profile.name,
+            startup_failure=True,
+        )
+
+    def _kill_group() -> None:
+        # Kill the whole process group so node/tool grandchildren die too — a
+        # bare proc.kill() reaches only the direct child. Fall back to the
+        # direct child if the pgid is unknown or already gone.
+        if pgid is not None:
+            process_group.kill_agent_group(pgid)
+        else:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+
+    # Any exception raised after spawn — the SystemExit that detach.py's SIGTERM
+    # handler raises while this thread is blocked reading stdout, a
+    # KeyboardInterrupt, or any error — must kill the whole group before the
+    # finally drops the sidecar; otherwise the agent tree reparents to init still
+    # holding its workspace-write sandbox, with no record left for the reaper.
+    try:
         try:
             pgid = os.getpgid(proc.pid)
         except (OSError, TypeError):
@@ -682,18 +712,6 @@ def _run_claude(
 
         lines: list[str] = []
         assert proc.stdout is not None
-
-        def _kill_group() -> None:
-            # Kill the whole process group so node/tool grandchildren die too — a
-            # bare proc.kill() reaches only the direct child. Fall back to the
-            # direct child if the pgid is unknown or already gone.
-            if pgid is not None:
-                process_group.kill_agent_group(pgid)
-            else:
-                try:
-                    proc.kill()
-                except OSError:
-                    pass
 
         # Enforce wall-clock timeout on the streaming loop via a watchdog thread.
         # proc.wait(timeout=...) only fires after stdout is drained, which never
@@ -761,20 +779,14 @@ def _run_claude(
         except (BrokenPipeError, ValueError, OSError):
             pass
         proc.wait()
-    except FileNotFoundError:
-        return AgentResult(
-            success=False,
-            output="ERROR: 'claude' CLI not found. Is it installed?",
-            session_id=None,
-            cost_usd=None,
-            exit_code=-1,
-            raw={},
-            profile_name=profile.name,
-            startup_failure=True,
-        )
+    except BaseException:
+        # SIGTERM→SystemExit, KeyboardInterrupt, or any post-spawn error: kill the
+        # whole group so it cannot outlive this process, then re-raise.
+        _kill_group()
+        raise
     finally:
-        # The group is gone by now (normal exit or _kill_group); drop its sidecar
-        # so the reaper doesn't chase a dead pgid on the next forge invocation.
+        # The group is dead by now (normal exit, an in-loop _kill_group, or the
+        # except above); drop its sidecar so the reaper doesn't chase a dead pgid.
         if pgid is not None:
             process_group.unregister_agent_group(pgid)
 

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -7,12 +7,14 @@ streams JSONL events, and returns an AgentResult.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import threading
 import time
 from pathlib import Path
 from typing import Any
 
+from theforge import process_group
 from theforge.agent_types import AgentResult, ModelUsage
 from theforge.log_util import _log_line
 from theforge.runners.stuck_detection import StuckTracker, build_observation
@@ -646,7 +648,14 @@ def _run_claude(
     deadline = start + profile.timeout_seconds
     timed_out = False
     stuck_monitor = _ClaudeStreamMonitor(profile)
+    # Track the spawned process group so every teardown branch kills the whole
+    # node/tool grandchild tree (not just the direct child) and the reaper can
+    # clean up if the sprint is SIGKILL-ed mid-run. Defined before the try so the
+    # finally can unregister even if Popen itself raises.
+    pgid: int | None = None
     try:
+        # start_new_session=True isolates the CLI (and its node/tool children)
+        # into their own process group, making the whole tree killable at once.
         proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -655,7 +664,15 @@ def _run_claude(
             text=True,
             cwd=str(working_dir),
             env=env,
+            start_new_session=True,
         )
+        try:
+            pgid = os.getpgid(proc.pid)
+        except (OSError, TypeError):
+            # OSError: child already gone. TypeError: non-int pid (test doubles).
+            pgid = None
+        if pgid is not None:
+            process_group.register_agent_group(pgid, sandbox_dir=working_dir)
         assert proc.stdin is not None
         # Send the initial prompt as a stream-json user message. stdin is kept
         # open so stuck-detection nudges can be injected as additional user
@@ -665,6 +682,18 @@ def _run_claude(
 
         lines: list[str] = []
         assert proc.stdout is not None
+
+        def _kill_group() -> None:
+            # Kill the whole process group so node/tool grandchildren die too — a
+            # bare proc.kill() reaches only the direct child. Fall back to the
+            # direct child if the pgid is unknown or already gone.
+            if pgid is not None:
+                process_group.kill_agent_group(pgid)
+            else:
+                try:
+                    proc.kill()
+                except OSError:
+                    pass
 
         # Enforce wall-clock timeout on the streaming loop via a watchdog thread.
         # proc.wait(timeout=...) only fires after stdout is drained, which never
@@ -676,12 +705,12 @@ def _run_claude(
                 if proc.poll() is not None:
                     return
                 if stop_event is not None and stop_event.is_set():
-                    proc.kill()
+                    _kill_group()
                     return
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     if proc.poll() is None:
-                        proc.kill()
+                        _kill_group()
                     return
                 time.sleep(min(0.5, remaining))
 
@@ -704,14 +733,14 @@ def _run_claude(
                     f"{stuck_monitor.iteration_count} iterations: "
                     f"{stuck_monitor.terminate_pattern}"
                 )
-                proc.kill()
+                _kill_group()
                 break
             if stop_event is not None and stop_event.is_set():
-                proc.kill()
+                _kill_group()
                 timed_out = True
                 break
             if time.monotonic() > deadline:
-                proc.kill()
+                _kill_group()
                 timed_out = True
                 break
             # Break as soon as the result event arrives — the stream is complete.
@@ -743,6 +772,11 @@ def _run_claude(
             profile_name=profile.name,
             startup_failure=True,
         )
+    finally:
+        # The group is gone by now (normal exit or _kill_group); drop its sidecar
+        # so the reaper doesn't chase a dead pgid on the next forge invocation.
+        if pgid is not None:
+            process_group.unregister_agent_group(pgid)
 
     if stuck_monitor.should_terminate:
         partial_output = "".join(lines)

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 import json
 import os
 import re
-import subprocess
 import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from theforge import process_group
 from theforge.agent_types import AgentResult, ModelUsage
 from theforge.log_util import _log_line
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
@@ -312,7 +312,10 @@ def _run_codex(
     label = profile.name or f"{profile.cli or profile.provider}/{profile.model}"
     _codex_env = build_workspace_env(working_dir, extra=secrets)
     outcome, elapsed = _run_with_heartbeat(
-        run_fn=lambda: subprocess.run(
+        # Group-isolated spawn: subprocess.run's own timeout kill reaches only
+        # `npm exec`, leaving node + the codex leaf alive. run_in_process_group
+        # killpg-s the whole npm→node→codex tree on timeout/teardown.
+        run_fn=lambda: process_group.run_in_process_group(
             cmd,
             input=stdin_prompt,
             capture_output=True,

--- a/tests/fake_bin/claude
+++ b/tests/fake_bin/claude
@@ -18,6 +18,10 @@ Controlled via FAKE_CLAUDE_MODE environment variable:
                 its PID to $FAKE_GRANDCHILD_PID_FILE, then emit nothing and
                 hang so the runner's timeout/stop path fires. Proves the group
                 kill reaches grandchildren, not just the direct child.
+  grandchild_stream
+              — like grandchild_hang but emit one non-result line first so the
+                runner's stream loop runs at least once; lets a test raise an
+                exception mid-stream to exercise the except-BaseException kill.
 """
 from __future__ import annotations
 
@@ -77,12 +81,16 @@ def _emit_tool_iteration() -> None:
     _emit({"type": "user", "message": {"role": "user", "content": [_TOOL_RESULT_ITEM]}})
 
 
-def _spawn_grandchild_and_hang() -> None:
+def _spawn_grandchild_and_hang(*, stream_first: bool = False) -> None:
     """Spawn a sleeping grandchild in this process group, record its PID, hang.
 
     The grandchild inherits this process's group (no start_new_session), so a
     group kill must reach it. A bare kill of the direct child (this fake CLI)
     would leave the grandchild alive — exactly the leak the fix closes.
+
+    When ``stream_first`` is set, emit one non-result assistant line before
+    hanging so the runner's stream loop body runs at least once (lets a test
+    inject an exception mid-stream to exercise the except-BaseException path).
     """
     _read_user_msg()
     grandchild = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
@@ -90,7 +98,10 @@ def _spawn_grandchild_and_hang() -> None:
     if pidfile:
         with open(pidfile, "w") as fh:
             fh.write(str(grandchild.pid))
-    # Emit nothing and hang so the runner's watchdog/stop path fires.
+    if stream_first:
+        _emit({"type": "assistant", "message": {"role": "assistant", "content": []}})
+        sys.stdout.flush()
+    # Emit nothing further and hang so the runner's teardown path fires.
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         time.sleep(0.1)
@@ -100,6 +111,9 @@ def _spawn_grandchild_and_hang() -> None:
 def main() -> None:
     if MODE == "grandchild_hang":
         _spawn_grandchild_and_hang()
+
+    if MODE == "grandchild_stream":
+        _spawn_grandchild_and_hang(stream_first=True)
 
     if MODE == "hang":
         # Consume initial prompt but never produce output; sleep until killed.

--- a/tests/fake_bin/claude
+++ b/tests/fake_bin/claude
@@ -13,11 +13,17 @@ Controlled via FAKE_CLAUDE_MODE environment variable:
   nudge       — emit two identical tool-call iterations to trigger stuck-
                 detection nudge, then read the nudge from stdin and respond
                 with a result event (nudge delivery test)
+  grandchild_hang
+              — spawn a long-sleeping grandchild (same process group), write
+                its PID to $FAKE_GRANDCHILD_PID_FILE, then emit nothing and
+                hang so the runner's timeout/stop path fires. Proves the group
+                kill reaches grandchildren, not just the direct child.
 """
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
 
@@ -71,7 +77,30 @@ def _emit_tool_iteration() -> None:
     _emit({"type": "user", "message": {"role": "user", "content": [_TOOL_RESULT_ITEM]}})
 
 
+def _spawn_grandchild_and_hang() -> None:
+    """Spawn a sleeping grandchild in this process group, record its PID, hang.
+
+    The grandchild inherits this process's group (no start_new_session), so a
+    group kill must reach it. A bare kill of the direct child (this fake CLI)
+    would leave the grandchild alive — exactly the leak the fix closes.
+    """
+    _read_user_msg()
+    grandchild = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    pidfile = os.environ.get("FAKE_GRANDCHILD_PID_FILE")
+    if pidfile:
+        with open(pidfile, "w") as fh:
+            fh.write(str(grandchild.pid))
+    # Emit nothing and hang so the runner's watchdog/stop path fires.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        time.sleep(0.1)
+    sys.exit(0)
+
+
 def main() -> None:
+    if MODE == "grandchild_hang":
+        _spawn_grandchild_and_hang()
+
     if MODE == "hang":
         # Consume initial prompt but never produce output; sleep until killed.
         # Uses a short-sleep loop capped at 3s so the test stays under the 5s

--- a/tests/fake_bin/npx
+++ b/tests/fake_bin/npx
@@ -14,6 +14,11 @@ Codex (FAKE_CODEX_MODE):
                   v0.142.x human summary (a bare `tokens used` total, no split)
                   to stdout, so tests can assert it is recorded cost-unknown
                   rather than fabricating a cost from a total alone
+  grandchild_hang
+                — spawn a long-sleeping grandchild in the same process group
+                  (mirroring npm→node→codex), write its PID to
+                  $FAKE_GRANDCHILD_PID_FILE, then hang past the runner timeout.
+                  Proves the group kill reaches past `npm exec` to the leaf.
 
 Gemini (FAKE_GEMINI_MODE):
   happy  — print {"response": "Task complete."} to stdout, exit 0 (default)
@@ -22,7 +27,9 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
+import time
 
 args = sys.argv[1:]
 
@@ -70,6 +77,17 @@ if "@openai/codex" in args:
         # Real Codex CLI v0.142.x human summary: a bare total on its own line.
         print("tokens used")
         print("11,374")
+        sys.exit(0)
+    if mode == "grandchild_hang":
+        grandchild = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        pidfile = os.environ.get("FAKE_GRANDCHILD_PID_FILE")
+        if pidfile:
+            with open(pidfile, "w") as fh:
+                fh.write(str(grandchild.pid))
+        # Hang past the runner timeout so the group-kill path fires.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            time.sleep(0.1)
         sys.exit(0)
     sys.stderr.write(f"fake npx(codex): unknown FAKE_CODEX_MODE={mode!r}\n")
     sys.exit(1)

--- a/tests/test_coord_gate_exec.py
+++ b/tests/test_coord_gate_exec.py
@@ -863,6 +863,28 @@ def test_run_shell_timeout_ignores_missing_process_group(tmp_path):
     proc.wait.assert_called_once_with()
 
 
+def test_run_shell_timeout_refuses_broadcast_pgid(tmp_path):
+    """A pgid <= 1 (e.g. an unset mock pid coerced through __index__ to 1) must
+    never reach killpg: os.killpg(1, ...) is kill(-1, ...), a session-wide
+    broadcast SIGKILL (#1793). The kill falls back to terminating the child."""
+    proc = mock.Mock()
+    proc.pid = 4321
+    proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="pytest -n auto", timeout=1)
+
+    with (
+        patch("theforge.coordinator.util.subprocess.Popen", return_value=proc),
+        patch("theforge.coordinator.util.os.getpgid", return_value=1) as mock_getpgid,
+        patch("theforge.coordinator.util.os.killpg") as mock_killpg,
+    ):
+        ok, output = _cu._run_shell("pytest -n auto --dist worksteal", tmp_path, timeout=1)
+
+    assert ok is False
+    mock_getpgid.assert_called_once_with(4321)
+    mock_killpg.assert_not_called()
+    proc.terminate.assert_called_once_with()
+    proc.wait.assert_called_once_with()
+
+
 def test_run_shell_kills_process_group_on_keyboard_interrupt(tmp_path):
     proc = mock.MagicMock()
     proc.pid = 4321

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -1,0 +1,288 @@
+"""Lifecycle tests for process-group isolation and the orphan reaper.
+
+Per the runner-lifecycle invariant these exercise *real* subprocesses via
+``tests/fake_bin/`` fake CLIs, not ``Popen`` mocks — a mock cannot show that a
+group kill reaches grandchildren (node/tool leaf) that a bare ``proc.kill()``
+would leave alive.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from theforge import process_group
+from theforge.config import ModelProfile
+from theforge.runners.runner_claude import _run_claude
+from theforge.runners.runner_codex import _run_codex
+
+_FAKE_BIN = Path(__file__).parent / "fake_bin"
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+# ---------------------------------------------------------------------------
+# Orphan reaper
+# ---------------------------------------------------------------------------
+
+
+class TestReapOrphanAgents:
+    def _write_sidecar(
+        self, project_root: Path, owner_pid: int, pgid: int, sandbox: str | None = None
+    ) -> Path:
+        agents_dir = project_root / ".forge" / "runs" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        path = agents_dir / f"{owner_pid}-{pgid}.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "owner_pid": owner_pid,
+                    "pgid": pgid,
+                    "run_id": "run-test",
+                    "sandbox_dir": sandbox,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_dead_owner_group_is_killed_and_sidecar_unlinked(self, tmp_path: Path) -> None:
+        """A sidecar whose owner sprint is dead → its group is killpg-ed and the file removed."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        # Owner pid that is guaranteed dead (never-assigned high pid).
+        sidecar = self._write_sidecar(
+            tmp_path, owner_pid=999_999, pgid=pgid, sandbox=str(tmp_path)
+        )
+        try:
+            reaped = process_group.reap_orphan_agents(tmp_path)
+            assert reaped == 1
+            assert _wait_until(lambda: proc.poll() is not None), "group was not killed"
+            assert not sidecar.exists(), "sidecar was not unlinked after reaping"
+        finally:
+            process_group.kill_agent_group(pgid)
+            proc.wait(timeout=5)
+
+    def test_live_owner_group_is_left_untouched(self, tmp_path: Path) -> None:
+        """A sidecar whose owner sprint is still alive → the group is not touched."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        # Owner is this test process — alive.
+        sidecar = self._write_sidecar(tmp_path, owner_pid=os.getpid(), pgid=pgid)
+        try:
+            reaped = process_group.reap_orphan_agents(tmp_path)
+            assert reaped == 0
+            assert sidecar.exists(), "live-owner sidecar must not be removed"
+            assert proc.poll() is None, "live-owner group must not be killed"
+        finally:
+            process_group.kill_agent_group(pgid)
+            sidecar.unlink(missing_ok=True)
+            proc.wait(timeout=5)
+
+    def test_missing_agents_dir_is_noop(self, tmp_path: Path) -> None:
+        assert process_group.reap_orphan_agents(tmp_path) == 0
+
+    def test_corrupt_sidecar_is_dropped(self, tmp_path: Path) -> None:
+        agents_dir = tmp_path / ".forge" / "runs" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        bad = agents_dir / "garbage.json"
+        bad.write_text("not json", encoding="utf-8")
+        assert process_group.reap_orphan_agents(tmp_path) == 0
+        assert not bad.exists()
+
+
+# ---------------------------------------------------------------------------
+# Registry sidecars (register / unregister)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_register_and_unregister_roundtrip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+        monkeypatch.setenv("FORGE_DETACHED_RUN_ID", "run-xyz")
+        pgid = 4242
+        process_group.register_agent_group(pgid, sandbox_dir=tmp_path)
+        sidecar = tmp_path / ".forge" / "runs" / "agents" / f"{os.getpid()}-{pgid}.json"
+        assert sidecar.exists()
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert data["pgid"] == pgid
+        assert data["owner_pid"] == os.getpid()
+        assert data["run_id"] == "run-xyz"
+
+        process_group.unregister_agent_group(pgid)
+        assert not sidecar.exists()
+
+    def test_register_is_noop_without_project_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FORGE_PROJECT_ROOT", raising=False)
+        # Must not raise and must not create anything.
+        process_group.register_agent_group(1234, sandbox_dir=tmp_path)
+        process_group.unregister_agent_group(1234)
+        assert not (tmp_path / ".forge").exists()
+
+
+# ---------------------------------------------------------------------------
+# run_in_process_group
+# ---------------------------------------------------------------------------
+
+
+class TestRunInProcessGroup:
+    def test_returns_completed_process(self, tmp_path: Path) -> None:
+        result = process_group.run_in_process_group(
+            [sys.executable, "-c", "print('hello')"],
+            capture_output=True,
+            text=True,
+        )
+        assert isinstance(result, subprocess.CompletedProcess)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hello"
+
+    def test_timeout_kills_grandchild(self, tmp_path: Path) -> None:
+        """On timeout the whole group dies — a grandchild spawned by the child too."""
+        pidfile = tmp_path / "gc.pid"
+        script = (
+            "import subprocess,sys,time,pathlib;"
+            "gc=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+            f"pathlib.Path(r'{pidfile}').write_text(str(gc.pid));"
+            "time.sleep(30)"
+        )
+        with pytest.raises(subprocess.TimeoutExpired):
+            process_group.run_in_process_group(
+                [sys.executable, "-c", script],
+                timeout=1.5,
+                capture_output=True,
+                text=True,
+            )
+        assert _wait_until(pidfile.exists, timeout=2.0)
+        gc_pid = int(pidfile.read_text().strip())
+        assert _wait_until(lambda: not _pid_alive(gc_pid)), (
+            "grandchild survived group timeout kill"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Runner-level group kill (real fake-CLI subprocess trees)
+# ---------------------------------------------------------------------------
+
+
+class _RunnerGroupKillBase:
+    _FAKE_BIN: ClassVar[Path] = _FAKE_BIN
+
+    def _ensure_exec(self, name: str) -> None:
+        script = self._FAKE_BIN / name
+        script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    def _patch_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        module: str,
+        mode_var: str,
+        mode: str,
+        pidfile: Path,
+    ) -> None:
+        fake_bin = self._FAKE_BIN
+        from theforge.workspace_env import build_workspace_env as _orig
+
+        def _build(workspace_path, base_env=None, *, extra=None):  # type: ignore[no-untyped-def]
+            env = _orig(workspace_path, base_env, extra=extra)
+            env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+            env[mode_var] = mode
+            env["FAKE_GRANDCHILD_PID_FILE"] = str(pidfile)
+            return env
+
+        monkeypatch.setattr(f"theforge.runners.{module}.build_workspace_env", _build)
+
+
+class TestClaudeGroupKill(_RunnerGroupKillBase):
+    def test_timeout_kills_grandchild(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._ensure_exec("claude")
+        pidfile = tmp_path / "gc.pid"
+        self._patch_env(
+            monkeypatch, "runner_claude", "FAKE_CLAUDE_MODE", "grandchild_hang", pidfile
+        )
+        profile = ModelProfile(
+            name="dev",
+            cli="claude",
+            model="claude-sonnet-4-5",
+            budget_usd=2.0,
+            timeout_seconds=2,
+            allowed_tools=("Bash",),
+        )
+        result = _run_claude(
+            prompt="do the thing",
+            profile=profile,
+            working_dir=tmp_path,
+            fallback_to_file=False,
+        )
+        assert result.success is False
+        assert _wait_until(pidfile.exists, timeout=3.0), "fake claude never spawned the grandchild"
+        gc_pid = int(pidfile.read_text().strip())
+        assert _wait_until(lambda: not _pid_alive(gc_pid)), (
+            "grandchild survived the runner's group kill — bare proc.kill() regression"
+        )
+
+
+class TestCodexGroupKill(_RunnerGroupKillBase):
+    def test_timeout_kills_grandchild(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._ensure_exec("npx")
+        pidfile = tmp_path / "gc.pid"
+        self._patch_env(monkeypatch, "runner_codex", "FAKE_CODEX_MODE", "grandchild_hang", pidfile)
+        profile = ModelProfile(
+            name="dev",
+            cli="codex",
+            model="gpt-5-codex",
+            budget_usd=2.0,
+            timeout_seconds=2,
+            allowed_tools=("Bash",),
+            sandbox_mode="none",
+        )
+        result = _run_codex(
+            prompt="do the thing",
+            profile=profile,
+            working_dir=tmp_path,
+        )
+        # Timeout is surfaced as a failure (npm exec never returned output).
+        assert result.success is False
+        assert _wait_until(pidfile.exists, timeout=3.0), "fake codex never spawned the grandchild"
+        gc_pid = int(pidfile.read_text().strip())
+        assert _wait_until(lambda: not _pid_alive(gc_pid)), (
+            "grandchild survived past `npm exec` — group kill did not reach the leaf"
+        )

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import stat
 import subprocess
 import sys
@@ -153,6 +154,50 @@ class TestRegistry:
         process_group.register_agent_group(1234, sandbox_dir=tmp_path)
         process_group.unregister_agent_group(1234)
         assert not (tmp_path / ".forge").exists()
+
+
+# ---------------------------------------------------------------------------
+# kill_agent_group guard (issue #1793)
+# ---------------------------------------------------------------------------
+
+
+class TestKillAgentGroupGuard:
+    """``kill_agent_group`` must never hand a pgid <= 1 (or a non-int) to killpg.
+
+    ``os.killpg(1, sig)`` is ``kill(-1, sig)`` — a broadcast SIGKILL to every
+    process the user can signal — and ``os.killpg(0, sig)`` targets the caller's
+    own group. A subprocess test double whose ``pid`` is unset coerces through
+    ``__index__`` to 1, so ``os.getpgid(pid)`` returns 1 with no error; without
+    the guard the watchdog then broadcast-kills the whole session (the Linux CI
+    hang this bug was filed for).
+    """
+
+    @pytest.mark.parametrize("bad_pgid", [1, 0, -1, "1", None])
+    def test_unsafe_pgid_never_reaches_killpg(
+        self, bad_pgid: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[object, int]] = []
+        monkeypatch.setattr(process_group.os, "killpg", lambda pg, sig: calls.append((pg, sig)))
+        process_group.kill_agent_group(bad_pgid)  # type: ignore[arg-type]
+        assert calls == [], f"killpg was invoked for unsafe pgid={bad_pgid!r}"
+
+    def test_real_group_is_killed(self) -> None:
+        """A genuine spawned group (pgid > 1) is still SIGKILL-ed."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        assert pgid > 1
+        try:
+            process_group.kill_agent_group(pgid)
+            assert _wait_until(lambda: proc.poll() is not None), "real group not killed"
+        finally:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except OSError:
+                pass
+            proc.wait(timeout=5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -257,6 +257,51 @@ class TestClaudeGroupKill(_RunnerGroupKillBase):
             "grandchild survived the runner's group kill — bare proc.kill() regression"
         )
 
+    def test_exception_after_spawn_kills_group(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A SystemExit unwinding mid-stream must kill the group, not just drop the sidecar.
+
+        Simulates detach.py's SIGTERM handler raising SystemExit while _run_claude
+        is blocked reading the agent's stdout (forge stop's graceful path). Before
+        the fix, the sole ``except FileNotFoundError`` let SystemExit fall straight
+        into the ``finally`` that unregistered the sidecar without ever killing the
+        group — the exact leak this bug was filed to close.
+        """
+        self._ensure_exec("claude")
+        pidfile = tmp_path / "gc.pid"
+        self._patch_env(
+            monkeypatch, "runner_claude", "FAKE_CLAUDE_MODE", "grandchild_stream", pidfile
+        )
+
+        # Raise SystemExit the first time the runner processes a stream line —
+        # i.e. while it is inside the stdout loop with the agent tree alive.
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            raise SystemExit(0)
+
+        monkeypatch.setattr("theforge.runners.runner_claude._process_stream_event", _boom)
+
+        profile = ModelProfile(
+            name="dev",
+            cli="claude",
+            model="claude-sonnet-4-5",
+            budget_usd=2.0,
+            timeout_seconds=30,
+            allowed_tools=("Bash",),
+        )
+        with pytest.raises(SystemExit):
+            _run_claude(
+                prompt="do the thing",
+                profile=profile,
+                working_dir=tmp_path,
+                fallback_to_file=False,
+            )
+        assert _wait_until(pidfile.exists, timeout=3.0), "fake claude never spawned the grandchild"
+        gc_pid = int(pidfile.read_text().strip())
+        assert _wait_until(lambda: not _pid_alive(gc_pid)), (
+            "grandchild survived a SystemExit unwind — the except-BaseException kill regressed"
+        )
+
 
 class TestCodexGroupKill(_RunnerGroupKillBase):
     def test_timeout_kills_grandchild(

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -13,6 +13,9 @@ import pytest
 from theforge.config import ModelProfile
 from theforge.runners.runner_codex import _run_codex
 
+# Spawn seam patched by the argv-construction tests below.
+_RUN_TARGET = "theforge.runners.runner_codex.process_group.run_in_process_group"
+
 
 def _make_profile(
     sandbox_mode: str = "workspace-write",
@@ -39,7 +42,7 @@ def _make_subprocess_mock(returncode: int = 0) -> MagicMock:
 
 
 def _extract_codex_cmd(mock_run: MagicMock) -> list[str]:
-    """Return the cmd list from the subprocess.run call."""
+    """Return the cmd list from the process_group.run_in_process_group call."""
     return mock_run.call_args[0][0]
 
 
@@ -50,11 +53,9 @@ class TestCodexSandboxFlag:
         """sandbox_mode=workspace-write → --sandbox workspace-write in cmd."""
         profile = _make_profile(sandbox_mode="workspace-write")
         mock_proc = _make_subprocess_mock()
-        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+        with patch(_RUN_TARGET, return_value=mock_proc):
             with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
-                with patch(
-                    "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-                ) as mock_run:
+                with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
                     _run_codex(
                         prompt="implement the thing",
                         profile=profile,
@@ -70,9 +71,7 @@ class TestCodexSandboxFlag:
         profile = _make_profile(sandbox_mode="read-only")
         mock_proc = _make_subprocess_mock()
         with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
-            with patch(
-                "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-            ) as mock_run:
+            with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
                 _run_codex(
                     prompt="review only",
                     profile=profile,
@@ -88,9 +87,7 @@ class TestCodexSandboxFlag:
         profile = _make_profile(sandbox_mode="none")
         mock_proc = _make_subprocess_mock()
         with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
-            with patch(
-                "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-            ) as mock_run:
+            with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
                 _run_codex(
                     prompt="debug run",
                     profile=profile,
@@ -103,9 +100,7 @@ class TestCodexSandboxFlag:
         """Resume path omits --sandbox because current Codex CLI rejects it there."""
         profile = _make_profile(sandbox_mode="workspace-write")
         mock_proc = _make_subprocess_mock()
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
             _run_codex(
                 prompt="continue",
                 profile=profile,
@@ -120,9 +115,7 @@ class TestCodexSandboxFlag:
         """sandbox_mode=none omits --sandbox on resume too."""
         profile = _make_profile(sandbox_mode="none")
         mock_proc = _make_subprocess_mock()
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
             _run_codex(
                 prompt="continue",
                 profile=profile,
@@ -137,9 +130,7 @@ class TestCodexSandboxFlag:
         """`codex exec resume` does not accept -C; working dir is passed via cwd= instead."""
         profile = _make_profile(sandbox_mode="workspace-write")
         mock_proc = _make_subprocess_mock()
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
             _run_codex(
                 prompt="continue",
                 profile=profile,
@@ -154,9 +145,7 @@ class TestCodexSandboxFlag:
         """Resume command keeps flags before the positional session id."""
         profile = _make_profile(sandbox_mode="workspace-write")
         mock_proc = _make_subprocess_mock()
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
             _run_codex(
                 prompt="continue",
                 profile=profile,
@@ -175,9 +164,7 @@ class TestCodexSandboxFlag:
         mock_proc = _make_subprocess_mock()
 
         with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
-            with patch(
-                "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-            ) as mock_run:
+            with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
                 _run_codex(
                     prompt="debug run",
                     profile=profile,

--- a/tests/test_runner_providers.py
+++ b/tests/test_runner_providers.py
@@ -16,6 +16,9 @@ from theforge.config import ApiFallbackConfig, ModelProfile
 from theforge.log_level import LogLevel, set_log_level
 from theforge.runners import log_agent_result, run_agent
 
+# Codex spawn seam patched by the tests below.
+_CODEX_RUN_TARGET = "theforge.runners.runner_codex.process_group.run_in_process_group"
+
 
 def _make_stream_mock(lines: list[str], returncode: int = 0, stderr: str = "") -> MagicMock:
     """Return a mock Popen object whose stdout yields the given JSONL lines."""
@@ -41,7 +44,7 @@ class TestRunCodex:
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="Code looks good.", stderr=""
         )
-        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc):
             result = run_agent(
                 prompt="review this code",
                 profile=codex_profile,
@@ -57,7 +60,7 @@ class TestRunCodex:
 
     def test_codex_timeout(self, codex_profile: ModelProfile, tmp_path: Path) -> None:
         with patch(
-            "theforge.runners.runner_codex.subprocess.run",
+            _CODEX_RUN_TARGET,
             side_effect=subprocess.TimeoutExpired(cmd="npx", timeout=300),
         ):
             result = run_agent(prompt="test", profile=codex_profile, working_dir=tmp_path)
@@ -69,7 +72,7 @@ class TestRunCodex:
 
     def test_codex_not_found(self, codex_profile: ModelProfile, tmp_path: Path) -> None:
         with patch(
-            "theforge.runners.runner_codex.subprocess.run",
+            _CODEX_RUN_TARGET,
             side_effect=FileNotFoundError(),
         ):
             result = run_agent(prompt="test", profile=codex_profile, working_dir=tmp_path)
@@ -80,9 +83,7 @@ class TestRunCodex:
 
     def test_codex_command_structure(self, codex_profile: ModelProfile, tmp_path: Path) -> None:
         mock_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="done", stderr="")
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc) as mock_run:
             run_agent(prompt="review", profile=codex_profile, working_dir=tmp_path)
 
         cmd = mock_run.call_args[0][0]
@@ -101,7 +102,7 @@ class TestRunCodex:
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="fallback stdout", stderr=""
         )
-        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc):
             result = run_agent(prompt="test", profile=codex_profile, working_dir=tmp_path)
 
         assert result.output == "fallback stdout"
@@ -110,7 +111,7 @@ class TestRunCodex:
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=1, stdout="partial work", stderr=""
         )
-        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc):
             result = run_agent(prompt="test", profile=codex_profile, working_dir=tmp_path)
 
         assert result.success is False
@@ -124,7 +125,7 @@ class TestRunCodex:
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=1, stdout="", stderr="codex error"
         )
-        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc):
             result = run_agent(prompt="test", profile=codex_profile, working_dir=tmp_path)
 
         assert result.output == "codex error"
@@ -140,9 +141,7 @@ class TestRunCodex:
             reasoning_effort="high",
         )
         mock_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="done", stderr="")
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc) as mock_run:
             run_agent(prompt="review", profile=profile, working_dir=tmp_path)
 
         cmd = mock_run.call_args[0][0]
@@ -154,9 +153,7 @@ class TestRunCodex:
         self, codex_profile: ModelProfile, tmp_path: Path
     ) -> None:
         mock_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="done", stderr="")
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc) as mock_run:
             run_agent(prompt="review", profile=codex_profile, working_dir=tmp_path)
 
         cmd = mock_run.call_args[0][0]
@@ -174,9 +171,7 @@ class TestRunCodex:
             reasoning_effort="medium",
         )
         mock_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="done", stderr="")
-        with patch(
-            "theforge.runners.runner_codex.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc) as mock_run:
             run_agent(prompt="review", profile=profile, working_dir=tmp_path)
 
         cmd = mock_run.call_args[0][0]
@@ -194,7 +189,7 @@ class TestRunCodex:
             args=[], returncode=0, stdout="reviewed", stderr=""
         )
         # Patch _get_codex_session_id to prove it is never called in pool mode.
-        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc):
             with patch(
                 "theforge.runners.runner_codex._get_codex_session_id", return_value="some-uuid"
             ) as mock_extract:
@@ -215,7 +210,7 @@ class TestRunCodex:
         mock_proc = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="reviewed", stderr=""
         )
-        with patch("theforge.runners.runner_codex.subprocess.run", return_value=mock_proc):
+        with patch(_CODEX_RUN_TARGET, return_value=mock_proc):
             with patch(
                 "theforge.runners.runner_codex._get_codex_session_id", return_value="abc-123"
             ) as mock_extract:

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -840,6 +840,11 @@ class TestClaudeCliStuckDetection:
         mock_proc.returncode = 0
         mock_proc.wait.return_value = 0
         mock_proc.poll.return_value = 0
+        # No such process → os.getpgid raises, so the runner's kill takes its
+        # documented direct-child fallback (proc.kill) instead of killpg-ing a
+        # bogus group id derived from a mock pid. The real group-kill path is
+        # covered by the fake-CLI subprocess tests in test_process_group.py.
+        mock_proc.pid = 2_000_000_000
 
         with patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc):
             result = _run_claude(


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 teardown leaks are resolved; no blocking regressions were found in the latest iteration. | [google-gemini-3.5-flash] The process-group isolation and orphan reaper implementation is robust, fully verified, and resolves all prior P1 findings. | [claude-sonnet] Cycle 1 P1 (SIGTERM/SystemExit unwinding _run_claude without killing the agent process group) is fixed: the claude runner now wraps its whole post-spawn body in try/except BaseException/finally, killing the group before dropping the sidecar on any exception, and a new fake-CLI regression test (test_exception_after_spawn_kills_group) reproduces the exact SystemExit-mid-stream scenario and confirms the grandchild dies. All 11 process_group tests plus the codex/claude runner suites pass. No regressions found in the iteration's diff (confined to runner_claude.py and test fixtures).

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $14.94
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: sprint death leaks agent subprocess to init — orphaned codex process holds workspace-write sandbox indefinitely (GitHub Issue #1649)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1649