### PR TITLE
Fix forge status --watch blanking board after story progress

### DIFF
--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -211,6 +211,27 @@ def write_bootstrap_state(
     per-story data.
     """
     state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
+
+    # If state file already exists and contains a sprint_id or non-waiting stories,
+    # don't overwrite it as this would blank the board during an active sprint
+    if state_path.exists():
+        try:
+            with open(state_path, encoding="utf-8") as f:
+                existing_data = yaml.safe_load(f) or {}
+
+            # Check if sprint_id is set (not None/null)
+            if existing_data.get("sprint_id") is not None:
+                return state_path
+
+            # Check if any story has a non-waiting status
+            existing_stories = existing_data.get("stories", [])
+            for story in existing_stories:
+                if story.get("status") != "waiting":
+                    return state_path
+        except (OSError, yaml.YAMLError):
+            # If we can't read the file, proceed with writing bootstrap state
+            pass
+
     state_path.parent.mkdir(parents=True, exist_ok=True)
 
     stories: list[dict] = []

--- a/tests/test_bootstrap_state_guard.py
+++ b/tests/test_bootstrap_state_guard.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import yaml
 from pathlib import Path
 
+import yaml
+
 from theforge.sprint.state_writer import write_bootstrap_state
-from theforge.sprint.story_state import SprintStoryState
 
 
 def test_write_bootstrap_state_does_not_overwrite_existing_sprint_id(tmp_path: Path) -> None:
@@ -37,8 +37,8 @@ def test_write_bootstrap_state_does_not_overwrite_existing_sprint_id(tmp_path: P
         run_id="test-run",
         project_root=tmp_path,
         sprint_name="different-sprint",  # Different name
-        sprint_phase="shape-gate",       # Different phase
-        issues=[{"number": 2}],          # Different issue
+        sprint_phase="shape-gate",  # Different phase
+        issues=[{"number": 2}],  # Different issue
     )
 
     # Should return the same path without overwriting
@@ -135,8 +135,10 @@ def test_write_bootstrap_state_allows_initial_write_when_no_state_file(tmp_path:
     assert current_data["stories"][0]["status"] == "waiting"
 
 
-def test_write_bootstrap_state_allows_overwrite_when_all_waiting_and_no_sprint_id(tmp_path: Path) -> None:
-    """Bootstrap write should proceed when state file exists but has no sprint_id and all stories waiting."""
+def test_write_bootstrap_state_allows_overwrite_when_all_waiting_and_no_sprint_id(
+    tmp_path: Path,
+) -> None:
+    """Bootstrap write proceeds when state exists with no sprint_id and all stories waiting."""
     # Create a state file that looks like a bootstrap state (no sprint_id, all waiting)
     state_dir = tmp_path / ".forge" / "runs"
     state_dir.mkdir(parents=True)

--- a/tests/test_bootstrap_state_guard.py
+++ b/tests/test_bootstrap_state_guard.py
@@ -1,0 +1,183 @@
+"""Test that write_bootstrap_state doesn't overwrite active sprint state."""
+
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+from theforge.sprint.state_writer import write_bootstrap_state
+from theforge.sprint.story_state import SprintStoryState
+
+
+def test_write_bootstrap_state_does_not_overwrite_existing_sprint_id(tmp_path: Path) -> None:
+    """Bootstrap write should be skipped if state file already has a sprint_id."""
+    # First, create a state file with a sprint_id (simulating an active sprint)
+    state_dir = tmp_path / ".forge" / "runs"
+    state_dir.mkdir(parents=True)
+    state_path = state_dir / "test-run.state"
+
+    # Write initial state with sprint_id set
+    initial_data = {
+        "sprint_name": "test-sprint",
+        "sprint_id": "sprint-123",  # This is set, not None
+        "sprint_phase": "underway",
+        "stories": [
+            {
+                "slug": "issue-1",
+                "status": "waiting",
+                "outcome": "waiting",
+            }
+        ],
+    }
+    with open(state_path, "w", encoding="utf-8") as f:
+        yaml.dump(initial_data, f)
+
+    # Now try to write bootstrap state - this should be a no-op
+    result_path = write_bootstrap_state(
+        run_id="test-run",
+        project_root=tmp_path,
+        sprint_name="different-sprint",  # Different name
+        sprint_phase="shape-gate",       # Different phase
+        issues=[{"number": 2}],          # Different issue
+    )
+
+    # Should return the same path without overwriting
+    assert result_path == state_path
+
+    # File should still contain the original data
+    with open(state_path, encoding="utf-8") as f:
+        current_data = yaml.safe_load(f)
+
+    assert current_data["sprint_id"] == "sprint-123"
+    assert current_data["sprint_name"] == "test-sprint"
+    assert current_data["sprint_phase"] == "underway"
+    assert len(current_data["stories"]) == 1
+    assert current_data["stories"][0]["slug"] == "issue-1"
+
+
+def test_write_bootstrap_state_does_not_overwrite_non_waiting_stories(tmp_path: Path) -> None:
+    """Bootstrap write should be skipped if state file has non-waiting stories."""
+    # First, create a state file with a story that's not waiting
+    state_dir = tmp_path / ".forge" / "runs"
+    state_dir.mkdir(parents=True)
+    state_path = state_dir / "test-run.state"
+
+    # Write initial state with a running story
+    initial_data = {
+        "sprint_name": "test-sprint",
+        "sprint_id": None,  # Still None, but we have a running story
+        "sprint_phase": "underway",
+        "stories": [
+            {
+                "slug": "issue-1",
+                "status": "running",  # Not waiting!
+                "outcome": "running",
+            }
+        ],
+    }
+    with open(state_path, "w", encoding="utf-8") as f:
+        yaml.dump(initial_data, f)
+
+    # Now try to write bootstrap state - this should be a no-op
+    result_path = write_bootstrap_state(
+        run_id="test-run",
+        project_root=tmp_path,
+        sprint_name="different-sprint",
+        sprint_phase="shape-gate",
+        issues=[{"number": 2}],
+    )
+
+    # Should return the same path without overwriting
+    assert result_path == state_path
+
+    # File should still contain the original data
+    with open(state_path, encoding="utf-8") as f:
+        current_data = yaml.safe_load(f)
+
+    assert current_data["sprint_id"] is None
+    assert current_data["sprint_name"] == "test-sprint"
+    assert current_data["sprint_phase"] == "underway"
+    assert len(current_data["stories"]) == 1
+    assert current_data["stories"][0]["status"] == "running"  # Still running!
+
+
+def test_write_bootstrap_state_allows_initial_write_when_no_state_file(tmp_path: Path) -> None:
+    """Bootstrap write should proceed when no state file exists."""
+    state_dir = tmp_path / ".forge" / "runs"
+    state_dir.mkdir(parents=True)
+    state_path = state_dir / "test-run.state"
+
+    # Confirm file doesn't exist yet
+    assert not state_path.exists()
+
+    # Write bootstrap state - this should succeed
+    result_path = write_bootstrap_state(
+        run_id="test-run",
+        project_root=tmp_path,
+        sprint_name="test-sprint",
+        sprint_phase="shape-gate",
+        issues=[{"number": 1, "title": "Test Issue"}],
+    )
+
+    # Should return the state path
+    assert result_path == state_path
+    assert state_path.exists()
+
+    # File should contain bootstrap data
+    with open(state_path, encoding="utf-8") as f:
+        current_data = yaml.safe_load(f)
+
+    assert current_data["sprint_name"] == "test-sprint"
+    assert current_data["sprint_phase"] == "shape-gate"
+    assert current_data["sprint_id"] is None  # Bootstrap sets this to None
+    assert len(current_data["stories"]) == 1
+    assert current_data["stories"][0]["slug"] == "issue-1"
+    assert current_data["stories"][0]["status"] == "waiting"
+
+
+def test_write_bootstrap_state_allows_overwrite_when_all_waiting_and_no_sprint_id(tmp_path: Path) -> None:
+    """Bootstrap write should proceed when state file exists but has no sprint_id and all stories waiting."""
+    # Create a state file that looks like a bootstrap state (no sprint_id, all waiting)
+    state_dir = tmp_path / ".forge" / "runs"
+    state_dir.mkdir(parents=True)
+    state_path = state_dir / "test-run.state"
+
+    # Write a bootstrap-like state
+    bootstrap_data = {
+        "sprint_name": "old-sprint",
+        "sprint_id": None,  # Still None
+        "sprint_phase": "shape-gate",
+        "stories": [
+            {
+                "slug": "issue-1",
+                "status": "waiting",  # Still waiting
+                "outcome": "waiting",
+            }
+        ],
+    }
+    with open(state_path, "w", encoding="utf-8") as f:
+        yaml.dump(bootstrap_data, f)
+
+    # Now try to write bootstrap state - this should proceed (overwrite)
+    result_path = write_bootstrap_state(
+        run_id="test-run",
+        project_root=tmp_path,
+        sprint_name="new-sprint",
+        sprint_phase="intake-remediation",
+        issues=[{"number": 2, "title": "New Issue"}],
+    )
+
+    # Should return the same path (overwrote the file)
+    assert result_path == state_path
+    assert state_path.exists()
+
+    # File should now contain the new bootstrap data
+    with open(state_path, encoding="utf-8") as f:
+        current_data = yaml.safe_load(f)
+
+    assert current_data["sprint_name"] == "new-sprint"
+    assert current_data["sprint_phase"] == "intake-remediation"
+    assert current_data["sprint_id"] is None
+    assert len(current_data["stories"]) == 1
+    assert current_data["stories"][0]["slug"] == "issue-2"
+    assert current_data["stories"][0]["status"] == "waiting"


### PR DESCRIPTION
# Fix forge status --watch blanking board after story progress

Fixes #1801: forge status --watch blanks whole board after story completes mid-sprint

The issue was that `write_bootstrap_state` was unconditionally overwriting the sprint state file, which would reset the sprint_id to null and all stories to waiting status when called during an active sprint (after a story had started progressing).

This fix adds a guard clause at the beginning of `write_bootstrap_state` that checks if the state file already exists and either:
1. Contains a non-null sprint_id (indicating an active sprint)
2. Contains any story with a non-waiting status (indicating sprint progress has begun)

If either condition is true, the function returns early without overwriting the file, preserving the current sprint state.

The fix maintains backward compatibility:
- Still writes bootstrap state when no state file exists (initial sprint startup)
- Still overwrites when state file exists but contains only waiting stories and no sprint_id (allows reset/reinitialization)
- All existing tests pass, plus new tests verify the fix works correctly

Assisted-by: Claude Code
