### PR TITLE
dev model escalation on persistent P1s

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -87,6 +87,8 @@ ROUTING_RATIONALE_STATES: frozenset[str] = frozenset(
 MECHANISM_DEV_PROMOTION = "_check_promotion"
 MECHANISM_POST_PLAN_DEMOTION = "post_plan_checkpoint"
 MECHANISM_REVIEWER_COMPLETION_DEPRIORITIZE = "reviewer_completion_rate"
+MECHANISM_PERSISTENT_P1_DEV_ESCALATION = "persistent_p1_dev_escalation"
+MECHANISM_RUN_SCOPED_RESET = "fresh_run_state_reset"
 
 
 @dataclass(frozen=True)
@@ -169,6 +171,30 @@ ROUTING_SYMMETRY_REGISTRY: tuple[RoutingSymmetryPair, ...] = (
         # audit-block builder directly, so grep for the mechanism token.
         promotion_test_token="completion",
         open_followup="reviewer-reinclusion",
+    ),
+    # In-run persistent-P1 dev escalation (#296): a repeated P1 across
+    # consecutive review cycles upgrades the dev model for the current run only.
+    # The inverse is the next story's fresh CoordinatorState construction, which
+    # resets the run-scoped flag and leaves cross-run tier/routing weights
+    # untouched.
+    RoutingSymmetryPair(
+        promotion=RoutingMechanism(
+            name=MECHANISM_PERSISTENT_P1_DEV_ESCALATION,
+            symbol="theforge.coordinator.review_phase._record_persistent_p1_dev_escalation",
+            audit_label="in_run_escalation",
+        ),
+        demotion=RoutingMechanism(
+            name=MECHANISM_RUN_SCOPED_RESET,
+            symbol="theforge.coordinator.engine._fresh_run_state",
+            audit_label="run_scoped_reset",
+        ),
+        promotion_tests=("tests/test_coord_preflight_escalation.py",),
+        demotion_tests=(
+            "tests/test_coord_preflight_escalation.py",
+            "tests/test_routing_symmetry_invariant.py",
+        ),
+        promotion_test_token="persistent_p1_dev_escalation",
+        demotion_test_token="_fresh_run_state",
     ),
 )
 

--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -162,6 +162,27 @@ def _render_dev_mechanisms(role_block: dict, lines: list[str]) -> None:
             lines,
         )
 
+    runtime_escalation = role_block.get("persistent_p1_dev_escalation") or {}
+    if runtime_escalation:
+        signal = runtime_escalation.get("signal") or {}
+        model_swap = runtime_escalation.get("model_swap") or {}
+        descriptions = signal.get("descriptions") or []
+        desc_text = f"; findings: {'; '.join(descriptions)}" if descriptions else ""
+        detail = (
+            f"{signal.get('kind', 'persistent_p1')} in {signal.get('file', '?')} "
+            f"(cycle {signal.get('review_cycle', '?')}) "
+            f"{model_swap.get('from_model', '?')} → {model_swap.get('to_model', '?')} "
+            f"[scope={runtime_escalation.get('scope', '?')}, "
+            f"return={runtime_escalation.get('return_path', '?')}]"
+            f"{desc_text}"
+        )
+        _render_mechanism(
+            "in-run persistent-P1 escalation",
+            _mechanism_state(checked=True, fired=bool(runtime_escalation.get("fired", True))),
+            detail,
+            lines,
+        )
+
 
 def _render_reviewer_mechanisms(role_block: dict, lines: list[str]) -> None:
     demo = role_block.get("demotion_check") or {}

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -97,6 +97,15 @@ LogLevel = None
 # ── Lazy runner import ────────────────────────────────────────────────
 
 
+def _fresh_run_state() -> CoordinatorState:
+    """Return a fresh per-run state container.
+
+    In-run routing escalations are scoped to this object, so constructing a new
+    state for the next story is the return path that clears them.
+    """
+    return CoordinatorState()
+
+
 def _ensure_runners() -> None:
     """Import theforge.runners and bind its symbols into this module's namespace.
 
@@ -751,7 +760,7 @@ def run_task(
             a successful APPROVE. Does NOT merge on ESCALATE or ALREADY_DONE.
     """
     _ensure_runners()
-    state = CoordinatorState()
+    state = _fresh_run_state()
     state.started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
     _task_start = time.monotonic()
     story_content = task.story_text if task.story_text is not None else load_story(task.story_path)
@@ -1488,7 +1497,7 @@ def run_review_only(
     (REQUEST_CHANGES — no DEV retry in review-only mode).
     """
     _ensure_runners()
-    state = CoordinatorState()
+    state = _fresh_run_state()
     state.started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
     _ro_task_start = time.monotonic()
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1706,7 +1706,8 @@ def _run_review_phase(
 
     # Escalate dev model on persistent P1 (only when explicitly enabled via forge.yaml)
     if (
-        config.retry.auto_model_escalation
+        config.assignment.adaptive_enabled
+        and config.retry.auto_model_escalation
         and _is_persistent_p1
         and not state.dev_escalated
         and (

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -10,6 +10,10 @@ from dataclasses import replace as _dc_replace
 from enum import Enum, auto
 from pathlib import Path
 
+from theforge.assignment import (
+    MECHANISM_PERSISTENT_P1_DEV_ESCALATION,
+    MECHANISM_RUN_SCOPED_RESET,
+)
 from theforge.config import ForgeConfig, apply_model_info
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.escalation_advisor import (
@@ -102,6 +106,41 @@ def _perform_dev_model_escalation(
     old_model = config.dev_profile.model
     new_dev = apply_model_info(config.dev_profile, next_info)
     return old_model, next_info.model, _dc_replace(config, dev_profile=new_dev)
+
+
+def _record_persistent_p1_dev_escalation(
+    state: CoordinatorState,
+    *,
+    previous_model: str,
+    escalated_model: str,
+    persistent_descriptions: list[str],
+    p1_file: str,
+) -> None:
+    """Attach the in-run persistent-P1 escalation to the canonical audit block."""
+    if not isinstance(state.routing_decision, dict):
+        state.routing_decision = {"origin": "preflight"}
+
+    dev_block = state.routing_decision.get("dev")
+    if not isinstance(dev_block, dict):
+        dev_block = {}
+        state.routing_decision["dev"] = dev_block
+
+    dev_block["persistent_p1_dev_escalation"] = {
+        "mechanism": MECHANISM_PERSISTENT_P1_DEV_ESCALATION,
+        "fired": True,
+        "scope": "run",
+        "return_path": MECHANISM_RUN_SCOPED_RESET,
+        "signal": {
+            "kind": "persistent_p1",
+            "review_cycle": state.review_cycle,
+            "file": p1_file,
+            "descriptions": list(persistent_descriptions),
+        },
+        "model_swap": {
+            "from_model": previous_model,
+            "to_model": escalated_model,
+        },
+    }
 
 
 def _build_reviewer_verdicts(state: CoordinatorState) -> dict[str, str]:
@@ -1689,6 +1728,13 @@ def _run_review_phase(
             _prev_result = state.review_results[-2]
             _persistent_descs = _persistent_p1_descriptions(
                 parsed_review.findings, _prev_result.findings
+            )
+            _record_persistent_p1_dev_escalation(
+                state,
+                previous_model=_old_model,
+                escalated_model=_new_model_name,
+                persistent_descriptions=_persistent_descs,
+                p1_file=_p1_file,
             )
             state.escalation_note = (
                 f"MODEL ESCALATION: A P1 finding persisted across review cycles. "

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -73,6 +73,19 @@ def _routing_block(*, dev_override: bool = False, reviewer_fired: bool = False) 
                 "reason": "no_dev_tier_demotion_mechanism_v1",
             },
             "post_plan_checkpoint": {"applied": False, "reason": "checkpoint_not_implemented_v1"},
+            "persistent_p1_dev_escalation": {
+                "mechanism": "persistent_p1_dev_escalation",
+                "fired": True,
+                "scope": "run",
+                "return_path": "fresh_run_state_reset",
+                "signal": {
+                    "kind": "persistent_p1",
+                    "review_cycle": 2,
+                    "file": "src/cli.py",
+                    "descriptions": ["cli.py never wires gate_override into TaskStory"],
+                },
+                "model_swap": {"from_model": "sonnet", "to_model": "opus"},
+            },
             "exploration": {"mode": "winner"},
             "final": {"model": "opus", "tier": "strong", "rationale": "[preflight] dev on strong"},
         },
@@ -159,6 +172,14 @@ def test_tri_state_distinguishes_not_checked_from_did_not_fire() -> None:
     # A reviewer health demotion that fired renders as fired.
     fired_text = "\n".join(explain.render_routing_decision(_routing_block(reviewer_fired=True)))
     assert "demotion (provider_health): fired" in fired_text
+
+
+def test_render_surfaces_in_run_persistent_p1_escalation() -> None:
+    text = "\n".join(explain.render_routing_decision(_routing_block()))
+    assert "in-run persistent-P1 escalation: fired" in text
+    assert "sonnet → opus" in text
+    assert "scope=run" in text
+    assert "return=fresh_run_state_reset" in text
 
 
 def test_reviewer_health_no_op_renders_checked_did_not_fire() -> None:

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -656,6 +656,65 @@ class TestDevModelEscalationIntegration:
     @patch("theforge.coordinator.preflight_flow.run_agent")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch_gate_shell()
+    def test_escalation_skipped_when_adaptive_assignment_disabled(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """Repeated P1s do not swap the dev model when adaptive assignment is disabled."""
+        config = _make_smart_config(tmp_path, max_review_cycles=3)
+        config = replace(
+            config,
+            assignment=replace(config.assignment, adaptive_enabled=False),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+
+        dev_profiles: list[str] = []
+
+        def tracking_agent(**kwargs):
+            dev_profiles.append(kwargs["profile"].model)
+            return _make_agent_result()
+
+        mock_agent.side_effect = tracking_agent
+
+        pool_call = {"n": 0}
+
+        def pool_side_effect(**kwargs):
+            pool_call["n"] += 1
+            if pool_call["n"] <= 2:
+                return [
+                    _make_agent_result(
+                        success=True,
+                        output=_PERSISTENT_P1_REVIEW,
+                        profile_name="claude-opus",
+                    )
+                ]
+            return [
+                _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+            ]
+
+        mock_pool.side_effect = pool_side_effect
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert result.state.dev_escalated is False
+        assert dev_profiles
+        assert all(model == "sonnet" for model in dev_profiles)
+        if result.state.routing_decision is not None:
+            assert (
+                result.state.routing_decision["dev"].get("persistent_p1_dev_escalation") is None
+            )
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
     def test_escalation_skipped_when_dev_attempt_unproductive(
         self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
     ):

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -33,6 +33,7 @@ from theforge.coordinator.preflight import (
 )
 from theforge.coordinator.state import CoordinatorState, Phase
 from theforge.review import ReviewFinding
+from theforge.task import TaskStory
 
 # ── Dev model escalation tests ────────────────────────────────────────
 
@@ -494,6 +495,17 @@ class TestDevModelEscalationIntegration:
         assert result.state.dev_escalated is True
         # After escalation, dev should have used opus
         assert "opus" in dev_profiles
+        persistent_p1_dev_escalation = result.state.routing_decision["dev"][
+            "persistent_p1_dev_escalation"
+        ]
+        assert persistent_p1_dev_escalation["mechanism"] == "persistent_p1_dev_escalation"
+        assert persistent_p1_dev_escalation["signal"]["kind"] == "persistent_p1"
+        assert persistent_p1_dev_escalation["model_swap"] == {
+            "from_model": "sonnet",
+            "to_model": "opus",
+        }
+        assert persistent_p1_dev_escalation["scope"] == "run"
+        assert persistent_p1_dev_escalation["return_path"] == "fresh_run_state_reset"
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")
@@ -684,6 +696,85 @@ class TestDevModelEscalationIntegration:
         assert "budget" not in result.message.lower()
         # Escalation flag never set (unproductive-attempt guard fired first)
         assert result.state.dev_escalated is False
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_run_scoped_reset_starts_next_story_at_normal_dev_tier(
+        self, mock_shell, mock_agent, mock_preflight, mock_plan_agent, mock_pool, tmp_path
+    ):
+        """A persistent-P1 escalation is scoped to one run; the next story starts fresh."""
+        config = _make_smart_config(tmp_path, max_review_cycles=3)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+        second_task = TaskStory(
+            name="Second Task",
+            story_path=tmp_path / "spec-second.md",
+            slug="test-task-2",
+        )
+        second_task.story_path.write_text(
+            "# Second Spec\n\nImplement the second thing.",
+            encoding="utf-8",
+        )
+        second_workspace = tmp_path / second_task.slug
+        second_workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+
+        first_run_profiles: list[str] = []
+
+        def first_run_agent(**kwargs):
+            first_run_profiles.append(kwargs["profile"].model)
+            return _make_agent_result()
+
+        mock_agent.side_effect = first_run_agent
+        pool_call = {"n": 0}
+
+        def first_run_pool(**kwargs):
+            pool_call["n"] += 1
+            if pool_call["n"] <= 2:
+                return [
+                    _make_agent_result(
+                        success=True,
+                        output=_PERSISTENT_P1_REVIEW,
+                        profile_name="claude-opus",
+                    )
+                ]
+            return [
+                _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")
+            ]
+
+        mock_pool.side_effect = first_run_pool
+
+        first_result = run_task(config, task)
+
+        assert first_result.success is True
+        assert first_result.state.dev_escalated is True
+        assert "opus" in first_run_profiles
+
+        mock_shell.side_effect = _shell_with_gate(second_workspace, "PASS")
+        second_run_profiles: list[str] = []
+
+        def second_run_agent(**kwargs):
+            second_run_profiles.append(kwargs["profile"].model)
+            return _make_agent_result()
+
+        mock_agent.side_effect = second_run_agent
+        mock_pool.side_effect = [
+            [_make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="claude-opus")]
+        ]
+
+        second_result = run_task(config, second_task)
+
+        assert second_result.success is True
+        assert second_result.state.dev_escalated is False
+        assert second_run_profiles
+        assert second_run_profiles[0] == "sonnet"
 
 
 class TestAutoModelEscalationFlag:

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -706,9 +706,7 @@ class TestDevModelEscalationIntegration:
         assert dev_profiles
         assert all(model == "sonnet" for model in dev_profiles)
         if result.state.routing_decision is not None:
-            assert (
-                result.state.routing_decision["dev"].get("persistent_p1_dev_escalation") is None
-            )
+            assert result.state.routing_decision["dev"].get("persistent_p1_dev_escalation") is None
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.plan_flow.run_agent")

--- a/tests/test_routing_symmetry_invariant.py
+++ b/tests/test_routing_symmetry_invariant.py
@@ -23,7 +23,9 @@ import pytest
 
 from theforge.assignment import (
     MECHANISM_DEV_PROMOTION,
+    MECHANISM_PERSISTENT_P1_DEV_ESCALATION,
     MECHANISM_POST_PLAN_DEMOTION,
+    MECHANISM_RUN_SCOPED_RESET,
     ROUTING_RATIONALE_DEMOTED,
     ROUTING_RATIONALE_PROMOTED,
     ROUTING_RATIONALE_STATES,
@@ -36,6 +38,7 @@ from theforge.assignment import (
     assign_models,
 )
 from theforge.config import AgentDef
+from theforge.coordinator.engine import _fresh_run_state
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CATALOGUE_DOC = _REPO_ROOT / "docs" / "routing-symmetry-followups.md"
@@ -120,6 +123,7 @@ def test_registry_is_non_empty_and_covers_dev_promotion():
     assert ROUTING_SYMMETRY_REGISTRY, "routing-symmetry registry must not be empty"
     promo_names = {pair.promotion.name for pair in ROUTING_SYMMETRY_REGISTRY}
     assert MECHANISM_DEV_PROMOTION in promo_names
+    assert MECHANISM_PERSISTENT_P1_DEV_ESCALATION in promo_names
 
 
 @pytest.mark.parametrize("pair", ROUTING_SYMMETRY_REGISTRY, ids=lambda p: p.promotion.name)
@@ -181,6 +185,19 @@ def test_dev_tier_pair_has_landed_tested_inverse_both_directions():
     assert pair.promotion.audit_label == ROUTING_RATIONALE_PROMOTED
     assert pair.demotion.audit_label == ROUTING_RATIONALE_DEMOTED
     assert {pair.promotion.audit_label, pair.demotion.audit_label} <= ROUTING_RATIONALE_STATES
+
+
+def test_persistent_p1_pair_registers_fresh_run_reset_inverse():
+    pair = next(
+        p
+        for p in ROUTING_SYMMETRY_REGISTRY
+        if p.promotion.name == MECHANISM_PERSISTENT_P1_DEV_ESCALATION
+    )
+    assert pair.demotion is not None
+    assert pair.demotion.name == MECHANISM_RUN_SCOPED_RESET
+    fresh = _fresh_run_state()
+    assert fresh.dev_escalated is False
+    assert fresh.routing_decision is None
 
 
 # ── Audit label ↔ code path (both directions exercised end-to-end) ──────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior adaptive-disabled regression is fixed; focused review found no blocking regressions. | [google-gemini-3.5-flash] The implementation of persistent-P1 dev model escalation is fully verified, including the fix for the static-routing regression when adaptive assignment is disabled.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.55
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

dev model escalation on persistent P1s (GitHub Issue #296)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #296