### PR TITLE
forge diagnose: add --timeout per-invocation override flag

### DIFF
--- a/src/theforge/cli/diagnose.py
+++ b/src/theforge/cli/diagnose.py
@@ -80,6 +80,11 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
     else:
         interactive = not config.diagnose.autonomous_default
 
+    timeout_override = getattr(args, "timeout", None)
+    if timeout_override is not None and timeout_override <= 0:
+        print(f"--timeout: must be > 0, got {timeout_override}", file=sys.stderr)
+        return 1
+
     # ── Concurrency ────────────────────────────────────────────────────
     # Per-issue diagnosis is independent (fresh-context investigative agent,
     # no shared mutable state), so it parallelizes cleanly under a worker cap
@@ -111,6 +116,7 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
             interactive=interactive,
             output_destination=destination,
             dry_run=args.dry_run,
+            timeout_seconds=timeout_override,
         )
         icon = "✓" if result.success else "✗"
         _cost = result.state.agent_cost_usd
@@ -203,6 +209,16 @@ def register_parser(subparsers: object) -> None:
         type=int,
         default=None,
         help="Maximum concurrent issue diagnoses (default: serial)",
+    )
+    p.add_argument(
+        "--timeout",
+        metavar="SECONDS",
+        type=float,
+        default=None,
+        help=(
+            "Per-invocation timeout override in seconds "
+            "(overrides forge.yaml diagnose.timeout_seconds)"
+        ),
     )
     p.add_argument(
         "--dry-run",

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -545,7 +545,9 @@ def _artifact_to_dict(artifact: DiagnosisArtifact) -> dict:
 # ── Profile selection ─────────────────────────────────────────────────
 
 
-def _build_diagnose_profile(config: ForgeConfig) -> ModelProfile:
+def _build_diagnose_profile(
+    config: ForgeConfig, *, timeout_seconds: float | None = None
+) -> ModelProfile:
     """Derive the investigative-agent profile from existing config.
 
     Reuses ``preflight_profile`` as the base — it's already an
@@ -553,13 +555,18 @@ def _build_diagnose_profile(config: ForgeConfig) -> ModelProfile:
     and overlays the diagnose-specific budget and timeout from
     ``config.diagnose``.  This avoids inventing a parallel profile-loading
     path while still giving the diagnose flow its own resource envelope.
+
+    ``timeout_seconds``, if given, overrides ``config.diagnose.timeout_seconds``
+    for this invocation only (e.g. ``forge diagnose --timeout``).
     """
     base = config.preflight_profile
     return dataclasses.replace(
         base,
         name="diagnose",
         budget_usd=config.diagnose.budget_usd,
-        timeout_seconds=config.diagnose.timeout_seconds,
+        timeout_seconds=(
+            timeout_seconds if timeout_seconds is not None else config.diagnose.timeout_seconds
+        ),
         phase="diagnose",
     )
 
@@ -719,6 +726,7 @@ def run_diagnose_flow(
     output_destination: str | None = None,
     dry_run: bool = False,
     confirm_landing: "callable | None" = None,
+    timeout_seconds: float | None = None,
 ) -> DiagnoseResult:
     """Run the diagnose flow for a single issue.
 
@@ -729,10 +737,12 @@ def run_diagnose_flow(
     can drive interactive mode without TTY.
 
     Budget and timeout enforcement: the agent profile carries
-    ``timeout_seconds`` and ``budget_usd`` from ``config.diagnose``.  The
-    runner enforces wall-clock timeout; this function additionally treats
-    a failed agent run as a partial-result outcome rather than a hard
-    failure, returning whatever YAML the agent emitted before exit.
+    ``timeout_seconds`` and ``budget_usd`` from ``config.diagnose``.  Pass
+    ``timeout_seconds`` to override the configured value for this run only
+    (e.g. ``forge diagnose --timeout``).  The runner enforces wall-clock
+    timeout; this function additionally treats a failed agent run as a
+    partial-result outcome rather than a hard failure, returning whatever
+    YAML the agent emitted before exit.
     """
     _ensure_runner()
     state = DiagnoseState(
@@ -797,6 +807,7 @@ def run_diagnose_flow(
             output_destination=output_destination,
             dry_run=dry_run,
             confirm_landing=confirm_landing,
+            timeout_seconds=timeout_seconds,
             emit=_emit,
             emit_phase=_emit_phase,
         )
@@ -823,6 +834,7 @@ def _run_diagnose_flow_body(
     output_destination: str | None,
     dry_run: bool,
     confirm_landing: "callable | None",
+    timeout_seconds: float | None = None,
     emit: "callable",
     emit_phase: "callable",
 ) -> DiagnoseResult:
@@ -921,7 +933,7 @@ def _run_diagnose_flow_body(
 
     # ── INVESTIGATE ───────────────────────────────────────────────────
     emit_phase(DiagnosePhase.INVESTIGATE)
-    profile = _build_diagnose_profile(config)
+    profile = _build_diagnose_profile(config, timeout_seconds=timeout_seconds)
     mode = "interactive" if interactive else "autonomous"
     prompt = build_diagnose_prompt(
         issue_number=issue_number,

--- a/tests/test_cli_diagnose_parallel.py
+++ b/tests/test_cli_diagnose_parallel.py
@@ -212,6 +212,14 @@ class TestParserArg:
         args = _parse(["--issue", "1", "--parallel", "3"])
         assert args.parallel == 3
 
+    def test_timeout_defaults_to_none(self):
+        args = _parse(["--issue", "1"])
+        assert args.timeout is None
+
+    def test_timeout_parsed_as_float(self):
+        args = _parse(["--issue", "1", "--timeout", "120"])
+        assert args.timeout == 120.0
+
 
 class TestCmdDiagnose:
     def _args(self, **over) -> argparse.Namespace:
@@ -223,6 +231,7 @@ class TestCmdDiagnose:
             autonomous=True,
             dry_run=False,
             parallel=None,
+            timeout=None,
             verbose=False,
         )
         base.update(over)
@@ -270,6 +279,42 @@ class TestCmdDiagnose:
             patch("theforge.cli.diagnose.run_diagnose_flow") as flow,
         ):
             rc = cmd_diagnose(self._args(parallel=0))
+        assert rc == 1
+        flow.assert_not_called()
+
+    def test_timeout_override_passed_to_flow(self, tmp_path):
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("x")
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", return_value=self._patched_config()),
+            patch("theforge.cli.diagnose.run_diagnose_flow", return_value=_result(1)) as flow,
+        ):
+            rc = cmd_diagnose(self._args(issue=["1"], timeout=120.0))
+        assert rc == 0
+        assert flow.call_args.kwargs["timeout_seconds"] == 120.0
+
+    def test_omitted_timeout_passes_none_to_flow(self, tmp_path):
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("x")
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", return_value=self._patched_config()),
+            patch("theforge.cli.diagnose.run_diagnose_flow", return_value=_result(1)) as flow,
+        ):
+            rc = cmd_diagnose(self._args(issue=["1"]))
+        assert rc == 0
+        assert flow.call_args.kwargs["timeout_seconds"] is None
+
+    def test_invalid_timeout_returns_error(self, tmp_path):
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("x")
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", return_value=self._patched_config()),
+            patch("theforge.cli.diagnose.run_diagnose_flow") as flow,
+        ):
+            rc = cmd_diagnose(self._args(timeout=0))
         assert rc == 1
         flow.assert_not_called()
 

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -1402,6 +1402,23 @@ class TestParseRelatedFindings:
         assert artifact.related_findings[0].summary == "dup"
 
 
+class TestBuildDiagnoseProfile:
+    def test_default_uses_config_timeout(self, tmp_path):
+        from theforge.coordinator import diagnose_flow
+
+        config = _make_config(tmp_path)
+        profile = diagnose_flow._build_diagnose_profile(config)
+        assert profile.timeout_seconds == config.diagnose.timeout_seconds
+
+    def test_override_replaces_config_timeout(self, tmp_path):
+        from theforge.coordinator import diagnose_flow
+
+        config = _make_config(tmp_path)
+        profile = diagnose_flow._build_diagnose_profile(config, timeout_seconds=42.0)
+        assert profile.timeout_seconds == 42.0
+        assert profile.timeout_seconds != config.diagnose.timeout_seconds
+
+
 class TestDiagnoseHeartbeat:
     """The investigative agent runs for up to the diagnose timeout; the flow must
     emit periodic progress so a live run is distinguishable from a hang."""


### PR DESCRIPTION
## Summary

--timeout override is correctly threaded CLI → run_diagnose_flow → _build_diagnose_profile with >0 validation and full test coverage; all three ACs satisfied.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $1.97
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose: add --timeout per-invocation override flag (GitHub Issue #1822)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1822