### PR TITLE
Assignment summary view — operator-facing render of the routing_decision block

### DIFF
--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -1,0 +1,350 @@
+"""forge explain subcommand — operator-facing render of routing_decision (#270).
+
+Reads the top-level ``routing_decision`` block that the router records for each
+run (#1391, ADR-0006 clause 7) and renders one coherent per-role assignment
+summary: selected agent, excluded candidates with canonical reasons, the profile
+signals the router weighed, adaptive-mechanism outcomes (distinguishing
+not-checked / checked-did-not-fire / checked-and-fired), exploration state, and
+the final rationale.
+
+This is a read-only convenience over the recorded block — it invokes no agents,
+re-reads no profiles, and never writes. The block is the contract; this view is
+one presentation of it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from theforge.cli.shared import _find_config
+from theforge.coordinator import audit_substrate
+
+# Roles rendered in routing order (preflight → planner → dev → reviewers).
+_ROLE_ORDER = ("preflight", "planner", "dev", "plan_review", "code_review")
+_ROLE_LABELS = {
+    "preflight": "PREFLIGHT",
+    "planner": "PLANNER",
+    "dev": "DEV",
+    "plan_review": "PLAN REVIEW",
+    "code_review": "CODE REVIEW",
+}
+
+# Human-readable expansion for the canonical exclusion-reason codes so the
+# excluded-candidate line answers "why was model X never a reviewer" directly.
+_REASON_TEXT = {
+    "none": "included",
+    "auth_missing": "excluded — provider credentials missing",
+    "transport_unavailable": "excluded — transport unavailable",
+    "tier_mismatch": "excluded — tier does not match role floor",
+    "anti_self_review": "excluded — anti-self-review (same model as the code under review)",
+    "phase_eligibility": "excluded — not eligible for this phase",
+    "explicit_override_locked": "preserved — locked by explicit forge.yaml override",
+}
+
+# Adaptive-mechanism tri-state glyphs (AC: absence of a mechanism must not be
+# confused with a failed condition).
+_STATE_NOT_CHECKED = ("○", "not checked")
+_STATE_DID_NOT_FIRE = ("◐", "checked, did not fire")
+_STATE_FIRED = ("●", "fired")
+
+
+def _reason_text(reason: str | None, detail: str | None = None) -> str:
+    base = _REASON_TEXT.get(reason or "", f"excluded — {reason}" if reason else "excluded")
+    if detail:
+        return f"{base} ({detail})"
+    return base
+
+
+def _mechanism_state(*, checked: bool, fired: bool) -> tuple[str, str]:
+    """Classify an adaptive mechanism into the tri-state render label."""
+    if not checked:
+        return _STATE_NOT_CHECKED
+    if fired:
+        return _STATE_FIRED
+    return _STATE_DID_NOT_FIRE
+
+
+def _fmt_signal(signal: dict) -> str:
+    """Render a consulted profile signal with raw + weighted + floor status."""
+    raw = signal.get("raw")
+    weighted = signal.get("weighted")
+    runs = signal.get("runs")
+    floor = signal.get("floor")
+    raw_s = f"{raw:.4f}" if isinstance(raw, (int, float)) else "—"
+    weighted_s = f"{weighted:.4f}" if isinstance(weighted, (int, float)) else "—"
+    floor_s = {"pass": "sample-floor pass", "fail": "sample-floor fail"}.get(
+        floor or "", f"sample-floor {floor or '?'}"
+    )
+    runs_s = runs if runs is not None else "?"
+    return f"raw={raw_s} weighted={weighted_s} runs={runs_s} ({floor_s})"
+
+
+def _render_candidate_pool(pool: list[dict], lines: list[str]) -> None:
+    for entry in pool or []:
+        name = entry.get("name", "?")
+        tier = entry.get("tier")
+        included = bool(entry.get("included"))
+        reason = entry.get("reason")
+        detail = entry.get("detail")
+        glyph = "✓" if included else "✗"
+        tier_s = f" [{tier}]" if tier else ""
+        lines.append(f"    {glyph} {name}{tier_s} — {_reason_text(reason, detail)}")
+        signals = entry.get("signals") or {}
+        success_rate = signals.get("success_rate")
+        if isinstance(success_rate, dict):
+            lines.append(f"        success_rate: {_fmt_signal(success_rate)}")
+
+
+def _render_mechanism(label: str, state: tuple[str, str], detail: str, lines: list[str]) -> None:
+    glyph, state_text = state
+    suffix = f" — {detail}" if detail else ""
+    lines.append(f"    {glyph} {label}: {state_text}{suffix}")
+
+
+def _render_dev_mechanisms(role_block: dict, lines: list[str]) -> None:
+    promo = role_block.get("promotion_check") or {}
+    # outcome == "not_checked" is the sentinel for a mechanism that never ran.
+    promo_checked = promo.get("outcome") != "not_checked"
+    promo_fired = bool(promo.get("fired"))
+    detail = (
+        f"{promo.get('outcome', '?')} "
+        f"({promo.get('escalations', 0)}/{promo.get('matching_records', 0)} matching escalations)"
+        if promo_checked
+        else "no promotion signal recorded"
+    )
+    _render_mechanism(
+        "promotion", _mechanism_state(checked=promo_checked, fired=promo_fired), detail, lines
+    )
+
+    demo = role_block.get("demotion_check") or {}
+    # applicable=False → no such mechanism exists in v1 (a complete explanation,
+    # not a gap). Otherwise the recorded fired flag drives the state.
+    demo_applicable = bool(demo.get("applicable", True))
+    _render_mechanism(
+        f"demotion ({demo.get('mechanism', '?')})",
+        _mechanism_state(checked=demo_applicable, fired=bool(demo.get("fired"))),
+        demo.get("reason", ""),
+        lines,
+    )
+
+    checkpoint = role_block.get("post_plan_checkpoint") or {}
+    applied = bool(checkpoint.get("applied"))
+    _render_mechanism(
+        "post-plan checkpoint",
+        _mechanism_state(checked=applied, fired=applied),
+        checkpoint.get("reason", ""),
+        lines,
+    )
+
+
+def _render_reviewer_mechanisms(role_block: dict, lines: list[str]) -> None:
+    demo = role_block.get("demotion_check") or {}
+    reason = demo.get("reason", "")
+    # A reviewer demotion is "not checked" only when there were no unhealthy
+    # candidates to weigh; otherwise it was checked and either fired or not.
+    checked = reason != "no_unhealthy_candidates"
+    detail = reason
+    depri = demo.get("deprioritized") or []
+    if depri:
+        detail = f"{reason} — deprioritized: {', '.join(depri)}"
+    _render_mechanism(
+        f"demotion ({demo.get('mechanism', '?')})",
+        _mechanism_state(checked=checked, fired=bool(demo.get("fired"))),
+        detail,
+        lines,
+    )
+
+
+def _render_final(role_block: dict, lines: list[str]) -> None:
+    final = role_block.get("final") or {}
+    if "models" in final:
+        models = final.get("models") or []
+        selected = ", ".join(models) if models else "(none)"
+    else:
+        model = final.get("model")
+        tier = final.get("tier")
+        selected = f"{model} [{tier}]" if tier else str(model)
+    lines.append(f"    selected: {selected}")
+    rationale = (final.get("rationale") or "").strip()
+    if rationale:
+        lines.append(f"    rationale: {rationale}")
+
+
+def render_routing_decision(block: dict) -> list[str]:
+    """Render the routing_decision block to a list of output lines.
+
+    Pure formatting over the recorded block — no I/O, no lookups.
+    """
+    lines: list[str] = []
+    origin = block.get("origin", "?")
+    lines.append(f"Routing decision (origin: {origin})")
+    lines.append("=" * 60)
+    for role in _ROLE_ORDER:
+        role_block = block.get(role)
+        if not isinstance(role_block, dict):
+            continue
+        lines.append("")
+        header = _ROLE_LABELS.get(role, role.upper())
+        if role == "dev":
+            score = role_block.get("score")
+            base = role_block.get("base_tier_from_score")
+            extra = []
+            if score is not None:
+                extra.append(f"score={score}")
+            if base:
+                extra.append(f"base tier={base}")
+            header += f"  ({', '.join(extra)})" if extra else ""
+        lines.append(header)
+        lines.append("-" * 60)
+
+        _render_final(role_block, lines)
+
+        lines.append("  candidate pool:")
+        _render_candidate_pool(role_block.get("candidate_pool") or [], lines)
+
+        exploration = role_block.get("exploration") or {}
+        lines.append(f"  exploration: {exploration.get('mode', '?')}")
+
+        if role == "dev":
+            lines.append("  adaptive mechanisms:")
+            _render_dev_mechanisms(role_block, lines)
+        elif role in ("plan_review", "code_review"):
+            lines.append("  adaptive mechanisms:")
+            _render_reviewer_mechanisms(role_block, lines)
+
+    lines.append("")
+    lines.append("=" * 60)
+    lines.append(
+        "Legend: ✓ included/selected  ✗ excluded   ● fired  ◐ checked, did not fire  ○ not checked"
+    )
+    return lines
+
+
+def _print_block(block: dict, label: str) -> int:
+    print(f"# {label}")
+    for line in render_routing_decision(block):
+        print(line)
+    return 0
+
+
+def _explain_from_record(record: dict, label: str) -> int:
+    """Render the routing_decision from a loaded audit record.
+
+    Distinguishes an absent block (pre-#1391 records, where the reader-side
+    migration backfills ``routing_decision: None``) from a present one so the
+    operator is never shown a misleading empty summary.
+    """
+    if "routing_decision" not in record or record.get("routing_decision") is None:
+        print(
+            f"[forge] {label}: no routing_decision block recorded for this run "
+            "(it predates the #1391 routing-decision record, so the assignment "
+            "rationale cannot be reconstructed).",
+            file=sys.stderr,
+        )
+        return 1
+    block = record["routing_decision"]
+    if not isinstance(block, dict):
+        print(
+            f"[forge] {label}: routing_decision block is malformed ({type(block).__name__}).",
+            file=sys.stderr,
+        )
+        return 1
+    return _print_block(block, label)
+
+
+def cmd_explain(args: object) -> int:
+    """Render the routing_decision block for a story, run, or per-run file."""
+    file_arg = getattr(args, "file", None)
+    if file_arg:
+        path = Path(file_arg).resolve()
+        if not path.exists():
+            print(f"[forge] audit file not found: {path}", file=sys.stderr)
+            return 1
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"[forge] could not read audit file {path}: {exc}", file=sys.stderr)
+            return 1
+        if not isinstance(record, dict):
+            print(f"[forge] audit file {path} is not a JSON object.", file=sys.stderr)
+            return 1
+        return _explain_from_record(record, path.name)
+
+    config_arg = getattr(args, "config", None)
+    config_path = _find_config(Path(config_arg).resolve() if config_arg else None)
+    if config_path is None:
+        print(
+            "[forge] forge.yaml not found. Run from a forge project root.",
+            file=sys.stderr,
+        )
+        return 1
+    project_root = config_path.parent
+
+    if not audit_substrate.has_audit_inputs(project_root):
+        print(
+            "[forge] no audit records found — nothing to explain.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        conn = audit_substrate.require_substrate(project_root)
+    except audit_substrate.SubstrateError as exc:
+        print(f"[forge] {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        run_id = getattr(args, "run", None)
+        story = getattr(args, "story", None)
+        if run_id:
+            record = audit_substrate.latest_record_for(conn, run_id=run_id)
+            label = f"run {run_id}"
+        else:
+            slug, issue_id = _resolve_story(story)
+            record = audit_substrate.latest_record_for(conn, slug=slug, issue_id=issue_id)
+            label = f"story {story}"
+    finally:
+        conn.close()
+
+    if record is None:
+        print(f"[forge] no audit record found for {label}.", file=sys.stderr)
+        return 1
+    return _explain_from_record(record, label)
+
+
+def _resolve_story(story: str) -> tuple[str | None, int | None]:
+    """Map a --story argument to a (slug, issue_id) lookup pair.
+
+    A bare or ``#``-prefixed integer is treated as a GitHub issue number; any
+    other string is treated as a slug (e.g. ``issue-270``).
+    """
+    stripped = story.lstrip("#").strip()
+    if stripped.isdigit():
+        return None, int(stripped)
+    return story, None
+
+
+def register_parser(subparsers: object) -> None:
+    """Register the 'explain' subcommand parser."""
+    parser = subparsers.add_parser(
+        "explain",
+        help="Render the routing_decision (assignment rationale) for a story or run",
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument(
+        "--story",
+        help="Story identifier: GitHub issue number (e.g. 270) or slug (e.g. issue-270)",
+    )
+    target.add_argument(
+        "--run",
+        help="Exact run id to explain",
+    )
+    target.add_argument(
+        "--file",
+        help="Path to a per-run audit JSON file (.forge/audits/runs/<run_id>.json)",
+    )
+    parser.add_argument(
+        "--config",
+        help="Path to forge.yaml (default: auto-detect)",
+    )

--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -142,9 +142,12 @@ def _render_dev_mechanisms(role_block: dict, lines: list[str]) -> None:
 def _render_reviewer_mechanisms(role_block: dict, lines: list[str]) -> None:
     demo = role_block.get("demotion_check") or {}
     reason = demo.get("reason", "")
-    # A reviewer demotion is "not checked" only when there were no unhealthy
-    # candidates to weigh; otherwise it was checked and either fired or not.
-    checked = reason != "no_unhealthy_candidates"
+    # Reviewer provider-health demotion is a LIVE mechanism the router always
+    # runs, so whenever the demotion_check block is present it WAS checked —
+    # `fired` alone distinguishes fired vs did-not-fire. A no-op outcome
+    # (e.g. reason "no_unhealthy_candidates") is "checked, did not fire", not
+    # "not checked". Only a wholly-absent block reads as not checked.
+    checked = bool(demo)
     detail = reason
     depri = demo.get("deprioritized") or []
     if depri:
@@ -288,8 +291,12 @@ def cmd_explain(args: object) -> int:
             file=sys.stderr,
         )
         return 1
+    # Strictly read-only: open_readonly never creates, migrates, or rebuilds the
+    # substrate (unlike require_substrate), so `forge explain` cannot mutate the
+    # index as a side effect. A missing/stale index fails with an explicit
+    # rebuild instruction rather than being silently regenerated.
     try:
-        conn = audit_substrate.require_substrate(project_root)
+        conn = audit_substrate.open_readonly(project_root)
     except audit_substrate.SubstrateError as exc:
         print(f"[forge] {exc}", file=sys.stderr)
         return 1

--- a/src/theforge/cli/main.py
+++ b/src/theforge/cli/main.py
@@ -11,6 +11,7 @@ from theforge.cli import (
     daemon,
     diagnose,
     eval_cmd,
+    explain,
     forge_yaml_guard,
     groom,
     hooks,
@@ -79,6 +80,7 @@ def build_parser() -> argparse.ArgumentParser:
     forge_yaml_guard.register_parser(subparsers)
     audit.register_parser(subparsers)
     audits_cmd.register_parser(subparsers)
+    explain.register_parser(subparsers)
     telemetry.register_parser(subparsers)
     daemon.register_parser(subparsers)
     eval_cmd.register_parser(subparsers)
@@ -120,6 +122,7 @@ def main() -> None:
         "check-story-config": forge_yaml_guard.cmd_check_story_config,
         "audit": audit.cmd_audit,
         "audits": audits_cmd.cmd_audits,
+        "explain": explain.cmd_explain,
         "telemetry": telemetry.cmd_telemetry,
         "daemon": daemon.cmd_daemon,
         "eval-preflight": eval_cmd.cmd_eval_preflight,

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -1314,6 +1314,43 @@ def count_records(conn: sqlite3.Connection) -> int:
     return int(row[0])
 
 
+def latest_record_for(
+    conn: sqlite3.Connection,
+    *,
+    slug: str | None = None,
+    issue_id: int | None = None,
+    run_id: str | None = None,
+) -> dict | None:
+    """Return the most-recent migrated record matching a story/run identifier.
+
+    Read-only lookup for operator-facing query surfaces (e.g. ``forge explain``).
+    Exactly one of ``slug`` / ``issue_id`` / ``run_id`` selects the record; a
+    ``run_id`` addresses a single run, while ``slug``/``issue_id`` return the
+    newest run for that story (ordered by ``started_at`` DESC). Returns ``None``
+    when nothing matches. Never writes.
+    """
+    if run_id is not None:
+        clause, param = "run_id = ?", run_id
+    elif slug is not None:
+        clause, param = "slug = ?", slug
+    elif issue_id is not None:
+        clause, param = "issue_id = ?", issue_id
+    else:
+        return None
+    row = conn.execute(
+        "SELECT raw_json, record_schema_version FROM audit_records "
+        f"WHERE {clause} ORDER BY COALESCE(started_at, '') DESC LIMIT 1",
+        (param,),
+    ).fetchone()
+    if row is None:
+        return None
+    if isinstance(row, sqlite3.Row):
+        raw, ver = row["raw_json"], row["record_schema_version"]
+    else:
+        raw, ver = row[0], row[1]
+    return _load_migrated(raw, ver)
+
+
 # ── Derived assignment-history view ──────────────────────────────────────
 
 

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -375,6 +375,34 @@ def require_substrate(project_root: Path) -> sqlite3.Connection:
     return conn
 
 
+def open_readonly(project_root: Path) -> sqlite3.Connection:
+    """Open the substrate strictly read-only — never create, migrate, or rebuild.
+
+    For operator-facing query surfaces (e.g. ``forge explain``) that must not
+    mutate the substrate as a side effect of reading it. Unlike
+    :func:`require_substrate` (which rebuilds stale/missing indexes) and
+    :func:`create_or_open` (which bootstraps a fresh DB and applies schema),
+    this opens the existing file with SQLite ``mode=ro`` so no write — not even
+    a schema migration — is possible. Raises :class:`SubstrateMissingError`
+    when the index file is absent, pointing the operator at
+    ``forge audits rebuild`` rather than silently regenerating it.
+    """
+    path = substrate_path(project_root)
+    if not path.exists():
+        raise SubstrateMissingError(
+            f"audit substrate not found at {path}. Run `forge audits rebuild` to create it."
+        )
+    try:
+        conn = sqlite3.connect(f"{path.as_uri()}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.DatabaseError as exc:
+        raise SubstrateCorruptError(
+            f"audit substrate at {path} could not be opened read-only: {exc}. "
+            "Run `forge audits rebuild [--include-legacy-history]` to recover."
+        ) from exc
+    return conn
+
+
 def _open_validated(path: Path) -> sqlite3.Connection:
     """Connect, run integrity_check, apply schema (idempotent)."""
     try:

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -1,0 +1,327 @@
+"""Tests for `forge explain` — operator-facing routing_decision render (#270).
+
+Covers the read-only view over the top-level routing_decision block (#1391):
+per-role rendering, the not-checked / did-not-fire / fired tri-state, the
+explicit_override_locked reason, the absent-block fallback, and the
+substrate-backed --story lookup. No agent calls or profile reads happen here —
+the view reads only the recorded block.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from theforge.cli import explain
+from theforge.coordinator import audit_substrate as sub
+
+
+def _routing_block(*, dev_override: bool = False, reviewer_fired: bool = False) -> dict:
+    """A representative routing_decision block covering every render branch."""
+    dev_pool = [
+        {
+            "name": "opus",
+            "tier": "strong",
+            "included": True,
+            "reason": "none",
+            "signals": {
+                "success_rate": {
+                    "raw": 0.8,
+                    "weighted": 0.8,
+                    "runs": 12,
+                    "floor": "pass",
+                    "rate": 0.8,
+                }
+            },
+        },
+        {"name": "deepseek", "tier": "strong", "included": False, "reason": "auth_missing"},
+    ]
+    dev_reason = "explicit_override_locked" if dev_override else "none"
+    if dev_override:
+        dev_pool[0]["reason"] = dev_reason
+    return {
+        "origin": "preflight",
+        "preflight": {
+            "candidate_pool": [
+                {"name": "sonnet", "tier": "mid", "included": True, "reason": "none"}
+            ],
+            "exploration": {"mode": "winner"},
+            "final": {"model": "sonnet", "tier": "mid", "rationale": "[preflight] cheap"},
+        },
+        "planner": {
+            "candidate_pool": [
+                {"name": "opus", "tier": "strong", "included": True, "reason": "none"}
+            ],
+            "exploration": {"mode": "winner"},
+            "final": {"model": "opus", "tier": "strong", "rationale": "[preflight] planner"},
+        },
+        "dev": {
+            "score": 9,
+            "base_tier_from_score": "strong",
+            "candidate_pool": dev_pool,
+            "promotion_check": {
+                "fired": False,
+                "matching_records": 4,
+                "escalations": 1,
+                "outcome": "no_promotion",
+            },
+            "demotion_check": {
+                "mechanism": "dev_tier_demotion",
+                "applicable": False,
+                "fired": False,
+                "checked": None,
+                "reason": "no_dev_tier_demotion_mechanism_v1",
+            },
+            "post_plan_checkpoint": {"applied": False, "reason": "checkpoint_not_implemented_v1"},
+            "exploration": {"mode": "winner"},
+            "final": {"model": "opus", "tier": "strong", "rationale": "[preflight] dev on strong"},
+        },
+        "plan_review": {
+            "candidate_pool": [
+                {"name": "gpt", "tier": "strong", "included": True, "reason": "none"}
+            ],
+            "demotion_check": {
+                "mechanism": "provider_health",
+                "fired": False,
+                "deprioritized": [],
+                "fell_back": [],
+                "reason": "no_unhealthy_candidates",
+            },
+            "exploration": {"mode": "winner"},
+            "final": {"models": ["gpt-5.4"], "rationale": "[preflight] plan reviewer"},
+        },
+        "code_review": {
+            "candidate_pool": [
+                {"name": "opus", "tier": "strong", "included": True, "reason": "none"},
+                {
+                    "name": "gpt",
+                    "tier": "strong",
+                    "included": False,
+                    "reason": "transport_unavailable",
+                    "detail": "health_deprioritized",
+                },
+            ],
+            "demotion_check": {
+                "mechanism": "provider_health",
+                "fired": reviewer_fired,
+                "deprioritized": ["gpt"] if reviewer_fired else [],
+                "fell_back": [],
+                "reason": (
+                    "health_deprioritized: gpt"
+                    if reviewer_fired
+                    else "no_unhealthy_candidates_in_pool"
+                ),
+            },
+            "exploration": {"mode": "winner"},
+            "final": {"models": ["opus"], "rationale": "[preflight] code reviewer"},
+        },
+    }
+
+
+def test_render_covers_every_role_and_selection() -> None:
+    lines = explain.render_routing_decision(_routing_block())
+    text = "\n".join(lines)
+    for header in ("PREFLIGHT", "PLANNER", "DEV", "PLAN REVIEW", "CODE REVIEW"):
+        assert header in text
+    # Selected agents and reviewer model lists both render.
+    assert "selected: sonnet [mid]" in text
+    assert "selected: opus" in text
+    assert "gpt-5.4" in text
+
+
+def test_render_signals_show_raw_weighted_and_floor() -> None:
+    text = "\n".join(explain.render_routing_decision(_routing_block()))
+    assert "raw=0.8000" in text
+    assert "weighted=0.8000" in text
+    assert "runs=12" in text
+    assert "sample-floor pass" in text
+
+
+def test_render_excluded_reason_is_scannable() -> None:
+    """ "why was model X never a reviewer" → the excluded-reason line."""
+    text = "\n".join(explain.render_routing_decision(_routing_block()))
+    assert "✗ deepseek" in text
+    assert "provider credentials missing" in text
+    # The health-deprioritized reviewer exclusion carries its detail.
+    assert "✗ gpt" in text
+    assert "transport unavailable" in text
+    assert "health_deprioritized" in text
+
+
+def test_tri_state_distinguishes_not_checked_from_did_not_fire() -> None:
+    """not-checked vs checked-did-not-fire vs fired must be distinguishable."""
+    # promotion checked but did not fire → ◐; dev-tier demotion not applicable → ○.
+    text = "\n".join(explain.render_routing_decision(_routing_block()))
+    assert "promotion: checked, did not fire" in text
+    assert "demotion (dev_tier_demotion): not checked" in text
+    assert "post-plan checkpoint: not checked" in text
+
+    # A reviewer health demotion that fired renders as fired.
+    fired_text = "\n".join(explain.render_routing_decision(_routing_block(reviewer_fired=True)))
+    assert "demotion (provider_health): fired" in fired_text
+
+
+def test_explicit_override_locked_reason_renders() -> None:
+    text = "\n".join(explain.render_routing_decision(_routing_block(dev_override=True)))
+    assert "locked by explicit forge.yaml override" in text
+
+
+def test_explain_from_file_renders_block(tmp_path: Path, capsys) -> None:
+    record = {"schema_version": 7, "routing_decision": _routing_block()}
+    path = tmp_path / "run-x.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    class _Args:
+        file = str(path)
+        story = None
+        run = None
+        config = None
+
+    rc = explain.cmd_explain(_Args())
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Routing decision (origin: preflight)" in out
+    assert "DEV" in out
+
+
+def test_absent_block_reports_explicitly(tmp_path: Path, capsys) -> None:
+    """Pre-#1391 records (routing_decision None) must say so, not render empty."""
+    record = {"schema_version": 6, "routing_decision": None}
+    path = tmp_path / "run-old.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    class _Args:
+        file = str(path)
+        story = None
+        run = None
+        config = None
+
+    rc = explain.cmd_explain(_Args())
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no routing_decision block recorded" in err
+    assert "#1391" in err
+
+
+def test_missing_block_key_reports_explicitly(tmp_path: Path, capsys) -> None:
+    record = {"schema_version": 7}
+    path = tmp_path / "run-nokey.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    class _Args:
+        file = str(path)
+        story = None
+        run = None
+        config = None
+
+    assert explain.cmd_explain(_Args()) == 1
+    assert "no routing_decision block recorded" in capsys.readouterr().err
+
+
+def test_resolve_story_issue_number_vs_slug() -> None:
+    assert explain._resolve_story("270") == (None, 270)
+    assert explain._resolve_story("#270") == (None, 270)
+    assert explain._resolve_story("issue-270") == ("issue-270", None)
+
+
+def _write_run_and_substrate(project_root: Path, record: dict) -> None:
+    """Persist a per-run JSON file and build the substrate over it (seam setup)."""
+    (project_root / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+    runs = sub.runs_dir(project_root)
+    runs.mkdir(parents=True, exist_ok=True)
+    (runs / f"{record['run_id']}.json").write_text(json.dumps(record), encoding="utf-8")
+    sub.rebuild_from_runs(project_root)
+
+
+def _story_record(run_id: str, slug: str, issue: int, started: str) -> dict:
+    return {
+        "schema_version": 7,
+        "run_id": run_id,
+        "task": {"slug": slug, "name": slug, "github_issue": issue},
+        "outcome": {"success": True, "final_phase": "DONE"},
+        "timing": {"started_at": started, "duration_seconds": 60.0},
+        "cost": {"total_usd": 1.0},
+        "totals": {"cost_usd": 1.0},
+        "routing_decision": _routing_block(),
+    }
+
+
+def test_explain_story_by_slug_via_substrate(tmp_path: Path, capsys) -> None:
+    """Seam: per-run record → substrate → `forge explain --story <slug>`."""
+    _write_run_and_substrate(
+        tmp_path, _story_record("run-270", "issue-270", 270, "2026-07-20T10:00:00+00:00")
+    )
+
+    class _Args:
+        file = None
+        story = "issue-270"
+        run = None
+        config = str(tmp_path / "forge.yaml")
+
+    assert explain.cmd_explain(_Args()) == 0
+    out = capsys.readouterr().out
+    assert "story issue-270" in out
+    assert "Routing decision (origin: preflight)" in out
+
+
+def test_explain_story_by_issue_number_returns_latest_run(tmp_path: Path, capsys) -> None:
+    """A bare issue number resolves via issue_id and returns the newest run."""
+    _write_run_and_substrate(
+        tmp_path, _story_record("run-old", "issue-270", 270, "2026-07-19T10:00:00+00:00")
+    )
+    # Second, newer run for the same issue.
+    runs = sub.runs_dir(tmp_path)
+    newer = _story_record("run-new", "issue-270", 270, "2026-07-21T10:00:00+00:00")
+    (runs / "run-new.json").write_text(json.dumps(newer), encoding="utf-8")
+    sub.rebuild_from_runs(tmp_path)
+
+    record = sub.latest_record_for(sub.require_substrate(tmp_path), issue_id=270)
+    assert record["run_id"] == "run-new"
+
+    class _Args:
+        file = None
+        story = "270"
+        run = None
+        config = str(tmp_path / "forge.yaml")
+
+    assert explain.cmd_explain(_Args()) == 0
+    assert "story 270" in capsys.readouterr().out
+
+
+def test_explain_story_not_found(tmp_path: Path, capsys) -> None:
+    _write_run_and_substrate(
+        tmp_path, _story_record("run-270", "issue-270", 270, "2026-07-20T10:00:00+00:00")
+    )
+
+    class _Args:
+        file = None
+        story = "issue-999"
+        run = None
+        config = str(tmp_path / "forge.yaml")
+
+    assert explain.cmd_explain(_Args()) == 1
+    assert "no audit record found for story issue-999" in capsys.readouterr().err
+
+
+def test_explain_no_audit_inputs(tmp_path: Path, capsys) -> None:
+    (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+
+    class _Args:
+        file = None
+        story = "issue-270"
+        run = None
+        config = str(tmp_path / "forge.yaml")
+
+    assert explain.cmd_explain(_Args()) == 1
+    assert "no audit records found" in capsys.readouterr().err
+
+
+def test_file_not_found_reports(tmp_path: Path, capsys) -> None:
+    class _Args:
+        file = str(tmp_path / "nope.json")
+        story = None
+        run = None
+        config = None
+
+    assert explain.cmd_explain(_Args()) == 1
+    assert "audit file not found" in capsys.readouterr().err

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -161,6 +161,26 @@ def test_tri_state_distinguishes_not_checked_from_did_not_fire() -> None:
     assert "demotion (provider_health): fired" in fired_text
 
 
+def test_reviewer_health_no_op_renders_checked_did_not_fire() -> None:
+    """A reviewer provider-health block that ran but found nothing to demote is a
+    LIVE, checked mechanism (fired=False) — it must render as "checked, did not
+    fire", never "not checked" (a present block is always a checked mechanism)."""
+    text = "\n".join(explain.render_routing_decision(_routing_block()))
+    # plan_review uses reason "no_unhealthy_candidates" with fired=False; that is
+    # a no-op outcome of a mechanism that DID run.
+    assert "demotion (provider_health): checked, did not fire" in text
+    assert "demotion (provider_health): not checked" not in text
+
+
+def test_reviewer_missing_block_renders_not_checked() -> None:
+    """Only a wholly-absent reviewer demotion_check reads as "not checked"."""
+    block = _routing_block()
+    block["plan_review"].pop("demotion_check")
+    lines = []
+    explain._render_reviewer_mechanisms(block["plan_review"], lines)
+    assert any("not checked" in line for line in lines)
+
+
 def test_explicit_override_locked_reason_renders() -> None:
     text = "\n".join(explain.render_routing_decision(_routing_block(dev_override=True)))
     assert "locked by explicit forge.yaml override" in text
@@ -301,6 +321,60 @@ def test_explain_story_not_found(tmp_path: Path, capsys) -> None:
 
     assert explain.cmd_explain(_Args()) == 1
     assert "no audit record found for story issue-999" in capsys.readouterr().err
+
+
+def test_explain_story_does_not_rebuild_missing_substrate(tmp_path: Path, capsys) -> None:
+    """Read-only guard: with per-run JSON present but the substrate absent,
+    `forge explain --story` must NOT create/rebuild the index — it fails with an
+    explicit rebuild instruction and leaves the filesystem unchanged."""
+    (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+    runs = sub.runs_dir(tmp_path)
+    runs.mkdir(parents=True, exist_ok=True)
+    rec = _story_record("run-270", "issue-270", 270, "2026-07-20T10:00:00+00:00")
+    (runs / "run-270.json").write_text(json.dumps(rec), encoding="utf-8")
+    # Substrate deliberately not built.
+    sub_path = sub.substrate_path(tmp_path)
+    assert not sub_path.exists()
+
+    class _Args:
+        file = None
+        story = "issue-270"
+        run = None
+        config = str(tmp_path / "forge.yaml")
+
+    assert explain.cmd_explain(_Args()) == 1
+    err = capsys.readouterr().err
+    assert "forge audits rebuild" in err
+    # The command must not have written the index as a side effect.
+    assert not sub_path.exists(), "explain must not rebuild the substrate"
+
+
+def test_explain_run_leaves_stale_substrate_unchanged(tmp_path: Path, capsys) -> None:
+    """Read-only guard: even when the substrate is stale (a per-run file changed
+    after the index was built), `forge explain --run` reads the existing index
+    without rewriting it — the file's mtime is unchanged."""
+    _write_run_and_substrate(
+        tmp_path, _story_record("run-270", "issue-270", 270, "2026-07-20T10:00:00+00:00")
+    )
+    sub_path = sub.substrate_path(tmp_path)
+    # Make the substrate stale relative to the source per-run file.
+    import os
+    import time
+
+    time.sleep(0.01)
+    newer = _story_record("run-270", "issue-270", 270, "2026-07-21T10:00:00+00:00")
+    (sub.runs_dir(tmp_path) / "run-270.json").write_text(json.dumps(newer), encoding="utf-8")
+    before = os.stat(sub_path).st_mtime_ns
+
+    class _Args:
+        file = None
+        story = None
+        run = "run-270"
+        config = str(tmp_path / "forge.yaml")
+
+    assert explain.cmd_explain(_Args()) == 0
+    after = os.stat(sub_path).st_mtime_ns
+    assert before == after, "explain must not rewrite/rebuild the substrate index"
 
 
 def test_explain_no_audit_inputs(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved: reviewer provider-health no-op renders as checked/did-not-fire, and story/run explain paths use a read-only substrate opener. | [google-gemini-3.5-flash] The implementation of forge explain is fully verified, read-only, and correctly handles all tri-state adaptive mechanism outcomes.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $6.78
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Assignment summary view — operator-facing render of the routing_decision block (GitHub Issue #270)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #270