### PR TITLE
Post-plan dev tier checkpoint — clean plan-review should de-risk dev assignment

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -1378,10 +1378,13 @@ def _build_routing_decision(
                 "checked": None,
                 "reason": "no_dev_tier_demotion_mechanism_v1",
             },
-            # Post-plan checkpoint (#1387) writes here once landed; absent in v1.
+            # Post-plan dev-tier checkpoint (#1387). Preflight records the
+            # not-yet-run sentinel; apply_post_plan_checkpoint() overwrites this
+            # block with the real decision after plan-review completes.
             "post_plan_checkpoint": {
-                "applied": False,
-                "reason": "checkpoint_not_implemented_v1",
+                "fired": False,
+                "decision": "pending",
+                "reason": "checkpoint_runs_after_plan_review",
             },
             # Challenger-sampling exploration (#325): the labeled, reconstructable
             # decision for the dev slot (mode + routing_key + pool + selection).
@@ -1484,6 +1487,196 @@ def reconcile_explicit_reviewer_pools(
     if code_reviewers:
         _rebuild("code_review", code_reviewers)
     return routing_decision
+
+
+# ── Post-plan dev-tier checkpoint (#1387, absorbs #1109) ───────────────
+
+# Enumerable rationale tokens for the post-plan checkpoint. Exhaustive so both
+# over- and under-correction are observable from routing_decision history
+# (ADR-0006 clause 7). ``plan_review_clean_medium`` is the only token that fires
+# a downgrade; every other token records why the original tier was preserved
+# (or the checkpoint skipped entirely).
+POST_PLAN_CHECKPOINT_RATIONALES: frozenset[str] = frozenset(
+    {
+        "plan_review_clean_medium",
+        "plan_tier_reduction_disabled",
+        "explicit_dev_override",
+        "complexity_not_medium",
+        "plan_review_not_approve",
+        "plan_review_cycles_exceeded",
+        "plan_review_p1_present",
+        "plan_review_p2_exceeded",
+        "no_reduced_tier_candidate",
+    }
+)
+
+
+def _reduced_tier(tier: str) -> str | None:
+    """Return the tier exactly one step below ``tier`` (never two); None at floor."""
+    idx = _TIER_ORDER.index(tier) if tier in _TIER_ORDER else None
+    if idx is None or idx == 0:
+        return None
+    return _TIER_ORDER[idx - 1]
+
+
+def apply_post_plan_checkpoint(
+    decision: AssignmentDecision,
+    agents: list[AgentDef],
+    assignment_config: AssignmentConfig,
+    complexity: str,
+    *,
+    plan_review_decision: str,
+    plan_review_cycles: int,
+    p1_count: int,
+    p2_count: int,
+    explicit_roles: set[str] | None = None,
+    secrets: dict[str, str] | None = None,
+) -> AssignmentDecision:
+    """Re-evaluate ONLY the dev tier after plan-review completes (#1387).
+
+    Pure deterministic function — no LLM, no I/O. This is the single post-plan
+    dev-tier demotion mechanism (ADR-0006 clause 5 recovery side): a clean
+    plan-review on a medium-band story permits stepping the preflight-assigned
+    (effective) dev tier down by exactly one level (``strong→mid``, ``mid→cheap``,
+    never two). Every gate condition below must hold, otherwise the original dev
+    tier is preserved unchanged:
+
+    * ``assignment.plan_tier_reduction`` is enabled
+    * dev is not an explicit override / locked role
+    * complexity is MEDIUM
+    * plan-review verdict is APPROVE
+    * plan-review cycle count is exactly 1
+    * plan-review P1 == 0
+    * plan-review P2 <= 1
+
+    The demotion baseline is the preflight-assigned effective dev tier already
+    recorded in ``decision.routing_decision['dev']['final']['tier']`` — the one
+    baseline, so the reduction can never double-count the promotion ratchet.
+    Every other role (preflight, planner, plan_review, code_review) is untouched.
+
+    Records the outcome into ``routing_decision['dev']['post_plan_checkpoint']``
+    with fired/decision/baseline_tier/final_tier/plan_present/rationale, and
+    updates ``routing_decision['dev']['final']`` when the tier actually changed so
+    the recorded final reflects the model that will run. Returns the (possibly
+    dev-updated) AssignmentDecision; the routing_decision dict is mutated in place
+    so callers sharing the reference observe the recorded decision.
+    """
+    from dataclasses import replace as _dc_replace  # noqa: PLC0415
+
+    explicit_roles = explicit_roles or set()
+    dev_block = (decision.routing_decision or {}).get("dev")
+    dev_block = dev_block if isinstance(dev_block, dict) else None
+
+    # Baseline = preflight-assigned effective dev tier. Prefer the recorded
+    # final.tier; fall back to the selected dev agent's registry tier.
+    baseline_tier: str | None = None
+    if dev_block is not None:
+        baseline_tier = (dev_block.get("final") or {}).get("tier")
+    baseline_tier = _selected_tier(agents, decision.dev.name, baseline_tier)
+
+    def _record(*, fired: bool, dec: str, rationale: str, final_tier: str | None) -> None:
+        block = {
+            "fired": fired,
+            "decision": dec,
+            "baseline_tier": baseline_tier,
+            "final_tier": final_tier if final_tier is not None else baseline_tier,
+            "plan_present": True,
+            "rationale": rationale,
+        }
+        if dev_block is not None:
+            dev_block["post_plan_checkpoint"] = block
+
+    # ── Bypass paths (skipped) — operator intent / conservative config ──
+    if not assignment_config.plan_tier_reduction:
+        _record(
+            fired=False,
+            dec="skipped",
+            rationale="plan_tier_reduction_disabled",
+            final_tier=baseline_tier,
+        )
+        return decision
+    if "dev" in explicit_roles:
+        _record(
+            fired=False,
+            dec="skipped",
+            rationale="explicit_dev_override",
+            final_tier=baseline_tier,
+        )
+        return decision
+
+    # ── Evidence gates (preserve on any failure) ───────────────────────
+    norm_complexity = _normalize_complexity(complexity)
+    if norm_complexity != "MEDIUM":
+        _record(
+            fired=False,
+            dec="preserve",
+            rationale="complexity_not_medium",
+            final_tier=baseline_tier,
+        )
+        return decision
+    if str(plan_review_decision).upper() != "APPROVE":
+        _record(
+            fired=False,
+            dec="preserve",
+            rationale="plan_review_not_approve",
+            final_tier=baseline_tier,
+        )
+        return decision
+    if plan_review_cycles != 1:
+        _record(
+            fired=False,
+            dec="preserve",
+            rationale="plan_review_cycles_exceeded",
+            final_tier=baseline_tier,
+        )
+        return decision
+    if p1_count != 0:
+        _record(
+            fired=False,
+            dec="preserve",
+            rationale="plan_review_p1_present",
+            final_tier=baseline_tier,
+        )
+        return decision
+    if p2_count > 1:
+        _record(
+            fired=False,
+            dec="preserve",
+            rationale="plan_review_p2_exceeded",
+            final_tier=baseline_tier,
+        )
+        return decision
+
+    # ── All gates passed — attempt the one-step demotion ───────────────
+    target_tier = _reduced_tier(baseline_tier) if baseline_tier else None
+    target_agent = _pick_agent(agents, target_tier, secrets) if target_tier is not None else None
+    if target_tier is None or target_agent is None:
+        _record(
+            fired=False,
+            dec="preserve",
+            rationale="no_reduced_tier_candidate",
+            final_tier=baseline_tier,
+        )
+        return decision
+
+    _record(
+        fired=True,
+        dec="downgrade",
+        rationale="plan_review_clean_medium",
+        final_tier=target_tier,
+    )
+    new_dev = _agent_to_profile(target_agent, role="dev")
+    if dev_block is not None:
+        final = dev_block.get("final")
+        if isinstance(final, dict):
+            final["model"] = new_dev.model
+            final["tier"] = target_tier
+            _base_rat = final.get("rationale", "")
+            final["rationale"] = (
+                f"{_base_rat}; post-plan checkpoint demotion {baseline_tier} → "
+                f"{target_tier} (clean plan-review on medium)"
+            ).lstrip("; ")
+    return _dc_replace(decision, dev=new_dev)
 
 
 # ── Challenger-sampling exploration integration (#325) ─────────────────

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -1531,6 +1531,9 @@ def apply_post_plan_checkpoint(
     p2_count: int,
     explicit_roles: set[str] | None = None,
     secrets: dict[str, str] | None = None,
+    model_profiles: dict | None = None,
+    domains: list[str] | None = None,
+    recency: object | None = None,
 ) -> AssignmentDecision:
     """Re-evaluate ONLY the dev tier after plan-review completes (#1387).
 
@@ -1553,6 +1556,11 @@ def apply_post_plan_checkpoint(
     recorded in ``decision.routing_decision['dev']['final']['tier']`` — the one
     baseline, so the reduction can never double-count the promotion ratchet.
     Every other role (preflight, planner, plan_review, code_review) is untouched.
+
+    ``model_profiles``/``domains``/``recency`` are threaded into the demoted-tier
+    agent pick so the cheaper tier is reranked by the same recency-weighted
+    success rate and domain tiebreak as the original dev assignment (they are
+    optional; omitting them falls back to the deterministic budget/price order).
 
     Records the outcome into ``routing_decision['dev']['post_plan_checkpoint']``
     with fired/decision/baseline_tier/final_tier/plan_present/rationale, and
@@ -1648,8 +1656,25 @@ def apply_post_plan_checkpoint(
         return decision
 
     # ── All gates passed — attempt the one-step demotion ───────────────
+    # Select the demoted-tier agent with the SAME recency-weighted success-rate
+    # reranking and domain tiebreak the original dev assignment used, so the
+    # cheaper tier still routes to its best-performing model rather than the raw
+    # budget-ordered default (#1387 review P2).
     target_tier = _reduced_tier(baseline_tier) if baseline_tier else None
-    target_agent = _pick_agent(agents, target_tier, secrets) if target_tier is not None else None
+    target_agent = (
+        _pick_agent(
+            agents,
+            target_tier,
+            secrets,
+            model_profiles=model_profiles,
+            role="dev",
+            complexity=norm_complexity,
+            domains=domains,
+            recency=recency,
+        )
+        if target_tier is not None
+        else None
+    )
     if target_tier is None or target_agent is None:
         _record(
             fired=False,

--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -130,13 +130,37 @@ def _render_dev_mechanisms(role_block: dict, lines: list[str]) -> None:
     )
 
     checkpoint = role_block.get("post_plan_checkpoint") or {}
-    applied = bool(checkpoint.get("applied"))
-    _render_mechanism(
-        "post-plan checkpoint",
-        _mechanism_state(checked=applied, fired=applied),
-        checkpoint.get("reason", ""),
-        lines,
-    )
+    # New shape (#1387): fired/decision/baseline_tier/final_tier/rationale. The
+    # checkpoint only runs after plan-review, so a "pending" decision (or a legacy
+    # applied/reason block) means it never ran for this story.
+    if "decision" in checkpoint or "rationale" in checkpoint:
+        decision = checkpoint.get("decision", "pending")
+        fired = bool(checkpoint.get("fired"))
+        checked = decision not in ("pending", "not_run")
+        rationale = checkpoint.get("rationale") or checkpoint.get("reason", "")
+        baseline = checkpoint.get("baseline_tier")
+        final_tier = checkpoint.get("final_tier")
+        if checked and baseline is not None and final_tier is not None:
+            detail = f"{decision} ({baseline} → {final_tier}) — {rationale}".rstrip(" —")
+        elif checked:
+            detail = f"{decision} — {rationale}".rstrip(" —")
+        else:
+            detail = rationale
+        _render_mechanism(
+            "post-plan checkpoint",
+            _mechanism_state(checked=checked, fired=fired),
+            detail,
+            lines,
+        )
+    else:
+        # Legacy applied/reason placeholder — tolerate defensively.
+        applied = bool(checkpoint.get("applied"))
+        _render_mechanism(
+            "post-plan checkpoint",
+            _mechanism_state(checked=applied, fired=applied),
+            checkpoint.get("reason", ""),
+            lines,
+        )
 
 
 def _render_reviewer_mechanisms(role_block: dict, lines: list[str]) -> None:

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -833,4 +833,5 @@ def _parse_assignment(assignment_raw: dict[str, Any]) -> AssignmentConfig:
             assignment_raw.get("reviewer_completion_threshold", 0.5)
         ),
         reviewer_completion_min_runs=int(assignment_raw.get("reviewer_completion_min_runs", 5)),
+        plan_tier_reduction=bool(assignment_raw.get("plan_tier_reduction", True)),
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -89,6 +89,14 @@ class AssignmentConfig:
     # low-completion reviewer is still selected when no better candidate exists.
     reviewer_completion_threshold: float = 0.5
     reviewer_completion_min_runs: int = 5
+    # Post-plan dev-tier checkpoint (#1387, absorbs #1109). When True (default), a
+    # clean plan-review on a medium-complexity story may step the preflight-assigned
+    # dev tier down by exactly one level (strong→mid, mid→cheap), counteracting
+    # promotion creep once the plan phase has resolved the uncertainty that drove
+    # the promotion. Set False for conservative routing that always honors the
+    # preflight-assigned dev tier. Only the dev role is re-evaluated; explicit dev
+    # overrides and locked roles always bypass the checkpoint.
+    plan_tier_reduction: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -1042,6 +1042,27 @@ def run_task(
         if _plan_result is not None:
             return _plan_result
 
+        # ── Post-plan dev-tier checkpoint apply (#1387) ───────────────
+        # plan_flow re-evaluated ONLY the dev tier after a clean plan-review and
+        # stored the (possibly demoted) decision on state. When the checkpoint
+        # actually changed dev, swap config.dev_profile before DEV runs; every
+        # other role (preflight, planner, plan_review, code_review) is untouched.
+        _checkpoint_decision = getattr(state, "_adaptive_decision", None)
+        _cp_block = (
+            (state.routing_decision or {}).get("dev", {}).get("post_plan_checkpoint", {})
+            if state.routing_decision
+            else {}
+        )
+        if _checkpoint_decision is not None and _cp_block.get("fired"):
+            import dataclasses  # noqa: PLC0415
+
+            config = dataclasses.replace(config, dev_profile=_checkpoint_decision.dev)
+            _log_verbose(
+                f"  [adaptive] post-plan checkpoint applied: dev → "
+                f"{_checkpoint_decision.dev.model} "
+                f"({_cp_block.get('baseline_tier')} → {_cp_block.get('final_tier')})"
+            )
+
         # ── stop_phase gate: stop before entering DEV ─────────────────
         if stop_phase is not None and stop_phase.value <= Phase.PLAN_REVIEW.value:
             return CoordinatorResult(

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -1111,6 +1111,47 @@ def _run_plan_agent_review(
 
         if merged_pr.verdict == "APPROVE":
             state.plan_review_decision = "approve"
+            # ── Post-plan dev-tier checkpoint (#1387) ──────────────────
+            # A clean plan-review resolves the uncertainty that may have
+            # promoted the dev tier at preflight. Re-evaluate ONLY the dev tier
+            # (max one step down) using the plan-review outcome as signal; every
+            # gate condition is enforced inside apply_post_plan_checkpoint. The
+            # updated decision (and its recorded post_plan_checkpoint block) is
+            # stored back on state so engine.py can swap config.dev_profile
+            # before entering DEV.
+            _adaptive = getattr(state, "_adaptive_decision", None)
+            if _adaptive is not None:
+                from theforge.assignment import (  # noqa: PLC0415
+                    apply_post_plan_checkpoint,
+                )
+
+                _latest_meta = (
+                    state.plan_attempt_metadata[-1] if state.plan_attempt_metadata else {}
+                )
+                _updated = apply_post_plan_checkpoint(
+                    _adaptive,
+                    config.agents,
+                    config.assignment,
+                    state.preflight_complexity or "medium",
+                    plan_review_decision="APPROVE",
+                    plan_review_cycles=state.plan_regen_count + 1,
+                    p1_count=int(_latest_meta.get("p1_count", 0)),
+                    p2_count=int(_latest_meta.get("p2_count", 0)),
+                    explicit_roles=getattr(state, "_explicit_roles", set()),
+                    secrets=config.secrets,
+                )
+                state._adaptive_decision = _updated
+                if _updated.routing_decision:
+                    state.routing_decision = _updated.routing_decision
+                _cp = (_updated.routing_decision.get("dev") or {}).get(
+                    "post_plan_checkpoint"
+                ) or {}
+                if _cp.get("fired"):
+                    _log(
+                        f"  ↳ post-plan checkpoint: dev {_cp.get('baseline_tier')} → "
+                        f"{_cp.get('final_tier')} ({_updated.dev.model}) — "
+                        f"{_cp.get('rationale')}"
+                    )
             if merged_pr.findings:
                 findings_text = plan_review_findings_to_text(merged_pr)
                 state.plan_agent_review_findings = findings_text

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -474,6 +474,66 @@ def _maybe_escalate_decompose(
     )
 
 
+def _apply_post_plan_dev_checkpoint(
+    state: CoordinatorState,
+    config: "ForgeConfig",
+) -> None:
+    """Re-evaluate ONLY the dev tier after a clean plan-review APPROVE (#1387).
+
+    Shared by every plan-review path that continues to DEV — the agent
+    plan-review APPROVE branch and the human/pending-file/remote APPROVE branch —
+    so a clean medium plan-review always runs and records the post-plan
+    checkpoint regardless of reviewer type. All gate conditions are enforced
+    inside :func:`apply_post_plan_checkpoint`; even a non-firing decision records
+    the audit block. Must be called AFTER ``record_plan_attempt()`` so the latest
+    per-attempt p1/p2 counts are available.
+    """
+    _adaptive = getattr(state, "_adaptive_decision", None)
+    if _adaptive is None:
+        return
+    from theforge.assignment import apply_post_plan_checkpoint  # noqa: PLC0415
+
+    # Rerank the demoted-tier pick on the same recency-weighted success-rate and
+    # domain signals the preflight dev assignment used — only under adaptive
+    # routing, mirroring assign_models (static mode ignores profile learning).
+    _adaptive_enabled = config.assignment.adaptive_enabled
+    _model_profiles = None
+    _recency = None
+    _domains = None
+    if _adaptive_enabled:
+        from theforge.model_profiles import load_profiles  # noqa: PLC0415
+
+        _model_profiles = load_profiles(config.project_root / ".forge" / "model_profiles.yaml")
+        _recency = config.assignment.recency
+        _domains = list(state.preflight_domains or [])
+
+    _latest_meta = state.plan_attempt_metadata[-1] if state.plan_attempt_metadata else {}
+    _updated = apply_post_plan_checkpoint(
+        _adaptive,
+        config.agents,
+        config.assignment,
+        state.preflight_complexity or "medium",
+        plan_review_decision="APPROVE",
+        plan_review_cycles=state.plan_regen_count + 1,
+        p1_count=int(_latest_meta.get("p1_count", 0)),
+        p2_count=int(_latest_meta.get("p2_count", 0)),
+        explicit_roles=getattr(state, "_explicit_roles", set()),
+        secrets=config.secrets,
+        model_profiles=_model_profiles,
+        domains=_domains,
+        recency=_recency,
+    )
+    state._adaptive_decision = _updated
+    if _updated.routing_decision:
+        state.routing_decision = _updated.routing_decision
+    _cp = (_updated.routing_decision.get("dev") or {}).get("post_plan_checkpoint") or {}
+    if _cp.get("fired"):
+        _log(
+            f"  ↳ post-plan checkpoint: dev {_cp.get('baseline_tier')} → "
+            f"{_cp.get('final_tier')} ({_updated.dev.model}) — {_cp.get('rationale')}"
+        )
+
+
 def _run_plan_phase(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -1112,46 +1172,10 @@ def _run_plan_agent_review(
         if merged_pr.verdict == "APPROVE":
             state.plan_review_decision = "approve"
             # ── Post-plan dev-tier checkpoint (#1387) ──────────────────
-            # A clean plan-review resolves the uncertainty that may have
-            # promoted the dev tier at preflight. Re-evaluate ONLY the dev tier
-            # (max one step down) using the plan-review outcome as signal; every
-            # gate condition is enforced inside apply_post_plan_checkpoint. The
-            # updated decision (and its recorded post_plan_checkpoint block) is
-            # stored back on state so engine.py can swap config.dev_profile
-            # before entering DEV.
-            _adaptive = getattr(state, "_adaptive_decision", None)
-            if _adaptive is not None:
-                from theforge.assignment import (  # noqa: PLC0415
-                    apply_post_plan_checkpoint,
-                )
-
-                _latest_meta = (
-                    state.plan_attempt_metadata[-1] if state.plan_attempt_metadata else {}
-                )
-                _updated = apply_post_plan_checkpoint(
-                    _adaptive,
-                    config.agents,
-                    config.assignment,
-                    state.preflight_complexity or "medium",
-                    plan_review_decision="APPROVE",
-                    plan_review_cycles=state.plan_regen_count + 1,
-                    p1_count=int(_latest_meta.get("p1_count", 0)),
-                    p2_count=int(_latest_meta.get("p2_count", 0)),
-                    explicit_roles=getattr(state, "_explicit_roles", set()),
-                    secrets=config.secrets,
-                )
-                state._adaptive_decision = _updated
-                if _updated.routing_decision:
-                    state.routing_decision = _updated.routing_decision
-                _cp = (_updated.routing_decision.get("dev") or {}).get(
-                    "post_plan_checkpoint"
-                ) or {}
-                if _cp.get("fired"):
-                    _log(
-                        f"  ↳ post-plan checkpoint: dev {_cp.get('baseline_tier')} → "
-                        f"{_cp.get('final_tier')} ({_updated.dev.model}) — "
-                        f"{_cp.get('rationale')}"
-                    )
+            # A clean plan-review resolves the uncertainty that may have promoted
+            # the dev tier at preflight. Re-evaluate ONLY the dev tier (max one
+            # step down); engine.py swaps config.dev_profile before DEV.
+            _apply_post_plan_dev_checkpoint(state, config)
             if merged_pr.findings:
                 findings_text = plan_review_findings_to_text(merged_pr)
                 state.plan_agent_review_findings = findings_text
@@ -1531,6 +1555,13 @@ def _run_human_plan_review(
             state.plan_structured = parse_plan_output(updated)
             plan_text = updated
             record_plan_attempt(state, [])
+            # ── Post-plan dev-tier checkpoint (#1387) ──────────────────
+            # Same demotion signal as the agent-review APPROVE path: a clean
+            # human/pending-file/remote approval on a medium story de-risks the
+            # dev tier too. A human approval carries no structured findings, so
+            # record_plan_attempt(state, []) yields p1=0/p2=0 — the checkpoint
+            # gates still enforce complexity/cycle-count before firing.
+            _apply_post_plan_dev_checkpoint(state, config)
             write_trace(
                 workspace_path
                 / ".forge/traces"

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -477,13 +477,17 @@ def _maybe_escalate_decompose(
 def _apply_post_plan_dev_checkpoint(
     state: CoordinatorState,
     config: "ForgeConfig",
+    plan_review_decision: str = "APPROVE",
 ) -> None:
-    """Re-evaluate ONLY the dev tier after a clean plan-review APPROVE (#1387).
+    """Re-evaluate ONLY the dev tier after a plan-review that proceeds to DEV (#1387).
 
     Shared by every plan-review path that continues to DEV — the agent
-    plan-review APPROVE branch and the human/pending-file/remote APPROVE branch —
-    so a clean medium plan-review always runs and records the post-plan
-    checkpoint regardless of reviewer type. All gate conditions are enforced
+    plan-review APPROVE branch, the human/pending-file/remote APPROVE branch, and
+    the refactor advisory branch (which proceeds regardless of verdict) — so the
+    post-plan checkpoint is always recorded. ``plan_review_decision`` carries the
+    real merged verdict so a non-APPROVE advisory continuation records
+    ``preserve``/``plan_review_not_approve`` rather than leaving the pending
+    sentinel. All gate conditions (including verdict == APPROVE) are enforced
     inside :func:`apply_post_plan_checkpoint`; even a non-firing decision records
     the audit block. Must be called AFTER ``record_plan_attempt()`` so the latest
     per-attempt p1/p2 counts are available.
@@ -513,7 +517,7 @@ def _apply_post_plan_dev_checkpoint(
         config.agents,
         config.assignment,
         state.preflight_complexity or "medium",
-        plan_review_decision="APPROVE",
+        plan_review_decision=plan_review_decision,
         plan_review_cycles=state.plan_regen_count + 1,
         p1_count=int(_latest_meta.get("p1_count", 0)),
         p2_count=int(_latest_meta.get("p2_count", 0)),
@@ -1218,6 +1222,12 @@ def _run_plan_agent_review(
 
         # Advisory mode (refactor work type): log findings but never reject
         if advisory:
+            # This branch proceeds to DEV regardless of verdict, so record the
+            # post-plan checkpoint with the ACTUAL merged verdict (#1387). A
+            # non-APPROVE advisory continuation lands preserve/plan_review_not_
+            # approve rather than leaving the pending sentinel; an APPROVE advisory
+            # is gated identically to the regular APPROVE path.
+            _apply_post_plan_dev_checkpoint(state, config, merged_pr.verdict)
             findings_text = plan_review_findings_to_text(merged_pr)
             state.plan_agent_review_findings = findings_text
             _log(

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -864,3 +864,27 @@ class TestSprintConfig:
         )
         with pytest.raises(ValueError, match="max_parallel"):
             load_config(config_path)
+
+
+class TestAssignmentPlanTierReduction:
+    """assignment.plan_tier_reduction (#1387) parsing — default true, explicit false."""
+
+    def test_omitted_defaults_true(self):
+        from theforge.config.models import _parse_assignment
+
+        cfg = _parse_assignment({"enabled": True})
+        assert cfg.plan_tier_reduction is True
+
+    def test_explicit_false_disables(self):
+        from theforge.config.models import _parse_assignment
+
+        cfg = _parse_assignment({"enabled": True, "plan_tier_reduction": False})
+        assert cfg.plan_tier_reduction is False
+
+    def test_load_config_threads_flag(self, tmp_path):
+        config_path = _write_config(
+            {"project": "test", "assignment": {"enabled": True, "plan_tier_reduction": False}},
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.assignment.plan_tier_reduction is False

--- a/tests/test_coord_post_plan_checkpoint_seam.py
+++ b/tests/test_coord_post_plan_checkpoint_seam.py
@@ -1,0 +1,189 @@
+"""End-to-end coordinator seam for the post-plan dev-tier checkpoint (#1387).
+
+Proves that a clean agent plan-review APPROVE on a medium story re-evaluates
+ONLY the dev tier, swaps ``config.dev_profile`` before DEV runs, and records the
+outcome in ``routing_decision.dev.post_plan_checkpoint``. Complements the pure
+gate-condition unit coverage in ``test_post_plan_checkpoint.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    APPROVE_REVIEW,
+    PREFLIGHT_PROCEED_MEDIUM,
+    _make_agent_result,
+    _make_task,
+    _shell_with_gate,
+    patch_gate_shell,
+)
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    AgentDef,
+    AssignmentConfig,
+    ForgeConfig,
+    LogConfig,
+    PlanAgentReviewConfig,
+    PlanConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.engine import run_task
+
+PLAN_AGENT_APPROVE = """\
+```yaml
+verdict: APPROVE
+findings: []
+```
+"""
+
+
+def _agents() -> list[AgentDef]:
+    return [
+        AgentDef(
+            name="haiku",
+            provider="anthropic",
+            model="haiku",
+            budget_usd=1.0,
+            timeout_seconds=600,
+            tier="cheap",
+        ),
+        AgentDef(
+            name="sonnet",
+            provider="anthropic",
+            model="sonnet",
+            budget_usd=3.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="opus",
+            provider="anthropic",
+            model="opus",
+            budget_usd=5.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+    ]
+
+
+def _make_config(tmp_path: Path, *, plan_tier_reduction: bool = True) -> ForgeConfig:
+    """Adaptive config: agents pool + plan_agent_review, medium → mid dev."""
+    par_config = PlanAgentReviewConfig(enabled=True, cli="claude", model="sonnet")
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        review_pool_is_default=True,
+        synthesis_profile=None,
+        agents=_agents(),
+        secrets={"ANTHROPIC_API_KEY": "k"},
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=False,
+            min_reviewers=1,
+            max_reviewers=1,
+            prefer_cross_provider=False,
+            plan_tier_reduction=plan_tier_reduction,
+        ),
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        plan=PlanConfig(enabled=True, budget_usd=0.50, timeout=300, validate_spec=False),
+        plan_agent_review=par_config,
+        log=LogConfig(enabled=False),
+    )
+
+
+def _run(config, tmp_path, dev_models: list):
+    """Drive run_task, capturing the dev profile model that reaches DEV."""
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+
+    def _capture_dev(*args, **kwargs):
+        dev_models.append(kwargs["profile"].model)
+        return _make_agent_result(success=True, output="Implemented.")
+
+    with (
+        patch("theforge.coordinator.review_pool.run_agent_pool") as mock_code_pool,
+        patch(
+            "theforge.coordinator.review_phase._human_review",
+            return_value=("approve", None),
+        ),
+        patch("theforge.coordinator.plan_flow.run_agent_pool") as mock_plan_pool,
+        patch("theforge.coordinator.plan_flow.run_agent") as mock_plan_agent,
+        patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+        patch("theforge.coordinator.dev_phase.run_agent", side_effect=_capture_dev),
+        patch_gate_shell() as mock_shell,
+    ):
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        mock_plan_agent.return_value = _make_agent_result(
+            success=True, output="# Plan\n\nGood plan.", cost_usd=0.10
+        )
+        mock_plan_pool.return_value = [
+            _make_agent_result(
+                success=True,
+                output=PLAN_AGENT_APPROVE,
+                cost_usd=0.08,
+                profile_name="plan-review",
+            )
+        ]
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+        return run_task(config, task, interactive=True)
+
+
+def test_clean_plan_review_downgrades_dev_before_dev_phase(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    config = _make_config(tmp_path)
+    dev_models: list = []
+    result = _run(config, tmp_path, dev_models)
+
+    assert result.success is True
+    assert result.state.plan_review_decision == "approve"
+
+    # The medium story assigned dev at mid tier (score 5). The clean plan-review
+    # stepped it down one level to cheap BEFORE the dev phase ran.
+    cp = result.state.routing_decision["dev"]["post_plan_checkpoint"]
+    assert cp["fired"] is True
+    assert cp["decision"] == "downgrade"
+    assert cp["baseline_tier"] == "mid"
+    assert cp["final_tier"] == "cheap"
+    assert cp["plan_present"] is True
+    assert cp["rationale"] == "plan_review_clean_medium"
+
+    # The dev phase actually ran on the demoted (cheap-tier) model.
+    assert dev_models == ["haiku"]
+    assert result.state._adaptive_decision.dev.model == "haiku"
+
+
+def test_disabled_flag_keeps_preflight_dev_tier(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    config = _make_config(tmp_path, plan_tier_reduction=False)
+    dev_models: list = []
+    result = _run(config, tmp_path, dev_models)
+
+    assert result.success is True
+    cp = result.state.routing_decision["dev"]["post_plan_checkpoint"]
+    assert cp["fired"] is False
+    assert cp["decision"] == "skipped"
+    assert cp["rationale"] == "plan_tier_reduction_disabled"
+    # Dev ran on the preflight-assigned mid tier, untouched.
+    assert dev_models == ["sonnet"]

--- a/tests/test_coord_post_plan_checkpoint_seam.py
+++ b/tests/test_coord_post_plan_checkpoint_seam.py
@@ -31,6 +31,7 @@ from theforge.config import (
     LogConfig,
     PlanAgentReviewConfig,
     PlanConfig,
+    PlanReviewConfig,
     RetryPolicy,
     WorkspaceConfig,
 )
@@ -187,3 +188,97 @@ def test_disabled_flag_keeps_preflight_dev_tier(tmp_path, monkeypatch):
     assert cp["rationale"] == "plan_tier_reduction_disabled"
     # Dev ran on the preflight-assigned mid tier, untouched.
     assert dev_models == ["sonnet"]
+
+
+def _make_human_config(tmp_path: Path) -> ForgeConfig:
+    """Adaptive config with HUMAN plan-review (blocking) instead of agent review."""
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        review_pool_is_default=True,
+        synthesis_profile=None,
+        agents=_agents(),
+        secrets={"ANTHROPIC_API_KEY": "k"},
+        assignment=AssignmentConfig(
+            # min/max reviewers = 0 → adaptive assigns no plan reviewers, so
+            # plan_agent_review stays disabled and the human plan-review path is
+            # exercised while _adaptive_decision is still populated. Code review
+            # falls back to the default review_pool (unchanged when 0 reviewers).
+            enabled=True,
+            escalation_memory=False,
+            min_reviewers=0,
+            max_reviewers=0,
+            prefer_cross_provider=False,
+            plan_tier_reduction=True,
+        ),
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        plan=PlanConfig(enabled=True, budget_usd=0.50, timeout=300, validate_spec=False),
+        plan_review=PlanReviewConfig(enabled=True, mode="blocking", timeout_seconds=300),
+        log=LogConfig(enabled=False),
+    )
+
+
+def test_human_plan_review_approve_also_runs_checkpoint(tmp_path, monkeypatch):
+    """A clean HUMAN plan-review APPROVE demotes dev too — not just agent review.
+
+    Regression guard for the iter-1 P1: the checkpoint was only wired into the
+    agent-review APPROVE branch, so human/pending-file/remote approvals reached
+    DEV with the preflight dev profile and a ``pending`` audit block.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    config = _make_human_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+
+    dev_models: list = []
+
+    def _capture_dev(*args, **kwargs):
+        dev_models.append(kwargs["profile"].model)
+        return _make_agent_result(success=True, output="Implemented.")
+
+    with (
+        patch("theforge.coordinator.review_pool.run_agent_pool") as mock_code_pool,
+        patch(
+            "theforge.coordinator.review_phase._human_review",
+            return_value=("approve", None),
+        ),
+        patch(
+            "theforge.coordinator.plan_flow._plan_review_interactive",
+            return_value="approve",
+        ),
+        patch("theforge.coordinator.plan_flow.run_agent") as mock_plan_agent,
+        patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+        patch("theforge.coordinator.dev_phase.run_agent", side_effect=_capture_dev),
+        patch_gate_shell() as mock_shell,
+    ):
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        mock_plan_agent.return_value = _make_agent_result(
+            success=True, output="# Plan\n\nGood plan.", cost_usd=0.10
+        )
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+        result = run_task(config, task, interactive=True)
+
+    assert result.success is True
+    assert result.state.plan_review_decision == "approve"
+    cp = result.state.routing_decision["dev"]["post_plan_checkpoint"]
+    assert cp["fired"] is True
+    assert cp["decision"] == "downgrade"
+    assert cp["baseline_tier"] == "mid"
+    assert cp["final_tier"] == "cheap"
+    assert cp["rationale"] == "plan_review_clean_medium"
+    assert dev_models == ["haiku"]

--- a/tests/test_coord_post_plan_checkpoint_seam.py
+++ b/tests/test_coord_post_plan_checkpoint_seam.py
@@ -44,6 +44,30 @@ findings: []
 ```
 """
 
+PLAN_AGENT_REJECT_P0 = """\
+```yaml
+verdict: REJECT
+findings:
+  - severity: P0
+    description: "Plan is architecturally broken — wrong module entirely"
+    suggestion: "Rethink the approach"
+```
+"""
+
+# Medium story that preflight classifies as refactor work → advisory plan review.
+PREFLIGHT_PROCEED_MEDIUM_REFACTOR = """\
+```yaml
+verdict: PROCEED
+complexity: medium
+work_type: refactor
+reason: "Refactor of an existing module."
+criteria_checked:
+  - criterion: "Feature X"
+    satisfied: false
+    evidence: "Not found in codebase"
+```
+"""
+
 
 def _agents() -> list[AgentDef]:
     return [
@@ -282,3 +306,68 @@ def test_human_plan_review_approve_also_runs_checkpoint(tmp_path, monkeypatch):
     assert cp["final_tier"] == "cheap"
     assert cp["rationale"] == "plan_review_clean_medium"
     assert dev_models == ["haiku"]
+
+
+def test_advisory_reject_records_preserve_and_keeps_dev_tier(tmp_path, monkeypatch):
+    """A refactor advisory plan-review REJECT proceeds to DEV but records the
+    checkpoint as preserve/plan_review_not_approve — never the pending sentinel.
+
+    Regression guard for the iter-1 P1: the advisory continue-to-DEV branch left
+    routing_decision.dev.post_plan_checkpoint at the pending sentinel.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "test-task"
+    workspace.mkdir()
+
+    dev_models: list = []
+
+    def _capture_dev(*args, **kwargs):
+        dev_models.append(kwargs["profile"].model)
+        return _make_agent_result(success=True, output="Implemented.")
+
+    with (
+        patch("theforge.coordinator.review_pool.run_agent_pool") as mock_code_pool,
+        patch(
+            "theforge.coordinator.review_phase._human_review",
+            return_value=("approve", None),
+        ),
+        patch("theforge.coordinator.plan_flow.run_agent_pool") as mock_plan_pool,
+        patch("theforge.coordinator.plan_flow.run_agent") as mock_plan_agent,
+        patch("theforge.coordinator.preflight_flow.run_agent") as mock_preflight,
+        patch("theforge.coordinator.dev_phase.run_agent", side_effect=_capture_dev),
+        patch_gate_shell() as mock_shell,
+    ):
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM_REFACTOR, cost_usd=0.05
+        )
+        mock_plan_agent.return_value = _make_agent_result(
+            success=True, output="# Plan\n\nRefactor plan.", cost_usd=0.10
+        )
+        # Advisory mode: a REJECT (P0) verdict is logged but does NOT block; the
+        # run proceeds to DEV via the advisory continue-to-DEV branch.
+        mock_plan_pool.return_value = [
+            _make_agent_result(
+                success=True,
+                output=PLAN_AGENT_REJECT_P0,
+                cost_usd=0.08,
+                profile_name="plan-review",
+            )
+        ]
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+        result = run_task(config, task, interactive=True)
+
+    assert result.success is True
+    assert result.state.preflight_work_type == "refactor"
+    cp = result.state.routing_decision["dev"]["post_plan_checkpoint"]
+    assert cp["fired"] is False
+    assert cp["decision"] == "preserve"
+    assert cp["baseline_tier"] == "mid"
+    assert cp["final_tier"] == "mid"
+    assert cp["rationale"] == "plan_review_not_approve"
+    # Dev ran on the untouched preflight-assigned mid tier.
+    assert dev_models == ["sonnet"]

--- a/tests/test_post_plan_checkpoint.py
+++ b/tests/test_post_plan_checkpoint.py
@@ -1,0 +1,287 @@
+"""Post-plan dev-tier checkpoint (#1387, absorbs #1109).
+
+Gate-condition and seam coverage for :func:`apply_post_plan_checkpoint`, the
+single post-plan dev-tier demotion mechanism (ADR-0006 clause 5 recovery side).
+Each gate condition independently preserves the preflight-assigned dev tier; a
+clean plan-review on a medium story steps that tier down by exactly one level.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from theforge.assignment import (
+    POST_PLAN_CHECKPOINT_RATIONALES,
+    AssignmentConfig,
+    AssignmentDecision,
+    _agent_to_profile,
+    apply_post_plan_checkpoint,
+)
+from theforge.config import AgentDef
+
+
+@pytest.fixture(autouse=True)
+def _keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+    monkeypatch.setenv("GOOGLE_API_KEY", "k")
+
+
+def _cfg(**kwargs) -> AssignmentConfig:
+    defaults = dict(enabled=True, max_cost_per_story_usd=100.0)
+    defaults.update(kwargs)
+    return AssignmentConfig(**defaults)
+
+
+def _agents() -> list[AgentDef]:
+    return [
+        AgentDef(
+            name="haiku",
+            provider="anthropic",
+            model="haiku",
+            budget_usd=1.0,
+            timeout_seconds=600,
+            tier="cheap",
+        ),
+        AgentDef(
+            name="sonnet",
+            provider="anthropic",
+            model="sonnet",
+            budget_usd=3.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="opus",
+            provider="anthropic",
+            model="opus",
+            budget_usd=5.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+    ]
+
+
+def _decision(agents: list[AgentDef], dev_name: str, baseline_tier: str) -> AssignmentDecision:
+    """Build a minimal decision whose dev role sits at ``baseline_tier``."""
+    dev_agent = next(a for a in agents if a.name == dev_name)
+    dev_profile = _agent_to_profile(dev_agent, role="dev")
+    return AssignmentDecision(
+        preflight=dev_profile,
+        planner=dev_profile,
+        plan_reviewers=[dev_profile],
+        dev=dev_profile,
+        code_reviewers=[dev_profile],
+        routing_decision={
+            "dev": {
+                "final": {
+                    "model": dev_agent.model,
+                    "tier": baseline_tier,
+                    "rationale": "[preflight] dev",
+                },
+                "post_plan_checkpoint": {
+                    "fired": False,
+                    "decision": "pending",
+                    "reason": "checkpoint_runs_after_plan_review",
+                },
+            }
+        },
+    )
+
+
+def _clean(**overrides):
+    """Kwargs for a clean medium APPROVE in 1 cycle, P1=0, P2<=1."""
+    base = dict(
+        complexity="MEDIUM",
+        plan_review_decision="APPROVE",
+        plan_review_cycles=1,
+        p1_count=0,
+        p2_count=0,
+    )
+    base.update(overrides)
+    return base
+
+
+def _block(decision: AssignmentDecision) -> dict:
+    return decision.routing_decision["dev"]["post_plan_checkpoint"]
+
+
+# ── Fire path: one-step demotion ───────────────────────────────────────
+
+
+def test_strong_to_mid_on_clean_medium():
+    agents = _agents()
+    decision = _decision(agents, "opus", "strong")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), **_clean())
+    block = _block(out)
+    assert block["fired"] is True
+    assert block["decision"] == "downgrade"
+    assert block["baseline_tier"] == "strong"
+    assert block["final_tier"] == "mid"
+    assert block["plan_present"] is True
+    assert block["rationale"] == "plan_review_clean_medium"
+    assert out.dev.model == "sonnet"
+    # dev.final is updated so the recorded final reflects the running model.
+    assert out.routing_decision["dev"]["final"]["tier"] == "mid"
+    assert out.routing_decision["dev"]["final"]["model"] == "sonnet"
+
+
+def test_mid_to_cheap_on_clean_medium():
+    agents = _agents()
+    decision = _decision(agents, "sonnet", "mid")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), **_clean())
+    block = _block(out)
+    assert block["fired"] is True
+    assert block["final_tier"] == "cheap"
+    assert out.dev.model == "haiku"
+
+
+def test_never_two_steps():
+    """strong baseline reduces to mid, never straight to cheap."""
+    agents = _agents()
+    decision = _decision(agents, "opus", "strong")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), **_clean())
+    assert _block(out)["final_tier"] == "mid"
+    assert out.dev.model == "sonnet"
+
+
+def test_p2_of_one_still_fires():
+    agents = _agents()
+    decision = _decision(agents, "opus", "strong")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), **_clean(p2_count=1))
+    assert _block(out)["fired"] is True
+
+
+# ── Bypass paths (skipped) ─────────────────────────────────────────────
+
+
+def test_disabled_config_skips():
+    agents = _agents()
+    decision = _decision(agents, "opus", "strong")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(plan_tier_reduction=False), **_clean())
+    block = _block(out)
+    assert block["fired"] is False
+    assert block["decision"] == "skipped"
+    assert block["rationale"] == "plan_tier_reduction_disabled"
+    assert out.dev.model == "opus"
+
+
+def test_explicit_dev_override_skips():
+    agents = _agents()
+    decision = _decision(agents, "opus", "strong")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), explicit_roles={"dev"}, **_clean())
+    block = _block(out)
+    assert block["fired"] is False
+    assert block["decision"] == "skipped"
+    assert block["rationale"] == "explicit_dev_override"
+    assert out.dev.model == "opus"
+
+
+# ── Gate failures (preserve) — each independent ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "overrides,rationale",
+    [
+        (dict(complexity="small"), "complexity_not_medium"),
+        (dict(complexity="large"), "complexity_not_medium"),
+        (dict(plan_review_decision="REJECT"), "plan_review_not_approve"),
+        (dict(plan_review_cycles=2), "plan_review_cycles_exceeded"),
+        (dict(p1_count=1), "plan_review_p1_present"),
+        (dict(p2_count=2), "plan_review_p2_exceeded"),
+    ],
+)
+def test_each_gate_failure_preserves(overrides, rationale):
+    agents = _agents()
+    decision = _decision(agents, "opus", "strong")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), **_clean(**overrides))
+    block = _block(out)
+    assert block["fired"] is False
+    assert block["decision"] == "preserve"
+    assert block["baseline_tier"] == "strong"
+    assert block["final_tier"] == "strong"
+    assert block["rationale"] == rationale
+    assert out.dev.model == "opus"
+
+
+def test_no_reduced_tier_candidate_at_floor():
+    """A cheap-tier baseline cannot step down further — preserve."""
+    agents = _agents()
+    decision = _decision(agents, "haiku", "cheap")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), **_clean())
+    block = _block(out)
+    assert block["fired"] is False
+    assert block["decision"] == "preserve"
+    assert block["rationale"] == "no_reduced_tier_candidate"
+    assert out.dev.model == "haiku"
+
+
+def test_no_authed_candidate_at_target_preserves(monkeypatch):
+    """When the only target-tier model lacks auth, the tier is preserved."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # opus (strong) baseline, but the sole mid model (sonnet) is anthropic with
+    # no key → no authed target candidate.
+    agents = [
+        AgentDef(
+            name="sonnet",
+            provider="anthropic",
+            model="sonnet",
+            budget_usd=3.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="gpt",
+            provider="openai",
+            model="gpt-5.4",
+            budget_usd=8.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+    ]
+    decision = _decision(agents, "gpt", "strong")
+    out = apply_post_plan_checkpoint(decision, agents, _cfg(), **_clean())
+    block = _block(out)
+    assert block["fired"] is False
+    assert block["rationale"] == "no_reduced_tier_candidate"
+
+
+# ── Rationale vocabulary is closed ─────────────────────────────────────
+
+
+def test_all_emitted_rationales_are_enumerable():
+    agents = _agents()
+    seen = set()
+    scenarios = [
+        _clean(),
+        _clean(complexity="small"),
+        _clean(plan_review_decision="REJECT"),
+        _clean(plan_review_cycles=3),
+        _clean(p1_count=2),
+        _clean(p2_count=5),
+    ]
+    for kwargs in scenarios:
+        out = apply_post_plan_checkpoint(
+            _decision(agents, "opus", "strong"), agents, _cfg(), **kwargs
+        )
+        seen.add(_block(out)["rationale"])
+    # Plus the bypass + floor rationales.
+    seen.add(
+        _block(
+            apply_post_plan_checkpoint(
+                _decision(agents, "opus", "strong"),
+                agents,
+                _cfg(plan_tier_reduction=False),
+                **_clean(),
+            )
+        )["rationale"]
+    )
+    seen.add(
+        _block(
+            apply_post_plan_checkpoint(
+                _decision(agents, "haiku", "cheap"), agents, _cfg(), **_clean()
+            )
+        )["rationale"]
+    )
+    assert seen <= POST_PLAN_CHECKPOINT_RATIONALES

--- a/tests/test_routing_decision_audit.py
+++ b/tests/test_routing_decision_audit.py
@@ -210,7 +210,10 @@ def test_full_reconstruction_from_block_alone(tmp_path, _keys_except_deepseek):
     # COMPLETE explanation, not a gap.
     assert dev["demotion_check"]["applicable"] is False
     assert dev["demotion_check"]["reason"]
-    assert dev["post_plan_checkpoint"]["applied"] is False
+    # Post-plan checkpoint (#1387) runs AFTER plan-review; preflight-time
+    # assignment records the not-yet-run sentinel.
+    assert dev["post_plan_checkpoint"]["fired"] is False
+    assert dev["post_plan_checkpoint"]["decision"] == "pending"
     assert dev["post_plan_checkpoint"]["reason"]
     assert dev["base_tier_from_score"] in ("cheap", "mid", "strong")
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation satisfies the post-plan checkpoint contract; focused checkpoint, seam, config, and audit tests pass. | [google-gemini-3.5-flash] The post-plan dev-tier checkpoint is fully implemented, thoroughly tested, and perfectly compliant with all acceptance criteria. | [claude-sonnet] Iteration 1 correctly fixes both issues from the prior review: the checkpoint now fires on every plan-review path that proceeds to DEV (agent APPROVE, human/pending/remote APPROVE, and refactor-advisory continue-to-DEV regardless of verdict), and the demoted-tier agent pick is now reranked with the same model_profiles/domains/recency signals used by the original dev assignment.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.09
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

Post-plan dev tier checkpoint — clean plan-review should de-risk dev assignment (GitHub Issue #1387)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1387