### PR TITLE
Collision soft-edge dependent is SKIPPED instead of dispatched on clean main when its queued-PR parent times out to MERGE_FAILED — violates dag.py's documented soft-edge release contract

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2726,6 +2726,14 @@ def run_sprint(
                                 dep, StoryOutcome.MERGE_FAILED, phase=dep_result.phase.name
                             )
                             del queued_prs[dep]
+                            # The parent reached a terminal-but-not-merged state:
+                            # its changes never landed, so the base is exactly the
+                            # clean state a collision soft edge guards. Record the
+                            # parent in the DAG's _finished set (not _completed) so
+                            # dag.ready() releases any collision (soft) dependent on
+                            # the next loop pass while a genuine depends_on (hard)
+                            # dependent stays blocked (still requires _completed).
+                            dag.mark_skipped(dep)
                             _write_story_audit(config, dep_task, dep_result, sprint_id=_sprint_id)
                             _log(
                                 f"✗ {dep}: queued PR {poll_result['status']} "
@@ -2837,6 +2845,13 @@ def run_sprint(
                 f" queued_prs={list(queued_prs.keys())}"
             )
             if not active and not queued_prs:
+                # A terminal-but-not-merged soft-edge parent may have just
+                # released a dependent's collision edge. Before declaring a
+                # deadlock and sweeping remaining tasks into SKIP, re-enter
+                # dispatch for anything now schedulable so a released, ready
+                # story runs on the current base instead of being skipped.
+                if any(t.slug not in active for t in dag.ready()):
+                    continue
                 # Deadlock: remaining tasks have unmet or budget-blocked deps
                 # Release any pending plan gates so worker threads can exit
                 for g_slug, _gate in plan_gates.items():
@@ -2844,6 +2859,12 @@ def run_sprint(
                     _gate.set()
                 plan_gates.clear()
                 for t in dag.remaining():
+                    # A mark_skipped earlier in THIS sweep can release a
+                    # sibling's soft edge; if that makes any task schedulable,
+                    # stop skipping and re-enter dispatch on the next loop pass
+                    # rather than sweeping the just-released sibling into a SKIP.
+                    if any(r.slug not in active for r in dag.ready()):
+                        break
                     unmet = dag.unmet_deps(t.slug)
                     if unmet:
                         dep_list = ", ".join(unmet)
@@ -2861,7 +2882,9 @@ def run_sprint(
                         _record_current_story_entry(t.slug, "SKIPPED", error="blocked")
                         _set_outcome(t.slug, StoryOutcome.SKIPPED, reason="blocked")
                     dag.mark_skipped(t.slug)
-                break
+                else:
+                    break
+                continue
 
             # No active workers but queued PRs are still in flight.
             # Poll each queued PR directly so dependents can be dispatched
@@ -2905,6 +2928,12 @@ def run_sprint(
                             _qp_slug, StoryOutcome.MERGE_FAILED, phase=_qp_result.phase.name
                         )
                         del queued_prs[_qp_slug]
+                        # Parent ended without merging; release its collision
+                        # (soft) edge by recording it in _finished. On the next
+                        # loop pass dag.ready() returns the released dependent and
+                        # it is dispatched onto the current (unchanged) base rather
+                        # than falling into the deadlock-cleanup skip below.
+                        dag.mark_skipped(_qp_slug)
                         _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
                         _log(f"✗ {_qp_slug}: queued PR {_qp_poll['status']} (no active workers)")
                 continue

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2726,13 +2726,16 @@ def run_sprint(
                                 dep, StoryOutcome.MERGE_FAILED, phase=dep_result.phase.name
                             )
                             del queued_prs[dep]
-                            # The parent reached a terminal-but-not-merged state:
-                            # its changes never landed, so the base is exactly the
-                            # clean state a collision soft edge guards. Record the
-                            # parent in the DAG's _finished set (not _completed) so
-                            # dag.ready() releases any collision (soft) dependent on
-                            # the next loop pass while a genuine depends_on (hard)
-                            # dependent stays blocked (still requires _completed).
+                            # Defensive/idempotent: the parent is normally already
+                            # in the DAG's _finished set (added when its PR was
+                            # queued, via the pending_integration classify branch),
+                            # so its collision (soft) edge is already released. This
+                            # call guarantees _finished membership on any path that
+                            # queued without that classification. _finished (not
+                            # _completed) is what keeps a genuine depends_on (hard)
+                            # dependent blocked. The redispatch of the released
+                            # dependent onto the current base is driven by the
+                            # dag.ready() re-check before the deadlock-cleanup sweep.
                             dag.mark_skipped(dep)
                             _write_story_audit(config, dep_task, dep_result, sprint_id=_sprint_id)
                             _log(
@@ -2928,11 +2931,15 @@ def run_sprint(
                             _qp_slug, StoryOutcome.MERGE_FAILED, phase=_qp_result.phase.name
                         )
                         del queued_prs[_qp_slug]
-                        # Parent ended without merging; release its collision
-                        # (soft) edge by recording it in _finished. On the next
-                        # loop pass dag.ready() returns the released dependent and
-                        # it is dispatched onto the current (unchanged) base rather
-                        # than falling into the deadlock-cleanup skip below.
+                        # Defensive/idempotent: the parent is normally already in
+                        # _finished (added when its PR was queued), so its collision
+                        # (soft) edge is already released; this guarantees it on any
+                        # path that skipped that classification. _finished (not
+                        # _completed) is what still blocks a hard depends_on
+                        # dependent. Actual redispatch of a released dependent onto
+                        # the current base comes from the dag.ready() re-check at the
+                        # top of the deadlock-cleanup branch, reached after the
+                        # `continue` below.
                         dag.mark_skipped(_qp_slug)
                         _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
                         _log(f"✗ {_qp_slug}: queued PR {_qp_poll['status']} (no active workers)")

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -607,6 +607,136 @@ class TestParallelDependencyGating:
         assert sprint.specs_succeeded == 1
         assert sprint.specs_skipped == 0
 
+    def test_collision_dependent_runs_on_current_base_when_queued_parent_times_out(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #1792: a collision (soft-edge) dependent must be dispatched onto
+        the current base when its queued-PR parent times out into MERGE_FAILED.
+
+        The collision DAG links story-b to story-a via ``collision_deps`` (a soft
+        edge whose sole purpose is to stop story-b from building on story-a's
+        *unmerged* changes). story-a is approved and its PR auto-merge-queued, but
+        the merge never lands: ``_poll_queued_pr`` reports ``timeout``. Because
+        story-a's changes never reached the base, the base is exactly the clean
+        state the soft edge was guarding, so story-b must run there — not be
+        marked SKIPPED(blocked) as it was before the fix.
+
+        This exercises the ready-loop queued-PR gate: story-b becomes ready the
+        instant story-a is queued (terminal-but-not-merged), the gate polls the
+        parent's PR, sees the timeout, marks story-a MERGE_FAILED, and re-enters
+        dispatch so story-b runs on the current base.
+        """
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md", "story-b.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = _make_config(tmp_path)
+
+        # story-a: approved, deferred merge queued (pending_integration).
+        result_a = _make_coordinator_result(success=True, cost=1.0)
+        result_a.landing_status = "pending_integration"
+        result_a.merge = {"action": "merge", "pending": True}
+        # story-b: clean run once dispatched onto the current base.
+        result_b = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+        run_order: list[str] = []
+
+        def _fake_run_task(cfg, task, **kwargs):  # noqa: ANN001
+            run_order.append(task.slug)
+            return {"story-a": result_a, "story-b": result_b}[task.slug]
+
+        def _fake_land_story(*args, **kwargs):  # noqa: ANN002, ANN003
+            return (
+                {"merge_queued": True, "pr_url": "https://github.com/x/y/pull/1"},
+                "pending_integration",
+            )
+
+        def _fake_poll(*args, **kwargs):  # noqa: ANN002, ANN003
+            run_order.append("poll")
+            return {"status": "timeout"}
+
+        with (
+            patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
+            patch(
+                "theforge.sprint.runner.compute_synthetic_edges",
+                return_value={"story-b": ["story-a"]},
+            ),
+            patch("theforge.coordinator.completion.land_story", side_effect=_fake_land_story),
+            patch("theforge.sprint.runner._poll_queued_pr", side_effect=_fake_poll),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        # The parent's queued PR timed out (MERGE_FAILED); the dependent was still
+        # dispatched onto the current base and ran to success — not skipped.
+        assert "story-b" in run_order
+        assert run_order.index("story-b") > run_order.index("poll")
+        assert sprint.specs_failed == 1  # story-a MERGE_FAILED
+        assert sprint.specs_succeeded == 1  # story-b ran on the clean base
+        assert sprint.specs_skipped == 0  # story-b was NOT stranded
+
+    def test_hard_dependent_still_skipped_when_queued_parent_times_out(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #1792 (soft/hard distinction): a genuine ``depends_on`` (hard)
+        dependent of a queued parent that times out into MERGE_FAILED must stay
+        SKIPPED — only a collision soft edge dissolves on parent failure.
+
+        story-h needs story-p's *result*, so a terminal-but-not-merged story-p
+        must propagate its failure to story-h. story-h is never ready while
+        story-p is only queued (a hard dep requires the parent to be *completed*,
+        which queuing does not provide), so the parent is polled from the
+        no-active-workers branch; when it times out, story-p is marked MERGE_FAILED
+        and story-h remains blocked and is skipped.
+        """
+        _make_spec_file(tmp_path, "Story P", "story-p")
+        _make_spec_file(tmp_path, "Story H", "story-h", depends_on=["story-p"])
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-p.md", "story-h.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = _make_config(tmp_path)
+
+        # story-p: approved, deferred merge queued.
+        result_p = _make_coordinator_result(success=True, cost=1.0)
+        result_p.landing_status = "pending_integration"
+        result_p.merge = {"action": "merge", "pending": True}
+        result_h = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+        run_order: list[str] = []
+
+        def _fake_run_task(cfg, task, **kwargs):  # noqa: ANN001
+            run_order.append(task.slug)
+            return {"story-p": result_p, "story-h": result_h}[task.slug]
+
+        def _fake_land_story(*args, **kwargs):  # noqa: ANN002, ANN003
+            return (
+                {"merge_queued": True, "pr_url": "https://github.com/x/y/pull/2"},
+                "pending_integration",
+            )
+
+        def _fake_poll(*args, **kwargs):  # noqa: ANN002, ANN003
+            run_order.append("poll")
+            return {"status": "timeout"}
+
+        with (
+            patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
+            patch("theforge.coordinator.completion.land_story", side_effect=_fake_land_story),
+            patch("theforge.sprint.runner._poll_queued_pr", side_effect=_fake_poll),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        # The hard dependent never ran; its parent's failure propagated as a skip.
+        assert "story-h" not in run_order
+        assert sprint.specs_failed == 1  # story-p MERGE_FAILED
+        assert sprint.specs_skipped == 1  # story-h blocked by failed hard dep
+        assert sprint.specs_succeeded == 0
+
     def test_resume_at_review_dependent_waits_for_queued_parent(self, tmp_path: Path) -> None:
         """Issue #1609 (incident path): a dependent re-entering via resume triage
         at REVIEW must honor the queued-parent reachability gate.


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The queued-PR timeout fix honors the soft-edge release contract, preserves hard-dependency blocking, and the focused regression tests pass. | [google-gemini-3.5-flash] The collision soft-edge release on queued-PR parent timeout/failure is fully resolved and verified with robust seam tests. | [claude-sonnet] Iteration 2 is a comment-only clarification resolving the prior P2 (misleading comment claiming mark_skipped(dep) was the release mechanism); no logic changed, confirmed by diff and full test-file pass (78/78).

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $7.17
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Collision soft-edge dependent is SKIPPED instead of dispatched on clean main when its queued-PR parent times out to MERGE_FAILED — violates dag.py's documented soft-edge release contract (GitHub Issue #1792)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1792