### PR TITLE
forge status --watch: REVIEW phase live view is opaque (no per-reviewer iter/stage/activity)

### DIFF
--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -255,7 +255,14 @@ def render_frame(
         delta = cost - prev
         new_costs[slug] = cost
 
-        last_evt = _last_audit_mtime(slug, run_id, project_root, sprint_log_dir)
+        # EVENT AGE ticks from the freshest of the audit.yaml mtime (dev/other
+        # phases) and the most recent reviewer tool-call event (REVIEW /
+        # PLAN_REVIEW). Each reviewer iteration rewrites .state and bumps
+        # last_reviewer_event_ts, so review no longer shows a frozen "—".
+        _audit_mtime = _last_audit_mtime(slug, run_id, project_root, sprint_log_dir)
+        _reviewer_ts = getattr(e, "last_event_ts", None)
+        _candidates = [t for t in (_audit_mtime, _reviewer_ts) if isinstance(t, (int, float))]
+        last_evt = max(_candidates) if _candidates else None
         if last_evt is None:
             age_str = "—"
             stalled = False

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -64,6 +64,7 @@ from .plan_trajectory import (
 from .preflight import _escalate_dev_model, _find_registry_key_for_profile
 from .preflight_evidence import render_partial_evidence
 from .remote_gates import _plan_review_remote
+from .reviewer_progress import ReviewerProgressChannel
 from .state import CoordinatorResult, CoordinatorState, Phase, PlanFindingRecord
 from .util import _fmt_cost, _fmt_duration, _log_phase, resolve_timeout_with_active
 
@@ -259,6 +260,7 @@ def _retry_transient_plan_review_failures(
     config: ForgeConfig,
     workspace_path: Path,
     attempt: int,
+    progress_channel: "ReviewerProgressChannel | None" = None,
 ) -> tuple[list["AgentResult"], list[dict]]:
     """Retry transient plan-review transport failures per reviewer."""
     max_retries = config.retry.max_plan_review_transport_retries
@@ -281,6 +283,8 @@ def _retry_transient_plan_review_failures(
                 f"  ↻ PLAN_REVIEW   {profile.name} transient transport failure "
                 f"(retry {retry_count}/{max_retries})"
             )
+            if progress_channel is not None:
+                progress_channel.set_retry(profile.name, retry_count, max_retries)
             retried = run_agent(
                 prompt=prompt,
                 profile=profile,
@@ -288,6 +292,7 @@ def _retry_transient_plan_review_failures(
                 quiet=True,
                 secrets=config.secrets,
                 session_id=current.session_id if profile.mode == "cli" else None,
+                progress_cb=progress_channel.cb if progress_channel is not None else None,
             )
             if retried.session_id:
                 state.plan_review_session_ids[profile.name] = retried.session_id
@@ -735,6 +740,7 @@ def _run_plan_phase(
                 notify=notify,
                 logger=logger,
                 advisory=(_work_type == "refactor"),
+                state_update_fn=state_update_fn,
             )
             if result is not None:
                 return result
@@ -834,6 +840,7 @@ def _run_plan_agent_review(
     notify: bool,
     logger: "StructuredLogger | None",
     advisory: bool = False,
+    state_update_fn: "Callable[[dict], None] | None" = None,
 ) -> CoordinatorResult | None:
     """Run agent-based plan review pool with regen loop.
 
@@ -884,12 +891,22 @@ def _run_plan_agent_review(
 
         _pr_start = time.monotonic()
         _pool_session_ids = [state.plan_review_session_ids.get(p.name) for p in par_profiles]
+        # Passive per-reviewer progress channel — identical contract to REVIEW.
+        _pr_channel = ReviewerProgressChannel(
+            reviewer_names=_pool_names,
+            phase="PLAN_REVIEW",
+            iteration=_attempt,
+            cost_usd=state.total_cost,
+            complexity=state.preflight_complexity,
+            state_update_fn=state_update_fn,
+        )
         pr_results = run_agent_pool(
             prompt=pr_prompt,
             profiles=par_profiles,
             working_dir=workspace_path,
             session_ids=_pool_session_ids,
             secrets=config.secrets,
+            progress_cb=_pr_channel.cb,
         )
         pr_results, _transport_retry_events = _retry_transient_plan_review_failures(
             prompt=pr_prompt,
@@ -899,6 +916,7 @@ def _run_plan_agent_review(
             config=config,
             workspace_path=workspace_path,
             attempt=_attempt,
+            progress_channel=_pr_channel,
         )
         state.plan_review_transport_retries.extend(_transport_retry_events)
         pr_results, _parse_retry_events = _retry_parse_failed_plan_reviews(

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -311,6 +311,10 @@ def _retry_transient_plan_review_failures(
             )
             current = retried
 
+        # A resolved retry marks the reviewer done (also clears the ↻rN/M glyph)
+        # so the pool-done count stays accurate.
+        if retry_count > 0 and current.success and progress_channel is not None:
+            progress_channel.cb({"label": profile.name, "done": True})
         retried_results[index] = current
 
     return retried_results, retry_events

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1016,6 +1016,7 @@ def _run_review_phase(
         max_review_parse_retries=max_parse_retries,
         logger=logger,
         stop_event=stop_event,
+        state_update_fn=state_update_fn,
     )
     state.last_cycle_reviewer_results = _named_parsed
 

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import dataclasses
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -45,6 +46,7 @@ from .review_context import (
     _parse_dev_handoff,
     hard_convention_review_kwargs,
 )
+from .reviewer_progress import ReviewerProgressChannel
 from .state import CoordinatorState, Phase, ReviewCycleMetadata
 
 if TYPE_CHECKING:
@@ -189,6 +191,7 @@ def _retry_transient_review_failures(
     pool_attempt: int,
     meta: ReviewCycleMetadata,
     stop_event: "threading.Event | None" = None,
+    progress_channel: "ReviewerProgressChannel | None" = None,
 ) -> list:
     """Retry per-reviewer transient transport failures with exponential backoff.
 
@@ -223,6 +226,9 @@ def _retry_transient_review_failures(
                 f"  ↻ {profile.name} transient transport failure "
                 f"(retry {retry_count}/{max_retries}) in {backoff:.0f}s"
             )
+            # Surface the retry live so the watch view shows ↻ rN/M immediately.
+            if progress_channel is not None:
+                progress_channel.set_retry(profile.name, retry_count, max_retries)
             if backoff > 0:
                 time.sleep(backoff)
             retried = run_agent(
@@ -233,6 +239,7 @@ def _retry_transient_review_failures(
                 secrets=config.secrets,
                 session_id=current.session_id if profile.mode == "cli" else None,
                 stop_event=stop_event,
+                progress_cb=progress_channel.cb if progress_channel is not None else None,
             )
             if retried.session_id:
                 state.reviewer_session_ids[profile.name] = retried.session_id
@@ -374,6 +381,7 @@ def _run_review_pool(
     max_review_parse_retries: int = 0,
     logger: Any | None = None,
     stop_event: "threading.Event | None" = None,
+    state_update_fn: "Callable[[dict], None] | None" = None,
 ) -> tuple[list, list, ReviewResult | None, list[ReviewResult], list[tuple[str, ReviewResult]]]:
     """Run the review pool and merge results.
 
@@ -537,6 +545,16 @@ def _run_review_pool(
     for _p, _sid in zip(pool, pool_session_ids):
         _tag = f"resuming {_sid[:8]}" if _sid else "new session"
         _log_verbose(f"  reviewer {_p.name}: {_tag}")
+    # Passive per-reviewer progress channel: aggregates iter/done/retry events
+    # into live .state so the watch view can render per-reviewer progress.
+    progress_channel = ReviewerProgressChannel(
+        reviewer_names=[p.name for p in pool],
+        phase="REVIEW",
+        iteration=state.review_cycle + 1,
+        cost_usd=state.total_cost,
+        complexity=state.preflight_complexity,
+        state_update_fn=state_update_fn,
+    )
     pool_results = run_agent_pool(
         prompt=review_prompts,
         profiles=pool,
@@ -544,6 +562,7 @@ def _run_review_pool(
         session_ids=pool_session_ids,
         secrets=config.secrets,
         stop_event=stop_event,
+        progress_cb=progress_channel.cb,
     )
     _pool_elapsed = time.monotonic() - _pool_start
     for profile, result in zip(pool, pool_results):
@@ -591,6 +610,7 @@ def _run_review_pool(
         pool_attempt=pool_attempt,
         meta=meta,
         stop_event=stop_event,
+        progress_channel=progress_channel,
     )
 
     # Per-profile budget enforcement BEFORE synthesis — exclude over-budget

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -264,6 +264,10 @@ def _retry_transient_review_failures(
         if current.success:
             meta.transient_outcomes[profile.name] = "transient_retried_then_succeeded"
             _log(f"  ✓ {profile.name} transient retry {retry_count} succeeded")
+            # The retry resolved the transient failure — mark the reviewer done
+            # (also clears the ↻rN/M glyph) so the pool-done count is accurate.
+            if progress_channel is not None:
+                progress_channel.cb({"label": profile.name, "done": True})
         else:
             meta.transient_outcomes[profile.name] = "transient_retried_then_failed"
             _log(f"  ✗ {profile.name} transient retries exhausted")

--- a/src/theforge/coordinator/reviewer_progress.py
+++ b/src/theforge/coordinator/reviewer_progress.py
@@ -1,0 +1,111 @@
+"""Passive per-reviewer progress channel for the live watch view.
+
+The reviewer pool runs several agents concurrently; each agent-loop iteration
+and completion is a structured event (not a parsed log line). This module
+aggregates those events, under a lock, into the live ``.state`` story ``detail``
+dict via the coordinator's ``state_update_fn`` so ``forge status --watch`` can
+render per-reviewer iteration / retry / pool-progress instead of a bare ``—``.
+
+The channel is a *pure event emitter*: it never influences control flow and a
+raising ``state_update_fn`` can never break a reviewer (every emit is wrapped).
+This respects the runners-don't-decide invariant — the runner emits, the
+coordinator aggregates, the CLI renders.
+
+Detail contract written into the story ``detail`` dict (replaced wholesale on
+each emit, since ``SprintStoryState`` transitions overwrite ``detail``):
+
+    reviewer_progress: {name: {"iter": int, "tool_calls": int,
+                               "retry": [n, m] | None, "done": bool}}
+    reviewer_pool_size: int
+    last_reviewer_event_ts: float   # epoch seconds of the freshest event
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable
+
+
+class ReviewerProgressChannel:
+    """Thread-safe aggregator of per-reviewer progress events.
+
+    Seed with every pool profile name so the first frame shows the whole pool.
+    Pass :attr:`cb` as ``progress_cb=`` to ``run_agent_pool``; call
+    :meth:`set_retry` from the transient-retry loop to surface ``↻ rN/M`` live.
+    """
+
+    def __init__(
+        self,
+        *,
+        reviewer_names: list[str],
+        phase: str,
+        iteration: int,
+        cost_usd: float,
+        complexity: object,
+        state_update_fn: "Callable[[dict], None] | None",
+    ) -> None:
+        self._phase = phase
+        self._iteration = iteration
+        self._cost_usd = cost_usd
+        self._complexity = complexity
+        self._state_update_fn = state_update_fn
+        self._lock = threading.Lock()
+        self._progress: dict[str, dict] = {
+            name: {"iter": 0, "tool_calls": 0, "retry": None, "done": False}
+            for name in reviewer_names
+        }
+
+    # ── event ingress ────────────────────────────────────────────────
+    def cb(self, event: dict) -> None:
+        """Ingest one reviewer event. Best-effort: never raises into the pool."""
+        try:
+            label = event.get("label")
+            with self._lock:
+                entry = self._progress.get(label)
+                if entry is None:
+                    return
+                if event.get("done"):
+                    entry["done"] = True
+                if "iter" in event:
+                    entry["iter"] = event["iter"]
+                if "tool_calls" in event:
+                    entry["tool_calls"] = event["tool_calls"]
+                self._emit_locked()
+        except Exception:
+            pass
+
+    def set_retry(self, name: str, retry_n: int, retry_max: int) -> None:
+        """Mark a reviewer as retrying (surfaces ``↻ rN/M``) and re-emit."""
+        try:
+            with self._lock:
+                entry = self._progress.get(name)
+                if entry is None:
+                    return
+                entry["retry"] = [retry_n, retry_max]
+                self._emit_locked()
+        except Exception:
+            pass
+
+    # ── state egress ─────────────────────────────────────────────────
+    def _emit_locked(self) -> None:
+        """Write the full review-scoped detail into live state. Caller holds lock."""
+        if self._state_update_fn is None:
+            return
+        detail = {
+            "reviewer_progress": {k: dict(v) for k, v in self._progress.items()},
+            "reviewer_pool_size": len(self._progress),
+            "last_reviewer_event_ts": time.time(),
+        }
+        try:
+            self._state_update_fn(
+                {
+                    "phase": self._phase,
+                    "iteration": self._iteration,
+                    "cost_usd": self._cost_usd,
+                    "complexity": self._complexity,
+                    "detail": detail,
+                }
+            )
+        except Exception:
+            pass

--- a/src/theforge/coordinator/reviewer_progress.py
+++ b/src/theforge/coordinator/reviewer_progress.py
@@ -65,10 +65,17 @@ class ReviewerProgressChannel:
                 entry = self._progress.get(label)
                 if entry is None:
                     return
+                # A fresh iteration/completion event means the reviewer is
+                # making progress again, so an outstanding transient-retry
+                # marker is stale — clear it. set_retry() re-arms it if the
+                # next attempt also fails, so ↻rN/M only shows while a retry
+                # is actually outstanding (AC #3: "while it is retrying").
                 if event.get("done"):
                     entry["done"] = True
+                    entry["retry"] = None
                 if "iter" in event:
                     entry["iter"] = event["iter"]
+                    entry["retry"] = None
                 if "tool_calls" in event:
                     entry["tool_calls"] = event["tool_calls"]
                 self._emit_locked()

--- a/src/theforge/coordinator/reviewer_progress.py
+++ b/src/theforge/coordinator/reviewer_progress.py
@@ -55,6 +55,12 @@ class ReviewerProgressChannel:
             name: {"iter": 0, "tool_calls": 0, "retry": None, "done": False}
             for name in reviewer_names
         }
+        # Emit the seeded pool state immediately so the watch view renders
+        # "pool 0/N done" the moment a reviewer pool starts — before any
+        # reviewer has emitted its first tool-call event — instead of falling
+        # back to legacy "running". Best-effort (never raises into the caller).
+        with self._lock:
+            self._emit_locked()
 
     # ── event ingress ────────────────────────────────────────────────
     def cb(self, event: dict) -> None:

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -191,6 +191,7 @@ class AgentLoopManager:
         provider_adapter: ProviderAdapter,
         finalizer: Finalizer | None = None,
         max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+        progress_cb: "Callable[[dict], None] | None" = None,
     ) -> None:
         self._profile = profile
         self._provider = provider
@@ -198,6 +199,8 @@ class AgentLoopManager:
         self._tools = {t.name: t for t in tools}
         self._adapter = provider_adapter
         self._finalizer = finalizer
+        # Passive per-iteration progress observer (no control-flow influence).
+        self._progress_cb = progress_cb
         # Per-profile max_iterations takes precedence over the constructor default
         self._max_iterations = profile.max_iterations or max_iterations
         self._usage = _UsageAccumulator()
@@ -354,6 +357,18 @@ class AgentLoopManager:
                 )
                 for name in turn_call_names:
                     _tool_call_counts[name] = _tool_call_counts.get(name, 0) + 1
+                # Passive progress emit — best-effort, never influences the loop.
+                if self._progress_cb is not None:
+                    try:
+                        self._progress_cb(
+                            {
+                                "label": label,
+                                "iter": iterations,
+                                "tool_calls": len(turn_call_names),
+                            }
+                        )
+                    except Exception:
+                        pass
 
             # Log text reasoning snippet at verbose level
             if turn.text_output and turn.text_output.strip():
@@ -694,6 +709,8 @@ def _run_loop_openai(
     profile: "ModelProfile",
     working_dir: Path,
     secrets: dict[str, str] | None = None,
+    *,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> AgentResult:
     """Run OpenAI provider in agent loop mode."""
     import openai
@@ -724,6 +741,7 @@ def _run_loop_openai(
         tools=tools,
         provider_adapter=adapter,
         finalizer=finalizer,
+        progress_cb=progress_cb,
     )
     try:
         result = manager.run(
@@ -758,6 +776,8 @@ def _run_loop_anthropic(
     profile: "ModelProfile",
     working_dir: Path,
     secrets: dict[str, str] | None = None,
+    *,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> AgentResult:
     """Run Anthropic provider in agent loop mode."""
     tools = _build_registry_tools(profile)
@@ -775,6 +795,7 @@ def _run_loop_anthropic(
         tools=tools,
         provider_adapter=adapter,
         finalizer=finalizer,
+        progress_cb=progress_cb,
     )
     return manager.run(
         initial_messages=[{"role": "user", "content": prompt}],
@@ -787,6 +808,8 @@ def _run_loop_google(
     profile: "ModelProfile",
     working_dir: Path,
     secrets: dict[str, str] | None = None,
+    *,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> AgentResult:
     """Run Google provider in agent loop mode."""
     tools = _build_registry_tools(profile)
@@ -804,6 +827,7 @@ def _run_loop_google(
         tools=tools,
         provider_adapter=adapter,
         finalizer=finalizer,
+        progress_cb=progress_cb,
     )
     return manager.run(
         initial_messages=[{"role": "user", "content": prompt}],
@@ -816,6 +840,8 @@ def _run_loop_deepseek(
     profile: "ModelProfile",
     working_dir: Path,
     secrets: dict[str, str] | None = None,
+    *,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> AgentResult:
     """Run DeepSeek provider in agent loop mode (OpenAI Chat Completions)."""
     client = _deepseek_client(profile, secrets)
@@ -836,6 +862,7 @@ def _run_loop_deepseek(
         tools=tools,
         provider_adapter=adapter,
         finalizer=finalizer,
+        progress_cb=progress_cb,
     )
     return manager.run(
         initial_messages=[{"role": "user", "content": prompt}],
@@ -861,6 +888,7 @@ def _run_single_api_model(
     working_dir: Path,
     secrets: dict[str, str] | None,
     plain_text: bool,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> AgentResult:
     """Invoke one model (profile.model) via the provider's runner.
 
@@ -891,7 +919,7 @@ def _run_single_api_model(
                 raw={},
                 profile_name=profile.name,
             )
-        return loop_runner(prompt, profile, working_dir, secrets)
+        return loop_runner(prompt, profile, working_dir, secrets, progress_cb=progress_cb)
     else:
         runner_fn = PROVIDER_RUNNERS.get(profile.provider)
         if not runner_fn:
@@ -915,6 +943,7 @@ def run_api_agent(
     quiet: bool = False,
     secrets: dict[str, str] | None = None,
     plain_text: bool = False,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> AgentResult:
     """Run a text-judgment agent via API, trying models in preference-list order.
 
@@ -964,6 +993,7 @@ def run_api_agent(
             working_dir=working_dir,
             secrets=secrets,
             plain_text=plain_text,
+            progress_cb=progress_cb,
         )
 
         if result.success:

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -438,6 +438,7 @@ def run_agent(
     secrets: dict[str, str] | None = None,
     plain_text: bool = False,
     stop_event: "threading.Event | None" = None,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> AgentResult:
     """Run an agent using the transport specified in its profile.
 
@@ -461,6 +462,7 @@ def run_agent(
             quiet=quiet,
             secrets=secrets or {},
             plain_text=plain_text,
+            progress_cb=progress_cb,
         )
         return replace(api_result, transport_used=api_result.transport_used or "api")
 
@@ -589,6 +591,7 @@ def run_agent_pool(
     secrets: dict[str, str] | None = None,
     plain_text: bool = False,
     stop_event: "threading.Event | None" = None,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> list[AgentResult]:
     """Run multiple agents concurrently, each with its own prompt or a shared prompt.
 
@@ -604,20 +607,32 @@ def run_agent_pool(
     if session_ids is not None:
         assert len(session_ids) == len(profiles), "session_ids must match profiles length"
 
+    def _emit_progress(event: dict) -> None:
+        """Fire the passive progress callback; a raising cb never breaks the pool."""
+        if progress_cb is None:
+            return
+        try:
+            progress_cb(event)
+        except Exception:
+            pass
+
     if len(profiles) == 1:
         sid = session_ids[0] if session_ids else None
-        return [
-            run_agent(
-                prompt=prompts[0],
-                profile=profiles[0],
-                working_dir=working_dir,
-                session_id=sid,
-                fallback_to_file=False,
-                secrets=secrets,
-                plain_text=plain_text,
-                stop_event=stop_event,
-            )
-        ]
+        only = profiles[0]
+        result = run_agent(
+            prompt=prompts[0],
+            profile=only,
+            working_dir=working_dir,
+            session_id=sid,
+            fallback_to_file=False,
+            secrets=secrets,
+            plain_text=plain_text,
+            stop_event=stop_event,
+            progress_cb=progress_cb,
+        )
+        only_label = only.name or f"{only.cli or only.provider}/{only.model}"
+        _emit_progress({"label": only_label, "done": True})
+        return [result]
 
     names = ", ".join(p.name or f"{p.cli or p.provider}/{p.model}" for p in profiles)
     _log(f"  Starting review pool: {names} (parallel)")
@@ -641,6 +656,7 @@ def run_agent_pool(
                 secrets=secrets,
                 plain_text=plain_text,
                 stop_event=stop_event,
+                progress_cb=progress_cb,
             )
         finally:
             agent_durations[idx] = time.monotonic() - t0
@@ -655,6 +671,7 @@ def run_agent_pool(
             try:
                 results[idx] = future.result()
                 _log(f"  ... {label} done ({duration:.0f}s)")
+                _emit_progress({"label": label, "done": True})
             except Exception as exc:
                 _log(f"  ... {label} failed ({duration:.0f}s): {exc}")
                 results[idx] = AgentResult(

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -631,7 +631,12 @@ def run_agent_pool(
             progress_cb=progress_cb,
         )
         only_label = only.name or f"{only.cli or only.provider}/{only.model}"
-        _emit_progress({"label": only_label, "done": True})
+        # Only a successful result means the reviewer is done. An unsuccessful
+        # (e.g. transient transport) result is a finished attempt the coordinator
+        # may still retry — marking it done would count/label it wrongly while
+        # the retry loop is running.
+        if getattr(result, "success", False):
+            _emit_progress({"label": only_label, "done": True})
         return [result]
 
     names = ", ".join(p.name or f"{p.cli or p.provider}/{p.model}" for p in profiles)
@@ -671,7 +676,13 @@ def run_agent_pool(
             try:
                 results[idx] = future.result()
                 _log(f"  ... {label} done ({duration:.0f}s)")
-                _emit_progress({"label": label, "done": True})
+                # Only mark the reviewer done when the attempt actually
+                # succeeded. A returned-but-unsuccessful result (transient
+                # transport failure) is a finished attempt the coordinator may
+                # still retry; counting it as done would falsely report it in the
+                # pool-done progress while the retry loop is still running.
+                if getattr(results[idx], "success", False):
+                    _emit_progress({"label": label, "done": True})
             except Exception as exc:
                 _log(f"  ... {label} failed ({duration:.0f}s): {exc}")
                 results[idx] = AgentResult(

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -28,6 +28,7 @@ class StoryStatusEntry:
     complexity: str | None = None
     complexity_score: int | None = None
     model: str | None = None
+    last_event_ts: float | None = None
 
 
 def _follow_redirect_chain(run_id: str, project_root: Path, max_hops: int = 20) -> str:
@@ -285,6 +286,37 @@ def _format_terminal_stage(iteration_usage: dict | None) -> str:
     return " / ".join(parts)
 
 
+def _reviewer_progress_stage(progress: dict, pool_size: object) -> tuple[str, str]:
+    """Render live per-reviewer progress into (stage, pool_detail).
+
+    stage joins per-reviewer entries as ``name=done`` / ``name=iterN`` with
+    ``↻rN/M`` appended when a retry is active, e.g.
+    ``deepseek=done, gemini=iter3 ↻r1/2``.  pool_detail is ``pool D/S done``
+    where D counts done reviewers and S is the pool size.
+    """
+    parts: list[str] = []
+    done_count = 0
+    for name, info in progress.items():
+        if not isinstance(info, dict):
+            continue
+        if info.get("done"):
+            seg = f"{name}=done"
+            done_count += 1
+        else:
+            iteration = info.get("iter")
+            if isinstance(iteration, int) and iteration > 0:
+                seg = f"{name}=iter{iteration}"
+            else:
+                seg = f"{name}=…"
+        retry = info.get("retry")
+        if isinstance(retry, (list, tuple)) and len(retry) == 2:
+            seg += f" ↻r{retry[0]}/{retry[1]}"
+        parts.append(seg)
+    total = pool_size if isinstance(pool_size, int) and pool_size > 0 else len(progress)
+    pool_detail = f"pool {done_count}/{total} done"
+    return ", ".join(parts), pool_detail
+
+
 def _review_detail(verdict: object, p1: object, p2: object) -> str:
     verdict_text = _nonempty_str(verdict)
     if isinstance(p1, int) and isinstance(p2, int):
@@ -493,6 +525,12 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
         return stage, " | ".join(detail_parts) or "running", complexity
 
     if phase_val == "REVIEW":
+        reviewer_progress = detail_data.get("reviewer_progress")
+        if isinstance(reviewer_progress, dict) and reviewer_progress:
+            stage, pool_detail = _reviewer_progress_stage(
+                reviewer_progress, detail_data.get("reviewer_pool_size")
+            )
+            return stage, pool_detail, complexity
         cycle = detail_data.get("review_cycle")
         stage = _format_usage_stage(cycle, detail_data.get("review_max_cycles"), "cycle")
         if not stage and isinstance(cycle, int):
@@ -509,6 +547,12 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
         return "", "running", complexity
 
     if phase_val == "PLAN_REVIEW":
+        reviewer_progress = detail_data.get("reviewer_progress")
+        if isinstance(reviewer_progress, dict) and reviewer_progress:
+            stage, pool_detail = _reviewer_progress_stage(
+                reviewer_progress, detail_data.get("reviewer_pool_size")
+            )
+            return stage, pool_detail, complexity
         current = detail_data.get("plan_attempt")
         maximum = detail_data.get("plan_max_attempts")
         stage = _format_usage_stage(current, maximum, "cycle")
@@ -806,6 +850,13 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
             model_raw = story.get("current_model")
             model_val = model_raw if isinstance(model_raw, str) and model_raw else None
 
+        _detail_dict = story.get("detail")
+        _last_event_ts: float | None = None
+        if isinstance(_detail_dict, dict):
+            _ts = _detail_dict.get("last_reviewer_event_ts")
+            if isinstance(_ts, (int, float)):
+                _last_event_ts = float(_ts)
+
         entries.append(
             StoryStatusEntry(
                 slug=slug,
@@ -821,6 +872,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                 complexity=complexity,
                 complexity_score=complexity_score,
                 model=model_val,
+                last_event_ts=_last_event_ts,
             )
         )
         if slug:

--- a/tests/test_coord_review_pool.py
+++ b/tests/test_coord_review_pool.py
@@ -538,6 +538,71 @@ class TestTransientRetry:
     @patch("theforge.coordinator.review_pool.log_agent_result")
     @patch("theforge.coordinator.review_pool.run_agent")
     @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_transient_retry_updates_reviewer_progress_state(
+        self, mock_pool, mock_run_agent, _mock_log, tmp_path
+    ):
+        """Production retry path: a transient-failed reviewer surfaces the retry
+        glyph via the aggregator, and a resolved retry clears it and marks done
+        (issue #1086, review cycle 1 P1)."""
+        r1 = _make_review_profile("r1")
+        r2 = _make_review_profile("r2")
+        config = _make_pool_config(tmp_path, [r1, r2], r1)
+        config = config.__class__(
+            **{
+                **config.__dict__,
+                "retry": RetryPolicy(
+                    max_review_transport_retries=2,
+                    review_quorum_threshold=2,
+                    review_transport_retry_backoff_seconds=0.0,
+                ),
+            }
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        # r1 comes back transient-failed from the pool; the retry then succeeds.
+        mock_pool.return_value = [
+            _make_agent_result(success=False, output="", profile_name="r1"),
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="r2"),
+        ]
+        mock_run_agent.return_value = _make_agent_result(
+            success=True, output=APPROVE_REVIEW, profile_name="r1"
+        )
+
+        captured: dict = {}
+
+        def _state_update(updates: dict) -> None:
+            detail = updates.get("detail")
+            if isinstance(detail, dict) and "reviewer_progress" in detail:
+                captured["detail"] = detail
+
+        meta = _meta()
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=False,
+            state_update_fn=_state_update,
+        )
+
+        # The final emitted detail reflects the resolved retry: r1 is done and
+        # carries no lingering retry marker (set_retry armed it, the success
+        # cleared it).
+        rp = captured["detail"]["reviewer_progress"]["r1"]
+        assert rp["done"] is True
+        assert rp["retry"] is None
+
+    @patch("theforge.coordinator.review_pool.time.sleep", lambda *_a, **_k: None)
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
     def test_transient_retry_exhausts_budget_records_failed_outcome(
         self, mock_pool, mock_run_agent, _mock_log, tmp_path
     ):

--- a/tests/test_runner_api_providers.py
+++ b/tests/test_runner_api_providers.py
@@ -280,7 +280,7 @@ class TestRunApiAgentLoopIntegration:
                 working_dir=tmp_path,
                 quiet=True,
             )
-            mock_fn.assert_called_once_with("review", profile, tmp_path, None)
+            mock_fn.assert_called_once_with("review", profile, tmp_path, None, progress_cb=None)
 
     def test_google_plain_text_with_tools_bypasses_loop_runner(self, tmp_path):
         profile = _make_profile(
@@ -593,7 +593,7 @@ class TestDeepSeekProvider:
         mock_fn = MagicMock(return_value=mock_result)
         with patch.dict("theforge.runners.api._LOOP_RUNNERS", {"deepseek": mock_fn}):
             run_api_agent(prompt="review", profile=profile, working_dir=tmp_path, quiet=True)
-        mock_fn.assert_called_once_with("review", profile, tmp_path, None)
+        mock_fn.assert_called_once_with("review", profile, tmp_path, None, progress_cb=None)
 
 
 class TestWriteFileHandler:

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -72,6 +72,7 @@ class TestHybridRunner:
             quiet=False,
             secrets={},
             plain_text=False,
+            progress_cb=None,
         )
         assert result == AgentResult(**{**mock_result.__dict__, "transport_used": "api"})
 
@@ -106,6 +107,7 @@ class TestHybridRunner:
             quiet=False,
             secrets={},
             plain_text=False,
+            progress_cb=None,
         )
         assert result == AgentResult(**{**mock_result.__dict__, "transport_used": "api"})
 

--- a/tests/test_runner_pool.py
+++ b/tests/test_runner_pool.py
@@ -294,6 +294,95 @@ class TestRunAgentPool:
         assert results[0].profile_name == "r1"
         assert results[1].profile_name == "r2"
 
+    def test_pool_emits_done_only_for_successful_results(self, tmp_path: Path) -> None:
+        """A returned-but-unsuccessful (transient) result must not fire a done event.
+
+        The coordinator's transient-retry loop may still re-run that reviewer, so
+        counting/labelling it done in the live watch view while the retry is
+        pending is wrong (issue #1086, review cycle 1 P1).
+        """
+        profiles = [
+            ModelProfile(
+                name="ok-reviewer",
+                cli="claude",
+                model="opus",
+                budget_usd=1.0,
+                timeout_seconds=300,
+                allowed_tools=(),
+            ),
+            ModelProfile(
+                name="transient-reviewer",
+                cli="claude",
+                model="sonnet",
+                budget_usd=1.0,
+                timeout_seconds=300,
+                allowed_tools=(),
+            ),
+        ]
+
+        def mock_run_agent(**kwargs):
+            profile = kwargs["profile"]
+            return AgentResult(
+                success=profile.name == "ok-reviewer",
+                output="done" if profile.name == "ok-reviewer" else "503 service unavailable",
+                session_id=None,
+                cost_usd=0.10,
+                exit_code=0 if profile.name == "ok-reviewer" else 1,
+                raw={},
+                profile_name=profile.name,
+            )
+
+        done_labels: list[str] = []
+
+        def progress_cb(event: dict) -> None:
+            if event.get("done"):
+                done_labels.append(event["label"])
+
+        with patch("theforge.runners.cli.run_agent", side_effect=mock_run_agent):
+            run_agent_pool(
+                prompt="review this",
+                profiles=profiles,
+                working_dir=tmp_path,
+                progress_cb=progress_cb,
+            )
+
+        assert done_labels == ["ok-reviewer"]
+        assert "transient-reviewer" not in done_labels
+
+    def test_pool_of_one_suppresses_done_on_unsuccessful_result(self, tmp_path: Path) -> None:
+        """The single-profile fast path also gates the done event on success."""
+        profile = ModelProfile(
+            name="solo",
+            cli="claude",
+            model="opus",
+            budget_usd=1.0,
+            timeout_seconds=300,
+            allowed_tools=(),
+        )
+
+        def mock_run_agent(**kwargs):
+            return AgentResult(
+                success=False,
+                output="connection reset",
+                session_id=None,
+                cost_usd=None,
+                exit_code=1,
+                raw={},
+                profile_name="solo",
+            )
+
+        done_labels: list[str] = []
+
+        with patch("theforge.runners.cli.run_agent", side_effect=mock_run_agent):
+            run_agent_pool(
+                prompt="review this",
+                profiles=[profile],
+                working_dir=tmp_path,
+                progress_cb=lambda e: done_labels.append(e["label"]) if e.get("done") else None,
+            )
+
+        assert done_labels == []
+
     def test_pool_runs_parallel(self, tmp_path: Path) -> None:
         """Agents are observed running concurrently (overlapping in-flight count > 1),
         proving parallelism directly instead of via a load-sensitive wall-clock budget."""

--- a/tests/test_status_reader_reviewer_progress.py
+++ b/tests/test_status_reader_reviewer_progress.py
@@ -180,6 +180,44 @@ class TestReviewerProgressSeam:
         assert entry.detail == "running"
         assert entry.last_event_ts is None
 
+    def test_retry_glyph_clears_on_next_progress_event(self, tmp_path: Path) -> None:
+        # AC #3: the ↻rN/M marker must show "while it is retrying", not stick for
+        # the rest of the review. A fresh iter/done event for the reviewer clears
+        # the retry marker; the pool-done count then reflects the resolution.
+        story: dict = {"slug": "s", "path": "s", "status": "running"}
+        channel = ReviewerProgressChannel(
+            reviewer_names=["gemini"],
+            phase="REVIEW",
+            iteration=1,
+            cost_usd=0.0,
+            complexity="medium",
+            state_update_fn=_worker_style_state_update(story),
+        )
+
+        # A transient retry is recorded → glyph is outstanding.
+        channel.set_retry("gemini", 1, 2)
+        _write_state(tmp_path, "run-x", story)
+        stage_mid = read_live_status("run-x", tmp_path)[0].stage
+        assert "↻r1/2" in stage_mid
+
+        # The retried attempt starts producing events → marker clears.
+        channel.cb({"label": "gemini", "iter": 4, "tool_calls": 2})
+        assert story["detail"]["reviewer_progress"]["gemini"]["retry"] is None
+        _write_state(tmp_path, "run-x", story)
+        stage_after = read_live_status("run-x", tmp_path)[0].stage
+        assert "↻" not in stage_after
+        assert "gemini=iter4" in stage_after
+
+        # A subsequent successful-retry done event clears it too and counts done.
+        channel.set_retry("gemini", 2, 2)
+        channel.cb({"label": "gemini", "done": True})
+        assert story["detail"]["reviewer_progress"]["gemini"]["retry"] is None
+        _write_state(tmp_path, "run-x", story)
+        entry = read_live_status("run-x", tmp_path)[0]
+        assert "gemini=done" in entry.stage
+        assert "↻" not in entry.stage
+        assert entry.detail == "pool 1/1 done"
+
     def test_raising_state_update_fn_never_breaks_channel(self, tmp_path: Path) -> None:
         def _boom(_updates: dict) -> None:
             raise RuntimeError("state write failed")

--- a/tests/test_status_reader_reviewer_progress.py
+++ b/tests/test_status_reader_reviewer_progress.py
@@ -1,0 +1,197 @@
+"""Reviewer-progress rendering + coordinator→state→renderer seam (issue #1086).
+
+The REVIEW / PLAN_REVIEW watch view surfaces per-reviewer iteration, retry, and
+pool-progress by writing a structured ``reviewer_progress`` contract into the
+live ``.state`` story ``detail`` dict. These tests cover:
+
+- ``_reviewer_progress_stage`` formatting (done / iter / retry / empty).
+- The seam: a ``ReviewerProgressChannel`` fed by a fake ``run_agent_pool``
+  progress stream writes ``reviewer_progress`` + ``last_reviewer_event_ts`` into
+  live state, and ``read_live_status`` renders per-reviewer STAGE + pool DETAIL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from theforge.coordinator.reviewer_progress import ReviewerProgressChannel
+from theforge.sprint.status_reader import (
+    _reviewer_progress_stage,
+    read_live_status,
+)
+
+# ── Unit: _reviewer_progress_stage ────────────────────────────────────────────
+
+
+class TestReviewerProgressStage:
+    def test_done_and_iter_mix(self) -> None:
+        progress = {
+            "deepseek": {"iter": 5, "tool_calls": 3, "retry": None, "done": True},
+            "gemini": {"iter": 3, "tool_calls": 1, "retry": None, "done": False},
+        }
+        stage, pool_detail = _reviewer_progress_stage(progress, 2)
+        assert stage == "deepseek=done, gemini=iter3"
+        assert pool_detail == "pool 1/2 done"
+
+    def test_retry_glyph_appended(self) -> None:
+        progress = {
+            "gemini": {"iter": 3, "tool_calls": 1, "retry": [1, 2], "done": False},
+        }
+        stage, pool_detail = _reviewer_progress_stage(progress, 1)
+        assert stage == "gemini=iter3 ↻r1/2"
+        assert pool_detail == "pool 0/1 done"
+
+    def test_zero_iter_shows_ellipsis(self) -> None:
+        progress = {"gpt": {"iter": 0, "tool_calls": 0, "retry": None, "done": False}}
+        stage, _pool = _reviewer_progress_stage(progress, 1)
+        assert stage == "gpt=…"
+
+    def test_pool_size_falls_back_to_len(self) -> None:
+        progress = {
+            "a": {"iter": 1, "tool_calls": 0, "retry": None, "done": True},
+            "b": {"iter": 2, "tool_calls": 0, "retry": None, "done": True},
+        }
+        _stage, pool_detail = _reviewer_progress_stage(progress, None)
+        assert pool_detail == "pool 2/2 done"
+
+    def test_all_done(self) -> None:
+        progress = {
+            "a": {"iter": 4, "tool_calls": 0, "retry": None, "done": True},
+            "b": {"iter": 6, "tool_calls": 0, "retry": None, "done": True},
+        }
+        stage, pool_detail = _reviewer_progress_stage(progress, 2)
+        assert stage == "a=done, b=done"
+        assert pool_detail == "pool 2/2 done"
+
+
+# ── Seam: channel → live .state → read_live_status ────────────────────────────
+
+
+def _worker_style_state_update(story: dict):
+    """Return a state_update_fn that mirrors the worker wrapper's detail semantics.
+
+    ``SprintStoryState`` transitions replace ``detail`` wholesale, so each emit
+    carries the complete review-scoped detail. This fake reproduces that: it sets
+    ``phase`` and replaces ``detail`` on every call.
+    """
+
+    def _update(updates: dict) -> None:
+        if "phase" in updates:
+            story["phase"] = updates["phase"]
+        incoming = updates.get("detail")
+        if isinstance(incoming, dict):
+            story["detail"] = dict(incoming)
+
+    return _update
+
+
+def _write_state(project_root: Path, run_id: str, story: dict) -> None:
+    runs_dir = project_root / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / f"{run_id}.state").write_text(
+        yaml.safe_dump({"sprint_name": "s", "stories": [story]}),
+        encoding="utf-8",
+    )
+
+
+class TestReviewerProgressSeam:
+    def test_review_pool_progress_flows_to_renderer(self, tmp_path: Path) -> None:
+        story: dict = {"slug": "issue-1075", "path": "Issue #1075", "status": "running"}
+        channel = ReviewerProgressChannel(
+            reviewer_names=["deepseek", "gemini", "gpt"],
+            phase="REVIEW",
+            iteration=1,
+            cost_usd=0.11,
+            complexity="medium",
+            state_update_fn=_worker_style_state_update(story),
+        )
+
+        # Fake run_agent_pool: fans out a sequence of per-reviewer iter/done
+        # events through the channel, exactly as the real pool would.
+        def fake_run_agent_pool(progress_cb) -> None:
+            progress_cb({"label": "deepseek", "iter": 1, "tool_calls": 2})
+            progress_cb({"label": "gemini", "iter": 1, "tool_calls": 1})
+            progress_cb({"label": "gemini", "iter": 3, "tool_calls": 4})
+            progress_cb({"label": "deepseek", "done": True})
+
+        fake_run_agent_pool(channel.cb)
+        # A transient retry on gemini surfaces the glyph live.
+        channel.set_retry("gemini", 1, 2)
+
+        # The live-state detail carries the structured contract.
+        detail = story["detail"]
+        assert set(detail["reviewer_progress"]) == {"deepseek", "gemini", "gpt"}
+        assert detail["reviewer_progress"]["deepseek"]["done"] is True
+        assert detail["reviewer_progress"]["gemini"]["iter"] == 3
+        assert detail["reviewer_progress"]["gemini"]["retry"] == [1, 2]
+        assert detail["reviewer_pool_size"] == 3
+        assert isinstance(detail["last_reviewer_event_ts"], float)
+
+        # Feed the state through the real renderer.
+        _write_state(tmp_path, "run-x", story)
+        entries = read_live_status("run-x", tmp_path)
+        assert entries is not None
+        entry = entries[0]
+        assert "deepseek=done" in entry.stage
+        assert "gemini=iter3 ↻r1/2" in entry.stage
+        assert entry.detail == "pool 1/3 done"
+        assert entry.last_event_ts == detail["last_reviewer_event_ts"]
+
+    def test_plan_review_pool_progress_flows_to_renderer(self, tmp_path: Path) -> None:
+        story: dict = {"slug": "issue-1075", "path": "Issue #1075", "status": "running"}
+        channel = ReviewerProgressChannel(
+            reviewer_names=["deepseek", "gemini"],
+            phase="PLAN_REVIEW",
+            iteration=0,
+            cost_usd=0.17,
+            complexity="large",
+            state_update_fn=_worker_style_state_update(story),
+        )
+        channel.cb({"label": "deepseek", "done": True})
+        channel.cb({"label": "gemini", "iter": 3, "tool_calls": 2})
+        channel.set_retry("gemini", 1, 2)
+
+        _write_state(tmp_path, "run-x", story)
+        entries = read_live_status("run-x", tmp_path)
+        assert entries is not None
+        entry = entries[0]
+        assert entry.phase == "PLAN_REVIEW"
+        assert "deepseek=done" in entry.stage
+        assert "gemini=iter3 ↻r1/2" in entry.stage
+        assert entry.detail == "pool 1/2 done"
+
+    def test_no_progress_data_falls_back(self, tmp_path: Path) -> None:
+        # Before any reviewer event, the REVIEW branch must keep its legacy
+        # cycle/verdict rendering rather than emit an empty per-reviewer stage.
+        story = {
+            "slug": "issue-1075",
+            "path": "Issue #1075",
+            "status": "running",
+            "phase": "REVIEW",
+            "detail": {"review_cycle": 1, "review_max_cycles": 3},
+        }
+        _write_state(tmp_path, "run-x", story)
+        entries = read_live_status("run-x", tmp_path)
+        assert entries is not None
+        entry = entries[0]
+        assert "iter" not in entry.stage  # not per-reviewer
+        assert entry.detail == "running"
+        assert entry.last_event_ts is None
+
+    def test_raising_state_update_fn_never_breaks_channel(self, tmp_path: Path) -> None:
+        def _boom(_updates: dict) -> None:
+            raise RuntimeError("state write failed")
+
+        channel = ReviewerProgressChannel(
+            reviewer_names=["a"],
+            phase="REVIEW",
+            iteration=1,
+            cost_usd=0.0,
+            complexity="small",
+            state_update_fn=_boom,
+        )
+        # Must not propagate — reviewers can never be broken by a bad state sink.
+        channel.cb({"label": "a", "iter": 1, "tool_calls": 1})
+        channel.set_retry("a", 1, 2)

--- a/tests/test_status_reader_reviewer_progress.py
+++ b/tests/test_status_reader_reviewer_progress.py
@@ -180,6 +180,36 @@ class TestReviewerProgressSeam:
         assert entry.detail == "running"
         assert entry.last_event_ts is None
 
+    def test_pool_start_shows_pool_zero_of_n_before_any_event(self, tmp_path: Path) -> None:
+        # Constructing the channel (i.e. a reviewer pool starting) must emit the
+        # seeded state immediately, so the row shows "pool 0/N done" rather than
+        # legacy "running" before any reviewer emits its first event.
+        story: dict = {"slug": "s", "path": "s", "status": "running"}
+        ReviewerProgressChannel(
+            reviewer_names=["deepseek", "gemini", "gpt"],
+            phase="REVIEW",
+            iteration=1,
+            cost_usd=0.0,
+            complexity="medium",
+            state_update_fn=_worker_style_state_update(story),
+        )
+
+        # The seeded detail is present with every reviewer at zero progress.
+        detail = story["detail"]
+        assert set(detail["reviewer_progress"]) == {"deepseek", "gemini", "gpt"}
+        assert all(not e["done"] for e in detail["reviewer_progress"].values())
+        assert detail["reviewer_pool_size"] == 3
+        assert isinstance(detail["last_reviewer_event_ts"], float)
+
+        _write_state(tmp_path, "run-x", story)
+        entry = read_live_status("run-x", tmp_path)[0]
+        assert entry.detail == "pool 0/3 done"
+        # STAGE lists each reviewer (no iterations yet → ellipsis, no ↻ glyph).
+        assert "deepseek=…" in entry.stage
+        assert "↻" not in entry.stage
+        # EVENT AGE has a source from the very first frame.
+        assert entry.last_event_ts == detail["last_reviewer_event_ts"]
+
     def test_retry_glyph_clears_on_next_progress_event(self, tmp_path: Path) -> None:
         # AC #3: the ↻rN/M marker must show "while it is retrying", not stick for
         # the rest of the review. A fresh iter/done event for the reviewer clears

--- a/tests/test_status_watch_reviewer_event_age.py
+++ b/tests/test_status_watch_reviewer_event_age.py
@@ -1,0 +1,73 @@
+"""EVENT AGE ticks from reviewer tool-call events during review (issue #1086).
+
+Before this change EVENT AGE only advanced when ``audit.yaml`` was touched, so a
+REVIEW / PLAN_REVIEW cycle showed a frozen ``—`` for its whole duration. The
+renderer now takes the freshest of the audit mtime and the per-entry
+``last_event_ts`` (bumped on every reviewer iteration), so review advances live.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from theforge.cli import status_watch
+
+
+def _entry(slug: str, *, status: str = "running", last_event_ts: float | None = None):
+    from theforge.sprint.status_reader import StoryStatusEntry
+
+    return StoryStatusEntry(
+        slug=slug,
+        path=slug,
+        status=status,
+        phase="REVIEW",
+        cost_usd=0.0,
+        last_event_ts=last_event_ts,
+    )
+
+
+def _render(tmp_path: Path, entries: list, *, now: float, audit_mtime: float | None) -> str:
+    state: dict = {"costs": {}, "interval": 2.0}
+    with (
+        patch("theforge.cli.sprint_status.display_sprint_status", return_value=0),
+        patch("theforge.sprint.status_reader.read_live_status", return_value=entries),
+        patch.object(status_watch, "_last_audit_mtime", return_value=audit_mtime),
+    ):
+        text, _ok, _err = status_watch.render_frame(
+            "run-x",
+            tmp_path,
+            state,
+            frame_idx=0,
+            color=False,
+            now_fn=lambda: now,
+        )
+    return text
+
+
+class TestReviewerEventAge:
+    def test_event_age_ticks_from_reviewer_event_without_audit(self, tmp_path: Path) -> None:
+        # audit.yaml absent/stale (mtime None) but a reviewer event landed 5s ago.
+        entries = [_entry("story-a", last_event_ts=995.0)]
+        text = _render(tmp_path, entries, now=1000.0, audit_mtime=None)
+        assert "5s" in text
+        # Not the frozen em-dash the old code showed for the whole review.
+        assert "  —  " not in text or "5s" in text
+
+    def test_freshest_source_wins(self, tmp_path: Path) -> None:
+        # Reviewer event (2s ago) is fresher than audit mtime (40s ago).
+        entries = [_entry("story-a", last_event_ts=998.0)]
+        text = _render(tmp_path, entries, now=1000.0, audit_mtime=960.0)
+        assert "2s" in text
+        assert "40s" not in text
+
+    def test_audit_mtime_used_when_no_reviewer_event(self, tmp_path: Path) -> None:
+        # DEV / other phases have no reviewer event — audit mtime still drives age.
+        entries = [_entry("story-a", last_event_ts=None)]
+        text = _render(tmp_path, entries, now=1000.0, audit_mtime=970.0)
+        assert "30s" in text
+
+    def test_dash_when_neither_source(self, tmp_path: Path) -> None:
+        entries = [_entry("story-a", last_event_ts=None)]
+        text = _render(tmp_path, entries, now=1000.0, audit_mtime=None)
+        assert "—" in text


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved, the cycle-2 pool-start opacity fix is covered, and I found no blocking regressions in the latest iteration. | [google-gemini-3.5-flash] The implementation is robust, fully verified, and resolves all prior P1 findings with comprehensive test coverage. | [claude-sonnet] Cycle-2 P1 is resolved: ReviewerProgressChannel now emits its seeded pool state synchronously in __init__ (under lock, via the already-exception-wrapped _emit_locked), so the watch row shows 'pool 0/N done' with every reviewer listed the moment a pool starts, before any provider event. Prior cycle-1 fixes remain intact. No regressions found in the touched file (reviewer_progress.py) or elsewhere; all 134 relevant tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $23.42
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status --watch: REVIEW phase live view is opaque (no per-reviewer iter/stage/activity) (GitHub Issue #1086)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1086