### PR TITLE
forge status REVIEW phase: STAGE always empty, DETAIL stale during in-flight cycle

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -940,6 +940,16 @@ def _run_review_phase(
                 "cost_usd": state.total_cost,
                 "complexity": state.preflight_complexity,
                 "current_model": f"panel({len(config.review_pool)})",
+                # Populate detail on REVIEW entry so STAGE renders cycle=N/M and
+                # the stale prior-phase detail (e.g. GATE/VALIDATE gate_status) is
+                # overwritten immediately. story_state.transition replaces detail
+                # wholesale, so supplying it here clears the leftover field.
+                "detail": {
+                    "review_cycle": state.review_cycle + 1,
+                    "review_max_cycles": (
+                        state.adaptive_review_max or config.retry.max_review_cycles
+                    ),
+                },
             }
         )
     if logger:
@@ -1182,6 +1192,13 @@ def _run_review_phase(
                 "cost_usd": state.total_cost,
                 "complexity": state.preflight_complexity,
                 "detail": {
+                    # Re-include cycle context so the wholesale detail replace at
+                    # story_state.transition does not wipe STAGE after a cycle
+                    # completes while DETAIL shows the P1/P2 counts.
+                    "review_cycle": state.review_cycle,
+                    "review_max_cycles": (
+                        state.adaptive_review_max or config.retry.max_review_cycles
+                    ),
                     "review_p1": _p1_count,
                     "review_p2": _p2_count,
                 },

--- a/src/theforge/coordinator/reviewer_progress.py
+++ b/src/theforge/coordinator/reviewer_progress.py
@@ -126,6 +126,11 @@ class ReviewerProgressChannel:
             "reviewer_progress": {k: dict(v) for k, v in self._progress.items()},
             "reviewer_pool_size": len(self._progress),
             "last_reviewer_event_ts": time.time(),
+            # Carry the cycle number so it survives this writer's wholesale detail
+            # replace. self._iteration is seeded at state.review_cycle + 1, i.e.
+            # the current cycle. Keeps STAGE cycle context present while reviewers
+            # are actively emitting events.
+            "review_cycle": self._iteration,
         }
         try:
             self._state_update_fn(

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -533,16 +533,24 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
         return stage, " | ".join(detail_parts) or "running", complexity
 
     if phase_val == "REVIEW":
+        cycle = detail_data.get("review_cycle")
+        cycle_stage = _format_usage_stage(cycle, detail_data.get("review_max_cycles"), "cycle")
+        if not cycle_stage and isinstance(cycle, int):
+            cycle_stage = f"cycle={cycle}"
         reviewer_progress = detail_data.get("reviewer_progress")
         if isinstance(reviewer_progress, dict) and reviewer_progress:
             stage, pool_detail = _reviewer_progress_stage(
                 reviewer_progress, detail_data.get("reviewer_pool_size")
             )
+            # Keep the cycle number visible during the in-flight window rather
+            # than showing only per-reviewer progress (issue #1488) — the
+            # reviewer_progress payload carries review_cycle for exactly this.
+            if cycle_stage and stage:
+                stage = f"{cycle_stage} {stage}"
+            elif cycle_stage:
+                stage = cycle_stage
             return stage, pool_detail, complexity
-        cycle = detail_data.get("review_cycle")
-        stage = _format_usage_stage(cycle, detail_data.get("review_max_cycles"), "cycle")
-        if not stage and isinstance(cycle, int):
-            stage = f"cycle={cycle}"
+        stage = cycle_stage
         p1 = detail_data.get("review_p1")
         p2 = detail_data.get("review_p2")
         detail = _review_detail(detail_data.get("review_verdict"), p1, p2)

--- a/tests/test_coord_review_phase_cycle.py
+++ b/tests/test_coord_review_phase_cycle.py
@@ -388,6 +388,47 @@ class TestRunFromReview:
         assert len(captured_session_ids) == 1
         assert captured_session_ids[0] == ["prior-rev-sess"]
 
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch_gate_shell()
+    def test_review_state_updates_carry_review_cycle(self, mock_shell, mock_pool, tmp_path):
+        """Every REVIEW-phase detail payload the coordinator emits carries
+        ``review_cycle`` so the status reader's STAGE column never goes blank
+        (issue #1488). Covers the entry write, the reviewer-progress seed, and the
+        cycle-completion write — the reader replaces detail wholesale, so each
+        writer must re-include the cycle.
+        """
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.return_value = (True, "", 0, False)
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        updates: list[dict] = []
+
+        result = run_from_review(config, task, workspace, state_update_fn=updates.append)
+        assert result.success is True
+
+        review_details = [
+            u["detail"]
+            for u in updates
+            if u.get("phase") == "REVIEW" and isinstance(u.get("detail"), dict)
+        ]
+        # At least the entry write and the completion write must have fired.
+        assert len(review_details) >= 2
+        # No REVIEW detail payload may drop the cycle — that is what the reader
+        # renders as STAGE, and a wholesale replace without it blanks the column.
+        assert all("review_cycle" in d for d in review_details)
+        # The entry write seeds cycle context (review_max_cycles, no counts yet).
+        assert any("review_max_cycles" in d and "review_p1" not in d for d in review_details)
+        # The completion write carries both the cycle AND the P1/P2 counts.
+        assert any(
+            "review_cycle" in d and "review_p1" in d and "review_p2" in d for d in review_details
+        )
+
 
 class TestHasPersistentP1:
     """Unit tests for _has_persistent_p1 in coord_preflight."""

--- a/tests/test_status_reader_reviewer_progress.py
+++ b/tests/test_status_reader_reviewer_progress.py
@@ -370,8 +370,9 @@ class TestReviewDetailContract:
         assert entry.detail == "running"
 
     def test_in_flight_reviewer_progress_renders_pool_stage(self, tmp_path: Path) -> None:
-        # While reviewers emit events the reviewer_progress dict drives STAGE; the
-        # cycle number is carried alongside for continuity.
+        # While reviewers emit events the reviewer_progress dict drives STAGE, but
+        # the cycle number must remain visible (issue #1488) — the operator saw
+        # only per-reviewer progress for the whole 14m in-flight window.
         story: dict = {"slug": "issue-1488", "path": "Issue #1488", "status": "running"}
         channel = ReviewerProgressChannel(
             reviewer_names=["deepseek", "gemini"],
@@ -387,7 +388,32 @@ class TestReviewDetailContract:
         assert story["detail"]["review_cycle"] == 2
         _write_state(tmp_path, "run-x", story)
         entry = read_live_status("run-x", tmp_path)[0]
+        # STAGE prefixes the cycle onto the per-reviewer progress.
+        assert entry.stage.startswith("cycle=2 ")
         assert "deepseek=iter1" in entry.stage
+        assert entry.detail == "pool 1/2 done"
+
+    def test_in_flight_stage_includes_cycle_with_max_when_present(self, tmp_path: Path) -> None:
+        # When both review_cycle and review_max_cycles are present alongside
+        # reviewer_progress, STAGE renders cycle=N/M then the per-reviewer stage.
+        story = {
+            "slug": "issue-1488",
+            "path": "Issue #1488",
+            "status": "running",
+            "phase": "REVIEW",
+            "detail": {
+                "review_cycle": 2,
+                "review_max_cycles": 3,
+                "reviewer_progress": {
+                    "deepseek": {"iter": 4, "tool_calls": 2, "retry": None, "done": False},
+                    "gemini": {"iter": 5, "tool_calls": 3, "retry": None, "done": True},
+                },
+                "reviewer_pool_size": 2,
+            },
+        }
+        _write_state(tmp_path, "run-x", story)
+        entry = read_live_status("run-x", tmp_path)[0]
+        assert entry.stage == "cycle=2/3 deepseek=iter4, gemini=done"
         assert entry.detail == "pool 1/2 done"
 
     def test_completion_detail_keeps_cycle_alongside_counts(self, tmp_path: Path) -> None:

--- a/tests/test_status_reader_reviewer_progress.py
+++ b/tests/test_status_reader_reviewer_progress.py
@@ -208,6 +208,9 @@ class TestReviewerProgressSeam:
         assert entries is not None
         entry = entries[0]
         assert "iter" not in entry.stage  # not per-reviewer
+        # On REVIEW entry (before any reviewer event) STAGE must still render the
+        # cycle from the seeded detail rather than go blank (issue #1488).
+        assert entry.stage == "cycle=1/3"
         assert entry.detail == "running"
         assert entry.last_event_ts is None
 
@@ -332,3 +335,78 @@ class TestReviewerProgressSeam:
         # Must not propagate — reviewers can never be broken by a bad state sink.
         channel.cb({"label": "a", "iter": 1, "tool_calls": 1})
         channel.set_retry("a", 1, 2)
+
+
+# ── REVIEW detail contract across entry / in-flight / completion (issue #1488) ─
+
+
+class TestReviewDetailContract:
+    """The REVIEW STAGE/DETAIL columns must stay meaningful across the whole
+    cycle: on entry (cycle rendered, no stale gate_status leaking), while
+    reviewers run (pool progress), and after a cycle completes (cycle STILL
+    rendered alongside the P1/P2 counts). This drives the real renderer with the
+    detail dicts the three coordinator writers now emit.
+    """
+
+    def test_entry_detail_renders_cycle_and_clears_prior_phase_gate_status(
+        self, tmp_path: Path
+    ) -> None:
+        # On REVIEW entry the writer replaces detail wholesale with the cycle
+        # context (review_phase.py). Even if the prior phase left gate_status
+        # behind, the fresh detail must not carry it, and STAGE must render.
+        story = {
+            "slug": "issue-1488",
+            "path": "Issue #1488",
+            "status": "running",
+            "phase": "REVIEW",
+            "detail": {"review_cycle": 1, "review_max_cycles": 3},
+        }
+        assert "gate_status" not in story["detail"]
+        _write_state(tmp_path, "run-x", story)
+        entry = read_live_status("run-x", tmp_path)[0]
+        assert entry.stage == "cycle=1/3"
+        # No leftover GATE/VALIDATE fragment surfaces in DETAIL.
+        assert "PASS" not in entry.detail
+        assert entry.detail == "running"
+
+    def test_in_flight_reviewer_progress_renders_pool_stage(self, tmp_path: Path) -> None:
+        # While reviewers emit events the reviewer_progress dict drives STAGE; the
+        # cycle number is carried alongside for continuity.
+        story: dict = {"slug": "issue-1488", "path": "Issue #1488", "status": "running"}
+        channel = ReviewerProgressChannel(
+            reviewer_names=["deepseek", "gemini"],
+            phase="REVIEW",
+            iteration=2,
+            cost_usd=0.0,
+            complexity="medium",
+            state_update_fn=_worker_style_state_update(story),
+        )
+        channel.cb({"label": "deepseek", "iter": 1, "tool_calls": 2})
+        channel.cb({"label": "gemini", "done": True})
+        # review_cycle rides along with the reviewer-progress detail.
+        assert story["detail"]["review_cycle"] == 2
+        _write_state(tmp_path, "run-x", story)
+        entry = read_live_status("run-x", tmp_path)[0]
+        assert "deepseek=iter1" in entry.stage
+        assert entry.detail == "pool 1/2 done"
+
+    def test_completion_detail_keeps_cycle_alongside_counts(self, tmp_path: Path) -> None:
+        # After a cycle completes the writer emits {review_cycle, review_max_cycles,
+        # review_p1, review_p2}. STAGE must still render the cycle and DETAIL the
+        # counts — neither goes blank (the original symptom).
+        story = {
+            "slug": "issue-1488",
+            "path": "Issue #1488",
+            "status": "running",
+            "phase": "REVIEW",
+            "detail": {
+                "review_cycle": 2,
+                "review_max_cycles": 3,
+                "review_p1": 0,
+                "review_p2": 0,
+            },
+        }
+        _write_state(tmp_path, "run-x", story)
+        entry = read_live_status("run-x", tmp_path)[0]
+        assert entry.stage == "cycle=2/3"
+        assert entry.detail == "0P1 0P2"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior in-flight REVIEW STAGE bug is resolved, and the touched runtime paths are covered by focused seam tests. | [google-gemini-3.5-flash] The REVIEW phase STAGE and DETAIL columns now correctly display the live cycle and reviewer progress without blanking or leaking stale gate status. | [claude-sonnet] Iteration 1 correctly fixes the in-flight STAGE cycle-number gap by prefixing cycle=N/M onto the reviewer-progress stage; no regressions found in the touched lines.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $5.71
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status REVIEW phase: STAGE always empty, DETAIL stale during in-flight cycle (GitHub Issue #1488)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1488