### PR TITLE
sprint status reports completed terminal-marker runs as crashed when state remains

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -120,6 +120,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     entries = None
     sprint_name = ""
     unexpected_end = False
+    terminal_outcome: str | None = None
     total_cost_usd: float | None = None
     duration_seconds: float | None = None
     sprint_phase: str | None = None
@@ -151,10 +152,17 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
         except Exception:
             pass
     else:
-        # PID file gone — check if state file still exists (unexpected exit).
+        # PID file gone. A leftover .state file means the run did not tear down
+        # its live state — but that is a *crash* only when no terminal outcome
+        # marker was written. A run that wrote <run_id>.ended terminated
+        # deliberately (completed/stopped/orphaned); its lingering .state must
+        # not be reported as an unexpected end.
         state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
         if state_path.exists():
-            unexpected_end = True
+            from theforge import detach as _detach
+
+            terminal_outcome = _detach.read_run_ended(run_id, project_root)
+            unexpected_end = terminal_outcome is None
             entries = read_live_status(run_id, project_root)
             if entries is not None:
                 sprint_name = _read_sprint_name_from_state(state_path)
@@ -162,7 +170,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     # For crashed sprints with an unreadable state file, show the banner with
     # an empty story list rather than falling through to sprint-summary (which
     # won't exist for crashed sprints).
-    if entries is None and unexpected_end:
+    if entries is None and (unexpected_end or terminal_outcome):
         entries = []
 
     # Fall back to completed sprint-summary.yaml
@@ -196,6 +204,10 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
         state_label = "live"
     elif unexpected_end:
         state_label = "crashed"
+    elif terminal_outcome:
+        # A terminal marker survived alongside .state: report the recorded
+        # outcome (completed/stopped/orphaned) rather than crash wording.
+        state_label = terminal_outcome
     else:
         state_label = "completed"
 

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -756,6 +756,68 @@ def test_display_sprint_status_crashed_sprint(tmp_path: Path) -> None:
     assert "unexpectedly" in output
 
 
+def test_display_sprint_status_terminal_marker_not_crashed(tmp_path: Path) -> None:
+    """A run with a .ended marker (no PID) is not crashed even if .state lingers.
+
+    Reproduces issue-1872: a sprint that wrote <run_id>.ended (e.g. an early
+    bootstrap error caught by cli/sprint.py) but left a bootstrap .state file
+    behind must report the recorded terminal outcome, not the crash banner.
+    """
+    _make_state_file(
+        tmp_path,
+        "ended-run",
+        "ended-sprint",
+        [
+            {
+                "slug": "issue-41",
+                "path": "Issue #41",
+                "status": "waiting",
+                "phase": None,
+                "cost_usd": 0.0,
+                "bundle_candidate": False,
+                "blocked_by": [],
+            }
+        ],
+    )
+    # Terminal outcome marker written by the clean-exit path.
+    (tmp_path / ".forge" / "runs" / "ended-run.ended").write_text("completed")
+
+    code, output = _run_sprint_status(tmp_path, "ended-run")
+
+    assert code == 0
+    assert "crashed" not in output
+    assert "unexpectedly" not in output
+    assert "[completed]" in output
+
+
+def test_display_sprint_status_stopped_marker_reports_outcome(tmp_path: Path) -> None:
+    """A stopped run's recorded outcome is surfaced instead of crash wording."""
+    _make_state_file(
+        tmp_path,
+        "stopped-run",
+        "stopped-sprint",
+        [
+            {
+                "slug": "issue-42",
+                "path": "Issue #42",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 0.05,
+                "bundle_candidate": False,
+                "blocked_by": [],
+            }
+        ],
+    )
+    (tmp_path / ".forge" / "runs" / "stopped-run.ended").write_text("stopped")
+
+    code, output = _run_sprint_status(tmp_path, "stopped-run")
+
+    assert code == 0
+    assert "crashed" not in output
+    assert "unexpectedly" not in output
+    assert "[stopped]" in output
+
+
 def test_display_sprint_status_column_header_present(tmp_path: Path) -> None:
     """Sprint display includes a column header row."""
     stories = [


### PR DESCRIPTION
## Summary

The change correctly reserves crashed status for PID-missing state files without a terminal marker, with focused regression coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.56
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

sprint status reports completed terminal-marker runs as crashed when state remains (GitHub Issue #1872)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1872