### PR TITLE
Review-fix handoffs can block coordinator validation by requiring self-reported gate PASS

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -694,6 +694,11 @@ def _run_dev_phase(
     )
     _test_cmd = config.validation.test_command or _gate_cmd
     _dev_entry_reason = state.retry_reason  # snapshot before consumed by prompt routing
+    # Reset the per-iteration gate-delegation flag. Only a review-fix / P2-cleanup
+    # prompt (build_fix_prompt with a non-skipped gate) delegates gate execution
+    # to the coordinator; every other prompt path leaves it False so the
+    # unproven-completion guard stays strict for ordinary iterations.
+    state.gate_delegated_this_iteration = False
     match state.retry_reason:
         case RetryReason.TIMEOUT_RESUME:
             prompt = (
@@ -725,6 +730,7 @@ def _run_dev_phase(
                 conventions=config.conventions_soft,
                 advisory_p2_only=True,
             )
+            state.gate_delegated_this_iteration = not _is_gate_skip(task.gate_override)
             state.dev_prompt_injected_finding_ids.append([])
             state.escalation_note = None
         case RetryReason.REVIEW_CHANGES | RetryReason.EXTEND if state.last_review_findings:
@@ -750,6 +756,7 @@ def _run_dev_phase(
                 surviving_families=state.surviving_families or None,
                 conventions=config.conventions_soft,
             )
+            state.gate_delegated_this_iteration = not _is_gate_skip(task.gate_override)
             injected_finding_ids = [r.finding_id for r in carry_forward_p1s]
             injected_finding_ids.extend(
                 r.finding_id for r in current_cycle_p1s if r.finding_id not in injected_finding_ids
@@ -994,7 +1001,26 @@ def _run_dev_phase(
     # than accept an unverified completion and waste a downstream gate run
     # rediscovering the failure. This is the coordinator catching what the dev
     # should have declared as a blocking failure (gate_result: BLOCKED).
-    if dev_result.success and dev_handoff_claims_unproven_completion(dev_result.dev_handoff or {}):
+    #
+    # Exception: a review-fix / P2-cleanup iteration whose prompt delegated gate
+    # execution to the coordinator (state.gate_delegated_this_iteration) is
+    # *expected* to hand off MET-without-PASS — the prompt told the agent not to
+    # re-run the gate. Escalating there would block the coordinator's own
+    # authoritative VALIDATE gate from running on the latest fix commit (see
+    # issue #1871). The delegation flag is set authoritatively by the coordinator
+    # at prompt-routing time, not read from the agent's handoff, so an ordinary
+    # iteration cannot bypass the guard by self-reporting `gate_delegated`
+    # (honor_gate_delegation=False below ignores the handoff-level marker here).
+    _claims_unproven = dev_result.success and dev_handoff_claims_unproven_completion(
+        dev_result.dev_handoff or {}, honor_gate_delegation=False
+    )
+    if _claims_unproven and state.gate_delegated_this_iteration:
+        _log_verbose(
+            "  Dev handoff claims completion without self-reported gate PASS, but "
+            "gate execution was delegated to the coordinator this iteration — "
+            "proceeding to VALIDATE for the authoritative gate result."
+        )
+    elif _claims_unproven:
         state.phase = Phase.ESCALATE
         state.error = (
             "Dev handoff claims completion (acceptance criteria MET) without gate PASS "

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -475,6 +475,15 @@ class CoordinatorState:
     plan_escalated: bool = False  # True once plan model escalation has occurred this run
     plan_escalation_note: str | None = None  # escalation context injected into regen prompt
     retry_reason: RetryReason | None = None  # see RetryReason enum for valid values
+    # True when the DEV prompt built for the current iteration delegated gate
+    # execution to the coordinator (a review-fix / P2-cleanup pass whose prompt
+    # tells the agent NOT to re-run the gate — see task.fix_prompts.build_fix_prompt).
+    # Authoritatively set by the coordinator at prompt-routing time, so the
+    # unproven-completion guard can distinguish a legitimately gate-delegated
+    # handoff from an ordinary handoff that merely omits gate evidence. Reset
+    # every DEV iteration; not agent-attested, so an ordinary iteration cannot
+    # spoof delegation by setting a handoff flag.
+    gate_delegated_this_iteration: bool = False
     last_cycle_reviewer_results: list[tuple[str, ReviewResult]] = field(
         default_factory=list
     )  # (profile_name, ReviewResult) pairs from the most recent pool run

--- a/src/theforge/schemas.py
+++ b/src/theforge/schemas.py
@@ -285,16 +285,31 @@ VALID_AC_STATUSES = ("MET", "PARTIAL", "NOT_MET")
 VALID_GATE_RESULTS = ("PASS", "FAIL", "BLOCKED")
 
 
-def dev_handoff_claims_unproven_completion(data: dict) -> bool:
+def dev_handoff_claims_unproven_completion(
+    data: dict, *, honor_gate_delegation: bool = True
+) -> bool:
     """Return True when a dev handoff claims completion without gate evidence.
 
     A completion claim is any acceptance_criteria entry marked ``status: MET``.
-    Such a claim is only proven when ``gate_result`` is exactly ``"PASS"``. A
-    missing gate_result, ``"FAIL"``, or ``"BLOCKED"`` all leave the completion
-    unproven — the gate was never shown to pass, so the claim lacks evidence.
+    Such a claim is normally only proven when ``gate_result`` is exactly
+    ``"PASS"``. A missing gate_result, ``"FAIL"``, or ``"BLOCKED"`` all leave the
+    completion unproven — the gate was never shown to pass, so the claim lacks
+    evidence.
 
     Handoffs that make no completion claim (all criteria PARTIAL/NOT_MET) never
     trip this check: gate_result stays optional for them.
+
+    Gate delegation exception: a review-fix iteration delegates gate execution to
+    the coordinator (see ``task.fix_prompts.build_fix_prompt``), which runs the
+    authoritative gate itself after the dev completes. Such a handoff legitimately
+    lacks a self-reported PASS. When ``honor_gate_delegation`` is set and the
+    handoff explicitly marks ``gate_delegated: true`` (strictly boolean ``True`` —
+    a missing, string, or otherwise malformed value is NOT delegation), the
+    completion claim is not treated as unproven. Callers that own authoritative
+    knowledge of whether the gate was actually delegated (e.g. the coordinator
+    dev-phase guard) pass ``honor_gate_delegation=False`` and gate on that
+    knowledge instead, so an ordinary iteration cannot bypass the check by
+    self-reporting the flag.
     """
     if not isinstance(data, dict):
         return False
@@ -304,7 +319,11 @@ def dev_handoff_claims_unproven_completion(data: dict) -> bool:
     claims_met = any(isinstance(ac, dict) and ac.get("status") == "MET" for ac in criteria)
     if not claims_met:
         return False
-    return data.get("gate_result") != "PASS"
+    if data.get("gate_result") == "PASS":
+        return False
+    if honor_gate_delegation and data.get("gate_delegated") is True:
+        return False
+    return True
 
 
 def validate_dev_handoff(data: Any) -> list[str]:

--- a/src/theforge/task/fix_prompts.py
+++ b/src/theforge/task/fix_prompts.py
@@ -86,6 +86,11 @@ def build_fix_prompt(
         else (
             f"- Do NOT re-run the gate (`{gate_command}`). "
             "The coordinator runs it automatically after you complete.\n        "
+            "- Gate execution is delegated to the coordinator this iteration. "
+            "Add `gate_delegated: true` to your `<forge_handoff>` block so the "
+            "handoff records that the gate is coordinator-owned. Leave "
+            "`gate_result` unset (or `BLOCKED`) — do NOT self-report "
+            "`gate_result: PASS` for a gate you did not run.\n        "
         )
     )
 

--- a/tests/test_coord_dev_unproven_completion.py
+++ b/tests/test_coord_dev_unproven_completion.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 from coord_test_helpers import (
     _PREFLIGHT_RESULT,
     APPROVE_REVIEW,
+    REQUEST_CHANGES_REVIEW,
     _make_agent_result,
     _make_config,
     _make_task,
@@ -20,7 +21,7 @@ from coord_test_helpers import (
     patch_gate_shell,
 )
 
-from theforge.coordinator.engine import run_task
+from theforge.coordinator.engine import run_from_review, run_task
 from theforge.coordinator.state import Phase
 
 
@@ -134,3 +135,147 @@ class TestUnprovenCompletionGuard:
         assert result.phase != Phase.ESCALATE
         # The unproven-completion guard did not block the review cycle.
         assert mock_pool.call_count >= 1
+
+
+def _delegated_fix_handoff() -> dict:
+    """A review-fix handoff that marks criteria MET, omits gate PASS (the fix
+    prompt told the agent not to re-run the gate), and records the coordinator
+    gate delegation via ``gate_delegated: true``."""
+    return {
+        "summary": "Fixed the P1 finding from review.",
+        "commits": [{"sha": "def5678", "message": "fix(x): address review finding"}],
+        "acceptance_criteria": [{"criterion": "It works", "status": "MET", "notes": "fixed"}],
+        "gate_delegated": True,
+        "story_deviations": "none",
+        "deferred_items": "none",
+    }
+
+
+class TestDelegatedFixHandoffCrossPhase:
+    """Seam-level DEV→VALIDATE→REVIEW coverage for the gate-delegation exception
+    (#1871). A review-rejected first commit followed by a fix handoff that marks
+    criteria MET without self-reported gate PASS must NOT escalate at the dev
+    seam: the coordinator's own authoritative VALIDATE gate runs on the latest
+    fix commit and routes to re-review or gate-failure retry based on that
+    result.
+    """
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_delegated_fix_handoff_validates_latest_commit_and_reroutes(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """REQUEST_CHANGES → delegated fix handoff (MET, no PASS) → gate PASS on
+        the fix commit → re-review APPROVE → DONE."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_agent.return_value = _make_agent_result(
+            success=True,
+            output="Fixed.",
+            profile_name="dev",
+            dev_handoff=_delegated_fix_handoff(),
+        )
+
+        pool_n = {"n": 0}
+
+        def pool_side(**kwargs):
+            pool_n["n"] += 1
+            if pool_n["n"] == 1:
+                return [
+                    _make_agent_result(
+                        success=True, output=REQUEST_CHANGES_REVIEW, profile_name="review"
+                    )
+                ]
+            return [_make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")]
+
+        mock_pool.side_effect = pool_side
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        # The delegated fix handoff did NOT escalate at the dev seam.
+        assert "without gate PASS evidence" not in (result.message or "")
+        # It proceeded to VALIDATE, which recorded the authoritative gate result
+        # for the latest fix commit.
+        assert result.state.gate_decisions == ["PASS"]
+        # Exactly one dev fix iteration ran, and the coordinator knew it delegated
+        # the gate for that iteration.
+        assert len(result.state.dev_results) == 1
+        assert result.state.gate_delegated_this_iteration is True
+        # Re-review ran on the fix commit (second review cycle → APPROVE).
+        assert result.state.review_cycle == 2
+        # No HANDOFF_NO_GATE_EVIDENCE telemetry was emitted for the delegated iter.
+        assert all(
+            t.gate_result != "HANDOFF_NO_GATE_EVIDENCE"
+            for t in result.state.dev_iteration_telemetry
+        )
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_delegated_fix_handoff_gate_fail_routes_to_retry_not_escalation(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        """A delegated fix handoff whose coordinator gate FAILs routes to the
+        authoritative gate-failure retry (recording FAIL for the fix commit),
+        NOT the dev-seam unproven-completion escalation."""
+        config = _make_config(tmp_path)  # max_dev_iterations=2
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        # Gate FAILs on the delegated fix commit, then PASSes on the retry.
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
+
+        # Iter 1: delegated fix handoff (MET, no PASS). Iter 2 (GATE_FAIL retry,
+        # not a review-fix): a well-formed completion with gate_result PASS.
+        agent_n = {"n": 0}
+
+        def agent_side(*args, **kwargs):
+            agent_n["n"] += 1
+            if agent_n["n"] == 1:
+                return _make_agent_result(
+                    success=True,
+                    output="Fixed.",
+                    profile_name="dev",
+                    dev_handoff=_delegated_fix_handoff(),
+                )
+            handoff = _delegated_fix_handoff()
+            del handoff["gate_delegated"]
+            handoff["gate_result"] = "PASS"
+            return _make_agent_result(
+                success=True, output="Fixed again.", profile_name="dev", dev_handoff=handoff
+            )
+
+        mock_agent.side_effect = agent_side
+
+        pool_n = {"n": 0}
+
+        def pool_side(**kwargs):
+            pool_n["n"] += 1
+            if pool_n["n"] == 1:
+                return [
+                    _make_agent_result(
+                        success=True, output=REQUEST_CHANGES_REVIEW, profile_name="review"
+                    )
+                ]
+            return [_make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")]
+
+        mock_pool.side_effect = pool_side
+
+        result = run_from_review(config, task, workspace)
+
+        # The delegated fix handoff was NOT escalated at the dev seam; the gate
+        # FAIL was recorded authoritatively and drove a gate-failure retry.
+        assert "without gate PASS evidence" not in (result.message or "")
+        assert result.state.gate_decisions == ["FAIL", "PASS"]
+        assert result.success is True
+        assert result.phase == Phase.DONE

--- a/tests/test_devhandoff_gate_delegation.py
+++ b/tests/test_devhandoff_gate_delegation.py
@@ -1,0 +1,110 @@
+"""Gate-delegation exception for the unproven-completion cross-field rule (#1871).
+
+A review-fix iteration delegates gate execution to the coordinator, which runs
+the authoritative gate itself. Such a handoff legitimately marks criteria MET
+without self-reporting ``gate_result: PASS``. When the handoff explicitly marks
+``gate_delegated: true`` the completion claim is no longer treated as unproven —
+but only a strictly boolean ``True`` marker counts, and callers that own
+authoritative delegation knowledge (the coordinator dev-phase guard) can opt out
+of honoring the self-reported marker entirely.
+"""
+
+from __future__ import annotations
+
+from theforge.schemas import dev_handoff_claims_unproven_completion, validate_dev_handoff
+
+
+def _completion(*, gate_result: str | None = None, gate_delegated=None) -> dict:
+    data: dict = {
+        "summary": "Fixed the review findings.",
+        "commits": [{"sha": "abc1234", "message": "fix(x): address review"}],
+        "acceptance_criteria": [
+            {"criterion": "It works", "status": "MET", "notes": "fixed and covered"}
+        ],
+        "story_deviations": "none",
+        "deferred_items": "none",
+    }
+    if gate_result is not None:
+        data["gate_result"] = gate_result
+    if gate_delegated is not None:
+        data["gate_delegated"] = gate_delegated
+    return data
+
+
+class TestUnprovenCompletionDelegation:
+    def test_ordinary_met_without_pass_is_unproven(self):
+        # No delegation marker → ordinary handoff → completion is unproven.
+        assert dev_handoff_claims_unproven_completion(_completion(gate_result=None)) is True
+
+    def test_ordinary_met_with_blocked_is_unproven(self):
+        assert dev_handoff_claims_unproven_completion(_completion(gate_result="BLOCKED")) is True
+
+    def test_delegated_met_without_pass_is_proven(self):
+        # Review-fix delegation marker present → not unproven; coordinator gates it.
+        data = _completion(gate_result=None, gate_delegated=True)
+        assert dev_handoff_claims_unproven_completion(data) is False
+
+    def test_delegated_met_with_blocked_is_proven(self):
+        # The delegated agent may report BLOCKED (it did not run the gate).
+        data = _completion(gate_result="BLOCKED", gate_delegated=True)
+        assert dev_handoff_claims_unproven_completion(data) is False
+
+    def test_delegated_with_gate_pass_is_still_proven(self):
+        # PASS alone already proves it; delegation marker is redundant but fine.
+        data = _completion(gate_result="PASS", gate_delegated=True)
+        assert dev_handoff_claims_unproven_completion(data) is False
+
+    def test_malformed_string_marker_is_not_honored(self):
+        # A truthy-but-not-boolean marker is malformed and must not be honored —
+        # strict validation, not "any truthy value means delegated".
+        data = _completion(gate_result=None, gate_delegated="true")
+        assert dev_handoff_claims_unproven_completion(data) is True
+
+    def test_malformed_integer_marker_is_not_honored(self):
+        data = _completion(gate_result=None, gate_delegated=1)
+        assert dev_handoff_claims_unproven_completion(data) is True
+
+    def test_false_marker_is_not_delegation(self):
+        data = _completion(gate_result=None, gate_delegated=False)
+        assert dev_handoff_claims_unproven_completion(data) is True
+
+    def test_honor_flag_off_ignores_self_reported_marker(self):
+        # The coordinator guard passes honor_gate_delegation=False and relies on
+        # its own authoritative delegation knowledge, so a self-reported marker
+        # cannot bypass the check for an ordinary iteration.
+        data = _completion(gate_result=None, gate_delegated=True)
+        assert dev_handoff_claims_unproven_completion(data, honor_gate_delegation=False) is True
+
+    def test_honor_flag_off_still_proven_when_gate_pass(self):
+        # PASS still proves completion regardless of the honor flag.
+        data = _completion(gate_result="PASS", gate_delegated=True)
+        assert dev_handoff_claims_unproven_completion(data, honor_gate_delegation=False) is False
+
+    def test_non_completion_handoff_never_trips(self):
+        data = _completion(gate_result=None)
+        data["acceptance_criteria"][0]["status"] = "PARTIAL"
+        assert dev_handoff_claims_unproven_completion(data) is False
+
+
+class TestValidateDevHandoffDelegationConsistency:
+    """validate_dev_handoff shares the cross-field rule (schemas.py) so a
+    delegated handoff must NOT be flagged as a structural completion-without-gate
+    error there either (plan-review P2 #1)."""
+
+    def test_ordinary_completion_without_pass_still_flagged(self):
+        errors = validate_dev_handoff(_completion(gate_result=None))
+        assert any("MET but gate_result is not PASS" in e for e in errors)
+
+    def test_delegated_completion_without_pass_not_flagged(self):
+        errors = validate_dev_handoff(_completion(gate_result=None, gate_delegated=True))
+        assert not any("MET but gate_result is not PASS" in e for e in errors)
+        # And the handoff is otherwise structurally valid.
+        assert errors == []
+
+    def test_delegated_completion_with_blocked_not_flagged(self):
+        errors = validate_dev_handoff(_completion(gate_result="BLOCKED", gate_delegated=True))
+        assert not any("MET but gate_result is not PASS" in e for e in errors)
+
+    def test_malformed_delegation_marker_still_flagged(self):
+        errors = validate_dev_handoff(_completion(gate_result=None, gate_delegated="yes"))
+        assert any("MET but gate_result is not PASS" in e for e in errors)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The review-fix handoff now reaches coordinator validation without weakening ordinary dev-handoff gate evidence checks. | [google-gemini-3.5-flash] The implementation successfully allows delegated review-fix handoffs to reach the coordinator gate without triggering the unproven-completion escalation. | [claude-sonnet] Gate-delegation flag correctly disambiguates review-fix handoffs from ordinary iterations, verified end-to-end DEV→VALIDATE→REVIEW; no P1s found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $6.74
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Review-fix handoffs can block coordinator validation by requiring self-reported gate PASS (GitHub Issue #1871)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1871