### PR TITLE
Clarify and enforce Codex sandbox continuity across exec resume

### DIFF
--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -84,16 +84,43 @@ def build_resume_argv(
     output_file: Path,
     session_id: str,
 ) -> list[str]:
-    """Construct argv for `codex exec resume` (prompt provided via stdin)."""
+    """Construct argv for `codex exec resume` (prompt provided via stdin).
+
+    Sandbox continuity is reasserted explicitly here rather than inherited from
+    the resumed session. The fresh `codex exec` run selects its containment with
+    ``--sandbox <mode>``, but the resume subcommand rejects that flag, so forge
+    restates the SAME native Codex policy via the config override
+    ``-c sandbox_mode=<mode>`` — accepted on the resume path — instead of trusting
+    the CLI to carry the original policy forward. This keeps containment a
+    mechanical guarantee of forge's rather than a documented assumption about CLI
+    inheritance.
+
+    ``--strict-config`` makes the reassertion fail closed: today codex silently
+    ignores an unrecognized ``-c`` key, so if a future CLI renames or drops the
+    ``sandbox_mode`` field the override would be dropped and the resume would run
+    under whatever policy the session defaulted to — a silent containment
+    downgrade. With ``--strict-config`` codex instead errors out on the unknown
+    field, and the run surfaces as a failure rather than a quiet loss of
+    containment.
+
+    ``sandbox_mode: none`` opts out of the reassertion (as on the fresh path);
+    the ``--full-auto`` alias is intentionally dropped because it is deprecated
+    (codex maps it to ``--sandbox workspace-write``) and would contradict an
+    explicit ``read-only`` override.
+    """
     cmd: list[str] = [
         "npx",
         "@openai/codex",
         "exec",
         "resume",
-        "--full-auto",
         "-m",
         profile.model,
     ]
+    # Reassert the session's sandbox policy explicitly (see docstring). Guarded
+    # by --strict-config so a future CLI that stops recognizing sandbox_mode
+    # fails loudly instead of silently downgrading containment.
+    if profile.sandbox_mode != "none":
+        cmd += ["--strict-config", "-c", f"sandbox_mode={profile.sandbox_mode}"]
     if profile.reasoning_effort:
         cmd += ["-c", f"model_reasoning_effort={profile.reasoning_effort}"]
     cmd += ["-o", str(output_file), session_id, "-"]
@@ -291,8 +318,9 @@ def _run_codex(
     output_file = Path(output_path_str)
 
     # Resume: `codex exec resume [flags] <id> -` (prompt via stdin).
-    # Current Codex CLI exposes `--full-auto` on resume but not `--sandbox`.
-    # Fresh runs still accept the explicit sandbox flag.
+    # The resume path rejects `--sandbox`, so build_resume_argv reasserts the
+    # same containment via `-c sandbox_mode=<mode>` (guarded by --strict-config
+    # to fail closed on CLI drift). Fresh runs still take the explicit --sandbox.
     # Fresh start: `codex exec [flags] <prompt>` (prompt as positional arg).
     if session_id:
         cmd: list[str] = build_resume_argv(

--- a/tests/contract/test_codex_cli_contract.py
+++ b/tests/contract/test_codex_cli_contract.py
@@ -90,6 +90,24 @@ def _replace_npx_with_codex(argv: list[str]) -> list[str]:
                 session_id="00000000-0000-0000-0000-000000000000",
             ),
         ),
+        (
+            # Reassertion contract: `-c sandbox_mode=read-only` under
+            # `--strict-config` must be accepted on the resume path (issue #1012).
+            "exec_resume_read_only",
+            lambda: runner_codex.build_resume_argv(
+                profile=_profile(sandbox_mode="read-only"),
+                output_file=Path("/tmp/contract-out.txt"),
+                session_id="00000000-0000-0000-0000-000000000000",
+            ),
+        ),
+        (
+            "exec_resume_no_sandbox",
+            lambda: runner_codex.build_resume_argv(
+                profile=_profile(sandbox_mode="none"),
+                output_file=Path("/tmp/contract-out.txt"),
+                session_id="00000000-0000-0000-0000-000000000000",
+            ),
+        ),
     ],
 )
 def test_codex_argv_accepted(shape: str, builder) -> None:

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -178,6 +178,77 @@ class TestCodexSandboxFlag:
         assert env_passed["OPENAI_API_KEY"] == "secret"
 
 
+class TestCodexResumeSandboxReassertion:
+    """Resume reasserts the session's sandbox policy explicitly (issue #1012).
+
+    The fresh run selects containment with ``--sandbox <mode>``; the resume
+    subcommand rejects that flag, so forge restates the same native policy via
+    ``-c sandbox_mode=<mode>`` guarded by ``--strict-config`` (fail closed on CLI
+    drift) rather than trusting the CLI to carry the policy forward.
+    """
+
+    def _resume_cmd(self, tmp_path: Path, sandbox_mode: str) -> list[str]:
+        profile = _make_profile(sandbox_mode=sandbox_mode)
+        mock_proc = _make_subprocess_mock()
+        with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
+            _run_codex(
+                prompt="continue",
+                profile=profile,
+                working_dir=tmp_path,
+                session_id="sess-abc123",
+            )
+        return _extract_codex_cmd(mock_run)
+
+    def test_workspace_write_reasserts_via_config_override(self, tmp_path: Path) -> None:
+        """workspace-write resume restates the policy with -c sandbox_mode, not --sandbox."""
+        cmd = self._resume_cmd(tmp_path, "workspace-write")
+        assert "--sandbox" not in cmd  # resume path rejects the flag
+        assert "-c" in cmd
+        c_idx = cmd.index("-c")
+        assert cmd[c_idx + 1] == "sandbox_mode=workspace-write"
+
+    def test_read_only_reasserts_matching_policy(self, tmp_path: Path) -> None:
+        """read-only resume restates read-only (continuity, not full-auto's workspace-write)."""
+        cmd = self._resume_cmd(tmp_path, "read-only")
+        assert "sandbox_mode=read-only" in cmd
+        assert "sandbox_mode=workspace-write" not in cmd
+
+    def test_strict_config_guards_the_reassertion(self, tmp_path: Path) -> None:
+        """--strict-config precedes the sandbox override so an unknown field fails closed."""
+        cmd = self._resume_cmd(tmp_path, "workspace-write")
+        assert "--strict-config" in cmd
+        # The guard must come before the override it protects.
+        assert cmd.index("--strict-config") < cmd.index("sandbox_mode=workspace-write")
+
+    def test_none_opts_out_of_reassertion(self, tmp_path: Path) -> None:
+        """sandbox_mode=none reasserts nothing and does not force the strict-config guard."""
+        cmd = self._resume_cmd(tmp_path, "none")
+        assert not any(a.startswith("sandbox_mode=") for a in cmd)
+        assert "--strict-config" not in cmd
+
+    def test_deprecated_full_auto_flag_dropped_on_resume(self, tmp_path: Path) -> None:
+        """--full-auto (deprecated; contradicts an explicit read-only override) is gone."""
+        assert "--full-auto" not in self._resume_cmd(tmp_path, "workspace-write")
+        assert "--full-auto" not in self._resume_cmd(tmp_path, "read-only")
+        assert "--full-auto" not in self._resume_cmd(tmp_path, "none")
+
+    def test_reassertion_coexists_with_reasoning_override(self, tmp_path: Path) -> None:
+        """Both -c overrides are present and each is validated under --strict-config."""
+        profile = _make_profile(sandbox_mode="read-only", reasoning_effort="high")
+        mock_proc = _make_subprocess_mock()
+        with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
+            _run_codex(
+                prompt="continue",
+                profile=profile,
+                working_dir=tmp_path,
+                session_id="sess-abc123",
+            )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "sandbox_mode=read-only" in cmd
+        assert "model_reasoning_effort=high" in cmd
+        assert "--strict-config" in cmd
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle tests — real subprocess, fake-CLI fixture
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The resume argv now reasserts Codex sandbox_mode without using the rejected --sandbox resume flag, and the focused runner tests pass. | [google-gemini-3.5-flash] The implementation successfully reasserts the Codex sandbox policy on exec resume with strict-config validation, fully satisfying all acceptance criteria.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $2.50
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Clarify and enforce Codex sandbox continuity across exec resume (GitHub Issue #1012)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1012