### PR TITLE
diagnose runs are invisible while running — no heartbeat, no forge status integration

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 
 from theforge.cli.shared import _find_config
+from theforge.cli.status_run_helpers import is_diagnose_run as _is_diagnose_run
 from theforge.cli.status_run_helpers import is_sprint_run as _is_sprint_run
 from theforge.config import load_config
 
@@ -274,7 +275,14 @@ def _show_recent_runs(project_root: Path) -> int:
         run_id = run["run_id"]
         slug = run["slug"]
         st = _detach.read_run_status(run_id, slug, project_root)
-        run_type = "sprint" if _is_sprint_run(run_id, project_root) else "single"
+        # Diagnose runs are PID-backed but non-sprint; check the diagnose marker
+        # before the sprint check so a live diagnose reads as its own type.
+        if _is_diagnose_run(run_id, project_root):
+            run_type = "diagnose"
+        elif _is_sprint_run(run_id, project_root):
+            run_type = "sprint"
+        else:
+            run_type = "single"
         cost_usd = st.get("cost_usd")
         elapsed_s = st.get("elapsed_seconds")
         cost_str = f"${cost_usd:.2f}" if cost_usd is not None else "—"
@@ -328,8 +336,12 @@ def _show_recent_runs(project_root: Path) -> int:
     return 0
 
 
-def _show_single_run_status(run_id: str, project_root: Path) -> None:
-    """Print a single-row status line for a non-sprint run."""
+def _show_single_run_status(run_id: str, project_root: Path, *, run_type: str = "single") -> None:
+    """Print a single-row status line for a non-sprint run.
+
+    ``run_type`` labels the row (``single`` or ``diagnose``) so an operator can
+    tell an in-flight diagnose apart from an ordinary single run at a glance.
+    """
     from theforge import detach as _detach
 
     # Try to find slug from PID file
@@ -356,9 +368,14 @@ def _show_single_run_status(run_id: str, project_root: Path) -> None:
     elapsed_str = f"{int(elapsed_s // 60)}m" if elapsed_s is not None else "—"
 
     story_label = slug or run_id
-    print(f"{'RUN ID':<12}  {'STORY':<30}  {'PHASE':<12}  {'COST':>7}  {'ELAPSED':>8}")
-    print("-" * 78)
-    print(f"{run_id:<12}  {story_label:<30}  {phase:<12}  {cost_str:>7}  {elapsed_str:>8}")
+    print(
+        f"{'RUN ID':<12}  {'TYPE':<8}  {'STORY':<30}  {'PHASE':<12}  {'COST':>7}  {'ELAPSED':>8}"
+    )
+    print("-" * 88)
+    print(
+        f"{run_id:<12}  {run_type:<8}  {story_label:<30}  "
+        f"{phase:<12}  {cost_str:>7}  {elapsed_str:>8}"
+    )
 
 
 def _is_completed_sprint(run_id: str, project_root: Path) -> bool:
@@ -399,7 +416,9 @@ def _render_status_blocks(run_ids: list[str], project_root: Path) -> int:
             else:
                 rc = display_sprint_status(run_id, project_root)
         else:
-            _show_single_run_status(run_id, project_root)
+            # Diagnose runs are non-sprint but get their own type label.
+            run_type = "diagnose" if _is_diagnose_run(run_id, project_root) else "single"
+            _show_single_run_status(run_id, project_root, run_type=run_type)
             rc = 0
         rcs.append(rc)
     if not rcs:

--- a/src/theforge/cli/status_run_helpers.py
+++ b/src/theforge/cli/status_run_helpers.py
@@ -45,6 +45,16 @@ def is_sprint_run(run_id: str, project_root: Path) -> bool:
     return False
 
 
+def is_diagnose_run(run_id: str, project_root: Path) -> bool:
+    """Return True when run_id belongs to a diagnose run.
+
+    Keyed off the ``.forge/runs/<run_id>.diagnose`` marker written by the
+    diagnose flow at run registration (before any diagnose-specific state
+    lands on disk). stdlib/Path-only, matching this module's style.
+    """
+    return (project_root / ".forge" / "runs" / f"{run_id}.diagnose").exists()
+
+
 def await_watchable_sprint_run(
     run_id: str,
     project_root: Path,

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import yaml
 
+from theforge import detach
 from theforge.config import ForgeConfig, ModelProfile
 from theforge.coordinator.diagnose_evidence import build_starting_evidence
 from theforge.coordinator.log_tee import get_worker_slug, set_worker_slug
@@ -475,6 +476,7 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
                 round(state.agent_cost_usd, 6) if state.agent_cost_usd is not None else None
             ),
             "duration_s": round(state.agent_duration_s, 3),
+            "failure_code": state.agent_failure_code,
             "raw_output_tail": state.agent_output[-2000:] if state.agent_output else "",
         },
         "landing": {
@@ -580,6 +582,7 @@ def _run_agent_with_heartbeat(
     working_dir: Path,
     secrets: dict[str, str] | None,
     heartbeat_interval_s: float | None = None,
+    on_heartbeat: "callable | None" = None,
 ) -> "object":
     """Run the investigative agent, emitting a periodic progress heartbeat.
 
@@ -588,12 +591,19 @@ def _run_agent_with_heartbeat(
     (always shown, not verbose-gated) so the operator can see the agent is still
     working rather than staring at a silent console for up to the full timeout.
 
+    ``on_heartbeat`` is the sink each heartbeat line is routed through; it
+    defaults to ``_progress_log`` (console only). ``run_diagnose_flow`` passes a
+    sink that also tees the line into the per-run log so ``forge logs`` follows
+    the heartbeat live.
+
     Any exception raised inside the agent thread is re-raised to the caller so
     the existing INVESTIGATE error handling is unchanged. Returns the
     ``AgentResult`` produced by ``run_agent``.
     """
     if heartbeat_interval_s is None:
         heartbeat_interval_s = _DIAGNOSE_HEARTBEAT_INTERVAL_S
+    if on_heartbeat is None:
+        on_heartbeat = _progress_log
     box: dict[str, object] = {}
 
     # The worker slug is thread-local; propagate it into the nested agent
@@ -621,7 +631,7 @@ def _run_agent_with_heartbeat(
         thread.join(timeout=heartbeat_interval_s)
         if thread.is_alive():
             elapsed = int(time.monotonic() - start)
-            _progress_log(
+            on_heartbeat(
                 f"  [diagnose] still investigating "
                 f"({elapsed}s elapsed, timeout {int(profile.timeout_seconds)}s)"
             )
@@ -730,7 +740,101 @@ def run_diagnose_flow(
         run_id=_generate_run_id(),
         started_at=_now_iso(),
     )
-    state.transition(DiagnosePhase.INIT, _now_iso())
+
+    # ── Register the run for live observability ────────────────────────
+    # Give the foreground diagnose flow the same PID-file + per-run-log
+    # registration detached sprint/run use, so ``forge status`` sees the live
+    # run and ``forge logs <run_id>`` can follow it. Bespoke and lightweight —
+    # no daemonize (diagnose stays foreground and, under --parallel, runs as
+    # threads sharing one PID; each thread owns its own run_id/file/marker).
+    slug = f"diagnose-{issue_number}"
+    state.run_slug = slug
+    log_fh = None
+    try:
+        log_dir = project_root / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_fh = open(  # noqa: SIM115 — closed in the finally below
+            log_dir / f"run-{state.run_id}.log", "a", encoding="utf-8"
+        )
+    except OSError:
+        log_fh = None
+    detach.write_pid(state.run_id, slug, project_root)
+    detach.write_diagnose_marker(state.run_id, project_root)
+
+    def _write_log(line: str) -> None:
+        if log_fh is None:
+            return
+        try:
+            log_fh.write(line + "\n")
+            log_fh.flush()
+        except OSError:
+            pass
+
+    def _emit(line: str) -> None:
+        """Tee a progress line into the per-run log AND the console."""
+        _write_log(line)
+        _progress_log(line)
+
+    def _emit_phase(phase: DiagnosePhase) -> None:
+        """Record a phase transition and tee it as a followable log line.
+
+        The literal ``[forge] ▸ <PHASE>`` prefix is the exact token
+        ``detach.read_run_status`` greps for, so ``forge status`` reports the
+        live phase off the per-run log.
+        """
+        state.transition(phase, _now_iso())
+        _write_log(f"[forge] ▸ {phase.name}")
+        _progress_log(f"▸ {phase.name}")
+
+    outcome = "completed"
+    try:
+        return _run_diagnose_flow_body(
+            state=state,
+            issue_number=issue_number,
+            config=config,
+            project_root=project_root,
+            interactive=interactive,
+            output_destination=output_destination,
+            dry_run=dry_run,
+            confirm_landing=confirm_landing,
+            emit=_emit,
+            emit_phase=_emit_phase,
+        )
+    except BaseException:
+        outcome = "stopped"
+        raise
+    finally:
+        if log_fh is not None:
+            try:
+                log_fh.close()
+            except OSError:
+                pass
+        detach.remove_pid(state.run_id, project_root)
+        detach.write_run_ended(state.run_id, project_root, outcome)
+
+
+def _run_diagnose_flow_body(
+    *,
+    state: DiagnoseState,
+    issue_number: int,
+    config: ForgeConfig,
+    project_root: Path,
+    interactive: bool,
+    output_destination: str | None,
+    dry_run: bool,
+    confirm_landing: "callable | None",
+    emit: "callable",
+    emit_phase: "callable",
+) -> DiagnoseResult:
+    """Body of :func:`run_diagnose_flow`, run under run registration.
+
+    Split out so the caller can wrap the entire flow in a try/finally that
+    tears down the PID file, diagnose marker, per-run log, and ``.ended``
+    sentinel on any exit path. ``emit`` tees a progress line into the per-run
+    log and the console; ``emit_phase`` records a phase transition and tees its
+    followable ``[forge] ▸ <PHASE>`` marker line.
+    """
+    emit_phase(DiagnosePhase.INIT)
 
     destination = output_destination or config.diagnose.output_destination
     if destination not in DIAGNOSE_OUTPUT_DESTINATIONS:
@@ -738,17 +842,17 @@ def run_diagnose_flow(
             f"Unknown output_destination {destination!r}; "
             f"valid: {sorted(DIAGNOSE_OUTPUT_DESTINATIONS)}"
         )
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
     # ── FETCH ─────────────────────────────────────────────────────────
-    state.transition(DiagnosePhase.FETCH, _now_iso())
+    emit_phase(DiagnosePhase.FETCH)
     try:
         issue = _gh_fetch_issue(issue_number, project_root)
     except Exception as exc:
         state.error = f"FETCH failed: {exc}"
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
@@ -777,7 +881,7 @@ def run_diagnose_flow(
             "deliverables; they are not candidates for forge diagnose. Close "
             "manually when the action is done."
         )
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
@@ -790,7 +894,7 @@ def run_diagnose_flow(
     issue_state = str(issue.get("state", "OPEN")).upper()
     if issue_state != "OPEN":
         state.error = f"Issue #{issue_number} is {issue_state.lower()}; refusing to diagnose"
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
@@ -809,14 +913,14 @@ def run_diagnose_flow(
     state.starting_evidence_labels = list(evidence.reference_labels)
     state.starting_evidence_chars = len(evidence.text)
     if evidence.reference_labels:
-        _progress_log(
+        emit(
             f"  [diagnose] pre-loaded {len(evidence.reference_labels)} evidence "
             f"excerpt(s) from issue-body references: "
             f"{', '.join(evidence.reference_labels)}"
         )
 
     # ── INVESTIGATE ───────────────────────────────────────────────────
-    state.transition(DiagnosePhase.INVESTIGATE, _now_iso())
+    emit_phase(DiagnosePhase.INVESTIGATE)
     profile = _build_diagnose_profile(config)
     mode = "interactive" if interactive else "autonomous"
     prompt = build_diagnose_prompt(
@@ -834,16 +938,26 @@ def run_diagnose_flow(
             profile=profile,
             working_dir=project_root,
             secrets=config.secrets,
+            on_heartbeat=emit,
         )
     except Exception as exc:
-        state.error = f"INVESTIGATE failed: {exc}"
+        # The runner RETURNS timeout/budget as an AgentResult (success=False,
+        # failure_code="timeout"); it does not raise. So this path is a genuine
+        # crash, not a timeout — label it as such.
+        state.error = f"INVESTIGATE crashed: {exc}"
         state.agent_duration_s = time.monotonic() - t0
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
     state.agent_duration_s = time.monotonic() - t0
     state.agent_output = getattr(agent_result, "output", "") or ""
+    # Capture the runner's machine-readable failure identifier (e.g. "timeout")
+    # so terminal messaging and the audit trail can distinguish a timeout from a
+    # budget breach or an empty completion. Normalize to str|None so a
+    # non-string value never reaches the YAML audit serializer.
+    _failure_code = getattr(agent_result, "failure_code", None)
+    state.agent_failure_code = _failure_code if isinstance(_failure_code, str) else None
     # Preserve an unmeasured cost (None) faithfully — a run killed at timeout
     # still spent real money, and coercing None to 0.0 would record that spend
     # as free in the audit. Reconstruction happens in the runner; here we only
@@ -868,7 +982,7 @@ def run_diagnose_flow(
         partial = True
 
     # ── PARSE ─────────────────────────────────────────────────────────
-    state.transition(DiagnosePhase.PARSE, _now_iso())
+    emit_phase(DiagnosePhase.PARSE)
     artifact = parse_diagnose_output(
         state.agent_output, issue_number=issue_number, partial=partial
     )
@@ -877,7 +991,7 @@ def run_diagnose_flow(
             f"PARSE failed: investigative agent did not emit a parseable YAML block. "
             f"Raw tail: {state.agent_output[-200:]!r}"
         )
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
@@ -904,12 +1018,21 @@ def run_diagnose_flow(
     # diagnosis landed" when there is nothing to review. Fail without mutating
     # any operator-visible state.
     if not artifact.has_substantive_content():
+        # Name the actual terminal cause rather than lumping timeout/budget/empty
+        # together (#1595). The runner returns "timeout" as a failure_code; a
+        # budget breach is detected above; anything else is an empty completion.
+        if state.agent_failure_code == "timeout":
+            cause = f"timed out after {int(profile.timeout_seconds)}s"
+        elif budget_exceeded:
+            cause = f"exceeded budget ${config.diagnose.budget_usd}"
+        else:
+            cause = "completed without emitting a diagnosis"
         state.error = (
-            "INVESTIGATE produced no diagnosis: the investigative agent "
-            "terminated (timeout, budget, or empty completion) without emitting "
-            "any substantive content. Nothing landed; issue body left untouched."
+            f"INVESTIGATE produced no diagnosis: the investigative agent {cause} "
+            "without emitting any substantive content. Nothing landed; issue body "
+            "left untouched."
         )
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
@@ -920,12 +1043,12 @@ def run_diagnose_flow(
     # described symptom cannot reproduce against code that is gone — report
     # "appears already resolved" (naming the removing commit) and write no
     # confirmed-cause body, rather than manufacturing a live diagnosis.
-    state.transition(DiagnosePhase.VERIFY_PREMISE, _now_iso())
+    emit_phase(DiagnosePhase.VERIFY_PREMISE)
     verdict = verify_premise(artifact, state.baseline_sha, project_root)
     if verdict.resolved:
         state.already_resolved = True
         state.absent_premises = verdict.absent
-        state.transition(DiagnosePhase.ALREADY_RESOLVED, _now_iso())
+        emit_phase(DiagnosePhase.ALREADY_RESOLVED)
         report = render_already_resolved_markdown(
             issue_number=issue_number,
             baseline_sha=state.baseline_sha,
@@ -953,7 +1076,7 @@ def run_diagnose_flow(
         partial_phase = (
             DiagnosePhase.BUDGET_EXCEEDED if budget_exceeded else DiagnosePhase.TIMEOUT_PARTIAL
         )
-        state.transition(partial_phase, _now_iso())
+        emit_phase(partial_phase)
         if interactive and confirm_landing is None:
             confirm_landing = _stdin_confirm
         if interactive and confirm_landing is not None:
@@ -970,14 +1093,22 @@ def run_diagnose_flow(
             write_diagnose_audit(state, project_root)
             return DiagnoseResult(success=False, state=state, message=state.error)
         write_diagnose_audit(state, project_root)
+        # Name the actual cause in the operator message rather than a generic
+        # "Partial diagnosis landed" (#1595).
+        if budget_exceeded:
+            cause_label = f"budget exceeded (${config.diagnose.budget_usd})"
+        elif state.agent_failure_code == "timeout":
+            cause_label = f"timed out after {int(profile.timeout_seconds)}s"
+        else:
+            cause_label = "incomplete diagnosis"
         return DiagnoseResult(
             success=False,
             state=state,
-            message="Partial diagnosis landed — operator review required",
+            message=f"Partial diagnosis landed ({cause_label}) — operator review required",
         )
 
     # ── LAND ──────────────────────────────────────────────────────────
-    state.transition(DiagnosePhase.LAND, _now_iso())
+    emit_phase(DiagnosePhase.LAND)
     if interactive and confirm_landing is None:
         confirm_landing = _stdin_confirm
     if interactive and confirm_landing is not None:
@@ -990,13 +1121,13 @@ def run_diagnose_flow(
         location = _land_artifact(state, artifact, destination, project_root, dry_run=dry_run)
     except Exception as exc:
         state.error = f"LAND failed: {exc}"
-        state.transition(DiagnosePhase.FAILED, _now_iso())
+        emit_phase(DiagnosePhase.FAILED)
         write_diagnose_audit(state, project_root)
         return DiagnoseResult(success=False, state=state, message=state.error)
 
     state.landing_destination = destination
     state.landed_location = location
-    state.transition(DiagnosePhase.DONE, _now_iso())
+    emit_phase(DiagnosePhase.DONE)
     write_diagnose_audit(state, project_root)
     return DiagnoseResult(
         success=True,

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -51,13 +51,14 @@ def write_pid(run_id: str, slug: str, project_root: Path) -> Path:
 
 
 def remove_pid(run_id: str, project_root: Path) -> None:
-    """Remove .forge/runs/<run-id>.pid (and the sprint marker), ignoring missing files."""
+    """Remove .forge/runs/<run-id>.pid (and run-type markers), ignoring missing files."""
     pid_file = project_root / ".forge" / "runs" / f"{run_id}.pid"
     try:
         pid_file.unlink()
     except FileNotFoundError:
         pass
     remove_sprint_marker(run_id, project_root)
+    remove_diagnose_marker(run_id, project_root)
 
 
 def write_sprint_marker(run_id: str, project_root: Path) -> Path:
@@ -86,6 +87,36 @@ def remove_sprint_marker(run_id: str, project_root: Path) -> None:
 def has_sprint_marker(run_id: str, project_root: Path) -> bool:
     """Return True when <run_id>.sprint marker exists."""
     return (project_root / ".forge" / "runs" / f"{run_id}.sprint").exists()
+
+
+def write_diagnose_marker(run_id: str, project_root: Path) -> Path:
+    """Mark <run_id> as a diagnose run before any diagnose state is written.
+
+    Diagnose runs execute in the foreground (and, under ``--parallel``, as
+    threads sharing one PID), so there is no detached child that writes a
+    per-run type marker. This marker lets ``forge status`` classify a live
+    PID-backed run as a diagnose before any diagnose-specific state exists on
+    disk — mirroring the sprint marker for the detached sprint path.
+    """
+    runs_dir = project_root / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    marker = runs_dir / f"{run_id}.diagnose"
+    marker.write_text("diagnose\n", encoding="utf-8")
+    return marker
+
+
+def remove_diagnose_marker(run_id: str, project_root: Path) -> None:
+    """Remove .forge/runs/<run_id>.diagnose, ignoring missing files."""
+    marker = project_root / ".forge" / "runs" / f"{run_id}.diagnose"
+    try:
+        marker.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def has_diagnose_marker(run_id: str, project_root: Path) -> bool:
+    """Return True when <run_id>.diagnose marker exists."""
+    return (project_root / ".forge" / "runs" / f"{run_id}.diagnose").exists()
 
 
 def write_run_ended(

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -230,6 +230,13 @@ class DiagnoseState:
     # nothing recognizable. Recorded so the audit shows exactly what the
     # orchestrator handed the agent (convention: instrument cross-phase data).
     starting_evidence_chars: int = 0
+    # Machine-readable failure identifier returned by the runner (e.g.
+    # "timeout"). None when the run did not fail or the runner reported no
+    # code. Recorded so the audit trail distinguishes a timeout from a crash.
+    agent_failure_code: str | None = None
+    # Followable-log slug for this run (``diagnose-<issue>``). Set at run
+    # registration so status/logs can resolve the per-run log file.
+    run_slug: str = ""
 
     def transition(self, new_phase: DiagnosePhase, when: str) -> None:
         self.phase = new_phase

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -178,7 +178,7 @@ class TestCmdStatusRouting:
 
         assert result == 0
         mock_dss.assert_called_once_with("run-a", config.project_root)
-        mock_single.assert_called_once_with("run-b", config.project_root)
+        mock_single.assert_called_once_with("run-b", config.project_root, run_type="single")
 
     def test_explicit_run_id_resolves_and_shows_status(
         self, tmp_path: Path, capsys: object

--- a/tests/test_diagnose_observability.py
+++ b/tests/test_diagnose_observability.py
@@ -1,0 +1,331 @@
+"""Seam-level integration tests for diagnose run observability.
+
+Covers the cross-boundary state flow added so ``forge diagnose`` runs are
+visible while running (convention 8):
+
+- a live diagnose registers a PID file + ``.diagnose`` marker + per-run log,
+  and ``is_diagnose_run`` / ``detach.list_active_runs`` observe it;
+- the finally block tears that registration down (PID/marker removed, ``.ended``
+  written) on both normal and exception exit;
+- ``forge logs`` resolves the diagnose per-run log path;
+- ``forge status`` labels the run TYPE=diagnose with the target slug;
+- terminal messages name the actual cause (timeout vs budget), per AC4.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from coord_test_helpers import _make_config
+
+from theforge import detach
+from theforge.agent_types import AgentResult
+from theforge.cli.status_run_helpers import is_diagnose_run
+
+
+def _agent_yaml_output(*, confirmed: bool = True) -> str:
+    payload = {
+        "observed_symptom": "Sprint flow drops the third story silently",
+        "reproduction_or_evidence": "Run forge sprint --issues 1,2,3 — story 3 never starts",
+        "hypotheses": [
+            {
+                "statement": "Worker pool size off-by-one",
+                "status": "confirmed" if confirmed else "inconclusive",
+                "evidence": "scheduler.py:142 reserves N-1 slots when N requested",
+            },
+        ],
+        "confirmed_cause": (
+            "Worker pool reserves N-1 slots in scheduler.py:142" if confirmed else ""
+        ),
+        "affected_code_path": "src/theforge/sprint/scheduler.py:142",
+        "fix_success_criterion": "Running with --parallel 3 completes all 3 stories",
+        "notes": "",
+    }
+    return f"```yaml\n{yaml.safe_dump(payload, sort_keys=False)}```"
+
+
+def _fake_agent_result(
+    output: str,
+    *,
+    success: bool = True,
+    cost: float | None = 0.05,
+    failure_code: str | None = None,
+) -> AgentResult:
+    return AgentResult(
+        success=success,
+        output=output,
+        session_id=None,
+        cost_usd=cost,
+        exit_code=0 if success else 1,
+        raw={},
+        failure_code=failure_code,
+    )
+
+
+class TestDiagnoseRunRegistration:
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_live_run_registers_pid_marker_and_log(
+        self, mock_agent, mock_fetch, mock_post, tmp_path: Path
+    ):
+        """While the agent runs, the run is observable as a live diagnose."""
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 77,
+            "title": "silent",
+            "body": "no output",
+            "state": "OPEN",
+        }
+        mock_post.return_value = "https://example/comment"
+
+        observed: dict = {}
+
+        def _capturing_agent(**_kwargs):
+            runs_dir = tmp_path / ".forge" / "runs"
+            observed["markers"] = [p.name for p in runs_dir.glob("*.diagnose")]
+            observed["pids"] = [p.name for p in runs_dir.glob("*.pid")]
+            observed["active"] = detach.list_active_runs(tmp_path)
+            observed["logs"] = [p for p in (tmp_path / ".forge" / "logs").rglob("run-*.log")]
+            return _fake_agent_result(_agent_yaml_output())
+
+        mock_agent.side_effect = _capturing_agent
+
+        result = run_diagnose_flow(
+            issue_number=77,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        run_id = result.state.run_id
+        # Mid-run the registration was present and observable.
+        assert observed["markers"] == [f"{run_id}.diagnose"]
+        assert observed["pids"] == [f"{run_id}.pid"]
+        active_ids = {r["run_id"] for r in observed["active"]}
+        assert run_id in active_ids
+        active_slugs = {r["slug"] for r in observed["active"]}
+        assert "diagnose-77" in active_slugs
+        # The classifier recognised the live PID-backed run as a diagnose.
+        # (Re-create the marker snapshot: it existed at capture time.)
+        assert observed["markers"], "expected a live .diagnose marker"
+        # A followable per-run log existed at the expected path.
+        assert observed["logs"] == [
+            tmp_path / ".forge" / "logs" / "diagnose-77" / f"run-{run_id}.log"
+        ]
+        assert result.state.run_slug == "diagnose-77"
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_normal_exit_tears_down_registration(
+        self, mock_agent, mock_fetch, mock_post, tmp_path: Path
+    ):
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 88,
+            "title": "x",
+            "body": "y",
+            "state": "OPEN",
+        }
+        mock_post.return_value = "https://example/comment"
+        mock_agent.return_value = _fake_agent_result(_agent_yaml_output())
+
+        result = run_diagnose_flow(
+            issue_number=88,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        run_id = result.state.run_id
+        runs_dir = tmp_path / ".forge" / "runs"
+        assert not (runs_dir / f"{run_id}.pid").exists()
+        assert not (runs_dir / f"{run_id}.diagnose").exists()
+        assert detach.read_run_ended(run_id, tmp_path) == "completed"
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_agent_crash_still_tears_down_registration(
+        self, mock_agent, mock_fetch, tmp_path: Path
+    ):
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 99,
+            "title": "x",
+            "body": "y",
+            "state": "OPEN",
+        }
+        mock_agent.side_effect = RuntimeError("boom")
+
+        result = run_diagnose_flow(
+            issue_number=99,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        # A raised agent error is caught inside the flow (crash, not timeout).
+        assert not result.success
+        assert "crashed" in result.message
+        run_id = result.state.run_id
+        runs_dir = tmp_path / ".forge" / "runs"
+        assert not (runs_dir / f"{run_id}.pid").exists()
+        assert not (runs_dir / f"{run_id}.diagnose").exists()
+        assert detach.read_run_ended(run_id, tmp_path) is not None
+
+
+class TestDiagnoseLogResolution:
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_forge_logs_resolves_diagnose_log(
+        self, mock_agent, mock_fetch, mock_post, tmp_path: Path
+    ):
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 55,
+            "title": "x",
+            "body": "y",
+            "state": "OPEN",
+        }
+        mock_post.return_value = "https://example/comment"
+        mock_agent.return_value = _fake_agent_result(_agent_yaml_output())
+
+        result = run_diagnose_flow(
+            issue_number=55,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        run_id = result.state.run_id
+        # forge logs resolves a run's log via the PID-file slug + _find_log_path.
+        resolved = detach._find_log_path("diagnose-55", run_id, tmp_path)
+        assert resolved is not None
+        assert resolved.exists()
+        assert resolved == (tmp_path / ".forge" / "logs" / "diagnose-55" / f"run-{run_id}.log")
+        # The per-run log carries the followable phase-transition markers.
+        contents = resolved.read_text(encoding="utf-8")
+        assert "[forge] ▸ INVESTIGATE" in contents
+
+
+class TestDiagnoseStatusLabel:
+    def test_status_labels_live_diagnose_run(self, tmp_path: Path, capsys):
+        """A live diagnose registration renders TYPE=diagnose with its slug."""
+        from theforge.cli.status import _show_single_run_status
+
+        run_id = "abc123def456"
+        slug = "diagnose-321"
+        # Simulate a live registration exactly as run_diagnose_flow writes it.
+        log_dir = tmp_path / ".forge" / "logs" / slug
+        log_dir.mkdir(parents=True)
+        (log_dir / f"run-{run_id}.log").write_text("[forge] ▸ INVESTIGATE\n")
+        detach.write_pid(run_id, slug, tmp_path)
+        detach.write_diagnose_marker(run_id, tmp_path)
+
+        assert is_diagnose_run(run_id, tmp_path)
+
+        _show_single_run_status(run_id, tmp_path, run_type="diagnose")
+        out = capsys.readouterr().out
+        assert "TYPE" in out
+        assert "diagnose" in out
+        assert slug in out
+        assert run_id in out
+
+
+class TestDiagnoseTerminalMessages:
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_timeout_message_names_timeout(self, mock_agent, mock_fetch, tmp_path: Path):
+        """A runner timeout (returned, not raised) yields a timeout-named message."""
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 111,
+            "title": "x",
+            "body": "y",
+            "state": "OPEN",
+        }
+        # Runner returns timeout: success=False, failure_code="timeout", TIMEOUT text.
+        mock_agent.return_value = _fake_agent_result(
+            "TIMEOUT: agent killed after 600s", success=False, failure_code="timeout"
+        )
+
+        result = run_diagnose_flow(
+            issue_number=111,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        assert not result.success
+        assert "timed out" in result.message
+        assert "600s" in result.message
+        assert result.state.agent_failure_code == "timeout"
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_budget_message_names_budget(self, mock_agent, mock_fetch, mock_post, tmp_path: Path):
+        """A budget breach yields a budget-named partial message."""
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 222,
+            "title": "x",
+            "body": "y",
+            "state": "OPEN",
+        }
+        mock_post.return_value = "https://example/comment"
+        # Complete diagnosis, but cost blows past the diagnose budget ceiling.
+        mock_agent.return_value = _fake_agent_result(
+            _agent_yaml_output(), success=True, cost=100.0
+        )
+
+        result = run_diagnose_flow(
+            issue_number=222,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        assert not result.success
+        assert "budget" in result.message.lower()
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_failure_code_recorded_in_audit(
+        self, mock_agent, mock_fetch, mock_post, tmp_path: Path
+    ):
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        config = _make_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 333,
+            "title": "x",
+            "body": "y",
+            "state": "OPEN",
+        }
+        mock_post.return_value = "https://example/comment"
+        mock_agent.return_value = _fake_agent_result(
+            "TIMEOUT: agent killed", success=False, failure_code="timeout"
+        )
+
+        result = run_diagnose_flow(
+            issue_number=333,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        audit = tmp_path / ".forge" / "audits" / f"diagnose-issue-333-{result.state.run_id}.yaml"
+        loaded = yaml.safe_load(audit.read_text())
+        assert loaded["agent"]["failure_code"] == "timeout"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the diagnose observability acceptance criteria, and the targeted tests passed. | [google-gemini-3.5-flash] The implementation successfully registers foreground diagnose runs for live observability, integrates them with forge status and forge logs, and provides accurate terminal messages on timeout or failure. | [claude-sonnet] Diagnose runs now register PID/marker/log like sprint/run, forge status labels them, and terminal messages accurately name timeout/budget/crash causes; all claims verified against code and tests pass (99 passed).

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $8.93
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

diagnose runs are invisible while running — no heartbeat, no forge status integration (GitHub Issue #1597)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1597