### PR TITLE
Adaptive routing thresholds collapse the 1–10 complexity score into 2–3 output buckets per axis

### DIFF
--- a/docs/adr/0006-adaptive-router-trust-boundary.md
+++ b/docs/adr/0006-adaptive-router-trust-boundary.md
@@ -282,6 +282,13 @@ agent invocations or new profile reads. The standard is: **a routing
 decision that cannot be reconstructed from the audit record alone is a
 defect in the router, not a gap in logging.** This is test-enforced as part
 of #1391's acceptance criteria, not left to review discretion.
+The score-to-routing policy each axis records in this block — which
+`complexity_score` bucket maps to which model tier or reviewer count — is
+owned by a single SSOT (`src/theforge/routing.py`) and described for operators
+in `docs/guides/routing-policy.md` (#1019). That guide is the canonical
+operator-facing statement of the intended per-axis bucket design; this clause
+does not restate the threshold tables.
+
 Operator-facing query surfaces (`forge explain`, `--dry-run` forms) are
 conveniences built on this block; the block is the contract. The operator-facing
 enable/disable/rollback procedure, the first-dogfood feature posture, and a

--- a/docs/guides/routing-policy.md
+++ b/docs/guides/routing-policy.md
@@ -1,0 +1,87 @@
+# Routing policy: what the complexity score controls
+
+TheForge's preflight assigns each story a **complexity score** from 1 to 10.
+That score is granular *as input*, but the routing *output* on each axis (which
+model tier, how many reviewers) is deliberately coarse — models and reviewers
+come in discrete units, not a continuous gradient, and aggressive bucketing
+keeps cost variance predictable. This guide is the operator-facing answer to the
+fair question "I see `complexity_score=4` in the audit — what would `8` do
+differently?" (issue #1019).
+
+The thresholds below are **not** duplicated prose: they are read directly from
+the single source of truth, `src/theforge/routing.py`
+(`ROUTING_POLICY` / the `*_BUCKETS` tables). If the code and this table ever
+disagree, the code wins — but the intent is that they never drift, because
+`routing.py` is the only place a threshold may live and this guide describes it.
+
+## The intended design (per axis)
+
+Every axis takes **option (a)**: the coarse buckets are the intended design.
+The score's extra resolution is retained as a signal for possible future
+finer-grained routing, not as a defect to be "fixed." No axis is rewired to
+finer granularity in this pass.
+
+| Axis | Buckets | Score → output | What an operator can tune |
+|---|---|---|---|
+| **Dev model tier** | 3 | 1–3 → `cheap`, 4–6 → `mid`, 7–10 → `strong` | Raise/lower the tier ceiling by editing `DEV_SCORE_TIER_BUCKETS`; the tier floor is never crossed by budget downgrades. |
+| **Plan model tier** (planner *and* reviewer models) | 2 | 1–5 → `mid`, 6–10 → `strong` | Edit `PLAN_SCORE_TIER_BUCKETS`. Planning quality is bimodal, so 2 buckets is deliberate. |
+| **Reviewer count** (plan-review + code-review) | 3 | 1–4 → `min`, 5–7 → midpoint, 8–10 → `max` | Set `assignment.min_reviewers` / `assignment.max_reviewers` in `forge.yaml`; the score selects which of {min, midpoint, max} applies. Edit `REVIEWER_SCORE_COUNT_BUCKETS` to move the boundaries. |
+| **reasoning_effort** | — | *not score-controlled* | Set per model via config/overrides (`reasoning_effort` / `thinking_budget` on a `ModelRef`); never derived from the score. |
+
+Notes:
+
+- **Reviewer count is bounded, not absolute.** The score picks a *target*
+  (`min` / midpoint / `max`); the actual number seated can be lower if the
+  candidate pool is exhausted (self-exclusion, cross-provider preference) or a
+  budget downgrade drops a reviewer. The audit records both the policy target
+  (`resolved_count`) and the number actually seated (`seated_count`).
+- **Static / band routing.** When adaptive routing is disabled, or preflight
+  produced no numeric score, the score axes fall back to the legacy
+  complexity-band tables (`LOW`/`MEDIUM`/`HIGH`). The `routing_decision` block
+  still records each axis with `applied: false` and the reason, so the fallback
+  is never silent.
+- **Why `reasoning_effort` is excluded.** It is a per-model capability knob, not
+  a per-story routing decision. Wiring it to the score would couple a model's
+  thinking budget to story complexity in a way operators cannot reason about
+  per model. It is listed in the axis table with `score_controlled: false` so
+  its exclusion is explicit, not an oversight.
+
+## Reading it in the audit
+
+Every run records a `routing_decision` block (see ADR-0006 clause 7). Each axis
+appears under the relevant role with the full policy view:
+
+```jsonc
+"dev": {
+  "score": 8,
+  "score_policy": {
+    "dev_tier": {
+      "axis": "dev_tier",
+      "score": 8,
+      "bucket": "strong",
+      "range": [7, 10],          // the covering score range
+      "thresholds": [3, 6, 10],  // the bucket ceilings actually applied
+      "output": "strong",        // the selected tier
+      "rationale": "3 buckets — splits the legacy MEDIUM band …"
+    }
+  }
+}
+```
+
+Reviewer roles (`plan_review`, `code_review`) carry two axes — `reviewer_tier`
+(the plan-tier axis) and `reviewer_count`. The `reasoning_effort` axis is
+recorded once at the top level of the block.
+
+`forge explain --story <id>` renders this block for a given run.
+
+## Changing the policy
+
+1. Edit the relevant `*_BUCKETS` tuple (or `ROUTING_POLICY` rationale) in
+   `src/theforge/routing.py`. That is the only place a threshold lives.
+2. Update the table above if a boundary moved.
+3. Run the routing tests: `tests/test_routing.py`,
+   `tests/test_assignment_routing_decision.py`.
+
+Do **not** hardcode a score threshold anywhere else — `assignment.py` and the
+coordinator route through `routing.py` precisely so the policy stays in one
+auditable place.

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -1462,8 +1462,6 @@ def _build_routing_decision(
     dev_effective_tier: str,
     preflight_tier: str | None,
     planner_tier: str | None,
-    min_reviewers: int = 1,
-    max_reviewers: int = 1,
     dev_signals: dict[str, dict],
     promotion_block: dict[str, object],
     planner_model: str,
@@ -1480,6 +1478,8 @@ def _build_routing_decision(
     pr_completion_audit: dict[str, object] | None = None,
     cr_completion_signals: dict[str, dict] | None = None,
     cr_completion_audit: dict[str, object] | None = None,
+    min_reviewers: int = 1,
+    max_reviewers: int = 1,
 ) -> dict[str, object]:
     """Assemble the per-role routing_decision explainability block (#1391).
 

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -25,7 +25,12 @@ from .config import (
 )
 from .config.auth import check_agent_auth
 from .config.models import price_tiebreak_signal
-from .routing import score_to_dev_tier
+from .routing import (
+    axis_decision,
+    score_to_dev_tier,
+    score_to_plan_tier,
+    score_to_reviewer_target,
+)
 
 log = logging.getLogger(__name__)
 
@@ -392,11 +397,16 @@ def _normalize_complexity_score(complexity_score: int | None) -> int | None:
 
 
 def _plan_tier_for_score(complexity: str, complexity_score: int | None) -> str:
-    """Return the planner tier, preferring score-driven routing when present."""
+    """Return the planner tier, preferring score-driven routing when present.
+
+    Score thresholds are owned by the canonical routing policy
+    (:func:`theforge.routing.score_to_plan_tier`); this is a thin adapter that
+    falls back to the legacy band when no numeric score is available.
+    """
     score = _normalize_complexity_score(complexity_score)
     if score is None:
         return PHASE_TIER["plan"][complexity]
-    return "mid" if score <= 5 else "strong"
+    return score_to_plan_tier(score)
 
 
 def _dev_tier_for_score(complexity: str, complexity_score: int | None) -> str:
@@ -413,13 +423,20 @@ def _reviewer_target_for_score(
     min_r: int,
     max_r: int,
 ) -> int:
-    """Return reviewer count, allowing same-band stories to diverge by score."""
+    """Return reviewer count, allowing same-band stories to diverge by score.
+
+    Bucket boundaries are owned by the canonical routing policy
+    (:func:`theforge.routing.score_to_reviewer_target`); this adapter resolves
+    the symbolic "min"/"mid"/"max" target against the configured reviewer
+    bounds. Falls back to the legacy band count when no numeric score exists.
+    """
     score = _normalize_complexity_score(complexity_score)
     if score is None:
         return _reviewer_count(complexity, min_r, max_r)
-    if score <= 4:
+    target = score_to_reviewer_target(score)
+    if target == "min":
         return min_r
-    if score >= 8:
+    if target == "max":
         return max_r
     return min_r + (max_r - min_r + 1) // 2
 
@@ -1410,6 +1427,31 @@ def _reviewer_completion_check(
     return block
 
 
+def _reviewer_count_policy(
+    score: int | None, min_r: int, max_r: int, seated: int
+) -> dict[str, object]:
+    """Reviewer-count axis decision augmented with the resolved concrete count.
+
+    :func:`theforge.routing.axis_decision` records the policy view (bucket,
+    thresholds, "min"/"mid"/"max" target); this resolves that symbolic target
+    against the configured reviewer bounds and records the number of reviewers
+    actually seated so a shortfall (candidate-pool exhaustion / budget drop) is
+    visible next to the policy target.
+    """
+    block = dict(axis_decision("reviewer_count", score))
+    if block.get("applied"):
+        target = str(block.get("output"))
+        block["resolved_count"] = {"min": min_r, "max": max_r}.get(
+            target, min_r + (max_r - min_r + 1) // 2
+        )
+    else:
+        block["resolved_count"] = None
+    block["min_reviewers"] = min_r
+    block["max_reviewers"] = max_r
+    block["seated_count"] = seated
+    return block
+
+
 def _build_routing_decision(
     decision: AssignmentDecision,
     agents: list[AgentDef],
@@ -1420,6 +1462,8 @@ def _build_routing_decision(
     dev_effective_tier: str,
     preflight_tier: str | None,
     planner_tier: str | None,
+    min_reviewers: int = 1,
+    max_reviewers: int = 1,
     dev_signals: dict[str, dict],
     promotion_block: dict[str, object],
     planner_model: str,
@@ -1524,6 +1568,12 @@ def _build_routing_decision(
         # discounted for taint before any per-role explanation. The runs remain in
         # the substrate (ADR-0002 refusal-to-forget); this is a read-time count.
         "excluded_for_taint": int(excluded_for_taint),
+        # Score-to-routing policy axis not tied to a single role: reasoning_effort
+        # is intentionally NOT score-controlled (config/override field only). Recorded
+        # top-level so its exclusion from score routing is explicit, never silent
+        # (#1019). The per-role score_policy blocks below cover the axes the score
+        # DOES control (dev tier, plan tier, reviewer count).
+        "reasoning_effort": axis_decision("reasoning_effort", score),
         "preflight": {
             "candidate_pool": _single_model_pool(
                 agents,
@@ -1540,6 +1590,8 @@ def _build_routing_decision(
             },
         },
         "planner": {
+            # Canonical plan-tier score policy (#1019).
+            "score_policy": {"plan_tier": axis_decision("plan_tier", score)},
             "candidate_pool": _single_model_pool(
                 agents,
                 planner_tier,
@@ -1557,6 +1609,9 @@ def _build_routing_decision(
         "dev": {
             "score": score,
             "base_tier_from_score": dev_base_tier,
+            # Canonical dev-tier score policy (#1019): bucket, thresholds, covering
+            # range, selected tier, and rationale, sourced from theforge.routing.
+            "score_policy": {"dev_tier": axis_decision("dev_tier", score)},
             "candidate_pool": dev_pool,
             # Domain preference (#155): the story's tags, the matching profile
             # slice per candidate (on each pool entry's ``signals.domain``), and
@@ -1605,6 +1660,15 @@ def _build_routing_decision(
             },
         },
         "plan_review": {
+            # Two score-derived outputs for a reviewer role (#1019): the reviewer
+            # MODEL tier (plan_tier axis) and the reviewer COUNT (reviewer_count
+            # axis, resolved against min/max_reviewers).
+            "score_policy": {
+                "reviewer_tier": axis_decision("plan_tier", score),
+                "reviewer_count": _reviewer_count_policy(
+                    score, min_reviewers, max_reviewers, len(decision.plan_reviewers)
+                ),
+            },
             "candidate_pool": _reviewer_candidate_pool(
                 agents,
                 pr_selected,
@@ -1624,6 +1688,12 @@ def _build_routing_decision(
             },
         },
         "code_review": {
+            "score_policy": {
+                "reviewer_tier": axis_decision("plan_tier", score),
+                "reviewer_count": _reviewer_count_policy(
+                    score, min_reviewers, max_reviewers, len(decision.code_reviewers)
+                ),
+            },
             "candidate_pool": _reviewer_candidate_pool(
                 agents,
                 cr_selected,
@@ -2520,6 +2590,8 @@ def assign_models(
             dev_effective_tier=_dev_effective_tier,
             preflight_tier=_preflight_tier,
             planner_tier=planner_target_tier,
+            min_reviewers=assignment_config.min_reviewers,
+            max_reviewers=assignment_config.max_reviewers,
             dev_signals=_dev_signals,
             promotion_block=_promotion_block,
             planner_model=dec.planner.model,

--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -97,6 +97,39 @@ def _render_candidate_pool(pool: list[dict], lines: list[str]) -> None:
             lines.append(f"        success_rate: {_fmt_signal(success_rate)}")
 
 
+def _render_score_policy(role_block: dict, lines: list[str]) -> None:
+    """Render the per-axis score-to-routing policy (#1019) for a role.
+
+    One line per axis naming the applied score bucket, its covering range, the
+    thresholds, and the selected output — the operator-facing view of what the
+    complexity score actually controlled. Axes not driven by the score (or with
+    no numeric score) print their recorded reason instead of a fabricated bucket.
+    """
+    policy = role_block.get("score_policy") or {}
+    if not isinstance(policy, dict) or not policy:
+        return
+    lines.append("  score policy:")
+    for axis in policy.values():
+        if not isinstance(axis, dict):
+            continue
+        name = axis.get("axis", "?")
+        if axis.get("applied"):
+            bucket = axis.get("bucket")
+            rng = axis.get("range")
+            thresholds = axis.get("thresholds")
+            output = axis.get("output")
+            detail = f"score={axis.get('score')} → bucket={bucket} range={rng} output={output}"
+            if isinstance(axis.get("resolved_count"), int):
+                detail += f" resolved_count={axis['resolved_count']}"
+            if isinstance(axis.get("seated_count"), int):
+                detail += f" seated={axis['seated_count']}"
+            if thresholds:
+                detail += f" (thresholds {thresholds})"
+        else:
+            detail = f"not applied — {axis.get('reason', 'not_score_controlled')}"
+        lines.append(f"    {name}: {detail}")
+
+
 def _render_mechanism(label: str, state: tuple[str, str], detail: str, lines: list[str]) -> None:
     glyph, state_text = state
     suffix = f" — {detail}" if detail else ""
@@ -256,6 +289,15 @@ def render_routing_decision(block: dict) -> list[str]:
     excluded_for_taint = block.get("excluded_for_taint")
     if isinstance(excluded_for_taint, int) and excluded_for_taint > 0:
         lines.append(f"excluded for taint: {excluded_for_taint} run(s) set aside (not deleted)")
+    # reasoning_effort is a score axis not tied to a role (#1019): recorded
+    # top-level as intentionally NOT score-controlled. Surface it so the operator
+    # sees the axis was considered and deliberately excluded, not overlooked.
+    reasoning = block.get("reasoning_effort")
+    if isinstance(reasoning, dict) and reasoning:
+        lines.append(
+            f"reasoning_effort: not score-controlled — {reasoning.get('reason', '')} "
+            f"({reasoning.get('rationale', '')})".rstrip()
+        )
     for role in _ROLE_ORDER:
         role_block = block.get(role)
         if not isinstance(role_block, dict):
@@ -275,6 +317,8 @@ def render_routing_decision(block: dict) -> list[str]:
         lines.append("-" * 60)
 
         _render_final(role_block, lines)
+
+        _render_score_policy(role_block, lines)
 
         lines.append("  candidate pool:")
         _render_candidate_pool(role_block.get("candidate_pool") or [], lines)

--- a/src/theforge/routing.py
+++ b/src/theforge/routing.py
@@ -1,25 +1,65 @@
-"""Shared deterministic routing policy tables.
+"""Canonical score-to-routing policy — the single SSOT for every axis.
 
-The numeric complexity score path is the canonical dev-tier policy for adaptive
-assignment. It intentionally splits the legacy MEDIUM band so localized work can
-stay cheap while broader cross-module work escalates sooner:
+This module is the one place that decides how the 1-10 preflight complexity
+score maps to a routing *output* on each axis (which model tier, how many
+reviewers). :mod:`theforge.assignment` consumes these tables; nothing else may
+hardcode a score threshold.
 
-- scores 1-3 route to ``cheap``
-- scores 4-6 route to ``mid``
-- scores 7-10 route to ``strong``
+The score is granular *as input* (1-10); the output on each axis is
+deliberately coarse — models and reviewers come in discrete units, not a
+continuous gradient, and aggressive bucketing limits cost variance (see
+issue #1019). The intended design per axis is stated below and encoded in
+:data:`ROUTING_POLICY`; the operator-facing narrative lives in
+``docs/guides/routing-policy.md`` (cross-linked from ADR-0006 clause 7).
 
-Keep score-threshold edits here so assignment, coordinator preflight, and
-static role derivation stay aligned. Raising the cheap-tier ceiling is a
-single-line change to ``DEV_SCORE_TIER_BUCKETS``.
+Intended design, per axis (all axes: option (a) — the coarse buckets are
+intentional and the score's extra resolution is a signal reserved for future
+finer-grained routing, not a defect):
+
+- **dev tier** — 3 buckets. Splits the legacy MEDIUM band so localized work
+  (1-3) stays cheap while broader cross-module work (7-10) escalates sooner.
+- **plan tier** — 2 buckets. Planning quality is bimodal: either the story is
+  mechanical enough for a mid planner (1-5) or it needs a strong one (6-10).
+- **reviewer count** (plan_review + code_review) — 3 buckets. Reviewer eyes are
+  the coarsest axis: min for low-risk (1-4), the configured midpoint for medium
+  (5-7), max for high-risk (8-10). Bounded by ``min_reviewers``/``max_reviewers``.
+- **reasoning_effort** — intentionally NOT score-controlled. It is a per-model
+  ModelProfile/ModelRef field set by config/overrides
+  (``config/role_derivation.py``), never derived from ``complexity_score``.
+  Recorded in the axis table so its omission from score routing is explicit
+  rather than silent.
+
+Raising a bucket ceiling is a single-line edit to the relevant ``*_BUCKETS``
+tuple here — assignment, coordinator preflight, and static role derivation all
+route through this module and stay aligned.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Per-axis bucket tables (ordered by inclusive upper bound) ──────────
 
 # Ordered upper-bound buckets for the 1-10 dev complexity score.
 DEV_SCORE_TIER_BUCKETS: tuple[tuple[int, str], ...] = (
     (3, "cheap"),
     (6, "mid"),
     (10, "strong"),
+)
+
+# Ordered upper-bound buckets for the planner / reviewer model tier.
+PLAN_SCORE_TIER_BUCKETS: tuple[tuple[int, str], ...] = (
+    (5, "mid"),
+    (10, "strong"),
+)
+
+# Ordered upper-bound buckets for the reviewer *count* axis. Outputs are the
+# symbolic count targets ("min"/"mid"/"max") the assignment layer resolves
+# against the configured ``min_reviewers``/``max_reviewers`` (and midpoint).
+REVIEWER_SCORE_COUNT_BUCKETS: tuple[tuple[int, str], ...] = (
+    (4, "min"),
+    (7, "mid"),
+    (10, "max"),
 )
 
 # Legacy enum fallback used when a numeric score is unavailable.
@@ -30,9 +70,150 @@ DEV_COMPLEXITY_TIER: dict[str, str] = {
 }
 
 
+def _bucket_for(buckets: tuple[tuple[int, str], ...], score: int) -> str:
+    """Return the output for the first bucket whose upper bound covers ``score``."""
+    for max_score, output in buckets:
+        if score <= max_score:
+            return output
+    return buckets[-1][1]
+
+
 def score_to_dev_tier(score: int) -> str:
     """Return the dev-phase tier for a 1-10 complexity score."""
-    for max_score, tier in DEV_SCORE_TIER_BUCKETS:
-        if score <= max_score:
-            return tier
-    return DEV_SCORE_TIER_BUCKETS[-1][1]
+    return _bucket_for(DEV_SCORE_TIER_BUCKETS, score)
+
+
+def score_to_plan_tier(score: int) -> str:
+    """Return the planner/reviewer model tier for a 1-10 complexity score."""
+    return _bucket_for(PLAN_SCORE_TIER_BUCKETS, score)
+
+
+def score_to_reviewer_target(score: int) -> str:
+    """Return the reviewer-count target token ("min"/"mid"/"max") for a score."""
+    return _bucket_for(REVIEWER_SCORE_COUNT_BUCKETS, score)
+
+
+# ── Canonical policy metadata (drives instrumentation + docs) ──────────
+
+
+@dataclass(frozen=True)
+class RoutingAxis:
+    """One score-derived routing axis and its canonical bucket policy.
+
+    ``key`` is the stable axis id recorded in ``routing_decision``. ``buckets``
+    is the ordered upper-bound table (empty when the axis is not score-driven).
+    ``score_controlled`` is False only for :data:`reasoning_effort`, whose value
+    comes from config/overrides — recorded so its exclusion from score routing
+    is explicit. ``rationale`` is the one-line operator-facing justification.
+    """
+
+    key: str
+    description: str
+    score_controlled: bool
+    buckets: tuple[tuple[int, str], ...]
+    rationale: str
+
+    def bucket_bounds(self, score: int) -> tuple[int, int]:
+        """Return the inclusive [lower, upper] score range covering ``score``."""
+        lower = 1
+        for upper, _ in self.buckets:
+            if score <= upper:
+                return (lower, upper)
+            lower = upper + 1
+        # Score above the top bucket's ceiling — clamp to the last bucket.
+        return (lower, self.buckets[-1][0])
+
+    def output_for(self, score: int) -> str:
+        """Return the selected bucket output for ``score``."""
+        return _bucket_for(self.buckets, score)
+
+    def bucket_name(self, score: int) -> str:
+        """Return the bucket label for ``score`` (same as the output token)."""
+        return self.output_for(score)
+
+
+ROUTING_POLICY: dict[str, RoutingAxis] = {
+    "dev_tier": RoutingAxis(
+        key="dev_tier",
+        description="Dev-phase model tier",
+        score_controlled=True,
+        buckets=DEV_SCORE_TIER_BUCKETS,
+        rationale=(
+            "3 buckets — splits the legacy MEDIUM band so localized work (1-3) "
+            "stays cheap while broad cross-module work (7-10) escalates sooner"
+        ),
+    ),
+    "plan_tier": RoutingAxis(
+        key="plan_tier",
+        description="Planner and reviewer model tier",
+        score_controlled=True,
+        buckets=PLAN_SCORE_TIER_BUCKETS,
+        rationale=(
+            "2 buckets — planning quality is bimodal: mid planner for mechanical "
+            "stories (1-5), strong planner for design-heavy ones (6-10)"
+        ),
+    ),
+    "reviewer_count": RoutingAxis(
+        key="reviewer_count",
+        description="Number of plan-review / code-review reviewers",
+        score_controlled=True,
+        buckets=REVIEWER_SCORE_COUNT_BUCKETS,
+        rationale=(
+            "3 buckets — min reviewers for low-risk (1-4), configured midpoint "
+            "for medium (5-7), max for high-risk (8-10), bounded by "
+            "min_reviewers/max_reviewers"
+        ),
+    ),
+    "reasoning_effort": RoutingAxis(
+        key="reasoning_effort",
+        description="Model reasoning-effort / thinking budget",
+        score_controlled=False,
+        buckets=(),
+        rationale=(
+            "intentionally NOT score-controlled — a per-model config/override "
+            "field (config/role_derivation.py), never derived from complexity_score"
+        ),
+    ),
+}
+
+
+def axis_decision(axis_key: str, score: int | None) -> dict[str, object]:
+    """Return the canonical routing-policy decision for an axis at a score.
+
+    Pure data assembly for the ``routing_decision`` audit block (#1391,
+    ADR-0006 clause 7). Records the score, bucket name, threshold values and the
+    covering range, the selected output, and the one-line rationale so every
+    axis explains itself from the audit alone. ``score`` is ``None`` under static
+    band routing (adaptive disabled) or when preflight produced no numeric score;
+    the block then records ``applied: False`` with the reason rather than a
+    fabricated bucket.
+    """
+    axis = ROUTING_POLICY[axis_key]
+    block: dict[str, object] = {
+        "axis": axis.key,
+        "description": axis.description,
+        "score": score,
+        "score_controlled": axis.score_controlled,
+        "thresholds": [upper for upper, _ in axis.buckets],
+        "rationale": axis.rationale,
+    }
+    if not axis.score_controlled:
+        block["applied"] = False
+        block["bucket"] = None
+        block["range"] = None
+        block["output"] = None
+        block["reason"] = "not_score_controlled"
+        return block
+    if score is None:
+        block["applied"] = False
+        block["bucket"] = None
+        block["range"] = None
+        block["output"] = None
+        block["reason"] = "no_numeric_score_static_band_routing"
+        return block
+    lower, upper = axis.bucket_bounds(score)
+    block["applied"] = True
+    block["bucket"] = axis.bucket_name(score)
+    block["range"] = [lower, upper]
+    block["output"] = axis.output_for(score)
+    return block

--- a/tests/test_assignment_routing_decision.py
+++ b/tests/test_assignment_routing_decision.py
@@ -333,6 +333,83 @@ def test_health_deprioritized_reviewer_is_excluded_not_falsely_included(monkeypa
         assert entry["reason"] in EXCLUSION_REASONS
 
 
+def test_score_policy_recorded_for_every_axis(_keys_except_deepseek):
+    """Each routing axis records score, bucket, thresholds/range, output, and an
+    explanation in routing_decision — the #1019 acceptance contract."""
+    decision = assign_models(_agents(), _cfg(), complexity="HIGH", complexity_score=9)
+    block = decision.routing_decision
+
+    # Dev tier axis.
+    dev_axis = block["dev"]["score_policy"]["dev_tier"]
+    assert dev_axis["axis"] == "dev_tier"
+    assert dev_axis["score"] == 9
+    assert dev_axis["bucket"] == "strong"
+    assert dev_axis["range"] == [7, 10]
+    assert dev_axis["thresholds"] == [3, 6, 10]
+    assert dev_axis["output"] == "strong"
+    assert dev_axis["rationale"]
+
+    # Plan tier axis.
+    plan_axis = block["planner"]["score_policy"]["plan_tier"]
+    assert plan_axis["bucket"] == "strong"
+    assert plan_axis["range"] == [6, 10]
+    assert plan_axis["thresholds"] == [5, 10]
+    assert plan_axis["output"] == "strong"
+
+    # Reviewer axes (tier + count) on both reviewer roles.
+    for role in ("plan_review", "code_review"):
+        sp = block[role]["score_policy"]
+        assert sp["reviewer_tier"]["output"] == "strong"
+        count = sp["reviewer_count"]
+        assert count["axis"] == "reviewer_count"
+        assert count["bucket"] == "max"  # score 9 → max reviewers
+        assert count["range"] == [8, 10]
+        assert count["thresholds"] == [4, 7, 10]
+        assert count["output"] == "max"
+        assert count["resolved_count"] == 3  # max_reviewers in _cfg
+        assert count["seated_count"] == len(
+            decision.plan_reviewers if role == "plan_review" else decision.code_reviewers
+        )
+        assert count["rationale"]
+
+
+def test_reasoning_effort_axis_recorded_as_not_score_controlled(_keys_except_deepseek):
+    """reasoning_effort appears in routing_decision, explicitly marked as NOT
+    score-controlled rather than silently omitted (#1019 / P2 plan note)."""
+    decision = assign_models(_agents(), _cfg(), complexity="HIGH", complexity_score=9)
+    axis = decision.routing_decision["reasoning_effort"]
+    assert axis["axis"] == "reasoning_effort"
+    assert axis["score_controlled"] is False
+    assert axis["applied"] is False
+    assert axis["output"] is None
+    assert axis["reason"] == "not_score_controlled"
+    assert axis["rationale"]
+
+
+def test_score_policy_low_score_routes_to_min_reviewers(_keys_except_deepseek):
+    """A low complexity score selects the min reviewer-count bucket — the coarse
+    3-bucket shape is intentional and its boundary is auditable."""
+    decision = assign_models(
+        _agents(), _cfg(min_reviewers=1, max_reviewers=3), complexity="LOW", complexity_score=2
+    )
+    dev_axis = decision.routing_decision["dev"]["score_policy"]["dev_tier"]
+    assert dev_axis["bucket"] == "cheap"
+    assert dev_axis["range"] == [1, 3]
+    count = decision.routing_decision["code_review"]["score_policy"]["reviewer_count"]
+    assert count["bucket"] == "min"
+    assert count["resolved_count"] == 1
+
+
+def test_score_policy_marks_static_fallback_without_score(_keys_except_deepseek):
+    """Static band routing (no numeric score) still records the axis with the
+    static-fallback reason and full threshold table — never a fabricated bucket."""
+    decision = assign_models(_agents(), _cfg(), complexity="HIGH", complexity_score=None)
+    dev_axis = decision.routing_decision["dev"]["score_policy"]["dev_tier"]
+    assert dev_axis["applied"] is False
+    assert dev_axis["reason"] == "no_numeric_score_static_band_routing"
+    assert dev_axis["thresholds"] == [3, 6, 10]
+
+
 def test_health_demotion_records_checked_but_not_fired(monkeypatch):
     """With no unhealthy models, the reviewer demotion_check still records a
     checked-but-didn't-fire outcome (AC clause 5), not silence."""

--- a/tests/test_assignment_routing_decision.py
+++ b/tests/test_assignment_routing_decision.py
@@ -400,6 +400,23 @@ def test_score_policy_low_score_routes_to_min_reviewers(_keys_except_deepseek):
     assert count["resolved_count"] == 1
 
 
+def test_score_policy_mid_score_routes_to_midpoint_reviewers(_keys_except_deepseek):
+    """A mid-range score (5-7) selects the midpoint reviewer-count bucket
+    end-to-end through _build_routing_decision / _reviewer_count_policy."""
+    decision = assign_models(
+        _agents(), _cfg(min_reviewers=1, max_reviewers=3), complexity="MEDIUM", complexity_score=6
+    )
+    dev_axis = decision.routing_decision["dev"]["score_policy"]["dev_tier"]
+    assert dev_axis["bucket"] == "mid"
+    assert dev_axis["range"] == [4, 6]
+    for role in ("plan_review", "code_review"):
+        count = decision.routing_decision[role]["score_policy"]["reviewer_count"]
+        assert count["bucket"] == "mid"
+        assert count["range"] == [5, 7]
+        # midpoint of [1, 3] = 1 + (3 - 1 + 1) // 2 = 2
+        assert count["resolved_count"] == 2
+
+
 def test_score_policy_marks_static_fallback_without_score(_keys_except_deepseek):
     """Static band routing (no numeric score) still records the axis with the
     static-fallback reason and full threshold table — never a fabricated bucket."""

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -161,6 +161,33 @@ def test_render_excluded_reason_is_scannable() -> None:
     assert "health_deprioritized" in text
 
 
+def test_render_surfaces_score_policy_per_axis() -> None:
+    """The #1019 score-to-routing policy is rendered per role, and the
+    reasoning_effort axis is surfaced as intentionally not score-controlled."""
+    from theforge.routing import axis_decision
+
+    block = _routing_block()
+    block["reasoning_effort"] = axis_decision("reasoning_effort", 9)
+    block["dev"]["score_policy"] = {"dev_tier": axis_decision("dev_tier", 9)}
+    block["planner"]["score_policy"] = {"plan_tier": axis_decision("plan_tier", 9)}
+    count_axis = dict(axis_decision("reviewer_count", 9))
+    count_axis["resolved_count"] = 3
+    count_axis["seated_count"] = 1
+    block["code_review"]["score_policy"] = {
+        "reviewer_tier": axis_decision("plan_tier", 9),
+        "reviewer_count": count_axis,
+    }
+
+    text = "\n".join(explain.render_routing_decision(block))
+    assert "score policy:" in text
+    assert "dev_tier: score=9 → bucket=strong range=[7, 10] output=strong" in text
+    assert "reviewer_count:" in text
+    assert "resolved_count=3" in text
+    assert "seated=1" in text
+    # reasoning_effort is surfaced top-level as deliberately excluded.
+    assert "reasoning_effort: not score-controlled" in text
+
+
 def test_tri_state_distinguishes_not_checked_from_did_not_fire() -> None:
     """not-checked vs checked-did-not-fire vs fired must be distinguishable."""
     # promotion checked but did not fire → ◐; dev-tier demotion not applicable → ○.

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 from theforge.coordinator.preflight import score_to_dev_tier as preflight_score_to_dev_tier
-from theforge.routing import DEV_COMPLEXITY_TIER, DEV_SCORE_TIER_BUCKETS, score_to_dev_tier
+from theforge.routing import (
+    DEV_COMPLEXITY_TIER,
+    DEV_SCORE_TIER_BUCKETS,
+    PLAN_SCORE_TIER_BUCKETS,
+    REVIEWER_SCORE_COUNT_BUCKETS,
+    ROUTING_POLICY,
+    axis_decision,
+    score_to_dev_tier,
+    score_to_plan_tier,
+    score_to_reviewer_target,
+)
 
 
 def test_dev_score_tier_buckets_are_canonical():
@@ -21,3 +31,75 @@ def test_dev_score_tier_buckets_are_canonical():
 
 def test_preflight_reexports_canonical_score_to_dev_tier():
     assert preflight_score_to_dev_tier is score_to_dev_tier
+
+
+def test_plan_score_tier_buckets_are_canonical():
+    assert PLAN_SCORE_TIER_BUCKETS == ((5, "mid"), (10, "strong"))
+    assert score_to_plan_tier(1) == "mid"
+    assert score_to_plan_tier(5) == "mid"
+    assert score_to_plan_tier(6) == "strong"
+    assert score_to_plan_tier(10) == "strong"
+
+
+def test_reviewer_count_buckets_are_canonical():
+    assert REVIEWER_SCORE_COUNT_BUCKETS == ((4, "min"), (7, "mid"), (10, "max"))
+    assert score_to_reviewer_target(4) == "min"
+    assert score_to_reviewer_target(5) == "mid"
+    assert score_to_reviewer_target(7) == "mid"
+    assert score_to_reviewer_target(8) == "max"
+
+
+def test_routing_policy_covers_every_axis():
+    # The canonical SSOT must name every score-derived axis plus the one axis
+    # documented as intentionally NOT score-controlled (#1019).
+    assert set(ROUTING_POLICY) == {
+        "dev_tier",
+        "plan_tier",
+        "reviewer_count",
+        "reasoning_effort",
+    }
+    assert ROUTING_POLICY["reasoning_effort"].score_controlled is False
+    for key in ("dev_tier", "plan_tier", "reviewer_count"):
+        assert ROUTING_POLICY[key].score_controlled is True
+        assert ROUTING_POLICY[key].rationale  # every axis states its rationale
+
+
+def test_axis_decision_records_bucket_range_threshold_and_output():
+    dec = axis_decision("dev_tier", 8)
+    assert dec["axis"] == "dev_tier"
+    assert dec["applied"] is True
+    assert dec["score"] == 8
+    assert dec["bucket"] == "strong"
+    assert dec["range"] == [7, 10]
+    assert dec["thresholds"] == [3, 6, 10]
+    assert dec["output"] == "strong"
+    assert dec["rationale"]
+
+    # Boundary story in the mid dev bucket resolves the covering range exactly.
+    mid = axis_decision("dev_tier", 4)
+    assert mid["bucket"] == "mid"
+    assert mid["range"] == [4, 6]
+
+    plan = axis_decision("plan_tier", 3)
+    assert plan["bucket"] == "mid"
+    assert plan["range"] == [1, 5]
+    assert plan["thresholds"] == [5, 10]
+
+
+def test_axis_decision_reasoning_effort_is_not_score_controlled():
+    dec = axis_decision("reasoning_effort", 9)
+    assert dec["score_controlled"] is False
+    assert dec["applied"] is False
+    assert dec["bucket"] is None
+    assert dec["output"] is None
+    assert dec["reason"] == "not_score_controlled"
+
+
+def test_axis_decision_without_score_records_static_fallback():
+    dec = axis_decision("dev_tier", None)
+    assert dec["applied"] is False
+    assert dec["bucket"] is None
+    assert dec["reason"] == "no_numeric_score_static_band_routing"
+    # Thresholds are still surfaced so the table is reconstructable even in
+    # static mode.
+    assert dec["thresholds"] == [3, 6, 10]


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Cycle-1 signature issue is resolved; the current implementation satisfies the routing-policy ACs and the targeted touched tests pass. | [google-gemini-3.5-flash] The score-to-routing policy thresholds are centralized in routing.py, fully documented, and instrumented across all axes with comprehensive test coverage. | [claude-sonnet] Cycle 1's P1 (defaulted params before required params in _build_routing_decision) is fixed — module imports cleanly and all keyword-only params are reordered correctly; both P2s from cycle 1 (forge explain not rendering score_policy, missing mid-bucket end-to-end test) are also addressed. No regressions found in the iteration-1 diff; 40 tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $8.50
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Adaptive routing thresholds collapse the 1–10 complexity score into 2–3 output buckets per axis (GitHub Issue #1019)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1019