### PR TITLE
Router aggregates exclude tainted runs — clause-4 consumption side

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -1095,6 +1095,7 @@ def _build_routing_decision(
     domains: list[str] | None = None,
     dev_domain_signals: dict[str, dict] | None = None,
     dev_domain_match: dict[str, object] | None = None,
+    excluded_for_taint: int = 0,
 ) -> dict[str, object]:
     """Assemble the per-role routing_decision explainability block (#1391).
 
@@ -1168,6 +1169,13 @@ def _build_routing_decision(
 
     return {
         "origin": origin,
+        # Excluded-for-taint count (ADR-0006 clause 4 + clause 7, #1852). How many
+        # historical runs the centralized taint gate set aside from the router-
+        # consumed escalation history because they failed their own trust checks.
+        # Surfaced at the top level so operators see how much history was
+        # discounted for taint before any per-role explanation. The runs remain in
+        # the substrate (ADR-0002 refusal-to-forget); this is a read-time count.
+        "excluded_for_taint": int(excluded_for_taint),
         "preflight": {
             "candidate_pool": _single_model_pool(
                 agents,
@@ -1338,6 +1346,7 @@ def assign_models(
     unhealthy_models: set[str] | None = None,
     routing_origin: str = "preflight",
     domains: list[str] | None = None,
+    excluded_for_taint: int = 0,
 ) -> AssignmentDecision:
     """Pure deterministic function — no LLM, no I/O.
 
@@ -1723,6 +1732,7 @@ def assign_models(
             domains=effective_domains,
             dev_domain_signals=_dev_domain_signals,
             dev_domain_match=_dev_domain_match,
+            excluded_for_taint=excluded_for_taint,
         )
         return _dc_replace(dec, routing_decision=block)
 

--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -184,6 +184,12 @@ def render_routing_decision(block: dict) -> list[str]:
     origin = block.get("origin", "?")
     lines.append(f"Routing decision (origin: {origin})")
     lines.append("=" * 60)
+    # Excluded-for-taint (ADR-0006 clause 4/7, #1852): how much router-consumed
+    # history was set aside because it failed its own trust checks. Only shown
+    # when present and non-zero so legacy blocks (no field) render unchanged.
+    excluded_for_taint = block.get("excluded_for_taint")
+    if isinstance(excluded_for_taint, int) and excluded_for_taint > 0:
+        lines.append(f"excluded for taint: {excluded_for_taint} run(s) set aside (not deleted)")
     for role in _ROLE_ORDER:
         role_block = block.get(role)
         if not isinstance(role_block, dict):

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -1420,7 +1420,11 @@ def _coerce_complexity_score(value: object) -> int | None:
     return None
 
 
-def derive_assignment_history(conn: sqlite3.Connection) -> list[dict]:
+def derive_assignment_history(
+    conn: sqlite3.Connection,
+    *,
+    stats: dict | None = None,
+) -> list[dict]:
     """Return assignment-history records derived from per-run audit records.
 
     Replaces the YAML snapshot at ``.forge/assignment_history.yaml`` as the
@@ -1433,13 +1437,28 @@ def derive_assignment_history(conn: sqlite3.Connection) -> list[dict]:
     reconstruct an :class:`EscalationRecord` are skipped — they predate
     adaptive routing and were never represented in the legacy YAML either.
 
+    Runs marked ``tainted`` by the trust-status marker (ADR-0006 clause 4) are
+    excluded before any projection: a run that failed its own trust checks
+    "doesn't teach", so it must not carry routing weight. Filtering routes
+    through the centralized :func:`trust_status.filter_tainted_records` gate so
+    the rule stays identical across every consumer. The tainted rows remain in
+    the substrate untouched (ADR-0002 refusal-to-forget); this is a read-time
+    gate. When ``stats`` is provided, its ``"excluded_for_taint"`` key is
+    incremented by the number of records set aside so callers (preflight) can
+    surface the count in ``routing_decision``.
+
     This is the CLI/export view (mapped complexity bands, derives dev model
     from preflight routing assignments). Adaptive routing uses the more
     runtime-faithful :func:`iter_escalation_records` instead, which derives
     dev model from ``cost.agents`` (the model that actually ran).
     """
+    from .trust_status import filter_tainted_records  # noqa: PLC0415
+
+    admissible, excluded = filter_tainted_records(iter_records(conn, order_by_started=True))
+    if stats is not None:
+        stats["excluded_for_taint"] = int(stats.get("excluded_for_taint", 0)) + excluded
     out: list[dict] = []
-    for record in iter_records(conn, order_by_started=True):
+    for record in admissible:
         slug = (record.get("task") or {}).get("slug")
         if not slug:
             continue
@@ -1516,7 +1535,14 @@ def iter_escalation_records(conn: sqlite3.Connection) -> Iterable[dict]:
     model from ``cost.agents`` — the model that actually ran). The CLI/export
     view :func:`derive_assignment_history` uses preflight assignments
     instead, which is the *intended* dev model rather than the executed one.
+
+    Runs marked ``tainted`` by the trust-status marker (ADR-0006 clause 4) are
+    dropped before ``_derive_escalation`` so a run that failed its own trust
+    checks never carries routing weight. The exclusion routes through the same
+    centralized :func:`trust_status.is_tainted` gate every other consumer uses.
     """
+    from .trust_status import is_tainted  # noqa: PLC0415
+
     rows = conn.execute(
         "SELECT raw_json, record_schema_version FROM audit_records "
         "ORDER BY COALESCE(started_at, '') ASC"
@@ -1528,6 +1554,8 @@ def iter_escalation_records(conn: sqlite3.Connection) -> Iterable[dict]:
             raw, ver = row[0], row[1]
         record = _load_migrated(raw, ver)
         if record is None:
+            continue
+        if is_tainted(record.get("trust_status")):
             continue
         derived = _derive_escalation(record)
         if derived is not None:

--- a/src/theforge/coordinator/escalation_history.py
+++ b/src/theforge/coordinator/escalation_history.py
@@ -19,12 +19,29 @@ from theforge.coordinator import audit_substrate
 def load_escalation_history_from_substrate(project_root: Path) -> list[EscalationRecord]:
     """Return escalation records derived from substrate audit rows.
 
+    Thin wrapper over :func:`load_escalation_history_with_taint_stats` that
+    discards the taint count for callers that only need the history list. See
+    that function for the full behavior contract.
+    """
+    records, _excluded = load_escalation_history_with_taint_stats(project_root)
+    return records
+
+
+def load_escalation_history_with_taint_stats(
+    project_root: Path,
+) -> tuple[list[EscalationRecord], int]:
+    """Return ``(escalation records, excluded-for-taint count)`` from substrate.
+
     Behavior:
       - Truly fresh repo (no substrate file *and* no legacy/per-run audit
-        inputs) → return ``[]``. Adaptive routing has no history to consume
+        inputs) → return ``([], 0)``. Adaptive routing has no history to consume
         and proceeds with its tier-only defaults.
       - Substrate present and valid → project escalation rows from the
-        audit table.
+        audit table. Runs marked ``tainted`` by the trust-status marker
+        (ADR-0006 clause 4) are excluded by
+        :func:`audit_substrate.derive_assignment_history`; the number set aside
+        is returned as the second element so preflight can surface it in the
+        ``routing_decision`` block (ADR-0006 clause 7).
       - Substrate missing or corrupt while audit inputs exist → propagate
         ``SubstrateMissingError`` / ``SubstrateCorruptError``. The spec
         requires a clear operator-facing error, not silent no-history
@@ -39,11 +56,12 @@ def load_escalation_history_from_substrate(project_root: Path) -> list[Escalatio
     """
     sub_path = audit_substrate.substrate_path(project_root)
     if not sub_path.exists() and not audit_substrate.has_audit_inputs(project_root):
-        return []
+        return [], 0
     conn = audit_substrate.require_substrate(project_root)
     try:
+        stats: dict = {}
         out: list[EscalationRecord] = []
-        for entry in audit_substrate.derive_assignment_history(conn):
+        for entry in audit_substrate.derive_assignment_history(conn, stats=stats):
             out.append(
                 EscalationRecord(
                     story=str(entry.get("story") or ""),
@@ -55,6 +73,6 @@ def load_escalation_history_from_substrate(project_root: Path) -> list[Escalatio
                     complexity_score=entry.get("complexity_score"),
                 )
             )
-        return out
+        return out, int(stats.get("excluded_for_taint", 0))
     finally:
         conn.close()

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -15,6 +15,7 @@ from theforge.config import ForgeConfig
 from theforge.model_profiles import RunOutcome, update_from_run
 
 from .state import CoordinatorState
+from .trust_status import derive_trust_status, is_tainted
 
 
 def _extract_reviewers(
@@ -73,6 +74,13 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         if state.dev_process_timeout_killed
         else ("stuck_pattern" if state.dev_process_stuck_terminated else None)
     )
+    # Taint marker (ADR-0006 clause 4, #1852): derive the run's aggregate
+    # trust_status from its mechanically-computed trust checks — the same
+    # derivation the audit writer records — and exclude a tainted run from every
+    # router-consumed capability aggregate. A run with no implemented check stays
+    # "unchecked" (admissible); only an affirmative failed check taints it.
+    trust_status = derive_trust_status(state.trust_checks.values())
+    run_tainted = is_tainted(trust_status)
     return RunOutcome(
         complexity=complexity,
         complexity_score=state.preflight_complexity_score,
@@ -106,6 +114,7 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         # Domain tags (#155) recorded by preflight, folded into per-domain dev
         # slices so future routing can prefer models strong in the story's domains.
         domains=list(state.preflight_domains or []),
+        dev_tainted=run_tainted,
     )
 
 

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -1093,10 +1093,13 @@ def _apply_preflight_config(
         DEFAULT_PREFLIGHT_PROFILE as _DEF_PRE,
     )
     from theforge.coordinator.escalation_history import (  # noqa: PLC0415
-        load_escalation_history_from_substrate as _load_esc_history_substrate,
+        load_escalation_history_with_taint_stats as _load_esc_history_substrate,
     )
 
-    _esc_history = _load_esc_history_substrate(config.project_root)
+    # Escalation history plus the count of runs the centralized taint gate set
+    # aside (ADR-0006 clause 4). The count is surfaced in the routing_decision
+    # block (clause 7) so operators see how much history was discounted.
+    _esc_history, _excluded_for_taint = _load_esc_history_substrate(config.project_root)
 
     from theforge.model_profiles import load_profiles as _load_profiles  # noqa: PLC0415
 
@@ -1166,6 +1169,7 @@ def _apply_preflight_config(
         model_profiles=_model_profiles,
         unhealthy_models=_unhealthy if _unhealthy else None,
         domains=list(state.preflight_domains or []),
+        excluded_for_taint=_excluded_for_taint,
     )
 
     # Splice the full explicit pools back into the decision so audit and

--- a/src/theforge/coordinator/trust_status.py
+++ b/src/theforge/coordinator/trust_status.py
@@ -17,7 +17,9 @@ results.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Callable, Iterable, TypeVar
+
+_T = TypeVar("_T")
 
 # ── Trust-status vocabulary ──────────────────────────────────────────────
 # Aggregate status of a run, derived mechanically from its trust_checks.
@@ -92,3 +94,66 @@ def derive_trust_status(trust_checks: Iterable[dict] | None) -> str:
         if result == CHECK_PASS:
             has_applicable = True
     return TRUST_TRUSTED if has_applicable else TRUST_UNCHECKED
+
+
+# ── Centralized routing taint gate (ADR-0006 clause 4, #1852) ─────────────
+# One admissibility rule, applied by every router-consumed aggregate and
+# profile lookup so "tainted runs don't teach" is enforced in exactly one
+# place rather than re-derived per call site. The rule is intentionally
+# asymmetric: only an affirmative ``tainted`` status excludes a run. A missing
+# status (legacy records that predate the marker), ``trusted``, and
+# ``unchecked`` are all admissible — taint requires a failed check, not the
+# absence of a proof.
+
+
+def is_tainted(trust_status: str | None) -> bool:
+    """Return True only when ``trust_status`` is the affirmative taint marker.
+
+    Missing/``None``, :data:`TRUST_TRUSTED`, and :data:`TRUST_UNCHECKED` are all
+    non-tainted. This is the single predicate every routing consumer routes its
+    admissibility decision through.
+    """
+    return trust_status == TRUST_TAINTED
+
+
+def is_routing_admissible(trust_status: str | None) -> bool:
+    """Return True when a run may carry routing weight (i.e. is not tainted).
+
+    The inverse of :func:`is_tainted`, named for the call sites that read it as
+    an inclusion test. Trusted, unchecked, and missing-status runs are all
+    admissible (ADR-0006 clause 4).
+    """
+    return not is_tainted(trust_status)
+
+
+def filter_tainted_records(
+    records: Iterable[_T],
+    *,
+    status_of: Callable[[_T], str | None] | None = None,
+    status_key: str = "trust_status",
+) -> tuple[list[_T], int]:
+    """Split ``records`` into (admissible, excluded-for-taint count).
+
+    Every router-consumed history/aggregate loader routes its records through
+    this one helper so the exclusion rule and the reported count can never
+    drift from each other. ``status_of`` extracts the trust status from a
+    record; when omitted, records are treated as mappings and the status is read
+    from ``status_key`` (defaulting to ``"trust_status"``). Records whose status
+    :func:`is_tainted` are dropped from the returned list and counted; all others
+    are preserved in order. The source records are never mutated — filtering is a
+    read-time gate (ADR-0002 refusal-to-forget), never a deletion.
+    """
+    admissible: list[_T] = []
+    excluded = 0
+    for record in records:
+        if status_of is not None:
+            status = status_of(record)
+        elif isinstance(record, dict):
+            status = record.get(status_key)
+        else:
+            status = None
+        if is_tainted(status):
+            excluded += 1
+        else:
+            admissible.append(record)
+    return admissible, excluded

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -115,10 +115,14 @@ class RunOutcome:
     domains: list[str] = field(default_factory=list)
     # Taint marker (ADR-0006 clause 4, #1851/#1852 seam). True when the run failed
     # its own trust checks (e.g. a reviewer that reviewed a stale checkout). A
-    # tainted run "doesn't teach": it is excluded from the per-domain routing
-    # aggregate and tallied visibly under ``tainted_runs`` instead. The taint
-    # marker is not yet produced upstream, so this defaults False (default-
-    # admissible per clause 4), but the exclusion path exists and is exercised.
+    # tainted run "doesn't teach": it is excluded from EVERY router-consumed
+    # capability aggregate this run would feed — the top-level dev bucket, the
+    # per-complexity and per-score bands, each per-domain slice, and the review
+    # and preflight sections — and tallied visibly under ``tainted_runs`` in each
+    # instead, never deleted. Derived from the run's ``trust_status`` (a
+    # ``tainted`` status is the only affirmative exclusion; missing/trusted/
+    # unchecked are all admissible), so this defaults False (default-admissible
+    # per clause 4).
     dev_tainted: bool = False
 
 
@@ -383,6 +387,41 @@ def _fold_dev_bucket(
     _fold_duration(bucket, duration_s, timeout_killed, timeout_limit_s)
 
 
+def _fold_dev_capability(
+    bucket: dict,
+    success: bool,
+    iterations: int,
+    cost_usd: float | None,
+    duration_s: float | None,
+    timeout_killed: bool,
+    timeout_limit_s: int | None,
+    termination_cause: str | None,
+    tainted: bool,
+) -> None:
+    """Fold one dev run into a capability bucket, excluding tainted runs.
+
+    Wraps :func:`_fold_dev_bucket` with the ADR-0006 clause-4 taint gate so the
+    top-level dev bucket and the per-complexity / per-score bands exclude runs
+    that failed their own trust checks exactly like the per-domain slice already
+    does. A ``tainted`` run "doesn't teach": it is kept out of the capability
+    accumulators (``runs``/``_successes``/…) and tallied under ``tainted_runs``
+    so the exclusion stays visible in the record, never silently dropped.
+    """
+    if tainted:
+        bucket["tainted_runs"] = int(bucket.get("tainted_runs", 0)) + 1
+        return
+    _fold_dev_bucket(
+        bucket,
+        success,
+        iterations,
+        cost_usd,
+        duration_s,
+        timeout_killed,
+        timeout_limit_s,
+        termination_cause,
+    )
+
+
 def _fold_domain_slice(
     bucket: dict,
     success: bool,
@@ -446,7 +485,11 @@ def _update_dev(
     domains: list[str] | None = None,
     tainted: bool = False,
 ) -> None:
-    if cost_usd is None:
+    # A tainted run is excluded from every capability accumulator (ADR-0006
+    # clause 4), so it never records a cost either — suppress the cost-unmeasured
+    # warning that would otherwise fire for a run whose cost is intentionally
+    # not folded.
+    if cost_usd is None and not tainted:
         log.warning(
             "[model_profiles] Dev run recorded cost-unmeasured (NOT $0.00): "
             "model=%s complexity=%s — transport reported no cost.",
@@ -454,7 +497,7 @@ def _update_dev(
             complexity,
         )
     dev = entry.setdefault("dev", {})
-    _fold_dev_bucket(
+    _fold_dev_capability(
         dev,
         success,
         iterations,
@@ -463,11 +506,12 @@ def _update_dev(
         timeout_killed,
         timeout_limit_s,
         termination_cause,
+        tainted,
     )
 
     by = dev.setdefault("by_complexity", {})
     bc = by.setdefault(complexity, {})
-    _fold_dev_bucket(
+    _fold_dev_capability(
         bc,
         success,
         iterations,
@@ -476,13 +520,14 @@ def _update_dev(
         timeout_killed,
         timeout_limit_s,
         termination_cause,
+        tainted,
     )
 
     if complexity_score is not None:
         score_key = str(int(complexity_score))
         by_score = dev.setdefault("by_complexity_score", {})
         sc = by_score.setdefault(score_key, {})
-        _fold_dev_bucket(
+        _fold_dev_capability(
             sc,
             success,
             iterations,
@@ -491,6 +536,7 @@ def _update_dev(
             timeout_killed,
             timeout_limit_s,
             termination_cause,
+            tainted,
         )
 
     # Per-domain slice (issue #155): fold this run into a bucket for each domain
@@ -515,8 +561,17 @@ def _update_dev(
         )
 
 
-def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float | None) -> None:
+def _update_review(
+    entry: dict, cycles: int, findings: int, cost_usd: float | None, tainted: bool = False
+) -> None:
     if cycles <= 0:
+        return
+    rev = entry.setdefault("review", {})
+    # Taint gate (ADR-0006 clause 4): a tainted run "doesn't teach", so its
+    # reviewer cycles are kept out of the completion-rate / findings / cost
+    # aggregates and tallied under ``tainted_runs`` instead.
+    if tainted:
+        rev["tainted_runs"] = int(rev.get("tainted_runs", 0)) + cycles
         return
     if cost_usd is None:
         log.warning(
@@ -525,7 +580,6 @@ def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float | No
             _entry_model_label(entry),
             cycles,
         )
-    rev = entry.setdefault("review", {})
     runs = int(rev.get("runs", 0)) + cycles
     find_sum = float(rev.get("_findings_sum", 0.0)) + float(findings)
     rev["runs"] = runs
@@ -534,14 +588,19 @@ def _update_review(entry: dict, cycles: int, findings: int, cost_usd: float | No
     _fold_cost(rev, cost_usd, unknown_count=cycles)
 
 
-def _update_preflight(entry: dict, cost_usd: float | None) -> None:
+def _update_preflight(entry: dict, cost_usd: float | None, tainted: bool = False) -> None:
+    pf = entry.setdefault("preflight", {})
+    # Taint gate (ADR-0006 clause 4): a tainted run is excluded from the
+    # preflight capability aggregate and tallied under ``tainted_runs`` instead.
+    if tainted:
+        pf["tainted_runs"] = int(pf.get("tainted_runs", 0)) + 1
+        return
     if cost_usd is None:
         log.warning(
             "[model_profiles] Preflight run recorded cost-unmeasured (NOT $0.00): "
             "model=%s — transport reported no cost.",
             _entry_model_label(entry),
         )
-    pf = entry.setdefault("preflight", {})
     runs = int(pf.get("runs", 0)) + 1
     pf["runs"] = runs
     _fold_cost(pf, cost_usd)
@@ -561,6 +620,7 @@ def _zero_dev_bucket(bucket: dict) -> None:
     bucket["avg_duration_s"] = 0.0
     bucket["max_duration_s"] = 0.0
     bucket["max_killed_timeout_s"] = 0.0
+    bucket["tainted_runs"] = 0
     bucket["harness_terminated"] = {
         "runs": 0,
         "by_cause": {},
@@ -601,9 +661,11 @@ def _recompute_dev_section(section: dict) -> None:
     ht_by_cause: dict[str, int] = {}
     ht_cost_sum = 0.0
     ht_cost_unknown = 0
+    tainted_runs = 0
     for band in COMPLEXITY_BANDS:
         bucket = by.setdefault(band, {})
         runs += int(bucket.get("runs", 0))
+        tainted_runs += int(bucket.get("tainted_runs", 0))
         successes += int(bucket.get("_successes", 0))
         iterations += float(bucket.get("_iterations_sum", 0.0))
         cost += float(bucket.get("_cost_sum", 0.0))
@@ -637,6 +699,7 @@ def _recompute_dev_section(section: dict) -> None:
     )
     section["max_duration_s"] = max_duration
     section["max_killed_timeout_s"] = max_killed_timeout
+    section["tainted_runs"] = tainted_runs
     ht_measured = ht_runs - ht_cost_unknown
     section["harness_terminated"] = {
         "runs": ht_runs,
@@ -679,10 +742,10 @@ def apply_run(data: dict, outcome: RunOutcome) -> dict:
             provider=outcome.preflight_provider,
             cli=outcome.preflight_cli,
         )
-        _update_preflight(pf_entry, outcome.preflight_cost_usd)
+        _update_preflight(pf_entry, outcome.preflight_cost_usd, tainted=outcome.dev_tainted)
     for name, (cycles, findings, cost) in outcome.reviewers.items():
         rev_entry = _ensure_model(data, name)
-        _update_review(rev_entry, cycles, findings, cost)
+        _update_review(rev_entry, cycles, findings, cost, tainted=outcome.dev_tainted)
     return data
 
 
@@ -710,6 +773,8 @@ def backfill_from_history(history_path: Path) -> dict:
     records = raw.get("escalations") or []
     if not isinstance(records, list):
         return data
+    from theforge.coordinator.trust_status import is_tainted  # noqa: PLC0415
+
     for r in records:
         if not isinstance(r, dict):
             continue
@@ -719,8 +784,13 @@ def backfill_from_history(history_path: Path) -> dict:
         band = _normalize_band(str(r.get("complexity") or ""))
         outcome = str(r.get("outcome") or "").strip().upper()
         success = outcome == "DONE"
+        # Taint gate (ADR-0006 clause 4): a run marked tainted "doesn't teach", so
+        # it is excluded from the seeded aggregates and tallied under
+        # ``tainted_runs`` instead. Legacy history rows carry no ``trust_status``
+        # and read as admissible (taint requires an affirmative failed check).
+        tainted = is_tainted(r.get("trust_status"))
         entry = _ensure_model(data, model)
-        _update_dev(entry, band, success, iterations=0, cost_usd=0.0)
+        _update_dev(entry, band, success, iterations=0, cost_usd=0.0, tainted=tainted)
     return data
 
 
@@ -1521,6 +1591,17 @@ def _merge_harness_terminated(target: dict, src: dict) -> None:
     tgt_ht["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
 
 
+def _merge_tainted_runs(target: dict, src: dict) -> None:
+    """Sum the visible ``tainted_runs`` counter of two buckets.
+
+    A no-op when neither side carries the counter (legacy buckets predating the
+    ADR-0006 clause-4 taint gate), so a merge never fabricates a zero key.
+    """
+    src_tainted = int(src.get("tainted_runs", 0))
+    if src_tainted or "tainted_runs" in target:
+        target["tainted_runs"] = int(target.get("tainted_runs", 0)) + src_tainted
+
+
 def _merge_dev(target: dict, src: dict) -> None:
     runs = int(target.get("runs", 0)) + int(src.get("runs", 0))
     successes = int(target.get("_successes", 0)) + int(src.get("_successes", 0))
@@ -1563,6 +1644,7 @@ def _merge_dev(target: dict, src: dict) -> None:
         target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
     _merge_duration(target, src)
     _merge_harness_terminated(target, src)
+    _merge_tainted_runs(target, src)
 
     src_by = src.get("by_complexity") or {}
     if src_by:
@@ -1607,6 +1689,7 @@ def _merge_dev(target: dict, src: dict) -> None:
                 )
             _merge_duration(bc_target, bc_src)
             _merge_harness_terminated(bc_target, bc_src)
+            _merge_tainted_runs(bc_target, bc_src)
 
     src_by_score = src.get("by_complexity_score") or {}
     if src_by_score:
@@ -1651,6 +1734,7 @@ def _merge_dev(target: dict, src: dict) -> None:
                 )
             _merge_duration(sc_target, sc_src)
             _merge_harness_terminated(sc_target, sc_src)
+            _merge_tainted_runs(sc_target, sc_src)
 
     src_by_domain = src.get("by_domain") or {}
     if src_by_domain:
@@ -1724,6 +1808,7 @@ def _merge_review(target: dict, src: dict) -> None:
         target["avg_findings"] = round(find_sum / runs, 4)
         measured = runs - cost_unknown
         target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
+    _merge_tainted_runs(target, src)
 
 
 def _merge_preflight(target: dict, src: dict) -> None:
@@ -1738,6 +1823,7 @@ def _merge_preflight(target: dict, src: dict) -> None:
     if runs > 0:
         measured = runs - cost_unknown
         target["avg_cost_usd"] = round(cost_sum / measured, 6) if measured > 0 else 0.0
+    _merge_tainted_runs(target, src)
 
 
 def _merge_entry(target: dict, src: dict) -> None:

--- a/tests/test_router_taint_exclusion.py
+++ b/tests/test_router_taint_exclusion.py
@@ -1,0 +1,382 @@
+"""Router-consumed aggregates exclude tainted runs — ADR-0006 clause 4 consumer half.
+
+Covers issue #1852: every router-consumed aggregate and profile lookup filters
+out runs the trust-status marker flagged ``tainted`` (a run that failed its own
+trust checks), while ``trusted`` and ``unchecked`` runs are still consumed, and
+the excluded-for-taint count surfaces in the ``routing_decision`` block. The
+filter is centralized in :mod:`theforge.coordinator.trust_status`; these tests
+exercise the primitive plus each consumer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.coordinator import audit_substrate as sub
+from theforge.coordinator.trust_status import (
+    TRUST_TAINTED,
+    TRUST_TRUSTED,
+    TRUST_UNCHECKED,
+    filter_tainted_records,
+    is_routing_admissible,
+    is_tainted,
+)
+from theforge.model_profiles import RunOutcome, apply_run, get_dev_success_rate
+
+# ── Step 1: centralized taint gate ─────────────────────────────────────────
+
+
+def test_is_tainted_only_for_affirmative_taint() -> None:
+    assert is_tainted(TRUST_TAINTED) is True
+    assert is_tainted(TRUST_TRUSTED) is False
+    assert is_tainted(TRUST_UNCHECKED) is False
+    assert is_tainted(None) is False
+    assert is_tainted("") is False
+
+
+def test_is_routing_admissible_is_inverse_of_taint() -> None:
+    assert is_routing_admissible(TRUST_TRUSTED) is True
+    assert is_routing_admissible(TRUST_UNCHECKED) is True
+    assert is_routing_admissible(None) is True
+    assert is_routing_admissible(TRUST_TAINTED) is False
+
+
+def test_filter_tainted_records_partitions_and_counts() -> None:
+    records = [
+        {"id": 1, "trust_status": TRUST_TRUSTED},
+        {"id": 2, "trust_status": TRUST_TAINTED},
+        {"id": 3, "trust_status": TRUST_UNCHECKED},
+        {"id": 4},  # missing status → admissible
+        {"id": 5, "trust_status": TRUST_TAINTED},
+    ]
+    admissible, excluded = filter_tainted_records(records)
+    assert [r["id"] for r in admissible] == [1, 3, 4]
+    assert excluded == 2
+
+
+def test_filter_tainted_records_custom_status_extractor() -> None:
+    records = [("a", TRUST_TRUSTED), ("b", TRUST_TAINTED)]
+    admissible, excluded = filter_tainted_records(records, status_of=lambda r: r[1])
+    assert [r[0] for r in admissible] == ["a"]
+    assert excluded == 1
+
+
+def test_filter_tainted_records_does_not_mutate_source() -> None:
+    records = [{"trust_status": TRUST_TAINTED}, {"trust_status": TRUST_TRUSTED}]
+    original = [dict(r) for r in records]
+    filter_tainted_records(records)
+    assert records == original
+
+
+# ── Step 3: model-profile aggregates exclude tainted ───────────────────────
+
+
+def _dev_outcome(*, success: bool, tainted: bool) -> RunOutcome:
+    return RunOutcome(
+        complexity="medium",
+        dev_model="sonnet",
+        dev_success=success,
+        dev_iterations=1,
+        dev_cost_usd=0.0,
+        dev_tainted=tainted,
+    )
+
+
+def test_dev_success_rate_includes_trusted_and_unchecked() -> None:
+    data: dict = {"models": {}}
+    # trusted + unchecked map to dev_tainted=False (both admissible).
+    for _ in range(2):
+        apply_run(data, _dev_outcome(success=True, tainted=False))
+    apply_run(data, _dev_outcome(success=False, tainted=False))
+    # 2 of 3 admissible runs succeeded.
+    assert get_dev_success_rate(data, "sonnet", "medium", min_runs=1) == round(2 / 3, 4)
+
+
+def test_dev_success_rate_excludes_tainted() -> None:
+    data: dict = {"models": {}}
+    apply_run(data, _dev_outcome(success=True, tainted=False))
+    # Five tainted failures must not drag the rate down: they don't teach.
+    for _ in range(5):
+        apply_run(data, _dev_outcome(success=False, tainted=True))
+    assert get_dev_success_rate(data, "sonnet", "medium", min_runs=1) == 1.0
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev["runs"] == 1  # tainted runs excluded from the sample
+    assert dev["tainted_runs"] == 5  # but visibly tallied, not deleted
+    assert dev["by_complexity"]["medium"]["tainted_runs"] == 5
+
+
+def test_all_tainted_dev_history_is_cold_start() -> None:
+    data: dict = {"models": {}}
+    for _ in range(6):
+        apply_run(data, _dev_outcome(success=True, tainted=True))
+    # No admissible runs → below the sample floor → no ranked rate.
+    assert get_dev_success_rate(data, "sonnet", "medium", min_runs=3) is None
+    dev = data["models"]["sonnet"]["dev"]
+    assert dev.get("runs", 0) == 0
+    assert dev["tainted_runs"] == 6
+
+
+def test_review_and_preflight_aggregates_exclude_tainted() -> None:
+    data: dict = {"models": {}}
+    tainted = RunOutcome(
+        complexity="medium",
+        dev_model="sonnet",
+        dev_success=True,
+        dev_iterations=1,
+        dev_cost_usd=0.0,
+        dev_tainted=True,
+        preflight_model="haiku",
+        preflight_cost_usd=0.0,
+        reviewers={"opus": (2, 3, 0.0)},
+    )
+    apply_run(data, tainted)
+    review = data["models"]["opus"]["review"]
+    preflight = data["models"]["haiku"]["preflight"]
+    # Reviewer completion + preflight capability aggregates saw zero admissible
+    # runs; the tainted cycles/run are tallied under tainted_runs instead.
+    assert review.get("runs", 0) == 0
+    assert review["tainted_runs"] == 2
+    assert preflight.get("runs", 0) == 0
+    assert preflight["tainted_runs"] == 1
+
+
+# ── Step 2: substrate escalation history excludes tainted ───────────────────
+
+
+def _run_record(
+    *,
+    run_id: str,
+    slug: str,
+    success: bool,
+    trust_status: str,
+    started_at: str,
+) -> dict:
+    return {
+        "run_id": run_id,
+        "record_schema_version": sub.CURRENT_RECORD_SCHEMA_VERSION,
+        "trust_status": trust_status,
+        "trust_checks": [],
+        "task": {"slug": slug},
+        "outcome": {"success": success, "final_phase": "DONE" if success else "ESCALATE"},
+        "timing": {"started_at": started_at, "duration_seconds": 1.0},
+        "preflight": {"complexity": "medium", "complexity_score": 5},
+        "cost": {
+            "total_usd": 1.0,
+            "agents": [
+                {
+                    "phase": "dev",
+                    "provider": "anthropic",
+                    "model": "sonnet",
+                    "cli": "claude",
+                    "name": "dev",
+                }
+            ],
+        },
+    }
+
+
+def _seed(conn, records: list[dict]) -> None:
+    for record in records:
+        sub.upsert_run_record(conn, record, provenance="native")
+    conn.commit()
+
+
+def test_escalation_history_includes_trusted_and_unchecked_excludes_tainted(
+    tmp_path: Path,
+) -> None:
+    from theforge.coordinator.escalation_history import (
+        load_escalation_history_with_taint_stats,
+    )
+
+    conn = sub.create_or_open(tmp_path)
+    try:
+        _seed(
+            conn,
+            [
+                _run_record(
+                    run_id="r-trusted",
+                    slug="s-trusted",
+                    success=False,
+                    trust_status=TRUST_TRUSTED,
+                    started_at="2026-03-01T10:00:00+00:00",
+                ),
+                _run_record(
+                    run_id="r-unchecked",
+                    slug="s-unchecked",
+                    success=True,
+                    trust_status=TRUST_UNCHECKED,
+                    started_at="2026-03-02T10:00:00+00:00",
+                ),
+                _run_record(
+                    run_id="r-tainted",
+                    slug="s-tainted",
+                    success=False,
+                    trust_status=TRUST_TAINTED,
+                    started_at="2026-03-03T10:00:00+00:00",
+                ),
+            ],
+        )
+    finally:
+        conn.close()
+
+    history, excluded = load_escalation_history_with_taint_stats(tmp_path)
+    slugs = {r.story for r in history}
+    assert slugs == {"s-trusted", "s-unchecked"}  # trusted + unchecked kept
+    assert "s-tainted" not in slugs  # tainted excluded
+    assert excluded == 1  # and counted
+
+
+def test_tainted_runs_remain_in_substrate(tmp_path: Path) -> None:
+    """ADR-0002 refusal-to-forget: filtering is read-time, never deletion."""
+    conn = sub.create_or_open(tmp_path)
+    try:
+        _seed(
+            conn,
+            [
+                _run_record(
+                    run_id="r-tainted",
+                    slug="s-tainted",
+                    success=False,
+                    trust_status=TRUST_TAINTED,
+                    started_at="2026-03-03T10:00:00+00:00",
+                )
+            ],
+        )
+        assert sub.count_records(conn) == 1  # row still present after filtering reads
+        loaded = sub.latest_record_for(conn, run_id="r-tainted")
+    finally:
+        conn.close()
+    assert loaded is not None
+    assert loaded["trust_status"] == TRUST_TAINTED
+
+
+# ── Step 4: excluded-for-taint count in routing_decision ───────────────────
+
+
+def test_routing_decision_records_excluded_for_taint() -> None:
+    from theforge.assignment import assign_models
+    from theforge.config import AgentDef, AssignmentConfig
+
+    agents = [
+        AgentDef(
+            name="claude-sonnet",
+            provider=None,
+            model="sonnet",
+            budget_usd=10.0,
+            timeout_seconds=300,
+            tier="cheap",
+            cli="claude",
+        )
+    ]
+    decision = assign_models(
+        agents,
+        AssignmentConfig(enabled=True, escalation_memory=True),
+        "medium",
+        complexity_score=5,
+        excluded_for_taint=3,
+    )
+    assert decision.routing_decision["excluded_for_taint"] == 3
+
+
+def test_routing_decision_excluded_for_taint_defaults_zero() -> None:
+    from theforge.assignment import assign_models
+    from theforge.config import AgentDef, AssignmentConfig
+
+    agents = [
+        AgentDef(
+            name="claude-sonnet",
+            provider=None,
+            model="sonnet",
+            budget_usd=10.0,
+            timeout_seconds=300,
+            tier="cheap",
+            cli="claude",
+        )
+    ]
+    decision = assign_models(
+        agents,
+        AssignmentConfig(enabled=True),
+        "medium",
+        complexity_score=5,
+    )
+    assert decision.routing_decision["excluded_for_taint"] == 0
+
+
+# ── Step 5: coordinator preflight seam end-to-end ──────────────────────────
+
+
+def test_preflight_seam_excludes_tainted_and_records_count(tmp_path: Path) -> None:
+    """The real preflight assignment seam consumes trusted/unchecked history,
+    ignores a tainted record, and the audit-visible routing_decision carries the
+    excluded-for-taint count."""
+    from dataclasses import replace
+
+    from coord_test_helpers import _make_config
+
+    from theforge.config import AgentDef, AssignmentConfig
+    from theforge.coordinator.preflight import _apply_preflight_config
+    from theforge.coordinator.state import CoordinatorState
+
+    # Seed history: two admissible ESCALATE rows for the same model (enough to
+    # feed promotion) plus one tainted row that must be ignored.
+    conn = sub.create_or_open(tmp_path)
+    try:
+        _seed(
+            conn,
+            [
+                _run_record(
+                    run_id="r-trusted",
+                    slug="s-trusted",
+                    success=False,
+                    trust_status=TRUST_TRUSTED,
+                    started_at="2026-03-01T10:00:00+00:00",
+                ),
+                _run_record(
+                    run_id="r-unchecked",
+                    slug="s-unchecked",
+                    success=False,
+                    trust_status=TRUST_UNCHECKED,
+                    started_at="2026-03-02T10:00:00+00:00",
+                ),
+                _run_record(
+                    run_id="r-tainted",
+                    slug="s-tainted",
+                    success=False,
+                    trust_status=TRUST_TAINTED,
+                    started_at="2026-03-03T10:00:00+00:00",
+                ),
+            ],
+        )
+    finally:
+        conn.close()
+
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="claude-sonnet",
+                provider=None,
+                model="sonnet",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="cheap",
+                cli="claude",
+            )
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=True,
+            max_cost_per_story_usd=None,
+        ),
+    )
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 5
+
+    _apply_preflight_config(config, state)
+
+    block = state.routing_decision
+    assert isinstance(block, dict)
+    # Only the single tainted record was set aside; the two admissible rows fed
+    # the router's history.
+    assert block["excluded_for_taint"] == 1


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation satisfies the clause-4 consumer-side taint filtering requirements, and the focused test suite passes. | [google-gemini-3.5-flash] The implementation of ADR-0006 clause-4 consumer-side taint filtering is exceptionally clean, centralized, and fully verified by comprehensive tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $8.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Router aggregates exclude tainted runs — clause-4 consumption side (GitHub Issue #1852)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1852