### PR TITLE
Sprint canonical run JSON path is not rebuild-safe when an existing run file is malformed

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -66,6 +66,14 @@ def _upsert_into_substrate(project_root: Path, record: dict) -> None:
         _log(f"warning: failed to update audit substrate: {exc}")
 
 
+def _replace_canonical_run_file(run_file: Path, record: dict) -> None:
+    """Atomically replace a canonical per-run JSON file."""
+    tmp_path = run_file.with_suffix(".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(record, f, default=str, indent=2)
+    tmp_path.replace(run_file)
+
+
 def _write_native_story_record(project_root: Path, audit_data: dict) -> None:
     """Write the canonical per-story run JSON and mirror it into the substrate."""
     run_id = audit_data.get("run_id")
@@ -97,13 +105,22 @@ def _write_native_story_record(project_root: Path, audit_data: dict) -> None:
         runs_dir.mkdir(parents=True, exist_ok=True)
         run_file = runs_dir / f"{run_id}.json"
         if not run_file.exists():
-            with open(run_file, "w", encoding="utf-8") as f:
-                json.dump(redacted, f, default=str, indent=2)
+            _replace_canonical_run_file(run_file, redacted)
             persisted = redacted
         else:
-            with open(run_file, encoding="utf-8") as f:
-                persisted = json.load(f)
-            if not isinstance(persisted, dict):
+            should_repair = False
+            try:
+                with open(run_file, encoding="utf-8") as f:
+                    persisted = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                persisted = redacted
+                should_repair = True
+            else:
+                if not isinstance(persisted, dict):
+                    persisted = redacted
+                    should_repair = True
+            if should_repair:
+                _replace_canonical_run_file(run_file, redacted)
                 persisted = redacted
 
         stat = run_file.stat()
@@ -122,7 +139,6 @@ def _write_native_story_record(project_root: Path, audit_data: dict) -> None:
             conn.close()
     except Exception as exc:  # noqa: BLE001
         _log(f"warning: failed to write native story audit record: {exc}")
-        _upsert_into_substrate(project_root, audit_data)
 
 
 def _build_advisory_summary(config: ForgeConfig | None) -> dict | None:

--- a/tests/test_coord_audit.py
+++ b/tests/test_coord_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -855,6 +856,67 @@ class TestSprintStoryAuditHistory:
         # Legacy jsonl path must NOT be written.
         history_path = tmp_path / ".forge" / "audits" / "history.jsonl"
         assert not history_path.exists()
+
+    def test_write_story_audit_repairs_malformed_existing_run_file(self, tmp_path: Path) -> None:
+        from theforge.sprint.audit import _write_story_audit
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        scenarios = {
+            "invalid-json": "not json{{{",
+            "non-object": "[1, 2, 3]",
+        }
+
+        for run_id, seeded in scenarios.items():
+            state = CoordinatorState()
+            state.log_dir = tmp_path / ".forge" / "logs" / task.slug
+            state.workspace_path = tmp_path / task.slug
+            state.workspace_path.mkdir(parents=True, exist_ok=True)
+            state.branch_name = f"forge/{task.slug}"
+            state.run_id = run_id
+            result = CoordinatorResult(
+                success=True,
+                phase=Phase.DONE,
+                state=state,
+                message="done",
+            )
+
+            run_file = audit_substrate.runs_dir(tmp_path) / f"{run_id}.json"
+            run_file.parent.mkdir(parents=True, exist_ok=True)
+            run_file.write_text(seeded, encoding="utf-8")
+
+            _write_story_audit(config, task, result)
+
+            persisted = json.loads(run_file.read_text(encoding="utf-8"))
+            assert isinstance(persisted, dict)
+            assert persisted["run_id"] == run_id
+            assert persisted["task"]["slug"] == task.slug
+
+            conn = audit_substrate.open_readonly(tmp_path)
+            try:
+                row = audit_substrate.latest_record_for(conn, run_id=run_id)
+            finally:
+                conn.close()
+            assert row is not None
+            assert row["task"]["slug"] == task.slug
+
+        summary = audit_substrate.rebuild_from_runs(tmp_path)
+        assert summary.failed == 0
+
+        for run_id in scenarios:
+            conn = audit_substrate.open_readonly(tmp_path)
+            try:
+                rebuilt = audit_substrate.latest_record_for(conn, run_id=run_id)
+                source_row = conn.execute(
+                    "SELECT source_path FROM audit_records WHERE run_id = ?",
+                    (run_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+            assert rebuilt is not None
+            assert rebuilt["task"]["slug"] == task.slug
+            assert source_row is not None
+            assert source_row["source_path"] == f".forge/audits/runs/{run_id}.json"
 
     def test_write_story_audit_logs_generate_failure(self, tmp_path: Path, capsys) -> None:
         from theforge.sprint.audit import _write_story_audit


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The fix repairs malformed canonical run files before mirroring and the focused rebuild regression passes. | [claude-opus] Malformed/non-object existing canonical run files are repaired atomically before substrate mirror, and the live-only fallback is removed; both edge cases are covered by a rebuild-safe regression test.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $0.76
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint canonical run JSON path is not rebuild-safe when an existing run file is malformed (GitHub Issue #1899)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1899