### PR TITLE
Claude dev runner can write outside story worktree via absolute paths

### DIFF
--- a/src/theforge/config/auth.py
+++ b/src/theforge/config/auth.py
@@ -20,51 +20,98 @@ _LOCAL_PREFIXES = (
 )
 
 
-def _sandbox_readiness(profile: ModelProfile) -> tuple[bool, str]:
-    """Return whether workspace-effect sandboxing is active for this profile.
+# CLI runners with no native sandbox flag — their write containment comes
+# solely from the host wrapper (sandbox-exec/bwrap). Codex, by contrast, passes
+# a provider-native ``--sandbox`` flag, so it is mechanically contained without
+# the host wrapper.
+_HOST_WRAPPED_CLIS = frozenset({"claude", "gemini"})
 
-    For CLI profiles, reports whether native CLI sandboxing is engaged based on
-    the profile's sandbox_mode field. For API profiles, probes whether the
-    platform can confine bash/tool effects to the working directory.
-    """
-    if profile.mode != "api":
-        # CLI profiles: sandboxing is active when sandbox_mode is not "none"
-        if profile.sandbox_mode == "none":
-            return (False, "sandbox disabled by sandbox_mode: none")
-        return (True, "")
-    if "bash" not in profile.allowed_tools:
-        return (True, "")
 
+def _host_sandbox_available() -> bool:
+    """Return True when the host sandbox wrapper (sandbox-exec/bwrap) is usable."""
     from theforge.runners.sandbox import workspace_effect_sandbox_command
 
     probe = workspace_effect_sandbox_command(["true"], Path.cwd())
-    if probe and probe[0] != "true":
-        return (True, "")
+    return bool(probe) and probe[0] != "true"
 
+
+def _host_unavailable_reason(effect_label: str) -> tuple[bool, str]:
+    """Build the (False, reason) tuple for an unavailable host sandbox."""
     system = platform.system()
     if system == "Darwin":
         return (
             False,
-            "workspace sandbox unavailable: sandbox-exec not usable; "
-            "bash/tool effects will run unsandboxed",
+            f"workspace sandbox unavailable: sandbox-exec not usable; {effect_label}",
         )
     if system == "Linux":
         return (
             False,
-            "workspace sandbox unavailable: bwrap not usable; "
-            "bash/tool effects will run unsandboxed",
+            f"workspace sandbox unavailable: bwrap not usable; {effect_label}",
         )
     return (True, "")
 
 
+def _sandbox_readiness(profile: ModelProfile) -> tuple[bool, str]:
+    """Return whether *mechanical* workspace containment is active for this profile.
+
+    ``True`` means agent writes are confined by a real OS mechanism (host
+    sandbox-exec/bwrap wrapper, or a provider-native sandbox flag). It is NOT
+    set merely because ``sandbox_mode != none`` — a native/prompt-only
+    permission mode is cooperative, not mechanical, so profiles that rely on the
+    host wrapper report ``False`` when that wrapper is unavailable (#1907).
+    """
+    if profile.mode != "api":
+        # CLI profiles: sandbox explicitly disabled → not contained.
+        if profile.sandbox_mode == "none":
+            return (False, "sandbox disabled by sandbox_mode: none")
+        # Claude/Gemini have no native sandbox; containment is the host wrapper.
+        if profile.cli in _HOST_WRAPPED_CLIS:
+            if _host_sandbox_available():
+                return (True, "")
+            return _host_unavailable_reason(
+                "CLI write containment cannot be enforced; refusing to run unsandboxed"
+            )
+        # Codex and other CLIs assert a provider-native --sandbox flag.
+        return (True, "")
+    if "bash" not in profile.allowed_tools:
+        return (True, "")
+
+    if _host_sandbox_available():
+        return (True, "")
+    return _host_unavailable_reason("bash/tool effects will run unsandboxed")
+
+
 def sandbox_available_for_profile(profile: ModelProfile) -> bool:
-    """Return True if workspace-effect sandboxing is available for *profile*.
+    """Return True if *mechanical* workspace containment is available for *profile*.
 
     Thin public wrapper around the private probe; safe to call repeatedly
     because the underlying sandbox availability check is lru_cache-backed.
     """
     available, _ = _sandbox_readiness(profile)
     return available
+
+
+def sandbox_containment_mode(profile: ModelProfile) -> str:
+    """Classify how a run's writes are contained, for audit/status output.
+
+    Distinguishes mechanically-contained runs from native-flag and
+    uncontained/prompt-only ones (#1907):
+
+    - ``"mechanical"`` — host sandbox wrapper (sandbox-exec/bwrap) confines writes.
+    - ``"native"``     — provider-native sandbox flag (e.g. Codex ``--sandbox``).
+    - ``"unavailable"``— containment requested but the host wrapper is missing;
+      the run fails closed rather than proceeding with prompt-only discipline.
+    - ``"none"``       — no containment (``sandbox_mode: none`` or no tool surface).
+    """
+    if profile.mode != "api":
+        if profile.sandbox_mode == "none":
+            return "none"
+        if profile.cli in _HOST_WRAPPED_CLIS:
+            return "mechanical" if _host_sandbox_available() else "unavailable"
+        return "native"
+    if "bash" not in profile.allowed_tools:
+        return "none"
+    return "mechanical" if _host_sandbox_available() else "unavailable"
 
 
 def _launcher_sandbox_readiness(profile: ModelProfile) -> tuple[bool, str]:

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -450,6 +450,7 @@ def _serialize_dev_iteration_metrics(state: CoordinatorState) -> list[dict]:
             "files_changed_count": item.files_changed_count,
             "tests_fixed_count": item.tests_fixed_count,
             "sandboxed": item.sandboxed,
+            "containment": item.containment,
             "agent_exit_code": item.agent_exit_code,
             "runner_failure_code": item.runner_failure_code,
             "runner_failure_summary": item.runner_failure_summary,

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import yaml
 
 from theforge.config import ForgeConfig, apply_model_info
-from theforge.config.auth import sandbox_available_for_profile
+from theforge.config.auth import sandbox_available_for_profile, sandbox_containment_mode
 from theforge.config.types import StuckDetectionConfig
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.review import append_convention_retry_findings
@@ -486,6 +486,7 @@ def record_dev_iteration_telemetry(
             tests_fixed_count=tests_fixed_count,
             meaningful_progress=meaningful_progress,
             sandboxed=state.sandboxed,
+            containment=state.dev_containment,
             agent_exit_code=dev_result.exit_code,
             runner_failure_code=dev_result.failure_code,
             runner_failure_summary=runner_failure_summary,
@@ -615,12 +616,22 @@ def _run_dev_phase(
     state.pending_dev_transport_retry_count = 0
     state.pending_dev_transport_retry_events = []
     # Probe sandbox availability once per run (lru_cache-backed — cheap on repeat calls).
+    # `sandboxed` is the mechanical-containment bool; `dev_containment` records the
+    # richer mode so audit/status distinguishes a wrapped run from a prompt-only one.
     state.sandboxed = sandbox_available_for_profile(config.dev_profile)
+    state.dev_containment = sandbox_containment_mode(config.dev_profile)
     if config.dev_profile.mode == "cli" and config.dev_profile.sandbox_mode == "none":
         _log(
             "  WARNING: sandbox_mode: none — dev agent runs without write containment. "
             "Use for debugging only."
         )
+    elif state.dev_containment == "unavailable":
+        _log(
+            "  WARNING: sandbox_mode requested but the host sandbox (sandbox-exec/bwrap) "
+            "is unavailable — dev run will fail closed rather than run prompt-only."
+        )
+    elif state.dev_containment == "mechanical":
+        _log("  dev write containment: mechanical (host sandbox wrapper)")
     _preserve_error_type = state.error_type == "max_iterations_no_submit"
     if not _preserve_error_type:
         state.error_type = None

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1877,6 +1877,7 @@ def _run_review_only_phase(
         **hard_convention_review_kwargs(config),
         assembled_context=review_context,
         sandboxed=state.sandboxed,
+        containment=state.dev_containment,
     )
 
     meta = ReviewCycleMetadata(

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -701,6 +701,7 @@ def _run_review_pool(
                     **hard_convention_review_kwargs(config),
                     assembled_context=review_context,
                     sandboxed=state.sandboxed,
+                    containment=state.dev_containment,
                     fix_claim_flags=fix_claim_flags,
                 )
                 for p in pool
@@ -724,6 +725,7 @@ def _run_review_pool(
                 **hard_convention_review_kwargs(config),
                 assembled_context=review_context,
                 sandboxed=state.sandboxed,
+                containment=state.dev_containment,
                 fix_claim_flags=fix_claim_flags,
             )
         )

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -203,6 +203,10 @@ class DevIterationTelemetry:
     tests_fixed_count: int = 0
     meaningful_progress: bool | None = None
     sandboxed: bool = True
+    # How writes were contained this iteration: "mechanical" (host sandbox
+    # wrapper), "native" (provider --sandbox flag), "unavailable" (fail-closed),
+    # or "none". Distinguishes real containment from prompt-only runs (#1907).
+    containment: str = "none"
     agent_exit_code: int | None = None
     runner_failure_code: str | None = None
     runner_failure_summary: str | None = None
@@ -477,7 +481,11 @@ class CoordinatorState:
     log_dir: Path | None = None  # per-story log directory under <project_root>/.forge/logs/
     error: str | None = None
     error_type: str | None = None
-    sandboxed: bool = False  # True if sandbox isolation was available at dev-phase entry
+    sandboxed: bool = False  # True if mechanical containment was available at dev-phase entry
+    # Containment classification for the dev run: "mechanical" | "native" |
+    # "unavailable" | "none". Surfaced in audit/status so a prompt-only run is
+    # never reported as mechanically contained (#1907).
+    dev_containment: str = "none"
     dev_escalated: bool = False  # True once model escalation has occurred this run
     timeout_escalation_used: bool = (
         False  # True once a timeout escalation has fired this sprint; gates re-escalation

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -22,6 +22,7 @@ from theforge.task.handoff_parser import ParseError, extract_dev_handoff
 from theforge.workspace_env import build_workspace_env
 
 from ..config import ModelProfile
+from .sandbox import workspace_effect_sandbox_command
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -38,6 +39,19 @@ def _log_verbose(msg: str) -> None:
 
 
 # ── Argv builder ──────────────────────────────────────────────────────
+
+
+def _claude_state_write_roots() -> tuple[Path, ...]:
+    """Home paths the Claude CLI must write to under sandbox containment.
+
+    Claude persists session transcripts, todos, telemetry, and config under
+    ``~/.claude`` (and legacy ``~/.claude.json``). Granting write access to
+    just these keeps session persistence working while leaving the worktree the
+    only project-side writable root — the containment boundary is not widened to
+    the project root or sibling worktrees.
+    """
+    home = Path.home()
+    return (home / ".claude", home / ".claude.json")
 
 
 def build_argv(
@@ -624,16 +638,61 @@ def _run_claude(
 ) -> AgentResult:
     """Invoke `claude -p --output-format stream-json --verbose` as a subprocess."""
     # NOTE: Claude CLI has no mechanically-enforced read-only mode. When
-    # sandbox_mode == "read-only" we apply --permission-mode default (set by
-    # build_argv) and log a warning so operators know the read-only constraint
-    # is not syscall-enforced.
+    # sandbox_mode == "read-only" the host wrapper still confines *writes* to
+    # the worktree (see below), but it does not enforce read-only; we log a
+    # warning so operators know that constraint is not syscall-enforced.
     if profile.sandbox_mode == "read-only":
         _log(
             "  WARNING: sandbox_mode=read-only is not mechanically enforced by Claude CLI; "
-            "applying --permission-mode default (writes require permission approval). "
+            "writes are contained to the worktree but reads are not restricted. "
             "Use a provider/API profile for true read-only enforcement."
         )
     cmd: list[str] = build_argv(profile=profile, session_id=session_id)
+
+    # Mechanical write containment: wrap the Claude CLI in the host sandbox
+    # (macOS sandbox-exec / Linux bwrap) so absolute-path writes and commits
+    # cannot escape the story worktree (#1907). Claude's native --permission-mode
+    # (added by build_argv) is retained as cooperative defense-in-depth, but it
+    # is NOT the containment boundary — a dev agent bypasses it with absolute
+    # paths, which is exactly how #1443 committed to the release checkout.
+    #
+    # Fail closed like runner_gemini: if the host sandbox is unavailable and
+    # sandbox_mode is not "none", refuse to run rather than fall back to
+    # prompt-only discipline. The earlier attempt (#920) was reverted (#925)
+    # because the sandbox blocked Claude's macOS Keychain auth ("Not logged
+    # in"); allow_credential_services now grants the securityd mach-lookup +
+    # keychain reads, and ~/.claude stays writable, so auth and session
+    # persistence survive containment.
+    if profile.sandbox_mode != "none":
+        sandboxed_cmd = workspace_effect_sandbox_command(
+            cmd,
+            working_dir,
+            extra_write_roots=_claude_state_write_roots(),
+            allow_credential_services=True,
+        )
+        if sandboxed_cmd[0] == cmd[0]:
+            _log(
+                f"✗ claude: sandbox_mode={profile.sandbox_mode!r} requested but platform "
+                "sandbox (sandbox-exec/bwrap) is unavailable — refusing to run unsandboxed. "
+                "Set sandbox_mode: none to explicitly opt out of write containment."
+            )
+            return AgentResult(
+                success=False,
+                output=(
+                    f"SANDBOX_UNAVAILABLE: sandbox_mode={profile.sandbox_mode!r} is set but "
+                    "the platform sandbox (sandbox-exec on macOS, bwrap on Linux) is not "
+                    "available on this host. Claude CLI relies on OS sandboxing for "
+                    "mechanical write containment. Set sandbox_mode: none to run without "
+                    "write containment."
+                ),
+                session_id=None,
+                cost_usd=None,
+                exit_code=-1,
+                raw={},
+                profile_name=profile.name,
+                startup_failure=True,
+            )
+        cmd = sandboxed_cmd
 
     # Unset CLAUDECODE so the subprocess isn't blocked by the nested-session check
     env = build_workspace_env(working_dir, extra=secrets)

--- a/src/theforge/runners/sandbox.py
+++ b/src/theforge/runners/sandbox.py
@@ -108,6 +108,98 @@ def _dedupe_resolved(paths: list[Path] | tuple[Path, ...]) -> tuple[Path, ...]:
     return tuple(out)
 
 
+def _parse_worktree_gitdir(git_file: Path, root: Path) -> Path | None:
+    """Resolve the real gitdir from a linked worktree's ``.git`` pointer file."""
+    content = git_file.read_text(encoding="utf-8").strip()
+    prefix = "gitdir:"
+    if not content.startswith(prefix):
+        return None
+    target = Path(content[len(prefix) :].strip())
+    if not target.is_absolute():
+        target = root / target
+    return target.resolve()
+
+
+def _resolve_common_dir(gitdir: Path) -> Path | None:
+    """Resolve the shared common dir (object store + refs) for a worktree gitdir."""
+    commondir_file = gitdir / "commondir"
+    if commondir_file.exists():
+        rel = commondir_file.read_text(encoding="utf-8").strip()
+        candidate = Path(rel)
+        if not candidate.is_absolute():
+            candidate = gitdir / candidate
+        return candidate.resolve()
+    # Standard layout fallback: <common>/worktrees/<name>.
+    if gitdir.parent.name == "worktrees":
+        return gitdir.parent.parent.resolve()
+    return None
+
+
+def _worktree_branch_namespace(gitdir: Path, common: Path) -> Path | None:
+    """Return the shared refs dir holding the worktree's *own* branch ref.
+
+    E.g. HEAD ``ref: refs/heads/feat/issue-1907`` → ``<common>/refs/heads/feat``.
+    Scoping to the branch's namespace lets the worktree update (and lock) its own
+    ref while leaving sibling namespaces like ``refs/heads/main`` / ``release``
+    read-only. Returns None for a detached HEAD (no shared branch ref).
+    """
+    head = (gitdir / "HEAD").read_text(encoding="utf-8").strip()
+    prefix = "ref:"
+    if not head.startswith(prefix):
+        return None
+    ref = head[len(prefix) :].strip()
+    if not ref:
+        return None
+    return (common / ref).resolve().parent
+
+
+def _git_worktree_write_roots(allowed_root: Path) -> tuple[Path, ...]:
+    """Writable git paths a wrapped CLI needs to commit *within* this worktree.
+
+    A linked git worktree keeps its private state under
+    ``<repo>/.git/worktrees/<name>`` and shares the object store and refs under
+    ``<repo>/.git`` — all outside the worktree root. Without write access there,
+    a legitimate ``git commit`` from the correctly-scoped worktree fails with
+    "Operation not permitted" (#1907 review P1).
+
+    Scope stays tight so containment is preserved: only the worktree's own
+    private gitdir, the shared object store and reflogs (a reflog cannot move a
+    ref), packed-refs, and the *namespace directory of the worktree's own branch
+    ref*. The main checkout's index/HEAD and other branches' refs stay
+    read-only, so ``cd <project-root> && git commit`` and
+    ``git update-ref refs/heads/main`` still fail mechanically (the #1443 vector).
+    """
+    root = allowed_root.resolve()
+    git_path = root / ".git"
+    try:
+        if not git_path.exists():
+            return ()
+        if git_path.is_dir():
+            # Non-worktree checkout: allowed_root is the repo itself; its whole
+            # .git is the private gitdir and there is no separate main checkout.
+            return (git_path.resolve(),)
+        gitdir = _parse_worktree_gitdir(git_path, root)
+        if gitdir is None:
+            return ()
+        roots: list[Path] = [gitdir]
+        common = _resolve_common_dir(gitdir)
+        if common is not None:
+            packed_refs = common / "packed-refs"
+            roots += [
+                common / "objects",
+                common / "logs",
+                packed_refs,
+                packed_refs.with_name("packed-refs.lock"),
+            ]
+            branch_ns = _worktree_branch_namespace(gitdir, common)
+            # Fall back to the shared refs dir only when the branch cannot be
+            # determined (e.g. detached HEAD) — a rare, functional degradation.
+            roots.append(branch_ns if branch_ns is not None else common / "refs")
+        return _dedupe_resolved(roots)
+    except OSError:
+        return ()
+
+
 @lru_cache(maxsize=None)
 def _credential_read_roots() -> tuple[Path, ...]:
     """Keychain directories a macOS CLI must open to authenticate under sandbox.
@@ -329,12 +421,17 @@ def workspace_effect_sandbox_command(
     access a CLI needs to authenticate under the sandbox (macOS securityd);
     without it, wrapping Claude reproduces the #925 "Not logged in" regression.
 
+    The worktree's own git internals (private gitdir, shared object store, and
+    its own branch-ref namespace) are granted automatically so ``git commit``
+    from the correctly-scoped worktree works, while the main checkout and other
+    branches' refs stay read-only.
+
     Returns *cmd* unchanged when no host sandbox (sandbox-exec/bwrap) is
     available — callers that require mechanical containment must detect this
     (``result[0] == cmd[0]``) and fail closed.
     """
     root = allowed_root.resolve()
-    extra_write_roots = tuple(extra_write_roots)
+    extra_write_roots = tuple(extra_write_roots) + _git_worktree_write_roots(root)
     blocked_worktrees = _blocked_worktree_roots(root)
     if _SYSTEM == "Darwin":
         profile = _macos_profile(

--- a/src/theforge/runners/sandbox.py
+++ b/src/theforge/runners/sandbox.py
@@ -90,6 +90,40 @@ def _blocked_worktree_roots(allowed_root: Path) -> tuple[Path, ...]:
     return tuple(blocked)
 
 
+def _dedupe_resolved(paths: list[Path] | tuple[Path, ...]) -> tuple[Path, ...]:
+    """Resolve + dedupe paths without dropping ones that do not exist yet.
+
+    Used for *write* roots the wrapped CLI may need to create on first use
+    (e.g. Claude's ``~/.claude`` state dir on a fresh host). Existence-filtering
+    those would silently strip the allowance and break the CLI under sandbox.
+    """
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for path in paths:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        out.append(resolved)
+    return tuple(out)
+
+
+@lru_cache(maxsize=None)
+def _credential_read_roots() -> tuple[Path, ...]:
+    """Keychain directories a macOS CLI must open to authenticate under sandbox.
+
+    Claude Code stores its OAuth token in the login Keychain, reached via
+    ``securityd``. Granting the ``com.apple.SecurityServer`` mach-lookup is not
+    enough on a host that does not otherwise expose ``$HOME`` for reads — the
+    client still opens the keychain database directory to locate the item. This
+    was the root cause of the #925 "Not logged in" regression that reverted the
+    prior Claude sandbox-wrapping attempt (#920).
+    """
+    return _unique_existing_paths(
+        [Path.home() / "Library" / "Keychains", Path("/Library") / "Keychains"]
+    )
+
+
 @lru_cache(maxsize=None)
 def _user_config_roots() -> tuple[Path, ...]:
     home = Path.home()
@@ -149,9 +183,12 @@ def _macos_profile(
     allowed_root: Path,
     *,
     extra_read_roots: tuple[Path, ...] = (),
+    extra_write_roots: tuple[Path, ...] = (),
     denied_read_roots: tuple[Path, ...] = (),
+    allow_credential_services: bool = False,
 ) -> str:
     root = allowed_root.resolve()
+    cred_read_roots = _credential_read_roots() if allow_credential_services else ()
     read_roots = _unique_existing_paths(
         [
             Path("/usr"),
@@ -163,6 +200,7 @@ def _macos_profile(
             Path("/System"),
             Path("/Applications"),
             *_workspace_read_roots(root),
+            *cred_read_roots,
             *extra_read_roots,
         ]
     )
@@ -171,29 +209,47 @@ def _macos_profile(
         f'    (subpath "{_escape_subpath(path)}")'
         for path in _unique_existing_paths(list(denied_read_roots))
     )
-    escaped_root = _escape_subpath(root)
+    # Write roots: worktree + ephemeral tmp/dev, plus any CLI-scoped state dirs
+    # (e.g. Claude's ~/.claude). Keeping this list tight is the containment
+    # boundary — never widen it to the project root or sibling worktrees.
+    write_roots = _dedupe_resolved(
+        [root, Path("/private/tmp"), Path("/tmp"), Path("/dev"), *extra_write_roots]
+    )
+    write_rules = "\n".join(f'    (subpath "{_escape_subpath(path)}")' for path in write_roots)
+    # A wrapped network-bound CLI (Gemini/Claude) needs outbound egress and DNS
+    # resolution via mDNSResponder; without these the launcher cannot reach its
+    # provider API. These are capability (not filesystem) grants, so they do not
+    # widen the write boundary. SecurityServer is added only when the CLI
+    # authenticates through the OS keychain (see _credential_read_roots).
+    service_lines = [
+        "(allow network-outbound)",
+        "(allow network-inbound)",
+        "(allow system-socket)",
+        '(allow mach-lookup (global-name "com.apple.mDNSResponder"))',
+    ]
+    if allow_credential_services:
+        service_lines.append('(allow mach-lookup (global-name "com.apple.SecurityServer"))')
+    service_block = "\n".join(service_lines)
     deny_block = ""
     if deny_rules:
         deny_block = f"""(deny file-read*
 {deny_rules}
 )
 """
-    return f'''(version 1)
+    return f"""(version 1)
 (deny default)
 (import "system.sb")
 (allow process-exec)
 (allow process-fork)
 (allow signal (target self))
+{service_block}
 (allow file-write*
-    (subpath "{escaped_root}")
-    (subpath "/private/tmp")
-    (subpath "/tmp")
-    (subpath "/dev")
+{write_rules}
 )
 (allow file-read*
 {read_rules}
 )
-{deny_block}'''
+{deny_block}"""
 
 
 def _linux_command(
@@ -201,6 +257,7 @@ def _linux_command(
     allowed_root: Path,
     *,
     extra_read_roots: tuple[Path, ...] = (),
+    extra_write_roots: tuple[Path, ...] = (),
     masked_read_roots: tuple[Path, ...] = (),
 ) -> list[str]:
     root = allowed_root.resolve()
@@ -237,11 +294,16 @@ def _linux_command(
         wrapped.extend(["--ro-bind-try", str(read_root), str(read_root)])
     for masked_root in _unique_existing_paths(list(masked_read_roots)):
         wrapped.extend(["--tmpfs", str(masked_root)])
+    wrapped.extend(["--bind", str(root), str(root)])
+    # CLI-scoped writable state (e.g. Claude's ~/.claude). --bind-try tolerates
+    # a path that does not exist yet so a fresh host can create it. Skip the
+    # worktree itself (already bound above) so we never double-bind it.
+    for write_root in _dedupe_resolved(extra_write_roots):
+        if write_root == root:
+            continue
+        wrapped.extend(["--bind-try", str(write_root), str(write_root)])
     wrapped.extend(
         [
-            "--bind",
-            str(root),
-            str(root),
             "--tmpfs",
             "/tmp",
             "--chdir",
@@ -252,11 +314,35 @@ def _linux_command(
     return wrapped
 
 
-def workspace_effect_sandbox_command(cmd: list[str], allowed_root: Path) -> list[str]:
+def workspace_effect_sandbox_command(
+    cmd: list[str],
+    allowed_root: Path,
+    *,
+    extra_write_roots: tuple[Path, ...] | list[Path] = (),
+    allow_credential_services: bool = False,
+) -> list[str]:
+    """Wrap *cmd* so filesystem writes are confined to *allowed_root*.
+
+    ``extra_write_roots`` grants additional writable paths a CLI needs for its
+    own state (e.g. Claude's ``~/.claude``) without widening the worktree
+    boundary. ``allow_credential_services`` additionally grants the OS keychain
+    access a CLI needs to authenticate under the sandbox (macOS securityd);
+    without it, wrapping Claude reproduces the #925 "Not logged in" regression.
+
+    Returns *cmd* unchanged when no host sandbox (sandbox-exec/bwrap) is
+    available — callers that require mechanical containment must detect this
+    (``result[0] == cmd[0]``) and fail closed.
+    """
     root = allowed_root.resolve()
+    extra_write_roots = tuple(extra_write_roots)
     blocked_worktrees = _blocked_worktree_roots(root)
     if _SYSTEM == "Darwin":
-        profile = _macos_profile(root, denied_read_roots=blocked_worktrees)
+        profile = _macos_profile(
+            root,
+            extra_write_roots=extra_write_roots,
+            denied_read_roots=blocked_worktrees,
+            allow_credential_services=allow_credential_services,
+        )
         if _sandbox_available(
             "sandbox-exec", ("sandbox-exec", "-p", "(version 1) (allow default)", "true")
         ):
@@ -264,7 +350,12 @@ def workspace_effect_sandbox_command(cmd: list[str], allowed_root: Path) -> list
         return cmd
     if _SYSTEM == "Linux":
         if _sandbox_available("bwrap", ("bwrap", "--ro-bind", "/", "/", "true")):
-            return _linux_command(cmd, root, masked_read_roots=blocked_worktrees)
+            return _linux_command(
+                cmd,
+                root,
+                extra_write_roots=extra_write_roots,
+                masked_read_roots=blocked_worktrees,
+            )
         return cmd
     return cmd
 

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -170,6 +170,7 @@ def build_review_prompt(
     no_scratch_files: bool | None = None,
     assembled_context: ContextPack | None = None,
     sandboxed: bool = True,
+    containment: str | None = None,
     fix_claim_flags: list[str] | None = None,
 ) -> str:
     """Build the review agent prompt.
@@ -394,7 +395,20 @@ def build_review_prompt(
               suggestion: ""
         """)
 
-    sandbox_label = "enabled" if sandboxed else "DISABLED (unsandboxed — effects ran unconfined)"
+    # Distinguish mechanical containment from native-flag / prompt-only runs so
+    # the reviewer knows whether write confinement was syscall-enforced (#1907).
+    _containment_labels = {
+        "mechanical": "MECHANICAL (host sandbox wrapper confined writes to the worktree)",
+        "native": "NATIVE (provider sandbox flag confined writes to the worktree)",
+        "unavailable": "DISABLED (containment requested but host sandbox unavailable)",
+        "none": "DISABLED (unsandboxed — effects ran unconfined)",
+    }
+    if containment is not None:
+        sandbox_label = _containment_labels.get(
+            containment, "enabled" if sandboxed else _containment_labels["none"]
+        )
+    else:
+        sandbox_label = "enabled" if sandboxed else _containment_labels["none"]
     _hard_block = render_hard_conventions_block(
         stack=stack,
         allowed_root_files=allowed_root_files,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,8 @@ def dev_profile() -> ModelProfile:
         budget_usd=2.0,
         timeout_seconds=900,
         allowed_tools=("Read", "Edit", "Write", "Bash"),
+        # sandbox wrapping is tested in test_runner_claude.py / test_runner_sandbox.py
+        sandbox_mode="none",
     )
 
 
@@ -256,6 +258,8 @@ def review_profile() -> ModelProfile:
         budget_usd=1.0,
         timeout_seconds=300,
         allowed_tools=("Read", "Bash"),
+        # sandbox wrapping is tested in test_runner_claude.py / test_runner_sandbox.py
+        sandbox_mode="none",
     )
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 import pytest
 
 from theforge.config import ModelProfile
-from theforge.config.auth import check_agent_auth
+from theforge.config.auth import (
+    check_agent_auth,
+    sandbox_available_for_profile,
+    sandbox_containment_mode,
+)
 
 # ── Helpers ────────────────────────────────────────────────────────────
 
@@ -314,3 +318,57 @@ def test_cli_profile_can_skip_sandbox_readiness_for_auth_only() -> None:
         ok, reason = check_agent_auth(profile, {}, include_sandbox_readiness=False)
     assert ok is True
     assert reason == ""
+
+
+# ── Mechanical containment readiness (#1907) ──────────────────────────
+
+
+def _sandbox_cli_profile(cli: str, sandbox_mode: str = "workspace-write") -> ModelProfile:
+    return ModelProfile(
+        name=f"{cli}-dev",
+        cli=cli,
+        model="sonnet",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=("Read", "Edit", "Write", "Bash"),
+        sandbox_mode=sandbox_mode,
+    )
+
+
+def test_claude_cli_readiness_follows_host_wrapper_available() -> None:
+    """Claude CLI is only 'mechanically sandboxed' when the host wrapper exists."""
+    profile = _sandbox_cli_profile("claude")
+    with patch("theforge.config.auth._host_sandbox_available", return_value=True):
+        assert sandbox_available_for_profile(profile) is True
+    with patch("theforge.config.auth._host_sandbox_available", return_value=False):
+        assert sandbox_available_for_profile(profile) is False
+
+
+def test_gemini_cli_readiness_follows_host_wrapper_available() -> None:
+    profile = _sandbox_cli_profile("gemini")
+    with patch("theforge.config.auth._host_sandbox_available", return_value=False):
+        assert sandbox_available_for_profile(profile) is False
+
+
+def test_claude_cli_sandbox_mode_none_is_not_mechanical() -> None:
+    """sandbox_mode=none must never report mechanical containment, wrapper or not."""
+    profile = _sandbox_cli_profile("claude", sandbox_mode="none")
+    with patch("theforge.config.auth._host_sandbox_available", return_value=True):
+        assert sandbox_available_for_profile(profile) is False
+
+
+def test_codex_cli_is_mechanical_without_host_wrapper() -> None:
+    """Codex asserts a provider-native --sandbox flag, so it stays mechanical."""
+    profile = _sandbox_cli_profile("codex")
+    with patch("theforge.config.auth._host_sandbox_available", return_value=False):
+        assert sandbox_available_for_profile(profile) is True
+
+
+def test_containment_mode_classifications() -> None:
+    claude = _sandbox_cli_profile("claude")
+    with patch("theforge.config.auth._host_sandbox_available", return_value=True):
+        assert sandbox_containment_mode(claude) == "mechanical"
+    with patch("theforge.config.auth._host_sandbox_available", return_value=False):
+        assert sandbox_containment_mode(claude) == "unavailable"
+    assert sandbox_containment_mode(_sandbox_cli_profile("claude", "none")) == "none"
+    assert sandbox_containment_mode(_sandbox_cli_profile("codex")) == "native"

--- a/tests/test_coord_sandbox.py
+++ b/tests/test_coord_sandbox.py
@@ -148,6 +148,87 @@ class TestStateAndAuditSandboxed:
             assert iteration["sandboxed"] is True
 
 
+class TestStateAndAuditContainment:
+    """Test that dev containment mode is recorded in state and audit (#1907)."""
+
+    @patch(
+        "theforge.coordinator.dev_phase.sandbox_containment_mode",
+        return_value="mechanical",
+    )
+    @patch("theforge.coordinator.dev_phase.sandbox_available_for_profile", return_value=True)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_containment_mode_recorded_in_state_and_audit(
+        self,
+        mock_shell,
+        mock_dev_agent,
+        mock_preflight_agent,
+        mock_pool,
+        mock_sandbox_probe,
+        mock_containment,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        _write_handoff(workspace)
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        mock_shell.side_effect = _shell_with_gate(workspace)
+        mock_dev_agent.return_value = _make_agent_result()
+        mock_preflight_agent.return_value = _PREFLIGHT_RESULT
+        mock_pool.return_value = [_make_agent_result(output=APPROVE_REVIEW)]
+
+        result = run_task(config, task)
+
+        assert result.state.dev_containment == "mechanical"
+        assert result.state.dev_iteration_telemetry, "Expected at least one dev iteration"
+        for item in result.state.dev_iteration_telemetry:
+            assert item.containment == "mechanical"
+
+        log = generate_audit_log(config, task, result)
+        for iteration in log["iterations"]["dev_loop"]:
+            assert iteration["containment"] == "mechanical"
+
+
+class TestReviewPromptContainment:
+    """Reviewer prompt distinguishes mechanical containment from prompt-only (#1907)."""
+
+    def _prompt(self, **kwargs: object) -> str:
+        from theforge.task import TaskStory
+
+        task = TaskStory(name="T", story_path=Path("/fake/spec.md"), slug="t")
+        return build_review_prompt(
+            task,
+            story_content="Implement X.",
+            commit_log="abc123 feat: x",
+            commit_diffs="diff --git ...",
+            workspace_path="/tmp/ws",
+            branch="feat/t",
+            handoff_content="gate_decision: PASS",
+            **kwargs,
+        )
+
+    def test_mechanical_containment_labeled(self) -> None:
+        prompt = self._prompt(sandboxed=True, containment="mechanical")
+        assert "Sandbox isolation: MECHANICAL" in prompt
+
+    def test_native_containment_labeled(self) -> None:
+        prompt = self._prompt(sandboxed=True, containment="native")
+        assert "Sandbox isolation: NATIVE" in prompt
+
+    def test_unavailable_containment_labeled_disabled(self) -> None:
+        prompt = self._prompt(sandboxed=False, containment="unavailable")
+        assert "Sandbox isolation: DISABLED" in prompt
+
+    def test_none_containment_labeled_disabled(self) -> None:
+        prompt = self._prompt(sandboxed=False, containment="none")
+        assert "Sandbox isolation: DISABLED" in prompt
+
+
 class TestReviewPromptSandboxStatus:
     """Test that build_review_prompt surfaces sandbox status correctly."""
 

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -288,6 +288,7 @@ class TestClaudeGroupKill(_RunnerGroupKillBase):
             budget_usd=2.0,
             timeout_seconds=2,
             allowed_tools=("Bash",),
+            sandbox_mode="none",
         )
         result = _run_claude(
             prompt="do the thing",
@@ -333,6 +334,7 @@ class TestClaudeGroupKill(_RunnerGroupKillBase):
             budget_usd=2.0,
             timeout_seconds=30,
             allowed_tools=("Bash",),
+            sandbox_mode="none",
         )
         with pytest.raises(SystemExit):
             _run_claude(

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -38,6 +38,41 @@ def _result_line(**fields: object) -> str:
     return json.dumps({"type": "result", **fields}) + "\n"
 
 
+def _make_claude_profile(sandbox_mode: str = "workspace-write") -> ModelProfile:
+    return ModelProfile(
+        name="dev",
+        cli="claude",
+        model="sonnet",
+        budget_usd=2.0,
+        timeout_seconds=900,
+        allowed_tools=("Read", "Edit", "Write", "Bash"),
+        sandbox_mode=sandbox_mode,
+    )
+
+
+def _fake_wrap(cmd: list[str], working_dir: Path, **kwargs: object) -> list[str]:
+    """Deterministic sandbox wrapper stub — prefixes a marker so tests do not
+    depend on whether the host actually has sandbox-exec/bwrap available."""
+    return ["sandbox-exec", "-p", "PROFILE", *cmd]
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_sandbox_wrapper():
+    """Claude lifecycle tests (with mocked Popen) exercise streaming/cost/session
+    behavior, not sandbox containment (covered by TestClaudeSandboxWrapper and
+    test_runner_sandbox.py). Neutralize the host sandbox wrapper with a
+    deterministic sandbox-exec prefix so these tests do not fail closed on
+    hosts/CI where sandbox-exec/bwrap is unavailable (the gate scrub can hide
+    it). Real-subprocess tests (TestClaudeLifecycle) run with sandbox_mode=none
+    so they exec the fake CLI directly; tests that assert wrapping override this
+    with their own patch."""
+    with patch(
+        "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+        side_effect=_fake_wrap,
+    ):
+        yield
+
+
 class TestHybridRunner:
     @pytest.fixture
     def api_profile(self) -> ModelProfile:
@@ -578,20 +613,18 @@ class TestClaudePermissionMode:
         return mock_popen.call_args[0][0]
 
     def test_workspace_write_adds_permission_mode(self, tmp_path: Path) -> None:
-        """sandbox_mode=workspace-write → --permission-mode default in cmd."""
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="workspace-write",
-        )
+        """sandbox_mode=workspace-write → --permission-mode default in the (wrapped) cmd."""
+        profile = _make_claude_profile("workspace-write")
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
-        with patch(
-            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-        ) as mock_popen:
+        with (
+            patch(
+                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+                side_effect=_fake_wrap,
+            ),
+            patch(
+                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+            ) as mock_popen,
+        ):
             run_agent(prompt="test", profile=profile, working_dir=tmp_path)
         cmd = self._popen_capture(mock_popen)
         assert "--permission-mode" in cmd
@@ -603,21 +636,19 @@ class TestClaudePermissionMode:
         mechanically enforced by Claude CLI."""
         import theforge.runners.runner_claude as _mod
 
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="read-only",
-        )
+        profile = _make_claude_profile("read-only")
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
-        with patch(
-            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-        ) as mock_popen:
-            with patch.object(_mod, "_log") as mock_log:
-                run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        with (
+            patch(
+                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+                side_effect=_fake_wrap,
+            ),
+            patch(
+                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+            ) as mock_popen,
+            patch.object(_mod, "_log") as mock_log,
+        ):
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
         cmd = self._popen_capture(mock_popen)
         assert "--permission-mode" in cmd
         # A warning must be logged explaining that read-only is not mechanically enforced
@@ -627,23 +658,115 @@ class TestClaudePermissionMode:
         )
 
     def test_none_omits_permission_mode(self, tmp_path: Path) -> None:
-        """sandbox_mode=none → no --permission-mode flag in cmd."""
-        profile = ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=900,
-            allowed_tools=("Read", "Edit", "Write", "Bash"),
-            sandbox_mode="none",
-        )
+        """sandbox_mode=none → no --permission-mode flag, and no sandbox wrapping."""
+        profile = _make_claude_profile("none")
         mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
-        with patch(
-            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-        ) as mock_popen:
+        with (
+            patch(
+                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+                side_effect=_fake_wrap,
+            ) as mock_wrap,
+            patch(
+                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+            ) as mock_popen,
+        ):
             run_agent(prompt="test", profile=profile, working_dir=tmp_path)
         cmd = self._popen_capture(mock_popen)
         assert "--permission-mode" not in cmd
+        mock_wrap.assert_not_called()
+        assert cmd[0] == "claude"
+
+
+class TestClaudeSandboxWrapper:
+    """Assert the Claude CLI is mechanically wrapped / fails closed (#1907)."""
+
+    def test_workspace_write_wraps_command(self, tmp_path: Path) -> None:
+        """sandbox_mode != none → the raw claude argv is wrapped, not passed to Popen directly."""
+        profile = _make_claude_profile("workspace-write")
+        mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
+        with (
+            patch(
+                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+                side_effect=_fake_wrap,
+            ) as mock_wrap,
+            patch(
+                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+            ) as mock_popen,
+        ):
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        mock_wrap.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
+        # Contained mode: Popen receives the wrapper, NOT the bare claude argv.
+        assert cmd[0] == "sandbox-exec"
+        assert cmd[0] != "claude"
+        assert "claude" in cmd
+
+    def test_wrapper_receives_credential_services_and_claude_state_roots(
+        self, tmp_path: Path
+    ) -> None:
+        """The wrap grants keychain auth + ~/.claude writes so containment does not break auth."""
+        profile = _make_claude_profile("workspace-write")
+        mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
+        with (
+            patch(
+                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+                side_effect=_fake_wrap,
+            ) as mock_wrap,
+            patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc),
+        ):
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        _, kwargs = mock_wrap.call_args
+        assert kwargs["allow_credential_services"] is True
+        write_roots = [str(p) for p in kwargs["extra_write_roots"]]
+        assert any(p.endswith("/.claude") for p in write_roots)
+
+    def test_read_only_also_wraps(self, tmp_path: Path) -> None:
+        """read-only still gets host-wrapped for write containment to the worktree."""
+        profile = _make_claude_profile("read-only")
+        mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
+        with (
+            patch(
+                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+                side_effect=_fake_wrap,
+            ) as mock_wrap,
+            patch("theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc),
+        ):
+            run_agent(prompt="test", profile=profile, working_dir=tmp_path)
+        mock_wrap.assert_called_once()
+
+    def test_sandbox_unavailable_fails_closed(self, tmp_path: Path) -> None:
+        """Host sandbox unavailable → runner fails closed without launching claude."""
+        profile = _make_claude_profile("workspace-write")
+        with (
+            patch(
+                "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+                side_effect=lambda cmd, wd, **kw: list(cmd),
+            ),
+            patch("theforge.runners.runner_claude.subprocess.Popen") as mock_popen,
+        ):
+            result = _run_claude(prompt="test", profile=profile, working_dir=tmp_path)
+        # Claude must NOT be launched — we fail before Popen.
+        mock_popen.assert_not_called()
+        assert result.success is False
+        assert result.startup_failure is True
+        assert result.exit_code == -1
+        assert "SANDBOX_UNAVAILABLE" in result.output
+
+    def test_none_mode_runs_unwrapped(self, tmp_path: Path) -> None:
+        """sandbox_mode=none → no wrapping; the bare claude argv is launched."""
+        profile = _make_claude_profile("none")
+        mock_proc = _make_stream_mock([_result_line(result="done", total_cost_usd=0.01)])
+        with (
+            patch("theforge.runners.runner_claude.workspace_effect_sandbox_command") as mock_wrap,
+            patch(
+                "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
+            ) as mock_popen,
+        ):
+            result = _run_claude(prompt="test", profile=profile, working_dir=tmp_path)
+        mock_wrap.assert_not_called()
+        mock_popen.assert_called_once()
+        assert mock_popen.call_args[0][0][0] == "claude"
+        assert result.success is True
 
 
 class TestClaudeSessionIdHelper:
@@ -958,12 +1081,18 @@ class TestRunAgentUnknownCli:
         assert result.profile_name == "dev"
 
 
-def test_claude_launcher_invokes_cmd_directly(dev_profile: ModelProfile, tmp_path: Path) -> None:
+def test_claude_launcher_invokes_cmd_directly_when_sandbox_none(tmp_path: Path) -> None:
+    """sandbox_mode=none is the only mode that launches the bare claude argv (#1907).
+
+    With containment requested the launcher is wrapped instead — see
+    TestClaudeSandboxWrapper.
+    """
+    profile = _make_claude_profile("none")
     mock_proc = _make_stream_mock([_result_line(result="done")])
     with patch(
         "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
     ) as mock_popen:
-        run_agent(prompt="test", profile=dev_profile, working_dir=tmp_path)
+        run_agent(prompt="test", profile=profile, working_dir=tmp_path)
     cmd = mock_popen.call_args[0][0]
     assert cmd[0] == "claude"
 
@@ -1010,6 +1139,9 @@ class TestClaudeLifecycle:
         monkeypatch.setattr("theforge.runners.runner_claude.build_workspace_env", _build)
 
     def _make_profile(self, timeout_seconds: int = 10, **kwargs: object) -> ModelProfile:
+        # sandbox_mode=none: these real-subprocess tests exec the fake CLI
+        # directly. Host sandbox wrapping is covered by TestClaudeSandboxWrapper.
+        kwargs.setdefault("sandbox_mode", "none")
         return ModelProfile(
             name="dev",
             cli="claude",

--- a/tests/test_runner_pool.py
+++ b/tests/test_runner_pool.py
@@ -32,6 +32,22 @@ def _result_line(**fields: object) -> str:
     return json.dumps({"type": "result", **fields}) + "\n"
 
 
+@pytest.fixture(autouse=True)
+def _neutralize_claude_sandbox_wrapper():
+    """These pool tests patch ``runner_claude.subprocess.Popen`` (which mutates
+    the shared ``subprocess`` module) and drive the Claude runner with default
+    workspace-write profiles. That would make the sandbox probe — which calls
+    ``subprocess.run`` — see the mocked Popen and report the host sandbox
+    unavailable, causing a spurious fail-closed. Neutralize the wrapper so pool
+    orchestration is what's under test; containment is covered in
+    test_runner_claude.py / test_runner_sandbox.py."""
+    with patch(
+        "theforge.runners.runner_claude.workspace_effect_sandbox_command",
+        side_effect=lambda cmd, working_dir, **kwargs: ["sandbox-exec", "-p", "P", *cmd],
+    ):
+        yield
+
+
 class TestRunAgentPool:
     """Test pool runner."""
 

--- a/tests/test_runner_sandbox.py
+++ b/tests/test_runner_sandbox.py
@@ -5,6 +5,7 @@ import os
 import platform
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -290,12 +291,18 @@ def test_workspace_effect_command_grants_worktree_git_writes_macos(tmp_path: Pat
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-only sandbox-exec test")
-def test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice(
-    tmp_path: Path,
-) -> None:
+def test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice() -> None:
     """Executable regression for #1443/#1907: under the real sandbox profile a
     legitimate commit inside the story worktree succeeds, while writing/committing
-    to the project root or a sibling worktree fails mechanically."""
+    to the project root or a sibling worktree fails mechanically.
+
+    The project tree is anchored under /private/var/tmp rather than pytest's
+    tmp_path: the sandbox profile intentionally grants write to /tmp (agent
+    scratch), and under the scrubbed gate (env -i strips TMPDIR) tmp_path lands
+    in /tmp, which would make every "write is denied" assertion vacuously fail.
+    /private/var/tmp is a real, writable, non-granted location on macOS — the
+    same relationship the real worktree has to the project checkout.
+    """
     git = shutil.which("git")
     if git is None:
         pytest.skip("git unavailable")
@@ -310,10 +317,13 @@ def test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice(
     if probe.returncode != 0 and "Operation not permitted" in (probe.stderr + probe.stdout):
         pytest.skip("sandbox-exec present but denied by host environment")
 
+    base = Path("/private/var/tmp")
+    if not base.is_dir():
+        pytest.skip("/private/var/tmp unavailable")
+
     from theforge.runners.sandbox import workspace_effect_sandbox_command
 
-    proot = tmp_path / "proj"
-    proot.mkdir()
+    proot = Path(tempfile.mkdtemp(dir=str(base))).resolve()
     env = {
         **os.environ,
         "GIT_AUTHOR_NAME": "t",
@@ -327,63 +337,66 @@ def test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice(
             [git, *args], cwd=str(cwd), capture_output=True, text=True, env=env, check=True
         )
 
-    _git("init", "-q", "-b", "main", cwd=proot)
-    (proot / "base.txt").write_text("hello\n", encoding="utf-8")
-    _git("add", "base.txt", cwd=proot)
-    _git("commit", "-qm", "init", cwd=proot)
-    main_sha_before = _git("rev-parse", "main", cwd=proot).stdout.strip()
-    (proot / ".forge" / "worktrees").mkdir(parents=True)
-    worktree = proot / ".forge" / "worktrees" / "issue-1443"
-    sibling = proot / ".forge" / "worktrees" / "issue-999"
-    _git("worktree", "add", "-q", str(worktree), "-b", "feat/issue-1443", cwd=proot)
-    _git("worktree", "add", "-q", str(sibling), "-b", "feat/issue-999", cwd=proot)
+    try:
+        _git("init", "-q", "-b", "main", cwd=proot)
+        (proot / "base.txt").write_text("hello\n", encoding="utf-8")
+        _git("add", "base.txt", cwd=proot)
+        _git("commit", "-qm", "init", cwd=proot)
+        main_sha_before = _git("rev-parse", "main", cwd=proot).stdout.strip()
+        (proot / ".forge" / "worktrees").mkdir(parents=True)
+        worktree = proot / ".forge" / "worktrees" / "issue-1443"
+        sibling = proot / ".forge" / "worktrees" / "issue-999"
+        _git("worktree", "add", "-q", str(worktree), "-b", "feat/issue-1443", cwd=proot)
+        _git("worktree", "add", "-q", str(sibling), "-b", "feat/issue-999", cwd=proot)
 
-    # Clear the lru-cached probe: an earlier test that mocked subprocess.run can
-    # have poisoned it to False for this worker.
-    from theforge.runners import sandbox as _sbmod
+        # Clear the lru-cached probe: an earlier test that mocked subprocess.run
+        # can have poisoned it to False for this worker.
+        from theforge.runners import sandbox as _sbmod
 
-    _sbmod._sandbox_available.cache_clear()
-    wrapped = workspace_effect_sandbox_command(["true"], worktree)
-    if wrapped[0] != "sandbox-exec":
-        pytest.skip("host sandbox wrapper unavailable in this environment")
-    profile = wrapped[2]
+        _sbmod._sandbox_available.cache_clear()
+        wrapped = workspace_effect_sandbox_command(["true"], worktree)
+        if wrapped[0] != "sandbox-exec":
+            pytest.skip("host sandbox wrapper unavailable in this environment")
+        profile = wrapped[2]
 
-    def _sandboxed(script: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            ["sandbox-exec", "-p", profile, "bash", "-c", script],
-            capture_output=True,
-            text=True,
-            env=env,
-            check=False,
+        def _sandboxed(script: str) -> subprocess.CompletedProcess:
+            return subprocess.run(
+                ["sandbox-exec", "-p", profile, "bash", "-c", script],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+
+        # 1. Legitimate commit inside the story worktree SUCCEEDS.
+        ok = _sandboxed(
+            f"cd {worktree} && echo work > feature.txt && {git} add feature.txt && "
+            f"{git} commit -qm 'legit worktree commit'"
         )
+        assert ok.returncode == 0, f"worktree commit failed: {ok.stderr}"
 
-    # 1. Legitimate commit inside the story worktree SUCCEEDS.
-    ok = _sandboxed(
-        f"cd {worktree} && echo work > feature.txt && {git} add feature.txt && "
-        f"{git} commit -qm 'legit worktree commit'"
-    )
-    assert ok.returncode == 0, f"worktree commit failed: {ok.stderr}"
+        # 2. Writing a source file in the project root FAILS.
+        rogue_write = _sandboxed(f"echo x > {proot}/rogue.txt")
+        assert rogue_write.returncode != 0
+        assert not (proot / "rogue.txt").exists()
 
-    # 2. Writing a source file in the project root FAILS.
-    rogue_write = _sandboxed(f"echo x > {proot}/rogue.txt")
-    assert rogue_write.returncode != 0
-    assert not (proot / "rogue.txt").exists()
+        # 3. The #1443 vector — commit from the project root — FAILS.
+        rogue_commit = _sandboxed(
+            f"cd {proot} && echo x >> base.txt && {git} add base.txt && {git} commit -qm rogue"
+        )
+        assert rogue_commit.returncode != 0
 
-    # 3. The #1443 vector — commit from the project root — FAILS.
-    rogue_commit = _sandboxed(
-        f"cd {proot} && echo x >> base.txt && {git} add base.txt && {git} commit -qm rogue"
-    )
-    assert rogue_commit.returncode != 0
+        # 4. Rewriting the main branch ref FAILS (main is unchanged).
+        rogue_ref = _sandboxed(f"cd {worktree} && {git} update-ref refs/heads/main HEAD")
+        assert rogue_ref.returncode != 0
+        assert _git("rev-parse", "main", cwd=proot).stdout.strip() == main_sha_before
 
-    # 4. Rewriting the main branch ref FAILS (main is unchanged).
-    rogue_ref = _sandboxed(f"cd {worktree} && {git} update-ref refs/heads/main HEAD")
-    assert rogue_ref.returncode != 0
-    assert _git("rev-parse", "main", cwd=proot).stdout.strip() == main_sha_before
-
-    # 5. Writing into a sibling worktree FAILS.
-    sibling_write = _sandboxed(f"echo x > {sibling}/rogue.txt")
-    assert sibling_write.returncode != 0
-    assert not (sibling / "rogue.txt").exists()
+        # 5. Writing into a sibling worktree FAILS.
+        sibling_write = _sandboxed(f"echo x > {sibling}/rogue.txt")
+        assert sibling_write.returncode != 0
+        assert not (sibling / "rogue.txt").exists()
+    finally:
+        shutil.rmtree(proot, ignore_errors=True)
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-only sandbox-exec test")

--- a/tests/test_runner_sandbox.py
+++ b/tests/test_runner_sandbox.py
@@ -154,6 +154,74 @@ def test_user_config_roots_excludes_sensitive_credentials(tmp_path: Path) -> Non
     assert fake_home / ".ssh" not in roots
 
 
+def test_macos_profile_grants_network_and_dns(tmp_path: Path) -> None:
+    """A wrapped network-bound CLI needs outbound egress + mDNS to reach its API (#1907)."""
+    from theforge.runners.sandbox import _macos_profile
+
+    profile = _macos_profile(tmp_path)
+    assert "(allow network-outbound)" in profile
+    assert '(allow mach-lookup (global-name "com.apple.mDNSResponder"))' in profile
+
+
+def test_macos_profile_credential_services_adds_keychain_access(tmp_path: Path) -> None:
+    """allow_credential_services grants securityd + keychain reads so auth survives (#1907)."""
+    from theforge.runners.sandbox import _macos_profile
+
+    without = _macos_profile(tmp_path)
+    assert "com.apple.SecurityServer" not in without
+
+    with_creds = _macos_profile(tmp_path, allow_credential_services=True)
+    assert '(allow mach-lookup (global-name "com.apple.SecurityServer"))' in with_creds
+    keychains = str((Path.home() / "Library" / "Keychains").resolve())
+    if (Path.home() / "Library" / "Keychains").exists():
+        assert keychains in with_creds
+
+
+def test_macos_profile_extra_write_roots_are_writable(tmp_path: Path) -> None:
+    """Claude's ~/.claude-style state dir appears in the file-write* block, not read-only."""
+    from theforge.runners.sandbox import _macos_profile
+
+    state_dir = tmp_path / "state"
+    profile = _macos_profile(tmp_path, extra_write_roots=(state_dir,))
+    write_block = profile.split("(allow file-read*")[0]
+    assert f'(subpath "{state_dir.resolve()}")' in write_block
+
+
+def test_linux_command_binds_extra_write_roots(tmp_path: Path) -> None:
+    from theforge.runners.sandbox import workspace_effect_sandbox_command
+
+    worktree = tmp_path / ".forge" / "worktrees" / "issue-1"
+    worktree.mkdir(parents=True)
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    with (
+        patch("theforge.runners.sandbox._SYSTEM", "Linux"),
+        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
+    ):
+        wrapped = workspace_effect_sandbox_command(
+            ["bash", "-c", "pwd"], worktree, extra_write_roots=(state_dir,)
+        )
+    assert "--bind-try" in wrapped
+    idx = wrapped.index("--bind-try")
+    assert wrapped[idx + 1] == str(state_dir.resolve())
+
+
+def test_workspace_effect_command_threads_credential_services(tmp_path: Path) -> None:
+    """allow_credential_services reaches the macOS profile through the public wrapper."""
+    from theforge.runners.sandbox import workspace_effect_sandbox_command
+
+    with (
+        patch("theforge.runners.sandbox._SYSTEM", "Darwin"),
+        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
+    ):
+        wrapped = workspace_effect_sandbox_command(
+            ["claude", "-p"], tmp_path, allow_credential_services=True
+        )
+    assert wrapped[0] == "sandbox-exec"
+    profile = wrapped[2]
+    assert "com.apple.SecurityServer" in profile
+
+
 @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-only sandbox-exec test")
 def test_macos_sandbox_profile_blocks_sibling_worktree_reads_in_practice(tmp_path: Path) -> None:
     from theforge.runners.sandbox import _blocked_worktree_roots, _macos_profile

--- a/tests/test_runner_sandbox.py
+++ b/tests/test_runner_sandbox.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import platform
 import shutil
 import subprocess
@@ -220,6 +221,169 @@ def test_workspace_effect_command_threads_credential_services(tmp_path: Path) ->
     assert wrapped[0] == "sandbox-exec"
     profile = wrapped[2]
     assert "com.apple.SecurityServer" in profile
+
+
+def _make_fake_linked_worktree(root: Path, name: str, branch: str) -> Path:
+    """Build a linked-worktree layout (``.git`` pointer file + gitdir) without git."""
+    common = root / ".git"
+    gitdir = common / "worktrees" / name
+    gitdir.mkdir(parents=True)
+    (gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    (gitdir / "HEAD").write_text(f"ref: {branch}\n", encoding="utf-8")
+    (common / "objects").mkdir(parents=True)
+    (common / "refs" / "heads").mkdir(parents=True)
+    worktree = root / ".forge" / "worktrees" / name
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+    return worktree
+
+
+def test_git_worktree_write_roots_scopes_to_branch_namespace(tmp_path: Path) -> None:
+    """The worktree's own gitdir/objects/branch-namespace are writable; the common
+    root and other branches' refs are not (preserves the #1443 containment)."""
+    from theforge.runners.sandbox import _git_worktree_write_roots
+
+    worktree = _make_fake_linked_worktree(tmp_path, "issue-1907", "refs/heads/feat/issue-1907")
+    common = tmp_path / ".git"
+
+    roots = {str(p) for p in _git_worktree_write_roots(worktree)}
+
+    assert str((common / "worktrees" / "issue-1907").resolve()) in roots
+    assert str((common / "objects").resolve()) in roots
+    assert str((common / "refs" / "heads" / "feat").resolve()) in roots
+    # Must NOT grant the common root (main index/HEAD) or the whole refs tree.
+    assert str(common.resolve()) not in roots
+    assert str((common / "refs").resolve()) not in roots
+    assert str((common / "refs" / "heads").resolve()) not in roots
+
+
+def test_git_worktree_write_roots_plain_repo_grants_whole_gitdir(tmp_path: Path) -> None:
+    """A non-worktree checkout (``.git`` is a real dir) grants its whole .git."""
+    from theforge.runners.sandbox import _git_worktree_write_roots
+
+    (tmp_path / ".git" / "objects").mkdir(parents=True)
+    roots = {str(p) for p in _git_worktree_write_roots(tmp_path)}
+    assert str((tmp_path / ".git").resolve()) in roots
+
+
+def test_git_worktree_write_roots_no_git_returns_empty(tmp_path: Path) -> None:
+    from theforge.runners.sandbox import _git_worktree_write_roots
+
+    assert _git_worktree_write_roots(tmp_path) == ()
+
+
+def test_workspace_effect_command_grants_worktree_git_writes_macos(tmp_path: Path) -> None:
+    """The generated macOS profile's write block includes the worktree git roots."""
+    from theforge.runners.sandbox import workspace_effect_sandbox_command
+
+    worktree = _make_fake_linked_worktree(tmp_path, "issue-1907", "refs/heads/feat/issue-1907")
+    common = tmp_path / ".git"
+    with (
+        patch("theforge.runners.sandbox._SYSTEM", "Darwin"),
+        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
+    ):
+        wrapped = workspace_effect_sandbox_command(["claude", "-p"], worktree)
+    profile = wrapped[2]
+    write_block = profile.split("(allow file-read*")[0]
+    assert f'(subpath "{(common / "objects").resolve()}")' in write_block
+    assert f'(subpath "{(common / "refs" / "heads" / "feat").resolve()}")' in write_block
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-only sandbox-exec test")
+def test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice(
+    tmp_path: Path,
+) -> None:
+    """Executable regression for #1443/#1907: under the real sandbox profile a
+    legitimate commit inside the story worktree succeeds, while writing/committing
+    to the project root or a sibling worktree fails mechanically."""
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git unavailable")
+    if shutil.which("sandbox-exec") is None:
+        pytest.skip("sandbox-exec unavailable")
+    probe = subprocess.run(
+        ["sandbox-exec", "-p", "(version 1)(allow default)", "true"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if probe.returncode != 0 and "Operation not permitted" in (probe.stderr + probe.stdout):
+        pytest.skip("sandbox-exec present but denied by host environment")
+
+    from theforge.runners.sandbox import workspace_effect_sandbox_command
+
+    proot = tmp_path / "proj"
+    proot.mkdir()
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t.co",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t.co",
+    }
+
+    def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [git, *args], cwd=str(cwd), capture_output=True, text=True, env=env, check=True
+        )
+
+    _git("init", "-q", "-b", "main", cwd=proot)
+    (proot / "base.txt").write_text("hello\n", encoding="utf-8")
+    _git("add", "base.txt", cwd=proot)
+    _git("commit", "-qm", "init", cwd=proot)
+    main_sha_before = _git("rev-parse", "main", cwd=proot).stdout.strip()
+    (proot / ".forge" / "worktrees").mkdir(parents=True)
+    worktree = proot / ".forge" / "worktrees" / "issue-1443"
+    sibling = proot / ".forge" / "worktrees" / "issue-999"
+    _git("worktree", "add", "-q", str(worktree), "-b", "feat/issue-1443", cwd=proot)
+    _git("worktree", "add", "-q", str(sibling), "-b", "feat/issue-999", cwd=proot)
+
+    # Clear the lru-cached probe: an earlier test that mocked subprocess.run can
+    # have poisoned it to False for this worker.
+    from theforge.runners import sandbox as _sbmod
+
+    _sbmod._sandbox_available.cache_clear()
+    wrapped = workspace_effect_sandbox_command(["true"], worktree)
+    if wrapped[0] != "sandbox-exec":
+        pytest.skip("host sandbox wrapper unavailable in this environment")
+    profile = wrapped[2]
+
+    def _sandboxed(script: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["sandbox-exec", "-p", profile, "bash", "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    # 1. Legitimate commit inside the story worktree SUCCEEDS.
+    ok = _sandboxed(
+        f"cd {worktree} && echo work > feature.txt && {git} add feature.txt && "
+        f"{git} commit -qm 'legit worktree commit'"
+    )
+    assert ok.returncode == 0, f"worktree commit failed: {ok.stderr}"
+
+    # 2. Writing a source file in the project root FAILS.
+    rogue_write = _sandboxed(f"echo x > {proot}/rogue.txt")
+    assert rogue_write.returncode != 0
+    assert not (proot / "rogue.txt").exists()
+
+    # 3. The #1443 vector — commit from the project root — FAILS.
+    rogue_commit = _sandboxed(
+        f"cd {proot} && echo x >> base.txt && {git} add base.txt && {git} commit -qm rogue"
+    )
+    assert rogue_commit.returncode != 0
+
+    # 4. Rewriting the main branch ref FAILS (main is unchanged).
+    rogue_ref = _sandboxed(f"cd {worktree} && {git} update-ref refs/heads/main HEAD")
+    assert rogue_ref.returncode != 0
+    assert _git("rev-parse", "main", cwd=proot).stdout.strip() == main_sha_before
+
+    # 5. Writing into a sibling worktree FAILS.
+    sibling_write = _sandboxed(f"echo x > {sibling}/rogue.txt")
+    assert sibling_write.returncode != 0
+    assert not (sibling / "rogue.txt").exists()
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-only sandbox-exec test")

--- a/tests/test_runner_stuck_detection.py
+++ b/tests/test_runner_stuck_detection.py
@@ -803,6 +803,9 @@ class TestClaudeCliStuckDetection:
             allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep"),
             phase="dev",
             stuck_detection=cfg,
+            # These real-subprocess tests exec the fake CLI directly; host
+            # sandbox wrapping is covered in test_runner_claude.py.
+            sandbox_mode="none",
         )
 
     def _build_stream(self, n_iterations: int) -> list[str]:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are fixed, the latest iteration only adjusts the executable test location, and no blocking regressions were found. | [google-gemini-3.5-flash] The Claude dev runner containment implementation is fully verified, robustly tested, and completely resolves all prior P1 findings. | [claude-sonnet] Iteration 2 fixes both cycle-1 P1s: the executable macOS test now proves a legitimate commit inside the story worktree succeeds while project-root writes/commits and main-ref rewrites still fail, and _git_worktree_write_roots grants only the worktree's own gitdir/objects/branch-namespace (not the whole refs tree or main checkout). Reproduced independently against this review worktree with sandbox-exec: worktree commit succeeded (exit 0), project-root commit and refs/heads/main rewrite both failed with 'Operation not permitted' (exit 128).

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $32.47
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Claude dev runner can write outside story worktree via absolute paths (GitHub Issue #1907)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1907