### PR TITLE
forge status --watch: surface reviewer time-nudge / timeout-proximity warnings

### DIFF
--- a/src/theforge/coordinator/reviewer_progress.py
+++ b/src/theforge/coordinator/reviewer_progress.py
@@ -15,7 +15,8 @@ Detail contract written into the story ``detail`` dict (replaced wholesale on
 each emit, since ``SprintStoryState`` transitions overwrite ``detail``):
 
     reviewer_progress: {name: {"iter": int, "tool_calls": int,
-                               "retry": [n, m] | None, "done": bool}}
+                               "retry": [n, m] | None, "done": bool,
+                               "nudge": int | None}}
     reviewer_pool_size: int
     last_reviewer_event_ts: float   # epoch seconds of the freshest event
 """
@@ -52,7 +53,13 @@ class ReviewerProgressChannel:
         self._state_update_fn = state_update_fn
         self._lock = threading.Lock()
         self._progress: dict[str, dict] = {
-            name: {"iter": 0, "tool_calls": 0, "retry": None, "done": False}
+            name: {
+                "iter": 0,
+                "tool_calls": 0,
+                "retry": None,
+                "done": False,
+                "nudge": None,
+            }
             for name in reviewer_names
         }
         # Emit the seeded pool state immediately so the watch view renders
@@ -79,11 +86,21 @@ class ReviewerProgressChannel:
                 if event.get("done"):
                     entry["done"] = True
                     entry["retry"] = None
+                    # The reviewer finalized: the imminent-timeout warning is no
+                    # longer relevant, so clear the nudge marker (AC: persists
+                    # until the reviewer finalizes or times out).
+                    entry["nudge"] = None
                 if "iter" in event:
                     entry["iter"] = event["iter"]
                     entry["retry"] = None
                 if "tool_calls" in event:
                     entry["tool_calls"] = event["tool_calls"]
+                if "nudge" in event:
+                    # A time-nudge was sent: the reviewer is within seconds of its
+                    # wall-clock deadline. Unlike ``retry``, this marker is NOT
+                    # cleared by subsequent iter events — the reviewer stays near
+                    # its deadline — it only clears on finalize (done above).
+                    entry["nudge"] = event["nudge"]
                 self._emit_locked()
         except Exception:
             pass

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -513,6 +513,14 @@ class AgentLoopManager:
                         messages = list(messages)
                         messages.append({"role": "user", "content": nudge_msg})
                         _log_verbose(f"  ⚠ {label} time nudge sent ({remaining_secs}s remaining)")
+                        # Passive progress emit — surface the imminent-timeout
+                        # signal in the live watch view. Best-effort; never
+                        # influences the loop.
+                        if self._progress_cb is not None:
+                            try:
+                                self._progress_cb({"label": label, "nudge": remaining_secs})
+                            except Exception:
+                                pass
 
         # Log iteration summary
         submit_names = _SUBMIT_TOOL_NAMES

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -291,7 +291,9 @@ def _reviewer_progress_stage(progress: dict, pool_size: object) -> tuple[str, st
 
     stage joins per-reviewer entries as ``name=done`` / ``name=iterN`` with
     ``↻rN/M`` appended when a retry is active, e.g.
-    ``deepseek=done, gemini=iter3 ↻r1/2``.  pool_detail is ``pool D/S done``
+    ``deepseek=done, gemini=iter3 ↻r1/2``.  A ``⚠Ns`` chip is appended for a
+    reviewer that has received a time-nudge (imminent-timeout warning) and not
+    yet finalized, e.g. ``gemini=iter3 ⚠116s``.  pool_detail is ``pool D/S done``
     where D counts done reviewers and S is the pool size.
     """
     parts: list[str] = []
@@ -311,6 +313,12 @@ def _reviewer_progress_stage(progress: dict, pool_size: object) -> tuple[str, st
         retry = info.get("retry")
         if isinstance(retry, (list, tuple)) and len(retry) == 2:
             seg += f" ↻r{retry[0]}/{retry[1]}"
+        # Imminent-timeout signal (distinct from retry/iter progress): a
+        # time-nudge was sent and the reviewer has not finalized. Persist until
+        # it finalizes (nudge cleared) or times out (row replaced by phase move).
+        nudge = info.get("nudge")
+        if not info.get("done") and isinstance(nudge, int) and nudge > 0:
+            seg += f" ⚠{nudge}s"
         parts.append(seg)
     total = pool_size if isinstance(pool_size, int) and pool_size > 0 else len(progress)
     pool_detail = f"pool {done_count}/{total} done"

--- a/tests/test_runner_api_loop.py
+++ b/tests/test_runner_api_loop.py
@@ -831,6 +831,64 @@ class TestTimeNudge:
         # All nudge messages should be identical (sent once, seen in subsequent turns)
         assert len(set(time_nudges)) == 1
 
+    def test_time_nudge_emits_progress_event(self, tmp_path):
+        """issue #1087: the time-nudge is surfaced to the progress callback so the
+        watch view can flag the reviewer's imminent timeout."""
+        call_count = [0]
+        current_time = [1000.0]
+        events: list[dict] = []
+
+        def adapter(messages, tools):
+            call_count[0] += 1
+            current_time[0] += 12.0
+            if call_count[0] <= 8:
+                return LoopTurn(
+                    tool_calls=[
+                        ToolCallRequest(
+                            id=f"c{call_count[0]}", name="glob", arguments={"pattern": "*.py"}
+                        )
+                    ],
+                    text_output=None,
+                    structured_data=None,
+                    usage=_make_usage(),
+                )
+            return LoopTurn(
+                tool_calls=[
+                    ToolCallRequest(
+                        id="submit1",
+                        name=SUBMIT_REVIEW,
+                        arguments={"verdict": "APPROVE", "summary": "ok"},
+                    )
+                ],
+                text_output=None,
+                structured_data=None,
+                usage=_make_usage(),
+            )
+
+        with patch("theforge.runners.api.time") as mock_time:
+            mock_time.monotonic = lambda: current_time[0]
+            profile = _make_profile(timeout_seconds=100)
+            manager = AgentLoopManager(
+                profile=profile,
+                provider="openai",
+                working_dir=tmp_path,
+                tools=list(TOOL_REGISTRY.values()),
+                provider_adapter=adapter,
+                max_iterations=50,
+                progress_cb=events.append,
+            )
+            result = manager.run(
+                initial_messages=[{"role": "user", "content": "go"}],
+                tool_schemas=[],
+            )
+
+        assert result.success
+        nudge_events = [e for e in events if "nudge" in e]
+        assert len(nudge_events) == 1
+        assert nudge_events[0]["label"] == profile.name
+        assert isinstance(nudge_events[0]["nudge"], int)
+        assert nudge_events[0]["nudge"] > 0
+
 
 class TestRedactToolCallArguments:
     """Unit tests for _redact_tool_call_arguments and _SENSITIVE_ARG_NAMES."""

--- a/tests/test_status_reader_reviewer_progress.py
+++ b/tests/test_status_reader_reviewer_progress.py
@@ -65,6 +65,37 @@ class TestReviewerProgressStage:
         assert stage == "a=done, b=done"
         assert pool_detail == "pool 2/2 done"
 
+    def test_nudge_chip_appended(self) -> None:
+        # issue #1087: an active reviewer that received a time-nudge shows a
+        # ⚠Ns imminent-timeout chip, distinct from iter/retry progress.
+        progress = {
+            "gemini": {"iter": 3, "tool_calls": 1, "retry": None, "done": False, "nudge": 116},
+        }
+        stage, _pool = _reviewer_progress_stage(progress, 1)
+        assert stage == "gemini=iter3 ⚠116s"
+
+    def test_nudge_chip_coexists_with_retry(self) -> None:
+        progress = {
+            "gemini": {"iter": 3, "tool_calls": 1, "retry": [1, 2], "done": False, "nudge": 90},
+        }
+        stage, _pool = _reviewer_progress_stage(progress, 1)
+        assert stage == "gemini=iter3 ↻r1/2 ⚠90s"
+
+    def test_nudge_chip_suppressed_when_done(self) -> None:
+        # A finalized reviewer never shows the imminent-timeout chip even if a
+        # stale nudge value lingers.
+        progress = {
+            "gemini": {"iter": 5, "tool_calls": 2, "retry": None, "done": True, "nudge": 116},
+        }
+        stage, _pool = _reviewer_progress_stage(progress, 1)
+        assert stage == "gemini=done"
+
+    def test_missing_nudge_field_is_tolerated(self) -> None:
+        # Legacy entries (pre-#1087) have no nudge key — must not raise.
+        progress = {"gpt": {"iter": 2, "tool_calls": 0, "retry": None, "done": False}}
+        stage, _pool = _reviewer_progress_stage(progress, 1)
+        assert stage == "gpt=iter2"
+
 
 # ── Seam: channel → live .state → read_live_status ────────────────────────────
 
@@ -247,6 +278,44 @@ class TestReviewerProgressSeam:
         assert "gemini=done" in entry.stage
         assert "↻" not in entry.stage
         assert entry.detail == "pool 1/1 done"
+
+    def test_time_nudge_flag_persists_until_finalize(self, tmp_path: Path) -> None:
+        # issue #1087: when the runner emits a time-nudge for an active reviewer,
+        # the row must flag imminent timeout (⚠Ns) and keep flagging it across
+        # subsequent iter events, then clear once the reviewer finalizes.
+        story: dict = {"slug": "s", "path": "s", "status": "running"}
+        channel = ReviewerProgressChannel(
+            reviewer_names=["gemini"],
+            phase="REVIEW",
+            iteration=1,
+            cost_usd=0.0,
+            complexity="medium",
+            state_update_fn=_worker_style_state_update(story),
+        )
+
+        # The runner surfaces the nudge (as run_agent's progress_cb would).
+        channel.cb({"label": "gemini", "iter": 3, "tool_calls": 4})
+        channel.cb({"label": "gemini", "nudge": 116})
+        assert story["detail"]["reviewer_progress"]["gemini"]["nudge"] == 116
+        _write_state(tmp_path, "run-x", story)
+        stage_nudged = read_live_status("run-x", tmp_path)[0].stage
+        assert "gemini=iter3 ⚠116s" in stage_nudged
+
+        # A later iter event must NOT clear the imminent-timeout flag — the
+        # reviewer is still within seconds of its deadline (unlike ↻ retry).
+        channel.cb({"label": "gemini", "iter": 4, "tool_calls": 2})
+        assert story["detail"]["reviewer_progress"]["gemini"]["nudge"] == 116
+        _write_state(tmp_path, "run-x", story)
+        stage_still = read_live_status("run-x", tmp_path)[0].stage
+        assert "gemini=iter4 ⚠116s" in stage_still
+
+        # Finalizing clears the flag.
+        channel.cb({"label": "gemini", "done": True})
+        assert story["detail"]["reviewer_progress"]["gemini"]["nudge"] is None
+        _write_state(tmp_path, "run-x", story)
+        entry = read_live_status("run-x", tmp_path)[0]
+        assert "gemini=done" in entry.stage
+        assert "⚠" not in entry.stage
 
     def test_raising_state_update_fn_never_breaks_channel(self, tmp_path: Path) -> None:
         def _boom(_updates: dict) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change wires the reviewer time-nudge event through the live progress channel and renders a distinct warning chip in status watch. | [google-gemini-3.5-flash] The implementation successfully surfaces reviewer time-nudge warnings in forge status --watch with robust persistence and clear visual distinction. | [claude-sonnet] Clean wire-through of the existing progress-channel pattern; nudge field persists across iter events and clears on finalize, rendered as a distinct ⚠Ns chip; well covered by unit and seam tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $3.39
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status --watch: surface reviewer time-nudge / timeout-proximity warnings (GitHub Issue #1087)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1087