### PR TITLE
GitHub Action: auto-close epic when last sub-issue closes

### DIFF
--- a/.github/workflows/close-epic-on-last-subissue.yml
+++ b/.github/workflows/close-epic-on-last-subissue.yml
@@ -1,0 +1,85 @@
+name: Close epic when last sub-issue closes
+
+# GitHub's native sub-issues give a parent a progress bar, but they do NOT
+# auto-close the parent when the last sub-issue closes. An epic whose work is
+# fully done therefore lingers open, inflating its milestone and misreporting
+# active work. This replicates the missing behavior: when a sub-issue closes,
+# check whether all of its parent's sub-issues are now closed, and if so close
+# the parent epic with a summary comment. (#1823, slice of epic #1725)
+#
+# Event-scoped, NOT a sweep: it reads only the single issue in the event payload
+# (github.event.issue), walks up to that issue's parent, and inspects only that
+# parent's sub-issues. It never enumerates the repository's open issues.
+#
+# Same shape as close-on-merge.yml: event-scoped trigger, gh CLI/API calls,
+# comment-and-close, idempotent (a parent that is already closed is a no-op).
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  close-parent-epic-if-complete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parent epic if all its sub-issues are closed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          # Walk up to the parent via the native sub-issue relationship. The
+          # closed-issue webhook payload does not carry the parent, so query it.
+          parent=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$number:Int!){
+              repository(owner:$owner,name:$repo){
+                issue(number:$number){ parent { number state } }
+              }
+            }' \
+            -f owner="$OWNER" -f repo="$REPO_NAME" -F number="$ISSUE_NUMBER" \
+            --jq '.data.repository.issue.parent.number // empty')
+
+          if [ -z "$parent" ]; then
+            echo "Issue #$ISSUE_NUMBER has no parent epic; nothing to do (by design)."
+            exit 0
+          fi
+
+          # Idempotent: if the parent is already closed we have nothing to do.
+          parent_state=$(gh issue view "$parent" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "MISSING")
+          if [ "$parent_state" != "OPEN" ]; then
+            echo "Parent epic #$parent is $parent_state; skipping."
+            exit 0
+          fi
+
+          # Enumerate the parent's sub-issues (paginated). One line per number.
+          all=$(gh api --paginate "repos/$REPO/issues/$parent/sub_issues" \
+            --jq '.[].number' | sort -un)
+          open=$(gh api --paginate "repos/$REPO/issues/$parent/sub_issues" \
+            --jq '.[] | select(.state == "open") | .number' | sort -un)
+
+          total_count=$(printf '%s\n' "$all" | grep -c '[0-9]' || true)
+          open_count=$(printf '%s\n' "$open" | grep -c '[0-9]' || true)
+
+          if [ "$total_count" -eq 0 ]; then
+            echo "Parent #$parent reports no sub-issues; leaving it open (nothing to gate on)."
+            exit 0
+          fi
+
+          if [ "$open_count" -ne 0 ]; then
+            echo "Parent epic #$parent still has $open_count open sub-issue(s); leaving it open."
+            exit 0
+          fi
+
+          # All sub-issues are closed: close the epic with a summary comment.
+          closed_list=$(printf '%s\n' "$all" | sed 's/^/#/' | paste -sd, - | sed 's/,/, /g')
+          echo "All $total_count sub-issue(s) of epic #$parent are closed; auto-closing."
+          gh issue close "$parent" --repo "$REPO" \
+            --comment "All $total_count sub-issue(s) are closed, so this epic is complete. Auto-closed when #$ISSUE_NUMBER, its last open sub-issue, closed. Sub-issues: $closed_list."

--- a/tests/test_close_epic_workflow.py
+++ b/tests/test_close_epic_workflow.py
@@ -1,0 +1,163 @@
+"""End-to-end behavior test for the close-epic-on-last-subissue workflow.
+
+The acceptance criterion "close the last sub-issue of a test epic and observe
+the parent close" cannot be exercised as a real GitHub Actions run until the
+workflow lands on the default branch. This test provides the equivalent,
+committed verification: it extracts the workflow's *actual* shell step and runs
+it under ``bash`` with the ``gh`` CLI stubbed at the process boundary, driving
+the same command sequence the Action performs at runtime.
+
+Because the script is read straight out of the YAML, the test stays in lockstep
+with the shipped workflow — editing the workflow logic re-runs the edited logic
+here. The external ``gh`` boundary is fully stubbed, so the test needs no
+network, no GitHub token, and no provider SDKs.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "close-epic-on-last-subissue.yml"
+)
+
+# A stub `gh` that answers the four call shapes the workflow makes, driven by
+# FAKE_* env vars. `gh api graphql` -> parent number; `gh api .../sub_issues`
+# -> all numbers, or just the open ones when the --jq carries a `select`;
+# `gh issue view` -> parent state; `gh issue close` -> recorded to $CLOSE_LOG.
+GH_STUB = r"""#!/usr/bin/env bash
+set -eu
+case "$1" in
+  api)
+    if [ "$2" = "graphql" ]; then
+      printf '%s' "${FAKE_PARENT:-}"
+      exit 0
+    fi
+    for a in "$@"; do
+      case "$a" in
+        *select*) printf '%s\n' ${FAKE_SUBS_OPEN:-}; exit 0 ;;
+      esac
+    done
+    printf '%s\n' ${FAKE_SUBS_ALL:-}
+    exit 0
+    ;;
+  issue)
+    case "$2" in
+      view) printf '%s' "${FAKE_PARENT_STATE:-OPEN}"; exit 0 ;;
+      close) printf '%s\n' "$*" >> "$CLOSE_LOG"; exit 0 ;;
+    esac
+    ;;
+esac
+echo "unexpected gh call: $*" >&2
+exit 1
+"""
+
+
+def _run_step(tmp_path: Path, fake_env: dict[str, str]) -> tuple[str, str]:
+    """Run the workflow's shell step with a stubbed gh; return (stdout, close_log)."""
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    steps = doc["jobs"]["close-parent-epic-if-complete"]["steps"]
+    script = steps[0]["run"]
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(GH_STUB)
+    gh.chmod(0o755)
+
+    close_log = tmp_path / "close.log"
+    close_log.write_text("")
+
+    env = {
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "CLOSE_LOG": str(close_log),
+        # Context the workflow reads from `env:` (github.* at runtime).
+        "GH_TOKEN": "stub",
+        "REPO": "fuzzypete/theforge",
+        "OWNER": "fuzzypete",
+        "REPO_NAME": "theforge",
+        "ISSUE_NUMBER": "1823",
+        **fake_env,
+    }
+
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"step failed: {proc.stderr}"
+    return proc.stdout, close_log.read_text()
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash required to run the workflow step"
+)
+
+
+def test_last_subissue_closed_closes_parent_with_summary(tmp_path):
+    """AC: last open sub-issue closing auto-closes the parent with a summary comment."""
+    stdout, close_log = _run_step(
+        tmp_path,
+        {
+            "FAKE_PARENT": "1725",
+            "FAKE_PARENT_STATE": "OPEN",
+            "FAKE_SUBS_ALL": "1801 1802 1823",
+            "FAKE_SUBS_OPEN": "",
+        },
+    )
+    assert "auto-closing" in stdout
+    # The parent epic was closed...
+    assert close_log.strip(), "expected `gh issue close` to be invoked"
+    assert "1725" in close_log
+    # ...with a summary comment listing every sub-issue.
+    assert "Sub-issues: #1801, #1802, #1823" in close_log
+    assert "its last open sub-issue" in close_log
+
+
+def test_open_subissue_leaves_parent_open(tmp_path):
+    """AC: an epic with any sub-issue still open is left open."""
+    stdout, close_log = _run_step(
+        tmp_path,
+        {
+            "FAKE_PARENT": "1725",
+            "FAKE_PARENT_STATE": "OPEN",
+            "FAKE_SUBS_ALL": "1801 1802 1823",
+            "FAKE_SUBS_OPEN": "1802",
+        },
+    )
+    assert "still has 1 open sub-issue" in stdout
+    assert close_log.strip() == "", "parent must not be closed while a sub-issue is open"
+
+
+def test_no_parent_is_noop(tmp_path):
+    """A closed issue with no parent epic is a no-op."""
+    stdout, close_log = _run_step(tmp_path, {"FAKE_PARENT": ""})
+    assert "no parent epic" in stdout
+    assert close_log.strip() == ""
+
+
+def test_already_closed_parent_is_idempotent(tmp_path):
+    """A parent that is already closed is skipped (idempotent)."""
+    stdout, close_log = _run_step(
+        tmp_path,
+        {
+            "FAKE_PARENT": "1725",
+            "FAKE_PARENT_STATE": "CLOSED",
+            "FAKE_SUBS_ALL": "1801 1802 1823",
+            "FAKE_SUBS_OPEN": "",
+        },
+    )
+    assert "is CLOSED; skipping" in stdout
+    assert close_log.strip() == ""


### PR DESCRIPTION
Closes #1823

Rescued from the interrupted sprint run that stranded #1823 after DONE/review approval and before durable PR integration. The rescued branch is replayed onto current `origin/release/v0.12`.

Verification:
- `pytest tests/test_close_epic_workflow.py`