### PR TITLE
forge status renders multi-line pending-decision reason unindented and truncated mid-sentence

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -548,6 +548,25 @@ def _show_ready_queue(project_root: Path, milestone: str | None) -> int:
     return 0
 
 
+_PENDING_REASON_LINE_LIMIT = 200
+
+
+def _print_pending_reason(reason: str) -> None:
+    """Print a (possibly multi-line) pending-decision reason under a `reason:` label.
+
+    Continuation lines are indented to stay visually attached to the label.
+    Each line is length-limited independently (never the whole multi-line
+    string as one slice) so a long final line isn't cut off before its
+    meaning-carrying tail.
+    """
+    lines = reason.splitlines() or [""]
+    for i, line in enumerate(lines):
+        if len(line) > _PENDING_REASON_LINE_LIMIT:
+            line = line[: _PENDING_REASON_LINE_LIMIT - 3] + "..."
+        prefix = "    reason: " if i == 0 else "             "
+        print(f"{prefix}{line}")
+
+
 def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:
     """Print the pending-decisions section."""
     pending_entries = pending_mod.list_pending(project_root)
@@ -558,7 +577,7 @@ def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:
             run_id = entry.get("run_id", "?")
             story = entry.get("story", "?")
             phase = entry.get("phase", "?")
-            reason = (entry.get("reason") or "")[:80]
+            reason = entry.get("reason") or ""
             created_at = entry.get("created_at", "")
             timeout_at_str = entry.get("timeout_at", "")
             options = entry.get("options", [])
@@ -582,7 +601,7 @@ def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:
             opts_str = "/".join(options) if options else ""
             print(f"  {run_id}  [{phase}]  story={story}  {status_str}")
             if reason:
-                print(f"    reason: {reason}")
+                _print_pending_reason(reason)
             if opts_str:
                 print(f"    options: {opts_str}")
             if created_at:

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from theforge.config import (
@@ -620,6 +621,65 @@ class TestAwaitWatchableSprintRun:
             patch("theforge.cli.status.time.monotonic", side_effect=[0.0, 0.2, 1.1]),
         ):
             assert _await_watchable_sprint_run("run-1", tmp_path, grace_seconds=1.0) is False
+
+
+class TestShowPendingDecisionsReason:
+    def test_multiline_reason_indented_and_not_truncated_mid_sentence(
+        self, capsys: object
+    ) -> None:
+        """Each line of a multi-line reason is indented under `reason:` and the
+        meaning-carrying tail of a long final line is preserved, not cut off."""
+        from theforge.cli.status import _show_pending_decisions
+
+        long_tail = "Max cycles (3) exhausted."
+        reason = "\n".join(["2/3 reviewers APPROVE", "PASS", long_tail])
+        entry = {
+            "run_id": "72a081f9c8c8",
+            "story": "issue-173",
+            "phase": "ESCALATE",
+            "reason": reason,
+            "created_at": "",
+            "timeout_at": "",
+            "options": ["approve", "reject", "continue"],
+        }
+        pending_mod = SimpleNamespace(list_pending=lambda project_root: [entry])
+
+        _show_pending_decisions(pending_mod, Path("."))
+
+        out = capsys.readouterr().out
+        lines = out.splitlines()
+
+        reason_line = next(line for line in lines if "reason:" in line)
+        reason_idx = lines.index(reason_line)
+        continuation_1 = lines[reason_idx + 1]
+        continuation_2 = lines[reason_idx + 2]
+
+        assert reason_line.startswith("    reason: 2/3 reviewers APPROVE")
+        assert continuation_1.startswith("             PASS")
+        assert continuation_1.strip() == "PASS"
+        assert continuation_2.startswith("             ")
+        assert long_tail in continuation_2
+
+    def test_single_long_line_truncated_with_marker_not_silently(self, capsys: object) -> None:
+        from theforge.cli.status import _show_pending_decisions
+
+        entry = {
+            "run_id": "abc123",
+            "story": "issue-1",
+            "phase": "ESCALATE",
+            "reason": "x" * 300,
+            "created_at": "",
+            "timeout_at": "",
+            "options": [],
+        }
+        pending_mod = SimpleNamespace(list_pending=lambda project_root: [entry])
+
+        _show_pending_decisions(pending_mod, Path("."))
+
+        out = capsys.readouterr().out
+        reason_line = next(line for line in out.splitlines() if "reason:" in line)
+        assert reason_line.endswith("...")
+        assert len(reason_line) < 250
 
 
 def test_sprint_status_absent_from_cli_parser() -> None:


### PR DESCRIPTION
## Summary

Multi-line pending-decision reason now splits on newlines, indents continuation lines under the reason: label, and truncates per-line with a marker; the original symptom is reproduced by a test and resolved.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $1.59
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge status renders multi-line pending-decision reason unindented and truncated mid-sentence (GitHub Issue #1748)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1748