### PR TITLE
[P2] issue-1341: Unknown mode strings (e.g. gate_timeout_scale: typo) ar

### DIFF
--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -481,6 +481,23 @@ def _validated_failed_test_pattern(raw: Any) -> str | None:
     return raw
 
 
+def _validated_gate_timeout_scale(raw: Any) -> str:
+    """Validate ``validation.gate_timeout_scale`` against supported modes."""
+    if raw is None:
+        return "adaptive"
+    if not isinstance(raw, str):
+        raise ValueError(
+            "forge.yaml validation.gate_timeout_scale must be a string "
+            "('adaptive' or 'fixed'), "
+            f"got {type(raw).__name__}."
+        )
+    if raw not in {"adaptive", "fixed"}:
+        raise ValueError(
+            f"forge.yaml validation.gate_timeout_scale must be 'adaptive' or 'fixed', got {raw!r}."
+        )
+    return raw
+
+
 def _resolve_project_root(config_path: Path) -> Path:
     """Resolve the project root for a given forge.yaml path.
 
@@ -584,7 +601,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         pre_validate_command=val_data.get("pre_validate_command"),
         failed_test_pattern=_validated_failed_test_pattern(val_data.get("failed_test_pattern")),
         gate_cpu_cores=val_data.get("gate_cpu_cores"),
-        gate_timeout_scale=str(val_data.get("gate_timeout_scale", "adaptive")),
+        gate_timeout_scale=_validated_gate_timeout_scale(val_data.get("gate_timeout_scale")),
         default_test_target=str(
             val_data.get("default_test_target", DEFAULT_VALIDATION.default_test_target)
         ),

--- a/src/theforge/sprint/gate_timeout_resolver.py
+++ b/src/theforge/sprint/gate_timeout_resolver.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+VALID_GATE_TIMEOUT_SCALES = frozenset({"adaptive", "fixed"})
+
 
 @dataclass(frozen=True)
 class GateTimeoutResolution:
@@ -47,7 +49,11 @@ def resolve_effective_gate_timeout(
     gate_demand_cores = gate_cpu_cores if gate_cpu_cores and gate_cpu_cores > 0 else safe_host
     demand = gate_demand_cores * safe_parallel
     factor = max(1.0, demand / safe_host)
-    normalized_mode = mode if mode in ("adaptive", "fixed") else "adaptive"
+    normalized_mode = str(mode)
+    if normalized_mode not in VALID_GATE_TIMEOUT_SCALES:
+        raise ValueError(
+            f"gate_timeout_scale must be 'adaptive' or 'fixed', got {normalized_mode!r}"
+        )
     if normalized_mode == "fixed":
         effective = int(baseline)
     else:

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1699,17 +1699,24 @@ def run_sprint(
         _host_cores = os.cpu_count() or 1
         _gate_cpu_raw = config.validation.gate_cpu_cores
         _gate_cpu_cores = int(_gate_cpu_raw) if _gate_cpu_raw else None
-        _mode = str(config.validation.gate_timeout_scale or "adaptive")
-        _gate_timeout_resolution = resolve_effective_gate_timeout(
-            baseline=_baseline_gate_timeout,
-            max_parallel=max_parallel,
-            host_cores=_host_cores,
-            gate_cpu_cores=_gate_cpu_cores,
-            mode=_mode,
-        )
     except (TypeError, ValueError):
         # Mock or partial config in tests; skip adaptive scaling silently.
         _gate_timeout_resolution = None
+    else:
+        _mode_raw = config.validation.gate_timeout_scale
+        if _mode_raw is None:
+            _mode = "adaptive"
+        elif not isinstance(_mode_raw, str):
+            # Mock or partial config in tests; skip adaptive scaling silently.
+            _gate_timeout_resolution = None
+        else:
+            _gate_timeout_resolution = resolve_effective_gate_timeout(
+                baseline=_baseline_gate_timeout,
+                max_parallel=max_parallel,
+                host_cores=_host_cores,
+                gate_cpu_cores=_gate_cpu_cores,
+                mode=_mode_raw,
+            )
     if _gate_timeout_resolution is not None:
         print(
             f"[sprint] gate_timeout: {_gate_timeout_resolution.reason}",

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -96,6 +96,24 @@ class TestLoadConfig:
         with pytest.raises(ValueError, match="failed_test_pattern is not a valid regex"):
             load_config(config_path)
 
+    def test_gate_timeout_scale_default_is_adaptive(self, tmp_path):
+        config_path = _write_config({"project": "p"}, tmp_path)
+        config = load_config(config_path)
+        assert config.validation.gate_timeout_scale == "adaptive"
+
+    def test_gate_timeout_scale_valid_mode_loads(self, tmp_path):
+        config_path = _write_config({"validation": {"gate_timeout_scale": "fixed"}}, tmp_path)
+        config = load_config(config_path)
+        assert config.validation.gate_timeout_scale == "fixed"
+
+    def test_gate_timeout_scale_invalid_mode_raises(self, tmp_path):
+        config_path = _write_config({"validation": {"gate_timeout_scale": "adaptvie"}}, tmp_path)
+        with pytest.raises(
+            ValueError,
+            match="validation.gate_timeout_scale must be 'adaptive' or 'fixed'",
+        ):
+            load_config(config_path)
+
     def test_custom_workspace(self, tmp_path):
         config_path = _write_config(
             {

--- a/tests/test_sprint_gate_timeout_scaling.py
+++ b/tests/test_sprint_gate_timeout_scaling.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
 
 from theforge.config import (
@@ -79,12 +80,11 @@ class TestResolveEffectiveGateTimeout:
         assert r.factor == 2.0
         assert r.effective_timeout == 60
 
-    def test_unknown_mode_defaults_to_adaptive(self) -> None:
-        r = resolve_effective_gate_timeout(
-            baseline=10, max_parallel=2, host_cores=2, gate_cpu_cores=2, mode="bogus"
-        )
-        assert r.mode == "adaptive"
-        assert r.effective_timeout == 20
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="gate_timeout_scale must be 'adaptive' or 'fixed'"):
+            resolve_effective_gate_timeout(
+                baseline=10, max_parallel=2, host_cores=2, gate_cpu_cores=2, mode="bogus"
+            )
 
 
 # ── Seam-level integration: runner → coordinator config propagation ──────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change fails closed for unknown gate timeout scale strings at config load and preserves resolver-level rejection. | [google-gemini-3.5-flash] Successfully validated gate_timeout_scale at config load time and hardened the resolver to reject unknown mode strings.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $0.62
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

[P2] issue-1341: Unknown mode strings (e.g. gate_timeout_scale: typo) ar (GitHub Issue #1370)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1370