### PR TITLE
Post-release doc review for v0.11.0

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -520,8 +520,10 @@ work is heavy. It must:
 A wrong ALREADY_DONE wastes a correct implementation. A wrong PROCEED on finished
 work burns $20+ on dev+review for nothing. A wrong complexity classification puts
 the wrong model on the job. **Do not suggest replacing preflight with a cheap/fast
-model.** The current DeepSeek-reasoner config is intentional — $0.30 for a careful
-classification that controls $20-50 of downstream spend is correct.
+model.** Spending ~$0.30 on a careful classification that controls $20-50 of
+downstream spend is correct. (TheForge now derives the preflight model
+adaptively from the `models:` list rather than pinning a single model — the
+principle stands regardless of which model wins the cheap-bucket tie-break.)
 
 ## Conventions
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -431,7 +431,7 @@ file, or a freshly-filed issue) and need to know what kind of work object it
 should become before grooming or diagnosing it.
 
 **The command never auto-invokes a producer.** `--next` prints a hint
-(`forge diagnose 123`, `forge groom 123`, etc.); it does not run it.
+(`forge diagnose --issue 123`, `forge groom 123`, etc.); it does not run it.
 `--next` output is human-readable in v0.11; no stable machine-readable
 contract is promised yet.
 
@@ -456,8 +456,8 @@ investigation-ready to implementation-ready. Bugs without a confirmed cause
 cannot be labeled `ready` (see `forge groom` below).
 
 ```bash
-forge diagnose <issue>          # investigate one issue
-forge diagnose <issue> --interactive
+forge diagnose --issue <issue>          # investigate one issue
+forge diagnose --issue <issue> --interactive
 ```
 
 `forge diagnose` is the third step of the mid-sprint capture flow — see

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -530,6 +530,95 @@ forge version
 
 ---
 
+## `forge index`
+
+Generate `.forge/index/modules.yaml`, the module map preflight and collision
+detection read to reason about the repository.
+
+```bash
+forge index
+```
+
+---
+
+## `forge check-story-config`
+
+Reject story-branch `forge.yaml` edits that fall outside the mutable allowlist.
+Runs as part of `make gate`; exit non-zero if a disallowed edit is present.
+
+```bash
+forge check-story-config
+```
+
+---
+
+## `forge todo`
+
+Capture and triage draft (`todo:draft`) GitHub todo issues. With no action it
+lists open drafts; pass title text to create one, or a subcommand to triage.
+
+```bash
+forge todo                       # list open todo:draft issues
+forge todo "tighten gate scrub"  # create a draft todo
+```
+
+Optional flags record provenance: `--from-sprint`, `--issue`, `--run-id`.
+
+---
+
+## `forge rca`
+
+Regenerate a sprint's root-cause-analysis artifact (`sprint-rca.yaml`) for a
+completed run.
+
+```bash
+forge rca <run-id>               # write/refresh the artifact
+forge rca <run-id> --check       # reproducibility check; exit 2 if it drifted
+```
+
+`--refresh` overwrites an existing artifact; `--check` compares the stored
+artifact against a fresh generation without writing.
+
+---
+
+## `forge audits`
+
+Manage the SQLite audit substrate (distinct from `forge audit`, which renders a
+single audit file).
+
+```bash
+forge audits rebuild                      # rebuild the substrate from per-run JSON
+forge audits show                         # render rows from the substrate
+forge audits skips                        # query shape-gate skip / stuck events
+forge audits export-assignment-history    # write a human-readable snapshot
+```
+
+---
+
+## `forge profiles`
+
+Inspect and maintain model capability profiles (the cumulative per-model
+counters adaptive routing reads).
+
+```bash
+forge profiles list              # show current profile counters
+forge profiles reset <model-id>  # reset counters for one canonical model ID
+```
+
+---
+
+## `forge migrate-profiles`
+
+Canonicalize legacy `model_profiles.yaml` and `assignment_history.yaml` keys to
+current canonical model IDs.
+
+```bash
+forge migrate-profiles           # migrate in place
+forge migrate-profiles --dry-run # print the migration report without writing
+```
+
+---
+
 ## Resume behavior
 
 | Interrupted state | Resume behavior | Notes |

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -601,8 +601,8 @@ Inspect and maintain model capability profiles (the cumulative per-model
 counters adaptive routing reads).
 
 ```bash
-forge profiles list              # show current profile counters
-forge profiles reset <model-id>  # reset counters for one canonical model ID
+forge profiles list                          # show current profile counters
+forge profiles reset --model <model-id>      # reset counters for one canonical model ID
 ```
 
 ---

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -368,7 +368,7 @@ plan_agent_review:
 
 # ── Notifications (optional) ──────────────────────────────
 notifications:
-  backend: ntfy               # "none", "ntfy", "osascript"
+  backend: ntfy               # "none", "ntfy", "slack", "osascript"
   ntfy:
     priority: high
     # url resolved from NTFY_URL in .forge/.env

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -165,7 +165,8 @@ and remove the old file.
 
 **Fix:**
 ```bash
-forge check-providers --verbose  # shows raw response from each provider
+forge check-providers            # smoke-tests every API-mode profile
+forge check-providers --profile dev  # test a single profile
 ```
 
 Common errors:

--- a/docs/plans/forge-storage-layout.md
+++ b/docs/plans/forge-storage-layout.md
@@ -1,7 +1,9 @@
 # Design Note: `.forge/` Storage Layout & Git Policy
 
-Predecessor to knowledge-capture Layer 1. Settles what gets tracked, what
-format it takes, and how existing consumers migrate.
+**Status: Shipped (v0.11.0).** The audit substrate
+(`coordinator/audit_substrate.py`, `forge audits rebuild`) and the git policy
+described here are live. Predecessor to knowledge-capture Layer 1. Settles what
+gets tracked, what format it takes, and how existing consumers migrate.
 
 ---
 

--- a/docs/plans/plan-review.md
+++ b/docs/plans/plan-review.md
@@ -1,6 +1,13 @@
 # Plan: Plan Review — Human Gate Between PLAN and DEV
 
-Generated 2026-03-16. For injection via `forge run specs/plan-review.md --plan docs/plans/plan-review.md`.
+**Status: Shipped (v0.10.0).** The PLAN_REVIEW phase and its `plan_agent_review`
+config (`mode`, `timeout_seconds`) are live. The file map and module names below
+predate the `coordinator/` and `config/` package refactor (e.g. `coordinator.py`
+→ `coordinator/engine.py`, `config.py` → `config/`, `coord_*.py` →
+`coordinator/*.py`) and the `specs/`→GitHub-issues migration; they are retained
+for historical context, not as a current source map.
+
+Generated 2026-03-16.
 
 ---
 

--- a/docs/plans/restart-meta-plan-2026-07.md
+++ b/docs/plans/restart-meta-plan-2026-07.md
@@ -1,7 +1,10 @@
 # TheForge Restart Meta-Plan — July 2026
 
 **Date:** 2026-07-07
-**Status:** Adopted as working plan (not yet executed)
+**Status:** Adopted and substantially executed. The wedge work has since shipped
+(refusal doctrine #1532, `forge shape` #1541, `forge groom` #1554; repo is at
+v0.12.0rc2). Retained as the record of the restart's framing; individual
+"parking lot" entries below may have moved since (see notes).
 **Provenance:** Drafted after an ~8-week pause (last commit 2026-05-12, `1b56c65`, v0.10.0rc17 + 10 unreleased commits). Based on (a) a full repo/milestone audit and (b) an adversarially-verified research sweep of the Feb–Jul 2026 agentic-SDLC landscape (Claude session), convergent with an independent Codex analysis of the same question.
 
 ---
@@ -86,7 +89,8 @@ At pause time, v0.11 had 99 open issues, ~70 of them `forge-finding` P2 `needs-g
 - Brief-to-sprint orchestration (vision.md document-in classification)
 - Daemon polish and detached-run ops beyond what Phase 0 requires
 - New provider adapters
-- `forge shape` (#367) and `forge groom` (#1034) epics
+- ~~`forge shape` (#367) and `forge groom` (#1034) epics~~ — **shipped** (MVPs
+  landed as #1541 and #1554); no longer parked.
 
 These wait for the wedge. The worst continuation path is resuming every thread as if no time passed.
 

--- a/docs/plans/session-resume-universal.md
+++ b/docs/plans/session-resume-universal.md
@@ -1,5 +1,10 @@
 # Plan: Universal Session Resume Across Forge Agents
 
+**Status: Shipped.** Session resume is live (`run_agent_pool(session_ids=…)` in
+`runners/cli.py`, session persistence in `coordinator/state.py`); the "What's
+broken" list below describes the pre-fix state and is retained for historical
+context.
+
 Generated 2026-03-16. Reviewed by Gemini (technical audit) and Codex (contract
 audit). Updated with findings from both reviews.
 

--- a/docs/post-release-reviews/v0.11.0.md
+++ b/docs/post-release-reviews/v0.11.0.md
@@ -86,6 +86,16 @@ Each entry: `<path>:<line> — doc says "<X>" — system says "<Y>" (verified by
     1541/1554`, `forge --help`). **Patched:** updated Status and struck the
     stale parking-lot entry.
 
+16. `docs/guides/cli-reference.md:3` — doc says "All commands available through
+    the `forge` CLI" — CLI says 29 subcommands exist but the reference had
+    sections for only 22; 7 shipped subcommands (`index`, `check-story-config`,
+    `audits`, `todo`, `rca`, `migrate-profiles`, `profiles`) had **no section**,
+    so the stated completeness claim was false (verified by: `forge --help`
+    lists 29 subcommands; `grep '^## ` + backtick + `forge' cli-reference.md`
+    showed 22). **Patched:** added a reference section for each of the 7 missing
+    commands (built from their live `--help` output), so the "All commands"
+    claim now holds — the reference documents all 29 subcommands.
+
 ### Filed as follow-up issues
 
 11. `docs/guides/choose-your-provider-setup.md:35,71,105,155,195`,
@@ -182,10 +192,9 @@ Each entry: `<path>:<line> — doc says "<X>" — system says "<Y>" (verified by
 
 - **CLI help text**: ran `forge --help` and `--help` for all 29 subcommands.
   Documented flag tables in `cli-reference.md` match actual `--help` output
-  except the two `diagnose`/`check-providers` items above. Note:
-  `cli-reference.md` omits sections for 7 shipped subcommands (`index`,
-  `check-story-config`, `audits`, `todo`, `rca`, `migrate-profiles`, `profiles`)
-  — recorded as a completeness gap, not a false claim; not blocking.
+  except the `diagnose`/`check-providers` items above. `cli-reference.md`
+  additionally claimed to cover "all commands" while omitting 7 shipped
+  subcommands — recorded as drift entry 16 and patched (all 29 now documented).
 
 - **docs/guides/** (all 10 present: `authoring.md`,
   `choose-your-provider-setup.md`, `cli-reference.md`,
@@ -254,7 +263,8 @@ make gate                                                 # 5459 passed, 29 skip
 
 ## Patches and follow-ups
 
-- **Patched in this PR** (#1783 branch `feat/issue-1783`): drift entries 1-10.
+- **Patched in this PR** (#1783 branch `feat/issue-1783`): drift entries 1-10
+  and 16.
 - **Follow-up issues:** #1815 (`profiles:` dead key across 3 guides), #1816
   (`auto_merge` manifest field unparsed), #1817 (release-notes/CHANGELOG
   hygiene + RELEASING gap), #1818 (`forge diagnose <N>` invalid hint in code),

--- a/docs/post-release-reviews/v0.11.0.md
+++ b/docs/post-release-reviews/v0.11.0.md
@@ -1,0 +1,261 @@
+# v0.11.0 post-release doc review
+
+Review of issue #1783. Verifies every concrete claim in public-facing and
+decision-preserving docs against the **system** (code, CLI, schema, git/gh
+state), not against other docs.
+
+Release tag: `v0.11.0` (commit `9af1764`, 2026-07-18). Working tree at review
+time was at `v0.12.0rc2-2-g977d616` with `pyproject.toml` `0.12.0rc2` — the tree
+is ahead of the reviewed release, so docs were checked against current `main`
+code (which is the code the current docs describe). Previous release tag is
+`v0.9.1` (2026-05-01); `v0.10.0` exists as a tag (`a62d8ca`, 2026-07-11) but its
+milestone content was forward-ported into `main` and folded into the v0.11.0
+release notes.
+
+Verification method note: no drift line and no scope checkbox below was closed on
+the basis of doc-vs-doc agreement. Each is backed by a command run or a
+source-of-truth file/line read, recorded inline and in the command log.
+
+## Drift entries
+
+Each entry: `<path>:<line> — doc says "<X>" — system says "<Y>" (verified by:
+<command / file:line>)`.
+
+### Patched in this review PR (feat/issue-1783)
+
+1. `docs/guides/cli-reference.md:459-460` — doc says `forge diagnose <issue>`
+   (positional) — CLI says `--issue` is a **required named flag**; `forge
+   diagnose 123` errors "the following arguments are required: --issue"
+   (verified by: `forge diagnose 123`, `forge diagnose --help`). **Patched:**
+   rewritten to `forge diagnose --issue <issue>`.
+
+2. `docs/guides/cli-reference.md:434` — doc's `--next` hint text shows `forge
+   diagnose 123` — same parser rejection as above (verified by: `forge diagnose
+   --help`). **Patched** to `forge diagnose --issue 123`. (The *code* that emits
+   this same invalid hint is tracked separately as #1818.)
+
+3. `docs/guides/troubleshooting.md:168` — doc says `forge check-providers
+   --verbose  # shows raw response from each provider` — CLI says "unrecognized
+   arguments: --verbose"; `check-providers` accepts only `--profile NAME` and
+   `--config` (verified by: `forge check-providers --verbose`, `forge
+   check-providers --help`). **Patched** to show the real flags.
+
+4. `CONVENTIONS.md:523` — doc says "The current DeepSeek-reasoner config is
+   intentional — $0.30 for a careful classification…" — config says
+   deepseek-reasoner is **disabled** and preflight is derived adaptively from the
+   `models:` list (verified by: `forge.yaml:22` "`- deepseek/deepseek-reasoner
+   # disabled 2026-05-09: flaky + slow`", `forge.yaml:4-5`). The don't-cheap-out
+   guidance is still valid; only the "current config is DeepSeek-reasoner"
+   factual claim was stale. **Patched:** kept the principle, dropped the stale
+   model pin.
+
+5. `docs/guides/inputs-reference.md:371` — comment lists notification backends
+   `"none", "ntfy", "osascript"` — code says `slack` is also a first-class
+   backend (verified by: `src/theforge/config/secrets.py:42-45`,
+   `NotificationConfig.backend` docstring at `src/theforge/config/types.py:68`,
+   and the repo's own `forge.yaml` `backend: slack` loading clean). **Patched:**
+   added `"slack"`.
+
+6. `docs/vision/compound-engineering.md:89,108` — doc says "#1516
+   diagnosis-staleness check *(open, v0.11.0)*" / "Once #1516 ships…" — gh says
+   **#1516 CLOSED** and shipped at `src/theforge/intake/diagnosis_staleness.py`
+   (verified by: `gh issue view 1516`, file exists). **Patched:** marked shipped.
+
+7. `docs/plans/plan-review.md` (file map: lines 3, 23, 45, 83, 114, 212,
+   286-298) — doc names `specs/plan-review.md`, `src/theforge/config.py`,
+   `coord_state.py`, `coord_notify.py`, `coordinator.py`, `coord_audit.py` — all
+   six **do not exist** (refactored into the `coordinator/` and `config/`
+   packages) (verified by: `test -e` on each path, all absent). The feature
+   shipped; only the file map is stale. **Patched:** added a `Status: Shipped
+   (v0.10.0)` header noting the map predates the package refactor.
+
+8. `docs/plans/forge-storage-layout.md` — reads as forward-looking but is
+   **shipped** (`coordinator/audit_substrate.py`, `forge audits rebuild`)
+   (verified by: file/CLI exist; issues #1429/#1465/#1467 merged). **Patched:**
+   added `Status: Shipped (v0.11.0)` header.
+
+9. `docs/plans/session-resume-universal.md` — "What's broken" list reads as live
+   but all items are fixed (`run_agent_pool(session_ids=…)` in
+   `runners/cli.py`, session state in `coordinator/state.py`) (verified by:
+   grep of those symbols). **Patched:** added `Status: Shipped` header.
+
+10. `docs/plans/restart-meta-plan-2026-07.md:3,88` — Status "Adopted… (not yet
+    executed)" and a parking-lot entry listing `forge shape`/`forge groom` as
+    deferred — both shipped (`forge shape` #1541 MERGED, `forge groom` #1554
+    MERGED, both present in `forge --help`) (verified by: `gh issue view
+    1541/1554`, `forge --help`). **Patched:** updated Status and struck the
+    stale parking-lot entry.
+
+### Filed as follow-up issues
+
+11. `docs/guides/choose-your-provider-setup.md:35,71,105,155,195`,
+    `docs/guides/local-models.md:25`, `docs/guides/inputs-reference.md:285-348`
+    — docs say dev/review/local models are configured via a top-level
+    `profiles:` block ("Classic manual profiles … remains supported") — schema
+    says `profiles` is a **removed key** in `_REMOVED_TOP_LEVEL_KEYS`
+    (`src/theforge/config/_loaders.py:33`); a `profiles:`-only config is silently
+    ignored and falls back to built-in defaults (`src/theforge/config/load.py:696-703`)
+    (verified by: in-memory `load_config` of a `profiles:`-only file → dev model
+    resolved to the default, not the configured model). Substantial multi-guide
+    rewrite → **follow-up #1815.**
+
+12. `docs/guides/inputs-reference.md:62,78` — doc lists sprint-manifest field
+    `auto_merge` (default `false`) — `SprintManifest` has no such field and
+    `load_sprint_manifest` never reads it; merge is governed by
+    `workspace.on_approve` (verified by: `grep auto_merge
+    src/theforge/sprint/manifest.py` → none; dataclass at `manifest.py:42-50`).
+    A user setting it gets a silent no-op → **follow-up #1816.**
+
+13. GitHub v0.11.0 release body + `CHANGELOG.md:8` — release body headlines "The
+    headline of **v0.10.0** is workflow determinism…", contains leaked editorial
+    HTML comments incl. an un-actioned "reconcile then" TODO, and `main`'s
+    CHANGELOG still has shipped v0.11.0 content under `## [Unreleased]` (the tag
+    has `## [0.11.0] — 2026-07-18`, `main` does not) so shipped content is
+    commingled with new v0.12.0 entries (verified by: `gh release view v0.11.0
+    --json body`, `git show v0.11.0:CHANGELOG.md`, `diff` vs working tree). The
+    release body is out-of-band (already published) and CHANGELOG reconciliation
+    is a RELEASING.md process gap → **follow-up #1817.**
+
+14. `src/theforge/intake/groom_flow.py:392,397`,
+    `src/theforge/intake/shape_render.py:146` — code emits next-step hint `forge
+    diagnose <N>` (positional) — parser requires `--issue`, so the printed
+    command fails; `sprint/rca.py:808` already emits the correct form (verified
+    by: `forge diagnose 123` error, grep of the emit sites). Code fix, not a doc
+    fix → **follow-up #1818.**
+
+15. `docs/vision.md:103,113,125,157,170,188` (dead `specs/` pointers),
+    `docs/postmortems/*` (~20 dangling links into gitignored `.forge/`),
+    duplicate `docs/postmortems/v0.5.0-gemini-2.5-pro.md` — `specs/` tree no
+    longer exists (verified by: `ls specs` → absent); postmortem link targets
+    are gitignored; the two gemini postmortem files are byte-identical.
+    Housekeeping → **follow-up #1819.**
+
+## Confirmed / no-drift (verified against system)
+
+- **README.md** — install sequences coherent (`pip install -e ".[dev]"`, entry
+  point `forge = theforge.cli:main`); quickstart path `examples/hello-forge/`
+  and `specs/add-greeting.md` exist; module map (`cli/config/coordinator/
+  runners/sprint/task/`, `review.py`, `schemas.py`) all exist; version badge is
+  a dynamic `sort=semver` GitHub tag badge (no literal version drift); Python
+  badge matches `requires-python = ">=3.11"`. (verified by: `ls` of paths, `grep
+  pyproject.toml`, `forge --help`).
+
+- **CHANGELOG.md** v0.11.0 section: 20 cited issue refs spot-checked via `gh
+  issue view <N> --json number,state,title,milestone` — all CLOSED; release body
+  == tag `[0.11.0]` section (210 vs 212 lines, differ only by heading/trailing
+  blank). The only CHANGELOG drift is the missing `[0.11.0]` heading on `main`
+  (entry 13). (verified by: `git log --oneline v0.9.1..v0.11.0`, per-issue `gh
+  issue view`, `diff`).
+
+- **CONVENTIONS.md** (root): state machine
+  `INIT→WORKSPACE→PREFLIGHT→PLAN→PLAN_REVIEW→DEV→VALIDATE→REVIEW→DONE/ESCALATE`
+  matches `coordinator/state.py:25-39`; schema rules (APPROVE+P1→error,
+  REQUEST_CHANGES+no-P1→error) confirmed at `schemas.py:175,180`; make targets,
+  gate scrub, `tests/fake_bin/`, `forge todo`, `forge status --ready`,
+  no-`forge queue`, `TaskSpec = TaskStory` alias all confirmed against code. Only
+  drift is line 523 (entry 4).
+
+- **6 directory-level CONVENTIONS.md** (`coordinator/config/cli/task/runners/
+  sprint`): every named module/function resolves — phase modules
+  `dev_phase.py`/`review_phase.py`/`validate_phase.py`, `load_config`,
+  `build_parser`, `parse_plan_output`, `build_argv`/`build_resume_argv`,
+  adapters, `dag/runner/collision/lock.py`. POSSIBLE nuance: `coordinator/
+  CONVENTIONS.md:12` "no LLM-driven routing" now coexists with advisory
+  LLM-invoking flows (`escalation_advisor_flow.py`, `diagnose_flow.py`) that
+  produce evidence but hold no decision authority — invariant holds in spirit;
+  recorded as advisory, no follow-up filed.
+
+- **CLAUDE.md / AGENTS.md**: pointer docs; all referenced subsystem dirs and
+  their `CONVENTIONS.md` exist. No prompt-construction claim contradicts code.
+
+- **RELEASING.md**: all script paths exist (`cut-rc.sh`, `promote-rc.sh`,
+  `release.sh`, `derive_changelog.py`); the post-release doc-review issue it
+  promises exists (this issue, #1783). Process gap (the `[Unreleased]→[0.11.0]`
+  reconciliation) folded into follow-up #1817.
+
+- **forge.yaml**: loads clean end-to-end via `forge check-config`; every key
+  maps to a real loader path under `src/theforge/config/`; custom-model overlay
+  provider map comments match `models.py:95-104`; the `v0.8 removed handoff_file`
+  guard comment matches `load.py:554-561`. The `forge.yaml:4` "v0.8 simple model
+  list" comment describes the v0.8 *schema format* (still current), so it is not
+  drift. (verified by: `forge check-config`, grep of loaders).
+
+- **CLI help text**: ran `forge --help` and `--help` for all 29 subcommands.
+  Documented flag tables in `cli-reference.md` match actual `--help` output
+  except the two `diagnose`/`check-providers` items above. Note:
+  `cli-reference.md` omits sections for 7 shipped subcommands (`index`,
+  `check-story-config`, `audits`, `todo`, `rca`, `migrate-profiles`, `profiles`)
+  — recorded as a completeness gap, not a false claim; not blocking.
+
+- **docs/guides/** (all 10 present: `authoring.md`,
+  `choose-your-provider-setup.md`, `cli-reference.md`,
+  `first-run-walkthrough.md`, `forge-storage.md`, `getting-started.md`,
+  `inputs-reference.md`, `local-models.md`, `model-reference.md`,
+  `troubleshooting.md`): frontmatter fields (`test_target` default `.`,
+  `gate_override`, `depends_on`) verified against `sprint/manifest.py` and
+  `coordinator/gate.py`; no stale `pytest_target` anywhere; shape-gate skip
+  codes/heading variants in `authoring.md` verified against
+  `src/theforge/shape_check/`; forge-storage gitignore/gitattributes blocks
+  verified against `cli/init_commands.py`; model IDs in `model-reference.md`/
+  `local-models.md` verified against `AGENT_REGISTRY` (`config/models.py`).
+  Drift found: entries 3, 5, 11, 12.
+
+- **docs/vision.md** and **docs/vision/** (5 files): direction matches
+  north-star/implementing code (9 typed refusal verdicts present, ADR-0001/0002
+  confirmed, CLI-first-with-API-fallback implemented). Drift found: entry 6
+  (compound-engineering #1516), entry 15 (vision.md `specs/` links).
+  `self-adapting-router.md` `PHASE_TIER` sketch differs from real table
+  (`assignment.py:93`) but is an illustrative "what we'd replace" sketch — not
+  drift.
+
+- **docs/plans/** (5 files): `plan-review`, `forge-storage-layout`,
+  `session-resume-universal` shipped (entries 7-9); `restart-meta-plan` executed
+  (entry 10); `knowledge-capture` MIXED — Layer 1 shipped, Layers 2-3 legitimately
+  still ACTIVE (no `.forge/knowledge/summaries/` writer, no `run_summaries`
+  config), so no drift there.
+
+- **docs/postmortems/** (4 files): all 22 referenced issues CLOSED and both PRs
+  (#402, #429) MERGED (verified by `gh`). Dangling `.forge/` links + duplicate
+  file recorded as entry 15.
+
+- **GitHub release notes** (`gh release view v0.11.0`): body matches tag
+  CHANGELOG `[0.11.0]` section; user-facing coverage is complete. Quality drift
+  (v0.10.0 headline + leaked comments) recorded as entry 13.
+
+## Verification commands log
+
+```
+forge --help                          # + --help for all 29 subcommands
+forge diagnose 123                    # confirmed: requires --issue
+forge check-providers --verbose       # confirmed: unrecognized argument
+forge check-providers --help
+forge check-config                    # forge.yaml loads clean
+git tag -l 'v*'
+git log -1 v0.11.0 ; git log -1 v0.10.0 ; git log -1 v0.9.1
+git merge-base --is-ancestor v0.10.0 v0.11.0   # not ancestor
+git show v0.11.0:CHANGELOG.md | grep -n '## \[0.11.0\]'
+git show 9af1764 -- CHANGELOG.md               # only heading added
+git log --oneline v0.9.1..v0.11.0              # 249 commits
+diff <(git show v0.11.0:CHANGELOG.md) CHANGELOG.md
+gh release view v0.11.0 [--json body]
+gh release view v0.10.0
+gh issue view 1516 1532 1541 1554 --json number,state,title
+gh issue view <20 CHANGELOG refs> --json number,state,title,milestone
+grep -n _REMOVED_TOP_LEVEL_KEYS src/theforge/config/_loaders.py
+grep -n auto_merge src/theforge/sprint/manifest.py       # none
+grep -n 'forge diagnose' src/theforge/intake/*.py src/theforge/sprint/rca.py
+grep -rn test_target/pytest_target src/theforge/          # no pytest_target
+python -c '<in-memory load_config of a profiles:-only forge.yaml>'   # tmp removed
+for f in <plan-review file map>; do test -e "$f"; done   # all 6 absent
+ls specs                                                  # absent
+find . -name CONVENTIONS.md ; ls docs/guides docs/vision docs/plans docs/postmortems
+make gate                                                 # 5459 passed, 29 skipped
+```
+
+## Patches and follow-ups
+
+- **Patched in this PR** (#1783 branch `feat/issue-1783`): drift entries 1-10.
+- **Follow-up issues:** #1815 (`profiles:` dead key across 3 guides), #1816
+  (`auto_merge` manifest field unparsed), #1817 (release-notes/CHANGELOG
+  hygiene + RELEASING gap), #1818 (`forge diagnose <N>` invalid hint in code),
+  #1819 (vision `specs/` links + postmortem housekeeping).

--- a/docs/vision/compound-engineering.md
+++ b/docs/vision/compound-engineering.md
@@ -86,7 +86,7 @@ Concrete instantiations of compound engineering in the current codebase and road
 - **`assignment_history.yaml` → adaptive router.** The earliest concrete compounding loop in TheForge: per-run model performance is recorded, future assignments adjust. Today this is the only routing decision that uses historical evidence. Future router work (a planned ADR before v0.13 implementation) generalizes this pattern.
 - **ADR-0001 intake readiness.** Operator corrections to half-formed issues used to evaporate (file → refuse → hand-edit → retry → next time same loop). The intake-readiness workflow captures each correction as a structured action (`forge shape`, `forge groom`, `forge diagnose`) that produces substrate-visible artifacts. The doctrine made the workflow worth defining; ADR-0001 made it concrete.
 - **ADR-0002 audit substrate.** The refusal-to-forget invariant — no operator-facing delete/redact API for run records — is compound engineering's most basic mechanical guarantee. Failures cannot be erased to make current state look better. The audit substrate is a record, not a portfolio.
-- **#1516 diagnosis-staleness check** *(open, v0.11.0)*. Once shipped, a diagnosis written against commit A will be mechanically detected as stale when commit B lands. The operator's earlier diagnostic work is preserved (compounding) and explicitly invalidated (refusal-capable) rather than silently rotting. Both axes in one feature.
+- **#1516 diagnosis-staleness check** *(shipped, v0.11.0 — `src/theforge/intake/diagnosis_staleness.py`)*. A diagnosis written against commit A is mechanically detected as stale when commit B lands. The operator's earlier diagnostic work is preserved (compounding) and explicitly invalidated (refusal-capable) rather than silently rotting. Both axes in one feature.
 
 ## Categories of compounding output
 
@@ -105,7 +105,7 @@ These are signals the system should make legible over time. Not all are implemen
 - **Rediscovery rate.** How often agents re-learn conventions, patterns, or failure modes the substrate already contains. A doctrine-aligned system trends this down.
 - **Refusal economics.** The remediation-to-runnable cost ratio (defined as a substrate query obligation in ADR-0002 §6). Makes refusal-capability legible as cost saved rather than friction felt.
 - **Operator-correction reuse.** How often a captured operator correction influences a later automated decision. Today this is partially measurable through the assignment-history → router loop; future work will broaden it.
-- **Diagnosis trust horizon.** How long a diagnosis stays valid before staleness invalidates it. Once #1516 ships, the staleness check will make this measurable mechanically; the metric over time tells us how aggressive the codebase's churn is relative to the diagnosis-decay rate.
+- **Diagnosis trust horizon.** How long a diagnosis stays valid before staleness invalidates it. The #1516 staleness check (shipped) makes this measurable mechanically; the metric over time tells us how aggressive the codebase's churn is relative to the diagnosis-decay rate.
 
 ## Relationship to other documents
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved: the CLI reference now documents all 29 top-level commands and the profiles reset example uses the required --model flag; I found no new P1 regressions. | [google-gemini-3.5-flash] All prior P1 findings are fully resolved, and the post-release doc review is complete and verified against the system. | [claude-sonnet] Both prior P1s are resolved: cli-reference.md documents all 29 subcommands, and the forge profiles reset --model <model-id> example now matches the required --model flag (verified against forge profiles reset --help). Spot-checked all other newly-added command examples (index, check-story-config, todo, rca, audits rebuild/show/skips/export-assignment-history, migrate-profiles, profiles list) against live --help output — all parse correctly. No regressions in the iteration-2 diff.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $20.21
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Post-release doc review for v0.11.0 (GitHub Issue #1783)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1783