### PR TITLE
forge status: show issue titles and dependency detail for waiting stories

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -23,13 +23,21 @@ def _issue_number_from_slug(text: str) -> int | None:
 
 
 def _ensure_titles(entries: list, project_root: Path, cache: dict) -> None:
-    """Populate ``cache`` (issue number -> title) for any entries not yet cached.
+    """Populate ``cache`` (issue number -> title | None) for uncached entries.
 
     Best-effort: collects issue numbers from each entry's path/slug and its
-    ``blocked_by`` items, fetches only the numbers absent from ``cache`` via the
-    sprint query primitive, and swallows failures so display degrades to bare
-    paths rather than erroring.
+    ``blocked_by`` items and resolves the ones absent from ``cache`` via the
+    sprint query primitive.
+
+    Fetches are done one number at a time so a single unresolvable issue cannot
+    discard the titles that did resolve — ``fetch_issues_by_numbers`` raises for
+    the whole batch when any requested number is missing. A number confirmed
+    absent from the repository is cached as ``None`` (a negative sentinel) so it
+    is not re-fetched on subsequent ``--watch`` frames; a transient ``gh``
+    failure is left uncached so a later frame can retry.
     """
+    from theforge.sprint.query import fetch_issues_by_numbers
+
     numbers: set[int] = set()
     for entry in entries:
         path = getattr(entry, "path", getattr(entry, "slug", "")) or ""
@@ -42,28 +50,29 @@ def _ensure_titles(entries: list, project_root: Path, cache: dict) -> None:
                 numbers.add(dep)
 
     missing = sorted(n for n in numbers if n not in cache)
-    if not missing:
-        return
-
-    try:
-        from theforge.sprint.query import fetch_issues_by_numbers
-
-        issues = fetch_issues_by_numbers(missing, project_root)
-    except Exception:
-        return
-
-    for issue in issues:
-        number = issue.get("number")
-        title = issue.get("title")
-        if isinstance(number, int) and isinstance(title, str):
-            cache[number] = title
+    for number in missing:
+        try:
+            issues = fetch_issues_by_numbers([number], project_root)
+        except RuntimeError as exc:
+            # Genuinely-absent numbers get a negative sentinel so they are not
+            # retried every frame; transient gh failures stay uncached to retry.
+            if "not found in this repository" in str(exc):
+                cache[number] = None
+            continue
+        except Exception:
+            continue
+        for issue in issues:
+            if issue.get("number") == number and isinstance(issue.get("title"), str):
+                cache[number] = issue["title"]
 
 
 def _format_story_cell(path: str, cache: dict) -> str:
     """Return ``#N <title>`` when the slug resolves to a cached title, else path."""
     num = _issue_number_from_slug(path)
-    if num is not None and num in cache:
-        return f"#{num} {cache[num]}"
+    if num is not None:
+        title = cache.get(num)
+        if title:
+            return f"#{num} {title}"
     return path
 
 

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -2,20 +2,100 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import sys
 import textwrap
 from pathlib import Path
 
+_ISSUE_REF_RE = re.compile(r"(?:issue-|#)(\d+)")
+_DETAIL_REF_RE = re.compile(r"#(\d+)")
 
-def display_sprint_status(run_id: str, project_root: Path) -> int:
+
+def _issue_number_from_slug(text: str) -> int | None:
+    """Extract N from an ``issue-N`` or ``#N`` token; None if it doesn't match."""
+    if not text:
+        return None
+    match = _ISSUE_REF_RE.search(text)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _ensure_titles(entries: list, project_root: Path, cache: dict) -> None:
+    """Populate ``cache`` (issue number -> title) for any entries not yet cached.
+
+    Best-effort: collects issue numbers from each entry's path/slug and its
+    ``blocked_by`` items, fetches only the numbers absent from ``cache`` via the
+    sprint query primitive, and swallows failures so display degrades to bare
+    paths rather than erroring.
+    """
+    numbers: set[int] = set()
+    for entry in entries:
+        path = getattr(entry, "path", getattr(entry, "slug", "")) or ""
+        num = _issue_number_from_slug(path)
+        if num is not None:
+            numbers.add(num)
+        for item in getattr(entry, "blocked_by", None) or []:
+            dep = _issue_number_from_slug(str(item))
+            if dep is not None:
+                numbers.add(dep)
+
+    missing = sorted(n for n in numbers if n not in cache)
+    if not missing:
+        return
+
+    try:
+        from theforge.sprint.query import fetch_issues_by_numbers
+
+        issues = fetch_issues_by_numbers(missing, project_root)
+    except Exception:
+        return
+
+    for issue in issues:
+        number = issue.get("number")
+        title = issue.get("title")
+        if isinstance(number, int) and isinstance(title, str):
+            cache[number] = title
+
+
+def _format_story_cell(path: str, cache: dict) -> str:
+    """Return ``#N <title>`` when the slug resolves to a cached title, else path."""
+    num = _issue_number_from_slug(path)
+    if num is not None and num in cache:
+        return f"#{num} {cache[num]}"
+    return path
+
+
+def _enrich_detail(detail: str, cache: dict) -> str:
+    """Append cached titles after each ``#N`` token in a detail string."""
+    if not detail:
+        return detail
+
+    def _repl(match: "re.Match") -> str:
+        token = match.group(0)
+        number = int(match.group(1))
+        title = cache.get(number)
+        return f"{token} {title}" if title else token
+
+    return _DETAIL_REF_RE.sub(_repl, detail)
+
+
+def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | None = None) -> int:
     """Display per-story status for a sprint run.
 
     Handles live (PID file present), completed (sprint-summary.yaml), and
     crashed (PID gone, .state still present) sprints.
     Returns 0 on success, 1 if no sprint data is found.
+
+    ``title_cache`` maps issue number -> GitHub title; when None a fresh local
+    dict is used (single-shot invocation). Watch mode passes a persistent dict
+    so titles fetched on frame 1 are reused on every subsequent frame.
     """
     import yaml
+
+    if title_cache is None:
+        title_cache = {}
 
     from theforge.sprint.status_reader import (
         find_live_state_path,
@@ -143,6 +223,9 @@ def display_sprint_status(run_id: str, project_root: Path) -> int:
         print("  No stories found.")
         return 0
 
+    # Best-effort GitHub title fetch (cached for --watch sessions).
+    _ensure_titles(entries, project_root, title_cache)
+
     # ── Story rows ───────────────────────────────────────────────────────
     status_icons = {
         "done": "✓",
@@ -170,11 +253,11 @@ def display_sprint_status(run_id: str, project_root: Path) -> int:
         bundle_slugs = "  ".join(e.slug for e in bundle_entries)
         print(f"[bundle: {bundle_slugs}]")
         for entry in bundle_entries:
-            _print_story_line(entry, status_icons, indent=2)
+            _print_story_line(entry, status_icons, indent=2, title_cache=title_cache)
         print()
 
     for entry in regular_entries:
-        _print_story_line(entry, status_icons, indent=0)
+        _print_story_line(entry, status_icons, indent=0, title_cache=title_cache)
 
     return 0
 
@@ -253,8 +336,14 @@ def _read_sprint_name_from_summary(summary_path: object) -> str:
         return ""
 
 
-def _print_story_line(entry: object, status_icons: dict, indent: int) -> None:
+def _print_story_line(
+    entry: object,
+    status_icons: dict,
+    indent: int,
+    title_cache: dict | None = None,
+) -> None:
     """Print a single story line for forge sprint-status."""
+    cache = title_cache if title_cache is not None else {}
     icon = status_icons.get(getattr(entry, "status", "waiting"), "?")
     path = getattr(entry, "path", getattr(entry, "slug", ""))
     status = getattr(entry, "status", "waiting")
@@ -283,7 +372,9 @@ def _print_story_line(entry: object, status_icons: dict, indent: int) -> None:
 
     prefix = " " * indent
     detail_width = _detail_column_width(indent)
-    path_lines = _wrap_cell(path, 28)
+    story_cell = _format_story_cell(path, cache)
+    detail = _enrich_detail(detail, cache)
+    path_lines = _wrap_cell(story_cell, 28)
     phase_lines = _wrap_cell(phase_str, 12)
     model_lines = _wrap_cell(model_str, 24)
     stage_lines = _wrap_cell(stage_str, 16)

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -212,15 +212,19 @@ def render_frame(
     in-place CURSOR_UP redraw region. ``state`` is mutated to record
     per-slug cost so the next frame can compute deltas.
     """
-    from theforge.cli.sprint_status import display_sprint_status
+    from theforge.cli.sprint_status import _format_story_cell, display_sprint_status
     from theforge.sprint.status_reader import read_live_status
+
+    # Persist the GitHub title cache across frames so titles fetched on frame 1
+    # are reused on every subsequent frame (zero re-fetch).
+    title_cache = state.setdefault("title_cache", {})
 
     buf = io.StringIO()
     err_buf = io.StringIO()
     # Capture stderr too: a mid-loop failure (e.g. state file just removed)
     # would otherwise scroll the terminal and break the in-place redraw math.
     with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(err_buf):
-        rc = display_sprint_status(run_id, project_root)
+        rc = display_sprint_status(run_id, project_root, title_cache=title_cache)
     base = buf.getvalue()
     snapshot_ok = rc == 0
 
@@ -300,6 +304,7 @@ def render_frame(
         if color and delta != 0 and abs(delta) >= 0.005:
             delta_str = _c(delta_str, DIM, True)
 
+        path = _format_story_cell(path, title_cache)
         path_disp = path if len(path) <= 30 else path[:29] + "…"
         act_padded = act + " " * max(0, _ACT_COL - len(label))
         overlay_lines.append(f"{path_disp:<30}  {act_padded}  {delta_str:>8}  {age_str:>9}")

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -348,7 +348,8 @@ def _waiting_detail(blocked_by: list[str]) -> str:
     if not blocked_by:
         return "waiting"
     if all(item.startswith("issue-") for item in blocked_by):
-        return f"depends on {', '.join(blocked_by)}"
+        refs = [f"#{item[len('issue-') :]}" for item in blocked_by]
+        return f"depends on {', '.join(refs)}"
     return "; ".join(blocked_by)
 
 

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -1284,14 +1284,64 @@ def test_ensure_titles_fetches_only_missing_numbers(monkeypatch, tmp_path: Path)
     _ensure_titles(entries, tmp_path, cache)
 
     assert cache == {10: "Title 10", 20: "Title 20"}
-    assert calls == [[10, 20]]
+    # Fetched one number at a time so a batch failure can't discard partials.
+    assert calls == [[10], [20]]
 
     # Second call with everything cached does not fetch again.
     _ensure_titles(entries, tmp_path, cache)
-    assert calls == [[10, 20]]
+    assert calls == [[10], [20]]
 
 
-def test_ensure_titles_degrades_on_fetch_failure(monkeypatch, tmp_path: Path) -> None:
+def test_ensure_titles_caches_partials_when_one_number_unresolvable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A single not-found number must not discard the titles that did resolve,
+    and the not-found number must not be re-fetched on the next frame."""
+    from dataclasses import dataclass, field
+
+    import theforge.sprint.query as query
+    from theforge.cli.sprint_status import _ensure_titles
+
+    @dataclass
+    class _Entry:
+        path: str
+        blocked_by: list = field(default_factory=list)
+
+    calls: list[list[int]] = []
+
+    def _fake_fetch(numbers, project_root=None):
+        calls.append(list(numbers))
+        # Number 20 does not exist in the repo — mirror the real primitive,
+        # which raises for the whole batch when a requested number is missing.
+        if 20 in numbers:
+            raise RuntimeError("Issue number(s) not found in this repository: 20")
+        return [{"number": n, "title": f"Title {n}"} for n in numbers]
+
+    monkeypatch.setattr(query, "fetch_issues_by_numbers", _fake_fetch)
+
+    entries = [_Entry("Issue #10", ["issue-20"])]
+    cache: dict = {}
+    _ensure_titles(entries, tmp_path, cache)
+
+    # 10 resolved and cached; 20 recorded as a negative sentinel.
+    assert cache == {10: "Title 10", 20: None}
+    assert calls == [[10], [20]]
+
+    # Next frame: nothing re-fetched — both numbers are already in the cache.
+    _ensure_titles(entries, tmp_path, cache)
+    assert calls == [[10], [20]]
+
+
+def test_format_story_cell_ignores_negative_sentinel() -> None:
+    from theforge.cli.sprint_status import _format_story_cell
+
+    # None sentinel (issue confirmed absent) must not render "#N None".
+    assert _format_story_cell("Issue #20", {20: None}) == "Issue #20"
+
+
+def test_ensure_titles_leaves_transient_failure_uncached(
+    monkeypatch, tmp_path: Path
+) -> None:
     from dataclasses import dataclass, field
 
     import theforge.sprint.query as query
@@ -1303,10 +1353,11 @@ def test_ensure_titles_degrades_on_fetch_failure(monkeypatch, tmp_path: Path) ->
         blocked_by: list = field(default_factory=list)
 
     def _boom(numbers, project_root=None):
-        raise RuntimeError("gh unavailable")
+        raise RuntimeError("gh issue view 10 failed: network down")
 
     monkeypatch.setattr(query, "fetch_issues_by_numbers", _boom)
 
     cache: dict = {}
     _ensure_titles([_Entry("Issue #10")], tmp_path, cache)
+    # Transient failure leaves the number uncached so a later frame can retry.
     assert cache == {}

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -146,7 +146,7 @@ def test_read_live_status_blocked_story(tmp_path: Path) -> None:
     assert entries[0].phase == "waiting"
     assert entries[0].stage == "dependency"
     assert entries[0].blocked_by == ["issue-98"]
-    assert entries[0].detail == "depends on issue-98"
+    assert entries[0].detail == "depends on #98"
 
 
 def test_read_live_status_merges_accumulated_prior_run_stories(tmp_path: Path) -> None:
@@ -341,7 +341,7 @@ def test_read_completed_status_blocked_by_from_depends_on(tmp_path: Path) -> Non
     assert by_slug["issue-6"].phase == "waiting"
     assert by_slug["issue-6"].stage == "dependency"
     assert by_slug["issue-6"].blocked_by == ["issue-5"]
-    assert by_slug["issue-6"].detail == "depends on issue-5"
+    assert by_slug["issue-6"].detail == "depends on #5"
     # Non-skipped stories should not show depends_on as blocked_by
     assert by_slug["issue-5"].blocked_by == []
     assert by_slug["issue-7"].blocked_by == []
@@ -612,7 +612,7 @@ def test_cmd_sprint_status_blocked_story_shows_dependency(tmp_path: Path) -> Non
 
     assert code == 0
     assert "Issue #31" in output
-    assert "issue-30" in output  # shows blocked_by slug in the dependency list
+    assert "#30" in output  # shows blocked_by dependency in #N notation
 
 
 def test_cmd_sprint_status_not_found(tmp_path: Path) -> None:
@@ -726,7 +726,7 @@ def test_display_sprint_status_live_row_shows_phase_and_status(tmp_path: Path) -
     assert "DEV" in output
     assert "blocked" in output
     assert "dependency" in output
-    assert "issue-10" in output  # blocked_by appears in detail
+    assert "#10" in output  # blocked_by appears in detail as #N notation
 
 
 def test_display_sprint_status_crashed_sprint(tmp_path: Path) -> None:
@@ -1223,3 +1223,90 @@ def test_completed_already_done_story_prefers_preflight_reason_over_outcome_mess
     )
 
     assert detail == "Preflight verdict: Main already satisfies all acceptance criteria."
+
+
+# ── Title cache + #N enrichment (issue #1486) ────────────────────────────────
+
+
+def test_issue_number_from_slug_variants() -> None:
+    from theforge.cli.sprint_status import _issue_number_from_slug
+
+    assert _issue_number_from_slug("issue-1424") == 1424
+    assert _issue_number_from_slug("Issue #1424") == 1424
+    assert _issue_number_from_slug("#1462") == 1462
+    assert _issue_number_from_slug("no-number-here") is None
+    assert _issue_number_from_slug("") is None
+
+
+def test_format_story_cell_uses_cached_title() -> None:
+    from theforge.cli.sprint_status import _format_story_cell
+
+    cache = {1424: "Write changelog gen"}
+    assert _format_story_cell("Issue #1424", cache) == "#1424 Write changelog gen"
+    # No cached title -> original path unchanged.
+    assert _format_story_cell("Issue #1425", cache) == "Issue #1425"
+    # Non-issue path unchanged.
+    assert _format_story_cell("some-file.md", cache) == "some-file.md"
+
+
+def test_enrich_detail_appends_titles_to_hash_tokens() -> None:
+    from theforge.cli.sprint_status import _enrich_detail
+
+    cache = {1462: "Fix audit rollup"}
+    assert _enrich_detail("depends on #1462", cache) == "depends on #1462 Fix audit rollup"
+    # Details with no #N tokens are unchanged.
+    assert _enrich_detail("parallel cap", cache) == "parallel cap"
+    # Unknown number left bare.
+    assert _enrich_detail("depends on #999", cache) == "depends on #999"
+
+
+def test_ensure_titles_fetches_only_missing_numbers(monkeypatch, tmp_path: Path) -> None:
+    from dataclasses import dataclass, field
+
+    import theforge.sprint.query as query
+    from theforge.cli.sprint_status import _ensure_titles
+
+    @dataclass
+    class _Entry:
+        path: str
+        blocked_by: list = field(default_factory=list)
+
+    calls: list[list[int]] = []
+
+    def _fake_fetch(numbers, project_root=None):
+        calls.append(list(numbers))
+        return [{"number": n, "title": f"Title {n}"} for n in numbers]
+
+    monkeypatch.setattr(query, "fetch_issues_by_numbers", _fake_fetch)
+
+    entries = [_Entry("Issue #10", ["issue-20"]), _Entry("Issue #10")]
+    cache: dict = {}
+    _ensure_titles(entries, tmp_path, cache)
+
+    assert cache == {10: "Title 10", 20: "Title 20"}
+    assert calls == [[10, 20]]
+
+    # Second call with everything cached does not fetch again.
+    _ensure_titles(entries, tmp_path, cache)
+    assert calls == [[10, 20]]
+
+
+def test_ensure_titles_degrades_on_fetch_failure(monkeypatch, tmp_path: Path) -> None:
+    from dataclasses import dataclass, field
+
+    import theforge.sprint.query as query
+    from theforge.cli.sprint_status import _ensure_titles
+
+    @dataclass
+    class _Entry:
+        path: str
+        blocked_by: list = field(default_factory=list)
+
+    def _boom(numbers, project_root=None):
+        raise RuntimeError("gh unavailable")
+
+    monkeypatch.setattr(query, "fetch_issues_by_numbers", _boom)
+
+    cache: dict = {}
+    _ensure_titles([_Entry("Issue #10")], tmp_path, cache)
+    assert cache == {}

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -1339,9 +1339,7 @@ def test_format_story_cell_ignores_negative_sentinel() -> None:
     assert _format_story_cell("Issue #20", {20: None}) == "Issue #20"
 
 
-def test_ensure_titles_leaves_transient_failure_uncached(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_ensure_titles_leaves_transient_failure_uncached(monkeypatch, tmp_path: Path) -> None:
     from dataclasses import dataclass, field
 
     import theforge.sprint.query as query

--- a/tests/test_cli_status_watch.py
+++ b/tests/test_cli_status_watch.py
@@ -960,7 +960,7 @@ class TestRenderFrameCapturesStderr:
     """render_frame must keep stderr OUT of the terminal but RETURN it for the caller."""
 
     def test_render_frame_returns_captured_stderr(self, tmp_path: Path) -> None:
-        def fake_display(_run_id: str, _project_root: Path) -> int:
+        def fake_display(_run_id: str, _project_root: Path, title_cache=None) -> int:
             import sys as _sys
 
             print("boom: cannot read state", file=_sys.stderr)
@@ -1054,3 +1054,34 @@ class TestAuditMtimeRunScoping:
 
         resolved = status_watch._resolve_sprint_log_dir("run-x", tmp_path)
         assert resolved == sprint_dir
+
+
+class TestWatchTitleCachePersistence:
+    """render_frame must reuse the same title cache dict across frames."""
+
+    def test_title_cache_persisted_in_state(self, tmp_path: Path) -> None:
+        seen_caches: list[dict] = []
+
+        def fake_display(_run_id: str, _project_root: Path, title_cache=None) -> int:
+            seen_caches.append(title_cache)
+            if title_cache is not None:
+                title_cache[42] = "cached title"
+            return 0
+
+        state: dict = {"costs": {}, "interval": 2.0}
+        with (
+            patch(
+                "theforge.cli.sprint_status.display_sprint_status",
+                side_effect=fake_display,
+            ),
+            patch(
+                "theforge.sprint.status_reader.read_live_status",
+                return_value=[],
+            ),
+        ):
+            status_watch.render_frame("run-x", tmp_path, state, 0, color=False)
+            status_watch.render_frame("run-x", tmp_path, state, 1, color=False)
+
+        # Same dict object handed to display on both frames, and it survives in state.
+        assert seen_caches[0] is seen_caches[1]
+        assert state["title_cache"] == {42: "cached title"}

--- a/tests/test_status_reader_elapsed.py
+++ b/tests/test_status_reader_elapsed.py
@@ -117,7 +117,7 @@ def test_completed_skipped_story_with_dependencies_keeps_waiting_detail() -> Non
     )
 
     assert stage == "dependency"
-    assert detail == "depends on issue-1"
+    assert detail == "depends on #1"
 
 
 def test_live_skipped_story_uses_reason_detail() -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior P1 batch-fetch failure is resolved, and the status title/detail behavior matches the requested runtime paths. | [google-gemini-3.5-flash] The implementation of issue titles and dependency detail formatting is robust, fully tested, and resolves the prior P1 batch-fetch issue. | [claude-sonnet] Prior P1 (all-or-nothing batch fetch discarding resolved titles and re-fetching every frame) is fixed by cef0d8c: titles are now fetched one issue number at a time, confirmed-absent numbers are cached with a None sentinel to avoid retry, and transient gh failures are left uncached to retry later; _format_story_cell/_enrich_detail correctly treat the None sentinel as absent. No regressions found in the fix.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $7.03
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status: show issue titles and dependency detail for waiting stories (GitHub Issue #1486)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1486