### PR TITLE
Show review cycle context during live DEV status

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -247,9 +247,10 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     }
 
     # Column header
+    stage_width = 20
     header = (
-        f"  {'STORY':<28}  {'STATUS':<8}  {'PHASE':<12}  {'MODEL':<24}  {'STAGE':<16}  "
-        f"{'COMPLEXITY':<10}  {'COST':>7}  {'ELAPSED':>7}  DETAIL"
+        f"  {'STORY':<28}  {'STATUS':<8}  {'PHASE':<12}  {'MODEL':<24}  "
+        f"{'STAGE':<{stage_width}}  {'COMPLEXITY':<10}  {'COST':>7}  {'ELAPSED':>7}  DETAIL"
     )
     print(header)
     print("  " + "-" * (len(header) - 2))
@@ -386,7 +387,8 @@ def _print_story_line(
     path_lines = _wrap_cell(story_cell, 28)
     phase_lines = _wrap_cell(phase_str, 12)
     model_lines = _wrap_cell(model_str, 24)
-    stage_lines = _wrap_cell(stage_str, 16)
+    stage_width = 20
+    stage_lines = _wrap_cell(stage_str, stage_width)
     detail_lines = _wrap_cell(detail if detail else "—", detail_width)
 
     line_count = max(
@@ -407,7 +409,7 @@ def _print_story_line(
             f"{status_cell:<8}  "
             f"{phase_lines[index] if index < len(phase_lines) else '':<12}  "
             f"{model_lines[index] if index < len(model_lines) else '':<24}  "
-            f"{stage_lines[index] if index < len(stage_lines) else '':<16}  "
+            f"{stage_lines[index] if index < len(stage_lines) else '':<{stage_width}}  "
             f"{complexity_cell:<10}  {cost_cell:>7}  {elapsed_cell:>7}  "
             f"{detail_lines[index] if index < len(detail_lines) else ''}"
         )
@@ -429,7 +431,27 @@ def _format_story_elapsed(elapsed_s: float | None) -> str:
 def _detail_column_width(indent: int) -> int:
     """Return an adaptive width for DETAIL so values wrap instead of truncating."""
     terminal_width = shutil.get_terminal_size((140, 20)).columns
-    fixed_width = indent + 2 + 28 + 2 + 8 + 2 + 12 + 2 + 24 + 2 + 16 + 2 + 10 + 2 + 7 + 2 + 7 + 2
+    stage_width = 20
+    fixed_width = (
+        indent
+        + 2
+        + 28
+        + 2
+        + 8
+        + 2
+        + 12
+        + 2
+        + 24
+        + 2
+        + stage_width
+        + 2
+        + 10
+        + 2
+        + 7
+        + 2
+        + 7
+        + 2
+    )
     return max(20, terminal_width - fixed_width)
 
 

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -433,24 +433,7 @@ def _detail_column_width(indent: int) -> int:
     terminal_width = shutil.get_terminal_size((140, 20)).columns
     stage_width = 20
     fixed_width = (
-        indent
-        + 2
-        + 28
-        + 2
-        + 8
-        + 2
-        + 12
-        + 2
-        + 24
-        + 2
-        + stage_width
-        + 2
-        + 10
-        + 2
-        + 7
-        + 2
-        + 7
-        + 2
+        indent + 2 + 28 + 2 + 8 + 2 + 12 + 2 + 24 + 2 + stage_width + 2 + 10 + 2 + 7 + 2 + 7 + 2
     )
     return max(20, terminal_width - fixed_width)
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -469,7 +469,13 @@ def _coordinator_loop(
                         "current_model": config.dev_profile.model,
                         "detail": {
                             "review_cycle": state.review_cycle,
+                            "review_max_cycles": (
+                                state.adaptive_review_max or config.retry.max_review_cycles
+                            ),
                             "dev_iteration": state.dev_iteration,
+                            "dev_max_iterations": (
+                                state.adaptive_dev_max or config.retry.max_dev_iterations
+                            ),
                         },
                     }
                 )
@@ -509,7 +515,13 @@ def _coordinator_loop(
                         "current_model": config.dev_profile.model,
                         "detail": {
                             "review_cycle": state.review_cycle,
+                            "review_max_cycles": (
+                                state.adaptive_review_max or config.retry.max_review_cycles
+                            ),
                             "dev_iteration": state.dev_iteration,
+                            "dev_max_iterations": (
+                                state.adaptive_dev_max or config.retry.max_dev_iterations
+                            ),
                         },
                     }
                 )

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -268,6 +268,39 @@ def _format_usage_stage(used: object, maximum: object, label: str) -> str:
     return ""
 
 
+def _format_live_dev_stage(detail_data: dict) -> str:
+    """Render DEV progress as outer review-cycle position plus dev iteration.
+
+    ``review_cycle`` is the count of completed/active review cycles in the
+    story's dev->review feedback loop. ``dev_iteration`` is the current dev
+    attempt inside that loop. Showing only the latter makes a later DEV retry
+    look indistinguishable from first-pass development once the per-cycle dev
+    counter has reset.
+    """
+    parts: list[str] = []
+    cycle = detail_data.get("review_cycle")
+    if isinstance(cycle, int):
+        cycle_stage = _format_usage_stage(
+            cycle,
+            detail_data.get("review_max_cycles"),
+            "cycle",
+        )
+        parts.append(cycle_stage or f"cycle={cycle}")
+
+    iteration = detail_data.get("dev_iteration")
+    iter_stage = _format_usage_stage(
+        iteration,
+        detail_data.get("dev_max_iterations"),
+        "iter",
+    )
+    if not iter_stage and isinstance(iteration, int):
+        iter_stage = f"iter={iteration}"
+    if iter_stage:
+        parts.append(iter_stage)
+
+    return " ".join(parts)
+
+
 def _format_terminal_stage(iteration_usage: dict | None) -> str:
     if not isinstance(iteration_usage, dict):
         return ""
@@ -517,10 +550,7 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
         return stage, "planning", complexity
 
     if phase_val == "DEV":
-        iteration = detail_data.get("dev_iteration")
-        stage = _format_usage_stage(iteration, detail_data.get("dev_max_iterations"), "iter")
-        if not stage and isinstance(iteration, int):
-            stage = f"iter={iteration}"
+        stage = _format_live_dev_stage(detail_data)
         current_finding = _nonempty_str(detail_data.get("current_finding"))
         files_touched = detail_data.get("files_touched")
         last_gate = _nonempty_str(detail_data.get("last_gate_result"))

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -119,6 +119,72 @@ def test_read_live_status_parses_state_file(tmp_path: Path) -> None:
     assert e2.detail == "waiting"
 
 
+def test_live_dev_stage_shows_review_cycle_and_dev_iteration(tmp_path: Path) -> None:
+    """DEV rows include the outer review-cycle position, not only the dev attempt.
+
+    In live coordinator state, ``review_cycle`` is the story's position in the
+    full dev->review feedback loop and ``dev_iteration`` is the current dev
+    attempt inside that cycle.
+    """
+    from theforge.sprint.status_reader import read_live_status
+
+    _make_state_file(
+        tmp_path,
+        "run-cycle",
+        "cycle-sprint",
+        [
+            {
+                "slug": "issue-130",
+                "path": "Issue #130",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 15.82,
+                "bundle_candidate": False,
+                "blocked_by": [],
+                "detail": {
+                    "review_cycle": 0,
+                    "review_max_cycles": 3,
+                    "dev_iteration": 0,
+                    "dev_max_iterations": 3,
+                },
+            },
+        ],
+    )
+
+    entry = read_live_status("run-cycle", tmp_path)[0]
+    assert entry.stage == "cycle=0/3 iter=0/3"
+
+
+def test_live_dev_stage_later_cycle_remains_global_context(tmp_path: Path) -> None:
+    """A DEV retry after review feedback must not collapse back to bare iter=N."""
+    from theforge.sprint.status_reader import read_live_status
+
+    _make_state_file(
+        tmp_path,
+        "run-cycle-2",
+        "cycle-sprint",
+        [
+            {
+                "slug": "issue-131",
+                "path": "Issue #131",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 2.00,
+                "bundle_candidate": False,
+                "blocked_by": [],
+                "detail": {
+                    "review_cycle": 2,
+                    "dev_iteration": 1,
+                    "dev_max_iterations": 3,
+                },
+            },
+        ],
+    )
+
+    entry = read_live_status("run-cycle-2", tmp_path)[0]
+    assert entry.stage == "cycle=2 iter=1/3"
+
+
 def test_read_live_status_blocked_story(tmp_path: Path) -> None:
     from theforge.sprint.status_reader import read_live_status
 


### PR DESCRIPTION
## Summary

This updates live sprint status so a running DEV row shows the story's position in the full dev/review loop, not only the current per-cycle dev attempt.

## What changed

- DEV live state now carries both review-cycle and dev-iteration maxima.
- `forge sprint-status` / `hforge status --watch` renders DEV stage as `cycle=N/M iter=N/M` when cycle context is available.
- The STAGE column is widened so the combined progress label fits in the common case.
- Tests pin both first-pass DEV and later review-cycle retry rendering.

## Why

Operators could see `iter=0` or `iter=N` without any indication of where the story sat in the broader plan/dev/review loop. That made active sprint status misleading during review-feedback cycles.

Closes #1881.

## Validation

- `pytest tests/test_cli_sprint_status.py tests/test_status_reader_reviewer_progress.py tests/test_cli_status_watch.py tests/test_coordinator.py tests/test_coord_audit_iteration_counts.py`
- `ruff check src/theforge/coordinator/engine.py src/theforge/sprint/status_reader.py src/theforge/cli/sprint_status.py tests/test_cli_sprint_status.py`
