### PR TITLE
promote-rc.sh: derive CHANGELOG section from milestone + tag range, stop relying on hand-curated [Unreleased]

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,8 +9,13 @@ This document defines how TheForge releases are cut, maintained, and hotfixed.
   `gh issue list --milestone v0.4.0 --state closed`.
 - **Package version = shipped artifact.** `pyproject.toml` holds the last released
   version (or `X.Y.Z.dev0` between releases). It is never bumped ahead of the tag.
-- **`[Unreleased]` accumulates.** CHANGELOG has an `[Unreleased]` section that grows
-  as work lands on `main`. At release time it is renamed to the version + date.
+- **The release CHANGELOG section is derived, not hand-curated.** At promote time
+  `promote-rc.sh` derives the `[X.Y.Z]` section from the milestone's closed issues
+  cross-referenced against the PR merges in the previous-tag..HEAD range, and
+  aborts the promote if the two disagree. The `[Unreleased]` section is now an
+  optional working-notes scratchpad — operators may scribble context there during
+  development, but its contents are not consulted for release notes and it is left
+  untouched at promote time.
 - **Sprints run against the right base branch.** `forge.yaml` (or an override config)
   sets `workspace.base_branch`. For main-line development this is `main`; for
   release-branch work it is `release/vX.Y`.
@@ -117,8 +122,11 @@ scripts/promote-rc.sh --dry-run X.Y.Z
 - requires milestone `vX.Y.Z` has zero open issues (this is where the milestone
   block lives, not in `cut-rc.sh`)
 - runs `make gate`
-- updates `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z] — YYYY-MM-DD`, new
-  `[Unreleased]` inserted)
+- derives the `[X.Y.Z] — YYYY-MM-DD` CHANGELOG section from milestone `vX.Y.Z` +
+  the PR merges in `<previous-tag>..HEAD`, aborting on any milestone/merge
+  mismatch, and splices it above the existing sections (leaving `[Unreleased]`
+  and its notes untouched). `promote-rc.sh --dry-run X.Y.Z` previews the derived
+  section without writing.
 - bumps `pyproject.toml` from `X.Y.ZrcN` to `X.Y.Z`
 - commits, tags `vX.Y.Z`, pushes
 - bumps `main` to the next `.dev0` version
@@ -160,22 +168,29 @@ git checkout main && git pull --ff-only
 make gate   # must pass
 ```
 
-### 3. Update CHANGELOG
+### 3. CHANGELOG (derived automatically)
 
-Rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`.
+You do **not** hand-write the release section. `promote-rc.sh` derives the
+`## [X.Y.Z] — YYYY-MM-DD` section by calling `scripts/derive_changelog.py`,
+which lists the milestone's closed issues, cross-references them against the PR
+merges in `<previous-tag>..HEAD`, and:
 
-Add a new `## [Unreleased]` section at the top for future work.
+- aborts the promote if a milestone issue has no corresponding merge, or a merged
+  PR (`(#N)` in its squash subject) has no milestone issue — surfacing the exact
+  discrepancy so you can fix milestone/PR linkage and retry;
+- otherwise groups entries by issue label (`bug`→Fixed, `enhancement`→Added,
+  `documentation`→Documentation, everything else→Changed) as `- Title (#N)`.
 
-Before continuing, verify the release section against both the milestone and the
-tag range:
+Preview the derived section without writing anything:
 
 ```bash
-gh issue list --milestone vX.Y.Z --state closed --limit 200
-git log --oneline <previous-release-tag>..HEAD
+scripts/promote-rc.sh --dry-run X.Y.Z
 ```
 
-The GitHub release body is generated from this CHANGELOG section, so missing
-items here become missing release notes.
+The GitHub release body is generated from this derived section, so the milestone
+and the tag range are the source of truth — a missing item is a milestone/PR
+linkage gap, not a CHANGELOG-editing miss. `[Unreleased]` is left untouched as an
+optional scratchpad and is not consulted.
 
 ### 4. Bump version
 

--- a/scripts/derive_changelog.py
+++ b/scripts/derive_changelog.py
@@ -35,9 +35,24 @@ import re
 import subprocess
 import sys
 
-# Trailing "(#1234)" on a squash-merge commit subject — this repo's forge
-# convention (e.g. "...surface reviewer time-nudge warnings (#1804)").
+# Trailing "(#1234)" on a squash-merge commit subject — the PR number GitHub
+# appends on squash merge (e.g. "...surface reviewer time-nudge warnings (#1804)").
+# This is the PR number, NOT the issue number; the milestone tracks ISSUES.
 _PR_NUM_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+# GitHub closing keywords in a commit body link the merge to the milestone
+# issue(s) it resolves — forge emits "Closes #1087". The issue number here is
+# what must cross-reference against the milestone; it routinely differs from the
+# trailing PR number (issue #1087 closed by PR #1804).
+_CLOSES_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+# git log record format: subject <US> body <RS>. The RS delimits commits so a
+# multi-line body (which carries the Closes trailers) stays attached to its
+# subject.
+_LOG_FORMAT = "%s%x1f%b%x1e"
 
 # Label -> Keep-a-Changelog section. First matching label (in this order) wins.
 _LABEL_SECTIONS = (
@@ -94,38 +109,59 @@ def fetch_milestone_issues(repo: str, version: str) -> list[dict]:
     return issues
 
 
-def fetch_merged_pr_numbers(prev_tag: str) -> set[int]:
-    """Return the set of PR numbers merged in prev_tag..HEAD.
+def fetch_merges(prev_tag: str) -> list[dict]:
+    """Return the PR merges in prev_tag..HEAD as [{pr, issues}].
 
-    Subjects without a trailing `(#N)` (version-bump chores, raw
-    `Merge pull request ...` subjects) are ignored so they don't trip the
-    reverse cross-reference.
+    Each entry carries the trailing `(#PR)` number (for reverse-check messaging)
+    and the set of milestone issue numbers the commit closes (its `Closes #N`
+    trailers). Commits with neither a trailing `(#N)` nor any closing trailer
+    (version-bump chores, raw `Merge pull request ...` subjects) are dropped so
+    they don't trip the reverse cross-reference.
     """
-    out = _run(["git", "log", "--pretty=%s", f"{prev_tag}..HEAD"])
-    numbers: set[int] = set()
-    for line in out.splitlines():
-        match = _PR_NUM_RE.search(line.strip())
-        if match:
-            numbers.add(int(match.group(1)))
-    return numbers
+    out = _run(["git", "log", f"--pretty=format:{_LOG_FORMAT}", f"{prev_tag}..HEAD"])
+    merges: list[dict] = []
+    for record in out.split("\x1e"):
+        if not record.strip():
+            continue
+        subject, _, body = record.partition("\x1f")
+        pr_match = _PR_NUM_RE.search(subject.strip())
+        pr_num = int(pr_match.group(1)) if pr_match else None
+        closed = {int(n) for n in _CLOSES_RE.findall(body)}
+        if pr_num is None and not closed:
+            continue
+        merges.append({"pr": pr_num, "issues": closed})
+    return merges
 
 
 def cross_reference(
-    issues: list[dict], merged: set[int], version: str, prev_tag: str
+    issues: list[dict], merges: list[dict], version: str, prev_tag: str
 ) -> list[str]:
-    """Return a list of discrepancy lines; empty means milestone ⇔ merges match."""
-    milestone_numbers = {issue["number"] for issue in issues}
-    discrepancies: list[str] = []
+    """Return a list of discrepancy lines; empty means milestone ⇔ merges match.
 
-    for number in sorted(milestone_numbers - merged):
+    Cross-references milestone ISSUE numbers against the issues each merge
+    *closes* (not the trailing PR number, which differs). Forward: every
+    milestone issue must be closed by some merge in the range. Reverse: every
+    merge in the range must close at least one milestone issue.
+    """
+    milestone_numbers = {issue["number"] for issue in issues}
+    closed_by_merges: set[int] = set()
+    for merge in merges:
+        closed_by_merges |= merge["issues"]
+
+    discrepancies: list[str] = []
+    for number in sorted(milestone_numbers - closed_by_merges):
         discrepancies.append(
             f"milestone v{version} has issue #{number} (closed) "
             f"with no PR merge in {prev_tag}..HEAD"
         )
-    for number in sorted(merged - milestone_numbers):
-        discrepancies.append(
-            f"PR #{number} merged in tag range with no v{version} milestone issue"
-        )
+    for merge in merges:
+        if merge["issues"] & milestone_numbers:
+            continue
+        if merge["pr"] is not None:
+            label = f"PR #{merge['pr']}"
+        else:
+            label = f"issue #{min(merge['issues'])}"
+        discrepancies.append(f"{label} merged in tag range with no v{version} milestone issue")
     return discrepancies
 
 
@@ -169,18 +205,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
     issues = fetch_milestone_issues(args.repo, args.version)
-    merged = fetch_merged_pr_numbers(args.prev_tag)
+    merges = fetch_merges(args.prev_tag)
 
     print(
         f"[forge]   {len(issues)} closed issues in milestone v{args.version}",
         file=sys.stderr,
     )
     print(
-        f"[forge]   {len(merged)} PR merges in {args.prev_tag}..HEAD",
+        f"[forge]   {len(merges)} PR merges in {args.prev_tag}..HEAD",
         file=sys.stderr,
     )
 
-    discrepancies = cross_reference(issues, merged, args.version, args.prev_tag)
+    discrepancies = cross_reference(issues, merges, args.version, args.prev_tag)
     if discrepancies:
         for line in discrepancies:
             print(f"[forge] ERROR: {line}", file=sys.stderr)

--- a/scripts/derive_changelog.py
+++ b/scripts/derive_changelog.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Derive a CHANGELOG release section from a GitHub milestone + git tag range.
+
+`promote-rc.sh` calls this at promote time instead of trusting a hand-curated
+`[Unreleased]` section. The milestone is canonical for "what's in this release";
+the PR merge commits in the tag range are canonical for "what actually changed".
+This script cross-references the two and refuses to render if they disagree, so
+an operator who forgot to milestone an issue (or milestoned one that never
+merged) gets a loud abort rather than silently-incomplete release notes.
+
+Usage:
+    derive_changelog.py --version X.Y.Z --prev-tag vA.B.C \\
+        --date YYYY-MM-DD [--repo fuzzypete/theforge]
+
+On success: prints the rendered `## [X.Y.Z] — DATE` section to stdout and
+progress/count lines to stderr, exits 0.
+On milestone/merge mismatch: prints each discrepancy to stderr, exits 1.
+
+The rendered section groups entries by the first matching issue label:
+    bug            -> Fixed
+    enhancement    -> Added
+    documentation  -> Documentation
+    (anything else / no label) -> Changed
+
+Kept pure and side-effect-free apart from the `gh`/`git` subprocess reads and
+the stdout/stderr writes, so it is unit-testable under a PATH-mocked `gh` and
+`git` (see tests/test_derive_changelog.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+# Trailing "(#1234)" on a squash-merge commit subject — this repo's forge
+# convention (e.g. "...surface reviewer time-nudge warnings (#1804)").
+_PR_NUM_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+# Label -> Keep-a-Changelog section. First matching label (in this order) wins.
+_LABEL_SECTIONS = (
+    ("bug", "Fixed"),
+    ("enhancement", "Added"),
+    ("documentation", "Documentation"),
+)
+
+# Keep-a-Changelog render order for the sections we emit.
+_SECTION_ORDER = ("Added", "Changed", "Fixed", "Documentation")
+
+_DEFAULT_SECTION = "Changed"
+
+
+def _run(cmd: list[str]) -> str:
+    """Run a subprocess and return its stdout, raising on non-zero exit."""
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {' '.join(cmd)}\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def fetch_milestone_issues(repo: str, version: str) -> list[dict]:
+    """Return closed issues in milestone vX.Y.Z as [{number, title, labels}]."""
+    out = _run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--milestone",
+            f"v{version}",
+            "--state",
+            "closed",
+            "--limit",
+            "500",
+            "--json",
+            "number,title,labels",
+        ]
+    )
+    raw = json.loads(out or "[]")
+    issues = []
+    for item in raw:
+        issues.append(
+            {
+                "number": item["number"],
+                "title": item["title"],
+                "labels": [lbl["name"] for lbl in item.get("labels", [])],
+            }
+        )
+    return issues
+
+
+def fetch_merged_pr_numbers(prev_tag: str) -> set[int]:
+    """Return the set of PR numbers merged in prev_tag..HEAD.
+
+    Subjects without a trailing `(#N)` (version-bump chores, raw
+    `Merge pull request ...` subjects) are ignored so they don't trip the
+    reverse cross-reference.
+    """
+    out = _run(["git", "log", "--pretty=%s", f"{prev_tag}..HEAD"])
+    numbers: set[int] = set()
+    for line in out.splitlines():
+        match = _PR_NUM_RE.search(line.strip())
+        if match:
+            numbers.add(int(match.group(1)))
+    return numbers
+
+
+def cross_reference(
+    issues: list[dict], merged: set[int], version: str, prev_tag: str
+) -> list[str]:
+    """Return a list of discrepancy lines; empty means milestone ⇔ merges match."""
+    milestone_numbers = {issue["number"] for issue in issues}
+    discrepancies: list[str] = []
+
+    for number in sorted(milestone_numbers - merged):
+        discrepancies.append(
+            f"milestone v{version} has issue #{number} (closed) "
+            f"with no PR merge in {prev_tag}..HEAD"
+        )
+    for number in sorted(merged - milestone_numbers):
+        discrepancies.append(
+            f"PR #{number} merged in tag range with no v{version} milestone issue"
+        )
+    return discrepancies
+
+
+def section_for(labels: list[str]) -> str:
+    """Map an issue's labels to a Keep-a-Changelog section (first match wins)."""
+    for label, section in _LABEL_SECTIONS:
+        if label in labels:
+            return section
+    return _DEFAULT_SECTION
+
+
+def render_section(issues: list[dict], version: str, date: str) -> str:
+    """Render the `## [X.Y.Z] — DATE` section grouped by label-derived section."""
+    grouped: dict[str, list[dict]] = {section: [] for section in _SECTION_ORDER}
+    for issue in issues:
+        grouped[section_for(issue["labels"])].append(issue)
+
+    lines = [f"## [{version}] — {date}", ""]
+    for section in _SECTION_ORDER:
+        entries = grouped[section]
+        if not entries:
+            continue
+        lines.append(f"### {section}")
+        lines.append("")
+        for issue in sorted(entries, key=lambda i: i["number"]):
+            lines.append(f"- {issue['title']} (#{issue['number']})")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Release version, e.g. 0.11.0")
+    parser.add_argument("--prev-tag", required=True, help="Previous release tag, e.g. v0.10.0")
+    parser.add_argument("--date", required=True, help="Release date YYYY-MM-DD")
+    parser.add_argument("--repo", default="fuzzypete/theforge", help="owner/name for gh queries")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    issues = fetch_milestone_issues(args.repo, args.version)
+    merged = fetch_merged_pr_numbers(args.prev_tag)
+
+    print(
+        f"[forge]   {len(issues)} closed issues in milestone v{args.version}",
+        file=sys.stderr,
+    )
+    print(
+        f"[forge]   {len(merged)} PR merges in {args.prev_tag}..HEAD",
+        file=sys.stderr,
+    )
+
+    discrepancies = cross_reference(issues, merged, args.version, args.prev_tag)
+    if discrepancies:
+        for line in discrepancies:
+            print(f"[forge] ERROR: {line}", file=sys.stderr)
+        print(
+            "[forge] aborting promote — fix milestone/PR linkage and retry",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "[forge]   ✓ all milestone issues have corresponding merges",
+        file=sys.stderr,
+    )
+    print(
+        "[forge]   ✓ all merges in tag range have corresponding milestone issues",
+        file=sys.stderr,
+    )
+
+    sys.stdout.write(render_section(issues, args.version, args.date))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -143,9 +143,21 @@ run make gate
 echo "==> Deriving CHANGELOG section for v$VERSION from milestone + tag range..."
 TODAY=$(date +%Y-%m-%d)
 
-PREV_TAG=$(git describe --tags --abbrev=0 --exclude '*rc*' --match 'v[0-9]*.[0-9]*.[0-9]*')
+# Previous release tag = the highest final (non-rc) tag strictly below v$VERSION.
+# NOT `git describe`: release tags are cut on isolated release/vX.Y branches and
+# never merged back to main, so they are not in HEAD's ancestry and describe
+# would miss them. `git tag --list` enumerates all refs regardless of ancestry,
+# so we sort the final tags together with the target and take the one that lands
+# immediately before it.
+PREV_TAG=$(
+    {
+        git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -viE 'rc[0-9]*$' || true
+        echo "v$VERSION"
+    } | sort -V -u | awk -v cur="v$VERSION" '$0 == cur { print prev; exit } { prev = $0 }'
+)
 if [[ -z "$PREV_TAG" ]]; then
     echo "Error: could not determine previous release tag for the derivation range." >&2
+    echo "       No final vX.Y.Z tag below v$VERSION exists (first release?)." >&2
     exit 1
 fi
 echo "    Previous release tag: $PREV_TAG"

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -146,14 +146,23 @@ TODAY=$(date +%Y-%m-%d)
 # Previous release tag = the highest final (non-rc) tag strictly below v$VERSION.
 # NOT `git describe`: release tags are cut on isolated release/vX.Y branches and
 # never merged back to main, so they are not in HEAD's ancestry and describe
-# would miss them. `git tag --list` enumerates all refs regardless of ancestry,
-# so we sort the final tags together with the target and take the one that lands
-# immediately before it.
+# would miss them. `git tag --list` enumerates all refs regardless of ancestry.
+# The version comparison is done in POSIX awk (component-wise numeric compare) —
+# NOT `sort -V`, which is a GNU extension the default macOS BSD `sort` rejects.
 PREV_TAG=$(
-    {
-        git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -viE 'rc[0-9]*$' || true
-        echo "v$VERSION"
-    } | sort -V -u | awk -v cur="v$VERSION" '$0 == cur { print prev; exit } { prev = $0 }'
+    git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -vi 'rc' | awk -v tgt="$VERSION" '
+        BEGIN { split(tgt, t, "."); t1 = t[1] + 0; t2 = t[2] + 0; t3 = t[3] + 0 }
+        {
+            v = $0; sub(/^v/, "", v); split(v, a, ".")
+            maj = a[1] + 0; min = a[2] + 0; pat = a[3] + 0
+            if (maj < t1 || (maj == t1 && (min < t2 || (min == t2 && pat < t3)))) {
+                if (!have || maj > bmaj || (maj == bmaj && (min > bmin || (min == bmin && pat > bpat)))) {
+                    have = 1; bmaj = maj; bmin = min; bpat = pat; best = $0
+                }
+            }
+        }
+        END { if (have) print best }
+    '
 )
 if [[ -z "$PREV_TAG" ]]; then
     echo "Error: could not determine previous release tag for the derivation range." >&2

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -133,19 +133,64 @@ fi
 echo "==> Running gate..."
 run make gate
 
-# --- 8. Update CHANGELOG ---
-echo "==> Updating CHANGELOG..."
+# --- 8. Derive and write the CHANGELOG section ---
+# The release section is DERIVED from milestone vX.Y.Z + the PR merges in
+# PREV_TAG..HEAD, not from the hand-curated [Unreleased] scratchpad. The helper
+# cross-references the two and exits non-zero on any mismatch (a milestone issue
+# with no merge, or a merged PR with no milestone issue), so incomplete release
+# notes abort the promote instead of shipping silently. [Unreleased] is left
+# untouched — operators may keep working notes there, but it is not consulted.
+echo "==> Deriving CHANGELOG section for v$VERSION from milestone + tag range..."
 TODAY=$(date +%Y-%m-%d)
-if [[ "$DRY_RUN" == false ]]; then
-    sed -i '' \
-        "s/^## \[Unreleased\]/## [$VERSION] — $TODAY/" \
-        CHANGELOG.md
-    sed -i '' \
-        "/^## \[$VERSION\]/i\\
-## [Unreleased]\\
-\\
-" \
-        CHANGELOG.md
+
+PREV_TAG=$(git describe --tags --abbrev=0 --exclude '*rc*' --match 'v[0-9]*.[0-9]*.[0-9]*')
+if [[ -z "$PREV_TAG" ]]; then
+    echo "Error: could not determine previous release tag for the derivation range." >&2
+    exit 1
+fi
+echo "    Previous release tag: $PREV_TAG"
+
+if ! RENDERED=$(python3 scripts/derive_changelog.py \
+        --version "$VERSION" \
+        --prev-tag "$PREV_TAG" \
+        --repo fuzzypete/theforge \
+        --date "$TODAY"); then
+    echo "[forge] aborting promote — fix milestone/PR linkage and retry" >&2
+    exit 1
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "==> [dry-run] derived CHANGELOG section for v$VERSION:"
+    echo "$RENDERED"
+else
+    echo "==> Writing CHANGELOG.md [$VERSION] section..."
+    # Splice the derived section in immediately above the first existing
+    # '## [' section that is NOT [Unreleased]. [Unreleased] and any notes under
+    # it are preserved verbatim as a non-consulted scratchpad. The rendered
+    # section is passed via FORGE_RENDERED so the heredoc stays free for the
+    # inline Python script.
+    FORGE_RENDERED="$RENDERED" python3 - <<'PYEOF'
+import os
+
+rendered = os.environ["FORGE_RENDERED"]
+
+with open("CHANGELOG.md", encoding="utf-8") as fh:
+    lines = fh.readlines()
+
+insert_at = len(lines)
+for i, line in enumerate(lines):
+    if line.startswith("## ["):
+        if line.startswith("## [Unreleased]"):
+            continue
+        insert_at = i
+        break
+
+block = rendered.rstrip("\n") + "\n\n"
+lines[insert_at:insert_at] = [block]
+
+with open("CHANGELOG.md", "w", encoding="utf-8") as fh:
+    fh.writelines(lines)
+PYEOF
 fi
 
 # --- 9. Bump pyproject from RC to final ---
@@ -169,7 +214,9 @@ if [[ "$DRY_RUN" == false ]]; then
         exit 1
     fi
 else
-    RELEASE_NOTES="(dry-run: would be extracted from CHANGELOG.md after bump)"
+    # Dry-run never wrote CHANGELOG.md, so reflect the derived section body
+    # (everything under the heading) rather than a static placeholder.
+    RELEASE_NOTES=$(printf '%s\n' "$RENDERED" | awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}")
 fi
 
 # --- 11. Commit, tag, push release branch ---

--- a/tests/test_derive_changelog.py
+++ b/tests/test_derive_changelog.py
@@ -1,0 +1,255 @@
+"""Tests for scripts/derive_changelog.py and the promote-rc.sh CHANGELOG seam.
+
+`derive_changelog.py` is the testable helper promote-rc.sh calls to build the
+release section from milestone state + tag-range PR merges, replacing the old
+blind `[Unreleased]` rename. Covers:
+  - label-grouped rendering (`- Title (#N)` under Added/Fixed/Documentation/Changed)
+  - cross-reference passes when milestone issues ⇔ `(#N)` merges match
+  - cross-reference aborts (non-zero + discrepancy lines) when a milestone issue
+    has no merge, or a merged PR has no milestone issue
+  - chore/merge subjects with no `(#N)` are ignored (do not trip the reverse check)
+
+Plus a seam test that runs `promote-rc.sh --dry-run` with the helper stubbed and
+the surrounding git/gh calls mocked, asserting the derived section is printed and
+CHANGELOG.md is left unmodified.
+
+The helper's `gh` and `git` reads are PATH-mocked with fake executables; the
+seam test uses exported bash functions so the mocks survive promote-rc.sh's
+`/opt/homebrew/bin` PATH prepend (functions beat PATH lookup).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "derive_changelog.py"
+PROMOTE = REPO_ROOT / "scripts" / "promote-rc.sh"
+
+
+def _write_fake_bins(bin_dir: Path, *, issues: list[dict], git_subjects: list[str]) -> None:
+    """Install fake `gh` and `git` on PATH for the derivation helper.
+
+    `gh issue list ... --json number,title,labels` -> the issues fixture.
+    `git log --pretty=%s <range>` -> the merge subjects fixture.
+    """
+    issues_file = bin_dir / "issues.json"
+    issues_file.write_text(json.dumps(issues), encoding="utf-8")
+    log_file = bin_dir / "gitlog.txt"
+    log_file.write_text("".join(f"{s}\n" for s in git_subjects), encoding="utf-8")
+
+    gh = bin_dir / "gh"
+    gh.write_text(f'#!/usr/bin/env bash\ncat "{issues_file}"\n')
+    gh.chmod(0o755)
+
+    git = bin_dir / "git"
+    git.write_text(
+        f'#!/usr/bin/env bash\nif [[ "$1" == "log" ]]; then\n    cat "{log_file}"\nfi\n'
+    )
+    git.chmod(0o755)
+
+
+def _run_derive(bin_dir: Path, *extra: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--version",
+            "0.11.0",
+            "--prev-tag",
+            "v0.10.0",
+            "--date",
+            "2026-07-19",
+            "--repo",
+            "fuzzypete/theforge",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def _issue(number: int, title: str, labels: list[str]) -> dict:
+    return {"number": number, "title": title, "labels": [{"name": n} for n in labels]}
+
+
+def test_renders_label_grouped_section(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    issues = [
+        _issue(101, "Add a shiny thing", ["enhancement"]),
+        _issue(102, "Fix a broken thing", ["bug"]),
+        _issue(103, "Document the thing", ["documentation"]),
+        _issue(104, "Refactor internals", ["chore"]),
+        _issue(105, "Unlabeled change", []),
+    ]
+    subjects = [
+        "Add a shiny thing (#101)",
+        "Fix a broken thing (#102)",
+        "Document the thing (#103)",
+        "Refactor internals (#104)",
+        "Unlabeled change (#105)",
+    ]
+    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+
+    result = _run_derive(bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert out.startswith("## [0.11.0] — 2026-07-19")
+    # Keep-a-Changelog section order: Added, Changed, Fixed, Documentation.
+    assert (
+        out.index("### Added")
+        < out.index("### Changed")
+        < out.index("### Fixed")
+        < out.index("### Documentation")
+    )
+    assert "- Add a shiny thing (#101)" in out
+    assert "- Fix a broken thing (#102)" in out
+    assert "- Document the thing (#103)" in out
+    # chore + unlabeled both fall through to Changed.
+    changed_block = out[out.index("### Changed") : out.index("### Fixed")]
+    assert "- Refactor internals (#104)" in changed_block
+    assert "- Unlabeled change (#105)" in changed_block
+
+
+def test_cross_reference_passes_when_matched(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    issues = [_issue(201, "Thing one", ["bug"]), _issue(202, "Thing two", ["enhancement"])]
+    subjects = ["Thing one (#201)", "Thing two (#202)"]
+    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+
+    result = _run_derive(bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "2 closed issues in milestone v0.11.0" in result.stderr
+    assert "2 PR merges in v0.10.0..HEAD" in result.stderr
+    assert "all milestone issues have corresponding merges" in result.stderr
+    assert "all merges in tag range have corresponding milestone issues" in result.stderr
+
+
+def test_aborts_when_milestone_issue_has_no_merge(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    issues = [_issue(301, "Merged thing", ["bug"]), _issue(302, "Never merged", ["bug"])]
+    subjects = ["Merged thing (#301)"]
+    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+
+    result = _run_derive(bin_dir)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert (
+        "milestone v0.11.0 has issue #302 (closed) with no PR merge in v0.10.0..HEAD"
+        in result.stderr
+    )
+
+
+def test_aborts_when_merge_has_no_milestone_issue(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    issues = [_issue(401, "Milestoned thing", ["bug"])]
+    subjects = ["Milestoned thing (#401)", "Rogue merge (#999)"]
+    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+
+    result = _run_derive(bin_dir)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "PR #999 merged in tag range with no v0.11.0 milestone issue" in result.stderr
+
+
+def test_ignores_subjects_without_pr_number(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    issues = [_issue(501, "Real change", ["enhancement"])]
+    subjects = [
+        "Real change (#501)",
+        "chore: begin v0.11.0.dev0 development [skip ci]",
+        "Merge pull request #77 from fuzzypete/some-branch",
+        "chore: release v0.10.0",
+    ]
+    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+
+    result = _run_derive(bin_dir)
+
+    # The no-(#N) chore/merge subjects must NOT be treated as merged PRs, so the
+    # reverse cross-reference stays clean and the render succeeds.
+    assert result.returncode == 0, result.stderr
+    assert "1 PR merges in v0.10.0..HEAD" in result.stderr
+    assert "- Real change (#501)" in result.stdout
+
+
+def test_promote_dry_run_prints_derived_section_without_writing(tmp_path):
+    """Seam test: promote-rc.sh --dry-run derives + prints, leaves CHANGELOG alone.
+
+    The derivation helper is stubbed (its own behavior is unit-tested above); this
+    exercises promote-rc.sh's wiring — that it calls the helper, echoes the
+    rendered section in dry-run, and does not touch CHANGELOG.md.
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(PROMOTE, scripts_dir / "promote-rc.sh")
+
+    sentinel = "## [0.11.0] — 2026-07-19\n\n### Added\n\n- Derived thing (#123)\n"
+    stub = scripts_dir / "derive_changelog.py"
+    stub.write_text(
+        "import sys\n"
+        "sys.stderr.write('[forge]   1 closed issues in milestone v0.11.0\\n')\n"
+        f"sys.stdout.write({sentinel!r})\n",
+        encoding="utf-8",
+    )
+
+    (tmp_path / "pyproject.toml").write_text('version = "0.11.0rc1"\n', encoding="utf-8")
+    original_changelog = (
+        "# Changelog\n\n## [Unreleased]\n\n- operator scratch note\n\n"
+        "## [0.10.0] — 2026-06-01\n\n- Old release note.\n"
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(original_changelog, encoding="utf-8")
+
+    env = os.environ.copy()
+    # Exported bash functions beat PATH, so they survive the script's
+    # `/opt/homebrew/bin` prepend where fake executables would be shadowed.
+    env["BASH_FUNC_git%%"] = """() {
+  case "$1 $2" in
+    "rev-parse --abbrev-ref") echo "release/v0.11" ;;
+    "status --porcelain") return 0 ;;
+    "show-ref --verify") return 1 ;;
+    "rev-parse --verify") return 1 ;;
+    "ls-remote --tags") return 0 ;;
+    "describe --tags") echo "v0.10.0" ;;
+    *) echo "+ git $*" ;;
+  esac
+}"""
+    env["BASH_FUNC_gh%%"] = """() {
+  if [[ "$1 $2" == "issue list" ]]; then
+    echo 0
+  fi
+}"""
+
+    result = subprocess.run(
+        ["bash", str(scripts_dir / "promote-rc.sh"), "--dry-run", "0.11.0"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "- Derived thing (#123)" in result.stdout
+    assert "[dry-run] derived CHANGELOG section for v0.11.0" in result.stdout
+    # CHANGELOG.md must be untouched in dry-run.
+    assert changelog.read_text(encoding="utf-8") == original_changelog

--- a/tests/test_derive_changelog.py
+++ b/tests/test_derive_changelog.py
@@ -4,17 +4,21 @@
 release section from milestone state + tag-range PR merges, replacing the old
 blind `[Unreleased]` rename. Covers:
   - label-grouped rendering (`- Title (#N)` under Added/Fixed/Documentation/Changed)
-  - cross-reference passes when milestone issues ⇔ `(#N)` merges match
+  - cross-reference passes when milestone issues ⇔ their closing merges match
+  - a milestone issue closed by a *different-numbered* PR still matches (the key
+    invariant: the milestone tracks issue numbers, the squash subject carries the
+    PR number, and they routinely differ — issue #1087 closed by PR #1804)
   - cross-reference aborts (non-zero + discrepancy lines) when a milestone issue
-    has no merge, or a merged PR has no milestone issue
-  - chore/merge subjects with no `(#N)` are ignored (do not trip the reverse check)
+    has no closing merge, or a merge closes no milestone issue
+  - chore/merge subjects with neither a trailing `(#N)` nor a `Closes #N` are ignored
 
-Plus a seam test that runs `promote-rc.sh --dry-run` with the helper stubbed and
-the surrounding git/gh calls mocked, asserting the derived section is printed and
-CHANGELOG.md is left unmodified.
+Plus seam tests that run `promote-rc.sh` with the helper stubbed and the
+surrounding git/gh calls mocked: one `--dry-run` (prints, does not write) and one
+real write (splices the derived section while preserving the `[Unreleased]`
+scratchpad).
 
 The helper's `gh` and `git` reads are PATH-mocked with fake executables; the
-seam test uses exported bash functions so the mocks survive promote-rc.sh's
+seam tests use exported bash functions so the mocks survive promote-rc.sh's
 `/opt/homebrew/bin` PATH prepend (functions beat PATH lookup).
 """
 
@@ -31,17 +35,25 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "derive_changelog.py"
 PROMOTE = REPO_ROOT / "scripts" / "promote-rc.sh"
 
+# Must mirror derive_changelog.py's git-log record format (subject US body RS).
+_US = "\x1f"
+_RS = "\x1e"
 
-def _write_fake_bins(bin_dir: Path, *, issues: list[dict], git_subjects: list[str]) -> None:
+
+def _write_fake_bins(bin_dir: Path, *, issues: list[dict], commits: list[tuple[str, str]]) -> None:
     """Install fake `gh` and `git` on PATH for the derivation helper.
 
     `gh issue list ... --json number,title,labels` -> the issues fixture.
-    `git log --pretty=%s <range>` -> the merge subjects fixture.
+    `git log --pretty=format:%s%x1f%b%x1e <range>` -> the commits fixture,
+    rendered in the exact record format the helper parses (subject, body).
     """
     issues_file = bin_dir / "issues.json"
     issues_file.write_text(json.dumps(issues), encoding="utf-8")
     log_file = bin_dir / "gitlog.txt"
-    log_file.write_text("".join(f"{s}\n" for s in git_subjects), encoding="utf-8")
+    log_file.write_text(
+        "".join(f"{subject}{_US}{body}{_RS}" for subject, body in commits),
+        encoding="utf-8",
+    )
 
     gh = bin_dir / "gh"
     gh.write_text(f'#!/usr/bin/env bash\ncat "{issues_file}"\n')
@@ -82,6 +94,11 @@ def _issue(number: int, title: str, labels: list[str]) -> dict:
     return {"number": number, "title": title, "labels": [{"name": n} for n in labels]}
 
 
+def _commit(pr: int, title: str, closes: int) -> tuple[str, str]:
+    """A forge squash merge: subject ends with the PR number, body Closes the issue."""
+    return (f"{title} (#{pr})", f"## Summary\n\nwork\n\nCloses #{closes}\n")
+
+
 def test_renders_label_grouped_section(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -92,14 +109,15 @@ def test_renders_label_grouped_section(tmp_path):
         _issue(104, "Refactor internals", ["chore"]),
         _issue(105, "Unlabeled change", []),
     ]
-    subjects = [
-        "Add a shiny thing (#101)",
-        "Fix a broken thing (#102)",
-        "Document the thing (#103)",
-        "Refactor internals (#104)",
-        "Unlabeled change (#105)",
+    # PR numbers deliberately differ from issue numbers.
+    commits = [
+        _commit(901, "Add a shiny thing", 101),
+        _commit(902, "Fix a broken thing", 102),
+        _commit(903, "Document the thing", 103),
+        _commit(904, "Refactor internals", 104),
+        _commit(905, "Unlabeled change", 105),
     ]
-    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+    _write_fake_bins(bin_dir, issues=issues, commits=commits)
 
     result = _run_derive(bin_dir)
 
@@ -113,9 +131,11 @@ def test_renders_label_grouped_section(tmp_path):
         < out.index("### Fixed")
         < out.index("### Documentation")
     )
+    # Entries carry the ISSUE number (from the milestone), not the PR number.
     assert "- Add a shiny thing (#101)" in out
     assert "- Fix a broken thing (#102)" in out
     assert "- Document the thing (#103)" in out
+    assert "#901" not in out  # PR numbers never leak into the rendered section
     # chore + unlabeled both fall through to Changed.
     changed_block = out[out.index("### Changed") : out.index("### Fixed")]
     assert "- Refactor internals (#104)" in changed_block
@@ -126,8 +146,8 @@ def test_cross_reference_passes_when_matched(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     issues = [_issue(201, "Thing one", ["bug"]), _issue(202, "Thing two", ["enhancement"])]
-    subjects = ["Thing one (#201)", "Thing two (#202)"]
-    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+    commits = [_commit(801, "Thing one", 201), _commit(802, "Thing two", 202)]
+    _write_fake_bins(bin_dir, issues=issues, commits=commits)
 
     result = _run_derive(bin_dir)
 
@@ -138,12 +158,33 @@ def test_cross_reference_passes_when_matched(tmp_path):
     assert "all merges in tag range have corresponding milestone issues" in result.stderr
 
 
+def test_milestone_issue_closed_by_different_pr_number(tmp_path):
+    """The regression the review caught: issue #1087 closed by PR #1804.
+
+    The milestone lists issue #1087; the squash subject ends `(#1804)` and the
+    body says `Closes #1087`. Cross-reference must match them via the closing
+    reference (not the trailing PR number) and the render must cite the issue.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    issues = [_issue(1087, "Surface reviewer time-nudge warnings", ["enhancement"])]
+    commits = [_commit(1804, "Surface reviewer time-nudge warnings", 1087)]
+    _write_fake_bins(bin_dir, issues=issues, commits=commits)
+
+    result = _run_derive(bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "- Surface reviewer time-nudge warnings (#1087)" in result.stdout
+    assert "all milestone issues have corresponding merges" in result.stderr
+    assert "all merges in tag range have corresponding milestone issues" in result.stderr
+
+
 def test_aborts_when_milestone_issue_has_no_merge(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     issues = [_issue(301, "Merged thing", ["bug"]), _issue(302, "Never merged", ["bug"])]
-    subjects = ["Merged thing (#301)"]
-    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+    commits = [_commit(701, "Merged thing", 301)]
+    _write_fake_bins(bin_dir, issues=issues, commits=commits)
 
     result = _run_derive(bin_dir)
 
@@ -159,51 +200,87 @@ def test_aborts_when_merge_has_no_milestone_issue(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     issues = [_issue(401, "Milestoned thing", ["bug"])]
-    subjects = ["Milestoned thing (#401)", "Rogue merge (#999)"]
-    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+    # PR #888 closes issue #999, which is not in the milestone.
+    commits = [_commit(801, "Milestoned thing", 401), _commit(888, "Rogue merge", 999)]
+    _write_fake_bins(bin_dir, issues=issues, commits=commits)
 
     result = _run_derive(bin_dir)
 
     assert result.returncode != 0
     assert result.stdout == ""
-    assert "PR #999 merged in tag range with no v0.11.0 milestone issue" in result.stderr
+    assert "PR #888 merged in tag range with no v0.11.0 milestone issue" in result.stderr
 
 
 def test_ignores_subjects_without_pr_number(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     issues = [_issue(501, "Real change", ["enhancement"])]
-    subjects = [
-        "Real change (#501)",
-        "chore: begin v0.11.0.dev0 development [skip ci]",
-        "Merge pull request #77 from fuzzypete/some-branch",
-        "chore: release v0.10.0",
+    commits = [
+        _commit(801, "Real change", 501),
+        ("chore: begin v0.11.0.dev0 development [skip ci]", ""),
+        ("Merge pull request #77 from fuzzypete/some-branch", ""),
+        ("chore: release v0.10.0", ""),
     ]
-    _write_fake_bins(bin_dir, issues=issues, git_subjects=subjects)
+    _write_fake_bins(bin_dir, issues=issues, commits=commits)
 
     result = _run_derive(bin_dir)
 
-    # The no-(#N) chore/merge subjects must NOT be treated as merged PRs, so the
-    # reverse cross-reference stays clean and the render succeeds.
+    # The no-(#N)/no-Closes chore/merge subjects must NOT be treated as merged
+    # PRs, so the reverse cross-reference stays clean and the render succeeds.
     assert result.returncode == 0, result.stderr
     assert "1 PR merges in v0.10.0..HEAD" in result.stderr
     assert "- Real change (#501)" in result.stdout
 
 
-def test_promote_dry_run_prints_derived_section_without_writing(tmp_path):
-    """Seam test: promote-rc.sh --dry-run derives + prints, leaves CHANGELOG alone.
+def _seam_env(dry_run: bool) -> dict:
+    """Environment with git/gh/make/sed mocked for a promote-rc.sh seam run.
 
-    The derivation helper is stubbed (its own behavior is unit-tested above); this
-    exercises promote-rc.sh's wiring — that it calls the helper, echoes the
-    rendered section in dry-run, and does not touch CHANGELOG.md.
+    Exported bash functions beat PATH, so they survive the script's
+    `/opt/homebrew/bin` prepend where fake executables would be shadowed. `sed`
+    is shimmed to `-i.bak` form so the script's BSD `sed -i ''` works on Linux CI
+    too; `command sed` reaches the real binary for non-in-place uses.
     """
+    env = os.environ.copy()
+    env["BASH_FUNC_git%%"] = """() {
+  case "$1 $2" in
+    "rev-parse --abbrev-ref") echo "release/v0.11" ;;
+    "status --porcelain") return 0 ;;
+    "show-ref --verify") return 1 ;;
+    "rev-parse --verify") return 1 ;;
+    "ls-remote --tags") return 0 ;;
+    "tag --list") echo "v0.10.0" ;;
+    *) echo "+ git $*" ;;
+  esac
+}"""
+    env["BASH_FUNC_gh%%"] = """() {
+  if [[ "$1 $2" == "issue list" ]]; then
+    echo 0
+  fi
+}"""
+    env["BASH_FUNC_make%%"] = "() {\n  return 0\n}"
+    env["BASH_FUNC_sed%%"] = """() {
+  if [[ "$1" == "-i" ]]; then
+    shift
+    if [[ -z "$1" ]]; then shift; fi
+    local script="$1"; shift
+    command sed -i.forgebak -e "$script" "$@"
+    for f in "$@"; do rm -f "$f.forgebak"; done
+  else
+    command sed "$@"
+  fi
+}"""
+    return env
+
+
+def _seam_setup(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Lay out a tmp repo with promote-rc.sh + a stubbed deriver. Returns
+    (scripts_dir, changelog_path, original_changelog)."""
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir()
     shutil.copy(PROMOTE, scripts_dir / "promote-rc.sh")
 
     sentinel = "## [0.11.0] — 2026-07-19\n\n### Added\n\n- Derived thing (#123)\n"
-    stub = scripts_dir / "derive_changelog.py"
-    stub.write_text(
+    (scripts_dir / "derive_changelog.py").write_text(
         "import sys\n"
         "sys.stderr.write('[forge]   1 closed issues in milestone v0.11.0\\n')\n"
         f"sys.stdout.write({sentinel!r})\n",
@@ -217,31 +294,17 @@ def test_promote_dry_run_prints_derived_section_without_writing(tmp_path):
     )
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(original_changelog, encoding="utf-8")
+    return scripts_dir, changelog, original_changelog
 
-    env = os.environ.copy()
-    # Exported bash functions beat PATH, so they survive the script's
-    # `/opt/homebrew/bin` prepend where fake executables would be shadowed.
-    env["BASH_FUNC_git%%"] = """() {
-  case "$1 $2" in
-    "rev-parse --abbrev-ref") echo "release/v0.11" ;;
-    "status --porcelain") return 0 ;;
-    "show-ref --verify") return 1 ;;
-    "rev-parse --verify") return 1 ;;
-    "ls-remote --tags") return 0 ;;
-    "describe --tags") echo "v0.10.0" ;;
-    *) echo "+ git $*" ;;
-  esac
-}"""
-    env["BASH_FUNC_gh%%"] = """() {
-  if [[ "$1 $2" == "issue list" ]]; then
-    echo 0
-  fi
-}"""
+
+def test_promote_dry_run_prints_derived_section_without_writing(tmp_path):
+    """Seam: promote-rc.sh --dry-run derives + prints, leaves CHANGELOG alone."""
+    scripts_dir, changelog, original = _seam_setup(tmp_path)
 
     result = subprocess.run(
         ["bash", str(scripts_dir / "promote-rc.sh"), "--dry-run", "0.11.0"],
         cwd=tmp_path,
-        env=env,
+        env=_seam_env(dry_run=True),
         capture_output=True,
         text=True,
         timeout=30,
@@ -252,4 +315,32 @@ def test_promote_dry_run_prints_derived_section_without_writing(tmp_path):
     assert "- Derived thing (#123)" in result.stdout
     assert "[dry-run] derived CHANGELOG section for v0.11.0" in result.stdout
     # CHANGELOG.md must be untouched in dry-run.
-    assert changelog.read_text(encoding="utf-8") == original_changelog
+    assert changelog.read_text(encoding="utf-8") == original
+
+
+def test_promote_writes_derived_section_preserving_unreleased(tmp_path):
+    """Seam: a real (non-dry-run) promote splices the derived section in above the
+    prior release while leaving the [Unreleased] scratchpad and its notes intact."""
+    scripts_dir, changelog, _ = _seam_setup(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(scripts_dir / "promote-rc.sh"), "0.11.0"],
+        cwd=tmp_path,
+        env=_seam_env(dry_run=False),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    written = changelog.read_text(encoding="utf-8")
+    # [Unreleased] and its scratch note are preserved verbatim.
+    assert "## [Unreleased]\n\n- operator scratch note" in written
+    # Derived section spliced in above the prior release, not into [Unreleased].
+    assert "## [0.11.0] — 2026-07-19" in written
+    assert "- Derived thing (#123)" in written
+    assert written.index("## [Unreleased]") < written.index("## [0.11.0]")
+    assert written.index("## [0.11.0]") < written.index("## [0.10.0]")
+    # The scratch note stays under [Unreleased], above the derived section.
+    assert written.index("- operator scratch note") < written.index("## [0.11.0]")

--- a/tests/test_derive_changelog.py
+++ b/tests/test_derive_changelog.py
@@ -241,6 +241,11 @@ def _seam_env(dry_run: bool) -> dict:
     too; `command sed` reaches the real binary for non-in-place uses.
     """
     env = os.environ.copy()
+    # `tag --list` returns an unsorted, mixed list: prior finals, an rc for the
+    # version being promoted, and a *higher* final. The script must select
+    # v0.10.0 (the highest final strictly below v0.11.0) using its POSIX-awk
+    # comparison — no `sort -V` — so this also guards the macOS/BSD-sort
+    # regression from cycle 2.
     env["BASH_FUNC_git%%"] = """() {
   case "$1 $2" in
     "rev-parse --abbrev-ref") echo "release/v0.11" ;;
@@ -248,7 +253,7 @@ def _seam_env(dry_run: bool) -> dict:
     "show-ref --verify") return 1 ;;
     "rev-parse --verify") return 1 ;;
     "ls-remote --tags") return 0 ;;
-    "tag --list") echo "v0.10.0" ;;
+    "tag --list") printf 'v0.11.0rc1\\nv0.9.0\\nv0.12.0\\nv0.10.0\\nv0.9.0-rc.1\\n' ;;
     *) echo "+ git $*" ;;
   esac
 }"""
@@ -314,6 +319,8 @@ def test_promote_dry_run_prints_derived_section_without_writing(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "- Derived thing (#123)" in result.stdout
     assert "[dry-run] derived CHANGELOG section for v0.11.0" in result.stdout
+    # Portable version selection picked the highest final tag below v0.11.0.
+    assert "Previous release tag: v0.10.0" in result.stdout
     # CHANGELOG.md must be untouched in dry-run.
     assert changelog.read_text(encoding="utf-8") == original
 
@@ -334,6 +341,8 @@ def test_promote_writes_derived_section_preserving_unreleased(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
+    # Portable version selection resolved PREV_TAG without GNU `sort -V`.
+    assert "Previous release tag: v0.10.0" in result.stdout
     written = changelog.read_text(encoding="utf-8")
     # [Unreleased] and its scratch note are preserved verbatim.
     assert "## [Unreleased]\n\n- operator scratch note" in written


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 findings are resolved, the focused regression tests pass, and I found no blocking regressions in the latest iteration. | [google-gemini-3.5-flash] All prior P1 findings are resolved, and the automated CHANGELOG derivation is robust, portable, and fully tested.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $8.05
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

promote-rc.sh: derive CHANGELOG section from milestone + tag range, stop relying on hand-curated [Unreleased] (GitHub Issue #1353)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1353