### PR TITLE
Sprint story audits emit canonical per-run JSON

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -63,6 +64,65 @@ def _upsert_into_substrate(project_root: Path, record: dict) -> None:
             conn.close()
     except Exception as exc:  # noqa: BLE001
         _log(f"warning: failed to update audit substrate: {exc}")
+
+
+def _write_native_story_record(project_root: Path, audit_data: dict) -> None:
+    """Write the canonical per-story run JSON and mirror it into the substrate."""
+    run_id = audit_data.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        _upsert_into_substrate(project_root, audit_data)
+        return
+
+    try:
+        from ..coordinator import audit_substrate
+        from ..coordinator.redact import redact
+
+        record = {
+            "schema_version": audit_substrate.CURRENT_RECORD_SCHEMA_VERSION,
+            "run_id": run_id,
+            "parent_run_id": None,
+            "forge_version": audit_data.get("forge_version"),
+        }
+        record.update(audit_data)
+        record["schema_version"] = audit_substrate.CURRENT_RECORD_SCHEMA_VERSION
+        record["run_id"] = run_id
+        record["parent_run_id"] = None
+        record["forge_version"] = audit_data.get("forge_version")
+
+        env_file = audit_substrate.secrets_env_path(project_root)
+        env_file_arg = env_file if env_file.exists() else None
+        redacted = redact(record, env_file_arg)
+
+        runs_dir = audit_substrate.runs_dir(project_root)
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        run_file = runs_dir / f"{run_id}.json"
+        if not run_file.exists():
+            with open(run_file, "w", encoding="utf-8") as f:
+                json.dump(redacted, f, default=str, indent=2)
+            persisted = redacted
+        else:
+            with open(run_file, encoding="utf-8") as f:
+                persisted = json.load(f)
+            if not isinstance(persisted, dict):
+                persisted = redacted
+
+        stat = run_file.stat()
+        conn = audit_substrate.create_or_open(project_root)
+        try:
+            audit_substrate.upsert_run_record(
+                conn,
+                persisted,
+                provenance="native",
+                source_path=str(run_file.relative_to(project_root)),
+                source_mtime=stat.st_mtime,
+                env_file=env_file_arg,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001
+        _log(f"warning: failed to write native story audit record: {exc}")
+        _upsert_into_substrate(project_root, audit_data)
 
 
 def _build_advisory_summary(config: ForgeConfig | None) -> dict | None:
@@ -1127,7 +1187,7 @@ def _write_story_audit(
 
     audits_dir = config.project_root / ".forge" / "audits"
     audits_dir.mkdir(parents=True, exist_ok=True)
-    _upsert_into_substrate(config.project_root, audit_data)
+    _write_native_story_record(config.project_root, audit_data)
 
     log_dir = result.state.log_dir
     if log_dir is None:

--- a/tests/test_coord_audit.py
+++ b/tests/test_coord_audit.py
@@ -811,7 +811,7 @@ class TestAuditStartStopPhase:
 
 class TestSprintStoryAuditHistory:
     def test_write_story_audit_persists_to_substrate(self, tmp_path: Path) -> None:
-        """Story audit goes into the SQLite substrate; legacy history.jsonl is gone."""
+        """Story audit goes into rebuildable native storage; legacy history.jsonl is gone."""
         from theforge.sprint.audit import _write_story_audit
 
         config = _make_config(tmp_path)
@@ -826,9 +826,32 @@ class TestSprintStoryAuditHistory:
 
         _write_story_audit(config, task, result)
 
-        # Substrate is the canonical write path — substrate file must exist.
+        run_file = audit_substrate.runs_dir(tmp_path) / "test-run-001.json"
+        assert run_file.exists()
+
+        # Substrate is the query path and must point at the canonical run file.
         sub_path = audit_substrate.substrate_path(tmp_path)
         assert sub_path.exists()
+        conn = audit_substrate.open_readonly(tmp_path)
+        try:
+            row = conn.execute(
+                "SELECT source_path FROM audit_records WHERE run_id = ?",
+                ("test-run-001",),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row["source_path"] == ".forge/audits/runs/test-run-001.json"
+
+        audit_substrate.rebuild_from_runs(tmp_path)
+        conn = audit_substrate.open_readonly(tmp_path)
+        try:
+            rebuilt = audit_substrate.latest_record_for(conn, run_id="test-run-001")
+        finally:
+            conn.close()
+        assert rebuilt is not None
+        assert rebuilt["task"]["slug"] == task.slug
+
         # Legacy jsonl path must NOT be written.
         history_path = tmp_path / ".forge" / "audits" / "history.jsonl"
         assert not history_path.exists()


### PR DESCRIPTION
## Summary
- write canonical `.forge/audits/runs/{run_id}.json` records from the sprint story audit path
- mirror SQLite rows from that canonical JSON with `source_path` set
- add a rebuild regression so sprint story records survive `forge audits rebuild`

Fixes #1896.

## Tests
- `pytest tests/test_coord_audit.py::TestSprintStoryAuditHistory tests/test_audits_rebuild.py tests/test_cli_audit_per_run.py -q`
- `pytest tests/test_sprint_run_id_rollover.py -q`
- `ruff check src/theforge/sprint/audit.py tests/test_coord_audit.py`
- `ruff format --check src/theforge/sprint/audit.py tests/test_coord_audit.py`