### PR TITLE
bug: enabled model with no run history is never dispatched — cheap-tier tie-break and cold-start ranking starve it permanently

### DIFF
--- a/docs/vision/self-adapting-router.md
+++ b/docs/vision/self-adapting-router.md
@@ -137,6 +137,13 @@ for complex stories). Within a week of real usage the router has enough signal
 to outperform any static config. New projects bootstrap from the global
 performance table; per-project overrides accumulate over time.
 
+When two models land in the same tier (same `cost_rank` and capability), the
+router breaks the tie on their real per-MTok price rather than on
+`models.enabled` list order — so an enabled but never-dispatched model is not
+starved by the accident of being listed second. That first dispatch is what
+lets a zero-history model accrue a profile entry, after which normal
+evidence-based ranking takes over (issue #1617).
+
 ## What Stays in forge.yaml
 
 Only what forge cannot discover:

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -23,6 +23,7 @@ from .config import (
     ModelProfile,
 )
 from .config.auth import check_agent_auth
+from .config.models import price_tiebreak_signal
 from .routing import score_to_dev_tier
 
 log = logging.getLogger(__name__)
@@ -178,9 +179,23 @@ def _decision_total(decision: AssignmentDecision) -> float:
 
 
 def _agents_by_tier(agents: list[AgentDef], tier: str) -> list[AgentDef]:
-    """Return agents matching tier, sorted by budget_usd ascending."""
+    """Return agents matching tier, sorted by budget_usd then real per-MTok price.
+
+    Within a tier every agent carries an identical even-split ``budget_usd``, so
+    that key alone leaves same-tier candidates tied and the stable sort falls back
+    to ``models.enabled`` list order — permanently starving whichever cheap-tier
+    model is listed second (issue #1617). Breaking the tie on the real per-MTok
+    price already carried on the registry lets the genuinely cheaper model win
+    deterministically instead of by pool order.
+    """
     matches = [a for a in agents if a.tier == tier]
-    return sorted(matches, key=lambda a: a.budget_usd)
+    return sorted(
+        matches,
+        key=lambda a: (
+            a.budget_usd,
+            price_tiebreak_signal(a.input_cost_per_mtok, a.output_cost_per_mtok),
+        ),
+    )
 
 
 def _rerank_by_profiles(
@@ -193,9 +208,10 @@ def _rerank_by_profiles(
     """Stable-sort candidates: high-success-rate first when enough data exists.
 
     Only role="dev" is profile-aware today; other roles pass through unchanged.
-    Candidates without ``min_runs`` observations retain their original relative
-    order (sort is stable) so the cheapest-budget tie-break still wins when
-    nobody has a track record yet.
+    Candidates without ``min_runs`` observations are ordered behind every
+    observed model but among themselves fall back to the real per-MTok price
+    (via :func:`price_tiebreak_signal`), so the cheapest unobserved model is the
+    first explored rather than whichever the pool happened to list first (#1617).
     """
     if not model_profiles or role != "dev":
         return candidates
@@ -212,7 +228,12 @@ def _rerank_by_profiles(
             cli=agent.cli,
         )
         if rate is None:
-            return (1, 0.0)
+            # Unobserved: sort behind observed models (leading 1), then cheapest
+            # first so a zero-history model still gets an evidence-gathering turn.
+            return (
+                1,
+                price_tiebreak_signal(agent.input_cost_per_mtok, agent.output_cost_per_mtok),
+            )
         # Negative rate so higher success sorts first among observed agents.
         return (0, -rate)
 

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -179,6 +179,11 @@ class AgentDef:
     strengths: tuple[str, ...] = ()
     registry_id: str | None = None
     registry_source: str = "builtin"
+    # Per-MTok pricing carried through from the registry so ranking helpers can
+    # break equal-tier ties by real cost rather than pool list order. See
+    # price_tiebreak_signal and issue #1617.
+    input_cost_per_mtok: float | None = None
+    output_cost_per_mtok: float | None = None
 
     @property
     def effective_provider(self) -> str | None:
@@ -227,6 +232,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="fast",
         capability=7,
         cost_rank=1,
+        input_cost_per_mtok=3.00,
+        output_cost_per_mtok=15.00,
     ),
     "claude/opus": AgentSpec(
         provider="anthropic",
@@ -235,6 +242,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=10,
         cost_rank=3,
+        input_cost_per_mtok=15.00,
+        output_cost_per_mtok=75.00,
     ),
     # ── OpenAI (CLI via Codex) ────────────────────────────────────────
     "openai/gpt-5.4": AgentSpec(
@@ -244,6 +253,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=9,
         cost_rank=2,
+        input_cost_per_mtok=1.25,
+        output_cost_per_mtok=10.00,
     ),
     "openai/gpt-5.4-mini": AgentSpec(
         provider="openai",
@@ -252,6 +263,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="cheap",
         capability=7,
         cost_rank=1,
+        input_cost_per_mtok=0.25,
+        output_cost_per_mtok=2.00,
     ),
     "openai/gpt-5.4-pro": AgentSpec(
         provider="openai",
@@ -260,6 +273,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=10,
         cost_rank=3,
+        input_cost_per_mtok=15.00,
+        output_cost_per_mtok=120.00,
     ),
     # ── DeepSeek (API) ────────────────────────────────────────────────
     "deepseek/deepseek-reasoner": AgentSpec(
@@ -269,6 +284,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=9,
         cost_rank=2,
+        input_cost_per_mtok=0.55,
+        output_cost_per_mtok=2.19,
     ),
     "deepseek/deepseek-chat": AgentSpec(
         provider="deepseek",
@@ -277,6 +294,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="fast",
         capability=7,
         cost_rank=1,
+        input_cost_per_mtok=0.27,
+        output_cost_per_mtok=1.10,
     ),
     # ── Google (API) ─────────────────────────────────────────────────
     "google/gemini-3-flash-preview": AgentSpec(
@@ -294,6 +313,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=9,
         cost_rank=2,
+        input_cost_per_mtok=2.00,
+        output_cost_per_mtok=12.00,
     ),
     "google/gemini-2.5-pro": AgentSpec(
         provider="google",
@@ -302,6 +323,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=8,
         cost_rank=2,
+        input_cost_per_mtok=1.25,
+        output_cost_per_mtok=10.00,
     ),
     # ── Local OpenAI-compatible models (route via Codex CLI with base_url) ──
     "openai/codestral": AgentSpec(
@@ -345,6 +368,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=9,
         cost_rank=2,
+        input_cost_per_mtok=1.25,
+        output_cost_per_mtok=10.00,
     ),
     "openai-api/gpt-5.4-mini": AgentSpec(
         provider="openai",
@@ -353,6 +378,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="cheap",
         capability=7,
         cost_rank=1,
+        input_cost_per_mtok=0.25,
+        output_cost_per_mtok=2.00,
     ),
     "openai-api/gpt-5.4-pro": AgentSpec(
         provider="openai",
@@ -361,6 +388,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         tier="strong",
         capability=10,
         cost_rank=3,
+        input_cost_per_mtok=15.00,
+        output_cost_per_mtok=120.00,
         # Reasoning-heavy — intentionally excluded from the preflight role.
         phase_eligibility=frozenset({"dev", "plan", "review"}),
     ),
@@ -373,6 +402,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         capability=8,
         cost_rank=2,
         dev_capable=False,
+        input_cost_per_mtok=1.25,
+        output_cost_per_mtok=10.00,
     ),
     "gemini-cli/gemini-3-flash-preview": AgentSpec(
         provider="google",
@@ -391,6 +422,8 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         capability=9,
         cost_rank=2,
         dev_capable=False,
+        input_cost_per_mtok=2.00,
+        output_cost_per_mtok=12.00,
     ),
 }
 
@@ -453,6 +486,38 @@ def custom_model_cost_rank(input_cost_per_mtok: float, output_cost_per_mtok: flo
     if price_signal <= 25.0:
         return 2
     return 3
+
+
+# Sentinel returned by ``price_tiebreak_signal`` when a candidate carries no
+# pricing data. It sorts *after* every priced candidate so unpriced models keep
+# their original relative order (list-order fallback) among themselves rather
+# than jumping ahead of a model whose real cost is known.
+_UNPRICED_SIGNAL: float = float("inf")
+
+
+def price_tiebreak_signal(
+    input_cost_per_mtok: float | None,
+    output_cost_per_mtok: float | None,
+) -> float:
+    """Return a per-MTok price signal for breaking equal-``cost_rank`` ties.
+
+    Two models can share a ``cost_rank`` band (and even a ``capability`` score) yet
+    differ substantially in real price — e.g. the cheap-tier bucket holds both
+    ``claude/sonnet`` and ``openai/gpt-5.4-mini``. Ranking helpers previously broke
+    that tie by ``models.enabled`` list order, permanently starving whichever model
+    was listed second. This collapses the two per-MTok costs into one comparable
+    number (``max`` of input/output, mirroring :func:`custom_model_cost_rank`'s
+    price banding) so the cheaper candidate wins the tie deterministically.
+
+    Candidates with no pricing data return :data:`_UNPRICED_SIGNAL` so they rank
+    behind any priced peer while preserving list order among unpriced models.
+    """
+    if input_cost_per_mtok is None and output_cost_per_mtok is None:
+        return _UNPRICED_SIGNAL
+    return max(
+        float(input_cost_per_mtok) if input_cost_per_mtok is not None else 0.0,
+        float(output_cost_per_mtok) if output_cost_per_mtok is not None else 0.0,
+    )
 
 
 def custom_model_dev_capable(transport: TransportSpec) -> bool:
@@ -618,7 +683,15 @@ def _planner_candidate_models(agents: list[AgentDef]) -> set[str]:
 
     candidate_models: set[str] = set()
     for tier in planner_tiers.values():
-        tier_agents = sorted([a for a in agents if a.tier == tier], key=lambda a: a.budget_usd)
+        # Mirror _agents_by_tier: equal-budget ties break on real per-MTok price
+        # so the predicted candidate matches the model assign_models actually picks.
+        tier_agents = sorted(
+            [a for a in agents if a.tier == tier],
+            key=lambda a: (
+                a.budget_usd,
+                price_tiebreak_signal(a.input_cost_per_mtok, a.output_cost_per_mtok),
+            ),
+        )
         if tier_agents:
             candidate_models.add(tier_agents[0].model)
         else:

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -15,7 +15,7 @@ from .defaults import (
     PROVIDER_SDK_MAP,
     SUPPORTED_CLIS,
 )
-from .models import AgentDef, AgentSpec, _resolve_model_info
+from .models import AgentDef, AgentSpec, _resolve_model_info, price_tiebreak_signal
 from .types import SUPPORTED_PROVIDERS, ApiFallbackConfig, ModelProfile
 
 _COST_RANK_TO_TIER = {1: "cheap", 2: "mid", 3: "strong"}
@@ -53,6 +53,8 @@ def _agents_from_models(
                 cli=info.cli,
                 registry_id=info.registry_id,
                 registry_source=info.registry_source,
+                input_cost_per_mtok=info.input_cost_per_mtok,
+                output_cost_per_mtok=info.output_cost_per_mtok,
             )
         )
     return agents
@@ -241,7 +243,14 @@ def _auto_assign_models(
     - each reviewer: remaining / pool_size
     """
     infos = [(m, _resolve_model_info(m, registry=registry)) for m in models]
-    sorted_models = sorted(infos, key=lambda x: (x[1].cost_rank, -x[1].capability))
+    sorted_models = sorted(
+        infos,
+        key=lambda x: (
+            x[1].cost_rank,
+            -x[1].capability,
+            price_tiebreak_signal(x[1].input_cost_per_mtok, x[1].output_cost_per_mtok),
+        ),
+    )
 
     dev_key, dev_info = sorted_models[0]
 

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from ..routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
 from .defaults import DEFAULT_DEV_PROFILE, DEFAULT_PREFLIGHT_PROFILE, DEFAULT_REVIEW_PROFILE
-from .models import AgentSpec, ModelInfo, _resolve_model_info
+from .models import AgentSpec, ModelInfo, _resolve_model_info, price_tiebreak_signal
 from .schema import (
     DevRoleConfig,
     ModelRef,
@@ -215,9 +215,18 @@ def derive_roles(
         _COMPLEXITY_NORM.get(complexity.lower()) if complexity is not None else None
     )
 
-    # Build (model_key, ModelInfo) pairs and sort: cheapest first, then by capability desc
+    # Build (model_key, ModelInfo) pairs and sort: cheapest cost_rank first, then
+    # capability desc, then real per-MTok price so equal-tier/equal-capability
+    # candidates break the tie by cost rather than models list order (#1617).
     infos = [(m, _resolve_model_info(m, registry=registry)) for m in models]
-    sorted_models = sorted(infos, key=lambda x: (x[1].cost_rank, -x[1].capability))
+    sorted_models = sorted(
+        infos,
+        key=lambda x: (
+            x[1].cost_rank,
+            -x[1].capability,
+            price_tiebreak_signal(x[1].input_cost_per_mtok, x[1].output_cost_per_mtok),
+        ),
+    )
 
     # Phase-eligibility-aware candidate pools — a model's AgentSpec may exclude it
     # from specific phases (e.g. a pro model excluded from preflight to avoid overspend).
@@ -269,7 +278,16 @@ def derive_roles(
     if norm_complexity == "LOW":
         mid_strong = [(k, i) for k, i in review_pairs if i.cost_rank >= 2]
         review_pairs = (
-            [min(mid_strong, key=lambda x: (x[1].cost_rank, -x[1].capability))]
+            [
+                min(
+                    mid_strong,
+                    key=lambda x: (
+                        x[1].cost_rank,
+                        -x[1].capability,
+                        price_tiebreak_signal(x[1].input_cost_per_mtok, x[1].output_cost_per_mtok),
+                    ),
+                )
+            ]
             if mid_strong
             else [review_pairs[0]]
         )

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -281,7 +281,10 @@ def _build_pool_entries(
     from ``ForgeConfig.model_registry``. When None, only built-ins are visible
     and custom-overlay model keys raise ValueError.
     """
-    from theforge.config.models import _resolve_model_info  # noqa: PLC0415
+    from theforge.config.models import (  # noqa: PLC0415
+        _resolve_model_info,
+        price_tiebreak_signal,
+    )
 
     info_view = model_info_view(registry)
     entries: list[tuple[int, str, ModelInfo]] = []
@@ -290,7 +293,15 @@ def _build_pool_entries(
         if info is None:
             info = _resolve_model_info(key, registry=registry)
         entries.append((info.cost_rank, key, info))
-    entries.sort(key=lambda x: (x[0], -x[2].capability))
+    # cost_rank asc, capability desc, then real per-MTok price so equal-tier /
+    # equal-capability candidates break the tie by cost rather than list order (#1617).
+    entries.sort(
+        key=lambda x: (
+            x[0],
+            -x[2].capability,
+            price_tiebreak_signal(x[2].input_cost_per_mtok, x[2].output_cost_per_mtok),
+        )
+    )
     return entries
 
 

--- a/tests/test_assignment_price_tiebreak.py
+++ b/tests/test_assignment_price_tiebreak.py
@@ -1,0 +1,253 @@
+"""Price-aware tie-break within an equal cost_rank / capability bucket (issue #1617).
+
+Regression suite for the starvation bug: an enabled cheap-tier model with no run
+history was never dispatched because every cheapest-tier selector broke the
+sonnet/mini tie by ``models.enabled`` list order (and, for dev, by cold-start
+last-place). These tests pin the fix — the genuinely cheaper model wins the tie
+by its real per-MTok price — across every ranking helper the fix touches:
+``_agents_by_tier``/``_rerank_by_profiles`` (assignment), ``derive_roles`` and
+``_auto_assign_models`` (config), and ``_build_pool_entries`` /
+``_apply_complexity_adaptation`` (coordinator preflight seam).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from theforge.assignment import (
+    AssignmentConfig,
+    _agents_by_tier,
+    _pick_agent,
+    _rerank_by_profiles,
+    assign_models,
+)
+from theforge.config import (
+    AGENT_REGISTRY,
+    DEFAULT_VALIDATION,
+    AgentDef,
+    ForgeConfig,
+    ModelProfile,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.config.models import MODEL_REGISTRY, price_tiebreak_signal
+from theforge.config.profiles import _agents_from_models, _auto_assign_models
+from theforge.config.role_derivation import derive_roles
+from theforge.config.types import PlanConfig
+from theforge.coordinator.preflight import _apply_complexity_adaptation, _build_pool_entries
+
+# The reported pool: cheap tier holds both sonnet and gpt-5.4-mini at
+# cost_rank=1, capability=7. Sonnet is listed FIRST — the exact ordering that
+# used to guarantee it won every cheap-tier tie.
+_POOL_SONNET_FIRST = ["claude/sonnet", "openai/gpt-5.4-mini"]
+_POOL_MINI_FIRST = ["openai/gpt-5.4-mini", "claude/sonnet"]
+
+
+@pytest.fixture(autouse=True)
+def _mock_api_keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("GOOGLE_API_KEY", "k")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+
+
+@pytest.fixture
+def _all_authed(monkeypatch):
+    """Isolate ranking from transport auth: the pool models dispatch via the
+    claude/codex CLIs, whose binaries aren't present in the test env. Force auth
+    so the tests exercise the price tie-break, not binary discovery."""
+    monkeypatch.setattr("theforge.assignment._has_auth", lambda *a, **k: True)
+
+
+# ── price_tiebreak_signal ──────────────────────────────────────────────
+
+
+def test_price_signal_uses_max_of_input_output():
+    # Mirrors custom_model_cost_rank's price banding: max(input, output).
+    assert price_tiebreak_signal(0.25, 2.00) == 2.00
+    assert price_tiebreak_signal(3.00, 15.00) == 15.00
+
+
+def test_price_signal_unpriced_sorts_last():
+    signal = price_tiebreak_signal(None, None)
+    assert signal == float("inf")
+    # A priced model always ranks ahead of an unpriced one.
+    assert price_tiebreak_signal(999.0, 999.0) < signal
+
+
+def test_price_signal_partial_data_treats_missing_as_zero():
+    assert price_tiebreak_signal(1.5, None) == 1.5
+    assert price_tiebreak_signal(None, 4.0) == 4.0
+
+
+# ── built-in registry now carries real prices ──────────────────────────
+
+
+def test_builtin_registry_populates_cheap_tier_costs():
+    sonnet = MODEL_REGISTRY["claude/sonnet"]
+    mini = MODEL_REGISTRY["openai/gpt-5.4-mini"]
+    assert (sonnet.input_cost_per_mtok, sonnet.output_cost_per_mtok) == (3.00, 15.00)
+    assert (mini.input_cost_per_mtok, mini.output_cost_per_mtok) == (0.25, 2.00)
+    # The cheaper model has the smaller tie-break signal.
+    assert price_tiebreak_signal(
+        mini.input_cost_per_mtok, mini.output_cost_per_mtok
+    ) < price_tiebreak_signal(sonnet.input_cost_per_mtok, sonnet.output_cost_per_mtok)
+
+
+# ── _agents_by_tier ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("pool", [_POOL_SONNET_FIRST, _POOL_MINI_FIRST])
+def test_agents_by_tier_orders_by_price_not_list_order(pool):
+    agents = _agents_from_models(pool, budget_usd=50.0)
+    ordered = _agents_by_tier(agents, "cheap")
+    assert [a.name for a in ordered] == ["openai-gpt-5.4-mini", "claude-sonnet"]
+
+
+def test_pick_agent_cheap_tier_picks_cheaper_model(_all_authed):
+    agents = _agents_from_models(_POOL_SONNET_FIRST, budget_usd=50.0)
+    picked = _pick_agent(agents, "cheap")
+    assert picked is not None
+    assert picked.model == "gpt-5.4-mini"
+
+
+# ── assign_models: adaptive preflight (the reported dispatch path) ──────
+
+
+@pytest.mark.parametrize("pool", [_POOL_SONNET_FIRST, _POOL_MINI_FIRST])
+def test_assign_models_preflight_dispatches_cheaper_cheap_tier(pool, _all_authed):
+    """Adaptive preflight (_pick_agent(agents, 'cheap')) must reach the cheaper model."""
+    agents = _agents_from_models(pool, budget_usd=50.0)
+    cfg = AssignmentConfig(
+        enabled=True,
+        min_reviewers=1,
+        max_reviewers=1,
+        prefer_cross_provider=False,
+        max_cost_per_story_usd=None,
+        escalation_memory=False,
+    )
+    decision = assign_models(agents, cfg, complexity="LOW")
+    assert decision.preflight.model == "gpt-5.4-mini"
+    # LOW dev also targets the cheap tier — the enabled model is now exercised.
+    assert decision.dev.model == "gpt-5.4-mini"
+
+
+# ── _rerank_by_profiles: cold-start ordering ───────────────────────────
+
+
+def _two_cheap_agents() -> list[AgentDef]:
+    return _agents_from_models(_POOL_SONNET_FIRST, budget_usd=50.0)
+
+
+def test_rerank_cold_start_orders_unobserved_by_price():
+    """With no history, the cheaper unobserved model is explored first."""
+    agents = _two_cheap_agents()
+    profiles = {"models": {}}  # truthy, but no per-model dev history
+    ranked = _rerank_by_profiles(agents, profiles, role="dev", complexity="LOW")
+    assert ranked[0].model == "gpt-5.4-mini"
+
+
+def test_rerank_observed_still_beats_cheaper_unobserved():
+    """Cold-start price ordering never overrides real evidence: an observed model
+    outranks a cheaper model that has no track record yet."""
+    agents = _two_cheap_agents()
+    profiles = {
+        "models": {
+            "claude-sonnet": {
+                "dev": {
+                    "runs": 10,
+                    "success_rate": 0.9,
+                    "by_complexity": {"small": {"runs": 10, "success_rate": 0.9}},
+                }
+            }
+        }
+    }
+    ranked = _rerank_by_profiles(agents, profiles, role="dev", complexity="LOW")
+    assert ranked[0].model == "sonnet"
+
+
+# ── derive_roles (load-time) ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("pool", [_POOL_SONNET_FIRST, _POOL_MINI_FIRST])
+def test_derive_roles_dev_picks_cheaper_cheap_tier(pool):
+    assignment = derive_roles(pool, complexity="LOW")
+    assert assignment.dev.ref.model == "gpt-5.4-mini"
+
+
+# ── _auto_assign_models (load-time, static) ────────────────────────────
+
+
+@pytest.mark.parametrize("pool", [_POOL_SONNET_FIRST, _POOL_MINI_FIRST])
+def test_auto_assign_dev_picks_cheaper_cheap_tier(pool):
+    dev_profile, _preflight, _pool, _synth = _auto_assign_models(pool, budget_usd=50.0)
+    assert dev_profile.model == "gpt-5.4-mini"
+
+
+# ── _build_pool_entries (coordinator preflight) ────────────────────────
+
+
+@pytest.mark.parametrize("pool", [_POOL_SONNET_FIRST, _POOL_MINI_FIRST])
+def test_build_pool_entries_orders_cheap_tier_by_price(pool):
+    entries = _build_pool_entries(pool)
+    cheap_keys = [key for rank, key, _ in entries if rank == 1]
+    assert cheap_keys[0] == "openai/gpt-5.4-mini"
+
+
+# ── Seam: complexity-adaptation config propagation ─────────────────────
+
+
+def _seam_config(tmp_path: Path, models: list[str]) -> ForgeConfig:
+    """Simple-mode ForgeConfig whose dev/preflight default to sonnet but whose
+    pool includes the cheaper cheap-tier model."""
+    dev = ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=6.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    mini = ModelProfile(
+        name="openai-gpt-5.4-mini",
+        cli=None,
+        provider="openai",
+        model="gpt-5.4-mini",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+    )
+    plan = PlanConfig(cli="claude", model="sonnet", budget_usd=0.5, timeout=600)
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=dev,
+        preflight_profile=dev,
+        review_pool=[mini],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        models=models,
+        plan=plan,
+        plan_model_is_default=True,
+        dev_profile_is_default=True,
+        review_pool_is_default=True,
+        model_registry=dict(AGENT_REGISTRY),
+        model_registry_sources={key: "builtin" for key in AGENT_REGISTRY},
+    )
+
+
+@pytest.mark.parametrize("pool", [_POOL_SONNET_FIRST, _POOL_MINI_FIRST])
+def test_complexity_adaptation_seam_routes_low_dev_to_cheaper_model(tmp_path, pool):
+    """Across the coordinator config-propagation boundary, a LOW story reroutes the
+    default dev model from sonnet to the cheaper enabled cheap-tier model."""
+    config = _seam_config(tmp_path, pool)
+    adapted = _apply_complexity_adaptation(config, "small")
+    assert adapted.dev_profile.model == "gpt-5.4-mini"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the reported sonnet/mini starvation case with runtime-consumed price tie-breaks and focused regression coverage. | [google-gemini-3.5-flash] Successfully resolved the cheap-tier starvation bug via a price-aware tie-break within equal cost_rank/capability buckets.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $7.20
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: enabled model with no run history is never dispatched — cheap-tier tie-break and cold-start ranking starve it permanently (GitHub Issue #1617)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1617