### PR TITLE
Plan model escalation on repeated plan review rejection

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -88,6 +88,7 @@ MECHANISM_DEV_PROMOTION = "_check_promotion"
 MECHANISM_POST_PLAN_DEMOTION = "post_plan_checkpoint"
 MECHANISM_REVIEWER_COMPLETION_DEPRIORITIZE = "reviewer_completion_rate"
 MECHANISM_PERSISTENT_P1_DEV_ESCALATION = "persistent_p1_dev_escalation"
+MECHANISM_PLAN_MODEL_ESCALATION = "plan_model_escalation"
 MECHANISM_RUN_SCOPED_RESET = "fresh_run_state_reset"
 
 
@@ -194,6 +195,30 @@ ROUTING_SYMMETRY_REGISTRY: tuple[RoutingSymmetryPair, ...] = (
             "tests/test_routing_symmetry_invariant.py",
         ),
         promotion_test_token="persistent_p1_dev_escalation",
+        demotion_test_token="_fresh_run_state",
+    ),
+    # In-run plan-model escalation (#330): N consecutive plan-review rejections
+    # upgrade the planner model to the next tier for the current story only. The
+    # inverse is the same next-story fresh CoordinatorState construction that
+    # resets the dev-side run-scoped flag — plan_escalated/plan_escalation_note
+    # default back to False/None, so no planner tier ratchets across stories.
+    RoutingSymmetryPair(
+        promotion=RoutingMechanism(
+            name=MECHANISM_PLAN_MODEL_ESCALATION,
+            symbol="theforge.coordinator.plan_flow._record_plan_model_escalation",
+            audit_label="in_run_escalation",
+        ),
+        demotion=RoutingMechanism(
+            name=MECHANISM_RUN_SCOPED_RESET,
+            symbol="theforge.coordinator.engine._fresh_run_state",
+            audit_label="run_scoped_reset",
+        ),
+        promotion_tests=("tests/test_coord_plan_flow_agent.py",),
+        demotion_tests=(
+            "tests/test_coord_plan_flow_agent.py",
+            "tests/test_routing_symmetry_invariant.py",
+        ),
+        promotion_test_token="plan_model_escalation",
         demotion_test_token="_fresh_run_state",
     ),
 )

--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -184,6 +184,27 @@ def _render_dev_mechanisms(role_block: dict, lines: list[str]) -> None:
         )
 
 
+def _render_planner_mechanisms(role_block: dict, lines: list[str]) -> None:
+    escalation = role_block.get("plan_model_escalation") or {}
+    if not escalation:
+        return
+    signal = escalation.get("signal") or {}
+    model_swap = escalation.get("model_swap") or {}
+    detail = (
+        f"{signal.get('kind', 'consecutive_plan_rejections')} "
+        f"({signal.get('rejections', '?')} rejection(s)) "
+        f"{model_swap.get('from_model', '?')} → {model_swap.get('to_model', '?')} "
+        f"[scope={escalation.get('scope', '?')}, "
+        f"return={escalation.get('return_path', '?')}]"
+    )
+    _render_mechanism(
+        "in-run plan-model escalation",
+        _mechanism_state(checked=True, fired=bool(escalation.get("fired", True))),
+        detail,
+        lines,
+    )
+
+
 def _render_reviewer_mechanisms(role_block: dict, lines: list[str]) -> None:
     demo = role_block.get("demotion_check") or {}
     reason = demo.get("reason", "")
@@ -264,6 +285,9 @@ def render_routing_decision(block: dict) -> list[str]:
         if role == "dev":
             lines.append("  adaptive mechanisms:")
             _render_dev_mechanisms(role_block, lines)
+        elif role == "planner" and role_block.get("plan_model_escalation"):
+            lines.append("  adaptive mechanisms:")
+            _render_planner_mechanisms(role_block, lines)
         elif role in ("plan_review", "code_review"):
             lines.append("  adaptive mechanisms:")
             _render_reviewer_mechanisms(role_block, lines)

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -22,6 +22,10 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 
 from theforge.artifacts import PLAN_PATH, ensure_parent_dir, plan_paths, resolve_plan_path
+from theforge.assignment import (
+    MECHANISM_PLAN_MODEL_ESCALATION,
+    MECHANISM_RUN_SCOPED_RESET,
+)
 from theforge.config import MODEL_REGISTRY, ForgeConfig, ModelProfile, apply_model_info
 from theforge.config.profiles import _apply_provider_fallback
 from theforge.log_level import _LOG_LEVEL, LogLevel
@@ -536,6 +540,48 @@ def _apply_post_plan_dev_checkpoint(
             f"  ↳ post-plan checkpoint: dev {_cp.get('baseline_tier')} → "
             f"{_cp.get('final_tier')} ({_updated.dev.model}) — {_cp.get('rationale')}"
         )
+
+
+def _record_plan_model_escalation(
+    state: CoordinatorState,
+    *,
+    previous_model: str,
+    escalated_model: str,
+    rejections: int,
+    findings: str,
+) -> None:
+    """Attach the in-run plan-model escalation to the canonical routing_decision.
+
+    Mirrors ``review_phase._record_persistent_p1_dev_escalation`` for the planner
+    role (ADR-0006 clause 7 / #1391): a telemetry log line is not enough — the
+    mechanism that fired, the consecutive-rejection signal, and the planner model
+    swap must all be reconstructable from the audit's ``routing_decision`` block.
+    ``scope``/``return_path`` record clause-5 symmetry: this escalation is
+    story-scoped and reset by the next story's fresh ``CoordinatorState``.
+    """
+    if not isinstance(state.routing_decision, dict):
+        state.routing_decision = {"origin": "preflight"}
+
+    planner_block = state.routing_decision.get("planner")
+    if not isinstance(planner_block, dict):
+        planner_block = {}
+        state.routing_decision["planner"] = planner_block
+
+    planner_block["plan_model_escalation"] = {
+        "mechanism": MECHANISM_PLAN_MODEL_ESCALATION,
+        "fired": True,
+        "scope": "run",
+        "return_path": MECHANISM_RUN_SCOPED_RESET,
+        "signal": {
+            "kind": "consecutive_plan_rejections",
+            "rejections": rejections,
+            "findings": findings,
+        },
+        "model_swap": {
+            "from_model": previous_model,
+            "to_model": escalated_model,
+        },
+    }
 
 
 def _run_plan_phase(
@@ -1302,6 +1348,13 @@ def _run_plan_agent_review(
                         f" acceptable plan. You are now running on an upgraded"
                         f" model ({_new_model}). Key findings from prior"
                         f" rejections: {findings_text}"
+                    )
+                    _record_plan_model_escalation(
+                        state,
+                        previous_model=_old_model,
+                        escalated_model=_new_model,
+                        rejections=state.plan_regen_count,
+                        findings=findings_text,
                     )
                     _log(
                         f"  Plan escalation:"

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -32,8 +32,9 @@ from theforge.config import (
     WorkspaceConfig,
 )
 from theforge.coordinator.audit import generate_audit_log
-from theforge.coordinator.engine import run_task
-from theforge.coordinator.state import Phase
+from theforge.coordinator.engine import _fresh_run_state, run_task
+from theforge.coordinator.plan_flow import _record_plan_model_escalation
+from theforge.coordinator.state import CoordinatorState, Phase
 
 # ── Local helpers ─────────────────────────────────────────────────────
 
@@ -632,6 +633,24 @@ findings:
         assert result.state.plan_escalation_note is not None
         assert "MODEL ESCALATION" in result.state.plan_escalation_note
 
+        # Escalation must be recorded in the canonical routing_decision block
+        # (ADR-0006 clause 7 / #1391), not only in a telemetry log line.
+        assert isinstance(result.state.routing_decision, dict)
+        planner_block = result.state.routing_decision.get("planner")
+        assert isinstance(planner_block, dict)
+        escalation = planner_block.get("plan_model_escalation")
+        assert isinstance(escalation, dict)
+        assert escalation["mechanism"] == "plan_model_escalation"
+        assert escalation["fired"] is True
+        # Clause-5 symmetry markers: story-scoped with a named return path.
+        assert escalation["scope"] == "run"
+        assert escalation["return_path"] == "fresh_run_state_reset"
+        # Consecutive-rejection signal and the concrete planner model swap.
+        assert escalation["signal"]["kind"] == "consecutive_plan_rejections"
+        assert escalation["signal"]["rejections"] == 2
+        assert escalation["model_swap"]["from_model"] == "sonnet"
+        assert escalation["model_swap"]["to_model"] == "opus"
+
         # The 3rd run_agent call (index 2) is the 2nd regen — should use opus
         # (call[0]=plan, call[1]=1st regen, call[2]=2nd regen, call[3]=dev;
         # preflight mocked separately)
@@ -644,6 +663,39 @@ findings:
         # The regen prompt should contain the escalation note
         regen_prompt = regen_call.kwargs.get("prompt") or regen_call[1].get("prompt")
         assert "MODEL ESCALATION" in regen_prompt
+
+    def test_plan_escalation_does_not_persist_into_next_story(self):
+        """Planner escalation is story-scoped (ADR-0006 clause 5 return path).
+
+        A story that escalated its planner leaves run-scoped state
+        (``plan_escalated``/``plan_escalation_note``) and the recorded
+        ``routing_decision`` escalation block set. The next story is a freshly
+        constructed ``CoordinatorState`` (``_fresh_run_state``), which resets all
+        of those to their defaults — so the escalated planner tier never ratchets
+        forward into the next story's planner assignment.
+        """
+        # Story 1: simulate an escalation having fired.
+        story1 = CoordinatorState()
+        story1.plan_regen_count = 2
+        story1.plan_escalated = True
+        story1.plan_escalation_note = "MODEL ESCALATION: rejected 2 time(s)."
+        _record_plan_model_escalation(
+            story1,
+            previous_model="sonnet",
+            escalated_model="opus",
+            rejections=2,
+            findings="P0: insufficient plan",
+        )
+        assert story1.plan_escalated is True
+        assert story1.routing_decision["planner"]["plan_model_escalation"]["fired"] is True
+
+        # Story 2: the return path is a fresh per-run state container. The escalated
+        # planner tier does not carry over — the next story starts from defaults.
+        story2 = _fresh_run_state()
+        assert story2.plan_escalated is False
+        assert story2.plan_escalation_note is None
+        assert story2.plan_regen_count == 0
+        assert story2.routing_decision is None
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))


### PR DESCRIPTION
## Summary

The change satisfies the plan-escalation audit and reset requirements, and the project gate passed.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $3.17
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Plan model escalation on repeated plan review rejection (GitHub Issue #330)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #330