### PR TITLE
Dev iterations can mutate worktree branch state, silently corrupting downstream integration

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -35,6 +35,7 @@ def mark_merge_failed(
     branch_name: str | None,
     *,
     arming_failed: bool = False,
+    inherited_dev_residue: bool = False,
 ) -> None:
     """Mutate state and result coherently when the merge step fails.
 
@@ -46,15 +47,33 @@ def mark_merge_failed(
     When ``arming_failed`` is True, the failure is the auto-merge *arming* RPC
     (the PR itself is fine); the message names the distinction so operators
     pursue branch-protection configuration instead of investigating the PR.
+
+    When ``inherited_dev_residue`` is True, integration refused git state a prior
+    DEV iteration left behind (issue #1365). Integration is the victim, not the
+    cause, so this is recorded as ``Phase.ESCALATE`` attributed to DEV rather
+    than ``Phase.MERGE_FAILED`` — the operator must not have to read the reflog
+    to discover the corruption originated upstream. ``landing_status`` stays
+    ``"failed"`` so the story still counts as unlanded, but the terminal phase
+    and message name DEV as responsible.
     """
-    state.phase = Phase.MERGE_FAILED
-    result.phase = Phase.MERGE_FAILED
+    if inherited_dev_residue:
+        state.phase = Phase.ESCALATE
+        result.phase = Phase.ESCALATE
+    else:
+        state.phase = Phase.MERGE_FAILED
+        result.phase = Phase.MERGE_FAILED
     result.success = False
     result.landing_status = "failed"
     cause = error or "unknown"
     state.error = cause
     branch_part = f" Branch '{branch_name}' carries reviewed work." if branch_name else ""
-    if arming_failed:
+    if inherited_dev_residue:
+        result.message = (
+            f"Integration refused inconsistent worktree git state left by the DEV "
+            f"phase: {cause}.{branch_part} This is a DEV-phase escalation, not a "
+            "merge failure — integration is the victim, not the cause."
+        )
+    elif arming_failed:
         result.message = (
             f"Auto-merge arming failed: {cause}.{branch_part} "
             "The PR itself is not rejected — configure branch protection on the "
@@ -588,6 +607,11 @@ def _step_fetch_rebase(push_cwd: Path, base_branch: str) -> dict:
         )
         return {
             "success": False,
+            # DEV-attributed classification flag: the failure originates in state
+            # a prior DEV iteration left behind, not in integration. Landing paths
+            # read this to escalate (DEV-attributed) rather than record the story
+            # as MERGE_FAILED — integration is the victim, not the cause (#1365).
+            "inherited_dev_residue": True,
             "error": (
                 f"dev left inconsistent git state: {_wt_state.inconsistency}"
                 f"{_wt_detail} present in worktree — attributed to the DEV phase, "
@@ -1164,6 +1188,9 @@ def _merge_pr(
                     merge_state=merge_state,
                     detail={
                         "error_context": fetch_rebase_result.get("error_context"),
+                        # Carry the DEV-attribution flag so landing paths escalate
+                        # instead of recording MERGE_FAILED (#1365).
+                        "inherited_dev_residue": fetch_rebase_result.get("inherited_dev_residue"),
                     },
                 )
 

--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -22,6 +22,7 @@ from .run_setup import delete_merge_state, load_merge_state, save_merge_state
 from .state import CoordinatorResult, CoordinatorState, CycleHistory, MergeStepState, Phase
 from .util import _fmt_duration, _log, _log_verbose, _run_shell
 from .workspace import _deindex_forge_artifacts, _merge_branch
+from .worktree_state import check_worktree_git_consistency
 
 _pr_log = logging.getLogger(__name__)
 MAX_MERGE_RETRIES = 3
@@ -569,6 +570,30 @@ def _step_fetch_rebase(push_cwd: Path, base_branch: str) -> dict:
     Returns ``{"success": True}`` or ``{"success": False, "error": ...}``.
     """
     _deindex_forge_artifacts(push_cwd)
+    # ── Refuse inherited worktree inconsistency (#1365) ──────────────────
+    # If a dev iteration left the worktree in an in-progress rebase/merge/
+    # cherry-pick/revert/bisect, git's own ``git rebase`` below fails with a
+    # raw "there is already a rebase-merge directory" error, and the operator
+    # must read the reflog to discover the residue originated upstream. Detect
+    # it here (residue-only; no pre-dev base SHA is available at this seam) and
+    # return a structured diagnosis that names the offending state and attributes
+    # it to the DEV phase, so corruption from one phase is never reframed as
+    # integration's failure. This is the victim refusing to be blamed; the
+    # authoritative fail-closed catch is at the DEV-phase boundary.
+    _wt_state = check_worktree_git_consistency(push_cwd)
+    if not _wt_state.consistent:
+        _wt_detail = f" ({_wt_state.detail})" if _wt_state.detail else ""
+        _pr_log.warning(
+            "refusing rebase: worktree left inconsistent by dev (%s)", _wt_state.inconsistency
+        )
+        return {
+            "success": False,
+            "error": (
+                f"dev left inconsistent git state: {_wt_state.inconsistency}"
+                f"{_wt_detail} present in worktree — attributed to the DEV phase, "
+                "not integration; refusing to rebase"
+            ),
+        }
     try:
         fetch_proc = subprocess.run(
             ["git", "fetch", "origin", base_branch],

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -47,6 +47,7 @@ from .util import (
     _log_verbose,
     resolve_timeout_with_active,
 )
+from .worktree_state import check_worktree_git_consistency
 
 # ── Lazy runner slot ──────────────────────────────────────────────────
 # None until first call; tests may replace before calling run_task.
@@ -1316,5 +1317,51 @@ def _run_dev_phase(
                 state=state,
                 message=state.error,
             )
+
+    # ── Worktree git-state consistency boundary (advance path only) ──────
+    # A dev iteration has no legitimate need to mutate the branch state of its
+    # worktree. Residue from a partially applied operation (in-progress
+    # rebase/merge/cherry-pick/revert/bisect), a clean-but-illegitimate HEAD/ref
+    # change (reset --hard / force-push behind the pre-dev base), a
+    # dev-introduced merge commit, or a checkout onto the wrong branch is
+    # corrupted state that must never flow silently into review or integration.
+    # Establish the boundary invariant here — fail-closed on residue, attributed
+    # to DEV — before advancing (#1365). Only runs on the successful-dev
+    # fall-through; the timeout/max-iterations retry returns above re-enter DEV.
+    #
+    # No expected_branch_name is passed: coordinator worktrees legitimately run
+    # on a detached HEAD (reused worktrees are checked out and rebased onto
+    # origin/{base_branch}), so a "must be on branch X" assertion would fire on
+    # every healthy run. The residue / base-ancestry / merge-commit checks are
+    # what catch the corrupted state this boundary exists to refuse.
+    _wt_state = check_worktree_git_consistency(
+        workspace_path,
+        expected_base_sha=state.last_dev_start_commit,
+        base_branch=config.workspace.base_branch,
+    )
+    if not _wt_state.consistent:
+        state.phase = Phase.ESCALATE
+        _wt_detail = f" ({_wt_state.detail})" if _wt_state.detail else ""
+        state.error = (
+            f"DEV phase left the worktree in an inconsistent git state "
+            f"({_wt_state.inconsistency}){_wt_detail} — refusing to advance to "
+            "review/integration"
+        )
+        record_dev_iteration_telemetry(
+            state,
+            workspace_path,
+            max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
+            gate_result="WORKTREE_STATE_INCONSISTENT",
+        )
+        _log(f"✗ ESCALATE   {state.error}")
+        if logger:
+            logger._safe_emit("escalate", reason=state.error, phase="DEV")
+        _escalate_notify(task, state, notify, config)
+        return CoordinatorResult(
+            success=False,
+            phase=state.phase,
+            state=state,
+            message=state.error,
+        )
 
     return None

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -1329,15 +1329,21 @@ def _run_dev_phase(
     # to DEV — before advancing (#1365). Only runs on the successful-dev
     # fall-through; the timeout/max-iterations retry returns above re-enter DEV.
     #
-    # No expected_branch_name is passed: coordinator worktrees legitimately run
-    # on a detached HEAD (reused worktrees are checked out and rebased onto
-    # origin/{base_branch}), so a "must be on branch X" assertion would fire on
-    # every healthy run. The residue / base-ancestry / merge-commit checks are
-    # what catch the corrupted state this boundary exists to refuse.
+    # expected_branch_name=branch_name enforces the spec's "refs matching what
+    # the coordinator expects" clause: a coordinator worktree is created on the
+    # story branch (`git worktree add <path> <branch>`) and every rebase keeps
+    # HEAD on it, so a dev iteration that ends detached — or checked out onto a
+    # different ref — has mutated branch state that integration would silently
+    # skip (it force-pushes the *named* branch, not the detached commit). A
+    # detached HEAD is treated as corrupt here exactly as workspace.py already
+    # treats it during worktree reuse. The branch check fails open on a git
+    # error (e.g. a non-repo scratch dir), so only a genuine wrong-ref state
+    # escalates.
     _wt_state = check_worktree_git_consistency(
         workspace_path,
         expected_base_sha=state.last_dev_start_commit,
         base_branch=config.workspace.base_branch,
+        expected_branch_name=branch_name,
     )
     if not _wt_state.consistent:
         state.phase = Phase.ESCALATE

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1031,6 +1031,7 @@ def run_task(
                     _merge_info.get("error"),
                     branch_name,
                     arming_failed=bool(_merge_info.get("arming_failed")),
+                    inherited_dev_residue=bool(_merge_info.get("inherited_dev_residue")),
                 )
 
         _total_elapsed = time.monotonic() - _task_start
@@ -1256,6 +1257,7 @@ def _run_resume_coordinator(
                     _merge_info.get("error"),
                     branch_name,
                     arming_failed=bool(_merge_info.get("arming_failed")),
+                    inherited_dev_residue=bool(_merge_info.get("inherited_dev_residue")),
                 )
 
         _total_elapsed = time.monotonic() - _task_start

--- a/src/theforge/coordinator/worktree_state.py
+++ b/src/theforge/coordinator/worktree_state.py
@@ -1,0 +1,249 @@
+"""Worktree git-state consistency checker: a boundary invariant, not a command police.
+
+A dev iteration has no legitimate need to mutate the branch state of its
+worktree: the worktree is scratch space for committing work, and integrating
+that work onto the base branch is the coordinator's job, done once at
+integration time. Residue from a partially applied operation (an in-progress
+rebase/merge/cherry-pick/revert/bisect), or a clean but illegitimate change to
+HEAD or refs (a ``reset --hard`` / force-push that rewound the base, a
+dev-introduced merge commit, a checkout onto the wrong branch), is corrupted
+state that must never flow silently into review or integration.
+
+This module provides a single stdlib-only checker used at two seams:
+
+* the end of the DEV phase — fail-closed, attributed to DEV, before advancing;
+* the start of integration's fetch/rebase — refusing inherited residue with a
+  structured, phase-attributed diagnosis instead of git's raw
+  "rebase-merge directory already exists" error.
+
+It is pure process control: stdlib :mod:`subprocess` only, no coordinator
+imports, no LLM, no prompt logic. Kept low-dependency like
+:mod:`theforge.coordinator.commit_guard`.
+
+Fail-open vs fail-closed mirrors ``commit_guard``: residue detection is
+fail-closed (residue present ⇒ inconsistent), while the ancestry / merge-commit
+/ branch checks fail-open on a git error so a transient git failure does not
+spuriously escalate an otherwise healthy run.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# In-progress operation markers. Each is checked under the worktree's own git
+# directory (resolved on-disk by :func:`_resolve_git_dir`) so the path lands
+# inside ``.git/worktrees/<slug>/`` for a linked worktree rather than the shared
+# ``.git`` — checking the wrong location would make the guard blind in exactly
+# the worktree case it exists to protect.
+_RESIDUE_MARKERS: tuple[tuple[str, str], ...] = (
+    ("rebase-merge", "in-progress rebase (rebase-merge)"),
+    ("rebase-apply", "in-progress rebase/am (rebase-apply)"),
+    ("MERGE_HEAD", "in-progress merge (MERGE_HEAD)"),
+    ("CHERRY_PICK_HEAD", "in-progress cherry-pick (CHERRY_PICK_HEAD)"),
+    ("REVERT_HEAD", "in-progress revert (REVERT_HEAD)"),
+    ("BISECT_LOG", "in-progress bisect (BISECT_LOG)"),
+)
+
+
+@dataclass(frozen=True)
+class WorktreeStateResult:
+    """Outcome of a worktree git-state consistency check.
+
+    ``consistent`` is True when no inconsistency was found. When False,
+    ``inconsistency`` names the offending state (a short human-readable label)
+    and ``detail`` carries any additional context.
+    """
+
+    consistent: bool
+    inconsistency: str | None = None
+    detail: str | None = None
+
+
+def _run_git(
+    workspace_path: Path, args: list[str], timeout: int = 10
+) -> subprocess.CompletedProcess | None:
+    """Run a git command in ``workspace_path``; return None on any failure.
+
+    A None return means the invocation could not be completed (git missing,
+    timeout, not a repo). Callers decide fail-open vs fail-closed on None.
+    """
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(workspace_path),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _stdout_str(proc: subprocess.CompletedProcess) -> str:
+    """Return a git process's stdout as a str, tolerating bytes.
+
+    ``_run_git`` requests ``text=True`` so real invocations yield str, but a
+    mocked ``subprocess.run`` may hand back bytes; coerce defensively so a test
+    double (or an odd locale) cannot crash the checker into a hard failure that
+    would be worse than the fail-open it is designed to degrade to.
+    """
+    out = proc.stdout
+    if isinstance(out, bytes):
+        return out.decode("utf-8", errors="replace")
+    if isinstance(out, str):
+        return out
+    # None, or a non-string stub (e.g. a MagicMock): treat as empty rather than
+    # letting a non-str value flow into int()/Path() and crash the check.
+    return ""
+
+
+def _resolve_git_dir(workspace_path: Path) -> Path:
+    """Resolve the git directory backing ``workspace_path`` via the filesystem.
+
+    In a normal checkout ``<workspace>/.git`` is a directory. In a linked
+    worktree it is a *file* containing ``gitdir: <path>`` that points into
+    ``<repo>/.git/worktrees/<slug>/`` — where this worktree's in-progress
+    operation markers actually live. Resolving this on-disk (rather than via
+    ``git rev-parse``) keeps the residue check free of subprocess: it cannot
+    perturb call-counting test doubles and cannot be blinded by a mocked git.
+
+    Falls back to ``<workspace>/.git`` when the pointer cannot be read, so a
+    malformed ``.git`` file degrades to the conventional location rather than
+    silently skipping the residue check.
+    """
+    dot_git = workspace_path / ".git"
+    if dot_git.is_dir():
+        return dot_git
+    if dot_git.is_file():
+        try:
+            text = dot_git.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return dot_git
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("gitdir:"):
+                target = Path(line[len("gitdir:") :].strip())
+                if not target.is_absolute():
+                    target = (workspace_path / target).resolve()
+                return target
+    return dot_git
+
+
+def _residue_inconsistency(workspace_path: Path) -> tuple[str, str] | None:
+    """Return ``(label, detail)`` for the first operation-residue marker present.
+
+    Fail-closed: residue present ⇒ inconsistent. Markers are located under the
+    worktree's own git directory so a linked worktree's mid-operation state is
+    detected, not the shared repo's. Returns None only when no residue is
+    positively found.
+    """
+    git_dir = _resolve_git_dir(workspace_path)
+    for name, label in _RESIDUE_MARKERS:
+        marker = git_dir / name
+        if marker.exists():
+            return label, f"{name} present at {marker}"
+    return None
+
+
+def check_worktree_git_consistency(
+    workspace_path: Path,
+    expected_base_sha: str | None = None,
+    base_branch: str | None = None,
+    expected_branch_name: str | None = None,
+) -> WorktreeStateResult:
+    """Assert the worktree is in a consistent git state.
+
+    Checks, in order (first inconsistency wins):
+
+    1. **Operation residue** (fail-closed): an in-progress rebase / merge /
+       cherry-pick / revert / bisect left in the worktree.
+    2. **Base ancestry** (fail-open): when ``expected_base_sha`` is given, HEAD
+       must still descend from it — catching a ``reset --hard`` / force-push
+       that rewound or moved HEAD off the pre-dev base.
+    3. **Dev-introduced merge commits** (fail-open): no merge commits in
+       ``expected_base_sha..HEAD``.
+    4. **Expected branch** (fail-open): when ``expected_branch_name`` is given,
+       HEAD must be on that branch — catching a clean checkout/detach onto a
+       different ref that would otherwise pass the ancestry and merge checks.
+
+    ``base_branch`` is accepted for symmetry with the callers and is currently
+    unused by the checks (ancestry is anchored to the concrete
+    ``expected_base_sha``); it is kept in the signature so integration seams can
+    pass it without a shape change if a future check needs it.
+
+    The ancestry / merge / branch checks fail *open* (return consistent on a git
+    error) so a transient git failure does not spuriously escalate a healthy
+    run; residue detection fails *closed*.
+    """
+    _ = base_branch  # reserved; see docstring
+
+    residue = _residue_inconsistency(workspace_path)
+    if residue is not None:
+        label, detail = residue
+        return WorktreeStateResult(consistent=False, inconsistency=label, detail=detail)
+
+    if expected_base_sha:
+        ancestor = _run_git(
+            workspace_path,
+            ["merge-base", "--is-ancestor", expected_base_sha, "HEAD"],
+        )
+        # returncode 0 = ancestor, 1 = not ancestor, other/None = git error.
+        if ancestor is not None and ancestor.returncode == 1:
+            return WorktreeStateResult(
+                consistent=False,
+                inconsistency="HEAD no longer descends from the pre-dev base",
+                detail=(
+                    f"HEAD is not a descendant of {expected_base_sha} — a reset/force-push "
+                    "rewound or moved the branch off its pre-dev base"
+                ),
+            )
+
+        # ``git log --merges`` (not ``rev-list``): enumerate merge commit SHAs in
+        # the range and count non-empty lines. A count > 0 means dev created a
+        # merge commit, which the coordinator — the sole party that integrates
+        # onto the base branch — must never inherit.
+        merges = _run_git(
+            workspace_path,
+            ["log", "--merges", "--format=%H", f"{expected_base_sha}..HEAD"],
+        )
+        if merges is not None and merges.returncode == 0:
+            merge_shas = [line for line in _stdout_str(merges).splitlines() if line.strip()]
+            if merge_shas:
+                return WorktreeStateResult(
+                    consistent=False,
+                    inconsistency="dev-introduced merge commit(s)",
+                    detail=(
+                        f"{len(merge_shas)} merge commit(s) in {expected_base_sha}..HEAD — "
+                        "integrating onto the base branch is the coordinator's job, not dev's"
+                    ),
+                )
+
+    if expected_branch_name:
+        head_ref = _run_git(workspace_path, ["symbolic-ref", "--quiet", "--short", "HEAD"])
+        if head_ref is not None and head_ref.returncode == 0:
+            current = _stdout_str(head_ref).strip()
+            if current and current != expected_branch_name:
+                return WorktreeStateResult(
+                    consistent=False,
+                    inconsistency="worktree on unexpected branch",
+                    detail=(
+                        f"HEAD is on '{current}', expected '{expected_branch_name}' — "
+                        "dev moved the worktree off the coordinator's story branch"
+                    ),
+                )
+        elif head_ref is not None and head_ref.returncode == 1:
+            # Exit 1 from symbolic-ref --quiet ⇒ detached HEAD; a fatal error
+            # (e.g. not a repo, exit 128) fails open instead of being misread as
+            # detached. A detached HEAD is not the coordinator's expected branch.
+            return WorktreeStateResult(
+                consistent=False,
+                inconsistency="worktree HEAD detached",
+                detail=(
+                    f"HEAD is detached, expected branch '{expected_branch_name}' — "
+                    "dev detached the worktree off the coordinator's story branch"
+                ),
+            )
+
+    return WorktreeStateResult(consistent=True)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -77,7 +77,12 @@ from .manifest import (
 from .query import NormalizedDependencyPlan, normalize_dependency_plan
 from .sources import StorySource
 from .state_writer import SprintStateWriter
-from .story_state import SprintStoryState, StoryOutcome, coerce_outcome
+from .story_state import (
+    SprintStoryState,
+    StoryOutcome,
+    coerce_outcome,
+    landing_failure_outcome,
+)
 
 _UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"codex", "gemini"})
 run_agent = None
@@ -1511,10 +1516,7 @@ def _classify_and_record(
         dag.mark_complete(task.slug)
     elif landing_status == "failed":
         merge_info = getattr(result, "merge", None) or {}
-        if isinstance(merge_info, dict) and merge_info.get("arming_failed"):
-            outcome = StoryOutcome.MERGE_ARMING_FAILED
-        else:
-            outcome = StoryOutcome.MERGE_FAILED
+        outcome = landing_failure_outcome(merge_info if isinstance(merge_info, dict) else None)
         dag.mark_skipped(task.slug)
     elif landing_status == "pending_integration":
         # Approved but merge deferred or queued — counts as succeeded, not yet in DAG
@@ -2630,7 +2632,13 @@ def run_sprint(
         if landing_status == "failed":
             from ..coordinator.completion import mark_merge_failed  # noqa: PLC0415
 
-            mark_merge_failed(result.state, result, merge_info.get("error"), branch)
+            mark_merge_failed(
+                result.state,
+                result,
+                merge_info.get("error"),
+                branch,
+                inherited_dev_residue=bool(merge_info.get("inherited_dev_residue")),
+            )
 
         if merge_info.get("merged"):
             merged_slugs.add(slug)
@@ -3198,11 +3206,7 @@ def run_sprint(
                         # failed — correct the canonical outcome (terminal-to-
                         # terminal correction is permitted).
                         _merge_info = result.merge if isinstance(result.merge, dict) else {}
-                        _failed_outcome = (
-                            StoryOutcome.MERGE_ARMING_FAILED
-                            if _merge_info.get("arming_failed")
-                            else StoryOutcome.MERGE_FAILED
-                        )
+                        _failed_outcome = landing_failure_outcome(_merge_info)
                         _set_outcome(slug, _failed_outcome, phase=result.phase.name)
                     changed = True
                     while changed:
@@ -3218,10 +3222,8 @@ def run_sprint(
                                         if isinstance(pending_result.merge, dict)
                                         else {}
                                     )
-                                    _pending_failed_outcome = (
-                                        StoryOutcome.MERGE_ARMING_FAILED
-                                        if _pending_merge_info.get("arming_failed")
-                                        else StoryOutcome.MERGE_FAILED
+                                    _pending_failed_outcome = landing_failure_outcome(
+                                        _pending_merge_info
                                     )
                                     _set_outcome(
                                         pending_slug,

--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -172,6 +172,29 @@ def coerce_outcome(value: object) -> StoryOutcome:
     return StoryOutcome.WAITING
 
 
+def landing_failure_outcome(merge_info: dict | None) -> StoryOutcome:
+    """Classify a failed landing (landing_status == "failed") into an outcome.
+
+    A merge-step failure is not one undifferentiated bucket. The merge_info flags
+    distinguish who is responsible so the operator is pointed at the right fix:
+
+    * ``inherited_dev_residue`` — integration refused git state a prior DEV
+      iteration left behind (issue #1365). Integration is the victim, so this is
+      a DEV-attributed ``ESCALATED``, never ``MERGE_FAILED``.
+    * ``arming_failed`` — the PR is fine; only ``gh pr merge --auto`` arming
+      failed → ``MERGE_ARMING_FAILED`` (configure branch protection).
+    * otherwise → ``MERGE_FAILED`` (the generic post-approval merge failure).
+
+    Centralised so every sprint landing site classifies identically.
+    """
+    m = merge_info or {}
+    if m.get("inherited_dev_residue"):
+        return StoryOutcome.ESCALATED
+    if m.get("arming_failed"):
+        return StoryOutcome.MERGE_ARMING_FAILED
+    return StoryOutcome.MERGE_FAILED
+
+
 @dataclass
 class StoryStateEntry:
     """Per-story state. The canonical record for one story in one sprint."""

--- a/tests/test_coord_worktree_state.py
+++ b/tests/test_coord_worktree_state.py
@@ -309,6 +309,86 @@ def test_dev_phase_escalates_when_successful_result_left_residue(tmp_path: Path)
     assert "DEV phase" in (state.error or "")
 
 
+def test_dev_phase_escalates_when_dev_left_head_detached(tmp_path: Path) -> None:
+    """A dev result that ends with a detached HEAD (committed off the story
+    branch) must escalate with a DEV-attributed error, not advance — integration
+    force-pushes the named branch, so the detached commit would be silently lost."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/t"], cwd=tmp_path, check=True)
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+    state.adaptive_dev_max = 3
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    # Dev commits on the branch, then detaches HEAD and commits there — the
+    # branch ref no longer points at HEAD.
+    def agent_side_effect(**_kwargs):
+        _commit(tmp_path, "onbranch.py")
+        subprocess.run(["git", "checkout", "-q", "--detach"], cwd=tmp_path, check=True)
+        _commit(tmp_path, "detached.py")
+        return _make_agent_result(success=True, output="Done.")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", side_effect=agent_side_effect)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/t", notify=False, logger=None
+        )
+
+    assert isinstance(result, CoordinatorResult)
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    assert "inconsistent git state" in (state.error or "")
+    assert "detached" in (state.error or "")
+    assert "DEV phase" in (state.error or "")
+
+
+def test_dev_phase_escalates_when_dev_left_wrong_branch(tmp_path: Path) -> None:
+    """A dev result that ends checked out on a different branch than the
+    coordinator's story branch must escalate rather than advance."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/t"], cwd=tmp_path, check=True)
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+    state.adaptive_dev_max = 3
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    def agent_side_effect(**_kwargs):
+        _commit(tmp_path, "work.py")
+        # Dev switches the worktree onto a different branch.
+        subprocess.run(["git", "checkout", "-q", "-b", "feat/other"], cwd=tmp_path, check=True)
+        return _make_agent_result(success=True, output="Done.")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", side_effect=agent_side_effect)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/t", notify=False, logger=None
+        )
+
+    assert isinstance(result, CoordinatorResult)
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    assert "unexpected branch" in (state.error or "")
+    assert "DEV phase" in (state.error or "")
+
+
 def test_dev_phase_advances_when_worktree_clean(tmp_path: Path) -> None:
     """A successful dev result with a clean worktree returns None to advance."""
     _init_repo(tmp_path)

--- a/tests/test_coord_worktree_state.py
+++ b/tests/test_coord_worktree_state.py
@@ -1,0 +1,397 @@
+"""Tests for the worktree git-state consistency boundary (#1365).
+
+A dev iteration has no legitimate need to mutate the branch state of its
+worktree. Residue from a partially applied operation (in-progress rebase /
+merge / cherry-pick / revert / bisect), a clean-but-illegitimate HEAD/ref
+change (reset --hard behind the pre-dev base, a dev-introduced merge commit, a
+checkout onto the wrong branch), is corrupted state that must never flow
+silently into review or integration.
+
+These tests cover:
+
+* the pure checker (`check_worktree_git_consistency`) against real temp repos;
+* the DEV-phase seam — a successful dev result that left residue escalates with
+  a DEV-attributed error instead of returning None to advance;
+* the integration seam — `_step_fetch_rebase` returns the structured
+  DEV-attributed error (and never invokes `git rebase`) when residue is present,
+  replaying the issue-1338 shape.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from coord_test_helpers import _make_agent_result  # noqa: E402
+
+from theforge.config import (  # noqa: E402
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import (  # noqa: E402
+    CoordinatorResult,
+    CoordinatorState,
+    Phase,
+)
+from theforge.coordinator.worktree_state import (  # noqa: E402
+    WorktreeStateResult,
+    check_worktree_git_consistency,
+)
+from theforge.task import TaskStory  # noqa: E402
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+
+
+def _head_sha(path: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _commit(path: Path, name: str, content: str = "x") -> str:
+    (path / name).write_text(content)
+    subprocess.run(["git", "add", name], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", f"add {name}"], cwd=path, check=True)
+    return _head_sha(path)
+
+
+# ── Unit tests: the pure checker ────────────────────────────────────────
+
+
+def test_clean_worktree_is_consistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    result = check_worktree_git_consistency(tmp_path, expected_base_sha=base, base_branch="main")
+    assert isinstance(result, WorktreeStateResult)
+    assert result.consistent is True
+    assert result.inconsistency is None
+
+
+def test_clean_worktree_with_new_commits_is_consistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    _commit(tmp_path, "a.py")
+    _commit(tmp_path, "b.py")
+    result = check_worktree_git_consistency(tmp_path, expected_base_sha=base, base_branch="main")
+    assert result.consistent is True
+
+
+def test_rebase_merge_residue_is_inconsistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    # Fabricate a rebase-merge directory as git would leave mid-rebase.
+    (tmp_path / ".git" / "rebase-merge").mkdir()
+    result = check_worktree_git_consistency(tmp_path, expected_base_sha=base)
+    assert result.consistent is False
+    assert "rebase-merge" in (result.inconsistency or "")
+
+
+def test_merge_head_residue_is_inconsistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / ".git" / "MERGE_HEAD").write_text(_head_sha(tmp_path) + "\n")
+    result = check_worktree_git_consistency(tmp_path)
+    assert result.consistent is False
+    assert "MERGE_HEAD" in (result.inconsistency or "")
+
+
+def test_genuine_interrupted_rebase_is_inconsistent(tmp_path: Path) -> None:
+    """A real conflicted `git rebase` leaves rebase-merge residue the checker catches."""
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    # Two branches that both edit the same line → a rebase conflict.
+    subprocess.run(["git", "checkout", "-q", "-b", "feat"], cwd=tmp_path, check=True)
+    (tmp_path / "conflict.txt").write_text("feat\n")
+    subprocess.run(["git", "add", "conflict.txt"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=tmp_path, check=True)
+    (tmp_path / "conflict.txt").write_text("main\n")
+    subprocess.run(["git", "add", "conflict.txt"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "checkout", "-q", "feat"], cwd=tmp_path, check=True)
+    # This rebase conflicts and leaves the worktree mid-rebase.
+    proc = subprocess.run(["git", "rebase", "main"], cwd=tmp_path, capture_output=True)
+    assert proc.returncode != 0, "expected the rebase to conflict"
+    try:
+        result = check_worktree_git_consistency(tmp_path, expected_base_sha=base)
+        assert result.consistent is False
+        assert "rebase" in (result.inconsistency or "").lower()
+    finally:
+        subprocess.run(["git", "rebase", "--abort"], cwd=tmp_path, capture_output=True)
+
+
+def test_reset_hard_behind_base_is_non_descendant(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit(tmp_path, "a.py")
+    pre_dev = _head_sha(tmp_path)  # base captured before dev
+    _commit(tmp_path, "b.py")
+    # Dev then rewinds HEAD behind the pre-dev base with a reset --hard.
+    subprocess.run(["git", "reset", "-q", "--hard", "HEAD~2"], cwd=tmp_path, check=True)
+    result = check_worktree_git_consistency(tmp_path, expected_base_sha=pre_dev)
+    assert result.consistent is False
+    assert "descends" in (result.inconsistency or "")
+
+
+def test_dev_introduced_merge_commit_is_inconsistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    # Create a side branch, then merge it back with a real merge commit.
+    subprocess.run(["git", "checkout", "-q", "-b", "side"], cwd=tmp_path, check=True)
+    _commit(tmp_path, "side.py")
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=tmp_path, check=True)
+    _commit(tmp_path, "main.py")
+    subprocess.run(
+        ["git", "merge", "-q", "--no-ff", "-m", "merge side", "side"], cwd=tmp_path, check=True
+    )
+    result = check_worktree_git_consistency(tmp_path, expected_base_sha=base)
+    assert result.consistent is False
+    assert "merge commit" in (result.inconsistency or "")
+
+
+def test_wrong_branch_is_inconsistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "other"], cwd=tmp_path, check=True)
+    result = check_worktree_git_consistency(
+        tmp_path, expected_base_sha=base, expected_branch_name="feat/story"
+    )
+    assert result.consistent is False
+    assert "unexpected branch" in (result.inconsistency or "")
+
+
+def test_detached_head_is_inconsistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "--detach"], cwd=tmp_path, check=True)
+    result = check_worktree_git_consistency(
+        tmp_path, expected_base_sha=base, expected_branch_name="feat/story"
+    )
+    assert result.consistent is False
+    assert "detached" in (result.inconsistency or "")
+
+
+def test_expected_branch_match_is_consistent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    base = _head_sha(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/story"], cwd=tmp_path, check=True)
+    result = check_worktree_git_consistency(
+        tmp_path, expected_base_sha=base, expected_branch_name="feat/story"
+    )
+    assert result.consistent is True
+
+
+def test_residue_resolves_via_linked_worktree_git_path(tmp_path: Path) -> None:
+    """In a linked worktree, residue lives under .git/worktrees/<slug>/ — the
+    checker must resolve it via `git rev-parse --git-path`, not the shared .git."""
+    main_repo = tmp_path / "main"
+    main_repo.mkdir()
+    _init_repo(main_repo)
+    base = _head_sha(main_repo)
+    wt = tmp_path / "wt"
+    subprocess.run(
+        ["git", "worktree", "add", "-q", "-b", "feat/story", str(wt)],
+        cwd=main_repo,
+        check=True,
+    )
+    # Clean linked worktree is consistent.
+    assert check_worktree_git_consistency(wt, expected_base_sha=base).consistent is True
+    # Residue in the linked worktree's private git dir must be detected.
+    git_path = subprocess.run(
+        ["git", "rev-parse", "--git-path", "rebase-merge"],
+        cwd=wt,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    resolved = Path(git_path)
+    if not resolved.is_absolute():
+        resolved = wt / resolved
+    resolved.mkdir(parents=True)
+    result = check_worktree_git_consistency(wt, expected_base_sha=base)
+    assert result.consistent is False
+    assert "rebase-merge" in (result.inconsistency or "")
+
+
+# ── Seam test 1: DEV-phase boundary escalates on inherited residue ──────
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+            base_branch="main",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        preflight_fallback_profile=None,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=3, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _run_dev(config, task, state, workspace, agent_result):
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", return_value=agent_result)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        return _run_dev_phase(
+            state, config, task, "# t\n", workspace, "feat/t", notify=False, logger=None
+        )
+
+
+def test_dev_phase_escalates_when_successful_result_left_residue(tmp_path: Path) -> None:
+    """A successful dev result that left rebase residue must escalate with a
+    DEV-attributed error instead of returning None to advance to review."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/t"], cwd=tmp_path, check=True)
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+    state.adaptive_dev_max = 3
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    # Dev produced a legitimate commit, but also left rebase-merge residue.
+    def agent_side_effect(**_kwargs):
+        _commit(tmp_path, "work.py")
+        (tmp_path / ".git" / "rebase-merge").mkdir()
+        return _make_agent_result(success=True, output="Done.")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", side_effect=agent_side_effect)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/t", notify=False, logger=None
+        )
+
+    assert isinstance(result, CoordinatorResult)
+    assert result.success is False
+    assert state.phase == Phase.ESCALATE
+    assert "inconsistent git state" in (state.error or "")
+    assert "rebase-merge" in (state.error or "")
+    assert "DEV phase" in (state.error or "")
+
+
+def test_dev_phase_advances_when_worktree_clean(tmp_path: Path) -> None:
+    """A successful dev result with a clean worktree returns None to advance."""
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/t"], cwd=tmp_path, check=True)
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    state = CoordinatorState()
+    state.adaptive_dev_max = 3
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    def agent_side_effect(**_kwargs):
+        _commit(tmp_path, "work.py")
+        return _make_agent_result(success=True, output="Done.")
+
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", side_effect=agent_side_effect)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/t", notify=False, logger=None
+        )
+
+    assert result is None
+    assert state.phase != Phase.ESCALATE
+
+
+# ── Seam test 2: integration refuses inherited residue, never rebases ───
+
+
+def test_step_fetch_rebase_refuses_inherited_residue_without_rebasing(tmp_path: Path) -> None:
+    """Replays issue-1338: a rebase-merge dir left by dev makes _step_fetch_rebase
+    return a structured DEV-attributed error and NEVER invoke `git rebase`."""
+    from theforge.coordinator import completion
+
+    _init_repo(tmp_path)
+    # Dev left half-completed rebase residue in the worktree.
+    (tmp_path / ".git" / "rebase-merge").mkdir()
+
+    called_git = []
+    real_run = subprocess.run
+
+    def spy_run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and len(cmd) >= 2 and cmd[0] == "git":
+            called_git.append(cmd[1])
+        return real_run(cmd, *args, **kwargs)
+
+    with patch.object(completion.subprocess, "run", side_effect=spy_run):
+        result = completion._step_fetch_rebase(tmp_path, "main")
+
+    assert result["success"] is False
+    assert "inconsistent git state" in result["error"]
+    assert "rebase-merge" in result["error"]
+    assert "DEV phase" in result["error"]
+    # The rebase must never have been attempted — no raw git rebase error.
+    assert "rebase" not in called_git
+    assert "fetch" not in called_git
+
+
+def test_step_fetch_rebase_proceeds_when_no_residue(tmp_path: Path) -> None:
+    """With a clean worktree the fetch/rebase path runs unchanged (fetch attempted)."""
+    from theforge.coordinator import completion
+
+    _init_repo(tmp_path)
+
+    attempted = []
+    real_run = subprocess.run
+
+    def spy_run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and len(cmd) >= 2 and cmd[0] == "git":
+            attempted.append(cmd[1])
+        return real_run(cmd, *args, **kwargs)
+
+    with patch.object(completion.subprocess, "run", side_effect=spy_run):
+        result = completion._step_fetch_rebase(tmp_path, "main")
+
+    # No origin remote → fetch fails, but the point is the residue guard did NOT
+    # short-circuit: the fetch was actually attempted.
+    assert "fetch" in attempted
+    assert result["success"] is False
+    assert "inconsistent git state" not in result["error"]

--- a/tests/test_coord_worktree_state.py
+++ b/tests/test_coord_worktree_state.py
@@ -448,6 +448,8 @@ def test_step_fetch_rebase_refuses_inherited_residue_without_rebasing(tmp_path: 
     assert "inconsistent git state" in result["error"]
     assert "rebase-merge" in result["error"]
     assert "DEV phase" in result["error"]
+    # DEV-attribution flag so landing paths escalate instead of MERGE_FAILED.
+    assert result["inherited_dev_residue"] is True
     # The rebase must never have been attempted — no raw git rebase error.
     assert "rebase" not in called_git
     assert "fetch" not in called_git
@@ -475,3 +477,140 @@ def test_step_fetch_rebase_proceeds_when_no_residue(tmp_path: Path) -> None:
     assert "fetch" in attempted
     assert result["success"] is False
     assert "inconsistent git state" not in result["error"]
+
+
+# ── Seam test 3: inherited residue is classified as DEV escalation, ─────
+#     never as a merge failure pinned on integration.
+
+
+def _merge_pr_config(tmp_path: Path):
+    from theforge.config import (
+        DEFAULT_DEV_PROFILE,
+        DEFAULT_PREFLIGHT_PROFILE,
+        DEFAULT_REVIEW_PROFILE,
+        DEFAULT_VALIDATION,
+        ForgeConfig,
+        LogConfig,
+        RetryPolicy,
+        WorkspaceConfig,
+    )
+
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+            on_approve="merge-pr",
+            auto_push=True,
+            base_branch="main",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def test_merge_pr_residue_propagates_dev_attribution_flag(tmp_path: Path) -> None:
+    """_merge_pr must surface the inherited_dev_residue flag (and never rebase)
+    when the worktree carries residue from a prior DEV iteration (#1365)."""
+    from theforge.coordinator import completion
+
+    config = _merge_pr_config(tmp_path)
+    task = TaskStory(name="test-task", slug="test-task", story_path="specs/t.md")
+    # Build the worktree the way _merge_pr resolves it and leave residue in it.
+    worktree = tmp_path / "test-task"
+    worktree.mkdir()
+    _init_repo(worktree)
+    (worktree / ".git" / "rebase-merge").mkdir()
+
+    review = MagicMock()
+    state = MagicMock()
+
+    git_verbs = []
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and cmd:
+            if cmd[0] == "gh":
+                # "already merged?" lookup → not merged, proceed to fetch/rebase.
+                return _make_mock_proc(0, "[]")
+            if cmd[0] == "git":
+                git_verbs.append(cmd[1] if len(cmd) > 1 else "")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch.object(completion.subprocess, "run", side_effect=fake_run):
+        merge_info = completion._merge_pr(config, task, "forge/test-task", review, state)
+
+    assert merge_info["success"] is False
+    assert merge_info.get("inherited_dev_residue") is True
+    assert "DEV phase" in merge_info["error"]
+    # Residue short-circuits before any rebase is attempted.
+    assert "rebase" not in git_verbs
+
+
+def _make_mock_proc(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def test_landing_failure_outcome_classifies_inherited_residue_as_escalated() -> None:
+    """The shared landing-failure classifier maps inherited DEV residue to a
+    DEV-attributed ESCALATED outcome, arming failures to MERGE_ARMING_FAILED, and
+    everything else to the generic MERGE_FAILED."""
+    from theforge.sprint.story_state import StoryOutcome, landing_failure_outcome
+
+    assert landing_failure_outcome({"inherited_dev_residue": True}) is StoryOutcome.ESCALATED
+    # Residue attribution takes precedence over a co-present arming flag.
+    assert (
+        landing_failure_outcome({"inherited_dev_residue": True, "arming_failed": True})
+        is StoryOutcome.ESCALATED
+    )
+    assert landing_failure_outcome({"arming_failed": True}) is StoryOutcome.MERGE_ARMING_FAILED
+    assert landing_failure_outcome({}) is StoryOutcome.MERGE_FAILED
+    assert landing_failure_outcome(None) is StoryOutcome.MERGE_FAILED
+
+
+def test_mark_merge_failed_inherited_residue_escalates_not_merge_failed() -> None:
+    """mark_merge_failed(inherited_dev_residue=True) records a DEV-attributed
+    Phase.ESCALATE — not Phase.MERGE_FAILED — so integration is not blamed for
+    state the DEV phase created."""
+    from theforge.coordinator.completion import mark_merge_failed
+    from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+
+    state = CoordinatorState()
+    result = CoordinatorResult(
+        success=True, phase=Phase.DONE, state=state, message="done", landing_status="failed"
+    )
+
+    mark_merge_failed(
+        state,
+        result,
+        "dev left inconsistent git state: in-progress rebase (rebase-merge)",
+        "forge/test-task",
+        inherited_dev_residue=True,
+    )
+
+    assert state.phase is Phase.ESCALATE
+    assert result.phase is Phase.ESCALATE
+    assert result.success is False
+    assert result.landing_status == "failed"
+    assert "DEV" in result.message
+    assert "merge failure" in result.message  # message disavows the merge-failure framing
+
+    # Contrast: a normal merge failure still records MERGE_FAILED.
+    state2 = CoordinatorState()
+    result2 = CoordinatorResult(
+        success=True, phase=Phase.DONE, state=state2, message="done", landing_status="failed"
+    )
+    mark_merge_failed(state2, result2, "conflict", "forge/test-task")
+    assert state2.phase is Phase.MERGE_FAILED
+    assert result2.phase is Phase.MERGE_FAILED


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved; the DEV boundary now enforces residue, ancestry, merge-commit, and branch checks, and inherited DEV residue is classified as ESCALATED rather than MERGE_FAILED. | [google-gemini-3.5-flash] The worktree git-state boundary invariant is fully enforced at both the DEV and integration seams, with correct terminal classification as a DEV-attributed escalation instead of MERGE_FAILED. | [claude-sonnet] Cycle 1's P1s (missing expected_branch_name at DEV seam) and Cycle 2's P1 (inherited residue misclassified as MERGE_FAILED) are all resolved and covered by targeted seam tests; landing_failure_outcome() is applied consistently at every non-queued landing-classification site, and queued-PR-timeout paths are correctly left untouched since residue always fails before a PR is queued. No regressions found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $24.04
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Dev iterations can mutate worktree branch state, silently corrupting downstream integration (GitHub Issue #1365)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1365