### PR TITLE
Codify epic conventions

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -331,13 +331,14 @@ sequencing claims.
 
 Source: `project_checkconfig_sequence.md`
 
-### Epic representation was chosen under incomplete comparison
+### Epic representation was revisited and resolved
 
-The current epic convention (`Epic:` title prefix plus labeling and tracking
-headers) emerged without a strong comparison against GitHub-native sub-issues
-and relationships. If epic representation is revisited, compare the current
-convention directly against the platform-native alternative rather than assuming
-the original pushback still holds.
+The prior epic convention (`Epic:` title prefix with prose tracking headers,
+no native linkage) was compared against GitHub-native sub-issues and
+superseded. Epics now use native sub-issues to enumerate their slices, use
+bounded framing instead of "tracked here forever," and never carry a work
+milestone — see the Epic section in `docs/guides/authoring.md`. This note is
+retained only as a historical record of the earlier undecided state.
 
 Source: `project_epic_representation_origin.md`
 

--- a/docs/guides/authoring.md
+++ b/docs/guides/authoring.md
@@ -297,6 +297,46 @@ retry:
 
 ---
 
+## Epic
+
+### Purpose
+
+A roadmap container that groups a body of related work into a single
+trackable parent — never a sprintable unit itself. The sprint-entry
+validator refuses epics outright (`epic_or_tracking`); their job is to
+organize slices, not to run.
+
+### Required shape
+
+- **Title** — `Epic: <theme>`, or the `epic` label applied. Either marker is
+  sufficient to trip `epic_or_tracking`; use both for clarity.
+- **Slices via native GitHub sub-issues** — every runnable piece of the
+  epic's work is linked as a GitHub sub-issue, not just referenced by number
+  in prose. "The epic's issues" must be answerable by reading the sub-issue
+  list, not by re-reading the body for `#refs`.
+- **Bounded body** — the epic describes a finite scope that is done when its
+  sub-issues are done. Do not write "post-MVP enhancements tracked here" or
+  "tracking issue, add more as they come up" — framing that keeps the epic
+  open forever. Genuinely new work that surfaces later is a *new* issue
+  (optionally linked as a sub-issue if it belongs to the same scope), not an
+  addition to a container that never closes.
+- **No work milestone** — an epic is never assigned to a work milestone.
+  Milestones hold sprintable slices; an epic's slices carry the milestone
+  individually. Use a label or a project view to see epics by roadmap
+  horizon instead. If you find an epic on a work milestone, remove the
+  milestone — that is always the fix, never re-target it to a different
+  milestone.
+
+### What to leave out
+
+- A milestone field. If `forge groom` or manual editing sets one on an
+  epic, clear it.
+- Perpetual-tracker language ("tracked here forever," "future work goes
+  here"). If the epic's current slices are all closed, the epic is done —
+  close it, and file whatever comes next as its own issue.
+
+---
+
 ## Rollup
 
 ### Purpose
@@ -307,8 +347,8 @@ its own issue and the pieces share context.
 
 A rollup is **not** an epic. Epics are tracking-only and are blocked by the
 sprint-entry validator. If your work decomposes into independent stories that
-need their own review cycles, file them separately and link them in a
-milestone or label, not in a rollup.
+need their own review cycles, file them separately and link them as GitHub
+sub-issues of an epic, or share a milestone/label — not in a rollup.
 
 ### Required sections
 


### PR DESCRIPTION
Closes #1824

Rescued from the interrupted sprint run that stranded #1824 after DONE/review approval and before durable PR integration. The rescued branch is replayed onto current `origin/release/v0.12`.

Verification:
- Clean cherry-pick onto current `origin/release/v0.12`
- Docs-only change; attempted targeted pytest command found no matching tests