### PR TITLE
Domain-aware adaptive routing — match model strengths to story type

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -263,6 +263,9 @@ def _rerank_by_profiles(
     complexity: str | None,
     min_runs: int = 3,
     signals_out: dict[str, dict] | None = None,
+    domains: list[str] | None = None,
+    domain_signals_out: dict[str, dict] | None = None,
+    rerank_audit: dict[str, object] | None = None,
 ) -> list[AgentDef]:
     """Stable-sort candidates: high-success-rate first when enough data exists.
 
@@ -271,15 +274,29 @@ def _rerank_by_profiles(
     observed model but among themselves fall back to the real per-MTok price
     (via :func:`price_tiebreak_signal`), so the cheapest unobserved model is the
     first explored rather than whichever the pool happened to list first (#1617).
+
+    Domain match (issue #155) is the *horizontal* preference axis. When
+    ``domains`` is present, an admissible per-domain success rate acts strictly as
+    a **tiebreaker** among candidates already tied on their complexity success
+    rate — it never overrides the complexity ranking (the vertical axis), never
+    promotes an unobserved model over an observed one, and never penalizes a
+    cold-start model (a candidate with no admissible domain data contributes a
+    neutral ``0.0`` tiebreak weight and keeps its complexity-driven / price
+    position). This keeps domain a preference within the eligible pool, per
+    ADR-0006 clause 1. ``rerank_audit`` (when supplied) records whether the domain
+    tiebreak actually changed the head of the ranking so explainability can mark
+    the decision influential or not.
     """
     if not model_profiles or role != "dev":
         return candidates
-    from theforge.model_profiles import get_dev_signal  # noqa: PLC0415
+    from theforge.model_profiles import get_dev_domain_signal, get_dev_signal  # noqa: PLC0415
 
-    def _key(agent: AgentDef) -> tuple[int, float]:
-        # Single lookup feeds both the ranking key and the explainability signal
-        # — reusing this pass rather than re-reading profiles keeps the audit's
-        # cost overhead bounded (#1391 AC: no profile re-reads).
+    requested_domains = [d for d in (domains or []) if isinstance(d, str) and d]
+
+    # One profile read per candidate feeds ranking AND the explainability signals
+    # (#1391 AC: no profile re-reads). Collect once, then sort in-memory.
+    rows: list[tuple[AgentDef, dict, dict | None]] = []
+    for agent in candidates:
         signal = get_dev_signal(
             model_profiles,
             agent.name,
@@ -291,18 +308,55 @@ def _rerank_by_profiles(
         )
         if signals_out is not None:
             signals_out[agent.name] = signal
+        dsignal: dict | None = None
+        if requested_domains:
+            dsignal = get_dev_domain_signal(
+                model_profiles,
+                agent.name,
+                requested_domains,
+                min_runs,
+                actual_model=agent.model,
+                provider=agent.provider,
+                cli=agent.cli,
+            )
+            if domain_signals_out is not None:
+                domain_signals_out[agent.name] = dsignal
+        rows.append((agent, signal, dsignal))
+
+    def _price(agent: AgentDef) -> float:
+        return price_tiebreak_signal(agent.input_cost_per_mtok, agent.output_cost_per_mtok)
+
+    def _complexity_key(row: tuple[AgentDef, dict, dict | None]) -> tuple:
+        agent, signal, _ = row
         rate = signal["rate"]
         if rate is None:
-            # Unobserved: sort behind observed models (leading 1), then cheapest
-            # first so a zero-history model still gets an evidence-gathering turn.
-            return (
-                1,
-                price_tiebreak_signal(agent.input_cost_per_mtok, agent.output_cost_per_mtok),
-            )
-        # Negative rate so higher success sorts first among observed agents.
-        return (0, -rate)
+            return (1, 0.0, _price(agent))
+        return (0, -rate, _price(agent))
 
-    return sorted(candidates, key=_key)
+    def _domain_aware_key(row: tuple[AgentDef, dict, dict | None]) -> tuple:
+        agent, signal, dsignal = row
+        rate = signal["rate"]
+        # Admissible domain rate becomes the tiebreak between the complexity rate
+        # and price; no admissible domain data → 0.0 (neutral, not a penalty).
+        drate = dsignal["rate"] if dsignal and dsignal.get("rate") is not None else 0.0
+        if rate is None:
+            # Cold start on complexity: keep static price ordering; domain is not
+            # a tiebreaker here (nothing to break — no complexity standing yet).
+            return (1, 0.0, 0.0, _price(agent))
+        return (0, -rate, -drate, _price(agent))
+
+    domain_sorted = [r[0] for r in sorted(rows, key=_domain_aware_key)]
+
+    if rerank_audit is not None and requested_domains:
+        complexity_sorted = [r[0] for r in sorted(rows, key=_complexity_key)]
+        cx_head = complexity_sorted[0].name if complexity_sorted else None
+        dm_head = domain_sorted[0].name if domain_sorted else None
+        rerank_audit["domain_applied"] = True
+        rerank_audit["domain_influenced"] = bool(cx_head and dm_head and cx_head != dm_head)
+        rerank_audit["complexity_only_head"] = cx_head
+        rerank_audit["domain_head"] = dm_head
+
+    return domain_sorted
 
 
 def _pick_agent(
@@ -313,21 +367,33 @@ def _pick_agent(
     role: str = "",
     complexity: str | None = None,
     signals_out: dict[str, dict] | None = None,
+    domains: list[str] | None = None,
+    domain_signals_out: dict[str, dict] | None = None,
+    rerank_audit: dict[str, object] | None = None,
 ) -> AgentDef | None:
     """Pick cheapest agent of the given tier that has usable auth.
 
     Skips API agents whose provider key is missing from the environment.
     When ``model_profiles`` is provided and ``role == "dev"``, agents with a
     higher observed success rate at the given complexity are preferred over
-    the budget-ordered default.
+    the budget-ordered default. When ``domains`` is present, an admissible
+    per-domain success rate breaks ties within that complexity ordering (#155).
 
-    When ``signals_out`` is provided, per-candidate profile signals consulted
-    during reranking are recorded into it (keyed by agent name) for the routing
-    explainability block — no extra profile reads beyond this pass.
+    When ``signals_out`` / ``domain_signals_out`` are provided, per-candidate
+    profile signals consulted during reranking are recorded into them (keyed by
+    agent name) for the routing explainability block — no extra profile reads
+    beyond this pass.
     """
     candidates = [a for a in _agents_by_tier(agents, tier) if _has_auth(a, secrets)]
     candidates = _rerank_by_profiles(
-        candidates, model_profiles, role, complexity, signals_out=signals_out
+        candidates,
+        model_profiles,
+        role,
+        complexity,
+        signals_out=signals_out,
+        domains=domains,
+        domain_signals_out=domain_signals_out,
+        rerank_audit=rerank_audit,
     )
     if not candidates:
         log.debug("No authed agents for tier %s — trying any tier with auth", tier)
@@ -1026,6 +1092,9 @@ def _build_routing_decision(
     explicit_roles: set[str],
     secrets: dict[str, str] | None,
     unhealthy_models: set[str] | None = None,
+    domains: list[str] | None = None,
+    dev_domain_signals: dict[str, dict] | None = None,
+    dev_domain_match: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Assemble the per-role routing_decision explainability block (#1391).
 
@@ -1047,9 +1116,38 @@ def _build_routing_decision(
     dev_pool = _single_model_pool(
         agents, dev_effective_tier, decision.dev.name, "dev" in explicit_roles, secrets
     )
+    dev_domain_signals = dev_domain_signals or {}
+    requested_domains = [d for d in (domains or []) if isinstance(d, str) and d]
     for entry in dev_pool:
         if entry.get("included") and entry["name"] in dev_signals:
-            entry["signals"] = {"success_rate": dev_signals[entry["name"]]}
+            signals: dict[str, object] = {"success_rate": dev_signals[entry["name"]]}
+            # Attach the per-domain slice the router weighed for this candidate so
+            # the matching profile slice, sample count, floor status, and
+            # raw/weighted values are all reconstructable from the audit (#155).
+            if requested_domains and entry["name"] in dev_domain_signals:
+                signals["domain"] = dev_domain_signals[entry["name"]]
+            entry["signals"] = signals
+
+    # Domain-match block (#155 / ADR-0006 clause 7). Present but explicitly
+    # non-influential when domains exist yet did not move the selection; omitted
+    # entirely when the story carried no domains (nothing to explain).
+    dev_domain_match = dev_domain_match or {}
+    domain_block: dict[str, object] | None = None
+    if requested_domains:
+        influenced = bool(dev_domain_match.get("domain_influenced"))
+        selected_slice = dev_domain_signals.get(decision.dev.name)
+        domain_block = {
+            "domains": requested_domains,
+            "influenced": influenced,
+            "complexity_only_head": dev_domain_match.get("complexity_only_head"),
+            "domain_head": dev_domain_match.get("domain_head"),
+            "selected_model_slice": selected_slice,
+            "reason": (
+                "domain_tiebreak_changed_selection"
+                if influenced
+                else "domain_signal_did_not_change_selection"
+            ),
+        }
 
     exploration = {"mode": "winner"}  # v1: on-policy only (#170/#325 not landed)
 
@@ -1104,6 +1202,11 @@ def _build_routing_decision(
             "score": score,
             "base_tier_from_score": dev_base_tier,
             "candidate_pool": dev_pool,
+            # Domain preference (#155): the story's tags, the matching profile
+            # slice per candidate (on each pool entry's ``signals.domain``), and
+            # whether the domain tiebreak changed the selection. Absent when the
+            # story carried no domain tags.
+            **({"domain_match": domain_block} if domain_block is not None else {}),
             "promotion_check": promotion_block,
             # Dev-tier demotion/recovery (ADR-0006 clause 5 tier-demotion) is a
             # future enforcement (#1389) — no dev-tier demotion runs in v1, so this
@@ -1234,6 +1337,7 @@ def assign_models(
     model_profiles: dict | None = None,
     unhealthy_models: set[str] | None = None,
     routing_origin: str = "preflight",
+    domains: list[str] | None = None,
 ) -> AssignmentDecision:
     """Pure deterministic function — no LLM, no I/O.
 
@@ -1258,6 +1362,12 @@ def assign_models(
     # Populated during the routing pass and consumed by _build_routing_decision
     # at the end so the block reflects the final (post-budget) decision.
     _dev_signals: dict[str, dict] = {}
+    # Per-domain dev signals (#155), keyed by agent name, collected in the same
+    # rerank pass as _dev_signals. _dev_domain_match records whether the domain
+    # tiebreak actually moved the selection so the routing_decision block can mark
+    # the decision influential or explicitly non-influential.
+    _dev_domain_signals: dict[str, dict] = {}
+    _dev_domain_match: dict[str, object] = {}
     _preflight_tier: str | None = None
     _dev_effective_tier: str = "cheap"
     _promotion_block: dict[str, object] = {
@@ -1273,6 +1383,9 @@ def assign_models(
     effective_history = history if adaptive_enabled else []
     effective_promotions = sprint_promotions if adaptive_enabled else None
     effective_profiles = model_profiles if adaptive_enabled else None
+    # Domain preference only applies under adaptive routing; in static mode the
+    # horizontal axis is ignored like the numeric score and profile learning.
+    effective_domains = domains if adaptive_enabled else None
     locked_roles = set(explicit_profiles)
     if not adaptive_enabled:
         rationale["adaptive_enabled"] = "false (static band-only routing)"
@@ -1359,6 +1472,9 @@ def assign_models(
             role="dev",
             complexity=norm_complexity,
             signals_out=_dev_signals,
+            domains=effective_domains,
+            domain_signals_out=_dev_domain_signals,
+            rerank_audit=_dev_domain_match,
         )
         if dev_agent is not None and effective_profiles:
             from theforge.model_profiles import get_dev_success_rate  # noqa: PLC0415
@@ -1373,6 +1489,16 @@ def assign_models(
             )
             if _rate is not None:
                 rationale["dev"] += f" (profile success_rate={_rate:.2f} @ {norm_complexity})"
+            # Domain match note (#155): only surfaced when the horizontal tiebreak
+            # actually moved the selection — the selected model's admissible
+            # per-domain rate over the story's domains.
+            if _dev_domain_match.get("domain_influenced") and dev_agent is not None:
+                _dsig = _dev_domain_signals.get(dev_agent.name)
+                if _dsig and _dsig.get("rate") is not None:
+                    rationale["dev"] += (
+                        f" (domain match {effective_domains}: "
+                        f"rate={_dsig['rate']:.2f} over {_dsig['runs']} runs)"
+                    )
         if dev_agent is None:
             # Guardrail: dev tier floor prevents cheap models on MEDIUM/HIGH and
             # mid models on HIGH.  dev_base_tier is the floor (cheap/mid/strong
@@ -1594,6 +1720,9 @@ def assign_models(
             explicit_roles=set(explicit_profiles),
             secrets=secrets,
             unhealthy_models=unhealthy_models,
+            domains=effective_domains,
+            dev_domain_signals=_dev_domain_signals,
+            dev_domain_match=_dev_domain_match,
         )
         return _dc_replace(dec, routing_decision=block)
 

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -611,6 +611,7 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "complexity_projection": state.preflight_complexity_projection,
                 "complexity_evidence": list(state.preflight_complexity_evidence or []),
                 "work_type": state.preflight_work_type,
+                "domains": list(state.preflight_domains or []),
                 "contract_change": state.preflight_contract_change,
                 "bundle_candidate": state.preflight_bundle_candidate,
                 "cost_usd": state.preflight_result.cost_usd if state.preflight_result else 0.0,

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -103,6 +103,9 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         else None,
         preflight_cost_usd=state.total_preflight_cost_measured,
         reviewers=_extract_reviewers(state),
+        # Domain tags (#155) recorded by preflight, folded into per-domain dev
+        # slices so future routing can prefer models strong in the story's domains.
+        domains=list(state.preflight_domains or []),
     )
 
 

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -429,6 +429,38 @@ def _parse_preflight_work_type(output: str) -> str:
     return "feature"
 
 
+def _parse_preflight_domains(output: str) -> list[str]:
+    """Extract the ``domains`` list from preflight agent output.
+
+    Returns a clean, ordered, de-duplicated list of canonical taxonomy tags
+    (see :mod:`theforge.domains`). Tags outside the fixed taxonomy are dropped,
+    mirroring how ``_parse_preflight_work_type`` rejects values outside its enum
+    — unknown tags are never carried into routing. A missing field, a non-list
+    value, or malformed YAML all yield ``[]`` (an explicit "no domains" fact,
+    routing-safe as a current-run signal under ADR-0006 bucket A).
+    """
+    from theforge.domains import validate_domains  # noqa: PLC0415
+
+    yaml_text = output
+    if "```yaml" in output:
+        start = output.index("```yaml") + len("```yaml")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+    elif "```" in output:
+        start = output.index("```") + len("```")
+        end = output.index("```", start)
+        yaml_text = output[start:end]
+
+    try:
+        parsed = yaml.safe_load(yaml_text)
+        if isinstance(parsed, dict):
+            return validate_domains(parsed.get("domains"))
+    except yaml.YAMLError:
+        pass
+
+    return []
+
+
 def _parse_preflight_warnings(output: str) -> list[str]:
     """Extract warnings list from preflight agent output. Returns [] if absent."""
     yaml_text = output
@@ -1133,6 +1165,7 @@ def _apply_preflight_config(
         secrets=config.secrets,
         model_profiles=_model_profiles,
         unhealthy_models=_unhealthy if _unhealthy else None,
+        domains=list(state.preflight_domains or []),
     )
 
     # Splice the full explicit pools back into the decision so audit and

--- a/src/theforge/coordinator/preflight_cache.py
+++ b/src/theforge/coordinator/preflight_cache.py
@@ -118,6 +118,7 @@ def apply_cached_preflight_state(
     state.preflight_complexity_evidence = list(cached_state.preflight_complexity_evidence or [])
     state.preflight_sufficiency = cached_state.preflight_sufficiency
     state.preflight_work_type = cached_state.preflight_work_type
+    state.preflight_domains = list(cached_state.preflight_domains or [])
     state.preflight_contract_change = cached_state.preflight_contract_change
     state.preflight_bundle_candidate = cached_state.preflight_bundle_candidate
     state.preflight_warnings = list(cached_state.preflight_warnings or [])

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -43,6 +43,7 @@ from .preflight import (
     _parse_preflight_complexity_score,
     _parse_preflight_contract_change,
     _parse_preflight_criteria_checked,
+    _parse_preflight_domains,
     _parse_preflight_likely_files,
     _parse_preflight_sufficiency,
     _parse_preflight_symptom_verification,
@@ -225,6 +226,7 @@ def _preflight_phase_end_fields(state: CoordinatorState) -> dict[str, object]:
         "validation_complexity_score": state.preflight_validation_complexity_score,
         "complexity_projection": state.preflight_complexity_projection,
         "complexity_routing": routing,
+        "domains": list(state.preflight_domains or []),
     }
 
 
@@ -494,6 +496,10 @@ def _run_preflight_phase(
             if work_type not in {"refactor", "mechanical"}:
                 work_type = "feature"
         state.preflight_work_type = work_type
+        # Domain tags (issue #155): the horizontal routing axis. Recorded as
+        # native structured telemetry so it is routing-safe as a current-run fact
+        # (ADR-0006 bucket A), consumed as an admissible preference in assignment.
+        state.preflight_domains = _parse_preflight_domains(preflight_result.output)
         contract_change = _parse_preflight_contract_change(preflight_result.output)
         state.preflight_contract_change = contract_change
         # preflight_bundle_candidate is no longer sourced from the preflight LLM —
@@ -854,6 +860,7 @@ def _run_preflight_phase(
         "complexity_evidence": list(state.preflight_complexity_evidence or []),
         "sufficiency": state.preflight_sufficiency,
         "contract_change": state.preflight_contract_change,
+        "domains": list(state.preflight_domains or []),
         "cost_usd": preflight_result.cost_usd,
         "duration_s": round(_preflight_elapsed, 2),
         "likely_files": state.preflight_likely_files,

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -393,6 +393,10 @@ class CoordinatorState:
     preflight_complexity_evidence: list[dict] = field(default_factory=list)
     preflight_sufficiency: str | None = None  # "implementation_ready" | "needs_planning"
     preflight_work_type: str | None = None  # "feature" | "refactor" | "mechanical" | "bug"
+    # Domain tags from the fixed taxonomy (theforge.domains) describing the KIND
+    # of work — the horizontal routing axis (issue #155). Empty list = "no domains"
+    # (an explicit current-run fact, routing-safe under ADR-0006 bucket A).
+    preflight_domains: list[str] = field(default_factory=list)
     preflight_contract_change: bool = False  # story intentionally alters a tested contract
     preflight_bundle_candidate: bool = False
     preflight_warnings: list[str] = field(default_factory=list)  # non-blocking advisories

--- a/src/theforge/domains.py
+++ b/src/theforge/domains.py
@@ -1,0 +1,104 @@
+"""Domain taxonomy — the fixed vocabulary of story-domain tags.
+
+Preflight tags every story with zero or more *domain* tags describing the kind
+of work it involves (``[react, css]``, ``[api, database]``, ``[cli, config]``).
+Domain is the *horizontal* axis of routing — complexity says how hard a story
+is, domain says what kind of work it is — so the adaptive router can prefer a
+model whose per-domain track record is strong for the story's domains
+(issue #155).
+
+This is a pure-data, stdlib-only module (project convention 4: keep pure-data
+types in low-dependency modules). It defines:
+
+- :data:`DOMAIN_TAXONOMY` — the closed set of allowed tags. Tags are selected
+  from this taxonomy, never invented as free text — an unknown tag is dropped
+  by :func:`validate_domains`, mirroring how the structured-output parsers in
+  ``coordinator/preflight.py`` reject values outside their enum.
+- :data:`DOMAIN_DESCRIPTIONS` — one-line intended-usage doc per tag. This is
+  the single source of truth the preflight prompt enumerates from, so the
+  prompt's advertised vocabulary can never drift from what the parser accepts.
+- :func:`normalize_domain` / :func:`validate_domains` — normalization and
+  admission helpers.
+
+ADR-0006 alignment: current-run domain tags are routing-safe only as structured
+preflight telemetry (bucket A, "slug/domain tags recorded by preflight").
+Historical per-domain performance is routing-safe only after aggregation and
+clause-2 admissibility checks — see ``model_profiles.get_dev_domain_signal``.
+"""
+
+from __future__ import annotations
+
+# ── The fixed taxonomy ─────────────────────────────────────────────────
+#
+# Each tag names a *kind of work / subject matter*, deliberately distinct from
+# work_type (feature/refactor/mechanical/bug), which names the SHAPE of the
+# change. A story may carry several tags (a React form backed by an API touches
+# both ``frontend`` and ``api``). Keep this set small and stable: it is a
+# schema-versioned routing input under ADR-0006 clause 2.5, and every added tag
+# starts cold (no history) until runs accumulate under it.
+DOMAIN_DESCRIPTIONS: dict[str, str] = {
+    "frontend": "Client-side UI structure, components, rendering, browser behavior.",
+    "react": "React-specific component work — hooks, JSX, component state.",
+    "css": "Stylesheets, layout, visual styling, responsive design.",
+    "api": "HTTP/RPC API endpoints, request/response handling, routing/controllers.",
+    "backend": "Server-side business logic and services not specific to the API surface.",
+    "database": "Schema, queries, migrations, ORM/persistence layers.",
+    "cli": "Command-line interfaces, argument parsing, terminal output/UX.",
+    "config": "Configuration files, settings, environment/flag handling.",
+    "testing": "Test authoring, fixtures, test harness or framework work.",
+    "docs": "Documentation, markdown, reference material, docstrings/comments.",
+    "infra": "Deployment, containers, cloud resources, provisioning.",
+    "ci": "CI/CD pipelines, build automation, release tooling.",
+    "concurrency": "Threads, async, parallelism, locking, cancellation, scheduling.",
+    "parsing": "Parsers, serialization, format/protocol encoding and decoding.",
+    "security": "Auth, secrets, crypto, permissions, input trust boundaries.",
+    "networking": "Sockets, transport protocols, connection handling, retries.",
+    "data-processing": "ETL, aggregation, numeric/data pipelines, transforms.",
+    "algorithms": "Algorithmic or computational logic — data structures, math.",
+}
+
+# The closed admission set. ``validate_domains`` drops anything not in here.
+DOMAIN_TAXONOMY: frozenset[str] = frozenset(DOMAIN_DESCRIPTIONS)
+
+
+def normalize_domain(tag: object) -> str | None:
+    """Normalize one raw tag to a canonical taxonomy tag, or ``None``.
+
+    Lowercases and trims surrounding whitespace, and folds interchangeable word
+    separators (spaces / underscores → hyphen) so ``"data_processing"`` and
+    ``"Data Processing"`` both resolve to ``"data-processing"``. Returns ``None``
+    when the result is not in :data:`DOMAIN_TAXONOMY` — unknown tags are dropped,
+    never guessed at.
+    """
+    if not isinstance(tag, str):
+        return None
+    norm = tag.strip().lower().replace("_", "-").replace(" ", "-")
+    return norm if norm in DOMAIN_TAXONOMY else None
+
+
+def validate_domains(raw: object) -> list[str]:
+    """Coerce a raw ``domains`` value into a clean, ordered, de-duplicated list.
+
+    Accepts the structured-output list the preflight agent emits. Non-list
+    inputs (absent field, scalar, malformed) yield ``[]``. Each element is
+    normalized via :func:`normalize_domain`; unknown tags are dropped. Order of
+    first appearance is preserved and duplicates are removed so the recorded
+    list is deterministic.
+    """
+    if not isinstance(raw, (list, tuple)):
+        return []
+    out: list[str] = []
+    for item in raw:
+        norm = normalize_domain(item)
+        if norm is not None and norm not in out:
+            out.append(norm)
+    return out
+
+
+def taxonomy_prompt_lines() -> str:
+    """Render the taxonomy as ``- tag: description`` lines for the preflight prompt.
+
+    The prompt enumerates the allowed vocabulary from this single source so the
+    advertised tags and the accepted tags cannot drift apart.
+    """
+    return "\n".join(f"        - `{tag}`: {desc}" for tag, desc in DOMAIN_DESCRIPTIONS.items())

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -16,6 +16,8 @@ Schema on disk::
           runs, success_rate, avg_iterations, avg_cost_usd
           by_complexity:
             small|medium|large: {runs, success_rate, avg_iterations, avg_cost_usd}
+          by_domain:
+            <tag>: {runs, success_rate, avg_iterations, avg_cost_usd}
         review:
           runs, avg_findings, avg_cost_usd
         preflight:
@@ -96,6 +98,11 @@ class RunOutcome:
     preflight_cli: str | None = None
     preflight_cost_usd: float | None = None  # None = cost unmeasured
     reviewers: dict[str, tuple[int, int, float]] = field(default_factory=dict)
+    # Domain tags for this run (issue #155), from the fixed taxonomy recorded by
+    # preflight. The dev outcome is folded into a per-domain slice for each tag so
+    # per-domain success rate can be aggregated deterministically. Empty = the run
+    # had no domain tags and contributes to no domain slice.
+    domains: list[str] = field(default_factory=list)
 
 
 # ── I/O ───────────────────────────────────────────────────────────────────
@@ -370,6 +377,7 @@ def _update_dev(
     timeout_killed: bool = False,
     timeout_limit_s: int | None = None,
     termination_cause: str | None = None,
+    domains: list[str] | None = None,
 ) -> None:
     if cost_usd is None:
         log.warning(
@@ -409,6 +417,25 @@ def _update_dev(
         sc = by_score.setdefault(score_key, {})
         _fold_dev_bucket(
             sc,
+            success,
+            iterations,
+            cost_usd,
+            duration_s,
+            timeout_killed,
+            timeout_limit_s,
+            termination_cause,
+        )
+
+    # Per-domain slice (issue #155): fold this run into a bucket for each domain
+    # tag it carried. A run tagged [api, database] folds identically into both
+    # the "api" and "database" buckets, so per-domain success rate is a real
+    # aggregation over authoritative run telemetry (ADR-0006 clause B), not a
+    # summary or profile-only derivation.
+    for domain in domains or []:
+        by_domain = dev.setdefault("by_domain", {})
+        dd = by_domain.setdefault(domain, {})
+        _fold_dev_bucket(
+            dd,
             success,
             iterations,
             cost_usd,
@@ -572,6 +599,7 @@ def apply_run(data: dict, outcome: RunOutcome) -> dict:
         timeout_killed=outcome.dev_timeout_killed,
         timeout_limit_s=outcome.dev_timeout_limit_s,
         termination_cause=outcome.dev_termination_cause,
+        domains=outcome.domains,
     )
     if outcome.preflight_model:
         pf_entry = _ensure_model(
@@ -744,6 +772,92 @@ def get_dev_success_rate(
         provider=provider,
         cli=cli,
     )["rate"]
+
+
+def get_dev_domain_signal(
+    profiles: dict,
+    model: str,
+    domains: list[str] | None,
+    min_runs: int = 3,
+    *,
+    actual_model: str | None = None,
+    provider: str | None = None,
+    cli: str | None = None,
+) -> dict:
+    """Return a per-domain dev routing signal for the story's domain tags (#155).
+
+    Aggregates the ``dev.by_domain`` slices for each requested tag across every
+    matching profile entry, then applies the same ADR-0006 clause-2 admissibility
+    gates the complexity signal uses so a domain rate can only ever be a
+    *preference within the eligible pool*, never eligibility itself:
+
+    - **Mechanical provenance / completeness (2.1–2.2):** the slice is folded by
+      :func:`_fold_dev_bucket`, which segregates harness-terminated runs out of
+      the capability counts — the same complete recording path the complexity
+      slice uses. No summary prose feeds this.
+    - **Sample floor (2.3):** ``rate`` is ``None`` until ``runs >= min_runs``;
+      below the floor the caller falls through to static tier/budget routing
+      (cold start is a static-routing condition, not a low-confidence one).
+    - **Recency (2.4):** ``weighted`` mirrors ``raw`` until the shared weighting
+      mechanism (#1392) lands — the key exists so the audit contract is stable.
+    - **Role specificity (per-role):** this reads only ``dev`` slices; it says
+      nothing about review reliability.
+    - **Schema stability (2.5):** legacy profiles simply lack ``by_domain`` and
+      read as no-data (cold start), never as a penalty.
+
+    A run tagged with several of the requested domains contributes to each of
+    those domain buckets, so the aggregate double-counts across overlap — this is
+    intentional: it rewards a model with broad demonstrated strength across the
+    story's domains. The per-domain breakdown is returned in ``by_domain`` so the
+    routing_decision block can show the matching profile slice per tag.
+
+    Returns ``rate=None`` with ``floor="fail"`` when ``domains`` is empty or no
+    domain data exists — an explicit no-signal status, never a negative score.
+    """
+    requested = [d for d in (domains or []) if isinstance(d, str) and d]
+    matching = _matching_profile_entries(
+        profiles,
+        model,
+        actual_model=actual_model,
+        provider=provider,
+        cli=cli,
+    )
+    per_domain: dict[str, dict] = {}
+    total_runs = 0
+    total_successes = 0.0
+    for domain in requested:
+        d_runs = 0
+        d_successes = 0.0
+        for _, entry in matching:
+            dev = entry.get("dev")
+            if not isinstance(dev, dict):
+                continue
+            dd = (dev.get("by_domain") or {}).get(domain)
+            if not isinstance(dd, dict):
+                continue
+            entry_runs = int(dd.get("runs", 0))
+            if entry_runs <= 0:
+                continue
+            d_runs += entry_runs
+            d_successes += _success_count(dd, entry_runs)
+        per_domain[domain] = {
+            "runs": d_runs,
+            "raw": round(d_successes / d_runs, 4) if d_runs > 0 else None,
+        }
+        total_runs += d_runs
+        total_successes += d_successes
+    raw = round(total_successes / total_runs, 4) if total_runs > 0 else None
+    floor_ok = total_runs >= min_runs and total_runs > 0
+    return {
+        "domains": requested,
+        "raw": raw,
+        # v1: no recency weighting (#1392) — weighted mirrors raw until it lands.
+        "weighted": raw,
+        "runs": total_runs,
+        "floor": "pass" if floor_ok else "fail",
+        "rate": raw if floor_ok else None,
+        "by_domain": per_domain,
+    }
 
 
 def get_dev_complexity_stats(
@@ -1424,6 +1538,50 @@ def _merge_dev(target: dict, src: dict) -> None:
                 )
             _merge_duration(sc_target, sc_src)
             _merge_harness_terminated(sc_target, sc_src)
+
+    src_by_domain = src.get("by_domain") or {}
+    if src_by_domain:
+        target_by_domain = target.setdefault("by_domain", {})
+        for domain, dd_src in src_by_domain.items():
+            if not isinstance(dd_src, dict):
+                continue
+            dd_target = target_by_domain.setdefault(domain, {})
+            dd_runs = int(dd_target.get("runs", 0)) + int(dd_src.get("runs", 0))
+            dd_succ = int(dd_target.get("_successes", 0)) + int(
+                dd_src.get(
+                    "_successes",
+                    round(float(dd_src.get("success_rate", 0.0)) * int(dd_src.get("runs", 0))),
+                )
+            )
+            dd_iter = float(dd_target.get("_iterations_sum", 0.0)) + float(
+                dd_src.get(
+                    "_iterations_sum",
+                    float(dd_src.get("avg_iterations", 0.0)) * int(dd_src.get("runs", 0)),
+                )
+            )
+            dd_cost = float(dd_target.get("_cost_sum", 0.0)) + float(
+                dd_src.get(
+                    "_cost_sum",
+                    float(dd_src.get("avg_cost_usd", 0.0)) * int(dd_src.get("runs", 0)),
+                )
+            )
+            dd_unknown = int(dd_target.get("_cost_unknown_runs", 0)) + int(
+                dd_src.get("_cost_unknown_runs", 0)
+            )
+            dd_target["runs"] = dd_runs
+            dd_target["_successes"] = dd_succ
+            dd_target["_iterations_sum"] = dd_iter
+            dd_target["_cost_sum"] = dd_cost
+            dd_target["_cost_unknown_runs"] = dd_unknown
+            if dd_runs > 0:
+                dd_target["success_rate"] = round(dd_succ / dd_runs, 4)
+                dd_target["avg_iterations"] = round(dd_iter / dd_runs, 4)
+                dd_measured = dd_runs - dd_unknown
+                dd_target["avg_cost_usd"] = (
+                    round(dd_cost / dd_measured, 6) if dd_measured > 0 else 0.0
+                )
+            _merge_duration(dd_target, dd_src)
+            _merge_harness_terminated(dd_target, dd_src)
 
 
 def _merge_review(target: dict, src: dict) -> None:

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -51,6 +51,16 @@ log = logging.getLogger(__name__)
 ROLES = ("dev", "review", "preflight")
 COMPLEXITY_BANDS = ("small", "medium", "large")
 
+# Per-domain recency window (issue #155 / ADR-0006 clause 2.4). Per-domain dev
+# outcomes maintain a bounded ring of their most recent genuine (non-tainted,
+# non-harness-terminated) results so the routing-admissible rate consults a
+# *windowed* view of history rather than a lifetime cumulative average — the
+# exact shape clause 2.4 forbids from carrying routing weight. This is a local,
+# deterministic windowing mechanism; when the shared decay mechanism (#1392)
+# lands it supersedes this without changing the read contract (raw + weighted
+# both recorded).
+DOMAIN_RECENCY_WINDOW = 20
+
 
 # ── Data carrier ──────────────────────────────────────────────────────────
 
@@ -103,6 +113,13 @@ class RunOutcome:
     # per-domain success rate can be aggregated deterministically. Empty = the run
     # had no domain tags and contributes to no domain slice.
     domains: list[str] = field(default_factory=list)
+    # Taint marker (ADR-0006 clause 4, #1851/#1852 seam). True when the run failed
+    # its own trust checks (e.g. a reviewer that reviewed a stale checkout). A
+    # tainted run "doesn't teach": it is excluded from the per-domain routing
+    # aggregate and tallied visibly under ``tainted_runs`` instead. The taint
+    # marker is not yet produced upstream, so this defaults False (default-
+    # admissible per clause 4), but the exclusion path exists and is exercised.
+    dev_tainted: bool = False
 
 
 # ── I/O ───────────────────────────────────────────────────────────────────
@@ -366,6 +383,55 @@ def _fold_dev_bucket(
     _fold_duration(bucket, duration_s, timeout_killed, timeout_limit_s)
 
 
+def _fold_domain_slice(
+    bucket: dict,
+    success: bool,
+    iterations: int,
+    cost_usd: float | None,
+    duration_s: float | None,
+    timeout_killed: bool,
+    timeout_limit_s: int | None,
+    termination_cause: str | None,
+    tainted: bool,
+) -> None:
+    """Fold one dev run into a per-domain slice with recency + taint handling.
+
+    Extends :func:`_fold_dev_bucket` with the two gates ADR-0006 requires before
+    a per-domain rate may carry routing weight (issue #155):
+
+    - **Taint exclusion (clause 4):** a ``tainted`` run "doesn't teach" — it is
+      kept out of the capability accumulators entirely and tallied under
+      ``tainted_runs`` so the exclusion is visible in the record, never silently
+      dropped.
+    - **Recency window (clause 2.4):** every genuine completed run (not tainted,
+      not harness-terminated) appends its outcome to a bounded ``_recent`` ring
+      (:data:`DOMAIN_RECENCY_WINDOW`). The routing-admissible rate is computed
+      from this window, so stale history decays out of relevance instead of
+      permanently weighting a lifetime cumulative average.
+    """
+    if tainted:
+        bucket["tainted_runs"] = int(bucket.get("tainted_runs", 0)) + 1
+        return
+    _fold_dev_bucket(
+        bucket,
+        success,
+        iterations,
+        cost_usd,
+        duration_s,
+        timeout_killed,
+        timeout_limit_s,
+        termination_cause,
+    )
+    # Only genuine completed runs enter the recency window. Harness-terminated
+    # runs (termination_cause set) never contribute capability data — mirror that
+    # here so the windowed rate matches the runs/_successes population exactly.
+    if termination_cause is None:
+        recent = bucket.setdefault("_recent", [])
+        recent.append(1 if success else 0)
+        if len(recent) > DOMAIN_RECENCY_WINDOW:
+            del recent[: len(recent) - DOMAIN_RECENCY_WINDOW]
+
+
 def _update_dev(
     entry: dict,
     complexity: str,
@@ -378,6 +444,7 @@ def _update_dev(
     timeout_limit_s: int | None = None,
     termination_cause: str | None = None,
     domains: list[str] | None = None,
+    tainted: bool = False,
 ) -> None:
     if cost_usd is None:
         log.warning(
@@ -430,11 +497,12 @@ def _update_dev(
     # tag it carried. A run tagged [api, database] folds identically into both
     # the "api" and "database" buckets, so per-domain success rate is a real
     # aggregation over authoritative run telemetry (ADR-0006 clause B), not a
-    # summary or profile-only derivation.
+    # summary or profile-only derivation. The slice fold applies the recency
+    # window and taint exclusion the domain routing signal reads through.
     for domain in domains or []:
         by_domain = dev.setdefault("by_domain", {})
         dd = by_domain.setdefault(domain, {})
-        _fold_dev_bucket(
+        _fold_domain_slice(
             dd,
             success,
             iterations,
@@ -443,6 +511,7 @@ def _update_dev(
             timeout_killed,
             timeout_limit_s,
             termination_cause,
+            tainted,
         )
 
 
@@ -600,6 +669,7 @@ def apply_run(data: dict, outcome: RunOutcome) -> dict:
         timeout_limit_s=outcome.dev_timeout_limit_s,
         termination_cause=outcome.dev_termination_cause,
         domains=outcome.domains,
+        tainted=outcome.dev_tainted,
     )
     if outcome.preflight_model:
         pf_entry = _ensure_model(
@@ -787,19 +857,29 @@ def get_dev_domain_signal(
     """Return a per-domain dev routing signal for the story's domain tags (#155).
 
     Aggregates the ``dev.by_domain`` slices for each requested tag across every
-    matching profile entry, then applies the same ADR-0006 clause-2 admissibility
-    gates the complexity signal uses so a domain rate can only ever be a
-    *preference within the eligible pool*, never eligibility itself:
+    matching profile entry, then clears the full ADR-0006 clause-2 admissibility
+    set so a domain rate can only ever be a *preference within the eligible
+    pool*, never eligibility itself. The value the router ranks on (``rate``) is
+    the **recency-weighted** rate, not the lifetime cumulative ``raw``:
 
     - **Mechanical provenance / completeness (2.1–2.2):** the slice is folded by
-      :func:`_fold_dev_bucket`, which segregates harness-terminated runs out of
+      :func:`_fold_domain_slice`, which segregates harness-terminated runs out of
       the capability counts — the same complete recording path the complexity
       slice uses. No summary prose feeds this.
     - **Sample floor (2.3):** ``rate`` is ``None`` until ``runs >= min_runs``;
       below the floor the caller falls through to static tier/budget routing
       (cold start is a static-routing condition, not a low-confidence one).
-    - **Recency (2.4):** ``weighted`` mirrors ``raw`` until the shared weighting
-      mechanism (#1392) lands — the key exists so the audit contract is stable.
+    - **Recency weighting (2.4):** ``weighted`` is computed from a bounded recent
+      window (:data:`DOMAIN_RECENCY_WINDOW`), a windowed view of history rather
+      than the lifetime cumulative aggregate clause 2.4 forbids. ``rate`` returns
+      the **weighted** value, so stale buckets decay out of routing weight; both
+      ``raw`` and ``weighted`` are recorded (clause 7). When the shared decay
+      mechanism (#1392) lands it supersedes this window without changing the read
+      contract.
+    - **Taint exclusion (clause 4):** tainted runs are never folded into the
+      capability counts or the window; they are tallied under ``tainted_runs``
+      (returned per-domain and in total) so the exclusion is visible and a
+      tainted bucket cannot carry routing weight.
     - **Role specificity (per-role):** this reads only ``dev`` slices; it says
       nothing about review reliability.
     - **Schema stability (2.5):** legacy profiles simply lack ``by_domain`` and
@@ -812,7 +892,8 @@ def get_dev_domain_signal(
     routing_decision block can show the matching profile slice per tag.
 
     Returns ``rate=None`` with ``floor="fail"`` when ``domains`` is empty or no
-    domain data exists — an explicit no-signal status, never a negative score.
+    admissible domain data exists — an explicit no-signal status, never a
+    negative score.
     """
     requested = [d for d in (domains or []) if isinstance(d, str) and d]
     matching = _matching_profile_entries(
@@ -825,9 +906,13 @@ def get_dev_domain_signal(
     per_domain: dict[str, dict] = {}
     total_runs = 0
     total_successes = 0.0
+    total_tainted = 0
+    recent_all: list[int] = []
     for domain in requested:
         d_runs = 0
         d_successes = 0.0
+        d_tainted = 0
+        d_recent: list[int] = []
         for _, entry in matching:
             dev = entry.get("dev")
             if not isinstance(dev, dict):
@@ -835,29 +920,57 @@ def get_dev_domain_signal(
             dd = (dev.get("by_domain") or {}).get(domain)
             if not isinstance(dd, dict):
                 continue
+            d_tainted += int(dd.get("tainted_runs", 0))
             entry_runs = int(dd.get("runs", 0))
             if entry_runs <= 0:
                 continue
             d_runs += entry_runs
             d_successes += _success_count(dd, entry_runs)
+            recent = dd.get("_recent")
+            if isinstance(recent, list):
+                d_recent.extend(int(v) for v in recent)
+        d_raw = round(d_successes / d_runs, 4) if d_runs > 0 else None
+        d_weighted = _windowed_rate(d_recent, fallback=d_raw)
         per_domain[domain] = {
             "runs": d_runs,
-            "raw": round(d_successes / d_runs, 4) if d_runs > 0 else None,
+            "raw": d_raw,
+            "weighted": d_weighted,
+            "tainted_runs": d_tainted,
         }
         total_runs += d_runs
         total_successes += d_successes
+        total_tainted += d_tainted
+        recent_all.extend(d_recent)
     raw = round(total_successes / total_runs, 4) if total_runs > 0 else None
+    weighted = _windowed_rate(recent_all, fallback=raw)
     floor_ok = total_runs >= min_runs and total_runs > 0
     return {
         "domains": requested,
         "raw": raw,
-        # v1: no recency weighting (#1392) — weighted mirrors raw until it lands.
-        "weighted": raw,
+        # Admissible ranked value is the recency-weighted window, not lifetime raw.
+        "weighted": weighted,
         "runs": total_runs,
+        "tainted_runs": total_tainted,
         "floor": "pass" if floor_ok else "fail",
-        "rate": raw if floor_ok else None,
+        "recency": "windowed",
+        "rate": weighted if floor_ok else None,
         "by_domain": per_domain,
     }
+
+
+def _windowed_rate(recent: list[int], *, fallback: float | None) -> float | None:
+    """Return the recency-weighted rate over a bounded recent-outcome window.
+
+    ``recent`` is the concatenation of the ``_recent`` rings clause 2.4 maintains
+    per domain slice (each already capped to :data:`DOMAIN_RECENCY_WINDOW`). The
+    mean over that window is the windowed view of history. Falls back to
+    ``fallback`` (the lifetime raw rate) only when no windowed data exists — e.g.
+    a legacy bucket predating the window — so the value is never silently zeroed.
+    """
+    if recent:
+        capped = recent[-DOMAIN_RECENCY_WINDOW:]
+        return round(sum(capped) / len(capped), 4)
+    return fallback
 
 
 def get_dev_complexity_stats(
@@ -1582,6 +1695,16 @@ def _merge_dev(target: dict, src: dict) -> None:
                 )
             _merge_duration(dd_target, dd_src)
             _merge_harness_terminated(dd_target, dd_src)
+            # Recency window (#155): concatenate the recent rings and re-cap so the
+            # merged slice keeps a bounded windowed view. Tainted tallies sum.
+            merged_recent = [int(v) for v in (dd_target.get("_recent") or [])] + [
+                int(v) for v in (dd_src.get("_recent") or [])
+            ]
+            if merged_recent:
+                dd_target["_recent"] = merged_recent[-DOMAIN_RECENCY_WINDOW:]
+            dd_target["tainted_runs"] = int(dd_target.get("tainted_runs", 0)) + int(
+                dd_src.get("tainted_runs", 0)
+            )
 
 
 def _merge_review(target: dict, src: dict) -> None:

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -1,6 +1,8 @@
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
+from theforge.domains import taxonomy_prompt_lines
+
 from .context_assembler import ContextPack
 from .conventions import render_conventions_block
 from .plan_parser import PlanData
@@ -34,6 +36,8 @@ def build_preflight_prompt(
 
             {assembled_context.content}
         """)
+
+    domain_taxonomy = taxonomy_prompt_lines()
 
     return dedent(f"""\
         You are a bounded forensic classifier for **{task.name}**.
@@ -177,6 +181,22 @@ def build_preflight_prompt(
 
         When verdict is ALREADY_DONE or BLOCKED, set work_type to "feature" as a placeholder.
 
+        ## Domain Classification
+
+        When verdict is PROCEED, also tag the story with zero or more **domains**
+        describing the *kind* of work it involves (what area of the codebase it
+        stresses), distinct from work_type (which describes the shape of the
+        change). Select tags ONLY from this fixed taxonomy — do not invent new
+        tags; any tag outside this set is dropped:
+
+{domain_taxonomy}
+
+        Emit `domains: []` when no taxonomy tag clearly applies. Prefer a small,
+        precise set (usually 1–3 tags) over speculative breadth — a tag should
+        reflect a domain the story genuinely exercises, not one it merely
+        mentions in passing. When verdict is ALREADY_DONE or BLOCKED, emit
+        `domains: []`.
+
         ## Spec Sufficiency Classification
 
         When verdict is PROCEED, also assess whether this spec is
@@ -244,6 +264,7 @@ def build_preflight_prompt(
         complexity_score: <integer 1-10>
         complexity: small | medium | large
         work_type: feature | refactor | mechanical | bug
+        domains: []  # or a list of tags from the fixed domain taxonomy
         contract_change: true | false
         reason: "<1-2 sentence explanation of your classification>"
         sufficiency: implementation_ready | needs_planning

--- a/tests/test_domain_routing.py
+++ b/tests/test_domain_routing.py
@@ -17,11 +17,6 @@ from pathlib import Path
 from theforge.assignment import AssignmentConfig, assign_models
 from theforge.config import AgentDef
 from theforge.coordinator.preflight import _parse_preflight_domains
-from theforge.domains import (
-    DOMAIN_TAXONOMY,
-    normalize_domain,
-    validate_domains,
-)
 from theforge.model_profiles import (
     RunOutcome,
     apply_run,
@@ -29,32 +24,8 @@ from theforge.model_profiles import (
 )
 from theforge.task import TaskStory, build_preflight_prompt
 
-# ── Taxonomy ───────────────────────────────────────────────────────────
-
-
-class TestTaxonomy:
-    def test_known_tags_pass(self):
-        for tag in ("react", "css", "api", "database", "cli", "config"):
-            assert tag in DOMAIN_TAXONOMY
-            assert normalize_domain(tag) == tag
-
-    def test_normalization_folds_case_and_separators(self):
-        assert normalize_domain("React") == "react"
-        assert normalize_domain(" data_processing ") == "data-processing"
-        assert normalize_domain("Data Processing") == "data-processing"
-
-    def test_unknown_tag_dropped(self):
-        assert normalize_domain("blockchain") is None
-        assert normalize_domain(123) is None
-
-    def test_validate_domains_dedups_and_drops_unknown(self):
-        assert validate_domains(["react", "css", "bogus", "React"]) == ["react", "css"]
-
-    def test_validate_domains_non_list_is_empty(self):
-        assert validate_domains(None) == []
-        assert validate_domains("react") == []
-        assert validate_domains({"react": 1}) == []
-
+# Taxonomy-module unit coverage lives in tests/test_domains.py (the source
+# mirror); this file covers the preflight→aggregation→routing seam.
 
 # ── Preflight parsing + prompt surface ─────────────────────────────────
 

--- a/tests/test_domain_routing.py
+++ b/tests/test_domain_routing.py
@@ -66,7 +66,9 @@ class TestPreflightPromptDomains:
 # ── Per-domain aggregation ─────────────────────────────────────────────
 
 
-def _record(data: dict, model: str, success: bool, *, domains, n: int = 1) -> None:
+def _record(
+    data: dict, model: str, success: bool, *, domains, n: int = 1, tainted: bool = False
+) -> None:
     for _ in range(n):
         apply_run(
             data,
@@ -77,6 +79,7 @@ def _record(data: dict, model: str, success: bool, *, domains, n: int = 1) -> No
                 dev_iterations=1,
                 dev_cost_usd=0.1,
                 domains=list(domains),
+                dev_tainted=tainted,
             ),
         )
 
@@ -89,8 +92,11 @@ class TestPerDomainAggregation:
         sig = get_dev_domain_signal(data, "A", ["api"])
         assert sig["runs"] == 4
         assert sig["raw"] == 0.75
-        assert sig["weighted"] == 0.75  # recency mirrors raw in v1
+        # All 4 runs fit the recency window, so weighted == raw here; rate is the
+        # recency-weighted value (never the lifetime raw).
+        assert sig["weighted"] == 0.75
         assert sig["rate"] == 0.75
+        assert sig["recency"] == "windowed"
         assert sig["floor"] == "pass"
 
     def test_sample_floor_gates_rate(self):
@@ -120,8 +126,55 @@ class TestPerDomainAggregation:
         _record(data, "A", True, domains=["api"], n=3)
         _record(data, "A", False, domains=["css"], n=3)
         sig = get_dev_domain_signal(data, "A", ["api", "css"])
-        assert sig["by_domain"]["api"] == {"runs": 3, "raw": 1.0}
-        assert sig["by_domain"]["css"] == {"runs": 3, "raw": 0.0}
+        assert sig["by_domain"]["api"] == {
+            "runs": 3,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "tainted_runs": 0,
+        }
+        assert sig["by_domain"]["css"] == {
+            "runs": 3,
+            "raw": 0.0,
+            "weighted": 0.0,
+            "tainted_runs": 0,
+        }
+
+    def test_recency_window_downweights_stale_history(self):
+        # 20 early successes then 5 recent failures: lifetime raw stays high, but
+        # the windowed rate drops as the stale successes fall out of the window.
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=20)
+        _record(data, "A", False, domains=["api"], n=5)
+        sig = get_dev_domain_signal(data, "A", ["api"])
+        assert sig["runs"] == 25
+        assert sig["raw"] == 0.8  # 20/25 lifetime
+        # Window is the last 20 outcomes: 15 successes + 5 failures = 0.75.
+        assert sig["weighted"] == 0.75
+        # The admissible ranked value is the recency-weighted one, not raw.
+        assert sig["rate"] == 0.75
+
+    def test_tainted_runs_excluded_from_domain_rate(self):
+        # Tainted runs "don't teach": they are tallied but never move the rate.
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=3)
+        _record(data, "A", False, domains=["api"], n=5, tainted=True)
+        sig = get_dev_domain_signal(data, "A", ["api"])
+        assert sig["runs"] == 3  # tainted runs excluded from the sample
+        assert sig["tainted_runs"] == 5
+        assert sig["raw"] == 1.0
+        assert sig["weighted"] == 1.0
+        assert sig["rate"] == 1.0  # unaffected by the 5 tainted failures
+        assert sig["by_domain"]["api"]["tainted_runs"] == 5
+
+    def test_all_tainted_history_is_cold_start(self):
+        # A bucket whose only history is tainted carries no routing weight.
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=6, tainted=True)
+        sig = get_dev_domain_signal(data, "A", ["api"])
+        assert sig["runs"] == 0
+        assert sig["tainted_runs"] == 6
+        assert sig["rate"] is None
+        assert sig["floor"] == "fail"
 
 
 # ── Assignment: domain match as a tie/preference signal ────────────────
@@ -213,12 +266,20 @@ class TestDomainTiebreak:
         assert dm["influenced"] is True
         assert dm["complexity_only_head"] == "mx"
         assert dm["domain_head"] == "my"
-        # Matching profile slice for the selected model is recorded.
-        assert dm["selected_model_slice"]["rate"] == 1.0
-        assert dm["selected_model_slice"]["runs"] == 3
+        # Matching profile slice for the selected model records the full
+        # admissibility surface: sample count, floor, and raw + weighted values.
+        slice_ = dm["selected_model_slice"]
+        assert slice_["rate"] == 1.0
+        assert slice_["runs"] == 3
+        assert slice_["floor"] == "pass"
+        assert slice_["raw"] == 1.0
+        assert slice_["weighted"] == 1.0
+        assert slice_["tainted_runs"] == 0
         # Per-candidate domain slice is attached to the pool entry too.
         pool = {e["name"]: e for e in d1.routing_decision["dev"]["candidate_pool"]}
         assert pool["my"]["signals"]["domain"]["rate"] == 1.0
+        assert pool["my"]["signals"]["domain"]["weighted"] == 1.0
+        assert pool["my"]["signals"]["domain"]["floor"] == "pass"
 
     def test_no_domains_omits_domain_match_block(self):
         agents = self._tie_agents()
@@ -254,6 +315,33 @@ class TestDomainTiebreak:
         assert d.dev.model == "mx-model"
         dm = d.routing_decision["dev"]["domain_match"]
         assert dm["influenced"] is False
+
+    def test_tainted_domain_history_does_not_sway_assignment(self):
+        # my's ONLY api evidence is tainted, so it carries no admissible domain
+        # signal; the complexity tie must fall through to price (cheaper mx wins)
+        # exactly as if my had no api history at all.
+        agents = self._tie_agents()  # mx cheaper, my pricier
+        data: dict = {"models": {}}
+        _record(data, "mx", True, domains=[], n=3)  # complexity 1.0
+        _record(data, "my", True, domains=[], n=3)  # complexity 1.0 (tie)
+        _record(data, "my", True, domains=["api"], n=5, tainted=True)  # tainted api only
+        d = assign_models(
+            agents,
+            _cfg(),
+            complexity="MEDIUM",
+            complexity_score=5,
+            model_profiles=data,
+            secrets=_SECRETS,
+            domains=["api"],
+        )
+        assert d.dev.model == "mx-model"
+        dm = d.routing_decision["dev"]["domain_match"]
+        assert dm["influenced"] is False
+        # The tainted evidence is visible but non-influential.
+        assert dm["selected_model_slice"] is None or dm["selected_model_slice"]["rate"] is None
+        my_slice = {e["name"]: e for e in d.routing_decision["dev"]["candidate_pool"]}["my"]
+        assert my_slice["signals"]["domain"]["tainted_runs"] == 5
+        assert my_slice["signals"]["domain"]["rate"] is None
 
 
 class TestColdStartNotPenalized:

--- a/tests/test_domain_routing.py
+++ b/tests/test_domain_routing.py
@@ -1,0 +1,370 @@
+"""Domain-aware adaptive routing (issue #155).
+
+Seam-level coverage for the preflight → profile-aggregation → assignment flow:
+
+- taxonomy validation / normalization
+- preflight ``domains`` parsing and prompt surface
+- deterministic per-domain aggregation in model_profiles with clause-2 gates
+- domain match as a tie/preference-only signal inside the eligible pool
+- cold-start models not penalized
+- routing_decision explainability when domain match influences the decision
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.assignment import AssignmentConfig, assign_models
+from theforge.config import AgentDef
+from theforge.coordinator.preflight import _parse_preflight_domains
+from theforge.domains import (
+    DOMAIN_TAXONOMY,
+    normalize_domain,
+    validate_domains,
+)
+from theforge.model_profiles import (
+    RunOutcome,
+    apply_run,
+    get_dev_domain_signal,
+)
+from theforge.task import TaskStory, build_preflight_prompt
+
+# ── Taxonomy ───────────────────────────────────────────────────────────
+
+
+class TestTaxonomy:
+    def test_known_tags_pass(self):
+        for tag in ("react", "css", "api", "database", "cli", "config"):
+            assert tag in DOMAIN_TAXONOMY
+            assert normalize_domain(tag) == tag
+
+    def test_normalization_folds_case_and_separators(self):
+        assert normalize_domain("React") == "react"
+        assert normalize_domain(" data_processing ") == "data-processing"
+        assert normalize_domain("Data Processing") == "data-processing"
+
+    def test_unknown_tag_dropped(self):
+        assert normalize_domain("blockchain") is None
+        assert normalize_domain(123) is None
+
+    def test_validate_domains_dedups_and_drops_unknown(self):
+        assert validate_domains(["react", "css", "bogus", "React"]) == ["react", "css"]
+
+    def test_validate_domains_non_list_is_empty(self):
+        assert validate_domains(None) == []
+        assert validate_domains("react") == []
+        assert validate_domains({"react": 1}) == []
+
+
+# ── Preflight parsing + prompt surface ─────────────────────────────────
+
+
+class TestParsePreflightDomains:
+    def test_parses_list(self):
+        out = "```yaml\nverdict: PROCEED\ndomains: [api, database]\n```"
+        assert _parse_preflight_domains(out) == ["api", "database"]
+
+    def test_drops_unknown_tags(self):
+        out = "```yaml\nverdict: PROCEED\ndomains: [api, quantum]\n```"
+        assert _parse_preflight_domains(out) == ["api"]
+
+    def test_missing_field_is_empty(self):
+        out = "```yaml\nverdict: PROCEED\ncomplexity: small\n```"
+        assert _parse_preflight_domains(out) == []
+
+    def test_malformed_yaml_is_empty(self):
+        assert _parse_preflight_domains("```yaml\n{{{ bad\n```") == []
+
+    def test_no_fences_still_parses(self):
+        assert _parse_preflight_domains("verdict: PROCEED\ndomains: [cli]\n") == ["cli"]
+
+
+class TestPreflightPromptDomains:
+    def test_prompt_advertises_taxonomy_and_field(self, tmp_path: Path):
+        spec = tmp_path / "s.md"
+        spec.write_text("# Test", encoding="utf-8")
+        task = TaskStory(name="T", story_path=spec, slug="t")
+        prompt = build_preflight_prompt(task, story_content="# Test")
+        assert "Domain Classification" in prompt
+        assert "domains: []" in prompt
+        # Enumerated from the single-source taxonomy.
+        assert "`react`" in prompt
+        assert "`database`" in prompt
+
+
+# ── Per-domain aggregation ─────────────────────────────────────────────
+
+
+def _record(data: dict, model: str, success: bool, *, domains, n: int = 1) -> None:
+    for _ in range(n):
+        apply_run(
+            data,
+            RunOutcome(
+                complexity="medium",
+                dev_model=model,
+                dev_success=success,
+                dev_iterations=1,
+                dev_cost_usd=0.1,
+                domains=list(domains),
+            ),
+        )
+
+
+class TestPerDomainAggregation:
+    def test_rate_is_deterministic_aggregation(self):
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=3)
+        _record(data, "A", False, domains=["api"], n=1)
+        sig = get_dev_domain_signal(data, "A", ["api"])
+        assert sig["runs"] == 4
+        assert sig["raw"] == 0.75
+        assert sig["weighted"] == 0.75  # recency mirrors raw in v1
+        assert sig["rate"] == 0.75
+        assert sig["floor"] == "pass"
+
+    def test_sample_floor_gates_rate(self):
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=2)  # below min_runs=3
+        sig = get_dev_domain_signal(data, "A", ["api"])
+        assert sig["runs"] == 2
+        assert sig["raw"] == 1.0
+        assert sig["rate"] is None  # gated below floor
+        assert sig["floor"] == "fail"
+
+    def test_cold_start_no_domain_data_is_no_signal(self):
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=3)
+        sig = get_dev_domain_signal(data, "A", ["database"])
+        assert sig["runs"] == 0
+        assert sig["rate"] is None
+        assert sig["floor"] == "fail"
+
+    def test_empty_domains_is_no_signal(self):
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=3)
+        assert get_dev_domain_signal(data, "A", [])["rate"] is None
+
+    def test_per_domain_slice_recorded(self):
+        data: dict = {"models": {}}
+        _record(data, "A", True, domains=["api"], n=3)
+        _record(data, "A", False, domains=["css"], n=3)
+        sig = get_dev_domain_signal(data, "A", ["api", "css"])
+        assert sig["by_domain"]["api"] == {"runs": 3, "raw": 1.0}
+        assert sig["by_domain"]["css"] == {"runs": 3, "raw": 0.0}
+
+
+# ── Assignment: domain match as a tie/preference signal ────────────────
+
+
+def _cfg(**kwargs) -> AssignmentConfig:
+    defaults = dict(
+        enabled=True,
+        min_reviewers=1,
+        max_reviewers=1,
+        prefer_cross_provider=False,
+        max_cost_per_story_usd=None,
+        escalation_memory=True,
+    )
+    defaults.update(kwargs)
+    return AssignmentConfig(**defaults)
+
+
+def _mid_agent(name: str, model: str, in_cost: float, out_cost: float) -> AgentDef:
+    return AgentDef(
+        name=name,
+        provider="anthropic",
+        model=model,
+        budget_usd=3.0,
+        timeout_seconds=600,
+        tier="mid",
+        input_cost_per_mtok=in_cost,
+        output_cost_per_mtok=out_cost,
+    )
+
+
+_SECRETS = {"ANTHROPIC_API_KEY": "k"}
+
+
+class TestDomainTiebreak:
+    def _tie_agents(self) -> list[AgentDef]:
+        # Two mid-tier candidates tied on complexity success rate; mx is cheaper.
+        return [
+            _mid_agent("mx", "mx-model", 1.0, 1.0),
+            _mid_agent("my", "my-model", 5.0, 5.0),
+        ]
+
+    def _tie_profiles(self) -> dict:
+        data: dict = {"models": {}}
+        # Both models: identical medium complexity rate 1.0 (floor passes).
+        _record(data, "mx", True, domains=[], n=3)
+        _record(data, "my", True, domains=["api"], n=3)  # my is strong at api
+        return data
+
+    def test_domain_breaks_tie_within_eligible_pool(self):
+        agents = self._tie_agents()
+        profiles = self._tie_profiles()
+        # Without domains: complexity tie → cheaper mx wins on price.
+        d0 = assign_models(
+            agents,
+            _cfg(),
+            complexity="MEDIUM",
+            complexity_score=5,
+            model_profiles=profiles,
+            secrets=_SECRETS,
+        )
+        assert d0.dev.model == "mx-model"
+        # With the api domain: my's admissible api rate breaks the tie.
+        d1 = assign_models(
+            agents,
+            _cfg(),
+            complexity="MEDIUM",
+            complexity_score=5,
+            model_profiles=profiles,
+            secrets=_SECRETS,
+            domains=["api"],
+        )
+        assert d1.dev.model == "my-model"
+
+    def test_routing_decision_records_domain_influence(self):
+        agents = self._tie_agents()
+        profiles = self._tie_profiles()
+        d1 = assign_models(
+            agents,
+            _cfg(),
+            complexity="MEDIUM",
+            complexity_score=5,
+            model_profiles=profiles,
+            secrets=_SECRETS,
+            domains=["api"],
+        )
+        dm = d1.routing_decision["dev"]["domain_match"]
+        assert dm["domains"] == ["api"]
+        assert dm["influenced"] is True
+        assert dm["complexity_only_head"] == "mx"
+        assert dm["domain_head"] == "my"
+        # Matching profile slice for the selected model is recorded.
+        assert dm["selected_model_slice"]["rate"] == 1.0
+        assert dm["selected_model_slice"]["runs"] == 3
+        # Per-candidate domain slice is attached to the pool entry too.
+        pool = {e["name"]: e for e in d1.routing_decision["dev"]["candidate_pool"]}
+        assert pool["my"]["signals"]["domain"]["rate"] == 1.0
+
+    def test_no_domains_omits_domain_match_block(self):
+        agents = self._tie_agents()
+        profiles = self._tie_profiles()
+        d0 = assign_models(
+            agents,
+            _cfg(),
+            complexity="MEDIUM",
+            complexity_score=5,
+            model_profiles=profiles,
+            secrets=_SECRETS,
+        )
+        assert "domain_match" not in d0.routing_decision["dev"]
+
+    def test_domain_present_but_non_influential_marked(self):
+        # my has api data, mx has none, but mx has the STRICTLY higher complexity
+        # rate, so the vertical axis decides and domain must not override it.
+        agents = self._tie_agents()
+        data: dict = {"models": {}}
+        _record(data, "mx", True, domains=[], n=4)  # mx rate 1.0
+        _record(data, "my", True, domains=["api"], n=2)
+        _record(data, "my", False, domains=["api"], n=2)  # my rate 0.5, api rate 0.5
+        d = assign_models(
+            agents,
+            _cfg(),
+            complexity="MEDIUM",
+            complexity_score=5,
+            model_profiles=data,
+            secrets=_SECRETS,
+            domains=["api"],
+        )
+        # mx wins on complexity rate; domain did not change the selection.
+        assert d.dev.model == "mx-model"
+        dm = d.routing_decision["dev"]["domain_match"]
+        assert dm["influenced"] is False
+
+
+class TestColdStartNotPenalized:
+    def test_no_domain_data_keeps_complexity_standing(self):
+        # zed has the best complexity rate but no domain data; it must still win
+        # over a domain-strong-but-weaker-complexity model.
+        agents = [
+            _mid_agent("zed", "zed-model", 1.0, 1.0),
+            _mid_agent("dom", "dom-model", 1.0, 1.0),
+        ]
+        data: dict = {"models": {}}
+        _record(data, "zed", True, domains=[], n=4)  # complexity rate 1.0, no domain
+        _record(data, "dom", True, domains=["api"], n=2)
+        _record(data, "dom", False, domains=["api"], n=2)  # complexity 0.5, api 0.5
+        d = assign_models(
+            agents,
+            _cfg(),
+            complexity="MEDIUM",
+            complexity_score=5,
+            model_profiles=data,
+            secrets=_SECRETS,
+            domains=["api"],
+        )
+        assert d.dev.model == "zed-model"
+
+
+# ── Seam: state.preflight_domains flows into telemetry + routing ───────
+
+
+class TestDomainSeam:
+    def test_bridge_carries_domains_into_profiles_then_routing(self, tmp_path: Path):
+        """Domains recorded on state flow through RunOutcome into per-domain
+        aggregation, and the aggregated slice then moves a routing tie."""
+        from theforge.config import (
+            DEFAULT_DEV_PROFILE,
+            DEFAULT_PREFLIGHT_PROFILE,
+            DEFAULT_REVIEW_PROFILE,
+            DEFAULT_VALIDATION,
+            ForgeConfig,
+            ModelProfile,
+            RetryPolicy,
+            WorkspaceConfig,
+        )
+        from theforge.coordinator.model_profiles_bridge import build_run_outcome
+        from theforge.coordinator.state import CoordinatorState
+
+        dev_profile = ModelProfile(
+            name="my",
+            cli=None,
+            provider="anthropic",
+            model="my-model",
+            budget_usd=3.0,
+            timeout_seconds=600,
+            allowed_tools=DEFAULT_DEV_PROFILE.allowed_tools,
+        )
+        config = ForgeConfig(
+            project="t",
+            project_root=tmp_path,
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+            ),
+            validation=DEFAULT_VALIDATION,
+            dev_profile=dev_profile,
+            preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+            review_pool=[DEFAULT_REVIEW_PROFILE],
+            synthesis_profile=None,
+            retry=RetryPolicy(),
+        )
+        data: dict = {"models": {}}
+        for _ in range(3):
+            state = CoordinatorState()
+            state.preflight_complexity = "medium"
+            state.preflight_complexity_score = 5
+            state.preflight_domains = ["api"]
+            outcome = build_run_outcome(config, state, success=True)
+            assert outcome.domains == ["api"]
+            apply_run(data, outcome)
+
+        sig = get_dev_domain_signal(
+            data, "my", ["api"], actual_model="my-model", provider="anthropic"
+        )
+        assert sig["rate"] == 1.0
+        assert sig["runs"] == 3

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,0 +1,107 @@
+"""Unit tests for the domain taxonomy module (issue #155).
+
+Mirror of ``src/theforge/domains.py`` — covers the closed taxonomy set, tag
+normalization/validation, and the prompt-line rendering used as the single
+source the preflight prompt enumerates from.
+"""
+
+from __future__ import annotations
+
+from theforge.domains import (
+    DOMAIN_DESCRIPTIONS,
+    DOMAIN_TAXONOMY,
+    normalize_domain,
+    taxonomy_prompt_lines,
+    validate_domains,
+)
+
+# ── The taxonomy set ───────────────────────────────────────────────────
+
+
+class TestTaxonomySet:
+    def test_taxonomy_matches_descriptions_keys(self):
+        # DOMAIN_TAXONOMY is the closed admission set derived from the docs map,
+        # so the two can never drift apart.
+        assert DOMAIN_TAXONOMY == frozenset(DOMAIN_DESCRIPTIONS)
+
+    def test_expected_core_tags_present(self):
+        for tag in ("react", "css", "api", "database", "cli", "config"):
+            assert tag in DOMAIN_TAXONOMY
+
+    def test_every_tag_is_lowercase_and_documented(self):
+        for tag, desc in DOMAIN_DESCRIPTIONS.items():
+            assert tag == tag.lower()
+            assert isinstance(desc, str) and desc.strip(), f"{tag} lacks a description"
+
+
+# ── normalize_domain ───────────────────────────────────────────────────
+
+
+class TestNormalizeDomain:
+    def test_known_tags_pass_through(self):
+        for tag in DOMAIN_TAXONOMY:
+            assert normalize_domain(tag) == tag
+
+    def test_case_is_folded(self):
+        assert normalize_domain("React") == "react"
+        assert normalize_domain("API") == "api"
+
+    def test_separators_folded_to_hyphen(self):
+        assert normalize_domain("data_processing") == "data-processing"
+        assert normalize_domain("Data Processing") == "data-processing"
+
+    def test_surrounding_whitespace_trimmed(self):
+        assert normalize_domain("  cli  ") == "cli"
+
+    def test_unknown_tag_is_none(self):
+        assert normalize_domain("blockchain") is None
+        assert normalize_domain("") is None
+
+    def test_non_string_is_none(self):
+        assert normalize_domain(123) is None
+        assert normalize_domain(None) is None
+        assert normalize_domain(["react"]) is None
+
+
+# ── validate_domains ───────────────────────────────────────────────────
+
+
+class TestValidateDomains:
+    def test_keeps_known_drops_unknown(self):
+        assert validate_domains(["react", "bogus", "css"]) == ["react", "css"]
+
+    def test_dedups_preserving_first_appearance_order(self):
+        assert validate_domains(["css", "react", "React", "css"]) == ["css", "react"]
+
+    def test_normalizes_each_element(self):
+        assert validate_domains(["Data_Processing", "API"]) == ["data-processing", "api"]
+
+    def test_accepts_tuple(self):
+        assert validate_domains(("cli", "config")) == ["cli", "config"]
+
+    def test_non_list_inputs_are_empty(self):
+        assert validate_domains(None) == []
+        assert validate_domains("react") == []
+        assert validate_domains(42) == []
+        assert validate_domains({"react": 1}) == []
+
+    def test_empty_list_is_empty(self):
+        assert validate_domains([]) == []
+
+    def test_all_unknown_is_empty(self):
+        assert validate_domains(["quantum", "blockchain"]) == []
+
+
+# ── taxonomy_prompt_lines ──────────────────────────────────────────────
+
+
+class TestTaxonomyPromptLines:
+    def test_renders_one_line_per_tag(self):
+        lines = taxonomy_prompt_lines().splitlines()
+        assert len(lines) == len(DOMAIN_DESCRIPTIONS)
+
+    def test_each_line_names_tag_and_description(self):
+        rendered = taxonomy_prompt_lines()
+        for tag, desc in DOMAIN_DESCRIPTIONS.items():
+            assert f"`{tag}`" in rendered
+            assert desc in rendered


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Cycle 1 P1 is fixed: per-domain routing now uses windowed weighted rates with tainted runs excluded, and I found no fix regressions. | [google-gemini-3.5-flash] Domain-aware adaptive routing is fully implemented and verified, with the prior P1 finding resolved. | [claude-sonnet] Cycle 1 P1 (weighted mirrored raw, so stale/tainted domain buckets carried full routing weight) is resolved with a real bounded recency window and a taint-exclusion seam; no regressions found in the touched files and full domain/model_profiles/assignment suites pass (141/141) with ruff clean.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $24.45
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Domain-aware adaptive routing — match model strengths to story type (GitHub Issue #155)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #155