### PR TITLE
Parallel sprint re-exec can strand completed stories as active-worktree collisions

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -213,8 +213,26 @@ def cmd_sprint(args: object) -> int:
     slugs = parse_manifest_slugs(config, manifest_path)
     # ``reexec`` was captured at the top of cmd_sprint, before setup_detached_child
     # popped FORGE_PREV_RUN_ID — do not recompute it here (the env signal is gone).
+    # On the re-exec path, resolve the prior generation's recorded outcomes so the
+    # launch guard can distinguish an already-completed worktree from a fresh
+    # collision. Mirror the runner's sprint-name resolution (manifest ``name``).
+    prior_outcomes: dict[str, str] | None = None
+    if reexec:
+        try:
+            from theforge.sprint.manifest import load_sprint_manifest  # noqa: PLC0415
+
+            prior_outcomes = _resolve_prior_outcomes(
+                config, load_sprint_manifest(manifest_path).name
+            )
+        except Exception:
+            prior_outcomes = None
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
-        slugs=slugs, config=config, resume=resume, allow_drop=reexec, force=force
+        slugs=slugs,
+        config=config,
+        resume=resume,
+        allow_drop=reexec,
+        force=force,
+        prior_outcomes=prior_outcomes,
     )
     if launch_error is not None:
         return launch_error
@@ -310,6 +328,7 @@ def _acquire_launch_locks(
     *,
     allow_drop: bool = False,
     force: bool = False,
+    prior_outcomes: dict[str, str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     return acquire_launch_story_locks(
         slugs=slugs,
@@ -317,7 +336,35 @@ def _acquire_launch_locks(
         resume=resume,
         allow_drop=allow_drop,
         force=force,
+        prior_outcomes=prior_outcomes,
     )
+
+
+def _resolve_prior_outcomes(config: object, sprint_name: str) -> dict[str, str]:
+    """Best-effort map of slug -> prior-generation outcome for the re-exec guard.
+
+    Resolves the logical sprint id the same way the runner does (from the
+    manifest ``name``) and reads the prior generation's accumulated story
+    outcomes from ``.forge/sprints/<id>/state.yaml``. Returns an empty map on any
+    failure so a lookup miss degrades to today's collision behavior — this must
+    never fail the launch.
+    """
+    try:
+        from theforge.sprint.audit import (  # noqa: PLC0415
+            _get_or_create_sprint_id,
+            _load_accumulated_stories,
+        )
+
+        sprint_id = _get_or_create_sprint_id(sprint_name, config.project_root)
+        outcomes: dict[str, str] = {}
+        for story in _load_accumulated_stories(sprint_id, config.project_root):
+            slug = story.get("slug")
+            if not slug:
+                continue
+            outcomes[slug] = str(story.get("outcome") or "").upper()
+        return outcomes
+    except Exception:
+        return {}
 
 
 def _resolve_base_branch_sha(config: object) -> str | None:
@@ -1005,8 +1052,18 @@ def _run_query_mode(
     # ``reexec`` is threaded in from cmd_sprint (captured before the detach
     # handoff popped FORGE_PREV_RUN_ID) — do not recompute it here.
     slugs = [task.slug for task, _src, _ref in resolved.stories]
+    # On the re-exec path, resolve the prior generation's recorded outcomes so
+    # the launch guard can reconcile already-completed worktrees instead of
+    # flattening them into fresh collisions. Best-effort — a miss degrades to
+    # today's behavior.
+    prior_outcomes = _resolve_prior_outcomes(config, resolved.name) if reexec else None
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
-        slugs=slugs, config=config, resume=resume, allow_drop=reexec, force=force
+        slugs=slugs,
+        config=config,
+        resume=resume,
+        allow_drop=reexec,
+        force=force,
+        prior_outcomes=prior_outcomes,
     )
     if launch_error is not None:
         return launch_error

--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -59,6 +59,12 @@ from theforge.sprint.status_reader import (
 # dependency-blocked skips, and launch-guard collisions. These route to the
 # SKIPPED / INTAKE section rather than getting their own FAILED heading, because
 # the operator's recovery action is reshaping/scheduling, not failure triage.
+#
+# ``sprint_state_stranded`` is deliberately NOT in this set: a worktree stranded
+# by a prior generation is a recoverable failure whose recovery is
+# resume/reconcile (not reshaping/scheduling), so it must render under its own
+# FAILED heading via ``_print_failed_by_class`` — the generic recovery path for
+# any primary class not routed to SKIPPED / INTAKE.
 _SKIPPED_INTAKE_CLASSES = frozenset(
     {
         "intake_shape",

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -11,6 +11,7 @@ import yaml
 from ..advisory_conventions import noteworthy_advisory_entries
 from ..coordinator.landing_record import build_landing_record
 from ..log_util import _log_line
+from .launch_guard import REASON_RECONCILE_PRIOR_DONE, REASON_STRANDED_WORKTREE
 from .manifest import ResolvedSprint, SprintManifest, SprintResult
 
 
@@ -511,6 +512,10 @@ def _write_sprint_audit(
             triage_action = triage_actions_by_ref.get(canonical_ref)
             if drop_reason == "preserved-escalated":
                 drop_outcome = "PRESERVED"
+            elif drop_reason == REASON_RECONCILE_PRIOR_DONE:
+                drop_outcome = "ALREADY_DONE"
+            elif drop_reason == REASON_STRANDED_WORKTREE:
+                drop_outcome = "DROPPED"
             elif drop_reason is not None:
                 drop_outcome = "DROPPED"
             elif triage_action == "skip_merged":
@@ -836,6 +841,10 @@ def _write_sprint_summary(
             triage_action = triage_actions_by_ref.get(canonical_ref)
             if drop_reason == "preserved-escalated":
                 drop_outcome = "PRESERVED"
+            elif drop_reason == REASON_RECONCILE_PRIOR_DONE:
+                drop_outcome = "ALREADY_DONE"
+            elif drop_reason == REASON_STRANDED_WORKTREE:
+                drop_outcome = "DROPPED"
             elif drop_reason is not None:
                 drop_outcome = "DROPPED"
             elif triage_action == "skip_merged":

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -23,6 +23,19 @@ from theforge.sprint.preflight import (
 REASON_PRESERVED_ESCALATED = "preserved-escalated"
 REASON_ACTIVE_WORKTREE = "active-worktree-collision"
 REASON_LOCK_HELD = "story-lock-held-by-other-process"
+# Re-exec drop reasons that distinguish a prior-generation worktree from a
+# genuine fresh collision. When a parallel sprint re-execs, a worktree left on
+# disk may correspond to a story the *prior generation* already finished (DONE)
+# or left partially complete (stranded). Classifying those against the prior
+# generation's recorded outcomes prevents a completed story from being reported
+# as a fresh ``active-worktree-collision`` and re-consumed.
+REASON_RECONCILE_PRIOR_DONE = "reconciled-prior-generation-done"
+REASON_STRANDED_WORKTREE = "stranded-prior-generation-worktree"
+
+# Prior-generation outcome strings (upper-cased) that mean the story succeeded
+# and its worktree should be reconciled/preserved rather than treated as a fresh
+# collision.
+_PRIOR_SUCCEEDED_OUTCOMES = frozenset({"DONE", "ALREADY_DONE"})
 
 
 def acquire_launch_story_locks(
@@ -32,6 +45,7 @@ def acquire_launch_story_locks(
     resume: bool,
     allow_drop: bool = False,
     force: bool = False,
+    prior_outcomes: dict[str, str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     """Acquire launch-time story locks after checking for active worktrees.
 
@@ -121,23 +135,60 @@ def acquire_launch_story_locks(
         return locked_fds, None, dropped
 
     # ── Re-exec path: convert every collision into a per-story drop ─────
+    #
+    # A worktree with commits ahead of base is not necessarily a fresh
+    # collision after a re-exec: the *prior generation* may have already
+    # finished this story (DONE) or left it partially complete (stranded).
+    # Classify each active worktree against the prior generation's recorded
+    # outcomes (``prior_outcomes``, slug -> upper-cased outcome) so a completed
+    # story is reconciled instead of being flattened into a launch collision.
+    prior_outcomes = prior_outcomes or {}
     active_worktrees = check_active_worktrees(
         schedulable,
         config.workspace.path_pattern,
         config.workspace.base_branch,
         config.project_root,
     )
+    reconciled_slugs: list[str] = []
+    stranded_slugs: list[str] = []
+    collision_slugs: list[str] = []
     for slug in active_worktrees:
-        dropped[slug] = REASON_ACTIVE_WORKTREE
+        prior_outcome = prior_outcomes.get(slug)
+        if prior_outcome in _PRIOR_SUCCEEDED_OUTCOMES:
+            dropped[slug] = REASON_RECONCILE_PRIOR_DONE
+            reconciled_slugs.append(slug)
+        elif prior_outcome:
+            # A prior-generation record exists but the story did not succeed —
+            # recoverable stranded sprint state, not a fresh collision.
+            dropped[slug] = REASON_STRANDED_WORKTREE
+            stranded_slugs.append(slug)
+        else:
+            dropped[slug] = REASON_ACTIVE_WORKTREE
+            collision_slugs.append(slug)
     remaining = [s for s in schedulable if s not in dropped]
-    if active_worktrees:
+    if reconciled_slugs:
         print(
-            f"[forge] DROPPED {', '.join(active_worktrees)}: active worktree "
+            f"[forge] RECONCILED {', '.join(reconciled_slugs)}: prior generation "
+            "already completed these stories; preserving their outcome instead of "
+            "re-running.",
+            file=sys.stderr,
+            flush=True,
+        )
+    if stranded_slugs:
+        print(
+            f"[forge] STRANDED {', '.join(stranded_slugs)}: prior generation left "
+            "unfinished sprint state; reporting as recoverable stranded work.",
+            file=sys.stderr,
+            flush=True,
+        )
+    if collision_slugs:
+        print(
+            f"[forge] DROPPED {', '.join(collision_slugs)}: active worktree "
             "collision after re-exec; continuing with remaining stories.",
             file=sys.stderr,
             flush=True,
         )
-        abort_for_active_worktrees(active_worktrees)
+        abort_for_active_worktrees(collision_slugs)
 
     # Acquire locks for everything that survived worktree checks.  On a lock
     # conflict, acquire_story_locks releases the partial set it was holding —

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -51,6 +51,14 @@ DONE_OUTCOMES = frozenset({"DONE", "ALREADY_DONE"})
 # Residual class assigned when no mechanical primary rule matches a story.
 UNKNOWN_CLASS = "unknown_needs_rca"
 
+# Drop reason string a re-exec launch guard records for a worktree that belongs
+# to a prior generation's *unfinished* story (stranded sprint state) rather than
+# a genuine fresh collision. Matched as a literal here — the engine is a pure
+# function over on-disk artifacts and deliberately avoids importing the
+# collision/launch-guard modules (which pull in subprocess/lock machinery). Keep
+# this in sync with ``launch_guard.REASON_STRANDED_WORKTREE``.
+_STRANDED_WORKTREE_REASON = "stranded-prior-generation-worktree"
+
 _EXCERPT_MAX_LEN = 240
 # Cap per-file text reads so a runaway log cannot blow up classification.
 _MAX_FILE_BYTES = 512 * 1024
@@ -196,6 +204,15 @@ RULES: tuple[RcaRule, ...] = (
         description="Deliverable is a human action no dev agent can perform.",
     ),
     RcaRule(
+        rule_id="sprint_state_stranded",
+        failure_class="sprint_state_stranded",
+        role="primary",
+        description=(
+            "Worktree belongs to a prior generation's unfinished story — "
+            "recoverable stranded sprint state, not a fresh launch collision."
+        ),
+    ),
+    RcaRule(
         rule_id="launch_guard_dropped",
         failure_class="launch_collision",
         role="primary",
@@ -261,6 +278,7 @@ _PRIMARY_PRIORITY: tuple[str, ...] = (
     "merge_arming_failed",
     "review_rejected",
     "operator_action",
+    "sprint_state_stranded",
     "launch_collision",
     "dependency_skip",
     "iteration_exhaustion",
@@ -675,8 +693,19 @@ def _signal_rule_hits(
         hits.append(("merge_arming_failed", summary_source, _outcome_excerpt()))
     if outcome == "OPERATOR_ACTION":
         hits.append(("operator_action_required", summary_source, _outcome_excerpt()))
-    if outcome in {"DROPPED", "PRESERVED"} or _nonempty(story.get("drop_reason")):
-        drop = _nonempty(story.get("drop_reason")) or error or "launch-guard drop"
+    drop_reason = _nonempty(story.get("drop_reason"))
+    if drop_reason == _STRANDED_WORKTREE_REASON:
+        # A prior-generation worktree left unfinished sprint state — a distinct,
+        # recoverable class that must not be flattened into a fresh collision.
+        hits.append(
+            (
+                "sprint_state_stranded",
+                summary_source,
+                _truncate(f"outcome={outcome}; stranded prior-generation sprint state"),
+            )
+        )
+    elif outcome in {"DROPPED", "PRESERVED"} or drop_reason:
+        drop = drop_reason or error or "launch-guard drop"
         hits.append(
             ("launch_guard_dropped", summary_source, _truncate(f"outcome={outcome}; {drop}"))
         )
@@ -800,6 +829,11 @@ def _recommend_actions(primary: str, contributing: list[str], story: dict) -> li
         ),
         "operator_action": f"perform the operator action described in {ref} (no dev agent can)",
         "launch_collision": (f"clear the active worktree/lock blocking {ref}, then re-sprint it"),
+        "sprint_state_stranded": (
+            f"re-resume/reconcile the sprint so {ref}'s prior-generation state is "
+            "recovered — do NOT clear the worktree and re-sprint fresh, which would "
+            "discard partial work"
+        ),
         "dependency_skip": _dependency_action(story, ref),
         "iteration_exhaustion": (
             f"raise the iteration budget for {ref} or narrow its scope, then re-run"

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2318,8 +2318,12 @@ def run_sprint(
             # The prior generation already completed this story; its worktree
             # collision is a reconcilable success, not a fresh drop. Mark it
             # ALREADY_DONE so it counts as succeeded and is preserved durably.
+            # Use mark_complete (not mark_skipped) so it satisfies the hard
+            # dependencies of any current story that depends_on this slug —
+            # a reconciled prior-DONE is a met dependency, exactly like a
+            # resume skip_merged, so dependents must not be stranded/skipped.
             _log(f"ALREADY_DONE {slug} (reconciled from prior generation)")
-            dag.mark_skipped(slug)
+            dag.mark_complete(slug)
             _set_outcome(slug, StoryOutcome.ALREADY_DONE, reason=reason)
             _record_current_story_entry(
                 slug,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -67,6 +67,10 @@ from .dag import (
 )
 from .display import _print_worker_status, _story_header
 from .gate_timeout_resolver import resolve_effective_gate_timeout
+from .launch_guard import (
+    REASON_RECONCILE_PRIOR_DONE,
+    REASON_STRANDED_WORKTREE,
+)
 from .lock import integration_lock
 from .manifest import (
     ResolvedSprint,
@@ -2044,7 +2048,15 @@ def run_sprint(
     # the batch preflight, where a re-exec'd merged story would be re-dispatched
     # into its stale round-1 worktree. When ``reconcile`` is False, skip_slugs is
     # empty and this is a no-op (no behavior change for plain fresh runs).
-    dispatch_tasks = [t for t in normalized.tasks if t.slug not in skip_slugs]
+    #
+    # Pre-launch drops (re-exec worktree collisions, reconciled prior-generation
+    # completions, stranded prior-generation state, preserved-escalated, lock
+    # conflicts) are handled by the dropped-slug loop further below and must
+    # never consume preflight or worker budget in this generation. Exclude them
+    # from every spend/dispatch path here alongside reconcile-skipped stories.
+    _dropped_exclusion = {s for s in (dropped_slugs or {}) if s in slug_to_context}
+    _no_dispatch_slugs = skip_slugs | _dropped_exclusion
+    dispatch_tasks = [t for t in normalized.tasks if t.slug not in _no_dispatch_slugs]
 
     intake_outcomes = _run_intake_remediation_pass(
         config=config,
@@ -2165,9 +2177,12 @@ def run_sprint(
         _update_state_phase(run_id, config.project_root, "preflight")
 
     # Re-derive the filter here: ``normalized`` may have been re-bound by the
-    # intake drop above, and reconcile-skipped merged stories must never enter
-    # the preflight batch (WORKSPACE re-entry against their stale worktree).
-    preflight_tasks = [t for t in normalized.tasks if t.slug not in skip_slugs]
+    # intake drop above, and reconcile-skipped merged stories (plus pre-launch
+    # dropped stories) must never enter the preflight batch (WORKSPACE re-entry
+    # against their stale worktree, or spending budget on an already-dropped
+    # story).
+    _no_dispatch_slugs = skip_slugs | {s for s in (dropped_slugs or {}) if s in slug_to_context}
+    preflight_tasks = [t for t in normalized.tasks if t.slug not in _no_dispatch_slugs]
     preflight_states = run_batch_preflight(
         preflight_tasks,
         config,
@@ -2299,6 +2314,36 @@ def run_sprint(
             dag.mark_skipped(slug)
             _set_outcome(slug, StoryOutcome.PRESERVED, reason=reason)
             _record_current_story_entry(slug, "PRESERVED", error=reason, error_type="dropped")
+        elif reason == REASON_RECONCILE_PRIOR_DONE:
+            # The prior generation already completed this story; its worktree
+            # collision is a reconcilable success, not a fresh drop. Mark it
+            # ALREADY_DONE so it counts as succeeded and is preserved durably.
+            _log(f"ALREADY_DONE {slug} (reconciled from prior generation)")
+            dag.mark_skipped(slug)
+            _set_outcome(slug, StoryOutcome.ALREADY_DONE, reason=reason)
+            _record_current_story_entry(
+                slug,
+                "ALREADY_DONE",
+                extras={
+                    "drop_reason": reason,
+                    "outcome_source": "reexec_reconcile",
+                },
+            )
+        elif reason == REASON_STRANDED_WORKTREE:
+            # A prior-generation worktree exists but the story did not succeed:
+            # recoverable stranded sprint state. Keep it DROPPED but retain the
+            # distinct reason so RCA/audit can tell it apart from a fresh
+            # collision (do NOT clear the worktree and re-sprint fresh).
+            _log(f"DROPPED {slug} (stranded prior-generation sprint state)")
+            dag.mark_skipped(slug)
+            _set_outcome(slug, StoryOutcome.DROPPED, reason=reason)
+            _record_current_story_entry(
+                slug,
+                "DROPPED",
+                error=reason,
+                error_type="dropped",
+                extras={"drop_reason": reason},
+            )
         else:
             _log(f"DROPPED {slug} (reason: {reason})")
             dag.mark_skipped(slug)
@@ -2406,6 +2451,21 @@ def run_sprint(
                 _status = "preserved"
                 _blocked_by = [f"preserved: {_drop_reason}"]
                 _detail = {"final_outcome": "ESCALATE"}
+            elif _drop_reason == REASON_RECONCILE_PRIOR_DONE:
+                # Prior generation already completed this story — surface it as
+                # done, reconciled, not a fresh drop.
+                _status = "done"
+                _blocked_by = []
+                _detail = {
+                    "final_outcome": "ALREADY_DONE",
+                    "outcome_source": "reexec_reconcile",
+                }
+            elif _drop_reason == REASON_STRANDED_WORKTREE:
+                # Recoverable stranded prior-generation sprint state — name it
+                # distinctly rather than as a generic drop.
+                _status = "failed"
+                _blocked_by = [f"stranded prior-generation sprint state: {_drop_reason}"]
+                _detail = {"final_outcome": "DROPPED", "drop_reason": _drop_reason}
             elif _drop_reason:
                 _status = "failed"
                 _blocked_by = [f"dropped: {_drop_reason}"]

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -569,6 +569,36 @@ def test_launch_collision_signal(tmp_path: Path) -> None:
     assert any("worktree" in a or "lock" in a for a in entry["recommended_next_actions"])
 
 
+def test_stranded_prior_generation_worktree_is_distinct_from_launch_collision(
+    tmp_path: Path,
+) -> None:
+    """Issue #1838: a worktree stranded by a prior generation classifies as
+    ``sprint_state_stranded`` (priority over ``launch_collision``) with a
+    reconcile-oriented action — not flattened into a fresh collision."""
+    from theforge.sprint.launch_guard import REASON_STRANDED_WORKTREE
+
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-1823",
+                    "outcome": "DROPPED",
+                    "drop_reason": REASON_STRANDED_WORKTREE,
+                }
+            ]
+        ),
+    )
+    entry = _build(d)["stories"]["issue-1823"]
+    assert entry["primary_failure_class"] == "sprint_state_stranded"
+    actions = " ".join(entry["recommended_next_actions"]).lower()
+    assert "reconcile" in actions or "resume" in actions
+    # The reconcile action must warn against clearing the worktree and
+    # re-sprinting fresh (which would discard partial work).
+    assert "do not" in actions or "not clear" in actions or "discard" in actions
+
+
 # ── Rule set discoverability ──────────────────────────────────────────────────
 
 

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -272,6 +272,89 @@ class TestGenuineCollisionDuringReexec:
         assert dropped == {}
 
 
+class TestReexecPriorOutcomeClassification:
+    """Issue #1838: an active worktree after re-exec is classified against the
+    prior generation's recorded outcomes — a 3-way split so a completed story is
+    reconciled, an unfinished prior story is reported as stranded, and only a
+    worktree with no prior record remains a genuine fresh collision."""
+
+    def _drop_for(
+        self, tmp_path: Path, capsys, prior_outcomes: dict[str, str]
+    ) -> tuple[dict[str, str], str]:
+        _make_worktree_with_audit(tmp_path, "issue-829", final_phase=None)
+        config = _mock_config(tmp_path)
+        completed = MagicMock(returncode=0, stdout="3\n")
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829", "issue-267"],
+                config=config,
+                resume=False,
+                allow_drop=True,
+                prior_outcomes=prior_outcomes,
+            )
+        from theforge.sprint.lock import release_story_locks
+
+        release_story_locks(locked_fds)
+        assert launch_error is None
+        return dropped, capsys.readouterr().err
+
+    def test_prior_done_worktree_is_reconciled_not_collision(self, tmp_path, capsys) -> None:
+        from theforge.sprint.launch_guard import (
+            REASON_ACTIVE_WORKTREE,
+            REASON_RECONCILE_PRIOR_DONE,
+        )
+
+        dropped, err = self._drop_for(tmp_path, capsys, {"issue-829": "DONE"})
+        assert dropped["issue-829"] == REASON_RECONCILE_PRIOR_DONE
+        assert dropped["issue-829"] != REASON_ACTIVE_WORKTREE
+        assert "issue-267" not in dropped
+        assert "RECONCILED" in err
+
+    def test_prior_already_done_worktree_is_reconciled(self, tmp_path, capsys) -> None:
+        from theforge.sprint.launch_guard import REASON_RECONCILE_PRIOR_DONE
+
+        dropped, _err = self._drop_for(tmp_path, capsys, {"issue-829": "ALREADY_DONE"})
+        assert dropped["issue-829"] == REASON_RECONCILE_PRIOR_DONE
+
+    def test_prior_unfinished_worktree_is_stranded(self, tmp_path, capsys) -> None:
+        from theforge.sprint.launch_guard import (
+            REASON_ACTIVE_WORKTREE,
+            REASON_STRANDED_WORKTREE,
+        )
+
+        dropped, err = self._drop_for(tmp_path, capsys, {"issue-829": "FAILED"})
+        assert dropped["issue-829"] == REASON_STRANDED_WORKTREE
+        assert dropped["issue-829"] != REASON_ACTIVE_WORKTREE
+        assert "STRANDED" in err
+
+    def test_no_prior_record_is_unchanged_active_collision(self, tmp_path, capsys) -> None:
+        from theforge.sprint.launch_guard import REASON_ACTIVE_WORKTREE
+
+        dropped, err = self._drop_for(tmp_path, capsys, {})
+        assert dropped["issue-829"] == REASON_ACTIVE_WORKTREE
+        assert "DROPPED" in err
+
+    def test_prior_outcomes_none_degrades_to_active_collision(self, tmp_path) -> None:
+        """Passing no prior_outcomes (today's default) keeps the collision path."""
+        _make_worktree_with_audit(tmp_path, "issue-829", final_phase=None)
+        config = _mock_config(tmp_path)
+        completed = MagicMock(returncode=0, stdout="3\n")
+        from theforge.sprint.launch_guard import REASON_ACTIVE_WORKTREE
+
+        with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829"],
+                config=config,
+                resume=False,
+                allow_drop=True,
+            )
+        from theforge.sprint.lock import release_story_locks
+
+        release_story_locks(locked_fds)
+        assert launch_error is None
+        assert dropped == {"issue-829": REASON_ACTIVE_WORKTREE}
+
+
 class TestAuditVisibilityForDroppedStories:
     def test_sprint_audit_records_dropped_and_preserved(self, tmp_path: Path) -> None:
         """_write_sprint_audit emits distinct DROPPED / PRESERVED outcomes with reasons."""

--- a/tests/test_sprint_reexec_reconcile.py
+++ b/tests/test_sprint_reexec_reconcile.py
@@ -189,6 +189,142 @@ def test_reexec_excludes_merged_story_from_preflight_and_dag_dispatch(
     assert result.total_cost_usd == pytest.approx(1.33)
 
 
+def test_reexec_reconcile_prior_done_drop_ends_succeeded_and_preserves_cost(
+    tmp_path: Path,
+) -> None:
+    """Issue #1838: a re-exec drop tagged ``reconciled-prior-generation-done``
+    (as the CLI passes when a worktree matches a prior-generation DONE story)
+    must end succeeded (ALREADY_DONE), be excluded from preflight + dispatch, and
+    carry the prior generation's cost — never re-run as a fresh collision."""
+    from theforge.sprint.launch_guard import REASON_RECONCILE_PRIOR_DONE
+
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+    config = _make_config(tmp_path)
+
+    sprint_id = _set_sprint_id(tmp_path)
+    _write_prior_sprint_audit(tmp_path, sprint_id, 0.33)
+    persist_accumulated_story_state(
+        sprint_id,
+        "Test Sprint",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "feature-a.md",
+                "slug": "feature-a",
+                "path": "feature-a.md",
+                "outcome": "DONE",
+                "cost_usd": 0.33,
+                "story_run_id": "run-prev",
+                "depends_on": [],
+            }
+        ],
+    )
+
+    def triage_side_effect(spec_path, config, project_root, *, task=None):
+        return StoryTriage(
+            story_path=spec_path,
+            action="full",
+            reason="x",
+            worktree_path=None,
+            slug=Path(spec_path).stem,
+        )
+
+    fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight", return_value={}
+        ) as mock_batch_preflight,
+        patch("theforge.sprint.runner.run_task", return_value=fresh_result) as mock_run_task,
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        result = run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            dropped_slugs={"feature-a": REASON_RECONCILE_PRIOR_DONE},
+        )
+
+    # (a) The reconciled story is excluded from preflight and dispatch.
+    preflight_slugs = [t.slug for t in mock_batch_preflight.call_args.args[0]]
+    assert "feature-a" not in preflight_slugs
+    dispatched_slugs = [c.args[1].slug for c in mock_run_task.call_args_list]
+    assert "feature-a" not in dispatched_slugs
+    assert dispatched_slugs == ["feature-b"]
+
+    # (b) It ends succeeded (ALREADY_DONE) and carries the prior cost.
+    assert result.specs_succeeded == 2
+    assert result.specs_failed == 0
+    assert result.total_cost_usd == pytest.approx(1.33)
+
+    # (c) The summary records it as ALREADY_DONE via the reconcile source.
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
+    )
+    by_slug = {s["slug"]: s for s in summary["stories"]}
+    assert by_slug["feature-a"]["outcome"] == "ALREADY_DONE"
+
+
+def test_reexec_stranded_drop_does_not_rerun_and_keeps_distinct_reason(
+    tmp_path: Path,
+) -> None:
+    """Issue #1838: a re-exec drop tagged ``stranded-prior-generation-worktree``
+    is a recoverable DROPPED (not re-run), and the distinct reason is retained on
+    the summary entry so RCA/audit can tell it apart from a fresh collision."""
+    from theforge.sprint.launch_guard import REASON_STRANDED_WORKTREE
+
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+    config = _make_config(tmp_path)
+    _set_sprint_id(tmp_path)
+
+    def triage_side_effect(spec_path, config, project_root, *, task=None):
+        return StoryTriage(
+            story_path=spec_path,
+            action="full",
+            reason="x",
+            worktree_path=None,
+            slug=Path(spec_path).stem,
+        )
+
+    fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight", return_value={}
+        ) as mock_batch_preflight,
+        patch("theforge.sprint.runner.run_task", return_value=fresh_result) as mock_run_task,
+    ):
+        result = run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            dropped_slugs={"feature-a": REASON_STRANDED_WORKTREE},
+        )
+
+    # Stranded story never re-runs and never consumes preflight budget.
+    preflight_slugs = [t.slug for t in mock_batch_preflight.call_args.args[0]]
+    assert "feature-a" not in preflight_slugs
+    dispatched_slugs = [c.args[1].slug for c in mock_run_task.call_args_list]
+    assert "feature-a" not in dispatched_slugs
+
+    # It is DROPPED (recoverable failure), distinct from the reconciled success.
+    assert result.specs_failed == 1
+    assert result.specs_succeeded == 1
+
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
+    )
+    by_slug = {s["slug"]: s for s in summary["stories"]}
+    assert by_slug["feature-a"]["outcome"] == "DROPPED"
+    assert by_slug["feature-a"]["drop_reason"] == REASON_STRANDED_WORKTREE
+
+
 def test_reexec_without_prev_run_id_does_not_reconcile(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_sprint_reexec_reconcile.py
+++ b/tests/test_sprint_reexec_reconcile.py
@@ -54,10 +54,13 @@ def _make_config(tmp_path: Path) -> ForgeConfig:
     )
 
 
-def _make_spec_file(tmp_path: Path, name: str, slug: str) -> Path:
+def _make_spec_file(
+    tmp_path: Path, name: str, slug: str, depends_on: list[str] | None = None
+) -> Path:
     spec = tmp_path / f"{slug}.md"
+    deps_line = f"depends_on: {depends_on}\n" if depends_on else ""
     spec.write_text(
-        f"---\nname: {name}\nslug: {slug}\n---\n# {name}\nDo the thing.",
+        f"---\nname: {name}\nslug: {slug}\n{deps_line}---\n# {name}\nDo the thing.",
         encoding="utf-8",
     )
     return spec
@@ -266,6 +269,73 @@ def test_reexec_reconcile_prior_done_drop_ends_succeeded_and_preserves_cost(
     )
     by_slug = {s["slug"]: s for s in summary["stories"]}
     assert by_slug["feature-a"]["outcome"] == "ALREADY_DONE"
+
+
+def test_reexec_reconcile_prior_done_satisfies_dependent_story(
+    tmp_path: Path,
+) -> None:
+    """Issue #1838 (iter 1): a story that hard-depends on a reconciled
+    prior-DONE slug must still run — the reconciled slug is a *met* dependency
+    (marked complete in the DAG), not a skip that strands its dependents."""
+    from theforge.sprint.launch_guard import REASON_RECONCILE_PRIOR_DONE
+
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b", depends_on=["feature-a"])
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+    config = _make_config(tmp_path)
+
+    sprint_id = _set_sprint_id(tmp_path)
+    _write_prior_sprint_audit(tmp_path, sprint_id, 0.33)
+    persist_accumulated_story_state(
+        sprint_id,
+        "Test Sprint",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "feature-a.md",
+                "slug": "feature-a",
+                "path": "feature-a.md",
+                "outcome": "DONE",
+                "cost_usd": 0.33,
+                "story_run_id": "run-prev",
+                "depends_on": [],
+            }
+        ],
+    )
+
+    def triage_side_effect(spec_path, config, project_root, *, task=None):
+        return StoryTriage(
+            story_path=spec_path,
+            action="full",
+            reason="x",
+            worktree_path=None,
+            slug=Path(spec_path).stem,
+        )
+
+    fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=fresh_result) as mock_run_task,
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        result = run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            dropped_slugs={"feature-a": REASON_RECONCILE_PRIOR_DONE},
+        )
+
+    # The dependent story ran (was NOT stranded/skipped as dependency-blocked)
+    # because feature-a reconciled as a met dependency.
+    dispatched_slugs = [c.args[1].slug for c in mock_run_task.call_args_list]
+    assert dispatched_slugs == ["feature-b"]
+
+    # Both stories succeed: feature-a ALREADY_DONE, feature-b freshly done.
+    assert result.specs_succeeded == 2
+    assert result.specs_failed == 0
+    assert result.specs_skipped == 0
 
 
 def test_reexec_stranded_drop_does_not_rerun_and_keeps_distinct_reason(


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Cycle 1 dependency regression is fixed; reconciled prior-DONE stories now satisfy hard dependencies, and I found no blocking regressions in the touched files. | [google-gemini-3.5-flash] The implementation successfully resolves the prior P1 finding by using dag.mark_complete for reconciled prior-DONE stories, ensuring dependent stories are not stranded.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** openai-gpt-5.4-mini, openai-gpt-5.4, google-gemini-3.5-flash, claude-opus, openai-gpt-5.5
- **Cost:** $12.92
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Parallel sprint re-exec can strand completed stories as active-worktree collisions (GitHub Issue #1838)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1838