### PR TITLE
Sprint-RCA mis-attributes non-quota failures to provider_quota — the bare "429" pattern matches inside cost_usd float digits (0.665994299…), overriding the real captured error and emitting bogus "wait for quota reset" remediation

### DIFF
--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -28,6 +28,7 @@ set. Grep it to see everything the mechanical classifier knows.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -54,6 +55,38 @@ _EXCERPT_MAX_LEN = 240
 # Cap per-file text reads so a runaway log cannot blow up classification.
 _MAX_FILE_BYTES = 512 * 1024
 
+# YAML/JSON keys whose values are numeric telemetry (cost, duration, token
+# counts) — never provider or error prose. Lines assigning these keys are
+# stripped from wholesale-scanned files before pattern matching so a coincidental
+# digit run inside a float (e.g. ``cost_usd: 0.6659942999999999`` which contains
+# the substring ``429``) can never fire a provider/HTTP rule. Matching is on the
+# field *name*, so a real error message that merely mentions cost is untouched.
+_TELEMETRY_KEYS: tuple[str, ...] = (
+    "cost",
+    "cost_usd",
+    "total_cost",
+    "total_cost_usd",
+    "duration",
+    "duration_s",
+    "duration_ms",
+    "elapsed",
+    "elapsed_s",
+    "latency",
+    "latency_ms",
+    "tokens",
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+    "price",
+    "price_usd",
+)
+_TELEMETRY_LINE_RE = re.compile(
+    r"^\s*[\"']?(?:" + "|".join(re.escape(k) for k in _TELEMETRY_KEYS) + r")[\"']?\s*[:=]",
+    re.IGNORECASE,
+)
+
 
 @dataclass(frozen=True)
 class RcaRule:
@@ -69,9 +102,14 @@ class RcaRule:
     failure_class: str
     role: str
     description: str
-    # Case-insensitive substrings scanned against text sources; any hit fires
-    # the rule. Empty for "signal" rules whose detection is field-derived
-    # (implemented in ``_signal_rule_hits``) rather than pattern-based.
+    # Case-insensitive patterns scanned against text sources; any hit fires the
+    # rule. Alphabetic patterns match as plain substrings. Purely-numeric
+    # patterns (HTTP status codes such as ``429``) match only as a standalone
+    # token — anchored with digit boundaries so they can never fire inside a
+    # longer number such as the fractional digits of a cost/duration float (see
+    # ``_pattern_matches``). Empty for "signal" rules whose detection is
+    # field-derived (implemented in ``_signal_rule_hits``) rather than
+    # pattern-based.
     patterns: tuple[str, ...] = ()
 
 
@@ -420,10 +458,16 @@ def _classify_story(
         story, slug, audit, summary_path, sprint_log_dir, logs_root, run_id
     )
 
-    # (rule_id, source, excerpt) triples in deterministic order.
-    hits: list[tuple[str, str, str]] = []
+    # (rule_id, source, excerpt, matched_pattern) tuples in deterministic order.
+    hits: list[tuple[str, str, str, str | None]] = []
     hits.extend(_text_rule_hits(text_sources))
     hits.extend(_signal_rule_hits(story, audit, summary_path, sprint_log_dir, logs_root))
+
+    # The story's explicitly-captured terminal error (summary + audit). A concrete
+    # captured cause takes precedence over an *ambiguous* pattern hit (e.g. a bare
+    # "429"): the incidental match is still recorded as evidence but must not drive
+    # primary classification or operator remediation when it is uncorroborated.
+    captured_error_text = _captured_error_text(story, audit)
 
     # Baseline evidence so an entry is never evidence-empty (AC: unknown stories
     # surface at least the captured outcome). Cite the *resolved* summary file
@@ -439,7 +483,7 @@ def _classify_story(
     evidence: list[dict] = []
     primary_classes: list[str] = []
     contributing_classes: list[str] = []
-    for rule_id, source, excerpt in hits:
+    for rule_id, source, excerpt, matched_pattern in hits:
         if rule_id in seen_rules:
             continue
         rule = RULES_BY_ID.get(rule_id)
@@ -448,6 +492,10 @@ def _classify_story(
         seen_rules.add(rule_id)
         evidence.append({"source": source, "rule_id": rule_id, "excerpt": excerpt})
         if rule.role == "primary":
+            if _is_ambiguous_primary(rule, matched_pattern, captured_error_text):
+                # Uncorroborated ambiguous hit: keep the evidence for the trace but
+                # do not let it classify — the captured non-provider outcome wins.
+                continue
             primary_classes.append(rule.failure_class)
         elif rule.role == "contributing":
             contributing_classes.append(rule.failure_class)
@@ -535,7 +583,11 @@ def _collect_text_sources(
                 continue
             if path.suffix.lower() not in {".log", ".txt", ".yaml", ".yml", ".md", ".json"}:
                 continue
-            text = _read_text(path)
+            # Strip numeric telemetry lines (cost/duration/token values) so a
+            # coincidental digit run inside a float cannot feed context-free
+            # pattern matching — e.g. `cost_usd: 0.6659942999999999` containing
+            # the substring `429`. Error/message prose is untouched.
+            text = _strip_telemetry(_read_text(path))
             if text:
                 sources.append(_TextSource(_rel(path, logs_root), text))
 
@@ -545,7 +597,9 @@ def _collect_text_sources(
     if run_log is not None:
         refs = _story_references(slug)
         matched_lines = [
-            line for line in _read_text(run_log).splitlines() if any(ref in line for ref in refs)
+            line
+            for line in _strip_telemetry(_read_text(run_log)).splitlines()
+            if any(ref in line for ref in refs)
         ]
         if matched_lines:
             sources.append(_TextSource(_rel(run_log, logs_root), "\n".join(matched_lines)))
@@ -553,19 +607,39 @@ def _collect_text_sources(
     return sources
 
 
-def _text_rule_hits(sources: list[_TextSource]) -> list[tuple[str, str, str]]:
-    """Fire every text rule whose pattern appears in any source."""
-    hits: list[tuple[str, str, str]] = []
+def _pattern_matches(pattern: str, lowered: str) -> bool:
+    """Return True when *pattern* is present in already-lowercased *lowered*.
+
+    Purely-numeric patterns (HTTP status codes such as ``429``) are matched with
+    digit boundaries so they fire only as a standalone token — never inside a
+    longer number such as the fractional digits of a cost/duration float. All
+    other (alphabetic) patterns keep plain substring semantics.
+    """
+    if pattern.isdigit():
+        return re.search(rf"(?<!\d){re.escape(pattern)}(?!\d)", lowered) is not None
+    return pattern in lowered
+
+
+def _text_rule_hits(sources: list[_TextSource]) -> list[tuple[str, str, str, str | None]]:
+    """Fire every text rule whose pattern appears in any source.
+
+    Each hit carries the concrete pattern that matched so classification can tell
+    an unambiguous provider phrase (``usage limit``) apart from an ambiguous bare
+    status code (``429``) when deciding precedence.
+    """
+    hits: list[tuple[str, str, str, str | None]] = []
     for rule in RULES:
         if not rule.patterns:
             continue
         for src in sources:
             lowered = src.text.lower()
-            matched_pattern = next((p for p in rule.patterns if p in lowered), None)
+            matched_pattern = next(
+                (p for p in rule.patterns if _pattern_matches(p, lowered)), None
+            )
             if matched_pattern is None:
                 continue
             excerpt = _first_matching_line(src.text, rule.patterns)
-            hits.append((rule.rule_id, src.source, excerpt))
+            hits.append((rule.rule_id, src.source, excerpt, matched_pattern))
             break  # one evidence per rule is enough
     return hits
 
@@ -576,8 +650,12 @@ def _signal_rule_hits(
     summary_path: Path,
     sprint_log_dir: Path,
     logs_root: Path,
-) -> list[tuple[str, str, str]]:
-    """Fire field-derived (signal) rules from summary/audit structured fields."""
+) -> list[tuple[str, str, str, str | None]]:
+    """Fire field-derived (signal) rules from summary/audit structured fields.
+
+    Signal hits carry ``None`` as the matched pattern — they are field-derived,
+    not pattern-derived, so the ambiguity-precedence check never applies to them.
+    """
     hits: list[tuple[str, str, str]] = []
     summary_source = _rel(summary_path, logs_root)
     audit_source = _rel(sprint_log_dir / str(story.get("slug") or "") / "audit.yaml", logs_root)
@@ -651,7 +729,7 @@ def _signal_rule_hits(
             )
         )
 
-    return hits
+    return [(rule_id, source, excerpt, None) for rule_id, source, excerpt in hits]
 
 
 def _select_primary(primary_classes: list[str]) -> str | None:
@@ -832,9 +910,57 @@ def _story_ref(story: dict) -> str:
 def _first_matching_line(text: str, patterns: tuple[str, ...]) -> str:
     for line in text.splitlines():
         lowered = line.lower()
-        if any(p in lowered for p in patterns):
+        if any(_pattern_matches(p, lowered) for p in patterns):
             return _truncate(line.strip())
     return _truncate(text.strip())
+
+
+def _strip_telemetry(text: str) -> str:
+    """Drop numeric-telemetry key/value lines (cost/duration/token counts) from
+    scannable text so their digit runs never feed context-free pattern matching.
+
+    Matching is on the field *name* at line start, so prose that merely mentions
+    cost (e.g. an error message) is preserved.
+    """
+    if not text:
+        return text
+    return "\n".join(line for line in text.splitlines() if not _TELEMETRY_LINE_RE.match(line))
+
+
+def _captured_error_text(story: dict, audit: dict) -> str:
+    """Lowercased concatenation of the story's explicitly-captured terminal error.
+
+    Sourced from the summary ``error`` and the per-story audit ``error`` /
+    ``outcome.message`` — the fields that carry the runner's real terminal-failure
+    detail. Used to let a concrete captured cause outrank an ambiguous pattern hit.
+    """
+    parts = [_nonempty(story.get("error")), _nonempty(audit.get("error"))]
+    outcome_block = audit.get("outcome") if isinstance(audit.get("outcome"), dict) else {}
+    parts.append(_nonempty(outcome_block.get("message")))
+    return "\n".join(p for p in parts if p).lower()
+
+
+def _is_ambiguous_primary(
+    rule: RcaRule, matched_pattern: str | None, captured_error_text: str
+) -> bool:
+    """Return True when a primary text-rule fired only on an ambiguous token.
+
+    An ambiguous match is a bare numeric status code (e.g. ``429``). Such a hit
+    must not drive primary classification when the story already carries a
+    concrete captured terminal error that does *not* itself corroborate the rule
+    with an unambiguous phrase — the captured non-provider outcome takes
+    precedence. A genuine unambiguous phrase (``usage limit``) is never demoted,
+    and when there is no captured error to contradict it a standalone status code
+    still classifies.
+    """
+    if matched_pattern is None or not matched_pattern.isdigit():
+        return False
+    if not captured_error_text:
+        return False
+    strong_patterns = [p for p in rule.patterns if not p.isdigit()]
+    if any(_pattern_matches(p, captured_error_text) for p in strong_patterns):
+        return False
+    return True
 
 
 def _truncate(text: str) -> str:

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -633,11 +633,14 @@ def _text_rule_hits(sources: list[_TextSource]) -> list[tuple[str, str, str, str
             continue
         for src in sources:
             lowered = src.text.lower()
-            matched_pattern = next(
-                (p for p in rule.patterns if _pattern_matches(p, lowered)), None
-            )
-            if matched_pattern is None:
+            matched = [p for p in rule.patterns if _pattern_matches(p, lowered)]
+            if not matched:
                 continue
+            # Prefer an unambiguous (non-numeric) pattern so a source that also
+            # contains a strong provider phrase (e.g. "HTTP 429 overloaded") is
+            # not reduced to its bare status code — otherwise the ambiguity guard
+            # would wrongly demote a genuinely-corroborated provider-limit hit.
+            matched_pattern = next((p for p in matched if not p.isdigit()), matched[0])
             excerpt = _first_matching_line(src.text, rule.patterns)
             hits.append((rule.rule_id, src.source, excerpt, matched_pattern))
             break  # one evidence per rule is enough

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -169,6 +169,111 @@ def test_provider_quota_with_gate_timeout(tmp_path: Path) -> None:
     assert "usage limit" in quota_ev["excerpt"].lower()
 
 
+# ── Engine: ambiguous "429" must not match inside cost/duration floats ────────
+
+
+def test_bare_429_in_cost_float_not_provider_quota(tmp_path: Path) -> None:
+    """The reported bug: a cost_usd float whose digits contain "429" must not be
+    classified provider_quota, and no "wait for quota reset" remediation fires.
+
+    Reproduces sprint 493cd6ae81e4 / #1747: the real failure is an empty-worktree
+    missing-work escalate, but ``cost_usd: 0.6659942999999999`` contains the
+    substring ``429`` and previously drove a spurious provider_usage_limit hit.
+    """
+    empty_worktree_err = (
+        "Gate exited PASS but branch has no commits ahead of base — "
+        "treating empty worktree as missing-work failure"
+    )
+    d = _sprint_dir(tmp_path, name="issues-927,1773,1747")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-1747", "outcome": "FAILED", "error": empty_worktree_err}]),
+    )
+    _write(
+        d / "issue-1747" / "audit.yaml",
+        {
+            "error": empty_worktree_err,
+            "error_type": None,
+            "cost": {"cost_usd": 0.6659942999999999, "dev_invocations": 1},
+        },
+    )
+    entry = _build(d)["stories"]["issue-1747"]
+    assert entry["primary_failure_class"] != "provider_quota"
+    assert entry["primary_failure_class"] == UNKNOWN_CLASS
+    rule_ids = {ev["rule_id"] for ev in entry["evidence"]}
+    assert "provider_usage_limit" not in rule_ids
+    assert not any("quota" in a.lower() for a in entry["recommended_next_actions"])
+    # The real captured error is still surfaced as baseline evidence.
+    assert any("empty worktree" in ev["excerpt"].lower() for ev in entry["evidence"])
+
+
+def test_standalone_429_status_still_detected(tmp_path: Path) -> None:
+    """A genuine standalone HTTP 429 in captured provider output still classifies.
+
+    Anchoring must not blind the rule to real rate-limit responses — only to
+    digit runs inside unrelated numbers.
+    """
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-1324", "outcome": "ESCALATE"}]),
+    )
+    cycle_dir = d / "issue-1324" / "review-cycle-1"
+    cycle_dir.mkdir(parents=True, exist_ok=True)
+    (cycle_dir / "openai-gpt.yaml").write_text(
+        "output: |\n  Provider returned HTTP 429 Too Many Requests\n",
+        encoding="utf-8",
+    )
+    entry = _build(d)["stories"]["issue-1324"]
+    assert entry["primary_failure_class"] == "provider_quota"
+    quota_ev = next(ev for ev in entry["evidence"] if ev["rule_id"] == "provider_usage_limit")
+    assert "429" in quota_ev["excerpt"]
+
+
+def test_ambiguous_429_yields_to_captured_non_provider_error(tmp_path: Path) -> None:
+    """A bare 429 hit must not outrank an explicit captured non-provider error.
+
+    Even when a standalone 429 appears in a scanned file, a concrete captured
+    terminal error describing a different cause takes precedence — the story is
+    not attributed to provider_quota and no quota remediation is emitted.
+    """
+    empty_worktree_err = (
+        "Gate exited PASS but branch has no commits ahead of base — "
+        "treating empty worktree as missing-work failure"
+    )
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-1747", "outcome": "FAILED", "error": empty_worktree_err}]),
+    )
+    story_dir = d / "issue-1747"
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "dev.log").write_text("transient blip: code 429 seen once\n", encoding="utf-8")
+    entry = _build(d)["stories"]["issue-1747"]
+    assert entry["primary_failure_class"] != "provider_quota"
+    assert not any("quota" in a.lower() for a in entry["recommended_next_actions"])
+
+
+def test_error_prose_mentioning_cost_is_preserved(tmp_path: Path) -> None:
+    """Telemetry redaction keys on field names, not the word 'cost' in prose.
+
+    An unambiguous provider phrase in an error message that also mentions cost
+    must still classify provider_quota.
+    """
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-1324", "outcome": "ESCALATE"}]),
+    )
+    story_dir = d / "issue-1324"
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "dev.log").write_text(
+        "The provider hit its usage limit before any cost accrued\n", encoding="utf-8"
+    )
+    entry = _build(d)["stories"]["issue-1324"]
+    assert entry["primary_failure_class"] == "provider_quota"
+
+
 # ── Engine: worker timeout + partial value ────────────────────────────────────
 
 

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -254,6 +254,35 @@ def test_ambiguous_429_yields_to_captured_non_provider_error(tmp_path: Path) -> 
     assert not any("quota" in a.lower() for a in entry["recommended_next_actions"])
 
 
+def test_corroborated_429_classifies_despite_captured_error(tmp_path: Path) -> None:
+    """A bare 429 corroborated by a strong phrase in the same source still classifies.
+
+    When a scanned provider log carries both an ambiguous status code and an
+    unambiguous provider-limit phrase ("HTTP 429 ... overloaded"), the hit is
+    corroborated and must classify provider_quota even though the story summary
+    holds an unrelated captured error — the ambiguity guard applies only to
+    uncorroborated bare status codes.
+    """
+    empty_worktree_err = (
+        "Gate exited PASS but branch has no commits ahead of base — "
+        "treating empty worktree as missing-work failure"
+    )
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-1324", "outcome": "FAILED", "error": empty_worktree_err}]),
+    )
+    story_dir = d / "issue-1324"
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "dev.log").write_text(
+        "Provider returned HTTP 429\nModel is overloaded, retry later\n", encoding="utf-8"
+    )
+    entry = _build(d)["stories"]["issue-1324"]
+    assert entry["primary_failure_class"] == "provider_quota"
+    assert {ev["rule_id"] for ev in entry["evidence"]} >= {"provider_usage_limit"}
+    assert any("quota" in a.lower() for a in entry["recommended_next_actions"])
+
+
 def test_error_prose_mentioning_cost_is_preserved(tmp_path: Path) -> None:
     """Telemetry redaction keys on field names, not the word 'cost' in prose.
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The cycle-1 regression is fixed, the original 429-in-cost symptom is covered, and the focused RCA test suite passes. | [google-gemini-3.5-flash] The fix successfully prevents mis-attribution of non-quota failures to provider_quota by anchoring numeric patterns, stripping telemetry lines, and prioritizing captured errors.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $4.20
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint-RCA mis-attributes non-quota failures to provider_quota — the bare "429" pattern matches inside cost_usd float digits (0.665994299…), overriding the real captured error and emitting bogus "wait for quota reset" remediation (GitHub Issue #1787)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1787