### PR TITLE
chore: land canonical per-run audit records

### DIFF
--- a/.forge/audits/runs/195fa3c6b2b7.json
+++ b/.forge/audits/runs/195fa3c6b2b7.json
@@ -1,0 +1,717 @@
+{
+  "schema_version": 9,
+  "run_id": "195fa3c6b2b7",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Score-driven reasoning effort \u2014 map complexity score to provider thinking budget per phase",
+    "slug": "issue-1108",
+    "story_path": null,
+    "story_text": "## What\n\nThe complexity score (1\u201310) currently drives only model tier selection and reviewer count. It does not affect reasoning effort \u2014 `reasoning_effort` and `thinking_budget` fields exist on `ModelRef` but are never set dynamically. A score-9 story gets the same thinking budget as a score-2 story on the same model.\n\n## Why\n\nModel tier selection and reasoning effort are orthogonal levers. A mid-tier model at high reasoning effort may outperform a strong-tier model at default effort on focused analytical tasks, at lower cost. The current design leaves the reasoning-effort knob always at default, discarding structured preflight information the system already has.\n\n## Acceptance Criteria\n\n- Score-to-reasoning-effort mapping is defined (suggested default: 1\u20133\u2192default/low, 4\u20136\u2192medium, 7\u20138\u2192high, 9\u201310\u2192max) and applied per-phase at assignment time.\n- Mapping is configurable per provider in `forge.yaml` because providers differ in how they express and honor reasoning effort.\n- The mapping applies independently to dev, plan, and review phases \u2014 plan may warrant higher effort than dev at the same score, for example.\n- If a provider does not support reasoning effort configuration, the field is ignored for that provider and the `routing_decision` block records the unsupported status.\n- The resolved reasoning effort, provider support status, score bucket, and threshold values are recorded in the `routing_decision` block from #1391, not only in a phase-end log line.\n- The feature does not create a separate rationale/audit surface; operator-facing output should read from `routing_decision`.\n- Tests cover per-phase mapping, provider override/config behavior, unsupported-provider handling, and `routing_decision` recording.\n\n## Notes\n\n- Depends on routing policy SSOT (#1107) \u2014 reasoning effort is another routing axis that benefits from a single policy table.\n- Distinct from model tier: changing tier changes the model; changing reasoning effort changes how hard the same model thinks.\n- Initial implementation can use the same three-bucket shape as dev tier; finer gradation can come later as empirical data accumulates.\n\n## References\n\n- ADR-0006 clause 7\n- #1391 \u2014 canonical `routing_decision` block\n",
+    "github_issue": 1108,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": false,
+    "final_phase": "ESCALATE",
+    "message": "Preflight: spec is blocked. The spec's entire premise contradicts an already-implemented, deliberate architectural decision in this exact codebase: src/theforge/routing.py explicitly marks the reasoning_effort axis as score_controlled=False with the rationale 'intentionally NOT score-controlled \u2014 a per-model config/override field, never derived from complexity_score', citing the SAME authorities the spec cites (issue #1391 and ADR-0006 clause 7). docs/guides/routing-policy.md further explains why: 'Wiring it to the score would couple a model's thinking budget to story complexity in a way operators cannot reason about per model.' This is not unimplemented work \u2014 it is work the codebase has already deliberately rejected and documented, under the same reference numbers the spec invokes as its own justification.",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T07:25:28.041013+00:00",
+    "finished_at": "2026-07-23T07:25:38.924311+00:00",
+    "duration_seconds": 10.883298
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1108",
+    "branch": "feat/issue-1108"
+  },
+  "iterations": {
+    "dev_attempts_total": 0,
+    "dev_iterations_productive": 0,
+    "review_cycles_total": 0,
+    "review_cycles": 0,
+    "dev_iterations": 0,
+    "gate_decisions": [],
+    "dev_loop": [],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [],
+    "usage_summary": {
+      "dev": {
+        "used": 0,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": false
+      },
+      "review": {
+        "used": 0,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": false,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": null,
+    "budget_consumption_log": []
+  },
+  "cost": {
+    "total_usd": 0.6578718499999999,
+    "dev_usd": 0,
+    "review_usd": 0,
+    "dev_invocations": 0,
+    "review_invocations": 0,
+    "agents": []
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "The spec's entire premise contradicts an already-implemented, deliberate architectural decision in this exact codebase: src/theforge/routing.py explicitly marks the reasoning_effort axis as score_controlled=False with the rationale 'intentionally NOT score-controlled \u2014 a per-model config/override field, never derived from complexity_score', citing the SAME authorities the spec cites (issue #1391 and ADR-0006 clause 7). docs/guides/routing-policy.md further explains why: 'Wiring it to the score would couple a model's thinking budget to story complexity in a way operators cannot reason about per model.' This is not unimplemented work \u2014 it is work the codebase has already deliberately rejected and documented, under the same reference numbers the spec invokes as its own justification.",
+    "complexity": "small",
+    "complexity_score": 2,
+    "implementation_complexity_score": 2,
+    "validation_complexity_score": 1,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 2",
+        "dimension": "implementation"
+      }
+    ],
+    "work_type": "feature",
+    "domains": [],
+    "contract_change": false,
+    "bundle_candidate": false,
+    "cost_usd": 0.6578718499999999,
+    "cached": true,
+    "original_verdict": "BLOCKED",
+    "source_run_id": "26abd6d13395",
+    "cache_snapshot": {
+      "worktree_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "b711a9ff6f45d2db719622f208c27d326f100dbe"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "current_worktree_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "current_evaluation_base_branch_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.6578718499999999,
+        "duration_s": 99.05,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "small",
+      "complexity_score": 2,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gemini-3.5-flash",
+          "source": "forge.yaml",
+          "canonical_id": "google/gemini-3.5-flash/api"
+        },
+        "plan_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          }
+        ],
+        "dev": {
+          "model": "sonnet",
+          "source": "builtin",
+          "canonical_id": "anthropic/sonnet/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "complexity score 2 (LOW) \u2192 tier cheap (profile success_rate=0.81 @ LOW); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 2 \u2192 tier mid ($8.33); per-story routing cost target: unset",
+        "plan_review": "1 reviewer(s), tier mid, providers ['openai'], complexity score 2; per-story routing cost target: unset",
+        "code_review": "1 reviewer(s), tier mid, providers ['openai'], complexity score 2; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 41.67,
+        "final_total_usd": 41.67,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "sonnet",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gemini-3.5-flash",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 41.67
+        }
+      },
+      "config_model_routing": {
+        "complexity": "small",
+        "complexity_score": 2,
+        "derived_plan_model": "gemini-3.5-flash",
+        "derived_dev_model": "gpt-5.4-mini",
+        "derived_review_pool": [
+          "gemini-3.5-flash"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [],
+  "dev_handoffs": [],
+  "dev_prompt_injections": [],
+  "reviews": [],
+  "reviewer_attempts": [],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": true,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": null,
+  "landing": null,
+  "landing_status": null,
+  "landing_event": null,
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": "Preflight: spec is blocked. The spec's entire premise contradicts an already-implemented, deliberate architectural decision in this exact codebase: src/theforge/routing.py explicitly marks the reasoning_effort axis as score_controlled=False with the rationale 'intentionally NOT score-controlled \u2014 a per-model config/override field, never derived from complexity_score', citing the SAME authorities the spec cites (issue #1391 and ADR-0006 clause 7). docs/guides/routing-policy.md further explains why: 'Wiring it to the score would couple a model's thinking budget to story complexity in a way operators cannot reason about per model.' This is not unimplemented work \u2014 it is work the codebase has already deliberately rejected and documented, under the same reference numbers the spec invokes as its own justification.",
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": null,
+  "finding_registry": [],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gemini-3.5-flash",
+        "tier": "mid",
+        "rationale": "[preflight] complexity score 2 \u2192 tier mid ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 2,
+      "base_tier_from_score": "cheap",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.807,
+              "weighted": 0.807,
+              "runs": 57,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.807
+            }
+          }
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "promotion_check": {
+        "fired": false,
+        "matching_records": 10,
+        "escalations": 0,
+        "outcome": "no_promotion"
+      },
+      "routing_rationale": {
+        "state": "stayed_at_preflight_tier",
+        "mechanism": null,
+        "from_tier": "cheap",
+        "to_tier": "cheap"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:small",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": "claude-sonnet",
+        "winner": "claude-sonnet",
+        "reason": "sprint_cap_reached",
+        "domains": []
+      },
+      "final": {
+        "model": "sonnet",
+        "tier": "cheap",
+        "rationale": "[preflight] complexity score 2 (LOW) \u2192 tier cheap (profile success_rate=0.81 @ LOW); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "anti_self_review"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 9,
+            "completed": 9,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 2,
+            "completed": 2,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5"
+        ],
+        "rationale": "[preflight] 1 reviewer(s), tier mid, providers ['openai'], complexity score 2; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 9,
+            "completed": 9,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 7,
+            "completed": 6,
+            "raw": 0.8571,
+            "weighted": 0.8611,
+            "rate": 0.8611,
+            "floor": "pass",
+            "selected": false
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5"
+        ],
+        "rationale": "[preflight] 1 reviewer(s), tier mid, providers ['openai'], complexity score 2; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [],
+  "trust_status": "unchecked",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.657872,
+      "duration_s": 99.05,
+      "outcome": "blocked"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": null,
+    "validate": null,
+    "review": null
+  },
+  "totals": {
+    "cost_usd": 0.657872,
+    "duration_s": 99.05,
+    "dev_attempts_total": 0,
+    "dev_iterations_productive": 0,
+    "review_cycles_total": 0,
+    "dev_iterations": 0,
+    "review_cycles": 0
+  },
+  "sprint_id": "849c9780c3bb",
+  "sprint_name": "issues-1899,158,1019,1108,1443,1489"
+}

--- a/.forge/audits/runs/250b58e44380.json
+++ b/.forge/audits/runs/250b58e44380.json
@@ -1,0 +1,1603 @@
+{
+  "schema_version": 9,
+  "run_id": "250b58e44380",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Escalation learning \u2014 auto-promotion from escalation history",
+    "slug": "issue-158",
+    "story_path": null,
+    "story_text": "---\ndepends_on:\n  - issue-169\n  - issue-283\n---\n\n## What\n\nBefore a story starts, the coordinator reads cross-run escalation history and model capability profiles to detect models that repeatedly fail at a given complexity band. When a pattern is detected, the coordinator pre-promotes the dev assignment to a higher tier \u2014 before the first iteration, not after a failure.\n\n## Why\n\nIn-run escalation (#296) reacts to failure after it happens \u2014 the dev agent burns cycles, hits persistent P1s, and then gets swapped. Cross-run learning prevents that waste entirely by recognizing \"sonnet fails at large-complexity dev 40% of the time\" and starting with opus from the beginning.\n\nThis is the learning layer that makes adaptive assignment improve over time rather than repeating the same mistakes across stories.\n\n## Depends On\n\n- #169 (model capability profiles) \u2014 the historical success/failure data this reads\n- #283 (adaptive model assignment) \u2014 the assignment function this modifies\n\n## Acceptance Criteria\n\n- Before assignment, the coordinator checks model profiles for the selected dev model's **recency-weighted** success rate at the story's complexity band, using the shared weighting mechanism (#1392 / ADR-0006 clause 2.4) \u2014 not a lifetime cumulative average\n- The escalation-history and profile reads **exclude runs flagged as tainted** by trust checks (ADR-0006 clause 4): a run that failed its own trust checks contributes no promotion weight\n- If the weighted success rate is below a configurable threshold (default: 60%) over a minimum sample size (default: 5 runs; ADR-0006 clause 2.3), the model is pre-promoted to the next tier; below the sample floor, no promotion fires and routing falls through to static tier logic\n- Pre-promotion is recorded in the `routing_decision` block (ADR-0006 clause 7 / #1391): the promotion mechanism firing, the evidence (model, complexity band, raw **and** recency-weighted success rate, sample size), and the resulting tier\n- **Symmetry / return path (ADR-0006 clause 5):** because this is a cross-run promotion, it has a paired, test-covered demotion. Recency weighting (clause 2.4) is the passive return path \u2014 as old failures age out, the weighted rate recovers and pre-promotion stops firing; the audit block records when the demotion could have fired but didn't (clause 7). A PR adding this promotion without the tested recovery path fails the clause-5 CI gate (#1389).\n- Pre-promotion respects the same guardrails as normal assignment (#168) \u2014 it cannot promote to a tier that violates guardrails\n- Pre-promotion is deterministic: same profile data + same complexity = same decision\n- Explicit profile overrides in forge.yaml bypass pre-promotion (override hierarchy, ADR-0006 clause 1)\n- Tests cover: pre-promotion triggers at threshold, no promotion above threshold, minimum sample size enforced, recency recovery reverses the promotion, tainted runs excluded from the rate, explicit override wins, guardrail compliance\n\n## ADR-0006 alignment (2026-07-21)\n\nThis is the cross-run promotion the ADR's \"one-way ratchet\" failure mode targets directly. Unlike the in-run escalations (#296/#330), it reads aggregated history, so it must obey the full admissibility set: recency weighting (clause 2.4 \u2014 no lifetime cumulative averages), sample floor (clause 2.3), taint exclusion (clause 4), a paired demotion via recency recovery (clause 5), audit recording (clause 7), and the operator override hierarchy (clause 1). The stale `depends_on` frontmatter (`issue-169`, `issue-283`) is file-story-era format; the prose \"Depends On\" section is authoritative \u2014 flag for cleanup if those slugs no longer map to live issues.\n\nReferences: ADR-0006 clauses 1, 2.3, 2.4, 4, 5, 7; #1392 (shared recency mechanism), #1391 (the `routing_decision` block), #1389 (clause-5 CI enforcement), #296 (the in-run counterpart).\n",
+    "github_issue": 158,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": true,
+    "final_phase": "DONE",
+    "message": "Task 'Escalation learning \u2014 auto-promotion from escalation history' completed. Review approved after 2 cycle(s), 1 dev iteration(s). Branch: feat/issue-158",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T06:35:46.728653+00:00",
+    "finished_at": "2026-07-23T07:15:58.683878+00:00",
+    "duration_seconds": 2411.955225
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-158",
+    "branch": "feat/issue-158"
+  },
+  "iterations": {
+    "dev_attempts_total": 2,
+    "dev_iterations_productive": 2,
+    "review_cycles_total": 2,
+    "review_cycles": 2,
+    "dev_iterations": 2,
+    "gate_decisions": [
+      "PASS",
+      "PASS"
+    ],
+    "dev_loop": [
+      {
+        "cycle": 0,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 15.908036499999998,
+        "duration_s": 1652.07,
+        "meaningful_progress": true,
+        "files_changed": [
+          "docs/assets/sample-routing-decision-run.json",
+          "docs/routing-symmetry-followups.md",
+          "docs/v0.13-dogfood-readiness.md",
+          "src/theforge/assignment.py",
+          "src/theforge/cli/explain.py",
+          "src/theforge/config/models.py",
+          "src/theforge/config/types.py",
+          "src/theforge/coordinator/preflight.py",
+          "tests/test_assignment.py",
+          "tests/test_assignment_routing_decision.py",
+          "tests/test_audit_substrate.py",
+          "tests/test_cli_explain.py",
+          "tests/test_complexity_score_persistence.py",
+          "tests/test_config_models.py",
+          "tests/test_coord_model_profiles_seam.py",
+          "tests/test_routing_decision_audit.py",
+          "tests/test_routing_symmetry_invariant.py"
+        ],
+        "files_changed_count": 17,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      },
+      {
+        "cycle": 1,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 8.128649999999999,
+        "duration_s": 374.17,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/assignment.py",
+          "src/theforge/coordinator/preflight.py",
+          "src/theforge/coordinator/state.py",
+          "tests/test_assignment.py",
+          "tests/test_coord_model_profiles_seam.py"
+        ],
+        "files_changed_count": 5,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      }
+    ],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [
+      {
+        "iteration": 1,
+        "max_iterations": 5,
+        "verdict": "REQUEST_CHANGES",
+        "finding_counts": {
+          "P1": 1,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 1,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 1,
+        "restated_findings": 0,
+        "cost_usd": 0.0,
+        "duration_s": 181.6
+      },
+      {
+        "iteration": 2,
+        "max_iterations": 5,
+        "verdict": "APPROVE",
+        "finding_counts": {
+          "P1": 0,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 0,
+        "restated_findings": 0,
+        "cost_usd": 0.0,
+        "duration_s": 124.27
+      }
+    ],
+    "usage_summary": {
+      "dev": {
+        "used": 2,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": true
+      },
+      "review": {
+        "used": 2,
+        "max": 5,
+        "hit_limit": false,
+        "early_finish": true,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 7,
+      "complexity_band_input": "medium",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "claude-opus",
+      "model_actual": "opus",
+      "model_provider": null,
+      "model_cli": "claude",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 1350,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 7,
+      "base_review": 5,
+      "profile_history_runs": 139,
+      "profile_avg_iterations": 1.6115,
+      "profile_avg_cost_usd": 4.378961,
+      "profile_raw_dev_max": 2.4173,
+      "estimate_headroom_factor": 2.0,
+      "iteration_derived_timeout_seconds": 1350,
+      "profile_max_duration_s": 2064.04,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 3097,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": true,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 3097,
+      "chosen_dev_cost_estimate_usd": 8.7579,
+      "review_history_sample_size": 22,
+      "p75_review": 2,
+      "chosen_review_max": 5,
+      "rationale": "derived dev limits from 139 medium-band profile runs with 1.5x iteration headroom and 2.0x cost-estimate headroom; timeout floored on observed run duration+headroom (3097s). review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-23T06:35:47.542719+00:00"
+      },
+      {
+        "cycle": 1,
+        "cycle_count": 1,
+        "total_count": 2,
+        "timestamp": "2026-07-23T07:06:55.701423+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": null,
+    "dev_usd": 24.036686499999995,
+    "review_usd": null,
+    "dev_invocations": 2,
+    "review_invocations": 4,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 15.908036499999998,
+        "duration_seconds": 1652.0733309999341,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.005907
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 15.902129499999997
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 8.128649999999999,
+        "duration_seconds": 374.1722935839789,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 8.128649999999999
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 90.7167554164771,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 90.7167554164771,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 62.04753083299147,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 62.04753083299147,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "Substantial adjacent infrastructure exists (recency-weighted profile signal, taint exclusion, routing_decision block, symmetry-invariant CI registry) but the specific success-rate-threshold-driven dev pre-promotion mechanism described is not implemented \u2014 the current _check_promotion trigger uses an ESCALATE-outcome count (>=2 of last 10), not a recency-weighted success-rate/threshold/sample-floor computation drawn from model capability profiles.",
+    "complexity": "medium",
+    "complexity_score": 7,
+    "implementation_complexity_score": 7,
+    "validation_complexity_score": 1,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 7",
+        "dimension": "implementation"
+      },
+      {
+        "rule_id": "implementation_contract_change",
+        "signal": "contract change forces at least medium implementation complexity (shared-interface blast radius)",
+        "dimension": "implementation"
+      }
+    ],
+    "work_type": "feature",
+    "domains": [
+      "backend"
+    ],
+    "contract_change": true,
+    "bundle_candidate": false,
+    "cost_usd": 1.10371155,
+    "cached": true,
+    "original_verdict": "PROCEED",
+    "source_run_id": "d96e64bc2094",
+    "cache_snapshot": {
+      "worktree_head": "fad876d0e321b32b048598e528984cd70f5eb533",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "fad876d0e321b32b048598e528984cd70f5eb533"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "fad876d0e321b32b048598e528984cd70f5eb533",
+      "current_worktree_head": "fad876d0e321b32b048598e528984cd70f5eb533",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "fad876d0e321b32b048598e528984cd70f5eb533",
+      "current_evaluation_base_branch_head": "fad876d0e321b32b048598e528984cd70f5eb533",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 1.10371155,
+        "duration_s": 173.13,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "medium",
+      "complexity_score": 7,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gpt-5.5",
+          "source": "forge.yaml",
+          "canonical_id": "openai/gpt-5.5/cli"
+        },
+        "plan_reviewers": [
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          }
+        ],
+        "dev": {
+          "model": "opus",
+          "source": "builtin",
+          "canonical_id": "anthropic/opus/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "MEDIUM dev promoted claude-opus (tier strong \u2192 strong) \u2014 2/10 recent MEDIUM stories escalated (profile success_rate=0.91 @ MEDIUM); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 7 \u2192 tier strong ($8.33); per-story routing cost target: unset",
+        "plan_review": "2 reviewer(s), tier strong, providers ['anthropic', 'google'], complexity score 7; per-story routing cost target: unset",
+        "code_review": "2 reviewer(s), tier strong, providers ['openai', 'google'], complexity score 7; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 58.33,
+        "final_total_usd": 58.33,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "opus",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gpt-5.5",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 58.33
+        }
+      },
+      "config_model_routing": {
+        "complexity": "medium",
+        "complexity_score": 7,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "opus",
+        "derived_review_pool": [
+          "gemini-3.5-flash",
+          "gpt-5.4",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/config",
+          "lines": 17
+        }
+      ],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/config",
+          "lines": 17
+        }
+      ],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/config",
+          "lines": 17
+        }
+      ],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-158/iter_1.yaml",
+      "handoff": {
+        "summary": "Replaced the ESCALATE-count dev promotion trigger with a profile-backed recency-weighted success-rate signal. Before the first iteration, assign_models reads the selected dev model's recency-weighted success rate at the story's complexity band via model_profiles.get_dev_signal (tainted runs already excluded, clause 4), and pre-promotes one tier when the weighted rate is below the configurable dev_promotion_threshold (default 0.60) over dev_promotion_min_runs (default 5); below the floor no promotion fires and static tier logic continues. The paired return path is passive recency recovery (clause 2.4/5): as old failures age out the weighted rate recovers and pre-promotion stops firing, recorded in the dev demotion_check block (_dev_recency_demotion_check) and registered as the dev-promotion pair's inverse (MECHANISM_DEV_RECENCY_RECOVERY) in ROUTING_SYMMETRY_REGISTRY. routing_decision.promotion_check now carries model, band, raw+weighted rate, sample size, taint count, threshold, floor, and resulting tier. Explicit overrides and guardrail/budget precedence are unchanged. Added config validation, unit + routing-audit + symmetry + a preflight seam integration test, and regenerated the committed sample routing-decision JSON and dogfood-readiness doc from the live router.",
+        "commits": [
+          {
+            "sha": "b36d5b9",
+            "message": "feat(assignment): profile-backed dev pre-promotion from escalation history (#158)"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "Coordinator checks the selected dev model's recency-weighted success rate at the complexity band using the shared weighting mechanism (not lifetime average)",
+            "status": "MET",
+            "notes": "_check_promotion calls get_dev_signal with the config recency params; the ranked value is the recency-weighted rate (#1392). raw is surfaced alongside for drift auditing."
+          },
+          {
+            "criterion": "Escalation-history and profile reads exclude tainted runs (clause 4)",
+            "status": "MET",
+            "notes": "get_dev_signal excludes tainted runs upstream and surfaces tainted_runs. test_tainted_runs_excluded_from_promotion_rate asserts tainted runs don't count toward the floor/rate and the count is surfaced."
+          },
+          {
+            "criterion": "Below configurable threshold (default 60%) over minimum sample size (default 5) pre-promotes to next tier; below floor no promotion, falls through to static tier",
+            "status": "MET",
+            "notes": "dev_promotion_threshold=0.60, dev_promotion_min_runs=5. Covered by test_promotion_fires_below_threshold, test_no_promotion_above_threshold, test_minimum_sample_size_suppresses_promotion."
+          },
+          {
+            "criterion": "Pre-promotion recorded in routing_decision: mechanism firing, evidence (model, band, raw and recency-weighted rate, sample size), resulting tier",
+            "status": "MET",
+            "notes": "_promotion_check_block records all fields; test_full_reconstruction_from_block_alone asserts they are present, and the dogfood sample JSON shows a real firing/recovered case."
+          },
+          {
+            "criterion": "Symmetry / return path (clause 5): paired tested demotion via recency recovery; audit records when demotion could have fired but didn't; PR without it fails the clause-5 CI gate",
+            "status": "MET",
+            "notes": "Registry pair's demotion re-pointed to MECHANISM_DEV_RECENCY_RECOVERY (symbol _dev_recency_demotion_check); test_recency_recovery_reverses_promotion + test_dev_tier_pair_registers_recency_recovery_inverse; the symmetry-invariant test passes with both directions reachable and tested."
+          },
+          {
+            "criterion": "Pre-promotion respects the same guardrails as normal assignment (#168) \u2014 cannot promote to a disallowed tier",
+            "status": "MET",
+            "notes": "Promotion goes through _promote_tier (clamps at top tier) and the unchanged _pick_agent/_enforce_budget path. test_guardrail_promotion_cannot_exceed_top_tier confirms strong stays strong."
+          },
+          {
+            "criterion": "Pre-promotion is deterministic: same profile data + same complexity = same decision",
+            "status": "MET",
+            "notes": "Pure computation, no RNG. test_pre_promotion_is_deterministic asserts identical decision and promotion_check across two runs."
+          },
+          {
+            "criterion": "Explicit profile overrides in forge.yaml bypass pre-promotion (clause 1)",
+            "status": "MET",
+            "notes": "Explicit dev override short-circuits before the check; promotion_check stays not_checked. test_explicit_override_bypasses_pre_promotion."
+          },
+          {
+            "criterion": "Tests cover trigger at threshold, no promotion above, min sample enforced, recency recovery reverses, tainted excluded, explicit override wins, guardrail compliance",
+            "status": "MET",
+            "notes": "All seven cases added in tests/test_assignment.py plus a preflight\u2192assign_models\u2192state seam integration test (convention 8) in test_coord_model_profiles_seam.py."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": [
+          "Design decision (per plan Step 5): the dev-promotion symmetry-registry inverse is re-pointed from the post-plan checkpoint (#1387) to the recency-recovery condition. The post-plan checkpoint remains a real, independently tested in-run demotion \u2014 it is simply no longer THIS promotion's registered inverse.",
+          "Kept the sprint_promotions sticky cache and the assign_models escalation_history parameter for call-site compatibility. escalation_history no longer drives promotion (profiles, seeded/backfilled from that same history, now do); it is read as a no-op. The sticky cache provides within-sprint stability while recovery is the cross-run passive path.",
+          "Flagging per the spec's ADR-0006 alignment note: the story's depends_on frontmatter slugs (issue-169, issue-283) are file-story-era format and do not map to live issues; the prose Depends On section (#169/#283) is authoritative. Left for backlog cleanup."
+        ],
+        "deferred_items": "none"
+      }
+    },
+    {
+      "iteration": 2,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-158/iter_1.yaml",
+      "handoff": {
+        "summary": "Cycle-1 P1 fix: removed the same-sprint sprint_promotions cache that could fire a dev pre-promotion with sample_size 0 and null raw/weighted rates, bypassing the sample floor. The recency-weighted profile signal (model_profiles.get_dev_signal, tainted runs excluded) is now the sole authoritative driver: a promotion can only fire via PROMOTION_OUTCOME_PROMOTED, which requires the sample floor met AND a non-null weighted rate below threshold, so routing_decision.promotion_check can never report a fired promotion without admissible evidence. Dropped the sprint_promotions parameter from _check_promotion and assign_models, the preflight sticky pre-population block (and its now-unused imports), and the dead CoordinatorState.sprint_promotions field. Determinism makes a same-sprint cache unnecessary and also lets the recency-recovery return path fire within a sprint. Added sample-floor-contract regression tests (unit + assign_models seam) plus updated the preflight seam integration test.",
+        "commits": [
+          {
+            "sha": "e5c2941",
+            "message": "fix(assignment): make profile signal the sole dev pre-promotion driver (iter 1)"
+          },
+          {
+            "sha": "b36d5b9",
+            "message": "feat(assignment): profile-backed dev pre-promotion from escalation history (#158)"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "Coordinator checks the selected dev model's recency-weighted success rate at the complexity band using the shared weighting mechanism (not lifetime average)",
+            "status": "MET",
+            "notes": "_check_promotion calls get_dev_signal with config recency params; ranks on the recency-weighted rate (#1392), with raw surfaced for drift auditing."
+          },
+          {
+            "criterion": "Escalation-history and profile reads exclude tainted runs (clause 4)",
+            "status": "MET",
+            "notes": "get_dev_signal excludes tainted runs and surfaces tainted_runs; test_tainted_runs_excluded_from_promotion_rate asserts they don't count toward the floor/rate."
+          },
+          {
+            "criterion": "Below configurable threshold (default 60%) over minimum sample size (default 5) pre-promotes; below floor no promotion, falls through to static tier",
+            "status": "MET",
+            "notes": "dev_promotion_threshold=0.60, dev_promotion_min_runs=5. The P1 fix hardens this: NO path (including the removed cache) can fire below the floor. Covered by test_promotion_fires_below_threshold, test_no_promotion_above_threshold, test_minimum_sample_size_suppresses_promotion, and new test_promotion_never_fires_without_admissible_evidence."
+          },
+          {
+            "criterion": "Pre-promotion recorded in routing_decision: mechanism firing, evidence (model, band, raw and weighted rate, sample size), resulting tier",
+            "status": "MET",
+            "notes": "_promotion_check_block records all fields; test_assign_models_promotion_check_never_reports_null_evidence_firing guards against null-evidence firings; test_full_reconstruction_from_block_alone asserts field presence."
+          },
+          {
+            "criterion": "Symmetry / return path (clause 5): paired tested recency-recovery demotion; audit records when it could have fired but didn't; clause-5 CI gate satisfied",
+            "status": "MET",
+            "notes": "Registry pair inverse is MECHANISM_DEV_RECENCY_RECOVERY (_dev_recency_demotion_check); recovery can now fire within a sprint too. test_recency_recovery_reverses_promotion + symmetry invariant pass."
+          },
+          {
+            "criterion": "Pre-promotion respects the same guardrails as normal assignment (#168) \u2014 cannot promote to a disallowed tier",
+            "status": "MET",
+            "notes": "Promotion goes through _promote_tier (clamps at top tier) and the unchanged _pick_agent/_enforce_budget path. test_guardrail_promotion_cannot_exceed_top_tier."
+          },
+          {
+            "criterion": "Pre-promotion is deterministic: same profile data + same complexity = same decision",
+            "status": "MET",
+            "notes": "Pure computation, no cache to introduce path-dependence. test_pre_promotion_is_deterministic."
+          },
+          {
+            "criterion": "Explicit profile overrides in forge.yaml bypass pre-promotion (clause 1)",
+            "status": "MET",
+            "notes": "Explicit dev override short-circuits before the check; promotion_check stays not_checked. test_explicit_override_bypasses_pre_promotion."
+          },
+          {
+            "criterion": "Tests cover trigger at threshold, no promotion above, min sample enforced, recency recovery reverses, tainted excluded, explicit override wins, guardrail compliance",
+            "status": "MET",
+            "notes": "All cases present in tests/test_assignment.py, plus the new no-evidence-never-fires regression tests and the preflight\u2192assign_models\u2192state seam integration test (convention 8)."
+          }
+        ],
+        "gate_result": "BLOCKED",
+        "gate_delegated": true,
+        "story_deviations": [
+          "Removed the sprint_promotions same-sprint cache entirely (parameter, preflight pre-population, and CoordinatorState field) rather than storing evidence with it. This directly resolves the cycle-1 P1 (no fired promotion without admissible evidence), keeps the profile signal as the single authoritative driver per the plan's approach, and makes the recency-recovery return path observable within a sprint as well as across sprints.",
+          "The dev-promotion symmetry-registry inverse remains the recency-recovery condition (plan Step 5); the post-plan checkpoint (#1387) stays a separate, independently tested in-run demotion.",
+          "Flagging per the spec's ADR-0006 alignment note: the story's depends_on frontmatter slugs (issue-169, issue-283) are file-story-era format and do not map to live issues; the prose Depends On section (#169/#283) is authoritative. Left for backlog cleanup."
+        ],
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    },
+    {
+      "iteration": 2,
+      "finding_ids": [
+        "4ae15398faa77242"
+      ]
+    }
+  ],
+  "reviews": [
+    {
+      "cycle": 1,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "REQUEST_CHANGES",
+      "summary": "[openai-gpt-5.5] Same-sprint cached promotions can still fire without any admissible profile evidence, so the implementation does not consistently enforce the profile-backed sample-floor contract. | [google-gemini-3.5-flash] The profile-backed dev pre-promotion from escalation history is fully implemented, robustly tested, and perfectly aligned with ADR-0006.",
+      "sanitization_audit": null,
+      "p1_count": 1,
+      "p2_count": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "file": "src/theforge/assignment.py",
+          "line": 951,
+          "description": "When sprint_promotions already contains the story complexity, assign_models pre-promotes the dev tier with sample_size: 0, raw_success_rate: null, and weighted_success_rate: null even when no model profile data is available.",
+          "reviewers": [
+            "openai-gpt-5.5"
+          ],
+          "reporter": "openai-gpt-5.5"
+        }
+      ],
+      "ac_verification": [
+        {
+          "criterion": "Before assignment, the coordinator checks model profiles for the selected dev model's recency-weighted success rate at the story's complexity band, using the shared weighting mechanism (#1392 / ADR-0006 clause 2.4) \u2014 not a lifetime cumulative average",
+          "status": "PARTIAL",
+          "evidence": "Normal routing calls _check_promotion from assign_models at src/theforge/assignment.py:2422 and _check_promotion calls get_dev_signal with recency at src/theforge/assignment.py:983; tests/test_assignment.py:436 and tests/test_assignment.py:500 cover weighted promotion/recovery. The sticky branch at src/theforge/assignment.py:951 returns before the profile read.; src/theforge/assignment.py:2422-2430 calls _check_promotion which uses get_dev_signal from model_profiles.py to retrieve the recency-weighted rate. Covered by tests/test_assignment.py:test_promotion_fires_below_threshold."
+        },
+        {
+          "criterion": "The escalation-history and profile reads exclude runs flagged as tainted by trust checks (ADR-0006 clause 4): a run that failed its own trust checks contributes no promotion weight",
+          "status": "PARTIAL",
+          "evidence": "Profile folding excludes tainted runs in src/theforge/model_profiles.py:469 and get_dev_signal surfaces tainted counts at src/theforge/model_profiles.py:1117; tests/test_assignment.py:536 covers tainted counts. The sticky promotion branch at src/theforge/assignment.py:951 does not consult taint-excluded profile data.; src/theforge/assignment.py:983-992 calls get_dev_signal which excludes tainted runs upstream. Covered by tests/test_assignment.py:test_tainted_runs_excluded_from_promotion_rate."
+        },
+        {
+          "criterion": "If the weighted success rate is below a configurable threshold (default: 60%) over a minimum sample size (default: 5 runs; ADR-0006 clause 2.3), the model is pre-promoted to the next tier; below the sample floor, no promotion fires and routing falls through to static tier logic",
+          "status": "PARTIAL",
+          "evidence": "Threshold and floor are implemented in src/theforge/assignment.py:1015 and src/theforge/assignment.py:1020 with config parsing at src/theforge/config/models.py:855; tests/test_assignment.py:436, tests/test_assignment.py:463, and tests/test_assignment.py:482 cover the normal path. The sticky path at src/theforge/assignment.py:951 fires with no rate and zero runs.; src/theforge/assignment.py:1015-1025 checks the sample floor and threshold. Covered by tests/test_assignment.py:test_minimum_sample_size_suppresses_promotion and test_promotion_fires_below_threshold."
+        },
+        {
+          "criterion": "Pre-promotion is recorded in the routing_decision block (ADR-0006 clause 7 / #1391): the promotion mechanism firing, the evidence (model, complexity band, raw and recency-weighted success rate, sample size), and the resulting tier",
+          "status": "PARTIAL",
+          "evidence": "_promotion_check_block records the evidence fields at src/theforge/assignment.py:1036 and _build_routing_decision attaches it at src/theforge/assignment.py:1793; tests/test_routing_decision_audit.py:206 checks field presence. For sticky_sprint_promotion, src/theforge/assignment.py:951 produces raw=None, weighted=None, and runs=0 while fired=True.; src/theforge/assignment.py:1028-1050 implements _promotion_check_block. Covered by tests/test_routing_decision_audit.py:test_full_reconstruction_from_block_alone."
+        },
+        {
+          "criterion": "Symmetry / return path (ADR-0006 clause 5): because this is a cross-run promotion, it has a paired, test-covered demotion. Recency weighting (clause 2.4) is the passive return path \u2014 as old failures age out, the weighted rate recovers and pre-promotion stops firing; the audit block records when the demotion could have fired but didn't (clause 7). A PR adding this promotion without the tested recovery path fails the clause-5 CI gate (#1389).",
+          "status": "PARTIAL",
+          "evidence": "The registry pairs _check_promotion with dev_recency_recovery at src/theforge/assignment.py:145, and tests/test_assignment.py:500 plus tests/test_routing_symmetry_invariant.py:177 cover the normal recovery path. The sticky cache branch at src/theforge/assignment.py:951 keeps promotion firing without a weighted recovery signal.; src/theforge/assignment.py:148-175 registers the symmetry pair with MECHANISM_DEV_RECENCY_RECOVERY. Covered by tests/test_assignment.py:test_recency_recovery_reverses_promotion and tests/test_routing_symmetry_invariant.py:test_dev_tier_pair_registers_recency_recovery_inverse."
+        },
+        {
+          "criterion": "Pre-promotion respects the same guardrails as normal assignment (#168) \u2014 it cannot promote to a tier that violates guardrails",
+          "status": "VERIFIED",
+          "evidence": "Promotion uses the one-step tier clamp in src/theforge/assignment.py:622 and the final selection still goes through _pick_agent and budget enforcement at src/theforge/assignment.py:2465 and src/theforge/assignment.py:2836. tests/test_assignment.py:1352 covers the top-tier ceiling.; src/theforge/assignment.py:2433 promotes the tier via _promote_tier which clamps at the top tier. Covered by tests/test_assignment.py:test_guardrail_promotion_cannot_exceed_top_tier."
+        },
+        {
+          "criterion": "Pre-promotion is deterministic: same profile data + same complexity = same decision",
+          "status": "VERIFIED",
+          "evidence": "_check_promotion is pure over its inputs at src/theforge/assignment.py:921 and assign_models consumes that result deterministically at src/theforge/assignment.py:2432. tests/test_assignment.py:594 asserts identical decisions and promotion blocks across repeated calls.; src/theforge/assignment.py:921-1026 is pure computation with no RNG. Covered by tests/test_assignment.py:test_pre_promotion_is_deterministic."
+        },
+        {
+          "criterion": "Explicit profile overrides in forge.yaml bypass pre-promotion (override hierarchy, ADR-0006 clause 1)",
+          "status": "VERIFIED",
+          "evidence": "assign_models short-circuits the dev override before _check_promotion at src/theforge/assignment.py:2401, leaving the default not_checked block from src/theforge/assignment.py:2362. tests/test_assignment.py:559 covers an override that would otherwise have promoted.; src/theforge/assignment.py:2401-2406 bypasses the check if 'dev' is in explicit_profiles. Covered by tests/test_assignment.py:test_explicit_override_bypasses_pre_promotion."
+        },
+        {
+          "criterion": "Tests cover: pre-promotion triggers at threshold, no promotion above threshold, minimum sample size enforced, recency recovery reverses the promotion, tainted runs excluded from the rate, explicit override wins, guardrail compliance",
+          "status": "PARTIAL",
+          "evidence": "The named normal-path tests exist in tests/test_assignment.py:436, tests/test_assignment.py:463, tests/test_assignment.py:482, tests/test_assignment.py:500, tests/test_assignment.py:536, tests/test_assignment.py:559, and tests/test_assignment.py:1352, with a seam test at tests/test_coord_model_profiles_seam.py:312. The suite does not cover the cached promotion path against the same sample-floor and evidence requirements.; tests/test_assignment.py implements all seven test cases. Covered by tests/test_assignment.py."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    },
+    {
+      "cycle": 2,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "APPROVE",
+      "summary": "[openai-gpt-5.5] Cycle-1 cache P1 is resolved; the profile signal is now the only pre-promotion driver, and the targeted assignment/routing/audit tests pass. | [google-gemini-3.5-flash] The Cycle-1 P1 finding is fully resolved by removing the same-sprint cache, making the recency-weighted profile signal the sole authoritative driver for dev pre-promotion.",
+      "sanitization_audit": null,
+      "p1_count": 0,
+      "p2_count": 0,
+      "findings": [],
+      "ac_verification": [
+        {
+          "criterion": "Before assignment, the coordinator checks model profiles for the selected dev model's recency-weighted success rate at the story's complexity band, using the shared weighting mechanism (#1392 / ADR-0006 clause 2.4) \u2014 not a lifetime cumulative average",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/coordinator/preflight.py:1164-1178 invokes assign_models during preflight with model_profiles; src/theforge/assignment.py:2393-2414 selects the dev agent for the base tier and calls _check_promotion before the final dev pick; src/theforge/assignment.py:970-985 calls model_profiles.get_dev_signal with the configured recency object; src/theforge/model_profiles.py:1081-1148 computes and returns the recency-weighted rate. Covered by tests/test_assignment.py:436-460 and tests/test_coord_model_profiles_seam.py:313-404.; src/theforge/assignment.py:970-979 calls get_dev_signal with the configured recency parameters; tests/test_assignment.py:436-459 (test_promotion_fires_below_threshold) covers this behavior."
+        },
+        {
+          "criterion": "The escalation-history and profile reads exclude runs flagged as tainted by trust checks (ADR-0006 clause 4): a run that failed its own trust checks contributes no promotion weight",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/model_profiles.py:1045-1148 surfaces tainted_runs separately from admissible runs, and _check_promotion consumes only the returned runs/rate at src/theforge/assignment.py:980-1008. Covered by tests/test_assignment.py:536-556, which verifies tainted runs do not count toward the sample floor and are recorded in the audit.; src/theforge/assignment.py:970-985 uses get_dev_signal which filters out tainted runs; tests/test_assignment.py:514-532 (test_tainted_runs_excluded_from_promotion_rate) asserts that tainted runs do not count toward the floor or rate."
+        },
+        {
+          "criterion": "If the weighted success rate is below a configurable threshold (default: 60%) over a minimum sample size (default: 5 runs; ADR-0006 clause 2.3), the model is pre-promoted to the next tier; below the sample floor, no promotion fires and routing falls through to static tier logic",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/config/types.py:89-102 defines dev_promotion_threshold=0.60 and dev_promotion_min_runs=5; src/theforge/config/models.py:855-865 parses those config values; src/theforge/assignment.py:1002-1008 suppresses below-floor signals and fires only below threshold; src/theforge/assignment.py:2416-2421 promotes one tier only when the signal fires. Covered by tests/test_assignment.py:436-497 and tests/test_config_models.py:888-935.; src/theforge/assignment.py:1003-1012 enforces the sample floor and threshold check; tests/test_assignment.py:481-496 (test_minimum_sample_size_suppresses_promotion) asserts that no promotion fires below the sample floor."
+        },
+        {
+          "criterion": "Pre-promotion is recorded in the routing_decision block (ADR-0006 clause 7 / #1391): the promotion mechanism firing, the evidence (model, complexity band, raw and recency-weighted success rate, sample size), and the resulting tier",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:1015-1037 builds the promotion_check audit block with mechanism, fired, model, complexity, raw_success_rate, weighted_success_rate, sample_size, and resulting_tier; src/theforge/assignment.py:1780 includes it in routing_decision. Covered by tests/test_assignment.py:455-460, tests/test_assignment.py:1134-1148, and tests/test_routing_decision_audit.py:206-225.; src/theforge/assignment.py:1015-1037 (_promotion_check_block) constructs the audit block; tests/test_routing_decision_audit.py:209-227 (test_full_reconstruction_from_block_alone) asserts all fields are present."
+        },
+        {
+          "criterion": "Symmetry / return path (ADR-0006 clause 5): because this is a cross-run promotion, it has a paired, test-covered demotion. Recency weighting (clause 2.4) is the passive return path \u2014 as old failures age out, the weighted rate recovers and pre-promotion stops firing; the audit block records when the demotion could have fired but didn't (clause 7). A PR adding this promotion without the tested recovery path fails the clause-5 CI gate (#1389).",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:145-173 registers dev pre-promotion with dev_recency_recovery as its inverse; src/theforge/assignment.py:1040-1084 records the recency-recovery demotion outcome; src/theforge/assignment.py:1790-1797 writes that block into routing_decision. Covered by tests/test_assignment.py:500-533 and tests/test_routing_symmetry_invariant.py:177-194.; src/theforge/assignment.py:148-174 registers MECHANISM_DEV_RECENCY_RECOVERY as the paired inverse of MECHANISM_DEV_PROMOTION; tests/test_assignment.py:499-527 (test_recency_recovery_reverses_promotion) covers the recovery path."
+        },
+        {
+          "criterion": "Pre-promotion respects the same guardrails as normal assignment (#168) \u2014 it cannot promote to a tier that violates guardrails",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:2416-2421 routes fired promotion through _promote_tier, and src/theforge/assignment.py:2444-2457 then selects the final dev agent via the normal _pick_agent path; src/theforge/assignment.py:2482-2524 preserves the dev tier floor fallback. Covered by tests/test_assignment.py:1386-1405.; src/theforge/assignment.py:2417-2421 promotes the tier and picks the agent using the standard guardrail-compliant path; tests/test_assignment.py:1386-1407 (test_guardrail_promotion_cannot_exceed_top_tier) asserts that promotion clamps at the top tier."
+        },
+        {
+          "criterion": "Pre-promotion is deterministic: same profile data + same complexity = same decision",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:920-1012 implements _check_promotion as a pure profile read and comparison, with the prior sprint_promotions cache removed from src/theforge/assignment.py:2278-2293 and src/theforge/coordinator/state.py:576. Covered by tests/test_assignment.py:594-609.; src/theforge/assignment.py:920-1012 is a pure function of the profile data and complexity; tests/test_assignment.py:558-571 (test_pre_promotion_is_deterministic) asserts determinism."
+        },
+        {
+          "criterion": "Explicit profile overrides in forge.yaml bypass pre-promotion (override hierarchy, ADR-0006 clause 1)",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:2386-2390 short-circuits the dev role when an explicit profile is present, leaving the default not_checked promotion block from src/theforge/assignment.py:2345-2362. Covered by tests/test_assignment.py:559-591.; src/theforge/assignment.py:2359-2374 bypasses the check when explicit overrides are present; tests/test_assignment.py:535-555 (test_explicit_override_bypasses_pre_promotion) covers this bypass."
+        },
+        {
+          "criterion": "Tests cover: pre-promotion triggers at threshold, no promotion above threshold, minimum sample size enforced, recency recovery reverses the promotion, tainted runs excluded from the rate, explicit override wins, guardrail compliance",
+          "status": "VERIFIED",
+          "evidence": "tests/test_assignment.py:436-460 covers promotion firing below threshold; tests/test_assignment.py:463-479 covers no promotion above threshold; tests/test_assignment.py:482-497 covers the sample floor; tests/test_assignment.py:500-533 covers recency recovery; tests/test_assignment.py:536-556 covers tainted runs; tests/test_assignment.py:559-591 covers explicit override bypass; tests/test_assignment.py:1386-1405 covers guardrail compliance. I also ran pytest -q tests/test_assignment.py tests/test_coord_model_profiles_seam.py tests/test_assignment_routing_decision.py tests/test_routing_decision_audit.py tests/test_routing_symmetry_invariant.py tests/test_config_models.py tests/test_cli_explain.py and pytest -q tests/test_coord_audit.py tests/test_routing.py tests/test_audit_substrate.py tests/test_complexity_score_persistence.py tests/test_dogfood_readiness_sample.py; both passed.; tests/test_assignment.py contains dedicated tests for each of these scenarios, all of which are passing."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    }
+  ],
+  "reviewer_attempts": [
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    }
+  ],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": false,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": {
+    "action": "merge-pr",
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1902",
+    "merged": false,
+    "merge_queued": true,
+    "success": true,
+    "error": null,
+    "auto_merge_queued": true,
+    "landing_path": "fresh-merge",
+    "guard_evidence": {
+      "branch": "feat/issue-158",
+      "pr_url": "https://github.com/fuzzypete/theforge/pull/1902",
+      "merge_queued": true
+    }
+  },
+  "landing": {
+    "outcome": "merge-queued",
+    "landing_path": "fresh-merge",
+    "fresh_pr_created": true,
+    "merged": false,
+    "merge_queued": true,
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1902",
+    "pr_merged_at": null
+  },
+  "landing_status": "pending_integration",
+  "landing_event": {
+    "landing_status": "pending_integration",
+    "landed": false,
+    "timestamp": "2026-07-23T07:15:58.683878+00:00"
+  },
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": null,
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": [
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_model_profiles_seam.py",
+      "detail": "tests/test_coord_model_profiles_seam.py has 1005 lines (limit 1000)",
+      "blocking": false
+    }
+  ],
+  "finding_registry": [
+    {
+      "finding_id": "4ae15398faa77242",
+      "cycle_first_seen": 1,
+      "cycle_last_seen": 1,
+      "file": "src/theforge/assignment.py",
+      "line": 951,
+      "severity": "P1",
+      "description": "When sprint_promotions already contains the story complexity, assign_models pre-promotes the dev tier with sample_size: 0, raw_success_rate: null, and weighted_success_rate: null even when no model profile data is available.",
+      "reporter": "openai-gpt-5.5",
+      "disposition": "fixed"
+    }
+  ],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.5",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 7 \u2192 tier strong ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 7,
+      "base_tier_from_score": "strong",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.9065,
+              "weighted": 0.9065,
+              "runs": 139,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.9065
+            },
+            "domain": {
+              "domains": [
+                "backend"
+              ],
+              "raw": 1.0,
+              "weighted": 1.0,
+              "runs": 1,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 1,
+                  "raw": 1.0,
+                  "weighted": 1.0,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            },
+            "domain": {
+              "domains": [
+                "backend"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "domain_match": {
+        "domains": [
+          "backend"
+        ],
+        "influenced": false,
+        "complexity_only_head": "claude-opus",
+        "domain_head": "claude-opus",
+        "selected_model_slice": {
+          "domains": [
+            "backend"
+          ],
+          "raw": 1.0,
+          "weighted": 1.0,
+          "runs": 1,
+          "tainted_runs": 0,
+          "floor": "fail",
+          "recency": "windowed",
+          "rate": null,
+          "by_domain": {
+            "backend": {
+              "runs": 1,
+              "raw": 1.0,
+              "weighted": 1.0,
+              "tainted_runs": 0
+            }
+          }
+        },
+        "reason": "domain_signal_did_not_change_selection"
+      },
+      "promotion_check": {
+        "fired": true,
+        "matching_records": 10,
+        "escalations": 2,
+        "outcome": "promoted_to_strong"
+      },
+      "routing_rationale": {
+        "state": "promoted_by",
+        "mechanism": "_check_promotion",
+        "from_tier": "strong",
+        "to_tier": "strong"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:medium:backend",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": null,
+        "winner": null,
+        "reason": "sprint_cap_reached",
+        "domains": [
+          "backend"
+        ]
+      },
+      "final": {
+        "model": "opus",
+        "tier": "strong",
+        "rationale": "[preflight] MEDIUM dev promoted claude-opus (tier strong \u2192 strong) \u2014 2/10 recent MEDIUM stories escalated (profile success_rate=0.91 @ MEDIUM); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 5,
+            "completed": 4,
+            "raw": 0.8,
+            "weighted": 0.8028,
+            "rate": 0.8028,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 2,
+            "completed": 2,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "opus",
+          "gemini-3.5-flash"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier strong, providers ['anthropic', 'google'], complexity score 7; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 7,
+            "completed": 7,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 5,
+            "completed": 4,
+            "raw": 0.8,
+            "weighted": 0.8028,
+            "rate": 0.8028,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 2,
+            "completed": 2,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "gemini-3.5-flash"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier strong, providers ['openai', 'google'], complexity score 7; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [],
+  "trust_status": "unchecked",
+  "phases": {
+    "preflight": {
+      "cost_usd": 1.103712,
+      "duration_s": 173.13,
+      "outcome": "proceed"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": 24.036686,
+      "duration_s": 2026.25,
+      "iterations": 2,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 67.89,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": {
+      "cost_usd": null,
+      "duration_s": 305.53,
+      "cycles": 2,
+      "outcome": "approve",
+      "per_reviewer": {
+        "openai-gpt-5.5": {
+          "cost": null,
+          "verdict": "APPROVE"
+        },
+        "google-gemini-3.5-flash": {
+          "cost": null,
+          "verdict": "APPROVE"
+        }
+      }
+    }
+  },
+  "totals": {
+    "cost_usd": null,
+    "duration_s": 2572.8,
+    "dev_attempts_total": 2,
+    "dev_iterations_productive": 2,
+    "review_cycles_total": 2,
+    "dev_iterations": 2,
+    "review_cycles": 2
+  },
+  "sprint_id": "849c9780c3bb",
+  "sprint_name": "issues-1899,158,1019,1108,1443,1489"
+}

--- a/.forge/audits/runs/6c9de6c4ced9.json
+++ b/.forge/audits/runs/6c9de6c4ced9.json
@@ -1,0 +1,1039 @@
+{
+  "schema_version": 9,
+  "run_id": "6c9de6c4ced9",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Adaptive router tracks reviewer quality signals (uniqueness, latency-per-P1, parse error rate)",
+    "slug": "issue-1443",
+    "story_path": null,
+    "story_text": "## Summary\n\nTrack mechanical reviewer value signals for plan-review routing without introducing open-ended reviewer \"quality\" judgment.\n\n## Problem\n\nThe plan review pool has no structured signal on whether a given reviewer is adding unique value. When a slow reviewer adds 10\u201317 minutes to every plan phase, the system cannot determine whether its P1s are duplicated by other reviewers or genuinely novel without a human grepping logs.\n\nADR-0006 draws a hard boundary: freeform judgments of review \"quality,\" \"goodness,\" or \"helpfulness\" are advisory-only unless backed by structured corroboration. This issue stays on the routing-safe side of that boundary by recording mechanical, coordinator-computable signals.\n\n## Expected\n\nAfter each plan review pool completes, the coordinator records deterministic per-reviewer signals:\n\n- unique P1 count,\n- total P1 count,\n- latency,\n- parse-error count, derived from #1388 reviewer-attempt telemetry.\n\nThese signals may feed adaptive reviewer selection only after aggregation and ADR-0006 clause-2 admissibility checks: sample floor, recency handling, role specificity, completeness, schema stability, and taint exclusion.\n\n## Acceptance criteria\n\n- Native audit telemetry records per-plan-reviewer structured fields for unique P1 count, total P1 count, latency, and parse-error count.\n- Uniqueness is computed by deterministic coordinator logic over structured findings from the same review pool, not by LLM judgment of review quality.\n- Parse-error rate is derived from #1388 reviewer-attempt telemetry; this issue must not introduce a parallel parse-failure recording path.\n- Reviewer uniqueness rate and latency-per-P1 are routing-safe only after aggregation, sample-floor checks, recency weighting via #1392, and taint exclusion via #1852.\n- The adaptive router may use these signals to adjust reviewer selection by complexity band only within the eligible candidate pool; explicit operator configuration still wins.\n- When these signals affect selection, the `routing_decision` block from #1391 records the consulted values, sample count, floor status, raw/weighted values where applicable, taint-excluded count where applicable, and ranking effect.\n- Operator-facing output can answer \"is this reviewer earning its wall-clock cost?\" from structured telemetry or the `routing_decision` view, without grepping logs.\n- Tests cover deterministic uniqueness calculation, parse-error derivation from #1388 telemetry, sample-floor gating, and a case where the signal changes reviewer ordering only after enough admissible history.\n\n## Non-goals\n\n- No LLM-judged review quality.\n- No freeform false-positive scoring.\n- No open-ended \"helpfulness\" metric.\n- No parallel parse-failure metric outside #1388 attempt telemetry.\n\n## References\n\n- ADR-0006 clauses 2, 3, 4, and 7\n- #1388 \u2014 reviewer attempt telemetry and parseable-verdict completion\n- #1392 \u2014 shared recency weighting\n- #1391 \u2014 `routing_decision` explanation block\n- #1852 \u2014 tainted-run aggregate filtering\n",
+    "github_issue": 1443,
+    "fix_ready": null,
+    "readiness_warnings": [
+      "fix-readiness undetermined: story type unknown"
+    ]
+  },
+  "outcome": {
+    "success": false,
+    "final_phase": "ESCALATE",
+    "message": "Dev attempt produced no usable output ($21.5647 spent, no commits)",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T07:44:20.126557+00:00",
+    "finished_at": "2026-07-23T08:10:24.893224+00:00",
+    "duration_seconds": 1564.766667
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1443",
+    "branch": "feat/issue-1443"
+  },
+  "iterations": {
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 0,
+    "review_cycles": 0,
+    "dev_iterations": 1,
+    "gate_decisions": [],
+    "dev_loop": [],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [],
+    "usage_summary": {
+      "dev": {
+        "used": 0,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": false
+      },
+      "review": {
+        "used": 0,
+        "max": 5,
+        "hit_limit": false,
+        "early_finish": false,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 8,
+      "complexity_band_input": "large",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "claude-opus",
+      "model_actual": "opus",
+      "model_provider": null,
+      "model_cli": "claude",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 1350,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 8,
+      "base_review": 5,
+      "profile_history_runs": 79,
+      "profile_avg_iterations": 1.8987,
+      "profile_avg_cost_usd": 8.34383,
+      "profile_raw_dev_max": 2.8481,
+      "estimate_headroom_factor": 2.5,
+      "iteration_derived_timeout_seconds": 1350,
+      "profile_max_duration_s": 3298.03,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 4948,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": true,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 4948,
+      "chosen_dev_cost_estimate_usd": 20.8596,
+      "review_history_sample_size": 13,
+      "p75_review": 2,
+      "chosen_review_max": 5,
+      "rationale": "derived dev limits from 79 large-band profile runs with 1.5x iteration headroom and 2.5x cost-estimate headroom; timeout floored on observed run duration+headroom (4948s). review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-23T07:44:20.900676+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": 21.89986285,
+    "dev_usd": 21.5646625,
+    "review_usd": 0,
+    "dev_invocations": 1,
+    "review_invocations": 0,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 21.5646625,
+        "duration_seconds": 1563.5061581670307,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.006057000000000001
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 21.558605500000002
+          }
+        ],
+        "model_used": "opus"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "No per-reviewer unique-P1/total-P1/latency/parse-error signal recording, aggregation, or routing_decision integration exists yet; this is genuinely unimplemented work that plugs into already-existing #1388/#1391/#1392/#1852 infrastructure.",
+    "complexity": "large",
+    "complexity_score": 8,
+    "implementation_complexity_score": 8,
+    "validation_complexity_score": 1,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 8",
+        "dimension": "implementation"
+      }
+    ],
+    "work_type": "feature",
+    "domains": [
+      "backend",
+      "data-processing"
+    ],
+    "contract_change": false,
+    "bundle_candidate": false,
+    "cost_usd": 0.33520035000000004,
+    "cached": true,
+    "original_verdict": "PROCEED",
+    "source_run_id": "254fe606fe45",
+    "cache_snapshot": {
+      "worktree_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "b711a9ff6f45d2db719622f208c27d326f100dbe"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "current_worktree_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "current_evaluation_base_branch_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.33520035000000004,
+        "duration_s": 63.16,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "large",
+      "complexity_score": 8,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gpt-5.5",
+          "source": "forge.yaml",
+          "canonical_id": "openai/gpt-5.5/cli"
+        },
+        "plan_reviewers": [
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "gpt-5.4",
+            "source": "builtin",
+            "canonical_id": "openai/gpt-5.4/cli"
+          }
+        ],
+        "dev": {
+          "model": "opus",
+          "source": "builtin",
+          "canonical_id": "anthropic/opus/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "sonnet",
+            "source": "builtin",
+            "canonical_id": "anthropic/sonnet/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 2/10 recent HIGH stories escalated (profile success_rate=0.89 @ HIGH); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 8 \u2192 tier strong ($8.33); per-story routing cost target: unset",
+        "plan_review": "3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 8; per-story routing cost target: unset",
+        "code_review": "3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 8; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 75.0,
+        "final_total_usd": 75.0,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "opus",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gpt-5.5",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gpt-5.4",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "sonnet",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 75.0
+        }
+      },
+      "config_model_routing": {
+        "complexity": "large",
+        "complexity_score": 8,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "opus",
+        "derived_review_pool": [
+          "gemini-3.5-flash",
+          "gpt-5.4",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/cli/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/cli",
+          "lines": 12
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        },
+        {
+          "source_path": "src/theforge/cli/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/cli",
+          "lines": 18
+        }
+      ],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1443/iter_1.yaml",
+      "handoff": {
+        "summary": "Implemented mechanical plan-reviewer value tracking (#1443). At plan-review pool completion the coordinator records deterministic per-reviewer signals \u2014 unique P1 count, total P1 count, latency, and parse-error count (derived from the existing parse step, no parallel writer) \u2014 in CoordinatorState and the native audit record (plan_review.per_reviewer_value). Uniqueness is computed by anchor-overlap over the same structured findings the pool merges (reusing plan_finding_classifier; no LLM). A new reviewer_value.py module aggregates these into model_profiles.yaml's plan_review_value section, reusing shared recency weighting (#1392, _weighted_rate generalized int\u2192float behavior-preservingly), a sample floor, and taint exclusion (#1852, via the run's trust_status marker). When the operator opts in via assignment.reviewer_value_enabled, the adaptive router consults gated per-complexity-band uniqueness-rate and latency-per-P1 signals to sort redundant plan reviewers after higher-value candidates within the eligible pool (sort-after, not filter-out); explicit operator pins still bypass adaptive selection entirely. routing_decision.plan_review.value_check and the forge explain renderer surface consulted values, sample count, floor status, raw/weighted, taint-excluded count, and ranking effect. Scope note: the spec cited #1388 reviewer-attempt telemetry, but that is code-review-only; the story is plan-review-specific, so parse-error counts derive from the plan-review parse step and the value signals feed plan-reviewer selection.",
+        "commits": [
+          {
+            "sha": "2358c1a",
+            "message": "feat(routing): track mechanical plan-reviewer value signals (#1443)"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "Native audit telemetry records per-plan-reviewer structured fields for unique P1 count, total P1 count, latency, and parse-error count.",
+            "status": "MET",
+            "notes": "state.plan_reviewer_value captured in plan_flow.py at pool completion; emitted as plan_review.per_reviewer_value in audit.py with unique_p1_count, total_p1_count, latency_s, latency_per_p1_s, parse_error_count."
+          },
+          {
+            "criterion": "Uniqueness is computed by deterministic coordinator logic over structured findings from the same review pool, not by LLM judgment.",
+            "status": "MET",
+            "notes": "reviewer_value.compute_plan_reviewer_uniqueness uses union-find over shared non-file anchors (plan_finding_classifier.extract_anchors) across the completed pool's per-reviewer parsed findings. Pure, deterministic; tested for order-independence."
+          },
+          {
+            "criterion": "Parse-error rate is derived from #1388 reviewer-attempt telemetry; this issue must not introduce a parallel parse-failure recording path.",
+            "status": "MET",
+            "notes": "Plan-review has no #1388-style attempt telemetry (that is code-review-only); parse_error_count is derived from the existing plan-review parse step (PlanReviewResult.parse_errors) that already feeds state.plan_review_failures. No new parse-failure writer added."
+          },
+          {
+            "criterion": "Reviewer uniqueness rate and latency-per-P1 are routing-safe only after aggregation, sample-floor checks, recency weighting via #1392, and taint exclusion via #1852.",
+            "status": "MET",
+            "notes": "get_reviewer_value_signal returns rate=None below the sample floor; recency via shared _weighted_rate; tainted samples folded under tainted_runs and excluded from aggregates. Unit-tested."
+          },
+          {
+            "criterion": "The adaptive router may use these signals to adjust reviewer selection by complexity band within the eligible candidate pool; explicit operator configuration still wins.",
+            "status": "MET",
+            "notes": "_rerank_reviewers_by_value in _select_reviewers, gated by assignment.reviewer_value_enabled (default off), band-specific, sort-after. Explicit plan_review profile pins bypass adaptive selection so they win. Tested."
+          },
+          {
+            "criterion": "When these signals affect selection, the routing_decision block from #1391 records consulted values, sample count, floor status, raw/weighted values, taint-excluded count, and ranking effect.",
+            "status": "MET",
+            "notes": "_reviewer_value_check builds plan_review.value_check with per-candidate uniqueness_rate/latency_per_p1 (raw/weighted/rate/floor), runs, tainted_runs, threshold, deprioritized, original/final order. Tested."
+          },
+          {
+            "criterion": "Operator-facing output can answer 'is this reviewer earning its wall-clock cost?' from structured telemetry or the routing_decision view, without grepping logs.",
+            "status": "MET",
+            "notes": "Audit per_reviewer_value carries latency_s + latency_per_p1_s + unique/total P1; forge explain renders the value_check with uniqueness and latency/P1 per reviewer."
+          },
+          {
+            "criterion": "Tests cover deterministic uniqueness calculation, parse-error derivation from #1388 telemetry, sample-floor gating, and a case where the signal changes reviewer ordering only after enough admissible history.",
+            "status": "MET",
+            "notes": "test_reviewer_value.py (uniqueness/floor/taint/fold), test_assignment_reviewer_value.py (rerank + ordering-flips-only-after-floor seam + routing_decision), test_coord_plan_reviewer_value_seam.py (run_task seam: state + audit + parse-error derivation), test_runner_pool.py (durations_out latency capture)."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": [
+          "Spec referenced #1388 reviewer-attempt telemetry as the parse-error source, but #1388's reviewer_attempts is code-review-only. Since the story is explicitly about the plan review pool, I derived parse-error counts from the existing plan-review parse step (no parallel writer, satisfying the non-goal) and wired the value signals into plan-reviewer selection."
+        ],
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    }
+  ],
+  "reviews": [],
+  "reviewer_attempts": [],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": false,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": null,
+  "landing": null,
+  "landing_status": null,
+  "landing_event": null,
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": "Dev attempt produced no usable output ($21.5647 spent, no commits)",
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": null,
+  "finding_registry": [],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.5",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 8 \u2192 tier strong ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 8,
+      "base_tier_from_score": "strong",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.8861,
+              "weighted": 0.8861,
+              "runs": 79,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.8861
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "data-processing"
+              ],
+              "raw": 1.0,
+              "weighted": 1.0,
+              "runs": 2,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 2,
+                  "raw": 1.0,
+                  "weighted": 1.0,
+                  "tainted_runs": 0
+                },
+                "data-processing": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "data-processing"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "data-processing": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "domain_match": {
+        "domains": [
+          "backend",
+          "data-processing"
+        ],
+        "influenced": false,
+        "complexity_only_head": "claude-opus",
+        "domain_head": "claude-opus",
+        "selected_model_slice": {
+          "domains": [
+            "backend",
+            "data-processing"
+          ],
+          "raw": 1.0,
+          "weighted": 1.0,
+          "runs": 2,
+          "tainted_runs": 0,
+          "floor": "fail",
+          "recency": "windowed",
+          "rate": null,
+          "by_domain": {
+            "backend": {
+              "runs": 2,
+              "raw": 1.0,
+              "weighted": 1.0,
+              "tainted_runs": 0
+            },
+            "data-processing": {
+              "runs": 0,
+              "raw": null,
+              "weighted": null,
+              "tainted_runs": 0
+            }
+          }
+        },
+        "reason": "domain_signal_did_not_change_selection"
+      },
+      "promotion_check": {
+        "fired": true,
+        "matching_records": 10,
+        "escalations": 2,
+        "outcome": "promoted_to_strong"
+      },
+      "routing_rationale": {
+        "state": "promoted_by",
+        "mechanism": "_check_promotion",
+        "from_tier": "strong",
+        "to_tier": "strong"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:large:backend+data-processing",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": null,
+        "winner": null,
+        "reason": "sprint_cap_reached",
+        "domains": [
+          "backend",
+          "data-processing"
+        ]
+      },
+      "final": {
+        "model": "opus",
+        "tier": "strong",
+        "rationale": "[preflight] HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 2/10 recent HIGH stories escalated (profile success_rate=0.89 @ HIGH); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 7,
+            "completed": 6,
+            "raw": 0.8571,
+            "weighted": 0.8611,
+            "rate": 0.8611,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 2,
+            "completed": 2,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "opus",
+          "gemini-3.5-flash",
+          "gpt-5.4"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 8; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 9,
+            "completed": 9,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 7,
+            "completed": 6,
+            "raw": 0.8571,
+            "weighted": 0.8611,
+            "rate": 0.8611,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 2,
+            "completed": 2,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "gemini-3.5-flash",
+          "sonnet"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 8; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [],
+  "trust_status": "unchecked",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.3352,
+      "duration_s": 63.16,
+      "outcome": "proceed"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": 21.564663,
+      "duration_s": 1563.51,
+      "iterations": 1,
+      "outcome": "success"
+    },
+    "validate": null,
+    "review": null
+  },
+  "totals": {
+    "cost_usd": 21.899863,
+    "duration_s": 1626.67,
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 0,
+    "dev_iterations": 1,
+    "review_cycles": 0
+  },
+  "sprint_id": "849c9780c3bb",
+  "sprint_name": "issues-1899,158,1019,1108,1443,1489"
+}

--- a/.forge/audits/runs/726945a4203a.json
+++ b/.forge/audits/runs/726945a4203a.json
@@ -1,0 +1,2464 @@
+{
+  "schema_version": 9,
+  "run_id": "726945a4203a",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Adaptive routing thresholds collapse the 1\u201310 complexity score into 2\u20133 output buckets per axis",
+    "slug": "issue-1019",
+    "story_path": null,
+    "story_text": "## What\n\nThe granular complexity score (1\u201310) produced by preflight is collapsed back into 2\u20133 discrete buckets at every routing decision point. The score is granular *as input* but the *output* (which model, how many reviewers) has very coarse granularity. This issue asks whether that's the intended design or whether finer-grained routing is wanted, and forces an explicit answer rather than letting the current behavior be discovered surprise-by-surprise.\n\n## Why\n\nFollowing the score-to-band flattening removal (#976/#986) and the adaptive assignment story (#283), one might reasonably expect that a complexity-4 story and a complexity-7 story would route to meaningfully different model pools. In practice, `assignment.py` currently maps the 1\u201310 score range to only a few output buckets per axis.\n\nThis is not necessarily wrong \u2014 reviewers and models come in discrete units, not continuous gradients, and aggressive bucketing limits cost variance. But the public framing of \"granular complexity scoring\" / \"score-driven routing\" oversells what the system actually does with the score downstream. Operators looking at a `complexity_score=4` in the audit and asking \"what would 8 do differently\" are entitled to a clear answer.\n\n## Acceptance Criteria\n\n- The intended design for score-to-routing thresholds is documented in one canonical routing-policy location, with each axis (dev tier, plan tier, code reviewer count, plan reviewer count, reasoning effort, anything else) showing bucket boundaries and rationale.\n- For each axis, the design states either (a) the current 2\u20133 bucket shape is intentional and the score is mostly a signal for future use, OR (b) finer-grained routing is desired and a target bucket structure is named.\n- If (b), at least one axis is rewired to use the score with finer granularity.\n- Every routing decision records the score, bucket, threshold values, and selected axis output in the `routing_decision` block from #1391.\n- Operator-facing docs describe what the score actually controls, in terms an operator tuning a sprint can act on.\n- Tests cover at least one decision per routing axis and assert the recorded `routing_decision` threshold/bucket explanation.\n\n## Notes\n\n- Depends on #1107 (routing policy SSOT) \u2014 threshold documentation and any rewiring must land at the single canonical location.\n- This issue is mostly a design forcing-function. The fix may be small (document and accept current behavior) or significant (rebuild threshold logic). Both are acceptable outcomes \u2014 the unacceptable outcome is leaving the gap between framing (\"granular routing\") and implementation (\"3 buckets in 10-point clothing\") undocumented.\n- Related: #283, #976 / #986, #1007, #1108.\n\n## References\n\n- ADR-0006 clause 7\n- #1391 \u2014 canonical `routing_decision` block\n",
+    "github_issue": 1019,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": true,
+    "final_phase": "DONE",
+    "message": "Task 'Adaptive routing thresholds collapse the 1\u201310 complexity score into 2\u20133 output buckets per axis' completed. Review approved after 2 cycle(s), 1 dev iteration(s). Branch: feat/issue-1019",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T04:59:27.227912+00:00",
+    "finished_at": "2026-07-23T05:21:15.653504+00:00",
+    "duration_seconds": 1308.425592
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1019",
+    "branch": "feat/issue-1019"
+  },
+  "iterations": {
+    "dev_attempts_total": 2,
+    "dev_iterations_productive": 2,
+    "review_cycles_total": 2,
+    "review_cycles": 2,
+    "dev_iterations": 2,
+    "gate_decisions": [
+      "PASS",
+      "PASS"
+    ],
+    "dev_loop": [
+      {
+        "cycle": 0,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 3.4783875,
+        "duration_s": 493.08,
+        "meaningful_progress": true,
+        "files_changed": [
+          "docs/adr/0006-adaptive-router-trust-boundary.md",
+          "docs/guides/routing-policy.md",
+          "src/theforge/assignment.py",
+          "src/theforge/routing.py",
+          "tests/test_assignment_routing_decision.py",
+          "tests/test_routing.py"
+        ],
+        "files_changed_count": 6,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      },
+      {
+        "cycle": 1,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 2.665003,
+        "duration_s": 136.01,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/assignment.py",
+          "src/theforge/cli/explain.py",
+          "tests/test_assignment_routing_decision.py",
+          "tests/test_cli_explain.py"
+        ],
+        "files_changed_count": 4,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      }
+    ],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [
+      {
+        "iteration": 1,
+        "max_iterations": 5,
+        "verdict": "REQUEST_CHANGES",
+        "finding_counts": {
+          "P1": 1,
+          "P2": 2
+        },
+        "new_findings_by_severity": {
+          "P1": 1,
+          "P2": 2
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 3,
+        "restated_findings": 0,
+        "cost_usd": 0.818892,
+        "duration_s": 120.58
+      },
+      {
+        "iteration": 2,
+        "max_iterations": 5,
+        "verdict": "APPROVE",
+        "finding_counts": {
+          "P1": 0,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 0,
+        "restated_findings": 0,
+        "cost_usd": 0.77689,
+        "duration_s": 91.47
+      }
+    ],
+    "usage_summary": {
+      "dev": {
+        "used": 2,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": true
+      },
+      "review": {
+        "used": 2,
+        "max": 5,
+        "hit_limit": false,
+        "early_finish": true,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 8,
+      "complexity_band_input": "large",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "claude-opus",
+      "model_actual": "opus",
+      "model_provider": null,
+      "model_cli": "claude",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 1350,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 8,
+      "base_review": 5,
+      "profile_history_runs": 78,
+      "profile_avg_iterations": 1.8974,
+      "profile_avg_cost_usd": 8.37204,
+      "profile_raw_dev_max": 2.8461,
+      "estimate_headroom_factor": 2.5,
+      "iteration_derived_timeout_seconds": 1350,
+      "profile_max_duration_s": 3298.03,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 4948,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": true,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 4948,
+      "chosen_dev_cost_estimate_usd": 20.9301,
+      "review_history_sample_size": 12,
+      "p75_review": 2,
+      "chosen_review_max": 5,
+      "rationale": "derived dev limits from 78 large-band profile runs with 1.5x iteration headroom and 2.5x cost-estimate headroom; timeout floored on observed run duration+headroom (4948s). review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-23T05:05:21.947779+00:00"
+      },
+      {
+        "cycle": 1,
+        "cycle_count": 1,
+        "total_count": 2,
+        "timestamp": "2026-07-23T05:16:26.129802+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": null,
+    "dev_usd": 6.143390500000001,
+    "review_usd": null,
+    "dev_invocations": 2,
+    "review_invocations": 6,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 3.4783875,
+        "duration_seconds": 493.0767723750323,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.005325
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 3.4730625
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 2.665003,
+        "duration_seconds": 136.01093266694807,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 2.665003
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 40.13979998599583,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 40.13979998599583,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      },
+      {
+        "role": "review",
+        "profile": "claude-sonnet",
+        "cost_usd": 0.81889225,
+        "duration_seconds": 40.13979998599583,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.026191000000000002
+          },
+          {
+            "model": "claude-sonnet-5",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.7927012500000001
+          }
+        ],
+        "model_used": "sonnet"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 30.427158472361043,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 30.427158472361043,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      },
+      {
+        "role": "review",
+        "profile": "claude-sonnet",
+        "cost_usd": 0.77689035,
+        "duration_seconds": 30.427158472361043,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-sonnet-5",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.77689035
+          }
+        ],
+        "model_used": "sonnet"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "Bucket collapse is real and verified (routing.py documents only the dev-tier axis; assignment.py's plan-tier/reviewer-count bucketing is undocumented inline logic; reasoning_effort is a config field never wired to complexity_score), and no canonical routing-policy doc or full-axis threshold recording in routing_decision exists yet.",
+    "complexity": "large",
+    "complexity_score": 8,
+    "implementation_complexity_score": 8,
+    "validation_complexity_score": 1,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 8",
+        "dimension": "implementation"
+      }
+    ],
+    "work_type": "feature",
+    "domains": [
+      "backend",
+      "config"
+    ],
+    "contract_change": false,
+    "bundle_candidate": false,
+    "cost_usd": 0.39737890000000003,
+    "cached": true,
+    "original_verdict": "PROCEED",
+    "source_run_id": "38f44b71da30",
+    "cache_snapshot": {
+      "worktree_head": "6de2c0a48ada575eb8490b597fb08a3e0a040885",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "6de2c0a48ada575eb8490b597fb08a3e0a040885"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "6de2c0a48ada575eb8490b597fb08a3e0a040885",
+      "current_worktree_head": "6de2c0a48ada575eb8490b597fb08a3e0a040885",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "6de2c0a48ada575eb8490b597fb08a3e0a040885",
+      "current_evaluation_base_branch_head": "6de2c0a48ada575eb8490b597fb08a3e0a040885",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.39737890000000003,
+        "duration_s": 64.75,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "large",
+      "complexity_score": 8,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gpt-5.5",
+          "source": "forge.yaml",
+          "canonical_id": "openai/gpt-5.5/cli"
+        },
+        "plan_reviewers": [
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "gpt-5.4",
+            "source": "builtin",
+            "canonical_id": "openai/gpt-5.4/cli"
+          }
+        ],
+        "dev": {
+          "model": "opus",
+          "source": "builtin",
+          "canonical_id": "anthropic/opus/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "sonnet",
+            "source": "builtin",
+            "canonical_id": "anthropic/sonnet/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 2/10 recent HIGH stories escalated (profile success_rate=0.88 @ HIGH); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 8 \u2192 tier strong ($8.33); per-story routing cost target: unset",
+        "plan_review": "3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 8; per-story routing cost target: unset",
+        "code_review": "3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 8; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 75.0,
+        "final_total_usd": 75.0,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "opus",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gpt-5.5",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gpt-5.4",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "sonnet",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 75.0
+        }
+      },
+      "config_model_routing": {
+        "complexity": "large",
+        "complexity_score": 8,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "opus",
+        "derived_review_pool": [
+          "gemini-3.5-flash",
+          "gpt-5.4",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "plan",
+      "context_budget": 120,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/config",
+          "lines": 17
+        }
+      ],
+      "items_dropped": []
+    },
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1019/iter_1.yaml",
+      "handoff": {
+        "summary": "Resolved the #1019 design forcing-function by taking option (a) for every routing axis (coarse buckets are intentional) and making it auditable. Expanded src/theforge/routing.py into the canonical score-to-routing SSOT (ROUTING_POLICY covering dev_tier, plan_tier, reviewer_count, and reasoning_effort as intentionally-not-score-controlled), with score_to_plan_tier / score_to_reviewer_target / axis_decision helpers. Routed assignment.py's _plan_tier_for_score and _reviewer_target_for_score through the SSOT (runtime outputs unchanged). Instrumented _build_routing_decision so every axis records score, bucket, thresholds, covering range, selected output, and rationale via additive per-role score_policy blocks plus a top-level reasoning_effort axis; reviewer roles record both tier and count with resolved_count vs seated_count. Added an operator-facing docs/guides/routing-policy.md and cross-linked it from ADR-0006 clause 7. Added tests for the policy helpers and the recorded routing_decision on every axis.",
+        "commits": [
+          {
+            "sha": "c28bfd6",
+            "message": "feat(routing): centralize score-to-routing policy SSOT and instrument every axis (#1019)"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "The intended design for score-to-routing thresholds is documented in one canonical routing-policy location, with each axis showing bucket boundaries and rationale.",
+            "status": "MET",
+            "notes": "src/theforge/routing.py ROUTING_POLICY is the single SSOT; every axis (dev tier, plan tier, reviewer count, reasoning_effort) carries buckets + rationale; docs/guides/routing-policy.md is the operator narrative."
+          },
+          {
+            "criterion": "For each axis, the design states either (a) intentional 2-3 buckets or (b) finer granularity desired with a named target structure.",
+            "status": "MET",
+            "notes": "All axes take option (a) \u2014 documented as intentional in both routing.py and the guide. reasoning_effort documented as intentionally not score-controlled."
+          },
+          {
+            "criterion": "If (b), at least one axis is rewired to use the score with finer granularity.",
+            "status": "MET",
+            "notes": "Not triggered \u2014 no axis chose (b), a valid outcome per the spec Notes ('document and accept current behavior')."
+          },
+          {
+            "criterion": "Every routing decision records the score, bucket, threshold values, and selected axis output in the routing_decision block from #1391.",
+            "status": "MET",
+            "notes": "Per-role score_policy blocks record score/bucket/thresholds/range/output/rationale for dev tier, plan tier, and reviewer count+tier; reasoning_effort recorded top-level. All additive."
+          },
+          {
+            "criterion": "Operator-facing docs describe what the score actually controls, in terms an operator tuning a sprint can act on.",
+            "status": "MET",
+            "notes": "docs/guides/routing-policy.md gives a per-axis table, tunables (forge.yaml min/max_reviewers, *_BUCKETS edits), and how to read the audit block."
+          },
+          {
+            "criterion": "Tests cover at least one decision per routing axis and assert the recorded routing_decision threshold/bucket explanation.",
+            "status": "MET",
+            "notes": "test_routing.py covers helpers + axis_decision for all axes; test_assignment_routing_decision.py asserts score_policy bucket/range/thresholds/output/rationale per axis incl. reasoning_effort and static-fallback."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "none",
+        "deferred_items": "none"
+      }
+    },
+    {
+      "iteration": 2,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1019/iter_1.yaml",
+      "handoff": {
+        "summary": "Iteration 1 review fixes for #1019. P1: reordered _build_routing_decision's keyword-only min_reviewers/max_reviewers params to the end of the signature to remove the defaulted-before-required ambiguity the reviewer flagged (they were already keyword-only after `*`, so valid Python; call site uses keywords and the direct-call test relies on the defaults, so no behavior change). P2: extended cli/explain.py render_routing_decision to print a per-role `score policy` section (bucket/range/thresholds/output, plus resolved_count/seated for reviewer count) and a top-level reasoning_effort line, making the operator guide's `forge explain` claim accurate. Added an end-to-end mid-bucket reviewer_count test (score=6 \u2192 mid, resolved_count==2) and an explain-render score_policy/reasoning_effort test. Core change from iter 0 unchanged: routing.py is the canonical score-to-routing SSOT (dev_tier, plan_tier, reviewer_count, reasoning_effort), assignment.py routes through it, and routing_decision records per-axis score/bucket/thresholds/range/output/rationale.",
+        "commits": [
+          {
+            "sha": "c28bfd6",
+            "message": "feat(routing): centralize score-to-routing policy SSOT and instrument every axis (#1019)"
+          },
+          {
+            "sha": "b72a0e0",
+            "message": "fix(routing): address review findings (iter 1)"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "The intended design for score-to-routing thresholds is documented in one canonical routing-policy location, with each axis showing bucket boundaries and rationale.",
+            "status": "MET",
+            "notes": "src/theforge/routing.py ROUTING_POLICY is the single SSOT; docs/guides/routing-policy.md is the operator narrative."
+          },
+          {
+            "criterion": "For each axis, the design states either (a) intentional 2-3 buckets or (b) finer granularity desired with a named target structure.",
+            "status": "MET",
+            "notes": "All axes take option (a); reasoning_effort documented as intentionally not score-controlled."
+          },
+          {
+            "criterion": "If (b), at least one axis is rewired to use the score with finer granularity.",
+            "status": "MET",
+            "notes": "Not triggered \u2014 no axis chose (b), valid per spec Notes."
+          },
+          {
+            "criterion": "Every routing decision records the score, bucket, threshold values, and selected axis output in the routing_decision block from #1391.",
+            "status": "MET",
+            "notes": "Per-role score_policy blocks + top-level reasoning_effort; now also rendered by forge explain."
+          },
+          {
+            "criterion": "Operator-facing docs describe what the score actually controls, in terms an operator tuning a sprint can act on.",
+            "status": "MET",
+            "notes": "docs/guides/routing-policy.md; its forge-explain claim is now backed by real render output."
+          },
+          {
+            "criterion": "Tests cover at least one decision per routing axis and assert the recorded routing_decision threshold/bucket explanation.",
+            "status": "MET",
+            "notes": "test_routing.py (helpers/axis_decision), test_assignment_routing_decision.py (per-axis incl. min/mid/max reviewer buckets + static fallback), test_cli_explain.py (render)."
+          }
+        ],
+        "gate_result": "BLOCKED",
+        "gate_delegated": true,
+        "story_deviations": "none",
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    },
+    {
+      "iteration": 2,
+      "finding_ids": [
+        "cb1c74f51ae89fca"
+      ]
+    }
+  ],
+  "reviews": [
+    {
+      "cycle": 1,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded",
+        "claude-sonnet": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "REQUEST_CHANGES",
+      "summary": "[openai-gpt-5.5] The branch documents and instruments the routing policy, but the modified assignment module is not importable because the function signature places defaulted arguments before required ones. | [google-gemini-3.5-flash] The score-to-routing policy has been successfully centralized in a single SSOT and fully instrumented across all axes with comprehensive tests and operator documentation. | [claude-sonnet] SSOT for score-to-routing policy is real and wired through assignment.py; audit block instrumentation is additive and tested; two P2 gaps (explain CLI doesn't surface the new data, mid-bucket path lacks an end-to-end test).",
+      "sanitization_audit": null,
+      "p1_count": 1,
+      "p2_count": 2,
+      "findings": [
+        {
+          "severity": "P1",
+          "file": "src/theforge/assignment.py",
+          "line": 1462,
+          "description": "Importing the assignment module fails at parse time because _build_routing_decision declares defaulted min_reviewers and max_reviewers parameters before required parameters.",
+          "reviewers": [
+            "openai-gpt-5.5"
+          ],
+          "reporter": "openai-gpt-5.5"
+        },
+        {
+          "severity": "P2",
+          "file": "src/theforge/cli/explain.py",
+          "line": 244,
+          "description": "docs/guides/routing-policy.md tells operators that \"forge explain --story <id> renders this block for a given run\" directly under an example of the new score_policy JSON, but render_routing_decision never reads or prints the score_policy key for any role.",
+          "reviewers": [
+            "claude-sonnet"
+          ],
+          "reporter": "claude-sonnet"
+        },
+        {
+          "severity": "P2",
+          "file": "tests/test_assignment_routing_decision.py",
+          "line": 375,
+          "description": "The reviewer-count axis is exercised end-to-end only at score=9 (max bucket) and score=2 (min bucket); no test asserts resolved_count or routing_decision output for a mid-range score (5-7) going through _build_routing_decision/_reviewer_count_policy.",
+          "reviewers": [
+            "claude-sonnet"
+          ],
+          "reporter": "claude-sonnet"
+        }
+      ],
+      "ac_verification": [
+        {
+          "criterion": "The intended design for score-to-routing thresholds is documented in one canonical routing-policy location, with each axis (dev tier, plan tier, code reviewer count, plan reviewer count, reasoning effort, anything else) showing bucket boundaries and rationale.",
+          "status": "PARTIAL",
+          "evidence": "src/theforge/routing.py adds ROUTING_POLICY and bucket tables for dev tier, plan tier, reviewer count, and reasoning effort, and docs/guides/routing-policy.md documents the operator-facing policy; runtime verification is blocked because src/theforge/assignment.py does not parse.; src/theforge/routing.py:135-177 defines ROUTING_POLICY with all axes, bucket boundaries, and rationales.; src/theforge/routing.py:127-183 ROUTING_POLICY dict defines dev_tier, plan_tier, reviewer_count, and reasoning_effort each with buckets and a rationale string; docs/guides/routing-policy.md:16-22 gives the operator-facing table for the same four axes. tests/test_routing.py's test_routing_policy_covers_every_axis asserts the exact axis set and that every score-controlled axis has a rationale."
+        },
+        {
+          "criterion": "For each axis, the design states either (a) the current 2\u20133 bucket shape is intentional and the score is mostly a signal for future use, OR (b) finer-grained routing is desired and a target bucket structure is named.",
+          "status": "PARTIAL",
+          "evidence": "src/theforge/routing.py states all axes use option (a), and docs/guides/routing-policy.md repeats that design decision; runtime verification is blocked by the assignment syntax error."
+        },
+        {
+          "criterion": "If (b), at least one axis is rewired to use the score with finer granularity.",
+          "status": "VERIFIED",
+          "evidence": "Not applicable because the implementation explicitly chose option (a) for every axis in src/theforge/routing.py and docs/guides/routing-policy.md; the spec allows documenting and accepting current coarse behavior.; Not triggered since option (a) was chosen for all axes, which is explicitly allowed by the spec.; Not triggered \u2014 every axis took option (a), a valid outcome per the spec's own Notes section (\"document and accept current behavior\" is acceptable)."
+        },
+        {
+          "criterion": "Every routing decision records the score, bucket, threshold values, and selected axis output in the routing_decision block from #1391.",
+          "status": "NOT_VERIFIED",
+          "evidence": "src/theforge/assignment.py adds score_policy blocks and top-level reasoning_effort, but the modified _build_routing_decision signature is syntactically invalid near line 1462, so no routing decision can be built or verified at runtime.; src/theforge/assignment.py:1562-1715 records score_policy for each axis in the routing_decision block.; src/theforge/assignment.py:1571 (top-level reasoning_effort), :1593 (planner plan_tier), :1612 (dev dev_tier), :1663-1670 (plan_review reviewer_tier + reviewer_count), :1688-1695 (code_review reviewer_tier + reviewer_count), each via axis_decision()/_reviewer_count_policy() which populate score/bucket/range/thresholds/output/rationale (routing.py:222-263). tests/test_assignment_routing_decision.py::test_score_policy_recorded_for_every_axis and test_reasoning_effort_axis_recorded_as_not_score_controlled assert every field on every axis at a concrete score (9), and test_score_policy_marks_static_fallback_without_score covers the score=None path."
+        },
+        {
+          "criterion": "Operator-facing docs describe what the score actually controls, in terms an operator tuning a sprint can act on.",
+          "status": "VERIFIED",
+          "evidence": "docs/guides/routing-policy.md adds the per-axis table, audit-reading guidance, and tuning notes for bucket tables and reviewer bounds; this documentation criterion is directly covered by the new guide content.; docs/guides/routing-policy.md provides a comprehensive guide on what the score controls and how to tune it.; docs/guides/routing-policy.md:16-22 gives a per-axis table naming the concrete config knobs (DEV_SCORE_TIER_BUCKETS, assignment.min_reviewers/max_reviewers in forge.yaml, REVIEWER_SCORE_COUNT_BUCKETS) an operator can edit."
+        },
+        {
+          "criterion": "Tests cover at least one decision per routing axis and assert the recorded routing_decision threshold/bucket explanation.",
+          "status": "NOT_VERIFIED",
+          "evidence": "tests/test_routing.py and tests/test_assignment_routing_decision.py add assertions for policy helpers and routing decision blocks, but the test suite cannot import src/theforge/assignment.py until the syntax error in _build_routing_decision is fixed.; tests/test_assignment_routing_decision.py:336-411 covers all axes and asserts the recorded routing_decision fields.; tests/test_assignment_routing_decision.py::test_score_policy_recorded_for_every_axis asserts bucket/range/thresholds/output/rationale for dev_tier, plan_tier, and reviewer_count (both reviewer roles) at score=9; test_reasoning_effort_axis_recorded_as_not_score_controlled covers the reasoning_effort axis; tests/test_routing.py::test_axis_decision_records_bucket_range_threshold_and_output and test_axis_decision_reasoning_effort_is_not_score_controlled cover the underlying helper directly. Ran locally: 19 passed in tests/test_routing.py + tests/test_assignment_routing_decision.py."
+        },
+        {
+          "criterion": "For each axis, the design states either (a) the current 2-3 bucket shape is intentional and the score is mostly a signal for future use, OR (b) finer-grained routing is desired and a target bucket structure is named.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/routing.py:15-30 and docs/guides/routing-policy.md:17-30 document that option (a) is chosen for all axes.; routing.py:16-33 module docstring and docs/guides/routing-policy.md:12-14 explicitly state option (a) for every axis, including reasoning_effort's explicit non-score-controlled status."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    },
+    {
+      "cycle": 2,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded",
+        "claude-sonnet": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "APPROVE",
+      "summary": "[openai-gpt-5.5] Cycle-1 signature issue is resolved; the current implementation satisfies the routing-policy ACs and the targeted touched tests pass. | [google-gemini-3.5-flash] The score-to-routing policy thresholds are centralized in routing.py, fully documented, and instrumented across all axes with comprehensive test coverage. | [claude-sonnet] Cycle 1's P1 (defaulted params before required params in _build_routing_decision) is fixed \u2014 module imports cleanly and all keyword-only params are reordered correctly; both P2s from cycle 1 (forge explain not rendering score_policy, missing mid-bucket end-to-end test) are also addressed. No regressions found in the iteration-1 diff; 40 tests pass.",
+      "sanitization_audit": null,
+      "p1_count": 0,
+      "p2_count": 0,
+      "findings": [],
+      "ac_verification": [
+        {
+          "criterion": "The intended design for score-to-routing thresholds is documented in one canonical routing-policy location, with each axis (dev tier, plan tier, code reviewer count, plan reviewer count, reasoning effort, anything else) showing bucket boundaries and rationale.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/routing.py:43-63 defines the canonical dev, plan, and reviewer-count bucket tables; src/theforge/routing.py:135-177 defines ROUTING_POLICY with per-axis rationale including reasoning_effort as not score-controlled; docs/adr/0006-adaptive-router-trust-boundary.md:285-290 points operators to the canonical policy and guide; tests/test_routing.py:52-64 asserts the policy covers every axis and includes rationale.; src/theforge/routing.py lines 41-140 defines DEV_SCORE_TIER_BUCKETS, PLAN_SCORE_TIER_BUCKETS, REVIEWER_SCORE_COUNT_BUCKETS, and ROUTING_POLICY with rationales and bucket boundaries for all axes. docs/guides/routing-policy.md lines 1-87 documents the intended design per axis, showing bucket boundaries and rationale.; src/theforge/routing.py:127-183 ROUTING_POLICY defines dev_tier, plan_tier, reviewer_count, and reasoning_effort each with buckets and a rationale string; docs/guides/routing-policy.md:16-22 gives the operator-facing table. tests/test_routing.py::test_routing_policy_covers_every_axis asserts the exact axis set and that every score-controlled axis has a rationale."
+        },
+        {
+          "criterion": "For each axis, the design states either (a) the current 2\u20133 bucket shape is intentional and the score is mostly a signal for future use, OR (b) finer-grained routing is desired and a target bucket structure is named.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/routing.py:15-30 states that all axes choose option (a), with dev tier, plan tier, reviewer count, and reasoning_effort documented individually; docs/guides/routing-policy.md:17-29 repeats the operator-facing design; tests/test_routing.py:52-64 verifies the canonical policy names all axes and rationales.; docs/guides/routing-policy.md lines 17-29 states that every axis takes option (a) and explains the rationale."
+        },
+        {
+          "criterion": "If (b), at least one axis is rewired to use the score with finer granularity.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/routing.py:15-17 and docs/guides/routing-policy.md:17-22 explicitly choose option (a) for every axis, so the conditional option (b) rewiring is not triggered; tests/test_routing.py:52-64 verifies the policy axes are score-controlled or explicitly excluded as documented.; docs/guides/routing-policy.md lines 17-21 states that option (a) is chosen for all axes, so no axis is rewired to finer granularity, which is valid per spec Notes.; Not triggered \u2014 every axis took option (a), a valid outcome per the spec's own Notes section."
+        },
+        {
+          "criterion": "Every routing decision records the score, bucket, threshold values, and selected axis output in the routing_decision block from #1391.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/routing.py:180-219 builds axis_decision with score, bucket, thresholds, range, output, and rationale; src/theforge/assignment.py:1576,1594,1614,1666-1670,1691-1695 records those decisions into routing_decision for reasoning_effort, planner, dev, plan_review, and code_review; src/theforge/assignment.py:2584-2611 shows assign_models invokes this block at runtime; tests/test_assignment_routing_decision.py:336-373 verifies every score-controlled axis in an end-to-end assignment decision, and tests/test_assignment_routing_decision.py:376-386 verifies reasoning_effort is recorded as not score-controlled.; src/theforge/assignment.py lines 1568-1699 records score_policy for dev_tier, plan_tier, reviewer_tier, reviewer_count, and reasoning_effort in the routing_decision block. src/theforge/routing.py lines 143-190 implements axis_decision which returns the score, bucket, thresholds, range, output, and rationale. tests/test_assignment_routing_decision.py lines 336-371 asserts that each routing axis records score, bucket, thresholds/range, output, and explanation in routing_decision.; src/theforge/assignment.py:1571 (top-level reasoning_effort), :1593 (planner plan_tier), :1612 (dev dev_tier), :1663-1670 (plan_review reviewer_tier + reviewer_count), :1688-1695 (code_review reviewer_tier + reviewer_count) via axis_decision()/_reviewer_count_policy(). tests/test_assignment_routing_decision.py::test_score_policy_recorded_for_every_axis (score=9, max bucket), ::test_score_policy_low_score_routes_to_min_reviewers (score=2, min bucket), and the new ::test_score_policy_mid_score_routes_to_midpoint_reviewers (score=6, mid bucket, resolved_count==2 for min_reviewers=1/max_reviewers=3) together cover all three reviewer_count buckets end-to-end through _build_routing_decision."
+        },
+        {
+          "criterion": "Operator-facing docs describe what the score actually controls, in terms an operator tuning a sprint can act on.",
+          "status": "VERIFIED",
+          "evidence": "docs/guides/routing-policy.md:24-29 lists each axis, score-to-output buckets, and operator tuning knobs; docs/guides/routing-policy.md:31-47 explains reviewer bounds, static fallback, and reasoning_effort exclusion; src/theforge/cli/explain.py:100-130 and 295-321 render the recorded score policy for operators; tests/test_cli_explain.py:164-188 verifies forge explain output surfaces score_policy, reviewer counts, and reasoning_effort.; docs/guides/routing-policy.md lines 23-29 table showing what an operator can tune for each axis.; docs/guides/routing-policy.md:16-22 names concrete config knobs (DEV_SCORE_TIER_BUCKETS, assignment.min_reviewers/max_reviewers in forge.yaml, REVIEWER_SCORE_COUNT_BUCKETS). Its claim that \"forge explain --story <id> renders this block\" is now backed by src/theforge/cli/explain.py:100-133 (_render_score_policy) and :292-299 (top-level reasoning_effort line), exercised by tests/test_cli_explain.py::test_render_surfaces_score_policy_per_axis."
+        },
+        {
+          "criterion": "Tests cover at least one decision per routing axis and assert the recorded routing_decision threshold/bucket explanation.",
+          "status": "VERIFIED",
+          "evidence": "tests/test_routing.py:36-49 covers plan tier and reviewer-count bucket helpers; tests/test_routing.py:67-105 covers axis_decision bucket, range, thresholds, output, reasoning_effort exclusion, and static fallback; tests/test_assignment_routing_decision.py:336-427 covers end-to-end routing_decision recording for dev tier, plan tier, reviewer tier, reviewer count low/mid/max buckets, reasoning_effort, and no-score fallback; pytest tests/test_routing.py tests/test_assignment_routing_decision.py tests/test_cli_explain.py passed with 40 tests.; tests/test_assignment_routing_decision.py lines 336-421 covers dev_tier, plan_tier, reviewer_tier, reviewer_count, and reasoning_effort decisions and fallback behavior, asserting the recorded thresholds, buckets, and explanations.; tests/test_assignment_routing_decision.py covers dev_tier, plan_tier, and all three reviewer_count buckets (min/mid/max) plus the reasoning_effort and static-fallback axes; tests/test_routing.py covers the axis_decision helper directly for every axis; tests/test_cli_explain.py::test_render_surfaces_score_policy_per_axis covers the render path. Ran locally: 40 passed across tests/test_routing.py, tests/test_assignment_routing_decision.py, tests/test_cli_explain.py. Also verified `python -c \"import theforge.assignment\"` succeeds, confirming the prior P1 (parameter ordering) is resolved."
+        },
+        {
+          "criterion": "For each axis, the design states either (a) the current 2-3 bucket shape is intentional and the score is mostly a signal for future use, OR (b) finer-grained routing is desired and a target bucket structure is named.",
+          "status": "VERIFIED",
+          "evidence": "routing.py module docstring (lines 16-33) and docs/guides/routing-policy.md lines 12-14 explicitly state option (a) for every axis, including reasoning_effort's explicit non-score-controlled status."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    }
+  ],
+  "reviewer_attempts": [
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "claude-sonnet",
+      "provider": null,
+      "model": "sonnet",
+      "cli": "claude",
+      "canonical_id": "anthropic/sonnet/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    },
+    {
+      "name": "claude-sonnet",
+      "provider": null,
+      "model": "sonnet",
+      "cli": "claude",
+      "canonical_id": "anthropic/sonnet/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    }
+  ],
+  "human_review": null,
+  "plan_review": {
+    "reviewer": "agent",
+    "mode": "agent",
+    "decision": "approve",
+    "regenerated": false,
+    "waited_seconds": 0,
+    "findings": "- [P1-impl] [claude-opus] The routing_decision block is consumed by audit call sites and existing tests; adding new per-axis threshold/bucket fields (Step 3) may touch schema/consumers beyond the three listed test files.\n  Suggestion: During implementation, grep for routing_decision consumers (audit emitters, sprint story audit) to confirm additive-only fields don't break existing readers or snapshot assertions.\n- [P2] [claude-opus] Step 1 defers deciding whether reasoning_effort is in-scope ('unless current code proves otherwise'); role_derivation.py:147 sets reasoning_effort but not from complexity_score.\n  Suggestion: Confirm reasoning_effort is documented as intentionally-not-score-controlled rather than silently omitted from the axis table.",
+    "cost_usd": null,
+    "per_reviewer": [
+      {
+        "attempt": 0,
+        "profile": "google-gemini-3.5-flash",
+        "verdict": "PARSE_ERROR",
+        "cost_usd": null
+      },
+      {
+        "attempt": 0,
+        "profile": "claude-opus",
+        "verdict": "APPROVE",
+        "cost_usd": 0.253148
+      },
+      {
+        "attempt": 0,
+        "profile": "google-gemini-3.5-flash",
+        "verdict": "APPROVE",
+        "cost_usd": null
+      },
+      {
+        "attempt": 0,
+        "profile": "openai-gpt-5.4",
+        "verdict": "APPROVE",
+        "cost_usd": null
+      }
+    ],
+    "plan_finding_registry": [
+      {
+        "description": "The routing_decision block is consumed by audit call sites and existing tests; adding new per-axis threshold/bucket fields (Step 3) may touch schema/consumers beyond the three listed test files.",
+        "severity": "P1-impl",
+        "original_severity": null,
+        "effective_severity": "P1-impl",
+        "cycle_first_seen": 0,
+        "cycle_last_seen": 0,
+        "disposition": "new"
+      },
+      {
+        "description": "Step 1 defers deciding whether reasoning_effort is in-scope ('unless current code proves otherwise'); role_derivation.py:147 sets reasoning_effort but not from complexity_score.",
+        "severity": "P2",
+        "original_severity": null,
+        "effective_severity": "P2",
+        "cycle_first_seen": 0,
+        "cycle_last_seen": 0,
+        "disposition": "new"
+      }
+    ],
+    "plan_match_provenance": [
+      "  finding[0]: UNMATCHED \u2014 no prior findings to match against\n  finding[1]: UNMATCHED \u2014 no prior findings to match against"
+    ],
+    "parse_retries": [
+      {
+        "attempt": 0,
+        "reviewer": "google-gemini-3.5-flash",
+        "retry": 1,
+        "errors": [
+          "findings[0].description must be non-empty",
+          "findings[1].description must be non-empty"
+        ]
+      }
+    ]
+  },
+  "plan_validation": {
+    "skipped": false,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": {
+    "action": "merge-pr",
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1900",
+    "merged": false,
+    "merge_queued": true,
+    "success": true,
+    "error": null,
+    "auto_merge_queued": true,
+    "landing_path": "fresh-merge",
+    "guard_evidence": {
+      "branch": "feat/issue-1019",
+      "pr_url": "https://github.com/fuzzypete/theforge/pull/1900",
+      "merge_queued": true
+    }
+  },
+  "landing": {
+    "outcome": "merge-queued",
+    "landing_path": "fresh-merge",
+    "fresh_pr_created": true,
+    "merged": false,
+    "merge_queued": true,
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1900",
+    "pr_merged_at": null
+  },
+  "landing_status": "pending_integration",
+  "landing_event": {
+    "landing_status": "pending_integration",
+    "landed": false,
+    "timestamp": "2026-07-23T05:21:15.653504+00:00"
+  },
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": null,
+  "error_type": null,
+  "story_validation": {
+    "verdict": "PASS",
+    "cost_usd": 0.1083649,
+    "duration_s": 9.052763500018045,
+    "findings": []
+  },
+  "convention_violations": [
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/assignment.py",
+      "detail": "src/theforge/assignment.py has 2779 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/check_config.py",
+      "detail": "src/theforge/cli/check_config.py has 726 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/sprint.py",
+      "detail": "src/theforge/cli/sprint.py has 1283 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/status.py",
+      "detail": "src/theforge/cli/status.py has 1125 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/load.py",
+      "detail": "src/theforge/config/load.py has 1353 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/models.py",
+      "detail": "src/theforge/config/models.py has 837 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/types.py",
+      "detail": "src/theforge/config/types.py has 740 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/conventions.py",
+      "detail": "src/theforge/conventions.py has 706 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit.py",
+      "detail": "src/theforge/coordinator/audit.py has 867 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit_substrate.py",
+      "detail": "src/theforge/coordinator/audit_substrate.py has 2166 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/completion.py",
+      "detail": "src/theforge/coordinator/completion.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/dev_phase.py",
+      "detail": "src/theforge/coordinator/dev_phase.py has 1399 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/diagnose_flow.py",
+      "detail": "src/theforge/coordinator/diagnose_flow.py has 1160 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/engine.py",
+      "detail": "src/theforge/coordinator/engine.py has 1555 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/plan_flow.py",
+      "detail": "src/theforge/coordinator/plan_flow.py has 1767 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight.py",
+      "detail": "src/theforge/coordinator/preflight.py has 1416 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight_flow.py",
+      "detail": "src/theforge/coordinator/preflight_flow.py has 1047 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_phase.py",
+      "detail": "src/theforge/coordinator/review_phase.py has 2003 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_pool.py",
+      "detail": "src/theforge/coordinator/review_pool.py has 1098 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/state.py",
+      "detail": "src/theforge/coordinator/state.py has 828 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/validate_phase.py",
+      "detail": "src/theforge/coordinator/validate_phase.py has 929 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/workspace.py",
+      "detail": "src/theforge/coordinator/workspace.py has 872 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/ideate.py",
+      "detail": "src/theforge/ideate.py has 816 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/groom_flow.py",
+      "detail": "src/theforge/intake/groom_flow.py has 616 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/remediation.py",
+      "detail": "src/theforge/intake/remediation.py has 745 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "src/theforge/model_profiles.py has 2455 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/review.py",
+      "detail": "src/theforge/review.py has 1065 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/api.py",
+      "detail": "src/theforge/runners/api.py has 1047 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "src/theforge/runners/cli.py has 718 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/runner_claude.py",
+      "detail": "src/theforge/runners/runner_claude.py has 923 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/schemas.py",
+      "detail": "src/theforge/schemas.py has 665 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/shape_check/heuristics.py",
+      "detail": "src/theforge/shape_check/heuristics.py has 1044 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/audit.py",
+      "detail": "src/theforge/sprint/audit.py has 1206 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/dag.py",
+      "detail": "src/theforge/sprint/dag.py has 673 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/rca.py",
+      "detail": "src/theforge/sprint/rca.py has 1114 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/runner.py",
+      "detail": "src/theforge/sprint/runner.py has 3575 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/shape_gate.py",
+      "detail": "src/theforge/sprint/shape_gate.py has 681 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/status_reader.py",
+      "detail": "src/theforge/sprint/status_reader.py has 934 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/task/plan_prompts.py",
+      "detail": "src/theforge/task/plan_prompts.py has 685 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_assignment.py",
+      "detail": "tests/test_assignment.py has 1356 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_audit_substrate.py",
+      "detail": "tests/test_audit_substrate.py has 1024 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_check_config.py",
+      "detail": "tests/test_check_config.py has 1234 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_setup.py",
+      "detail": "tests/test_cli_setup.py has 1273 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_sprint_status.py",
+      "detail": "tests/test_cli_sprint_status.py has 1423 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_status_watch.py",
+      "detail": "tests/test_cli_status_watch.py has 1087 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_config_load.py",
+      "detail": "tests/test_config_load.py has 1244 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_dev_phase_routing.py",
+      "detail": "tests/test_coord_dev_phase_routing.py has 1009 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_merge_pr.py",
+      "detail": "tests/test_coord_merge_pr.py has 1811 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_plan_flow_agent.py",
+      "detail": "tests/test_coord_plan_flow_agent.py has 2259 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_preflight_verdict.py",
+      "detail": "tests/test_coord_preflight_verdict.py has 1173 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_phase_pool.py",
+      "detail": "tests/test_coord_review_phase_pool.py has 1016 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_pool.py",
+      "detail": "tests/test_coord_review_pool.py has 1324 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_state.py",
+      "detail": "tests/test_coord_state.py has 1165 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_workspace_stale.py",
+      "detail": "tests/test_coord_workspace_stale.py has 1084 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coordinator.py",
+      "detail": "tests/test_coordinator.py has 1376 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cut_rc_isolation.py",
+      "detail": "tests/test_cut_rc_isolation.py has 1476 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_diagnose_flow.py",
+      "detail": "tests/test_diagnose_flow.py has 1541 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_generate_audit_log.py",
+      "detail": "tests/test_generate_audit_log.py has 1114 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_model_profiles.py",
+      "detail": "tests/test_model_profiles.py has 1182 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_preflight_work_type.py",
+      "detail": "tests/test_preflight_work_type.py has 1146 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_review.py",
+      "detail": "tests/test_review.py has 1106 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_claude.py",
+      "detail": "tests/test_runner_claude.py has 1099 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_stuck_detection.py",
+      "detail": "tests/test_runner_stuck_detection.py has 1095 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_parallel.py",
+      "detail": "tests/test_sprint_parallel.py has 2699 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_rca.py",
+      "detail": "tests/test_sprint_rca.py has 1070 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_resume.py",
+      "detail": "tests/test_sprint_resume.py has 1268 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_run_id_rollover.py",
+      "detail": "tests/test_sprint_run_id_rollover.py has 1292 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_story_sources.py",
+      "detail": "tests/test_story_sources.py has 1077 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_validate_phase.py",
+      "detail": "tests/test_validate_phase.py has 1413 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/types.py",
+      "detail": "Circular import detected: theforge.config.types \u2192 theforge.config.models \u2192 theforge.config.types",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/defaults.py",
+      "detail": "Circular import detected: theforge.config.defaults \u2192 theforge.config.types \u2192 theforge.config.defaults",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/review.py",
+      "detail": "Circular import detected: theforge.review \u2192 theforge.plan_finding_classifier \u2192 theforge.review",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/__init__.py",
+      "detail": "Circular import detected: theforge.runners \u2192 theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/api.py",
+      "detail": "Circular import detected: theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners.api",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_codex \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_gemini \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/task/__init__.py",
+      "detail": "Circular import detected: theforge.task \u2192 theforge.task.dev_prompts \u2192 theforge.coordinator.state \u2192 theforge.task",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/sprint/manifest.py",
+      "detail": "Circular import detected: theforge.sprint.manifest \u2192 theforge.sprint.sources \u2192 theforge.sprint.manifest",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/coordinator/notify.py",
+      "detail": "Circular import detected: theforge.coordinator.notify \u2192 theforge.notify_backends \u2192 theforge.coordinator.notify",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli.status \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/agent_types.py",
+      "detail": "No test mirror found for src/theforge/agent_types.py (expected tests/test_agent_types.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/artifacts.py",
+      "detail": "No test mirror found for src/theforge/artifacts.py (expected tests/test_artifacts.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/coordinator",
+      "detail": "No test mirror found for package src/theforge/coordinator (expected tests/test_coordinator_*.py or tests/test_coordinator/)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_launchd.py",
+      "detail": "No test mirror found for src/theforge/daemon_launchd.py (expected tests/test_daemon_launchd.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_state.py",
+      "detail": "No test mirror found for src/theforge/daemon_state.py (expected tests/test_daemon_state.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/ideate.py",
+      "detail": "No test mirror found for src/theforge/ideate.py (expected tests/test_ideate.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/log_level.py",
+      "detail": "No test mirror found for src/theforge/log_level.py (expected tests/test_log_level.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/review_finding_classifier.py",
+      "detail": "No test mirror found for src/theforge/review_finding_classifier.py (expected tests/test_review_finding_classifier.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/root_file_conventions.py",
+      "detail": "No test mirror found for src/theforge/root_file_conventions.py (expected tests/test_root_file_conventions.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/runners",
+      "detail": "No test mirror found for package src/theforge/runners (expected tests/test_runners_*.py or tests/test_runners/)",
+      "blocking": false
+    }
+  ],
+  "finding_registry": [
+    {
+      "finding_id": "cb1c74f51ae89fca",
+      "cycle_first_seen": 1,
+      "cycle_last_seen": 1,
+      "file": "src/theforge/assignment.py",
+      "line": 1462,
+      "severity": "P1",
+      "description": "Importing the assignment module fails at parse time because _build_routing_decision declares defaulted min_reviewers and max_reviewers parameters before required parameters.",
+      "reporter": "openai-gpt-5.5",
+      "disposition": "fixed"
+    },
+    {
+      "finding_id": "497149f6881bf939",
+      "cycle_first_seen": 1,
+      "cycle_last_seen": 1,
+      "file": "src/theforge/cli/explain.py",
+      "line": 244,
+      "severity": "P2",
+      "description": "docs/guides/routing-policy.md tells operators that \"forge explain --story <id> renders this block for a given run\" directly under an example of the new score_policy JSON, but render_routing_decision never reads or prints the score_policy key for any role.",
+      "reporter": "claude-sonnet",
+      "disposition": "net_new"
+    },
+    {
+      "finding_id": "1a77e6c4f3617572",
+      "cycle_first_seen": 1,
+      "cycle_last_seen": 1,
+      "file": "tests/test_assignment_routing_decision.py",
+      "line": 375,
+      "severity": "P2",
+      "description": "The reviewer-count axis is exercised end-to-end only at score=9 (max bucket) and score=2 (min bucket); no test asserts resolved_count or routing_decision output for a mid-range score (5-7) going through _build_routing_decision/_reviewer_count_policy.",
+      "reporter": "claude-sonnet",
+      "disposition": "net_new"
+    }
+  ],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 1,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.5",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 8 \u2192 tier strong ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 8,
+      "base_tier_from_score": "strong",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.8846,
+              "weighted": 0.8846,
+              "runs": 78,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.8846
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "config"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "config": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "config"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "config": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "domain_match": {
+        "domains": [
+          "backend",
+          "config"
+        ],
+        "influenced": false,
+        "complexity_only_head": "claude-opus",
+        "domain_head": "claude-opus",
+        "selected_model_slice": {
+          "domains": [
+            "backend",
+            "config"
+          ],
+          "raw": null,
+          "weighted": null,
+          "runs": 0,
+          "tainted_runs": 0,
+          "floor": "fail",
+          "recency": "windowed",
+          "rate": null,
+          "by_domain": {
+            "backend": {
+              "runs": 0,
+              "raw": null,
+              "weighted": null,
+              "tainted_runs": 0
+            },
+            "config": {
+              "runs": 0,
+              "raw": null,
+              "weighted": null,
+              "tainted_runs": 0
+            }
+          }
+        },
+        "reason": "domain_signal_did_not_change_selection"
+      },
+      "promotion_check": {
+        "fired": true,
+        "matching_records": 10,
+        "escalations": 2,
+        "outcome": "promoted_to_strong"
+      },
+      "routing_rationale": {
+        "state": "promoted_by",
+        "mechanism": "_check_promotion",
+        "from_tier": "strong",
+        "to_tier": "strong"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "preserve",
+        "baseline_tier": "strong",
+        "final_tier": "strong",
+        "plan_present": true,
+        "rationale": "complexity_not_medium"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:large:backend+config",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": null,
+        "winner": null,
+        "reason": "sprint_cap_reached",
+        "domains": [
+          "backend",
+          "config"
+        ]
+      },
+      "final": {
+        "model": "opus",
+        "tier": "strong",
+        "rationale": "[preflight] HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 2/10 recent HIGH stories escalated (profile success_rate=0.88 @ HIGH); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 3,
+            "completed": 2,
+            "raw": 0.6667,
+            "weighted": 0.6667,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "opus",
+          "gemini-3.5-flash",
+          "gpt-5.4"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 8; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 5,
+            "completed": 5,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 3,
+            "completed": 2,
+            "raw": 0.6667,
+            "weighted": 0.6667,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "gemini-3.5-flash",
+          "sonnet"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 8; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [
+    {
+      "check": "reviewer_tree_currency",
+      "result": "pass",
+      "producer": "coordinator.review_context.reviewer_tree_currency",
+      "evidence": {
+        "base_branch": "release/v0.13",
+        "expected_commits": [
+          "c28bfd6 feat(routing): centralize score-to-routing policy SSOT and instrument every axis (#1019)",
+          "b72a0e0 fix(routing): address review findings (iter 1)"
+        ],
+        "actual_commits": [
+          "c28bfd6 feat(routing): centralize score-to-routing policy SSOT and instrument every axis (#1019)",
+          "b72a0e0 fix(routing): address review findings (iter 1)"
+        ],
+        "missing_from_branch": [],
+        "omitted_from_handoff": []
+      }
+    }
+  ],
+  "trust_status": "trusted",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.397379,
+      "duration_s": 64.75,
+      "outcome": "proceed"
+    },
+    "plan": {
+      "cost_usd": null,
+      "duration_s": 35.93,
+      "outcome": "success",
+      "plan_structured": {
+        "approach": "Keep the current coarse 2-3 bucket behavior as the explicit intended design for this story, avoiding routing rewires unless review rejects that product decision. Centralize all score-to-routing policy data in the existing routing module, make assignment consume it, and expose the applied score/bucket/threshold/output in routing_decision for every axis.",
+        "steps": [
+          {
+            "id": 1,
+            "description": "Establish the canonical routing policy SSOT for all axes.",
+            "files": [
+              "src/theforge/routing.py"
+            ],
+            "action": "modify",
+            "details": "Expand the existing dev-tier-only routing policy into a complete score-to-routing policy table covering dev tier, plan tier, code reviewer count, plan reviewer count, reasoning effort, and any other score-derived routing axis found while implementing. For each axis, record bucket boundaries, bucket names, selected output, and rationale. Mark the existing 2-3 bucket shape as intentional for dev tier, plan tier, and reviewer counts; mark reasoning_effort as intentionally not score-controlled unless current code proves otherwise."
+          },
+          {
+            "id": 2,
+            "description": "Route assignment decisions through the canonical policy.",
+            "files": [
+              "src/theforge/assignment.py"
+            ],
+            "action": "modify",
+            "details": "Replace inline score threshold logic in _plan_tier_for_score, _dev_tier_for_score, and _reviewer_target_for_score with lookups/helpers backed by src/theforge/routing.py. Preserve current runtime outputs unless Step 1 identifies an existing axis already intended to be finer-grained.",
+            "depends_on": [
+              1
+            ]
+          },
+          {
+            "id": 3,
+            "description": "Add full per-axis routing_decision instrumentation.",
+            "files": [
+              "src/theforge/assignment.py"
+            ],
+            "action": "modify",
+            "details": "Update _build_routing_decision and related helpers so each routing axis records complexity_score, bucket name, threshold values or bucket range, selected output, and a short explanation/rationale from the canonical policy. Include dev model tier, planner model tier, code reviewer count, plan reviewer count, and reasoning_effort status/output if present in the routing_decision block.",
+            "depends_on": [
+              1,
+              2
+            ]
+          },
+          {
+            "id": 4,
+            "description": "Document operator-facing routing controls.",
+            "files": [
+              "docs/routing-policy.md",
+              "docs/adr/0006-adaptive-router-trust-boundary.md"
+            ],
+            "action": "create",
+            "details": "Create an operator-facing routing policy document that explains what complexity_score actually controls, how each bucket boundary affects model tier or reviewer count, and what a sprint operator can tune. Cross-link ADR-0006 clause 7 to this canonical policy document without duplicating detailed threshold tables beyond what the implementation treats as authoritative.",
+            "depends_on": [
+              1
+            ]
+          },
+          {
+            "id": 5,
+            "description": "Cover routing policy and audit output in tests.",
+            "files": [
+              "tests/test_routing.py",
+              "tests/test_assignment_routing_decision.py",
+              "tests/test_routing_decision_audit.py"
+            ],
+            "action": "modify",
+            "details": "Add or update focused tests covering at least one decision for every routing axis. Assert that routing_decision includes the score, bucket, threshold/range, selected output, and explanation for each axis, and keep existing behavior assertions for the current 2-3 bucket outputs.",
+            "depends_on": [
+              1,
+              2,
+              3
+            ]
+          }
+        ],
+        "criteria_mapping": [
+          {
+            "criterion": "The intended design for score-to-routing thresholds is documented in one canonical routing-policy location, with each axis (dev tier, plan tier, code reviewer count, plan reviewer count, reasoning effort, anything else) showing bucket boundaries and rationale.",
+            "steps": [
+              1,
+              4
+            ]
+          },
+          {
+            "criterion": "For each axis, the design states either (a) the current 2\u20133 bucket shape is intentional and the score is mostly a signal for future use, OR (b) finer-grained routing is desired and a target bucket structure is named.",
+            "steps": [
+              1,
+              4
+            ]
+          },
+          {
+            "criterion": "If (b), at least one axis is rewired to use the score with finer granularity.",
+            "steps": [
+              1,
+              2
+            ]
+          },
+          {
+            "criterion": "Every routing decision records the score, bucket, threshold values, and selected axis output in the routing_decision block from #1391.",
+            "steps": [
+              3,
+              5
+            ]
+          },
+          {
+            "criterion": "Operator-facing docs describe what the score actually controls, in terms an operator tuning a sprint can act on.",
+            "steps": [
+              4
+            ]
+          },
+          {
+            "criterion": "Tests cover at least one decision per routing axis and assert the recorded routing_decision threshold/bucket explanation.",
+            "steps": [
+              5
+            ]
+          }
+        ],
+        "risks": [
+          {
+            "description": "The story leaves the product decision open: coarse buckets may be intentional, or finer-grained routing may be desired.",
+            "mitigation": "Choose the smallest viable documented design: preserve current coarse behavior and explicitly label it intentional per axis. Only rewire finer granularity if implementation discovers an already-approved target structure in existing policy docs or tests."
+          },
+          {
+            "description": "#1107 routing policy SSOT is a dependency but does not exist yet.",
+            "mitigation": "Establish the missing SSOT in this story by extending src/theforge/routing.py as the authoritative implementation policy and linking operator docs to it."
+          },
+          {
+            "description": "routing_decision schema changes may break existing audit tests or consumers expecting the old block shape.",
+            "mitigation": "Add fields compatibly where possible, avoid removing existing keys, and update tests to assert the new per-axis explanation while preserving existing behavior."
+          }
+        ]
+      },
+      "attempt_plans": []
+    },
+    "plan_review": {
+      "cost_usd": null,
+      "duration_s": 295.16,
+      "iterations": 4,
+      "outcome": "approve",
+      "per_reviewer": [
+        {
+          "attempt": 0,
+          "profile": "google-gemini-3.5-flash",
+          "verdict": "PARSE_ERROR",
+          "cost_usd": null
+        },
+        {
+          "attempt": 0,
+          "profile": "claude-opus",
+          "verdict": "APPROVE",
+          "cost_usd": 0.253148
+        },
+        {
+          "attempt": 0,
+          "profile": "google-gemini-3.5-flash",
+          "verdict": "APPROVE",
+          "cost_usd": null
+        },
+        {
+          "attempt": 0,
+          "profile": "openai-gpt-5.4",
+          "verdict": "APPROVE",
+          "cost_usd": null
+        }
+      ]
+    },
+    "dev": {
+      "cost_usd": 6.143391,
+      "duration_s": 629.09,
+      "iterations": 2,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 103.27,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": {
+      "cost_usd": null,
+      "duration_s": 211.7,
+      "cycles": 2,
+      "outcome": "approve",
+      "per_reviewer": {
+        "claude-sonnet": {
+          "cost": 1.595783,
+          "verdict": "APPROVE"
+        },
+        "google-gemini-3.5-flash": {
+          "cost": null,
+          "verdict": "APPROVE"
+        },
+        "openai-gpt-5.5": {
+          "cost": null,
+          "verdict": "APPROVE"
+        }
+      }
+    }
+  },
+  "totals": {
+    "cost_usd": null,
+    "duration_s": 1339.9,
+    "dev_attempts_total": 2,
+    "dev_iterations_productive": 2,
+    "review_cycles_total": 2,
+    "dev_iterations": 2,
+    "review_cycles": 2
+  },
+  "sprint_id": "f6aaf4313b7c",
+  "sprint_name": "issues-1019"
+}

--- a/.forge/audits/runs/8900fb5fa804.json
+++ b/.forge/audits/runs/8900fb5fa804.json
@@ -1,0 +1,1744 @@
+{
+  "schema_version": 9,
+  "run_id": "8900fb5fa804",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Sprint RCA/status misclassifies already-done no-op stories from issue body text",
+    "slug": "issue-1911",
+    "story_path": null,
+    "story_text": "## What happened\n\nIn sprint run `47acc396fb8f`, issue #1904 carried an accepted cached preflight verdict of `ALREADY_DONE`, but the generated sprint RCA assigned it `primary_failure_class: intake_shape`.\n\nThe evidence cited for that classification was historical prose embedded in the issue body and echoed into the story's preflight log \u2014 narrative describing an intake failure the story had experienced on a different host, weeks earlier \u2014 rather than anything the current run produced. The same RCA entry simultaneously carried the run's real terminal outcome as baseline evidence, and still ranked the prose-derived class first. Its recommended next action was to reshape an issue body that intake had not rejected in that run.\n\nThe final status output surfaced contradictory signals for the same story: intake-flavoured wording, a failed no-commit escalation, and an entry under partial value because dev had run once.\n\nNote for whoever picks this up: the literal marker strings that trigger this misclassification are deliberately not quoted in this issue body, because quoting them would cause this issue to reproduce the bug on itself the next time it is sprinted.\n\n## Diagnosis\n\n- **Observed symptom:** sprint RCA assigns a story a primary failure class read out of prose inside the issue body, rather than from the run's structured outcome, and then recommends a remediation that does not apply to what happened.\n- **Evidence:** run `47acc396fb8f`, story #1904 \u2014 the generated RCA records `primary_failure_class: intake_shape`, with evidence excerpts quoting the issue's own narrative text and the preflight log's echo of that same text, while the identical entry also carries the run's true terminal outcome (`outcome=FAILED`, empty-branch escalation) as baseline evidence. The story's actual preflight verdict for that run was a cached already-done, and no intake rejection occurred.\n- **Ruled out:** cross-story contamination out of the shared sprint run log \u2014 that source is filtered to lines that reference the story by slug or number, so it could not have supplied another story's text. Also ruled out: the existing ambiguity guard, which demands corroboration from the captured error only for purely-numeric patterns and therefore never constrains alphabetic ones.\n- **Confirmed cause:** the classifier gathers every readable text file beneath the story's log directory as an undifferentiated blob of scannable text, and those files embed operator-authored story text; primary classification rules that match on plain substrings therefore fire on an issue that merely *describes* a failure mode. Compounding it, the single evidence source derived from the structured run outcome is declared informational and by construction can never classify.\n- **Affected code path:** `src/theforge/sprint/rca.py` \u2014 `_collect_text_sources` (the per-story log-directory scan), `_text_rule_hits`, the intake-family primary rules and their substring patterns, the informational baseline rule, and `_is_ambiguous_primary`.\n- **Fix-success criterion:** a story whose issue body quotes a failure mode it did not experience in the current run is classified from that run's structured outcome, and the recommended next action matches what actually occurred.\n\n## Expected\n\nPost-run classification must be derived from what the run recorded, not from text the operator wrote. Structured outcomes, verdicts, and audit fields are the system's own account of what happened; issue bodies and agent transcripts are input to the run and describe things that may never have occurred in it. A diagnostic layer that scans them as evidence will always be strongest exactly where a project documents its own failure modes, and it will confidently misdirect the operator toward remediating a problem the run did not have. Where a classifier keeps a text-scanning path at all, evidence drawn from run state has to outrank evidence drawn from authored prose, and a class that no structured field corroborates should not be presented as the primary finding or drive a recommended action.\n",
+    "github_issue": 1911,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": true,
+    "final_phase": "DONE",
+    "message": "Task 'Sprint RCA/status misclassifies already-done no-op stories from issue body text' completed. Review approved after 1 cycle(s), 1 dev iteration(s). Branch: feat/issue-1911",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-24T15:16:41.925780+00:00",
+    "finished_at": "2026-07-24T15:26:58.786884+00:00",
+    "duration_seconds": 616.861104
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1911",
+    "branch": "feat/issue-1911"
+  },
+  "iterations": {
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 1,
+    "review_cycles": 1,
+    "dev_iterations": 1,
+    "gate_decisions": [
+      "PASS"
+    ],
+    "dev_loop": [
+      {
+        "cycle": 0,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": null,
+        "duration_s": 344.2,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/sprint/rca.py",
+          "tests/test_sprint_rca.py"
+        ],
+        "files_changed_count": 2,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "gpt-5.4",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      }
+    ],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [
+      {
+        "iteration": 1,
+        "max_iterations": 5,
+        "verdict": "APPROVE",
+        "finding_counts": {
+          "P1": 0,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 0,
+        "restated_findings": 0,
+        "cost_usd": 1.254177,
+        "duration_s": 168.91
+      }
+    ],
+    "usage_summary": {
+      "dev": {
+        "used": 1,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": true
+      },
+      "review": {
+        "used": 1,
+        "max": 5,
+        "hit_limit": false,
+        "early_finish": true,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 6,
+      "complexity_band_input": "medium",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "openai-gpt-5.4",
+      "model_actual": "gpt-5.4",
+      "model_provider": null,
+      "model_cli": "codex",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 1350,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 6,
+      "base_review": 5,
+      "profile_history_runs": 53,
+      "profile_avg_iterations": 1.1509,
+      "profile_avg_cost_usd": 0.0,
+      "profile_raw_dev_max": 1.7264,
+      "estimate_headroom_factor": 2.0,
+      "iteration_derived_timeout_seconds": 1350,
+      "profile_max_duration_s": 656.48,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 985,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": false,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 1350,
+      "chosen_dev_cost_estimate_usd": 0.01,
+      "review_history_sample_size": 17,
+      "p75_review": 2,
+      "chosen_review_max": 5,
+      "rationale": "derived dev limits from 53 medium-band profile runs with 1.5x iteration headroom and 2.0x cost-estimate headroom; timeout scaled from static per-iteration baseline. review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-24T15:17:33.119534+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": null,
+    "dev_usd": null,
+    "review_usd": null,
+    "dev_invocations": 1,
+    "review_invocations": 2,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "openai-gpt-5.4",
+        "cost_usd": null,
+        "duration_seconds": 344.2024618338328,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.4"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 84.37908912496641,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "claude-opus",
+        "cost_usd": 1.2541775,
+        "duration_seconds": 84.37908912496641,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.022568
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 1.2316095
+          }
+        ],
+        "model_used": "opus"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "PROCEED",
+    "reason": "Repo inspection confirms the described mechanism exactly: _collect_text_sources (rca.py:563) wholesale-scans every readable file under a story's log directory, the intake_shape rules match plain alphabetic substrings (rca.py:169-179) with no corroboration requirement, _is_ambiguous_primary (rca.py:1027) only gates purely-numeric patterns and never constrains alphabetic ones, and the captured_outcome rule is declared role=\"informational\" (rca.py:269-275) so it can never classify or outrank a text-derived primary class. This is unfixed and implementable.",
+    "complexity": "medium",
+    "complexity_score": 6,
+    "implementation_complexity_score": 6,
+    "validation_complexity_score": 1,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 6",
+        "dimension": "implementation"
+      }
+    ],
+    "work_type": "bug",
+    "domains": [
+      "backend"
+    ],
+    "contract_change": false,
+    "bundle_candidate": false,
+    "cost_usd": 0.4162485,
+    "cached": false,
+    "original_verdict": null,
+    "source_run_id": null,
+    "cache_snapshot": {
+      "worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "5854876d1600164ada352673c6d41fdb8cfa03e0"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "current_worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "current_evaluation_base_branch_head": "5854876d1600164ada352673c6d41fdb8cfa03e0",
+      "status": "invalidated",
+      "reason": "evaluation_base_branch_head_changed"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.4162485,
+        "duration_s": 49.81,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "medium",
+      "complexity_score": 6,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gpt-5.5",
+          "source": "forge.yaml",
+          "canonical_id": "openai/gpt-5.5/cli"
+        },
+        "plan_reviewers": [
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          }
+        ],
+        "dev": {
+          "model": "gpt-5.4",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "complexity score 6 (MEDIUM) \u2192 tier mid (profile success_rate=1.00 @ MEDIUM); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 6 \u2192 tier strong ($8.33); per-story routing cost target: unset",
+        "plan_review": "2 reviewer(s), tier strong, providers ['anthropic', 'google'], complexity score 6; per-story routing cost target: unset",
+        "code_review": "2 reviewer(s), tier strong, providers ['openai', 'anthropic'], complexity score 6; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 58.33,
+        "final_total_usd": 58.33,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "gpt-5.4",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gpt-5.5",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 58.33
+        }
+      },
+      "config_model_routing": {
+        "complexity": "medium",
+        "complexity_score": 6,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "gemini-3.5-flash",
+        "derived_review_pool": [
+          "gpt-5.4",
+          "opus",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "preflight",
+      "context_budget": 200,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    },
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/sprint/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/sprint",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/sprint/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/sprint",
+          "lines": 17
+        }
+      ],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/sprint/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/sprint",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/sprint/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/sprint",
+          "lines": 17
+        }
+      ],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1911/iter_1.yaml",
+      "handoff": {
+        "summary": "Updated sprint RCA classification so structured current-run evidence from summary and audit fields outranks broad text scans, added provenance-aware text-source handling for preflight/operator-authored artifacts, and tightened intake-shape ambiguity rules so historical issue-body prose cannot become the primary RCA without structured corroboration. Added a regression test covering the cached-ALREADY_DONE plus echoed intake-prose false positive and bumped the RCA ruleset version to reflect the changed classifier behavior.",
+        "commits": [
+          {
+            "sha": "1f6e124",
+            "message": "fix(sprint): prioritize structured rca evidence"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "Post-run classification must be derived from what the run recorded, not from text the operator wrote.",
+            "status": "MET",
+            "notes": "Structured sources are now tagged separately, selected ahead of broad text scans, and preflight/operator-authored artifacts can no longer supply an uncorroborated intake primary."
+          },
+          {
+            "criterion": "A class that no structured field corroborates should not be presented as the primary finding or drive a recommended action.",
+            "status": "MET",
+            "notes": "Intake-family alphabetic text hits are now treated as ambiguous unless structured current-run fields corroborate them; the new regression asserts the story falls back to structured outcome/unknown handling instead of intake-shape remediation."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "none",
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    }
+  ],
+  "reviews": [
+    {
+      "cycle": 1,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "claude-opus"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "claude-opus"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "claude-opus": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "APPROVE",
+      "summary": "[openai-gpt-5.5] No blocking issues found; the RCA classifier now prevents the observed cached ALREADY_DONE plus historical intake-prose false primary, and the extra resume-path commit is covered. | [claude-opus] RCA classifier now derives primary class from structured run state and demotes uncorroborated intake prose from authored artifacts; regression test reproduces the production symptom and genuine intake drops still classify via structured summary error.",
+      "sanitization_audit": null,
+      "p1_count": 0,
+      "p2_count": 0,
+      "findings": [],
+      "ac_verification": [
+        {
+          "criterion": "Symptom resolution: sprint RCA assigned intake_shape from historical issue-body prose echoed into preflight logs instead of the current run's cached ALREADY_DONE and empty-branch outcome.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/sprint/rca.py:521 keeps text evidence but separates structured and text primary classes, src/theforge/sprint/rca.py:556 selects structured primary classes before text-derived fallbacks, and src/theforge/sprint/rca.py:1111 treats non-structured intake_shape text hits as ambiguous unless structured current-run fields corroborate them. tests/test_sprint_rca.py:464 reproduces run 47acc396fb8f with preflight ALREADY_DONE, the empty-branch error text, and echoed intake prose, then asserts the result is unknown_needs_rca with diagnose rather than reshape actions at tests/test_sprint_rca.py:510. The related cached ALREADY_DONE resume behavior is invoked at src/theforge/coordinator/engine.py:1276 and covered by tests/test_coord_resume_cached_already_done.py:68 and tests/test_coord_resume_cached_already_done.py:96."
+        },
+        {
+          "criterion": "Symptom resolution: sprint RCA assigned a story a primary failure class read out of historical prose in the issue body / preflight echo rather than the run's structured outcome, and recommended an inapplicable remediation.",
+          "status": "VERIFIED",
+          "evidence": "rca.py:1111-1116 gates intake_shape text hits: a match from a non-structured source (preflight/.md tagged 'authored' by _text_source_kind_for_path at 1127-1134) is ambiguous unless _structured_run_text (1057-1092) contains an intake pattern, so it is recorded as evidence but excluded from primary_classes (_classify_story 527-544). _select_primary (823-848) makes structured classes outrank text classes. The regression test test_cached_already_done_structured_outcome_vetoes_historical_intake_prose (test_sprint_rca.py:464-517) rebuilds run 47acc396fb8f / issue-1904 with the empty-worktree FAILED outcome plus echoed dropped_after_fix prose in preflight-raw.log/preflight.yaml and asserts primary_failure_class == unknown_needs_rca, no 'reshape' action, a 'diagnose' action, and that intake_dropped_after_fix is still kept as evidence. test_intake_shape_drop (336-354) confirms a genuine drop recorded in story.error (structured source) still classifies as intake_shape, so the fix does not over-correct."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    }
+  ],
+  "reviewer_attempts": [
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "claude-opus",
+      "provider": null,
+      "model": "opus",
+      "cli": "claude",
+      "canonical_id": "anthropic/opus/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    }
+  ],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": false,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": {
+    "action": "merge-pr",
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1916",
+    "merged": false,
+    "merge_queued": true,
+    "success": true,
+    "error": null,
+    "auto_merge_queued": true,
+    "landing_path": "fresh-merge",
+    "guard_evidence": {
+      "branch": "feat/issue-1911",
+      "pr_url": "https://github.com/fuzzypete/theforge/pull/1916",
+      "merge_queued": true
+    }
+  },
+  "landing": {
+    "outcome": "merge-queued",
+    "landing_path": "fresh-merge",
+    "fresh_pr_created": true,
+    "merged": false,
+    "merge_queued": true,
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1916",
+    "pr_merged_at": null
+  },
+  "landing_status": "pending_integration",
+  "landing_event": {
+    "landing_status": "pending_integration",
+    "landed": false,
+    "timestamp": "2026-07-24T15:26:58.786884+00:00"
+  },
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": null,
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": [
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/assignment.py",
+      "detail": "src/theforge/assignment.py has 3293 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/check_config.py",
+      "detail": "src/theforge/cli/check_config.py has 726 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/sprint.py",
+      "detail": "src/theforge/cli/sprint.py has 1283 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/status.py",
+      "detail": "src/theforge/cli/status.py has 1125 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/load.py",
+      "detail": "src/theforge/config/load.py has 1353 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/models.py",
+      "detail": "src/theforge/config/models.py has 874 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/types.py",
+      "detail": "src/theforge/config/types.py has 768 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/conventions.py",
+      "detail": "src/theforge/conventions.py has 706 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit.py",
+      "detail": "src/theforge/coordinator/audit.py has 907 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit_substrate.py",
+      "detail": "src/theforge/coordinator/audit_substrate.py has 2166 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/completion.py",
+      "detail": "src/theforge/coordinator/completion.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/dev_phase.py",
+      "detail": "src/theforge/coordinator/dev_phase.py has 1410 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/diagnose_flow.py",
+      "detail": "src/theforge/coordinator/diagnose_flow.py has 1160 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/engine.py",
+      "detail": "src/theforge/coordinator/engine.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/plan_flow.py",
+      "detail": "src/theforge/coordinator/plan_flow.py has 1808 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight.py",
+      "detail": "src/theforge/coordinator/preflight.py has 1397 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight_flow.py",
+      "detail": "src/theforge/coordinator/preflight_flow.py has 1054 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_phase.py",
+      "detail": "src/theforge/coordinator/review_phase.py has 2004 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_pool.py",
+      "detail": "src/theforge/coordinator/review_pool.py has 1100 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/state.py",
+      "detail": "src/theforge/coordinator/state.py has 840 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/validate_phase.py",
+      "detail": "src/theforge/coordinator/validate_phase.py has 929 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/workspace.py",
+      "detail": "src/theforge/coordinator/workspace.py has 872 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/ideate.py",
+      "detail": "src/theforge/ideate.py has 816 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/groom_flow.py",
+      "detail": "src/theforge/intake/groom_flow.py has 616 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/remediation.py",
+      "detail": "src/theforge/intake/remediation.py has 745 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "src/theforge/model_profiles.py has 2750 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/review.py",
+      "detail": "src/theforge/review.py has 1065 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/api.py",
+      "detail": "src/theforge/runners/api.py has 1047 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "src/theforge/runners/cli.py has 730 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/runner_claude.py",
+      "detail": "src/theforge/runners/runner_claude.py has 982 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/schemas.py",
+      "detail": "src/theforge/schemas.py has 665 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/shape_check/heuristics.py",
+      "detail": "src/theforge/shape_check/heuristics.py has 1044 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/audit.py",
+      "detail": "src/theforge/sprint/audit.py has 1222 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/dag.py",
+      "detail": "src/theforge/sprint/dag.py has 673 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/rca.py",
+      "detail": "src/theforge/sprint/rca.py has 1201 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/runner.py",
+      "detail": "src/theforge/sprint/runner.py has 3575 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/shape_gate.py",
+      "detail": "src/theforge/sprint/shape_gate.py has 681 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/status_reader.py",
+      "detail": "src/theforge/sprint/status_reader.py has 934 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/task/plan_prompts.py",
+      "detail": "src/theforge/task/plan_prompts.py has 685 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_assignment.py",
+      "detail": "tests/test_assignment.py has 1571 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_audit_substrate.py",
+      "detail": "tests/test_audit_substrate.py has 1020 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_check_config.py",
+      "detail": "tests/test_check_config.py has 1234 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_setup.py",
+      "detail": "tests/test_cli_setup.py has 1273 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_sprint_status.py",
+      "detail": "tests/test_cli_sprint_status.py has 1423 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_status_watch.py",
+      "detail": "tests/test_cli_status_watch.py has 1087 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_config_load.py",
+      "detail": "tests/test_config_load.py has 1244 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_dev_phase_routing.py",
+      "detail": "tests/test_coord_dev_phase_routing.py has 1009 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_merge_pr.py",
+      "detail": "tests/test_coord_merge_pr.py has 1811 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_model_profiles_seam.py",
+      "detail": "tests/test_coord_model_profiles_seam.py has 1155 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_plan_flow_agent.py",
+      "detail": "tests/test_coord_plan_flow_agent.py has 2259 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_preflight_verdict.py",
+      "detail": "tests/test_coord_preflight_verdict.py has 1173 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_phase_pool.py",
+      "detail": "tests/test_coord_review_phase_pool.py has 1016 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_pool.py",
+      "detail": "tests/test_coord_review_pool.py has 1324 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_state.py",
+      "detail": "tests/test_coord_state.py has 1165 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_workspace_stale.py",
+      "detail": "tests/test_coord_workspace_stale.py has 1084 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coordinator.py",
+      "detail": "tests/test_coordinator.py has 1376 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cut_rc_isolation.py",
+      "detail": "tests/test_cut_rc_isolation.py has 1476 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_diagnose_flow.py",
+      "detail": "tests/test_diagnose_flow.py has 1541 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_generate_audit_log.py",
+      "detail": "tests/test_generate_audit_log.py has 1114 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_model_profiles.py",
+      "detail": "tests/test_model_profiles.py has 1182 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_preflight_work_type.py",
+      "detail": "tests/test_preflight_work_type.py has 1146 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_review.py",
+      "detail": "tests/test_review.py has 1106 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_claude.py",
+      "detail": "tests/test_runner_claude.py has 1231 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_stuck_detection.py",
+      "detail": "tests/test_runner_stuck_detection.py has 1098 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_parallel.py",
+      "detail": "tests/test_sprint_parallel.py has 2699 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_rca.py",
+      "detail": "tests/test_sprint_rca.py has 1127 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_resume.py",
+      "detail": "tests/test_sprint_resume.py has 1268 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_run_id_rollover.py",
+      "detail": "tests/test_sprint_run_id_rollover.py has 1292 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_story_sources.py",
+      "detail": "tests/test_story_sources.py has 1077 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_validate_phase.py",
+      "detail": "tests/test_validate_phase.py has 1413 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/types.py",
+      "detail": "Circular import detected: theforge.config.types \u2192 theforge.config.models \u2192 theforge.config.types",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/defaults.py",
+      "detail": "Circular import detected: theforge.config.defaults \u2192 theforge.config.types \u2192 theforge.config.defaults",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/review.py",
+      "detail": "Circular import detected: theforge.review \u2192 theforge.plan_finding_classifier \u2192 theforge.review",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "Circular import detected: theforge.model_profiles \u2192 theforge.reviewer_value \u2192 theforge.model_profiles",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/__init__.py",
+      "detail": "Circular import detected: theforge.runners \u2192 theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/api.py",
+      "detail": "Circular import detected: theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners.api",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_codex \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_gemini \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/task/__init__.py",
+      "detail": "Circular import detected: theforge.task \u2192 theforge.task.dev_prompts \u2192 theforge.coordinator.state \u2192 theforge.task",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/sprint/manifest.py",
+      "detail": "Circular import detected: theforge.sprint.manifest \u2192 theforge.sprint.sources \u2192 theforge.sprint.manifest",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/coordinator/notify.py",
+      "detail": "Circular import detected: theforge.coordinator.notify \u2192 theforge.notify_backends \u2192 theforge.coordinator.notify",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli.status \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/agent_types.py",
+      "detail": "No test mirror found for src/theforge/agent_types.py (expected tests/test_agent_types.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/artifacts.py",
+      "detail": "No test mirror found for src/theforge/artifacts.py (expected tests/test_artifacts.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/coordinator",
+      "detail": "No test mirror found for package src/theforge/coordinator (expected tests/test_coordinator_*.py or tests/test_coordinator/)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_launchd.py",
+      "detail": "No test mirror found for src/theforge/daemon_launchd.py (expected tests/test_daemon_launchd.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_state.py",
+      "detail": "No test mirror found for src/theforge/daemon_state.py (expected tests/test_daemon_state.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/ideate.py",
+      "detail": "No test mirror found for src/theforge/ideate.py (expected tests/test_ideate.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/log_level.py",
+      "detail": "No test mirror found for src/theforge/log_level.py (expected tests/test_log_level.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/review_finding_classifier.py",
+      "detail": "No test mirror found for src/theforge/review_finding_classifier.py (expected tests/test_review_finding_classifier.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/root_file_conventions.py",
+      "detail": "No test mirror found for src/theforge/root_file_conventions.py (expected tests/test_root_file_conventions.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/runners",
+      "detail": "No test mirror found for package src/theforge/runners (expected tests/test_runners_*.py or tests/test_runners/)",
+      "blocking": false
+    }
+  ],
+  "finding_registry": [],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.5",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 6 \u2192 tier strong ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 6,
+      "base_tier_from_score": "mid",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.8302,
+              "weighted": 1.0,
+              "runs": 53,
+              "tainted_runs": 1,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 1.0
+            },
+            "domain": {
+              "domains": [
+                "backend"
+              ],
+              "raw": 1.0,
+              "weighted": 1.0,
+              "runs": 3,
+              "tainted_runs": 1,
+              "floor": "pass",
+              "recency": "windowed",
+              "rate": 1.0,
+              "by_domain": {
+                "backend": {
+                  "runs": 3,
+                  "raw": 1.0,
+                  "weighted": 1.0,
+                  "tainted_runs": 1
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            },
+            "domain": {
+              "domains": [
+                "backend"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        }
+      ],
+      "domain_match": {
+        "domains": [
+          "backend"
+        ],
+        "influenced": false,
+        "complexity_only_head": "openai-gpt-5.4",
+        "domain_head": "openai-gpt-5.4",
+        "selected_model_slice": {
+          "domains": [
+            "backend"
+          ],
+          "raw": 1.0,
+          "weighted": 1.0,
+          "runs": 3,
+          "tainted_runs": 1,
+          "floor": "pass",
+          "recency": "windowed",
+          "rate": 1.0,
+          "by_domain": {
+            "backend": {
+              "runs": 3,
+              "raw": 1.0,
+              "weighted": 1.0,
+              "tainted_runs": 1
+            }
+          }
+        },
+        "reason": "domain_signal_did_not_change_selection"
+      },
+      "promotion_check": {
+        "fired": false,
+        "matching_records": 1,
+        "escalations": 0,
+        "outcome": "no_promotion"
+      },
+      "routing_rationale": {
+        "state": "stayed_at_preflight_tier",
+        "mechanism": null,
+        "from_tier": "mid",
+        "to_tier": "mid"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:medium:backend",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": "openai-gpt-5.4",
+        "winner": "openai-gpt-5.4",
+        "reason": "sprint_cap_reached",
+        "domains": [
+          "backend"
+        ]
+      },
+      "final": {
+        "model": "gpt-5.4",
+        "tier": "mid",
+        "rationale": "[preflight] complexity score 6 (MEDIUM) \u2192 tier mid (profile success_rate=1.00 @ MEDIUM); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "claude-opus": {
+            "attempted": 1,
+            "completed": 1,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 12,
+            "completed": 11,
+            "raw": 0.9167,
+            "weighted": 0.9218,
+            "rate": 0.9218,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 6,
+            "completed": 6,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "opus",
+          "gemini-3.5-flash"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier strong, providers ['anthropic', 'google'], complexity score 6; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 15,
+            "completed": 15,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "claude-opus": {
+            "attempted": 1,
+            "completed": 1,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 12,
+            "completed": 11,
+            "raw": 0.9167,
+            "weighted": 0.9218,
+            "rate": 0.9218,
+            "floor": "pass",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 6,
+            "completed": 6,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "opus"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier strong, providers ['openai', 'anthropic'], complexity score 6; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [
+    {
+      "check": "reviewer_tree_currency",
+      "result": "fail",
+      "producer": "coordinator.review_context.reviewer_tree_currency",
+      "evidence": {
+        "base_branch": "release/v0.13",
+        "expected_commits": [
+          "1f6e124 fix(sprint): prioritize structured rca evidence"
+        ],
+        "actual_commits": [
+          "a2760d5 Cached ALREADY_DONE preflight still enters dev and fails empty branch (#1915)",
+          "1f6e124 fix(sprint): prioritize structured rca evidence"
+        ],
+        "missing_from_branch": [],
+        "omitted_from_handoff": [
+          "a2760d5 Cached ALREADY_DONE preflight still enters dev and fails empty branch (#1915)"
+        ]
+      }
+    }
+  ],
+  "trust_status": "tainted",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.416249,
+      "duration_s": 49.81,
+      "outcome": "proceed"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": null,
+      "duration_s": 344.2,
+      "iterations": 1,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 39.76,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": {
+      "cost_usd": null,
+      "duration_s": 168.76,
+      "cycles": 1,
+      "outcome": "approve",
+      "per_reviewer": {
+        "claude-opus": {
+          "cost": 1.254177,
+          "verdict": "APPROVE"
+        },
+        "openai-gpt-5.5": {
+          "cost": null,
+          "verdict": "APPROVE"
+        }
+      }
+    }
+  },
+  "totals": {
+    "cost_usd": null,
+    "duration_s": 602.54,
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 1,
+    "dev_iterations": 1,
+    "review_cycles": 1
+  },
+  "sprint_id": "9f94c1e93249",
+  "sprint_name": "issues-1910,1911,1899"
+}

--- a/.forge/audits/runs/a65b6de03cec.json
+++ b/.forge/audits/runs/a65b6de03cec.json
@@ -1,0 +1,1611 @@
+{
+  "schema_version": 9,
+  "run_id": "a65b6de03cec",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Cached ALREADY_DONE preflight still enters dev and fails empty branch",
+    "slug": "issue-1910",
+    "story_path": null,
+    "story_text": "## What happened\n\nIn sprint run `47acc396fb8f` (`forge sprint --issues 1907,1904 --base-branch release/v0.13`), issue #1904 had cached preflight `original_verdict: ALREADY_DONE` with `cache_validation.status: accepted` and `symptom_verification.status: verified_resolved`.\n\nDespite that terminal preflight verdict, the sprint created a worktree, invoked dev once, ran gate, and then escalated because the branch had no commits ahead of base:\n\n```text\nGate exited PASS but branch has no commits ahead of base \u2014 treating empty worktree as missing-work failure\n```\n\nThe story audit records `dev_attempts_total: 1` even though the accepted cached preflight said the story was already done.\n\n## Expected\n\nAn accepted cached `ALREADY_DONE` preflight verdict should be terminal for that story. Sprint should not enter DEV, run gate, require commits, or escalate an empty branch for work that preflight has already verified as complete.\n\n## Diagnosis\n\n- **Observed symptom:** a story whose preflight verdict is served from cache as already-done still enters the dev loop, runs gate, and then escalates because its branch carries no commits.\n- **Evidence:** run `47acc396fb8f`, story #1904 \u2014 the story audit records `preflight.verdict: cached`, `preflight_original_verdict: ALREADY_DONE`, `cache_validation.status: accepted` with `reason: git_state_match`, and a phase trace of `preflight: already_done` \u2192 `plan: null` \u2192 `dev: success (1 iteration, $0.29)` \u2192 `validate: pass`, terminating on \"branch has no commits ahead of base\". `reviews: 0` and `escalation: null`, so nothing between preflight and dev reconsidered the verdict.\n- **Ruled out:** the deliberate already-done override, which re-enters the loop when a branch carries commits without a prior approval \u2014 it requires commits ahead of base, and the accepted cache snapshot records the worktree head equal to the base branch head, so there were none. Also ruled out: the cache applier failing to carry the verdict, since it copies the cached preflight verdict onto live state verbatim before any routing decision.\n- **Confirmed cause:** the resume entry point applies a valid cached preflight state and its derived config, then falls through directly into the coordinator loop without ever dispatching the verdict. The non-resume entry point routes an identically-cached state through the verdict handler, and even the resume path's cache-*invalid* branch handles the already-done signal \u2014 only the cache-valid branch has no dispatch at all, so a terminal verdict is loaded and then ignored.\n- **Affected code path:** `src/theforge/coordinator/engine.py` \u2014 the cache-valid branch of `_run_resume_coordinator` (which calls `apply_cached_preflight_state` and `_apply_preflight_config`, then proceeds straight to `_coordinator_loop`) against the cached branch of `run_task`, which calls `_handle_preflight_verdict`; verdict routing lives in `src/theforge/coordinator/preflight_flow.py`.\n- **Fix-success criterion:** a story whose cached already-done verdict validates reaches a terminal done outcome on the resume path, without invoking dev, running gate, or escalating an empty branch.\n",
+    "github_issue": 1910,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": true,
+    "final_phase": "DONE",
+    "message": "Task 'Cached ALREADY_DONE preflight still enters dev and fails empty branch' completed. Review approved after 1 cycle(s), 1 dev iteration(s). Branch: feat/issue-1910",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-24T15:04:30.986842+00:00",
+    "finished_at": "2026-07-24T15:13:23.493146+00:00",
+    "duration_seconds": 532.506304
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1910",
+    "branch": "feat/issue-1910"
+  },
+  "iterations": {
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 1,
+    "review_cycles": 1,
+    "dev_iterations": 1,
+    "gate_decisions": [
+      "PASS"
+    ],
+    "dev_loop": [
+      {
+        "cycle": 0,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 2.1187749999999994,
+        "duration_s": 378.46,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/coordinator/engine.py",
+          "tests/test_coord_resume_cached_already_done.py"
+        ],
+        "files_changed_count": 2,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      }
+    ],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [
+      {
+        "iteration": 1,
+        "max_iterations": 5,
+        "verdict": "APPROVE",
+        "finding_counts": {
+          "P1": 0,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 0,
+        "restated_findings": 0,
+        "cost_usd": 0.0,
+        "duration_s": 89.58
+      }
+    ],
+    "usage_summary": {
+      "dev": {
+        "used": 1,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": true
+      },
+      "review": {
+        "used": 1,
+        "max": 5,
+        "hit_limit": false,
+        "early_finish": true,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 6,
+      "complexity_band_input": "medium",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "claude-opus",
+      "model_actual": "opus",
+      "model_provider": null,
+      "model_cli": "claude",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 1350,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 6,
+      "base_review": 5,
+      "profile_history_runs": 140,
+      "profile_avg_iterations": 1.6143,
+      "profile_avg_cost_usd": 4.521408,
+      "profile_raw_dev_max": 2.4215,
+      "estimate_headroom_factor": 2.0,
+      "iteration_derived_timeout_seconds": 1350,
+      "profile_max_duration_s": 2064.04,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 3097,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": true,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 3097,
+      "chosen_dev_cost_estimate_usd": 9.0428,
+      "review_history_sample_size": 17,
+      "p75_review": 2,
+      "chosen_review_max": 5,
+      "rationale": "derived dev limits from 140 medium-band profile runs with 1.5x iteration headroom and 2.0x cost-estimate headroom; timeout floored on observed run duration+headroom (3097s). review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-24T15:04:32.236003+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": null,
+    "dev_usd": 2.1187749999999994,
+    "review_usd": null,
+    "dev_invocations": 1,
+    "review_invocations": 2,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 2.1187749999999994,
+        "duration_seconds": 378.4556055001449,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.003789
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 2.1149859999999996
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 44.71202152094338,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 44.71202152094338,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "The cache-valid branch of _run_resume_coordinator (engine.py:1257-1268) applies the cached preflight state/config but, unlike run_task's identically-cached branch (engine.py:944-969), never calls _handle_preflight_verdict, so a terminal ALREADY_DONE verdict is silently dropped and execution falls through into rebase/_coordinator_loop, which runs dev/gate and escalates on an empty branch.",
+    "complexity": "medium",
+    "complexity_score": 6,
+    "implementation_complexity_score": 6,
+    "validation_complexity_score": 3,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 6",
+        "dimension": "implementation"
+      },
+      {
+        "rule_id": "cost_bearing_dogfood",
+        "signal": "acceptance criteria require a real cost-bearing invocation ('run' \u2026 'forge sprint'), not a test fixture",
+        "dimension": "validation"
+      }
+    ],
+    "work_type": "bug",
+    "domains": [],
+    "contract_change": false,
+    "bundle_candidate": false,
+    "cost_usd": 0.3652554,
+    "cached": true,
+    "original_verdict": "PROCEED",
+    "source_run_id": "0792275824eb",
+    "cache_snapshot": {
+      "worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "current_worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "current_evaluation_base_branch_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.3652554,
+        "duration_s": 54.27,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "medium",
+      "complexity_score": 6,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gpt-5.5",
+          "source": "forge.yaml",
+          "canonical_id": "openai/gpt-5.5/cli"
+        },
+        "plan_reviewers": [
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          }
+        ],
+        "dev": {
+          "model": "opus",
+          "source": "builtin",
+          "canonical_id": "anthropic/opus/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "complexity score 6 (MEDIUM) \u2192 tier mid (profile success_rate=0.83 @ MEDIUM); EXPLORATION empirical winner opus (tier strong) routed for key dev:medium (promotion/dethrone off the static-tier pick); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 6 \u2192 tier strong ($8.33); per-story routing cost target: unset",
+        "plan_review": "2 reviewer(s), tier strong, providers ['anthropic', 'google'], complexity score 6; per-story routing cost target: unset",
+        "code_review": "2 reviewer(s), tier strong, providers ['openai', 'google'], complexity score 6; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 58.33,
+        "final_total_usd": 58.33,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "opus",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gpt-5.5",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 58.33
+        }
+      },
+      "config_model_routing": {
+        "complexity": "medium",
+        "complexity_score": 6,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "gemini-3.5-flash",
+        "derived_review_pool": [
+          "gpt-5.4",
+          "opus",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1910/iter_1.yaml",
+      "handoff": {
+        "summary": "Fixed the resume path so an accepted cached ALREADY_DONE preflight verdict is terminal. In src/theforge/coordinator/engine.py, the cache-valid branch of _run_resume_coordinator applied the cached preflight state and config but never dispatched the verdict, so a terminal ALREADY_DONE was silently dropped and execution fell through into dev/gate and escalated the empty branch. Mirrored run_task's identically-cached branch: call _handle_preflight_verdict, return the terminal result (firing the post-run hook), or set skip_dev_first_iter for the ALREADY_DONE-with-commits override. Added a seam-level regression test (tests/test_coord_resume_cached_already_done.py) covering run_from_dev and run_from_review terminating in DONE without invoking dev/gate/review, plus preservation of the commits-ahead override.",
+        "commits": [
+          {
+            "sha": "8b8dbbf",
+            "message": "fix(coordinator): dispatch cached preflight verdict on resume path"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "An accepted cached ALREADY_DONE preflight verdict should be terminal for that story; sprint should not enter DEV, run gate, require commits, or escalate an empty branch.",
+            "status": "MET",
+            "notes": "Resume cache-valid branch now dispatches the verdict via _handle_preflight_verdict and returns the terminal DONE result before any rebase/coordinator loop. Seam tests assert DONE with dev/review/gate never invoked on the empty-branch case, and that the deliberate commits-ahead override still re-enters REVIEW skipping DEV."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "none",
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    }
+  ],
+  "reviews": [
+    {
+      "cycle": 1,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "APPROVE",
+      "summary": "[openai-gpt-5.5] The resume path now dispatches validated cached ALREADY_DONE verdicts before entering dev/gate, with seam coverage for both resume entry points and the commits-ahead override. | [google-gemini-3.5-flash] Successfully fixed the resume path to dispatch and honor cached ALREADY_DONE preflight verdicts, preventing empty-branch escalations.",
+      "sanitization_audit": null,
+      "p1_count": 0,
+      "p2_count": 0,
+      "findings": [],
+      "ac_verification": [
+        {
+          "criterion": "Symptom resolution: accepted cached ALREADY_DONE preflight still enters DEV/GATE and escalates an empty branch instead of terminating as already done",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/coordinator/engine.py:1266 dispatches the cache-valid resume state through the shared preflight verdict handler, src/theforge/coordinator/engine.py:1287 returns the terminal result before the resume rebase and coordinator loop, and src/theforge/coordinator/engine.py:1293 preserves the ALREADY_DONE-with-commits review override. tests/test_coord_resume_cached_already_done.py:64 covers run_from_dev terminating DONE without dev/review/gate on an empty branch, tests/test_coord_resume_cached_already_done.py:92 covers run_from_review for the same symptom, and tests/test_coord_resume_cached_already_done.py:118 covers the commits-ahead override. Targeted verification: pytest tests/test_coord_resume_cached_already_done.py -q passed with 3 tests."
+        },
+        {
+          "criterion": "Symptom resolution: An accepted cached ALREADY_DONE preflight verdict should be terminal for that story; sprint should not enter DEV, run gate, require commits, or escalate an empty branch.",
+          "status": "VERIFIED",
+          "evidence": "Implemented in src/theforge/coordinator/engine.py:1266-1294. Verified by tests in tests/test_coord_resume_cached_already_done.py, which covers run_from_dev and run_from_review terminating in DONE without invoking dev/gate/review, and preserves the commits-ahead override."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    }
+  ],
+  "reviewer_attempts": [
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    }
+  ],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": true,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": {
+    "action": "merge-pr",
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1915",
+    "merged": false,
+    "merge_queued": true,
+    "success": true,
+    "error": null,
+    "auto_merge_queued": true,
+    "landing_path": "fresh-merge",
+    "guard_evidence": {
+      "branch": "feat/issue-1910",
+      "pr_url": "https://github.com/fuzzypete/theforge/pull/1915",
+      "merge_queued": true
+    }
+  },
+  "landing": {
+    "outcome": "merge-queued",
+    "landing_path": "fresh-merge",
+    "fresh_pr_created": true,
+    "merged": false,
+    "merge_queued": true,
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1915",
+    "pr_merged_at": null
+  },
+  "landing_status": "pending_integration",
+  "landing_event": {
+    "landing_status": "pending_integration",
+    "landed": false,
+    "timestamp": "2026-07-24T15:13:23.493146+00:00"
+  },
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": null,
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": [
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/assignment.py",
+      "detail": "src/theforge/assignment.py has 3293 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/check_config.py",
+      "detail": "src/theforge/cli/check_config.py has 726 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/sprint.py",
+      "detail": "src/theforge/cli/sprint.py has 1283 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/status.py",
+      "detail": "src/theforge/cli/status.py has 1125 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/load.py",
+      "detail": "src/theforge/config/load.py has 1353 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/models.py",
+      "detail": "src/theforge/config/models.py has 874 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/types.py",
+      "detail": "src/theforge/config/types.py has 768 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/conventions.py",
+      "detail": "src/theforge/conventions.py has 706 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit.py",
+      "detail": "src/theforge/coordinator/audit.py has 907 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit_substrate.py",
+      "detail": "src/theforge/coordinator/audit_substrate.py has 2166 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/completion.py",
+      "detail": "src/theforge/coordinator/completion.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/dev_phase.py",
+      "detail": "src/theforge/coordinator/dev_phase.py has 1410 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/diagnose_flow.py",
+      "detail": "src/theforge/coordinator/diagnose_flow.py has 1160 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/engine.py",
+      "detail": "src/theforge/coordinator/engine.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/plan_flow.py",
+      "detail": "src/theforge/coordinator/plan_flow.py has 1808 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight.py",
+      "detail": "src/theforge/coordinator/preflight.py has 1397 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight_flow.py",
+      "detail": "src/theforge/coordinator/preflight_flow.py has 1054 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_phase.py",
+      "detail": "src/theforge/coordinator/review_phase.py has 2004 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_pool.py",
+      "detail": "src/theforge/coordinator/review_pool.py has 1100 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/state.py",
+      "detail": "src/theforge/coordinator/state.py has 840 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/validate_phase.py",
+      "detail": "src/theforge/coordinator/validate_phase.py has 929 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/workspace.py",
+      "detail": "src/theforge/coordinator/workspace.py has 872 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/ideate.py",
+      "detail": "src/theforge/ideate.py has 816 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/groom_flow.py",
+      "detail": "src/theforge/intake/groom_flow.py has 616 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/remediation.py",
+      "detail": "src/theforge/intake/remediation.py has 745 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "src/theforge/model_profiles.py has 2750 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/review.py",
+      "detail": "src/theforge/review.py has 1065 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/api.py",
+      "detail": "src/theforge/runners/api.py has 1047 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "src/theforge/runners/cli.py has 730 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/runner_claude.py",
+      "detail": "src/theforge/runners/runner_claude.py has 982 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/schemas.py",
+      "detail": "src/theforge/schemas.py has 665 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/shape_check/heuristics.py",
+      "detail": "src/theforge/shape_check/heuristics.py has 1044 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/audit.py",
+      "detail": "src/theforge/sprint/audit.py has 1206 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/dag.py",
+      "detail": "src/theforge/sprint/dag.py has 673 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/rca.py",
+      "detail": "src/theforge/sprint/rca.py has 1114 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/runner.py",
+      "detail": "src/theforge/sprint/runner.py has 3575 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/shape_gate.py",
+      "detail": "src/theforge/sprint/shape_gate.py has 681 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/status_reader.py",
+      "detail": "src/theforge/sprint/status_reader.py has 934 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/task/plan_prompts.py",
+      "detail": "src/theforge/task/plan_prompts.py has 685 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_assignment.py",
+      "detail": "tests/test_assignment.py has 1571 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_audit_substrate.py",
+      "detail": "tests/test_audit_substrate.py has 1020 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_check_config.py",
+      "detail": "tests/test_check_config.py has 1234 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_setup.py",
+      "detail": "tests/test_cli_setup.py has 1273 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_sprint_status.py",
+      "detail": "tests/test_cli_sprint_status.py has 1423 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_status_watch.py",
+      "detail": "tests/test_cli_status_watch.py has 1087 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_config_load.py",
+      "detail": "tests/test_config_load.py has 1244 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_dev_phase_routing.py",
+      "detail": "tests/test_coord_dev_phase_routing.py has 1009 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_merge_pr.py",
+      "detail": "tests/test_coord_merge_pr.py has 1811 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_model_profiles_seam.py",
+      "detail": "tests/test_coord_model_profiles_seam.py has 1155 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_plan_flow_agent.py",
+      "detail": "tests/test_coord_plan_flow_agent.py has 2259 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_preflight_verdict.py",
+      "detail": "tests/test_coord_preflight_verdict.py has 1173 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_phase_pool.py",
+      "detail": "tests/test_coord_review_phase_pool.py has 1016 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_pool.py",
+      "detail": "tests/test_coord_review_pool.py has 1324 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_state.py",
+      "detail": "tests/test_coord_state.py has 1165 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_workspace_stale.py",
+      "detail": "tests/test_coord_workspace_stale.py has 1084 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coordinator.py",
+      "detail": "tests/test_coordinator.py has 1376 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cut_rc_isolation.py",
+      "detail": "tests/test_cut_rc_isolation.py has 1476 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_diagnose_flow.py",
+      "detail": "tests/test_diagnose_flow.py has 1541 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_generate_audit_log.py",
+      "detail": "tests/test_generate_audit_log.py has 1114 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_model_profiles.py",
+      "detail": "tests/test_model_profiles.py has 1182 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_preflight_work_type.py",
+      "detail": "tests/test_preflight_work_type.py has 1146 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_review.py",
+      "detail": "tests/test_review.py has 1106 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_claude.py",
+      "detail": "tests/test_runner_claude.py has 1231 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_stuck_detection.py",
+      "detail": "tests/test_runner_stuck_detection.py has 1098 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_parallel.py",
+      "detail": "tests/test_sprint_parallel.py has 2699 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_rca.py",
+      "detail": "tests/test_sprint_rca.py has 1070 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_resume.py",
+      "detail": "tests/test_sprint_resume.py has 1268 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_run_id_rollover.py",
+      "detail": "tests/test_sprint_run_id_rollover.py has 1292 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_story_sources.py",
+      "detail": "tests/test_story_sources.py has 1077 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_validate_phase.py",
+      "detail": "tests/test_validate_phase.py has 1413 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/types.py",
+      "detail": "Circular import detected: theforge.config.types \u2192 theforge.config.models \u2192 theforge.config.types",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/defaults.py",
+      "detail": "Circular import detected: theforge.config.defaults \u2192 theforge.config.types \u2192 theforge.config.defaults",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/review.py",
+      "detail": "Circular import detected: theforge.review \u2192 theforge.plan_finding_classifier \u2192 theforge.review",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "Circular import detected: theforge.model_profiles \u2192 theforge.reviewer_value \u2192 theforge.model_profiles",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/__init__.py",
+      "detail": "Circular import detected: theforge.runners \u2192 theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/api.py",
+      "detail": "Circular import detected: theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners.api",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_codex \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_gemini \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/task/__init__.py",
+      "detail": "Circular import detected: theforge.task \u2192 theforge.task.dev_prompts \u2192 theforge.coordinator.state \u2192 theforge.task",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/sprint/manifest.py",
+      "detail": "Circular import detected: theforge.sprint.manifest \u2192 theforge.sprint.sources \u2192 theforge.sprint.manifest",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/coordinator/notify.py",
+      "detail": "Circular import detected: theforge.coordinator.notify \u2192 theforge.notify_backends \u2192 theforge.coordinator.notify",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli.status \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/agent_types.py",
+      "detail": "No test mirror found for src/theforge/agent_types.py (expected tests/test_agent_types.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/artifacts.py",
+      "detail": "No test mirror found for src/theforge/artifacts.py (expected tests/test_artifacts.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/coordinator",
+      "detail": "No test mirror found for package src/theforge/coordinator (expected tests/test_coordinator_*.py or tests/test_coordinator/)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_launchd.py",
+      "detail": "No test mirror found for src/theforge/daemon_launchd.py (expected tests/test_daemon_launchd.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_state.py",
+      "detail": "No test mirror found for src/theforge/daemon_state.py (expected tests/test_daemon_state.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/ideate.py",
+      "detail": "No test mirror found for src/theforge/ideate.py (expected tests/test_ideate.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/log_level.py",
+      "detail": "No test mirror found for src/theforge/log_level.py (expected tests/test_log_level.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/review_finding_classifier.py",
+      "detail": "No test mirror found for src/theforge/review_finding_classifier.py (expected tests/test_review_finding_classifier.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/root_file_conventions.py",
+      "detail": "No test mirror found for src/theforge/root_file_conventions.py (expected tests/test_root_file_conventions.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/runners",
+      "detail": "No test mirror found for package src/theforge/runners (expected tests/test_runners_*.py or tests/test_runners/)",
+      "blocking": false
+    }
+  ],
+  "finding_registry": [],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.5",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 6 \u2192 tier strong ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 6,
+      "base_tier_from_score": "mid",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "promotion_check": {
+        "fired": false,
+        "matching_records": 0,
+        "escalations": 0,
+        "outcome": "no_promotion"
+      },
+      "routing_rationale": {
+        "state": "stayed_at_preflight_tier",
+        "mechanism": null,
+        "from_tier": "strong",
+        "to_tier": "strong"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:medium",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": "claude-opus",
+        "winner": "claude-opus",
+        "reason": "sprint_cap_reached",
+        "domains": []
+      },
+      "final": {
+        "model": "opus",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 6 (MEDIUM) \u2192 tier mid (profile success_rate=0.83 @ MEDIUM); EXPLORATION empirical winner opus (tier strong) routed for key dev:medium (promotion/dethrone off the static-tier pick); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 11,
+            "completed": 10,
+            "raw": 0.9091,
+            "weighted": 0.9141,
+            "rate": 0.9141,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 6,
+            "completed": 6,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "opus",
+          "gemini-3.5-flash"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier strong, providers ['anthropic', 'google'], complexity score 6; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 13,
+            "completed": 13,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 11,
+            "completed": 10,
+            "raw": 0.9091,
+            "weighted": 0.9141,
+            "rate": 0.9141,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 6,
+            "completed": 6,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "gemini-3.5-flash"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier strong, providers ['openai', 'google'], complexity score 6; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [
+    {
+      "check": "reviewer_tree_currency",
+      "result": "pass",
+      "producer": "coordinator.review_context.reviewer_tree_currency",
+      "evidence": {
+        "base_branch": "release/v0.13",
+        "expected_commits": [
+          "8b8dbbf fix(coordinator): dispatch cached preflight verdict on resume path"
+        ],
+        "actual_commits": [
+          "8b8dbbf fix(coordinator): dispatch cached preflight verdict on resume path"
+        ],
+        "missing_from_branch": [],
+        "omitted_from_handoff": []
+      }
+    }
+  ],
+  "trust_status": "trusted",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.365255,
+      "duration_s": 54.27,
+      "outcome": "proceed"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": 2.118775,
+      "duration_s": 378.46,
+      "iterations": 1,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 51.92,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": {
+      "cost_usd": null,
+      "duration_s": 89.42,
+      "cycles": 1,
+      "outcome": "approve",
+      "per_reviewer": {
+        "google-gemini-3.5-flash": {
+          "cost": null,
+          "verdict": "APPROVE"
+        },
+        "openai-gpt-5.5": {
+          "cost": null,
+          "verdict": "APPROVE"
+        }
+      }
+    }
+  },
+  "totals": {
+    "cost_usd": null,
+    "duration_s": 574.07,
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 1,
+    "dev_iterations": 1,
+    "review_cycles": 1
+  },
+  "sprint_id": "9f94c1e93249",
+  "sprint_name": "issues-1910,1911,1899"
+}

--- a/.forge/audits/runs/ae03f522b1f8.json
+++ b/.forge/audits/runs/ae03f522b1f8.json
@@ -1,0 +1,855 @@
+{
+  "schema_version": 9,
+  "run_id": "ae03f522b1f8",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "forge diagnose output fails sprint intake bug-shape gate",
+    "slug": "issue-1904",
+    "story_path": null,
+    "story_text": "## What happened\n\nOn HDP running TheForge `0.13.0rc2`, `forge diagnose --issue 226,227 --parallel 2 --autonomous` landed useful `## Diagnosis` sections on both bugs. Immediately after, `hforge sprint --issues 226,227 ...` skipped both at intake with `intake_shape \u2014 kind: dropped_after_fix` and `needs_diagnosis`.\n\nThe sprint never created worker workspaces and reported `$0.00 / 0m`.\n\n## Evidence\n\nHDP sprint state for run `29f6980172fb` records both issues as `DROPPED_AFTER_FIX` with:\n\n```text\n[needs_diagnosis] rerun gate still failing; candidate posted as issue comment ...\nBug has no Diagnosis section \u2014 not fix-ready. Add a '## Diagnosis' section containing a \"**Observed symptom:**\" bullet ...\n```\n\nBut both issue bodies already contained `## Diagnosis` sections produced by `forge diagnose`. The output shape used narrative subsections such as:\n\n```md\n## Diagnosis\n\n### Observed symptom\n...\n### Reproduction / evidence\n...\n### Hypotheses tested\n...\n### Confirmed cause\n...\n### Affected code path\n...\n### Fix-success criterion\n...\n```\n\nThe intake gate expected exact bold bullets under `## Diagnosis`:\n\n```md\n- **Observed symptom:** ...\n- **Evidence:** ...\n- **Ruled out:** ...\n- **Confirmed cause:** ...\n- **Affected code path:** ...\n- **Fix-success criterion:** ...\n```\n\n## Expected\n\n`forge diagnose` should emit a diagnosis shape that `forge sprint` intake recognizes as fix-ready, or intake should accept the canonical diagnosis structure that `forge diagnose` emits.\n\nRunning `forge diagnose` on a symptom bug should not produce an issue body that the next `forge sprint` rejects as `needs_diagnosis`.\n\n## Confirmed downstream impact\n\nThis blocks v0.13 dogfooding because downstream operators are now running `forge diagnose` before sprinting bugs. If diagnose and intake disagree on the required schema, the recommended workflow creates false intake failures and confusing `dropped_after_fix` output.\n\n## Related product note\n\nThis is separate from, but adjacent to, #1901 about distinguishing agent-verifiable ACs from operator validation ACs.\n\n## Acceptance criteria\n\n- [ ] The diagnosis artifact emitted by `forge diagnose` satisfies the bug-shape gate used by sprint intake.\n- [ ] Sprint intake recognizes diagnose-produced issue bodies as fix-ready when the required diagnosis fields are present.\n- [ ] A regression test covers a diagnose-produced `## Diagnosis` section passing intake shape validation.\n- [ ] Intake status/error wording distinguishes schema mismatch from actual missing diagnosis; avoid misleading `dropped_after_fix` when the issue was not fixed or implemented.\n",
+    "github_issue": 1904,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": false,
+    "final_phase": "ESCALATE",
+    "message": "Gate exited PASS but branch has no commits ahead of base \u2014 treating empty worktree as missing-work failure (handoff parse errors: commits must be non-empty)",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T15:55:22.373465+00:00",
+    "finished_at": "2026-07-23T15:57:35.744230+00:00",
+    "duration_seconds": 133.370765
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1904",
+    "branch": "feat/issue-1904"
+  },
+  "iterations": {
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 0,
+    "review_cycles": 0,
+    "dev_iterations": 1,
+    "gate_decisions": [
+      "PASS"
+    ],
+    "dev_loop": [],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [],
+    "usage_summary": {
+      "dev": {
+        "used": 0,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": false
+      },
+      "review": {
+        "used": 0,
+        "max": 4,
+        "hit_limit": false,
+        "early_finish": false,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 3,
+      "complexity_band_input": "small",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "claude-sonnet",
+      "model_actual": "sonnet",
+      "model_provider": null,
+      "model_cli": "claude",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 900,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 3,
+      "base_review": 4,
+      "profile_history_runs": 57,
+      "profile_avg_iterations": 1.1404,
+      "profile_avg_cost_usd": 0.614836,
+      "profile_raw_dev_max": 1.7106,
+      "estimate_headroom_factor": 1.5,
+      "iteration_derived_timeout_seconds": 900,
+      "profile_max_duration_s": 357.72,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 537,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": false,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 900,
+      "chosen_dev_cost_estimate_usd": 0.9223,
+      "review_history_sample_size": 13,
+      "p75_review": 2,
+      "chosen_review_max": 4,
+      "rationale": "derived dev limits from 57 small-band profile runs with 1.5x iteration headroom and 1.5x cost-estimate headroom; timeout scaled from static per-iteration baseline. review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-23T15:55:23.043419+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": 1.0230773,
+    "dev_usd": 0.28670070000000003,
+    "review_usd": 0,
+    "dev_invocations": 1,
+    "review_invocations": 0,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "claude-sonnet",
+        "cost_usd": 0.28670070000000003,
+        "duration_seconds": 93.35197020799387,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.004143
+          },
+          {
+            "model": "claude-sonnet-5",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.2825577
+          }
+        ],
+        "model_used": "sonnet"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "The shape gate (theforge.shape_check.heuristics.diagnosis_completeness) matches required Diagnosis components by case-insensitive substring token, not by strict bold-bullet format, so diagnose's narrative '### Observed symptom' / '### Confirmed cause' headings already satisfy it; a dedicated seam test already asserts this contract holds.",
+    "complexity": "small",
+    "complexity_score": 3,
+    "implementation_complexity_score": 2,
+    "validation_complexity_score": 3,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 2",
+        "dimension": "implementation"
+      },
+      {
+        "rule_id": "cost_bearing_dogfood",
+        "signal": "acceptance criteria require a real cost-bearing invocation ('running' \u2026 'forge diagnose'), not a test fixture",
+        "dimension": "validation"
+      }
+    ],
+    "work_type": "bug",
+    "domains": [],
+    "contract_change": false,
+    "bundle_candidate": false,
+    "cost_usd": 0.7363765999999999,
+    "cached": true,
+    "original_verdict": "ALREADY_DONE",
+    "source_run_id": "122dacc899fb",
+    "cache_snapshot": {
+      "worktree_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "current_worktree_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "current_evaluation_base_branch_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.7363765999999999,
+        "duration_s": 129.76,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "small",
+      "complexity_score": 3,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gemini-3.5-flash",
+          "source": "forge.yaml",
+          "canonical_id": "google/gemini-3.5-flash/api"
+        },
+        "plan_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          }
+        ],
+        "dev": {
+          "model": "sonnet",
+          "source": "builtin",
+          "canonical_id": "anthropic/sonnet/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "complexity score 3 (LOW) \u2192 tier cheap (profile success_rate=0.81 @ LOW); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 3 \u2192 tier mid ($8.33); per-story routing cost target: unset",
+        "plan_review": "1 reviewer(s), tier mid, providers ['openai'], complexity score 3; per-story routing cost target: unset",
+        "code_review": "1 reviewer(s), tier mid, providers ['openai'], complexity score 3; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 41.67,
+        "final_total_usd": 41.67,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "sonnet",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gemini-3.5-flash",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 41.67
+        }
+      },
+      "config_model_routing": {
+        "complexity": "small",
+        "complexity_score": 3,
+        "derived_plan_model": "gemini-3.5-flash",
+        "derived_dev_model": "gpt-5.4-mini",
+        "derived_review_pool": [
+          "gemini-3.5-flash"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1904/iter_1.yaml",
+      "handoff": {
+        "summary": "Verified (did not implement) that the reported bug \u2014 forge diagnose output being rejected by sprint intake's bug-shape gate \u2014 does not reproduce on current HEAD. diagnosis_completeness() in shape_check/heuristics.py matches required Diagnosis components by case-insensitive substring token against required_diagnosis_tokens(), not by strict bold-bullet format, so diagnose's narrative '### Observed symptom' / '### Confirmed cause' headings (rendered by diagnose_types.render_artifact_markdown) already satisfy it. Ran the existing seam test tests/test_diagnose_flow.py::test_default_destination_lands_in_body_and_satisfies_shape_gate (passes), and independently reviewed check_bug_missing_diagnosis in shape_check/heuristics.py which already emits three distinguishable reason codes/detail strings: needs_diagnosis (section missing entirely), needs_diagnosis (section present but incomplete, listing missing components), and diagnosis_cause_unknown (advisory \u2014 hypotheses ruled out but cause unresolved). Ran full `make gate` (5882 passed, 31 skipped) to confirm the baseline is healthy. No code changes made \u2014 this is a pre-existing fix (likely #1629) that already resolved the symptom described in the rc2-era bug report.",
+        "commits": [],
+        "acceptance_criteria": [
+          {
+            "criterion": "The diagnosis artifact emitted by forge diagnose satisfies the bug-shape gate used by sprint intake.",
+            "status": "MET",
+            "notes": "diagnosis_completeness() does substring matching, not strict format matching; verified via seam test."
+          },
+          {
+            "criterion": "Sprint intake recognizes diagnose-produced issue bodies as fix-ready when the required diagnosis fields are present.",
+            "status": "MET",
+            "notes": "derive_fix_ready() returns fix_ready=True for diagnose-produced bodies with a confirmed cause; covered by existing tests/test_fix_readiness.py."
+          },
+          {
+            "criterion": "A regression test covers a diagnose-produced ## Diagnosis section passing intake shape validation.",
+            "status": "MET",
+            "notes": "tests/test_diagnose_flow.py::test_default_destination_lands_in_body_and_satisfies_shape_gate already covers this end-to-end (run_diagnose_flow -> diagnosis_completeness)."
+          },
+          {
+            "criterion": "Intake status/error wording distinguishes schema mismatch from actual missing diagnosis; avoid misleading dropped_after_fix when the issue was not fixed or implemented.",
+            "status": "MET",
+            "notes": "check_bug_missing_diagnosis already produces distinct reason codes/detail text for missing-section vs incomplete-section vs cause-unknown states."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "No implementation changes were made \u2014 investigation confirmed the reported bug does not reproduce on current HEAD (per preflight verdict ALREADY_DONE), and independent verification (seam test run + manual review of check_bug_missing_diagnosis) agreed.",
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    }
+  ],
+  "reviews": [],
+  "reviewer_attempts": [],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": true,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": null,
+  "landing": null,
+  "landing_status": null,
+  "landing_event": null,
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": "Gate exited PASS but branch has no commits ahead of base \u2014 treating empty worktree as missing-work failure (handoff parse errors: commits must be non-empty)",
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": null,
+  "finding_registry": [],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gemini-3.5-flash",
+        "tier": "mid",
+        "rationale": "[preflight] complexity score 3 \u2192 tier mid ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 3,
+      "base_tier_from_score": "cheap",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.807,
+              "weighted": 0.807,
+              "runs": 57,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.807
+            }
+          }
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "promotion_check": {
+        "fired": false,
+        "matching_records": 10,
+        "escalations": 1,
+        "outcome": "no_promotion"
+      },
+      "routing_rationale": {
+        "state": "stayed_at_preflight_tier",
+        "mechanism": null,
+        "from_tier": "cheap",
+        "to_tier": "cheap"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:small",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": "claude-sonnet",
+        "winner": "claude-sonnet",
+        "reason": "not_cadence_run",
+        "domains": []
+      },
+      "final": {
+        "model": "sonnet",
+        "tier": "cheap",
+        "rationale": "[preflight] complexity score 3 (LOW) \u2192 tier cheap (profile success_rate=0.81 @ LOW); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "anti_self_review"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 11,
+            "completed": 11,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 4,
+            "completed": 4,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5"
+        ],
+        "rationale": "[preflight] 1 reviewer(s), tier mid, providers ['openai'], complexity score 3; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 11,
+            "completed": 11,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 9,
+            "completed": 8,
+            "raw": 0.8889,
+            "weighted": 0.8935,
+            "rate": 0.8935,
+            "floor": "pass",
+            "selected": false
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5"
+        ],
+        "rationale": "[preflight] 1 reviewer(s), tier mid, providers ['openai'], complexity score 3; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [],
+  "trust_status": "unchecked",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.736377,
+      "duration_s": 129.76,
+      "outcome": "already_done"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": 0.286701,
+      "duration_s": 93.35,
+      "iterations": 1,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 38.79,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": null
+  },
+  "totals": {
+    "cost_usd": 1.023077,
+    "duration_s": 261.9,
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 0,
+    "dev_iterations": 1,
+    "review_cycles": 0
+  },
+  "sprint_id": "cb1ed713b3a2",
+  "sprint_name": "issues-1907,1904"
+}

--- a/.forge/audits/runs/d3e4bb0833c3.json
+++ b/.forge/audits/runs/d3e4bb0833c3.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": 9,
+  "run_id": "d3e4bb0833c3",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Sprint canonical run JSON path is not rebuild-safe when an existing run file is malformed",
+    "slug": "issue-1899",
+    "story_path": null,
+    "story_text": "What happened:\n\n#1897 makes sprint story audits write canonical `.forge/audits/runs/{run_id}.json` files and mirrors SQLite rows from that path. The clean path is covered, but the existing-file path is not rebuild-safe when the canonical JSON already exists and is malformed or not a JSON object. In that case the writer can fall back to a live SQLite upsert while leaving the bad canonical file in place, so `forge explain` may work until `forge audits rebuild` and then fail again.\n\nExpected behavior:\n\nThe sprint story audit writer must never leave a native SQLite row whose `source_path` points at an unreadable or non-object canonical run file. If an existing canonical file is malformed, the behavior should be explicit and rebuild-safe: either repair/replace it under a defined immutability rule, write a distinct recoverable record, or refuse the substrate mirror rather than creating a row rebuild cannot reproduce.\n\nDiagnosis:\n\nThe clean case added by #1897 writes `.forge/audits/runs/{run_id}.json`, sets SQLite `source_path`, and survives rebuild. The untested edge is the branch that encounters a pre-existing bad file. That path can preserve a broken canonical source while still updating the live substrate, recreating the same live-vs-rebuild split #1896 was meant to close.\n\nFix success observable:\n\nA regression test seeds an existing malformed or non-object `.forge/audits/runs/{run_id}.json`, invokes the sprint story audit writer, runs `forge audits rebuild`, and verifies the final behavior is explicit and rebuild-safe rather than silently losing the story record.",
+    "github_issue": 1899,
+    "fix_ready": false,
+    "readiness_warnings": [
+      "bug missing Diagnosis section \u2014 not fix-ready (run `forge diagnose` or add diagnosis manually)"
+    ]
+  },
+  "outcome": {
+    "success": false,
+    "final_phase": "ESCALATE",
+    "message": "Workspace creation failed: WORKSPACE abort: base branch 'release/v0.13' has diverged from origin (local is 1 ahead, 1 behind). Run: git rebase origin/release/v0.13",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T09:08:08.151336+00:00",
+    "finished_at": "2026-07-23T09:08:09.609720+00:00",
+    "duration_seconds": 1.458384
+  },
+  "workspace": {
+    "path": null,
+    "branch": null
+  },
+  "iterations": {
+    "dev_attempts_total": 0,
+    "dev_iterations_productive": 0,
+    "review_cycles_total": 0,
+    "review_cycles": 0,
+    "dev_iterations": 0,
+    "gate_decisions": [],
+    "dev_loop": [],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [],
+    "usage_summary": {
+      "dev": {
+        "used": 0,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": false
+      },
+      "review": {
+        "used": 0,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": false,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": null,
+    "budget_consumption_log": []
+  },
+  "cost": {
+    "total_usd": 0.0,
+    "dev_usd": 0,
+    "review_usd": 0,
+    "dev_invocations": 0,
+    "review_invocations": 0,
+    "agents": []
+  },
+  "preflight": null,
+  "context_manifests": [],
+  "dev_handoffs": [],
+  "dev_prompt_injections": [],
+  "reviews": [],
+  "reviewer_attempts": [],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": true,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": null,
+  "landing": null,
+  "landing_status": null,
+  "landing_event": null,
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": "WORKSPACE abort: base branch 'release/v0.13' has diverged from origin (local is 1 ahead, 1 behind). Run: git rebase origin/release/v0.13",
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": null,
+  "finding_registry": [],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": null,
+  "trust_checks": [],
+  "trust_status": "unchecked",
+  "phases": {
+    "preflight": null,
+    "plan": null,
+    "plan_review": null,
+    "dev": null,
+    "validate": null,
+    "review": null
+  },
+  "totals": {
+    "cost_usd": 0.0,
+    "duration_s": 0.0,
+    "dev_attempts_total": 0,
+    "dev_iterations_productive": 0,
+    "review_cycles_total": 0,
+    "dev_iterations": 0,
+    "review_cycles": 0
+  },
+  "sprint_id": "849c9780c3bb",
+  "sprint_name": "issues-1899,158,1019,1108,1443,1489"
+}

--- a/.forge/audits/runs/d6c8d6e911d6.json
+++ b/.forge/audits/runs/d6c8d6e911d6.json
@@ -1,0 +1,2250 @@
+{
+  "schema_version": 9,
+  "run_id": "d6c8d6e911d6",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Extend adaptive routing to all agent roles using reliability signals",
+    "slug": "issue-1489",
+    "story_path": null,
+    "story_text": "## Summary\n\nAdaptive model routing should account for observed performance across all agent roles, not only the dev role.\n\n## Problem\n\nThe system currently learns from dev outcomes, but reviewer, planner, plan-reviewer, and preflight selection are routed primarily by tier and budget. A model that is slow, flaky, or otherwise poor in a non-dev role keeps getting picked regardless of local run history. This makes repeated sprint pain possible even when accumulated evidence clearly shows the model is unreliable for that role.\n\nThe profile surface also only captures a narrow set of success/cost data today. Non-dev routing needs complete, structured role-specific telemetry: attempts, timeouts, transport failures, parse failures, latency, and role/phase attribution. Without that, any non-dev routing profile would be too weak or biased to trust.\n\n## Expected\n\nNon-dev routing may use role-specific historical signals only when they satisfy ADR-0006 clause 2: mechanically recorded, complete over the relevant attempts, sample-floor gated, recency-aware, schema-stable, role-specific, and traceable to authoritative native telemetry.\n\nThis issue extends adaptive routing beyond dev, but it does not create new signal semantics by itself. It consumes the role-specific signals produced by narrower issues such as #1388 (reviewer attempt completion), #1392 (shared recency weighting), #1443 (mechanical reviewer value signals, once groomed), and #1852 (taint filtering).\n\n## Acceptance criteria\n\n- Non-dev model selection can use observed role-specific performance only when the matching signal has cleared ADR-0006 clause-2 admissibility requirements: sample floor, completeness, recency handling, schema compatibility, and per-role scope.\n- Reliability signals relevant to routing are recorded as authoritative native telemetry or deterministic aggregations over it, not as log prose, LLM summaries, or profile-only state.\n- Historical role-specific aggregates exclude tainted runs through the centralized filter from #1852.\n- A model with repeated poor reliability in a role is deprioritized for that role without requiring manual removal from `forge.yaml`.\n- Deprioritization is a sort-after, not a filter-out: an operator-enabled candidate remains eligible unless explicit configuration excludes it.\n- Explicit CLI / `forge.yaml` configuration still wins over learned preference, per ADR-0006 clause 1.\n- Routing decisions that use role-specific profile history record the consulted signal, sample count, floor status, raw and weighted values where applicable, taint-excluded count where applicable, and ranking effect in the `routing_decision` block from #1391.\n- Tests cover at least one non-dev role where sufficient reliable history changes ordering, one cold-start case where ordering falls back to static policy, and one explicit override case where learned preference does not override operator configuration.\n\n## Example\n\nIf a strong-tier reviewer model repeatedly times out or fails transport during review, future review assignment should prefer another eligible strong-tier reviewer after the unreliable model has enough admissible attempts. The decision is recorded in `routing_decision` so it is not a silent demotion.\n\n## References\n\n- ADR-0006 clauses 1, 2, 4, and 7\n- #1391 \u2014 canonical `routing_decision` block\n- #1388 \u2014 reviewer attempt-completion telemetry\n- #1392 \u2014 shared recency weighting\n- #1852 \u2014 tainted-run aggregate filtering\n",
+    "github_issue": 1489,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": true,
+    "final_phase": "DONE",
+    "message": "Task 'Extend adaptive routing to all agent roles using reliability signals' completed. Review approved after 2 cycle(s), 1 dev iteration(s). Branch: feat/issue-1489",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T08:26:03.406042+00:00",
+    "finished_at": "2026-07-23T09:06:04.379453+00:00",
+    "duration_seconds": 2400.973411
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1489",
+    "branch": "feat/issue-1489"
+  },
+  "iterations": {
+    "dev_attempts_total": 2,
+    "dev_iterations_productive": 2,
+    "review_cycles_total": 2,
+    "review_cycles": 2,
+    "dev_iterations": 2,
+    "gate_decisions": [
+      "PASS",
+      "PASS"
+    ],
+    "dev_loop": [
+      {
+        "cycle": 0,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 9.01884675,
+        "duration_s": 1162.08,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/assignment.py",
+          "src/theforge/coordinator/model_profiles_bridge.py",
+          "src/theforge/model_profiles.py",
+          "tests/test_assignment_role_reliability.py",
+          "tests/test_coord_model_profiles_seam.py"
+        ],
+        "files_changed_count": 5,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      },
+      {
+        "cycle": 1,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 10.093474499999997,
+        "duration_s": 715.62,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/coordinator/model_profiles_bridge.py",
+          "src/theforge/coordinator/preflight_flow.py",
+          "src/theforge/model_profiles.py",
+          "tests/test_assignment_role_reliability.py",
+          "tests/test_coord_model_profiles_seam.py",
+          "tests/test_coord_preflight_fallback.py"
+        ],
+        "files_changed_count": 6,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      }
+    ],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [
+      {
+        "iteration": 1,
+        "max_iterations": 5,
+        "verdict": "REQUEST_CHANGES",
+        "finding_counts": {
+          "P1": 1,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 1,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 1,
+        "restated_findings": 0,
+        "cost_usd": 1.199096,
+        "duration_s": 225.69
+      },
+      {
+        "iteration": 2,
+        "max_iterations": 5,
+        "verdict": "APPROVE",
+        "finding_counts": {
+          "P1": 0,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 0,
+        "restated_findings": 0,
+        "cost_usd": 1.854469,
+        "duration_s": 150.36
+      }
+    ],
+    "usage_summary": {
+      "dev": {
+        "used": 2,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": true
+      },
+      "review": {
+        "used": 2,
+        "max": 5,
+        "hit_limit": false,
+        "early_finish": true,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 9,
+      "complexity_band_input": "large",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "claude-opus",
+      "model_actual": "opus",
+      "model_provider": null,
+      "model_cli": "claude",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 1350,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 9,
+      "base_review": 5,
+      "profile_history_runs": 80,
+      "profile_avg_iterations": 1.8875,
+      "profile_avg_cost_usd": 8.50909,
+      "profile_raw_dev_max": 2.8312,
+      "estimate_headroom_factor": 2.5,
+      "iteration_derived_timeout_seconds": 1350,
+      "profile_max_duration_s": 3298.03,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 4948,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": true,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 4948,
+      "chosen_dev_cost_estimate_usd": 21.2727,
+      "review_history_sample_size": 8,
+      "p75_review": 2,
+      "chosen_review_max": 5,
+      "rationale": "derived dev limits from 80 large-band profile runs with 1.5x iteration headroom and 2.5x cost-estimate headroom; timeout floored on observed run duration+headroom (4948s). review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-23T08:27:13.131421+00:00"
+      },
+      {
+        "cycle": 1,
+        "cycle_count": 1,
+        "total_count": 2,
+        "timestamp": "2026-07-23T08:50:54.965885+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": null,
+    "dev_usd": 19.112321249999997,
+    "review_usd": null,
+    "dev_invocations": 2,
+    "review_invocations": 6,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 9.01884675,
+        "duration_seconds": 1162.082823166973,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.005737
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 9.01310975
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 10.093474499999997,
+        "duration_seconds": 715.6225450419588,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 10.093474499999997
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 75.18453838870239,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 75.18453838870239,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      },
+      {
+        "role": "review",
+        "profile": "claude-sonnet",
+        "cost_usd": 1.1990958,
+        "duration_seconds": 75.18453838870239,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.039134999999999996
+          },
+          {
+            "model": "claude-sonnet-5",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 1.1599608
+          }
+        ],
+        "model_used": "sonnet"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 50.07185018066472,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 50.07185018066472,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      },
+      {
+        "role": "review",
+        "profile": "claude-sonnet",
+        "cost_usd": 1.8544692,
+        "duration_seconds": 50.07185018066472,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-sonnet-5",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 1.8544692
+          }
+        ],
+        "model_used": "sonnet"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "PROCEED",
+    "reason": "Preflight and planner selection (src/theforge/assignment.py:2727-2767) call _pick_agent() without model_profiles, so they use pure tier/budget ordering today; only dev (and reviewer via _select_reviewers) consult reliability signals. Extending reliability-based routing to preflight/planner while adding new structured telemetry and routing_decision fields is unfinished, cross-module work.",
+    "complexity": "large",
+    "complexity_score": 9,
+    "implementation_complexity_score": 9,
+    "validation_complexity_score": 1,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 9",
+        "dimension": "implementation"
+      },
+      {
+        "rule_id": "implementation_contract_change",
+        "signal": "contract change forces at least medium implementation complexity (shared-interface blast radius)",
+        "dimension": "implementation"
+      }
+    ],
+    "work_type": "feature",
+    "domains": [
+      "backend",
+      "config"
+    ],
+    "contract_change": true,
+    "bundle_candidate": false,
+    "cost_usd": 0.3275200499999999,
+    "cached": false,
+    "original_verdict": null,
+    "source_run_id": null,
+    "cache_snapshot": {
+      "worktree_head": "2358c1a88b53a024e3925298921a4e2775213064",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "2358c1a88b53a024e3925298921a4e2775213064"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "current_worktree_head": "2358c1a88b53a024e3925298921a4e2775213064",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "b711a9ff6f45d2db719622f208c27d326f100dbe",
+      "current_evaluation_base_branch_head": "2358c1a88b53a024e3925298921a4e2775213064",
+      "status": "invalidated",
+      "reason": "worktree_head_changed"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.3275200499999999,
+        "duration_s": 68.61,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "large",
+      "complexity_score": 9,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gpt-5.5",
+          "source": "forge.yaml",
+          "canonical_id": "openai/gpt-5.5/cli"
+        },
+        "plan_reviewers": [
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "gpt-5.4",
+            "source": "builtin",
+            "canonical_id": "openai/gpt-5.4/cli"
+          }
+        ],
+        "dev": {
+          "model": "opus",
+          "source": "builtin",
+          "canonical_id": "anthropic/opus/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "sonnet",
+            "source": "builtin",
+            "canonical_id": "anthropic/sonnet/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 3/10 recent HIGH stories escalated (profile success_rate=0.88 @ HIGH); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 9 \u2192 tier strong ($8.33); per-story routing cost target: unset",
+        "plan_review": "3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 9; per-story routing cost target: unset",
+        "code_review": "3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 9; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 75.0,
+        "final_total_usd": 75.0,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "opus",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gpt-5.5",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gpt-5.4",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "sonnet",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 75.0
+        }
+      },
+      "config_model_routing": {
+        "complexity": "large",
+        "complexity_score": 9,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "opus",
+        "derived_review_pool": [
+          "gemini-3.5-flash",
+          "gpt-5.4",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "preflight",
+      "context_budget": 200,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    },
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        }
+      ],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        }
+      ],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        }
+      ],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1489/iter_1.yaml",
+      "handoff": {
+        "summary": "Extended adaptive routing from dev-only to the preflight and planner roles (reviewer roles already had it via #1388/#1443). Added a per-role reliability completion signal to model_profiles (planner section + preflight completion counters, shared fold helper, get_role_reliability_signal with sample-floor/recency/taint/schema gating, plus merge/reset coverage), a sort-after rerank in assignment (_rerank_single_by_reliability wired through _pick_agent into preflight/planner selection) with a routing_decision reliability_check audit block, and bridge derivation of the completion booleans and planner identity from native coordinator state. Explicit config and static mode bypass learned preference.",
+        "commits": [
+          {
+            "sha": "d4cd45d",
+            "message": "feat(routing): extend adaptive routing to preflight and planner via reliability signals"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "Non-dev model selection can use observed role-specific performance only when the matching signal has cleared ADR-0006 clause-2 admissibility (sample floor, completeness, recency handling, schema compatibility, per-role scope).",
+            "status": "MET",
+            "notes": "get_role_reliability_signal gates rate on floor='pass' (min_runs) and schema_ok, reads a per-role section, applies recency weighting via _weighted_rate. Below floor / bad schema returns rate=None \u2192 static fallback."
+          },
+          {
+            "criterion": "Reliability signals recorded as authoritative native telemetry or deterministic aggregations over it, not prose/LLM/profile-only state.",
+            "status": "MET",
+            "notes": "Completion counters are deterministically folded from native telemetry (preflight_result/degraded, plan_output/structured) via the bridge; no LLM or log-prose input."
+          },
+          {
+            "criterion": "Historical role-specific aggregates exclude tainted runs through the centralized filter from #1852.",
+            "status": "MET",
+            "notes": "_update_preflight/_update_planner apply the run-level taint gate (from is_tainted/derive_trust_status), tally tainted_runs, and the signal surfaces tainted_runs. Covered by test_role_reliability_signal_excludes_tainted_runs."
+          },
+          {
+            "criterion": "A model with repeated poor reliability in a role is deprioritized without manual forge.yaml removal.",
+            "status": "MET",
+            "notes": "_rerank_single_by_reliability sorts below-floor models after; test_preflight_low_reliability_reorders_selection and test_planner_low_reliability_reorders_selection."
+          },
+          {
+            "criterion": "Deprioritization is sort-after, not filter-out; operator-enabled candidate stays eligible unless explicit config excludes it.",
+            "status": "MET",
+            "notes": "Stable sort-after on original index; test_low_reliability_is_sort_after_not_filter_out shows a lone unreliable candidate still selected."
+          },
+          {
+            "criterion": "Explicit CLI/forge.yaml configuration still wins over learned preference (ADR-0006 clause 1).",
+            "status": "MET",
+            "notes": "Explicit preflight/planner branches short-circuit before _pick_agent; test_explicit_preflight_override_beats_learned_preference and test_static_mode_ignores_role_reliability."
+          },
+          {
+            "criterion": "Routing decisions using role-specific history record consulted signal, sample count, floor status, raw/weighted values, taint-excluded count, and ranking effect in routing_decision (#1391).",
+            "status": "MET",
+            "notes": "reliability_check block per role via _role_reliability_check; test_preflight_reliability_audit_records_signal_and_effect and test_cold_start_audit_shows_no_demotion assert the fields."
+          },
+          {
+            "criterion": "Tests cover a non-dev role where reliable history changes ordering, a cold-start fallback, and an explicit override.",
+            "status": "MET",
+            "notes": "Added tests/test_assignment_role_reliability.py (14 tests) covering all three plus audit/seam, and a build_run_outcome seam test in test_coord_model_profiles_seam.py."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": [
+          "Reused the existing reviewer_completion_threshold/min_runs config for the preflight/planner reliability floor instead of adding new AssignmentConfig fields \u2014 same semantics (a completion-rate floor), avoids config-surface churn for a solo operator. Flag if a distinct knob is wanted."
+        ],
+        "deferred_items": "none"
+      }
+    },
+    {
+      "iteration": 2,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1489/iter_1.yaml",
+      "handoff": {
+        "summary": "Iteration 1 fixes the P1: non-dev (preflight/planner) reliability was folded once per phase under the configured primary profile, so retry/fallback attempts were misattributed and transport-retry failures hidden. Reworked to per-attempt attribution: added a RoleAttempt carrier and preflight_attempts/planner_attempts lists on RunOutcome, folded each attempt's completion under the model that ran it (_update_role_completion) decoupled from the per-phase runs/cost fold (which keeps the single tainted-run tally). preflight_flow now records provider/cli + a per-attempt completed flag; the bridge lifts raw['attempts'] and folds planner transport-retries as failed attempts plus each plan_results invocation. The routing rerank, routing_decision audit, and signal accessor from cycle 0 are unchanged and now receive complete-over-attempts data. Added per-attempt unit tests and seam tests for preflight retry/fallback and planner transport-retry telemetry.",
+        "commits": [
+          {
+            "sha": "d4cd45d",
+            "message": "feat(routing): extend adaptive routing to preflight and planner via reliability signals"
+          },
+          {
+            "sha": "e035547",
+            "message": "fix(routing): fold non-dev reliability per attempt, not per phase (iter 1)"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "Non-dev model selection can use observed role-specific performance only when the matching signal has cleared ADR-0006 clause-2 admissibility (sample floor, completeness, recency handling, schema compatibility, per-role scope).",
+            "status": "MET",
+            "notes": "get_role_reliability_signal gates on floor/schema_ok/per-role section/recency; now complete over attempts after the iter-1 fix."
+          },
+          {
+            "criterion": "Reliability signals recorded as authoritative native telemetry or deterministic aggregations over it.",
+            "status": "MET",
+            "notes": "Folded per native invocation from preflight raw['attempts'] and plan_results/plan_transport_retries \u2014 no prose/LLM."
+          },
+          {
+            "criterion": "Historical role-specific aggregates exclude tainted runs through the centralized filter from #1852.",
+            "status": "MET",
+            "notes": "Per-phase fold owns the single tainted-run tally; per-attempt fold skips tainted. Covered by test_role_reliability_signal_excludes_tainted_runs and test_review_and_preflight_aggregates_exclude_tainted."
+          },
+          {
+            "criterion": "A model with repeated poor reliability in a role is deprioritized without manual forge.yaml removal.",
+            "status": "MET",
+            "notes": "Sort-after rerank unchanged from cycle 0; now fed correctly-attributed per-attempt history."
+          },
+          {
+            "criterion": "Deprioritization is sort-after, not filter-out.",
+            "status": "MET",
+            "notes": "test_low_reliability_is_sort_after_not_filter_out."
+          },
+          {
+            "criterion": "Explicit CLI/forge.yaml configuration still wins over learned preference (ADR-0006 clause 1).",
+            "status": "MET",
+            "notes": "Explicit branches short-circuit before rerank; test_explicit_preflight_override_beats_learned_preference and test_static_mode_ignores_role_reliability."
+          },
+          {
+            "criterion": "Routing decisions record consulted signal, sample count, floor status, raw/weighted values, taint-excluded count, and ranking effect in routing_decision.",
+            "status": "MET",
+            "notes": "reliability_check block per role; audit tests unchanged and passing."
+          },
+          {
+            "criterion": "Tests cover ordering-change, cold-start, and explicit-override; plus per-attempt attribution.",
+            "status": "MET",
+            "notes": "Added test_preflight_retry_then_fallback_attributes_per_attempt, test_planner_transport_retry_folds_failed_attempt, and seam tests test_seam_preflight_parse_retry_and_fallback_attributed_per_model / test_seam_planner_transport_retry_folds_failed_attempt."
+          }
+        ],
+        "gate_result": "BLOCKED",
+        "gate_delegated": true,
+        "story_deviations": [
+          "Reused reviewer_completion_threshold/min_runs config for the preflight/planner reliability floor instead of adding new AssignmentConfig fields (unchanged from cycle 0).",
+          "Planner attempts are attributed to the planner profile identity; mid-plan model escalation (rare) would attribute an escalated invocation to the base planner \u2014 documented in _extract_planner_attempts as a known minor imprecision, far smaller than the collapse it replaces."
+        ],
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    },
+    {
+      "iteration": 2,
+      "finding_ids": [
+        "93085795703d6c55"
+      ]
+    }
+  ],
+  "reviews": [
+    {
+      "cycle": 1,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded",
+        "claude-sonnet": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "REQUEST_CHANGES",
+      "summary": "[openai-gpt-5.5] The routing rerank itself is wired, but the new telemetry bridge is not complete over non-dev attempts, so learned reliability can reward or miss failed preflight/planner attempts. | [google-gemini-3.5-flash] The implementation successfully extends adaptive routing to preflight and planner roles using robust, admissibility-gated reliability signals with full auditability. | [claude-sonnet] Well-structured extension of adaptive routing to preflight/planner with correct sort-after semantics, taint/schema/floor gating, explicit-override bypass, and thorough seam-level tests; no P1 defects found.",
+      "sanitization_audit": null,
+      "p1_count": 1,
+      "p2_count": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "file": "src/theforge/coordinator/model_profiles_bridge.py",
+          "line": 145,
+          "description": "When preflight retries after a parse failure or falls back to a fallback model, the run outcome collapses all native preflight attempts into one final completion boolean recorded under the configured primary preflight profile.",
+          "reviewers": [
+            "openai-gpt-5.5"
+          ],
+          "reporter": "openai-gpt-5.5"
+        }
+      ],
+      "ac_verification": [
+        {
+          "criterion": "Non-dev model selection can use observed role-specific performance only when the matching signal has cleared ADR-0006 clause-2 admissibility requirements: sample floor, completeness, recency handling, schema compatibility, and per-role scope.",
+          "status": "PARTIAL",
+          "evidence": "src/theforge/model_profiles.py:1393 implements get_role_reliability_signal with per-role sections, schema_ok, min_runs floor, and _weighted_rate, and src/theforge/assignment.py:2898 and src/theforge/assignment.py:2932 invoke it for preflight/planner selection; however src/theforge/coordinator/model_profiles_bridge.py:145 collapses preflight retries/fallbacks into one final primary-profile outcome, so completeness over relevant attempts is not satisfied.; src/theforge/model_profiles.py:1393-1483 implements get_role_reliability_signal with sample floor (attempted >= min_runs), completeness, recency weighting (_weighted_rate), schema compatibility (schema_ok), and per-role scope (role parameter).; src/theforge/model_profiles.py get_role_reliability_signal (~L1390-1480) gates rate to non-None only when `floor_ok = schema_ok and attempted >= min_runs and attempted > 0, reads a per-role section (entry.get(role)`), and applies recency weighting via _weighted_rate. Tests test_role_reliability_signal_cold_start_below_floor and test_role_reliability_signal_schema_incompatible_forces_cold_start in tests/test_assignment_role_reliability.py verify the floor/schema gating concretely."
+        },
+        {
+          "criterion": "Reliability signals relevant to routing are recorded as authoritative native telemetry or deterministic aggregations over it, not as log prose, LLM summaries, or profile-only state.",
+          "status": "PARTIAL",
+          "evidence": "src/theforge/coordinator/model_profiles_bridge.py:145 and src/theforge/coordinator/model_profiles_bridge.py:156 derive booleans from CoordinatorState rather than prose or LLM summaries, but the preflight derivation ignores the authoritative per-attempt telemetry recorded at src/theforge/coordinator/preflight_flow.py:321.; src/theforge/coordinator/model_profiles_bridge.py:137-174 derives preflight_completed and planner_completed from native coordinator state.; src/theforge/coordinator/model_profiles_bridge.py derives preflight_completed from state.preflight_result.success / state.preflight_degraded (verified against preflight_flow.py L393-433 where preflight_degraded is set deterministically on parse-error or agent failure) and planner_completed from state.plan_output/state.plan_structured. No LLM or log-prose input; folded via _fold_completion_counters in model_profiles.py."
+        },
+        {
+          "criterion": "Historical role-specific aggregates exclude tainted runs through the centralized filter from #1852.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/coordinator/model_profiles_bridge.py:138 derives run_tainted via derive_trust_status/is_tainted, src/theforge/model_profiles.py:975 and src/theforge/model_profiles.py:993 pass outcome.dev_tainted into preflight/planner folds, src/theforge/model_profiles.py:758 and src/theforge/model_profiles.py:788 tally tainted_runs without folding completion counters, and tests/test_assignment_role_reliability.py:126 verifies tainted preflight runs are excluded from attempted counts.; src/theforge/model_profiles.py:750-780 and get_role_reliability_signal exclude tainted runs from the completion rate and track them under tainted_runs.; model_profiles.py _update_preflight/_update_planner (~L738-806) check tainted first and tally under tainted_runs, returning before folding completion counters. get_role_reliability_signal surfaces tainted_runs separately from attempted. test_role_reliability_signal_excludes_tainted_runs confirms tainted attempts are excluded from attempted and floor stays \"fail\"."
+        },
+        {
+          "criterion": "A model with repeated poor reliability in a role is deprioritized for that role without requiring manual removal from forge.yaml.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:579 implements _rerank_single_by_reliability, src/theforge/assignment.py:2898 and src/theforge/assignment.py:2932 wire it into preflight and planner picks, and tests/test_assignment_role_reliability.py:170 and tests/test_assignment_role_reliability.py:202 verify low-reliability preflight and planner models reorder behind reliable alternatives.; src/theforge/assignment.py:579-640 implements _rerank_single_by_reliability which sorts low-reliability candidates after more-reliable ones.; assignment.py _rerank_single_by_reliability (~L579-643) sorts candidates with is_low below threshold after reliable ones. Verified by test_preflight_low_reliability_reorders_selection and test_planner_low_reliability_reorders_selection."
+        },
+        {
+          "criterion": "Deprioritization is a sort-after, not a filter-out: an operator-enabled candidate remains eligible unless explicit configuration excludes it.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:626 sorts low-reliability candidates after others while keeping them in rows, src/theforge/assignment.py:703 still returns the first remaining candidate, and tests/test_assignment_role_reliability.py:211 verifies a lone unreliable preflight candidate remains selected.; src/theforge/assignment.py:628 uses a stable sort where low-reliability candidates are assigned a key of 1 and others 0, so they are sorted after but not filtered out.; _rerank_single_by_reliability never drops candidates, only reorders via stable sort on (is_low, idx). test_low_reliability_is_sort_after_not_filter_out shows a lone unreliable candidate is still selected."
+        },
+        {
+          "criterion": "Explicit CLI / forge.yaml configuration still wins over learned preference, per ADR-0006 clause 1.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:2687 disables effective_profiles in static mode, src/theforge/assignment.py:2892 and src/theforge/assignment.py:2921 bypass learned preflight/planner selection for explicit profiles, and tests/test_assignment_role_reliability.py:222 plus tests/test_assignment_role_reliability.py:251 verify explicit override and static routing ignore learned reliability.; src/theforge/assignment.py:2892-2894 and 2921-2924 bypass _pick_agent when explicit overrides are present.; assignment.py L2892/L2921 explicit branches (\"preflight\" in explicit_profiles, \"planner\" in explicit_profiles) short-circuit before _pick_agent runs, so reliability signals/audit stay empty and _role_reliability_check returns {} (omitted from routing_decision). Verified traced explicit-profile identity (config.plan.* rebuilt fields match _adaptive_decision.planner used later in plan_flow.py L713-733) so bridge telemetry correctly attributes to the model that actually ran. test_explicit_preflight_override_beats_learned_preference and test_static_mode_ignores_role_reliability both assert `\"reliability_check\" not in decision.routing_decision[...]`."
+        },
+        {
+          "criterion": "Routing decisions that use role-specific profile history record the consulted signal, sample count, floor status, raw and weighted values where applicable, taint-excluded count where applicable, and ranking effect in the routing_decision block from #1391.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:1818 builds reliability_check with attempted/completed/raw/weighted/rate/floor/schema_ok/tainted_runs and ranking effect, src/theforge/assignment.py:2037 and src/theforge/assignment.py:2059 attach it under preflight/planner routing_decision blocks, and tests/test_assignment_role_reliability.py:275 plus tests/test_assignment_role_reliability.py:307 verify fired and cold-start audit contents.; src/theforge/assignment.py:1819-1862 implements _role_reliability_check which records all of these fields in the reliability_check block.; assignment.py _role_reliability_check (~L1819-1865) builds a per-candidate block with attempted/completed/raw/weighted/rate/floor/schema_ok/tainted_runs/ selected, plus mechanism/fired/threshold/min_runs/deprioritized/original_order/ final_order at the top level, wired into _build_routing_decision's preflight/planner blocks. test_preflight_reliability_audit_records_signal_and_effect and test_cold_start_audit_shows_no_demotion assert these fields concretely."
+        },
+        {
+          "criterion": "Tests cover at least one non-dev role where sufficient reliable history changes ordering, one cold-start case where ordering falls back to static policy, and one explicit override case where learned preference does not override operator configuration.",
+          "status": "VERIFIED",
+          "evidence": "tests/test_assignment_role_reliability.py:170 covers reliable non-dev history changing preflight ordering, tests/test_assignment_role_reliability.py:187 covers cold-start fallback to static ordering, and tests/test_assignment_role_reliability.py:222 covers explicit preflight override winning over learned preference.; tests/test_assignment_role_reliability.py covers all of these cases.; tests/test_assignment_role_reliability.py: reorder for preflight and planner (test_preflight_low_reliability_reorders_selection, test_planner_low_reliability_reorders_selection), cold-start (test_preflight_cold_start_preserves_static_order), explicit override (test_explicit_preflight_override_beats_learned_preference), plus a coordinator-bridge seam roundtrip (test_bridge_roundtrip_teaches_role_reliability and test_seam_bridge_derives_preflight_and_planner_reliability in tests/test_coord_model_profiles_seam.py) satisfying convention 8."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    },
+    {
+      "cycle": 2,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded",
+        "claude-sonnet": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "APPROVE",
+      "summary": "[openai-gpt-5.5] Cycle 1 P1 is resolved: preflight fallback/retry and planner transport retry telemetry now folds per attempt, and I found no P1 regressions. | [google-gemini-3.5-flash] The implementation successfully extends adaptive routing to preflight and planner roles using reliability signals, and resolves the prior P1 by folding reliability per attempt rather than per phase. | [claude-sonnet] Iteration 1 correctly fixes the Cycle 1 P1 (collapsed per-phase attribution) with per-attempt RoleAttempt tracking; verified against preflight_flow.py's retry/fallback control flow and plan_flow.py's transport-retry/plan_results split, confirmed no double-counting, and all 58 relevant tests pass locally.",
+      "sanitization_audit": null,
+      "p1_count": 0,
+      "p2_count": 0,
+      "findings": [],
+      "ac_verification": [
+        {
+          "criterion": "Non-dev model selection can use observed role-specific performance only when the matching signal has cleared ADR-0006 clause-2 admissibility requirements: sample floor, completeness, recency handling, schema compatibility, and per-role scope.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/model_profiles.py:1433 defines get_role_reliability_signal with per-role lookup, schema_ok handling, sample-floor gating, and recency weighting; src/theforge/assignment.py:610 consumes that signal per candidate and src/theforge/assignment.py:2898 and src/theforge/assignment.py:2932 invoke it for preflight and planner. tests/test_assignment_role_reliability.py:248 covers sufficient preflight history changing ordering, tests/test_assignment_role_reliability.py:261 covers cold-start fallback, tests/test_assignment_role_reliability.py:274 covers planner ordering, and tests/test_assignment_role_reliability.py:235 covers schema-incompatible cold start.; src/theforge/model_profiles.py:1433-1523 (get_role_reliability_signal implements all clause-2 admissibility checks); tests/test_assignment_role_reliability.py:209-241 (test_role_reliability_signal_excludes_tainted_runs, test_role_reliability_signal_cold_start_below_floor, test_role_reliability_signal_schema_incompatible_forces_cold_start); model_profiles.py get_role_reliability_signal (~L1430-1520, unchanged from cycle 0) gates rate to non-None only when schema_ok and attempted>=min_runs. Now fed complete-over-attempts data by the iter-1 fix. test_role_reliability_signal_cold_start_below_floor and test_role_reliability_signal_schema_incompatible_forces_cold_start verify floor/schema gating."
+        },
+        {
+          "criterion": "Reliability signals relevant to routing are recorded as authoritative native telemetry or deterministic aggregations over it, not as log prose, LLM summaries, or profile-only state.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/coordinator/preflight_flow.py:323 records native preflight attempt dictionaries with completed/provider/cli fields, src/theforge/coordinator/model_profiles_bridge.py:103 lifts raw attempts into RoleAttempt values, src/theforge/coordinator/model_profiles_bridge.py:140 derives planner attempts from plan_transport_retries and plan_results, and src/theforge/model_profiles.py:1018 and src/theforge/model_profiles.py:1037 deterministically fold those attempts. tests/test_coord_model_profiles_seam.py:1027 covers bridge extraction from native state.; src/theforge/coordinator/model_profiles_bridge.py:103-179 (_extract_preflight_attempts and _extract_planner_attempts extract attempts from native state); tests/test_coord_model_profiles_seam.py:1025-1153 (test_seam_bridge_derives_preflight_and_planner_reliability, test_seam_preflight_parse_retry_and_fallback_attributed_per_model, test_seam_planner_transport_retry_folds_failed_attempt); preflight_flow.py L316-340 _record_attempt/_attempt_failed derive \"completed\" deterministically from result.success and _is_parse_degraded; plan_flow.py's plan_transport_retries (L234-241) and plan_results (L796/1566/1761, one final entry per top-level attempt, never duplicated with a transport-retry entry) feed _extract_planner_attempts in model_profiles_bridge.py. No prose/LLM input."
+        },
+        {
+          "criterion": "Historical role-specific aggregates exclude tainted runs through the centralized filter from #1852.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/coordinator/model_profiles_bridge.py:216 derives run_tainted from trust checks, src/theforge/model_profiles.py:797 skips tainted per-attempt reliability folding, and src/theforge/model_profiles.py:809 and src/theforge/model_profiles.py:832 tally tainted preflight/planner phase runs without folding them. tests/test_assignment_role_reliability.py:194 verifies tainted preflight attempts do not contribute to attempted/completed counts and remain visible via tainted_runs.; src/theforge/model_profiles.py:781-798 (_update_role_completion skips tainted runs); tests/test_assignment_role_reliability.py:178-208 (test_role_reliability_signal_excludes_tainted_runs); model_profiles.py _update_role_completion (~L781-798) skips folding when tainted (no tally, since the per-phase fold owns the single tainted_runs count) and _update_preflight/_update_planner retain the taint gate. test_role_reliability_signal_excludes_tainted_runs and test_review_and_preflight_aggregates_exclude_tainted (tests/test_router_taint_exclusion.py) both pass locally."
+        },
+        {
+          "criterion": "A model with repeated poor reliability in a role is deprioritized for that role without requiring manual removal from forge.yaml.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:622 computes low reliability after the sample floor and src/theforge/assignment.py:628 reranks the candidate list. tests/test_assignment_role_reliability.py:248 verifies preflight selection moves from pf-a to pf-b on poor history, and tests/test_assignment_role_reliability.py:274 verifies planner selection moves from pl-a to pl-b.; src/theforge/assignment.py:579-643 (_rerank_single_by_reliability deprioritizes low-reliability models); tests/test_assignment_role_reliability.py:244-254 (test_preflight_low_reliability_reorders_selection); assignment.py _rerank_single_by_reliability (unchanged from cycle 0) now consumes correctly-attributed per-attempt data. test_preflight_low_reliability_reorders_selection and test_planner_low_reliability_reorders_selection pass."
+        },
+        {
+          "criterion": "Deprioritization is a sort-after, not a filter-out: an operator-enabled candidate remains eligible unless explicit configuration excludes it.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:626 keeps every candidate in rows and src/theforge/assignment.py:628 performs a stable sort rather than removing low-reliability candidates. tests/test_assignment_role_reliability.py:285 verifies the only unreliable preflight candidate remains selected.; src/theforge/assignment.py:579-643 (_rerank_single_by_reliability performs a stable sort-after); tests/test_assignment_role_reliability.py:271-280 (test_low_reliability_is_sort_after_not_filter_out); test_low_reliability_is_sort_after_not_filter_out passes."
+        },
+        {
+          "criterion": "Explicit CLI / forge.yaml configuration still wins over learned preference, per ADR-0006 clause 1.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:2892 takes the explicit preflight profile branch before reliability reranking, src/theforge/assignment.py:2921 does the same for planner, and src/theforge/assignment.py:2687 disables profile learning in static mode. tests/test_assignment_role_reliability.py:296 verifies explicit preflight override suppresses learned reranking, and tests/test_assignment_role_reliability.py:326 verifies static mode ignores role reliability.; src/theforge/assignment.py:2892-2947 (assign_models short-circuits on explicit overrides); tests/test_assignment_role_reliability.py:283-314 (test_explicit_preflight_override_beats_learned_preference); assignment.py explicit branches (L2892/L2921, unchanged) short-circuit before the rerank. test_explicit_preflight_override_beats_learned_preference and test_static_mode_ignores_role_reliability pass."
+        },
+        {
+          "criterion": "Routing decisions that use role-specific profile history record the consulted signal, sample count, floor status, raw and weighted values where applicable, taint-excluded count where applicable, and ranking effect in the routing_decision block from #1391.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/assignment.py:1839 records attempted/completed/raw/weighted/rate/floor/schema_ok/tainted_runs per candidate, src/theforge/assignment.py:1851 records threshold/min_runs/deprioritized/ranking effect, and src/theforge/assignment.py:2040 and src/theforge/assignment.py:2062 attach the block to preflight and planner routing_decision sections. tests/test_assignment_role_reliability.py:344 verifies the preflight audit includes signal values and original/final order, and tests/test_assignment_role_reliability.py:370 verifies cold-start audit records floor fail without demotion.; src/theforge/assignment.py:1819-1851 (_role_reliability_check builds the audit block); tests/test_assignment_role_reliability.py:328-361 (test_preflight_reliability_audit_records_signal_and_effect); _role_reliability_check (unchanged from cycle 0) still builds the reliability_check block from signals now correctly attributed per attempt. test_preflight_reliability_audit_records_signal_and_effect and test_cold_start_audit_shows_no_demotion pass."
+        },
+        {
+          "criterion": "Tests cover at least one non-dev role where sufficient reliable history changes ordering, one cold-start case where ordering falls back to static policy, and one explicit override case where learned preference does not override operator configuration.",
+          "status": "VERIFIED",
+          "evidence": "tests/test_assignment_role_reliability.py:248 covers non-dev ordering changes, tests/test_assignment_role_reliability.py:261 covers cold-start static ordering, tests/test_assignment_role_reliability.py:296 covers explicit override, tests/test_assignment_role_reliability.py:118 covers preflight retry/fallback attribution, tests/test_assignment_role_reliability.py:146 covers planner transport retry attribution, and tests/test_coord_model_profiles_seam.py:1073 and tests/test_coord_model_profiles_seam.py:1131 cover the seam-level failure modes. I ran pytest -q tests/test_assignment_role_reliability.py tests/test_coord_model_profiles_seam.py::test_seam_bridge_derives_preflight_and_planner_reliability tests/test_coord_model_profiles_seam.py::test_seam_preflight_parse_retry_and_fallback_attributed_per_model tests/test_coord_model_profiles_seam.py::test_seam_planner_transport_retry_folds_failed_attempt tests/test_coord_preflight_fallback.py, and all 29 tests passed.; tests/test_assignment_role_reliability.py:244-314 (test_preflight_low_reliability_reorders_selection, test_preflight_cold_start_preserves_static_order, test_explicit_preflight_override_beats_learned_preference); Cycle-0 coverage retained plus new per-attempt regression tests: test_preflight_retry_then_fallback_attributes_per_attempt, test_planner_transport_retry_folds_failed_attempt, test_seam_preflight_parse_retry_and_fallback_attributed_per_model, and test_seam_planner_transport_retry_folds_failed_attempt \u2014 the last two directly reproduce the Cycle 1 P1 scenario end-to-end (preflight_flow attempts list \u2192 bridge \u2192 aggregator) and assert the primary's completion count is never improved by a later fallback success."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    }
+  ],
+  "reviewer_attempts": [
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "claude-sonnet",
+      "provider": null,
+      "model": "sonnet",
+      "cli": "claude",
+      "canonical_id": "anthropic/sonnet/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    },
+    {
+      "name": "claude-sonnet",
+      "provider": null,
+      "model": "sonnet",
+      "cli": "claude",
+      "canonical_id": "anthropic/sonnet/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    }
+  ],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": false,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": {
+    "action": "merge-pr",
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1903",
+    "merged": false,
+    "merge_queued": true,
+    "success": true,
+    "error": null,
+    "auto_merge_queued": true,
+    "landing_path": "fresh-merge",
+    "guard_evidence": {
+      "branch": "feat/issue-1489",
+      "pr_url": "https://github.com/fuzzypete/theforge/pull/1903",
+      "merge_queued": true
+    }
+  },
+  "landing": {
+    "outcome": "merge-queued",
+    "landing_path": "fresh-merge",
+    "fresh_pr_created": true,
+    "merged": false,
+    "merge_queued": true,
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1903",
+    "pr_merged_at": null
+  },
+  "landing_status": "pending_integration",
+  "landing_event": {
+    "landing_status": "pending_integration",
+    "landed": false,
+    "timestamp": "2026-07-23T09:06:04.379453+00:00"
+  },
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": null,
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": [
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/assignment.py",
+      "detail": "src/theforge/assignment.py has 3293 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/check_config.py",
+      "detail": "src/theforge/cli/check_config.py has 726 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/sprint.py",
+      "detail": "src/theforge/cli/sprint.py has 1283 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/status.py",
+      "detail": "src/theforge/cli/status.py has 1125 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/load.py",
+      "detail": "src/theforge/config/load.py has 1353 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/models.py",
+      "detail": "src/theforge/config/models.py has 874 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/types.py",
+      "detail": "src/theforge/config/types.py has 768 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/conventions.py",
+      "detail": "src/theforge/conventions.py has 706 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit.py",
+      "detail": "src/theforge/coordinator/audit.py has 906 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit_substrate.py",
+      "detail": "src/theforge/coordinator/audit_substrate.py has 2166 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/completion.py",
+      "detail": "src/theforge/coordinator/completion.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/dev_phase.py",
+      "detail": "src/theforge/coordinator/dev_phase.py has 1399 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/diagnose_flow.py",
+      "detail": "src/theforge/coordinator/diagnose_flow.py has 1160 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/engine.py",
+      "detail": "src/theforge/coordinator/engine.py has 1555 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/plan_flow.py",
+      "detail": "src/theforge/coordinator/plan_flow.py has 1808 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight.py",
+      "detail": "src/theforge/coordinator/preflight.py has 1397 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight_flow.py",
+      "detail": "src/theforge/coordinator/preflight_flow.py has 1054 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_phase.py",
+      "detail": "src/theforge/coordinator/review_phase.py has 2003 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_pool.py",
+      "detail": "src/theforge/coordinator/review_pool.py has 1098 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/state.py",
+      "detail": "src/theforge/coordinator/state.py has 832 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/validate_phase.py",
+      "detail": "src/theforge/coordinator/validate_phase.py has 929 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/workspace.py",
+      "detail": "src/theforge/coordinator/workspace.py has 872 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/ideate.py",
+      "detail": "src/theforge/ideate.py has 816 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/groom_flow.py",
+      "detail": "src/theforge/intake/groom_flow.py has 616 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/remediation.py",
+      "detail": "src/theforge/intake/remediation.py has 745 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "src/theforge/model_profiles.py has 2750 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/review.py",
+      "detail": "src/theforge/review.py has 1065 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/api.py",
+      "detail": "src/theforge/runners/api.py has 1047 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "src/theforge/runners/cli.py has 730 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/runner_claude.py",
+      "detail": "src/theforge/runners/runner_claude.py has 923 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/schemas.py",
+      "detail": "src/theforge/schemas.py has 665 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/shape_check/heuristics.py",
+      "detail": "src/theforge/shape_check/heuristics.py has 1044 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/audit.py",
+      "detail": "src/theforge/sprint/audit.py has 1206 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/dag.py",
+      "detail": "src/theforge/sprint/dag.py has 673 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/rca.py",
+      "detail": "src/theforge/sprint/rca.py has 1114 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/runner.py",
+      "detail": "src/theforge/sprint/runner.py has 3575 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/shape_gate.py",
+      "detail": "src/theforge/sprint/shape_gate.py has 681 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/status_reader.py",
+      "detail": "src/theforge/sprint/status_reader.py has 934 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/task/plan_prompts.py",
+      "detail": "src/theforge/task/plan_prompts.py has 685 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_assignment.py",
+      "detail": "tests/test_assignment.py has 1571 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_audit_substrate.py",
+      "detail": "tests/test_audit_substrate.py has 1020 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_check_config.py",
+      "detail": "tests/test_check_config.py has 1234 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_setup.py",
+      "detail": "tests/test_cli_setup.py has 1273 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_sprint_status.py",
+      "detail": "tests/test_cli_sprint_status.py has 1423 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_status_watch.py",
+      "detail": "tests/test_cli_status_watch.py has 1087 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_config_load.py",
+      "detail": "tests/test_config_load.py has 1244 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_dev_phase_routing.py",
+      "detail": "tests/test_coord_dev_phase_routing.py has 1009 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_merge_pr.py",
+      "detail": "tests/test_coord_merge_pr.py has 1811 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_model_profiles_seam.py",
+      "detail": "tests/test_coord_model_profiles_seam.py has 1155 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_plan_flow_agent.py",
+      "detail": "tests/test_coord_plan_flow_agent.py has 2259 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_preflight_verdict.py",
+      "detail": "tests/test_coord_preflight_verdict.py has 1173 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_phase_pool.py",
+      "detail": "tests/test_coord_review_phase_pool.py has 1016 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_pool.py",
+      "detail": "tests/test_coord_review_pool.py has 1324 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_state.py",
+      "detail": "tests/test_coord_state.py has 1165 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_workspace_stale.py",
+      "detail": "tests/test_coord_workspace_stale.py has 1084 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coordinator.py",
+      "detail": "tests/test_coordinator.py has 1376 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cut_rc_isolation.py",
+      "detail": "tests/test_cut_rc_isolation.py has 1476 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_diagnose_flow.py",
+      "detail": "tests/test_diagnose_flow.py has 1541 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_generate_audit_log.py",
+      "detail": "tests/test_generate_audit_log.py has 1114 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_model_profiles.py",
+      "detail": "tests/test_model_profiles.py has 1182 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_preflight_work_type.py",
+      "detail": "tests/test_preflight_work_type.py has 1146 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_review.py",
+      "detail": "tests/test_review.py has 1106 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_claude.py",
+      "detail": "tests/test_runner_claude.py has 1099 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_stuck_detection.py",
+      "detail": "tests/test_runner_stuck_detection.py has 1095 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_parallel.py",
+      "detail": "tests/test_sprint_parallel.py has 2699 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_rca.py",
+      "detail": "tests/test_sprint_rca.py has 1070 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_resume.py",
+      "detail": "tests/test_sprint_resume.py has 1268 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_run_id_rollover.py",
+      "detail": "tests/test_sprint_run_id_rollover.py has 1292 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_story_sources.py",
+      "detail": "tests/test_story_sources.py has 1077 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_validate_phase.py",
+      "detail": "tests/test_validate_phase.py has 1413 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/types.py",
+      "detail": "Circular import detected: theforge.config.types \u2192 theforge.config.models \u2192 theforge.config.types",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/defaults.py",
+      "detail": "Circular import detected: theforge.config.defaults \u2192 theforge.config.types \u2192 theforge.config.defaults",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/review.py",
+      "detail": "Circular import detected: theforge.review \u2192 theforge.plan_finding_classifier \u2192 theforge.review",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "Circular import detected: theforge.model_profiles \u2192 theforge.reviewer_value \u2192 theforge.model_profiles",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/__init__.py",
+      "detail": "Circular import detected: theforge.runners \u2192 theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/api.py",
+      "detail": "Circular import detected: theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners.api",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_codex \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_gemini \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/task/__init__.py",
+      "detail": "Circular import detected: theforge.task \u2192 theforge.task.dev_prompts \u2192 theforge.coordinator.state \u2192 theforge.task",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/sprint/manifest.py",
+      "detail": "Circular import detected: theforge.sprint.manifest \u2192 theforge.sprint.sources \u2192 theforge.sprint.manifest",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/coordinator/notify.py",
+      "detail": "Circular import detected: theforge.coordinator.notify \u2192 theforge.notify_backends \u2192 theforge.coordinator.notify",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli.status \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/agent_types.py",
+      "detail": "No test mirror found for src/theforge/agent_types.py (expected tests/test_agent_types.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/artifacts.py",
+      "detail": "No test mirror found for src/theforge/artifacts.py (expected tests/test_artifacts.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/coordinator",
+      "detail": "No test mirror found for package src/theforge/coordinator (expected tests/test_coordinator_*.py or tests/test_coordinator/)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_launchd.py",
+      "detail": "No test mirror found for src/theforge/daemon_launchd.py (expected tests/test_daemon_launchd.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_state.py",
+      "detail": "No test mirror found for src/theforge/daemon_state.py (expected tests/test_daemon_state.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/ideate.py",
+      "detail": "No test mirror found for src/theforge/ideate.py (expected tests/test_ideate.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/log_level.py",
+      "detail": "No test mirror found for src/theforge/log_level.py (expected tests/test_log_level.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/review_finding_classifier.py",
+      "detail": "No test mirror found for src/theforge/review_finding_classifier.py (expected tests/test_review_finding_classifier.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/root_file_conventions.py",
+      "detail": "No test mirror found for src/theforge/root_file_conventions.py (expected tests/test_root_file_conventions.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/runners",
+      "detail": "No test mirror found for package src/theforge/runners (expected tests/test_runners_*.py or tests/test_runners/)",
+      "blocking": false
+    }
+  ],
+  "finding_registry": [
+    {
+      "finding_id": "93085795703d6c55",
+      "cycle_first_seen": 1,
+      "cycle_last_seen": 1,
+      "file": "src/theforge/coordinator/model_profiles_bridge.py",
+      "line": 145,
+      "severity": "P1",
+      "description": "When preflight retries after a parse failure or falls back to a fallback model, the run outcome collapses all native preflight attempts into one final completion boolean recorded under the configured primary preflight profile.",
+      "reporter": "openai-gpt-5.5",
+      "disposition": "fixed"
+    }
+  ],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.5",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 9 \u2192 tier strong ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 9,
+      "base_tier_from_score": "strong",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.875,
+              "weighted": 0.875,
+              "runs": 80,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.875
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "config"
+              ],
+              "raw": 0.75,
+              "weighted": 0.75,
+              "runs": 4,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "recency": "windowed",
+              "rate": 0.75,
+              "by_domain": {
+                "backend": {
+                  "runs": 3,
+                  "raw": 0.6667,
+                  "weighted": 0.6667,
+                  "tainted_runs": 0
+                },
+                "config": {
+                  "runs": 1,
+                  "raw": 1.0,
+                  "weighted": 1.0,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "config"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "config": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "domain_match": {
+        "domains": [
+          "backend",
+          "config"
+        ],
+        "influenced": false,
+        "complexity_only_head": "claude-opus",
+        "domain_head": "claude-opus",
+        "selected_model_slice": {
+          "domains": [
+            "backend",
+            "config"
+          ],
+          "raw": 0.75,
+          "weighted": 0.75,
+          "runs": 4,
+          "tainted_runs": 0,
+          "floor": "pass",
+          "recency": "windowed",
+          "rate": 0.75,
+          "by_domain": {
+            "backend": {
+              "runs": 3,
+              "raw": 0.6667,
+              "weighted": 0.6667,
+              "tainted_runs": 0
+            },
+            "config": {
+              "runs": 1,
+              "raw": 1.0,
+              "weighted": 1.0,
+              "tainted_runs": 0
+            }
+          }
+        },
+        "reason": "domain_signal_did_not_change_selection"
+      },
+      "promotion_check": {
+        "fired": true,
+        "matching_records": 10,
+        "escalations": 3,
+        "outcome": "promoted_to_strong"
+      },
+      "routing_rationale": {
+        "state": "promoted_by",
+        "mechanism": "_check_promotion",
+        "from_tier": "strong",
+        "to_tier": "strong"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:large:backend+config",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": "claude-opus",
+        "winner": "claude-opus",
+        "reason": "sprint_cap_reached",
+        "domains": [
+          "backend",
+          "config"
+        ]
+      },
+      "final": {
+        "model": "opus",
+        "tier": "strong",
+        "rationale": "[preflight] HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 3/10 recent HIGH stories escalated (profile success_rate=0.88 @ HIGH); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 7,
+            "completed": 6,
+            "raw": 0.8571,
+            "weighted": 0.8611,
+            "rate": 0.8611,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 2,
+            "completed": 2,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "opus",
+          "gemini-3.5-flash",
+          "gpt-5.4"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 9; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 9,
+            "completed": 9,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 7,
+            "completed": 6,
+            "raw": 0.8571,
+            "weighted": 0.8611,
+            "rate": 0.8611,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 2,
+            "completed": 2,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "gemini-3.5-flash",
+          "sonnet"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 9; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [],
+  "trust_status": "unchecked",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.32752,
+      "duration_s": 68.61,
+      "outcome": "proceed"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": 19.112321,
+      "duration_s": 1877.71,
+      "iterations": 2,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 67.96,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": {
+      "cost_usd": null,
+      "duration_s": 375.77,
+      "cycles": 2,
+      "outcome": "approve",
+      "per_reviewer": {
+        "claude-sonnet": {
+          "cost": 3.053565,
+          "verdict": "APPROVE"
+        },
+        "openai-gpt-5.5": {
+          "cost": null,
+          "verdict": "APPROVE"
+        },
+        "google-gemini-3.5-flash": {
+          "cost": null,
+          "verdict": "APPROVE"
+        }
+      }
+    }
+  },
+  "totals": {
+    "cost_usd": null,
+    "duration_s": 2390.04,
+    "dev_attempts_total": 2,
+    "dev_iterations_productive": 2,
+    "review_cycles_total": 2,
+    "dev_iterations": 2,
+    "review_cycles": 2
+  },
+  "sprint_id": "849c9780c3bb",
+  "sprint_name": "issues-1899,158,1019,1108,1443,1489"
+}

--- a/.forge/audits/runs/e2cf37c36b15.json
+++ b/.forge/audits/runs/e2cf37c36b15.json
@@ -1,0 +1,1738 @@
+{
+  "schema_version": 9,
+  "run_id": "e2cf37c36b15",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Sprint canonical run JSON path is not rebuild-safe when an existing run file is malformed",
+    "slug": "issue-1899",
+    "story_path": null,
+    "story_text": "What happened:\n\n#1897 makes sprint story audits write canonical `.forge/audits/runs/{run_id}.json` files and mirrors SQLite rows from that path. The clean path is covered, but the existing-file path is not rebuild-safe when the canonical JSON already exists and is malformed or not a JSON object. In that case the writer can fall back to a live SQLite upsert while leaving the bad canonical file in place, so `forge explain` may work until `forge audits rebuild` and then fail again.\n\nExpected behavior:\n\nThe sprint story audit writer must never leave a native SQLite row whose `source_path` points at an unreadable or non-object canonical run file. If an existing canonical file is malformed, the behavior should be explicit and rebuild-safe: either repair/replace it under a defined immutability rule, write a distinct recoverable record, or refuse the substrate mirror rather than creating a row rebuild cannot reproduce.\n\nDiagnosis:\n\nThe clean case added by #1897 writes `.forge/audits/runs/{run_id}.json`, sets SQLite `source_path`, and survives rebuild. The untested edge is the branch that encounters a pre-existing bad file. That path can preserve a broken canonical source while still updating the live substrate, recreating the same live-vs-rebuild split #1896 was meant to close.\n\nFix success observable:\n\nA regression test seeds an existing malformed or non-object `.forge/audits/runs/{run_id}.json`, invokes the sprint story audit writer, runs `forge audits rebuild`, and verifies the final behavior is explicit and rebuild-safe rather than silently losing the story record.\n\n## Diagnosis\n\n**Baseline:** `2358c1a88b53a024e3925298921a4e2775213064` captured at `2026-07-23T14:55:06.346910+00:00`\n\n**Inspected files:**\n\n- `src/theforge/sprint/audit.py` \u2014 `sha256:e99810b2649636b797ec27f45583d305a957eb5f39eeeb5b45e55eb9a560b689`\n- `src/theforge/coordinator/audit_substrate.py` \u2014 `sha256:017f6e9b82000c792e7e6b75fe41500b290cfcdc0ddeee573f0365784874a0d8`\n- `tests/test_coord_audit.py` \u2014 `sha256:766a6df05961bacd24e038b155f4e7c31d33e7e05f039f91176509fdf00c50f3`\n\n### Observed symptom\n\nWhen `.forge/audits/runs/{run_id}.json` already exists but is malformed\n(invalid JSON) or a valid-but-non-object JSON value, the sprint story\naudit writer (`_write_native_story_record` in src/theforge/sprint/audit.py)\nstill produces a live, queryable SQLite row for that run_id \u2014 but the row\neither has no `source_path` (invalid-JSON case) or a `source_path` pointing\nat a file whose on-disk content cannot reproduce the row (non-object case).\nAfter `forge audits rebuild` (audit_substrate.rebuild_from_runs), which\ndrops and rebuilds the native table purely from `.forge/audits/runs/*.json`,\nthe row silently disappears with no operator-facing indication tied to the\noriginal story/run \u2014 it only appears as a generic rebuild-failure line\nkeyed to the run_id/filename.\n\n### Reproduction / evidence\n\nReproduced directly against src/theforge/sprint/audit.py and\nsrc/theforge/coordinator/audit_substrate.py at HEAD (1932364c, current\nrelease/v0.13 tip):\n\nCase A (invalid JSON): seed .forge/audits/runs/bad-run.json with\n\"not json{{{\", then call _write_native_story_record(tmp, {\"run_id\":\n\"bad-run\", ...}). Result: json.load() raises JSONDecodeError inside the\ntry block (audit.py:104-105), caught by the outer `except Exception` at\naudit.py:123, which logs a warning and falls back to\n_upsert_into_substrate() (audit.py:125). That path calls\nupsert_run_record() with no source_path (audit.py:36-63), so the row is\ninserted with provenance='native', source_path=NULL. Before rebuild: row\nexists and is queryable (`forge explain` style query). After calling\naudit_substrate.rebuild_from_runs(tmp): rebuild_from_runs unlinks the\nsubstrate file and rebuilds solely from *.json files in runs_dir; since\nbad-run.json still contains \"not json{{{\", it is recorded as a rebuild\nfailure (`rebuild_from_runs` audit_substrate.py:1128-1134) and the row is\ngone entirely \u2014 no row for run_id \"bad-run\" exists post-rebuild.\n\nCase B (valid JSON, non-object): seed .forge/audits/runs/bad2.json with\n`[1, 2, 3]`. _write_native_story_record reads it successfully\n(audit.py:104-105), detects `not isinstance(persisted, dict)`\n(audit.py:106) and sets `persisted = redacted` in memory only \u2014 the\non-disk bad2.json is never rewritten. It proceeds to\nupsert_run_record(persisted, source_path=\".forge/audits/runs/bad2.json\",\n...) (audit.py:112-119), so before rebuild there is a fully-formed live\nrow whose source_path points at a file that cannot reproduce it. After\nrebuild_from_runs: bad2.json is loaded, `not isinstance(record, dict)`\nreports \"missing run_id\" (audit_substrate.py:1135-1138), and the row is\ndropped \u2014 the run_id \"bad2\" record is gone post-rebuild.\n\nBoth reproductions were run with a Python script directly importing\ntheforge.sprint.audit._write_native_story_record and\ntheforge.coordinator.audit_substrate.rebuild_from_runs against a temp\nproject root; output confirmed row present pre-rebuild / absent\npost-rebuild in both cases.\n\nThe only test added by #1897 (tests/test_coord_audit.py\nTestSprintStoryAuditHistory::test_write_story_audit_persists_to_substrate,\nlines 813-857) only covers the case where run_file does not yet exist \u2014\nit never seeds a pre-existing bad file, matching the issue's stated gap.\n\n### Hypotheses tested\n\n- **[confirmed]** The malformed-existing-file branch in _write_native_story_record silently produces a substrate row that rebuild_from_runs cannot reconstruct from the canonical JSON file, because the in-memory `persisted = redacted` substitution is never written back to disk and/or the exception fallback path omits source_path entirely.\n  - Evidence: Direct reproduction (Cases A and B above) shows a live row exists pre-rebuild and is unconditionally dropped by rebuild_from_runs post-rebuild, for both the JSONDecodeError path (audit.py:104-105 -> except at 123 -> _upsert_into_substrate with no source_path) and the non-object-JSON path (audit.py:106-107, in-memory-only substitution, source_path still points at the untouched bad file).\n- **[ruled out]** rebuild_from_runs itself has a bug that drops good records\n  - Evidence: rebuild_from_runs behaves exactly as documented/designed for its stated contract (rebuild strictly from valid per-run JSON files, with only legacy_history_jsonl and shape_skip_events rows explicitly preserved across the drop-and-recreate). The defect is upstream: the writer allows a live row to exist whose canonical source file cannot satisfy that contract.\n- **[ruled out]** The clean/happy-path write logic (new-file case, audit.py:99-102) is itself broken\n  - Evidence: test_write_story_audit_persists_to_substrate (tests/test_coord_audit.py:813-857) exercises exactly this path and passes; my reproduction only touched the pre-existing-file branch (audit.py:103-107) and the top-level except fallback (audit.py:123-125).\n\n### Confirmed cause\n\nIn `_write_native_story_record` (src/theforge/sprint/audit.py:69-125), when\n`.forge/audits/runs/{run_id}.json` already exists, the function either (a)\nlets a `json.JSONDecodeError` propagate to the outer `except Exception`\n(line 123), which falls back to `_upsert_into_substrate` \u2014 an old-style\nlive-only mirror that calls `upsert_run_record` with no `source_path`\n(line 125, via `_upsert_into_substrate` at lines 39-63) \u2014 or (b) when the\nexisting file parses as valid JSON but is not a dict, silently substitutes\nan in-memory `redacted` record (line 107) without ever rewriting the\non-disk file, then upserts that in-memory record into SQLite with\n`source_path` pointing at the still-malformed file (lines 109-119). In\nboth cases a fully queryable SQLite row is created/updated with no\nreproducible canonical JSON backing it. `rebuild_from_runs`\n(src/theforge/coordinator/audit_substrate.py:1057-1184) drops and rebuilds\nthe native table strictly from what it can parse out of\n`.forge/audits/runs/*.json`, so any such row silently disappears on the\nnext rebuild, recreating the exact live-vs-rebuild split #1896 was meant\nto close, but scoped to the \"pre-existing bad file\" branch that #1897's\ntests never exercised.\n\n### Affected code path\n\nsrc/theforge/sprint/audit.py:69-125 (`_write_native_story_record`),\nspecifically the `else` branch at lines 103-107 (existing-file read/parse)\nand the top-level `except Exception` fallback at lines 123-125.\n\n### Fix-success criterion\n\nA regression test seeds a pre-existing `.forge/audits/runs/{run_id}.json`\nthat is (1) invalid JSON and (2) valid JSON but not an object, invokes\n`_write_story_audit`/`_write_native_story_record` for that same run_id,\nand then runs `forge audits rebuild` (`audit_substrate.rebuild_from_runs`).\nIn both cases the post-rebuild substrate state must be consistent with\nwhatever state existed pre-rebuild: either the row is absent in both\nbefore and after (writer explicitly refuses to mirror against a bad\ncanonical file), or the row is present in both before and after (writer\nrepairs/replaces the canonical file under a defined immutability rule, or\nwrites a distinct clearly-marked recoverable record that rebuild also\nrecognizes). The one outcome the fix must eliminate is the one observed\nhere: a live row pre-rebuild that vanishes post-rebuild with no\noperator-visible signal tied to the original story/run.\n\n### Notes\n\nI did not investigate whether an \"immutability rule\" for canonical run\nfiles already exists elsewhere in the codebase (e.g. whether run files are\never expected to be rewritten after creation for other reasons) \u2014 that\ndesign decision (repair vs. distinct-record vs. refuse) is left to the fix\nflow per the issue's own phrasing of acceptable resolutions.\n",
+    "github_issue": 1899,
+    "fix_ready": true,
+    "readiness_warnings": []
+  },
+  "outcome": {
+    "success": true,
+    "final_phase": "DONE",
+    "message": "Task 'Sprint canonical run JSON path is not rebuild-safe when an existing run file is malformed' completed. Review approved after 1 cycle(s), 1 dev iteration(s). Branch: feat/issue-1899",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-24T15:04:30.987192+00:00",
+    "finished_at": "2026-07-24T15:09:27.780906+00:00",
+    "duration_seconds": 296.793714
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1899",
+    "branch": "feat/issue-1899"
+  },
+  "iterations": {
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 1,
+    "review_cycles": 1,
+    "dev_iterations": 1,
+    "gate_decisions": [
+      "PASS"
+    ],
+    "dev_loop": [
+      {
+        "cycle": 0,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": null,
+        "duration_s": 183.73,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/sprint/audit.py",
+          "tests/test_coord_audit.py"
+        ],
+        "files_changed_count": 2,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "gpt-5.4",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      }
+    ],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [
+      {
+        "iteration": 1,
+        "max_iterations": 4,
+        "verdict": "APPROVE",
+        "finding_counts": {
+          "P1": 0,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 0,
+        "restated_findings": 0,
+        "cost_usd": 0.472182,
+        "duration_s": 56.55
+      }
+    ],
+    "usage_summary": {
+      "dev": {
+        "used": 1,
+        "max": 3,
+        "hit_limit": false,
+        "early_finish": true
+      },
+      "review": {
+        "used": 1,
+        "max": 4,
+        "hit_limit": false,
+        "early_finish": true,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 5,
+      "complexity_band_input": "medium",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "openai-gpt-5.4",
+      "model_actual": "gpt-5.4",
+      "model_provider": null,
+      "model_cli": "codex",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 900,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 5,
+      "base_review": 4,
+      "profile_history_runs": 52,
+      "profile_avg_iterations": 1.1538,
+      "profile_avg_cost_usd": 0.0,
+      "profile_raw_dev_max": 1.7307,
+      "estimate_headroom_factor": 2.0,
+      "iteration_derived_timeout_seconds": 900,
+      "profile_max_duration_s": 656.48,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 985,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": true,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 985,
+      "chosen_dev_cost_estimate_usd": 0.01,
+      "review_history_sample_size": 18,
+      "p75_review": 2,
+      "chosen_review_max": 4,
+      "rationale": "derived dev limits from 52 medium-band profile runs with 1.5x iteration headroom and 2.0x cost-estimate headroom; timeout floored on observed run duration+headroom (985s). review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-24T15:04:31.812298+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": null,
+    "dev_usd": null,
+    "review_usd": null,
+    "dev_invocations": 1,
+    "review_invocations": 2,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "openai-gpt-5.4",
+        "cost_usd": null,
+        "duration_seconds": 183.73394612502307,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.4"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 28.20974264596589,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "claude-opus",
+        "cost_usd": 0.472182,
+        "duration_seconds": 28.20974264596589,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.011127
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.461055
+          }
+        ],
+        "model_used": "opus"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "Direct inspection of src/theforge/sprint/audit.py confirms the existing-file branch (lines 103-107) and exception fallback (lines 123-125) in _write_native_story_record can produce a live SQLite row with no source_path or a source_path pointing at an unrepaired malformed file, which rebuild_from_runs (audit_substrate.py:1128-1138) then silently drops. This is unfixed at HEAD and is a bounded fix within one function.",
+    "complexity": "medium",
+    "complexity_score": 5,
+    "implementation_complexity_score": 5,
+    "validation_complexity_score": 5,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 5",
+        "dimension": "implementation"
+      },
+      {
+        "rule_id": "validation_surface_count",
+        "signal": "6 operator-visible surfaces enumerated in acceptance criteria: bad-run.json, bad2.json, forge audits rebuild, forge explain, forge/audits/runs/bad-run.json, forge/audits/runs/bad2.json",
+        "dimension": "validation"
+      }
+    ],
+    "work_type": "bug",
+    "domains": [
+      "backend",
+      "database"
+    ],
+    "contract_change": false,
+    "bundle_candidate": false,
+    "cost_usd": 0.288682,
+    "cached": true,
+    "original_verdict": "PROCEED",
+    "source_run_id": "0a20b6982403",
+    "cache_snapshot": {
+      "worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "current_worktree_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "current_evaluation_base_branch_head": "aa98c26fb620f6122d173ff846043ac6d03b3aea",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.288682,
+        "duration_s": 30.72,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "medium",
+      "complexity_score": 5,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gemini-3.5-flash",
+          "source": "forge.yaml",
+          "canonical_id": "google/gemini-3.5-flash/api"
+        },
+        "plan_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          }
+        ],
+        "dev": {
+          "model": "gpt-5.4",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "complexity score 5 (MEDIUM) \u2192 tier mid (profile success_rate=0.83 @ MEDIUM); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 5 \u2192 tier mid ($8.33); per-story routing cost target: unset",
+        "plan_review": "2 reviewer(s), tier mid, providers ['openai', 'anthropic'], complexity score 5; per-story routing cost target: unset",
+        "code_review": "2 reviewer(s), tier mid, providers ['openai', 'anthropic'], complexity score 5; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 58.33,
+        "final_total_usd": 58.33,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "gpt-5.4",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gemini-3.5-flash",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 58.33
+        }
+      },
+      "config_model_routing": {
+        "complexity": "medium",
+        "complexity_score": 5,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "gemini-3.5-flash",
+        "derived_review_pool": [
+          "gpt-5.4",
+          "opus",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [],
+      "items_dropped": []
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1899/iter_1.yaml",
+      "handoff": {
+        "summary": "Made sprint story audit persistence rebuild-safe when a canonical run JSON already exists but is malformed or not a JSON object. The writer now repairs those canonical files atomically with the redacted native record before mirroring into SQLite, and it no longer falls back to creating a live-only substrate row for valid run_ids. Added a regression test covering both invalid-JSON and non-object existing run files and verifying the row survives `forge audits rebuild` with the canonical source path intact.",
+        "commits": [
+          {
+            "sha": "2a19f9f",
+            "message": "fix(sprint): repair malformed canonical run files"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "The sprint story audit writer must never leave a native SQLite row whose source_path points at an unreadable or non-object canonical run file.",
+            "status": "MET",
+            "notes": "Malformed and non-object existing canonical run files are now replaced atomically with the redacted canonical record before substrate upsert, so mirrored rows always point at a readable object-backed `.forge/audits/runs/{run_id}.json` file."
+          },
+          {
+            "criterion": "A regression test seeds an existing malformed or non-object `.forge/audits/runs/{run_id}.json`, invokes the sprint story audit writer, runs `forge audits rebuild`, and verifies the final behavior is explicit and rebuild-safe rather than silently losing the story record.",
+            "status": "MET",
+            "notes": "Added coverage for both invalid JSON and valid non-object JSON. The test writes the story audit, confirms the canonical file is repaired, runs `rebuild_from_runs`, and verifies the record is still present afterward with the canonical source path."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "none",
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    }
+  ],
+  "reviews": [
+    {
+      "cycle": 1,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "claude-opus"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "claude-opus"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "claude-opus": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "APPROVE",
+      "summary": "[openai-gpt-5.5] The fix repairs malformed canonical run files before mirroring and the focused rebuild regression passes. | [claude-opus] Malformed/non-object existing canonical run files are repaired atomically before substrate mirror, and the live-only fallback is removed; both edge cases are covered by a rebuild-safe regression test.",
+      "sanitization_audit": null,
+      "p1_count": 0,
+      "p2_count": 0,
+      "findings": [],
+      "ac_verification": [
+        {
+          "criterion": "Symptom resolution: existing malformed or non-object canonical run JSON files no longer produce live SQLite rows that disappear after forge audits rebuild.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/sprint/audit.py:112-124 catches unreadable JSON and non-object canonical files and replaces them with the redacted object record before src/theforge/sprint/audit.py:129-137 mirrors the row with the canonical source_path; src/theforge/sprint/audit.py:140-141 also removes the old live-only fallback for valid run_ids. tests/test_coord_audit.py:865-888 seeds both invalid JSON and non-object files and invokes the story audit writer, while tests/test_coord_audit.py:890-919 verifies the file is repaired and the row remains present with the canonical source_path after rebuild_from_runs. The focused regression test passed with pytest."
+        },
+        {
+          "criterion": "The sprint story audit writer must never leave a native SQLite row whose source_path points at an unreadable or non-object canonical run file.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/sprint/audit.py:110-124 \u2014 the existing-file branch now wraps json.load in try/except catching OSError/JSONDecodeError and checks isinstance dict; on either failure it sets should_repair and calls _replace_canonical_run_file (lines 69-74) to atomically rewrite the file with the redacted dict before upsert_run_record at line 129 sets source_path from the now-readable file. The prior except-branch fallback to _upsert_into_substrate (which wrote a source_path-less row) is removed at line 141. Test tests/test_coord_audit.py:860-923 seeds both 'not json{{{' and '[1, 2, 3]' and asserts the on-disk file is a repaired dict and the row points at the canonical path."
+        },
+        {
+          "criterion": "A regression test seeds an existing malformed or non-object .forge/audits/runs/{run_id}.json, invokes the sprint story audit writer, runs forge audits rebuild, and verifies the final behavior is explicit and rebuild-safe rather than silently losing the story record.",
+          "status": "VERIFIED",
+          "evidence": "tests/test_coord_audit.py:860-923 \u2014 test_write_story_audit_repairs_malformed_existing_run_file seeds both invalid-JSON and non-object run files, calls _write_story_audit, asserts the canonical file is repaired and the pre-rebuild row exists, then calls audit_substrate.rebuild_from_runs (asserts summary.failed == 0) and re-queries to confirm the record survives with source_path == '.forge/audits/runs/{run_id}.json' for both scenarios."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    }
+  ],
+  "reviewer_attempts": [
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "claude-opus",
+      "provider": null,
+      "model": "opus",
+      "cli": "claude",
+      "canonical_id": "anthropic/opus/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    }
+  ],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": true,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": {
+    "action": "merge-pr",
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1914",
+    "merged": false,
+    "merge_queued": true,
+    "success": true,
+    "error": null,
+    "auto_merge_queued": true,
+    "landing_path": "fresh-merge",
+    "guard_evidence": {
+      "branch": "feat/issue-1899",
+      "pr_url": "https://github.com/fuzzypete/theforge/pull/1914",
+      "merge_queued": true
+    }
+  },
+  "landing": {
+    "outcome": "merge-queued",
+    "landing_path": "fresh-merge",
+    "fresh_pr_created": true,
+    "merged": false,
+    "merge_queued": true,
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1914",
+    "pr_merged_at": null
+  },
+  "landing_status": "pending_integration",
+  "landing_event": {
+    "landing_status": "pending_integration",
+    "landed": false,
+    "timestamp": "2026-07-24T15:09:27.780906+00:00"
+  },
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": null,
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": [
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/assignment.py",
+      "detail": "src/theforge/assignment.py has 3293 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/check_config.py",
+      "detail": "src/theforge/cli/check_config.py has 726 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/sprint.py",
+      "detail": "src/theforge/cli/sprint.py has 1283 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/status.py",
+      "detail": "src/theforge/cli/status.py has 1125 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/load.py",
+      "detail": "src/theforge/config/load.py has 1353 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/models.py",
+      "detail": "src/theforge/config/models.py has 874 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/types.py",
+      "detail": "src/theforge/config/types.py has 768 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/conventions.py",
+      "detail": "src/theforge/conventions.py has 706 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit.py",
+      "detail": "src/theforge/coordinator/audit.py has 907 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit_substrate.py",
+      "detail": "src/theforge/coordinator/audit_substrate.py has 2166 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/completion.py",
+      "detail": "src/theforge/coordinator/completion.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/dev_phase.py",
+      "detail": "src/theforge/coordinator/dev_phase.py has 1410 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/diagnose_flow.py",
+      "detail": "src/theforge/coordinator/diagnose_flow.py has 1160 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/engine.py",
+      "detail": "src/theforge/coordinator/engine.py has 1555 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/plan_flow.py",
+      "detail": "src/theforge/coordinator/plan_flow.py has 1808 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight.py",
+      "detail": "src/theforge/coordinator/preflight.py has 1397 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight_flow.py",
+      "detail": "src/theforge/coordinator/preflight_flow.py has 1054 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_phase.py",
+      "detail": "src/theforge/coordinator/review_phase.py has 2004 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_pool.py",
+      "detail": "src/theforge/coordinator/review_pool.py has 1100 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/state.py",
+      "detail": "src/theforge/coordinator/state.py has 840 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/validate_phase.py",
+      "detail": "src/theforge/coordinator/validate_phase.py has 929 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/workspace.py",
+      "detail": "src/theforge/coordinator/workspace.py has 872 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/ideate.py",
+      "detail": "src/theforge/ideate.py has 816 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/groom_flow.py",
+      "detail": "src/theforge/intake/groom_flow.py has 616 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/remediation.py",
+      "detail": "src/theforge/intake/remediation.py has 745 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "src/theforge/model_profiles.py has 2750 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/review.py",
+      "detail": "src/theforge/review.py has 1065 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/api.py",
+      "detail": "src/theforge/runners/api.py has 1047 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "src/theforge/runners/cli.py has 730 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/runner_claude.py",
+      "detail": "src/theforge/runners/runner_claude.py has 982 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/schemas.py",
+      "detail": "src/theforge/schemas.py has 665 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/shape_check/heuristics.py",
+      "detail": "src/theforge/shape_check/heuristics.py has 1044 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/audit.py",
+      "detail": "src/theforge/sprint/audit.py has 1222 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/dag.py",
+      "detail": "src/theforge/sprint/dag.py has 673 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/rca.py",
+      "detail": "src/theforge/sprint/rca.py has 1114 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/runner.py",
+      "detail": "src/theforge/sprint/runner.py has 3575 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/shape_gate.py",
+      "detail": "src/theforge/sprint/shape_gate.py has 681 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/status_reader.py",
+      "detail": "src/theforge/sprint/status_reader.py has 934 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/task/plan_prompts.py",
+      "detail": "src/theforge/task/plan_prompts.py has 685 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_assignment.py",
+      "detail": "tests/test_assignment.py has 1571 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_audit_substrate.py",
+      "detail": "tests/test_audit_substrate.py has 1020 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_check_config.py",
+      "detail": "tests/test_check_config.py has 1234 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_setup.py",
+      "detail": "tests/test_cli_setup.py has 1273 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_sprint_status.py",
+      "detail": "tests/test_cli_sprint_status.py has 1423 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_status_watch.py",
+      "detail": "tests/test_cli_status_watch.py has 1087 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_config_load.py",
+      "detail": "tests/test_config_load.py has 1244 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_dev_phase_routing.py",
+      "detail": "tests/test_coord_dev_phase_routing.py has 1009 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_merge_pr.py",
+      "detail": "tests/test_coord_merge_pr.py has 1811 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_model_profiles_seam.py",
+      "detail": "tests/test_coord_model_profiles_seam.py has 1155 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_plan_flow_agent.py",
+      "detail": "tests/test_coord_plan_flow_agent.py has 2259 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_preflight_verdict.py",
+      "detail": "tests/test_coord_preflight_verdict.py has 1173 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_phase_pool.py",
+      "detail": "tests/test_coord_review_phase_pool.py has 1016 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_pool.py",
+      "detail": "tests/test_coord_review_pool.py has 1324 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_state.py",
+      "detail": "tests/test_coord_state.py has 1165 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_workspace_stale.py",
+      "detail": "tests/test_coord_workspace_stale.py has 1084 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coordinator.py",
+      "detail": "tests/test_coordinator.py has 1376 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cut_rc_isolation.py",
+      "detail": "tests/test_cut_rc_isolation.py has 1476 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_diagnose_flow.py",
+      "detail": "tests/test_diagnose_flow.py has 1541 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_generate_audit_log.py",
+      "detail": "tests/test_generate_audit_log.py has 1114 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_model_profiles.py",
+      "detail": "tests/test_model_profiles.py has 1182 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_preflight_work_type.py",
+      "detail": "tests/test_preflight_work_type.py has 1146 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_review.py",
+      "detail": "tests/test_review.py has 1106 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_claude.py",
+      "detail": "tests/test_runner_claude.py has 1231 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_stuck_detection.py",
+      "detail": "tests/test_runner_stuck_detection.py has 1098 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_parallel.py",
+      "detail": "tests/test_sprint_parallel.py has 2699 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_rca.py",
+      "detail": "tests/test_sprint_rca.py has 1070 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_resume.py",
+      "detail": "tests/test_sprint_resume.py has 1268 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_run_id_rollover.py",
+      "detail": "tests/test_sprint_run_id_rollover.py has 1292 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_story_sources.py",
+      "detail": "tests/test_story_sources.py has 1077 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_validate_phase.py",
+      "detail": "tests/test_validate_phase.py has 1413 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/types.py",
+      "detail": "Circular import detected: theforge.config.types \u2192 theforge.config.models \u2192 theforge.config.types",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/defaults.py",
+      "detail": "Circular import detected: theforge.config.defaults \u2192 theforge.config.types \u2192 theforge.config.defaults",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/review.py",
+      "detail": "Circular import detected: theforge.review \u2192 theforge.plan_finding_classifier \u2192 theforge.review",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "Circular import detected: theforge.model_profiles \u2192 theforge.reviewer_value \u2192 theforge.model_profiles",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/__init__.py",
+      "detail": "Circular import detected: theforge.runners \u2192 theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/api.py",
+      "detail": "Circular import detected: theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners.api",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_codex \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_gemini \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/task/__init__.py",
+      "detail": "Circular import detected: theforge.task \u2192 theforge.task.dev_prompts \u2192 theforge.coordinator.state \u2192 theforge.task",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/sprint/manifest.py",
+      "detail": "Circular import detected: theforge.sprint.manifest \u2192 theforge.sprint.sources \u2192 theforge.sprint.manifest",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/coordinator/notify.py",
+      "detail": "Circular import detected: theforge.coordinator.notify \u2192 theforge.notify_backends \u2192 theforge.coordinator.notify",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli.status \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/agent_types.py",
+      "detail": "No test mirror found for src/theforge/agent_types.py (expected tests/test_agent_types.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/artifacts.py",
+      "detail": "No test mirror found for src/theforge/artifacts.py (expected tests/test_artifacts.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/coordinator",
+      "detail": "No test mirror found for package src/theforge/coordinator (expected tests/test_coordinator_*.py or tests/test_coordinator/)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_launchd.py",
+      "detail": "No test mirror found for src/theforge/daemon_launchd.py (expected tests/test_daemon_launchd.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_state.py",
+      "detail": "No test mirror found for src/theforge/daemon_state.py (expected tests/test_daemon_state.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/ideate.py",
+      "detail": "No test mirror found for src/theforge/ideate.py (expected tests/test_ideate.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/log_level.py",
+      "detail": "No test mirror found for src/theforge/log_level.py (expected tests/test_log_level.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/review_finding_classifier.py",
+      "detail": "No test mirror found for src/theforge/review_finding_classifier.py (expected tests/test_review_finding_classifier.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/root_file_conventions.py",
+      "detail": "No test mirror found for src/theforge/root_file_conventions.py (expected tests/test_root_file_conventions.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/runners",
+      "detail": "No test mirror found for package src/theforge/runners (expected tests/test_runners_*.py or tests/test_runners/)",
+      "blocking": false
+    }
+  ],
+  "finding_registry": [],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gemini-3.5-flash",
+        "tier": "mid",
+        "rationale": "[preflight] complexity score 5 \u2192 tier mid ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 5,
+      "base_tier_from_score": "mid",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.8269,
+              "weighted": 0.8269,
+              "runs": 52,
+              "tainted_runs": 1,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.8269
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "database"
+              ],
+              "raw": 1.0,
+              "weighted": 1.0,
+              "runs": 2,
+              "tainted_runs": 1,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 2,
+                  "raw": 1.0,
+                  "weighted": 1.0,
+                  "tainted_runs": 1
+                },
+                "database": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            },
+            "domain": {
+              "domains": [
+                "backend",
+                "database"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "database": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        }
+      ],
+      "domain_match": {
+        "domains": [
+          "backend",
+          "database"
+        ],
+        "influenced": false,
+        "complexity_only_head": "openai-gpt-5.4",
+        "domain_head": "openai-gpt-5.4",
+        "selected_model_slice": {
+          "domains": [
+            "backend",
+            "database"
+          ],
+          "raw": 1.0,
+          "weighted": 1.0,
+          "runs": 2,
+          "tainted_runs": 1,
+          "floor": "fail",
+          "recency": "windowed",
+          "rate": null,
+          "by_domain": {
+            "backend": {
+              "runs": 2,
+              "raw": 1.0,
+              "weighted": 1.0,
+              "tainted_runs": 1
+            },
+            "database": {
+              "runs": 0,
+              "raw": null,
+              "weighted": null,
+              "tainted_runs": 0
+            }
+          }
+        },
+        "reason": "domain_signal_did_not_change_selection"
+      },
+      "promotion_check": {
+        "fired": false,
+        "matching_records": 0,
+        "escalations": 0,
+        "outcome": "no_promotion"
+      },
+      "routing_rationale": {
+        "state": "stayed_at_preflight_tier",
+        "mechanism": null,
+        "from_tier": "mid",
+        "to_tier": "mid"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:medium:backend+database",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": null,
+        "winner": null,
+        "reason": "sprint_cap_reached",
+        "domains": [
+          "backend",
+          "database"
+        ]
+      },
+      "final": {
+        "model": "gpt-5.4",
+        "tier": "mid",
+        "rationale": "[preflight] complexity score 5 (MEDIUM) \u2192 tier mid (profile success_rate=0.83 @ MEDIUM); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "anti_self_review"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 13,
+            "completed": 13,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 6,
+            "completed": 6,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "opus"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier mid, providers ['openai', 'anthropic'], complexity score 5; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 13,
+            "completed": 13,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 11,
+            "completed": 10,
+            "raw": 0.9091,
+            "weighted": 0.9141,
+            "rate": 0.9141,
+            "floor": "pass",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 6,
+            "completed": 6,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "opus"
+        ],
+        "rationale": "[preflight] 2 reviewer(s), tier mid, providers ['openai', 'anthropic'], complexity score 5; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [
+    {
+      "check": "reviewer_tree_currency",
+      "result": "pass",
+      "producer": "coordinator.review_context.reviewer_tree_currency",
+      "evidence": {
+        "base_branch": "release/v0.13",
+        "expected_commits": [
+          "2a19f9f fix(sprint): repair malformed canonical run files"
+        ],
+        "actual_commits": [
+          "2a19f9f fix(sprint): repair malformed canonical run files"
+        ],
+        "missing_from_branch": [],
+        "omitted_from_handoff": []
+      }
+    }
+  ],
+  "trust_status": "trusted",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.288682,
+      "duration_s": 30.72,
+      "outcome": "proceed"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": null,
+      "duration_s": 183.73,
+      "iterations": 1,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 45.88,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": {
+      "cost_usd": null,
+      "duration_s": 56.42,
+      "cycles": 1,
+      "outcome": "approve",
+      "per_reviewer": {
+        "claude-opus": {
+          "cost": 0.472182,
+          "verdict": "APPROVE"
+        },
+        "openai-gpt-5.5": {
+          "cost": null,
+          "verdict": "APPROVE"
+        }
+      }
+    }
+  },
+  "totals": {
+    "cost_usd": null,
+    "duration_s": 316.75,
+    "dev_attempts_total": 1,
+    "dev_iterations_productive": 1,
+    "review_cycles_total": 1,
+    "dev_iterations": 1,
+    "review_cycles": 1
+  },
+  "sprint_id": "9f94c1e93249",
+  "sprint_name": "issues-1910,1911,1899"
+}

--- a/.forge/audits/runs/e567be28c0e4.json
+++ b/.forge/audits/runs/e567be28c0e4.json
@@ -1,0 +1,2528 @@
+{
+  "schema_version": 9,
+  "run_id": "e567be28c0e4",
+  "parent_run_id": null,
+  "forge_version": "0.1.0",
+  "task": {
+    "name": "Claude dev runner can write outside story worktree via absolute paths",
+    "slug": "issue-1907",
+    "story_path": null,
+    "story_text": "## What happened\n\nDuring the sprint for `issues-1899,158,1019,1108,1443,1489`, issue #1443 ran in a story worktree:\n\n```text\n/Users/pwickersham/src/theforge/.forge/worktrees/issue-1443\nbranch feat/issue-1443\n```\n\nThe dev prompt and Claude session metadata both identified that worktree as the working directory. However, the Claude dev agent used absolute paths back to the main project checkout and committed there:\n\n```text\ncd /Users/pwickersham/src/theforge && git commit ...\n```\n\nThat created commit `2358c1a` on local `release/v0.13`, while the story worktree branch `feat/issue-1443` still had zero commits. The coordinator then reported:\n\n```text\nDev attempt produced no usable output ($21.5647 spent, no commits)\n```\n\nThat was mechanically true for the story worktree, but operationally misleading: usable work existed, just in the wrong checkout. The stray commit also caused local `release/v0.13` to diverge from `origin/release/v0.13`, which later caused #1899 to fail workspace setup.\n\n## Why this matters\n\nThis is a workspace containment failure, not a prompt-compliance problem. The runner relied on cwd/prompt discipline plus Claude's native permission mode, but #1443 shows a dev agent can still write/commit outside the intended story worktree by using absolute paths.\n\nFor v0.13 dogfooding, story isolation has to be mechanical. A dev run that can mutate the release/base checkout can corrupt sprint state, produce false no-commit failures, and poison subsequent workspace setup.\n\n## Acceptance criteria\n\n- When `sandbox_mode != none`, Claude dev runs cannot write to or commit from the project root or sibling worktrees.\n- A command like `cd /Users/pwickersham/src/theforge && git commit ...` fails mechanically during a contained dev run whose story worktree is `/Users/pwickersham/src/theforge/.forge/worktrees/issue-1443`.\n- A regression test proves the Claude runner command is wrapped or otherwise confined when host sandbox support exists.\n- If containment cannot be provided, the Claude dev runner fails closed rather than running with only cwd/prompt discipline.\n- Audit/review/status output distinguishes mechanically contained runs from prompt-only/native-permission-mode runs.\n- The fix should reuse the existing workspace containment machinery where possible, likely the same `workspace_effect_sandbox_command` path Gemini uses for workspace-write containment.\n\n## Evidence\n\n- #1443 dev log/handoff claimed commit `2358c1a` and gate pass.\n- Local git showed `2358c1a` on `release/v0.13`, not `feat/issue-1443`.\n- The #1443 worktree remained at the old base with zero commits ahead.\n- The sprint summary classified #1443 as failed/no commits and #1899 later failed because `release/v0.13` had diverged.\n- The #1443 implementation was later included inside PR #1903 for #1489, so the work was not lost, but the workflow state was corrupted.\n\n## References\n\n- #1443 \u2014 triggering story\n- #1489 / PR #1903 \u2014 later PR that included the stray #1443 commit\n- #1905 \u2014 divergence classified as `unknown_needs_rca`\n- #1906 \u2014 sprint summary/status wording bug for already-done stories\n",
+    "github_issue": 1907,
+    "fix_ready": false,
+    "readiness_warnings": [
+      "bug missing Diagnosis section \u2014 not fix-ready (run `forge diagnose` or add diagnosis manually)"
+    ]
+  },
+  "outcome": {
+    "success": true,
+    "final_phase": "DONE",
+    "message": "Task 'Claude dev runner can write outside story worktree via absolute paths' completed. Review approved after 2 cycle(s), 2 dev iteration(s). Branch: feat/issue-1907",
+    "error_type": null,
+    "start_phase": null,
+    "stop_phase": null
+  },
+  "timing": {
+    "started_at": "2026-07-23T16:05:34.196388+00:00",
+    "finished_at": "2026-07-23T17:03:58.307293+00:00",
+    "duration_seconds": 3504.110905
+  },
+  "workspace": {
+    "path": "/Users/pwickersham/src/theforge/.forge/worktrees/issue-1907",
+    "branch": "feat/issue-1907"
+  },
+  "iterations": {
+    "dev_attempts_total": 3,
+    "dev_iterations_productive": 3,
+    "review_cycles_total": 2,
+    "review_cycles": 2,
+    "dev_iterations": 3,
+    "gate_decisions": [
+      "PASS",
+      "FAIL",
+      "PASS"
+    ],
+    "dev_loop": [
+      {
+        "cycle": 0,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 15.276316749999994,
+        "duration_s": 1907.74,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/config/auth.py",
+          "src/theforge/coordinator/audit.py",
+          "src/theforge/coordinator/dev_phase.py",
+          "src/theforge/coordinator/review_phase.py",
+          "src/theforge/coordinator/review_pool.py",
+          "src/theforge/coordinator/state.py",
+          "src/theforge/runners/runner_claude.py",
+          "src/theforge/runners/sandbox.py",
+          "src/theforge/task/review_prompts.py",
+          "tests/conftest.py",
+          "tests/test_auth.py",
+          "tests/test_coord_sandbox.py",
+          "tests/test_runner_claude.py",
+          "tests/test_runner_pool.py",
+          "tests/test_runner_sandbox.py",
+          "tests/test_runner_stuck_detection.py"
+        ],
+        "files_changed_count": 16,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      },
+      {
+        "cycle": 1,
+        "iteration": 1,
+        "max_iterations": 3,
+        "gate_result": "FAIL",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error",
+          "tests/test_runner_sandbox.py::test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 7.996303750000001,
+        "duration_s": 766.31,
+        "meaningful_progress": true,
+        "files_changed": [
+          "src/theforge/runners/sandbox.py",
+          "tests/test_runner_sandbox.py"
+        ],
+        "files_changed_count": 2,
+        "tests_fixed_count": 0,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      },
+      {
+        "cycle": 1,
+        "iteration": 2,
+        "max_iterations": 3,
+        "gate_result": "PASS",
+        "failed_tests": [
+          "tests/test_coord_preflight_escalation.py::TestDevModelEscalationIntegration::test_done_path_records_escalation_via_substrate_without_import_error"
+        ],
+        "gate_output_format_recognized": true,
+        "cost_usd": 5.7972019999999995,
+        "duration_s": 386.17,
+        "meaningful_progress": true,
+        "files_changed": [
+          "tests/test_runner_sandbox.py"
+        ],
+        "files_changed_count": 1,
+        "tests_fixed_count": 1,
+        "sandboxed": true,
+        "agent_exit_code": 0,
+        "runner_failure_code": null,
+        "runner_failure_summary": null,
+        "cli_quota_error_observed": false,
+        "transport_fallback_fired": false,
+        "transport_fallback_reason": null,
+        "transport_used": "cli",
+        "model_used": "opus",
+        "transport_retry_count": 0,
+        "transport_retry_events": []
+      }
+    ],
+    "gate_debug": [],
+    "gate_diagnostic": [],
+    "review_loop": [
+      {
+        "iteration": 1,
+        "max_iterations": 5,
+        "verdict": "REQUEST_CHANGES",
+        "finding_counts": {
+          "P1": 2,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 2,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 2,
+        "restated_findings": 0,
+        "cost_usd": 1.374456,
+        "duration_s": 183.28
+      },
+      {
+        "iteration": 2,
+        "max_iterations": 5,
+        "verdict": "APPROVE",
+        "finding_counts": {
+          "P1": 0,
+          "P2": 0
+        },
+        "new_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "repeated_findings_by_severity": {
+          "P1": 0,
+          "P2": 0
+        },
+        "novel_findings": 0,
+        "restated_findings": 0,
+        "cost_usd": 1.465084,
+        "duration_s": 124.09
+      }
+    ],
+    "usage_summary": {
+      "dev": {
+        "used": 3,
+        "max": 3,
+        "hit_limit": true,
+        "early_finish": false
+      },
+      "review": {
+        "used": 2,
+        "max": 5,
+        "hit_limit": false,
+        "early_finish": true,
+        "early_terminated": false
+      }
+    },
+    "adaptive_limits": {
+      "enabled": true,
+      "complexity_score_input": 8,
+      "complexity_band_input": "large",
+      "floor_dev": 3,
+      "floor_review": 3,
+      "cap_dev": 5,
+      "cap_review": 5,
+      "model_name": "claude-opus",
+      "model_actual": "opus",
+      "model_provider": null,
+      "model_cli": "claude",
+      "headroom_factor": 1.5,
+      "min_profile_runs": 3,
+      "base_timeout_seconds": 1350,
+      "base_dev_cost_estimate_usd": 8.333333333333334,
+      "static_dev_max": 3,
+      "complexity_score_used": 8,
+      "base_review": 5,
+      "profile_history_runs": 81,
+      "profile_avg_iterations": 1.8889,
+      "profile_avg_cost_usd": 8.639994,
+      "profile_raw_dev_max": 2.8334,
+      "estimate_headroom_factor": 2.5,
+      "iteration_derived_timeout_seconds": 1350,
+      "profile_max_duration_s": 3298.03,
+      "profile_max_killed_timeout_s": 0.0,
+      "duration_floor_seconds": 4948,
+      "kill_floor_seconds": 0,
+      "timeout_floored_on_observation": true,
+      "chosen_dev_max": 3,
+      "chosen_dev_timeout_seconds": 4948,
+      "chosen_dev_cost_estimate_usd": 21.6,
+      "review_history_sample_size": 13,
+      "p75_review": 2,
+      "chosen_review_max": 5,
+      "rationale": "derived dev limits from 81 large-band profile runs with 1.5x iteration headroom and 2.5x cost-estimate headroom; timeout floored on observed run duration+headroom (4948s). review history stayed within the complexity-derived review base."
+    },
+    "budget_consumption_log": [
+      {
+        "cycle": 0,
+        "cycle_count": 1,
+        "total_count": 1,
+        "timestamp": "2026-07-23T16:05:34.998106+00:00"
+      },
+      {
+        "cycle": 1,
+        "cycle_count": 1,
+        "total_count": 2,
+        "timestamp": "2026-07-23T16:41:05.536257+00:00"
+      },
+      {
+        "cycle": 1,
+        "cycle_count": 2,
+        "total_count": 3,
+        "timestamp": "2026-07-23T16:54:44.225656+00:00"
+      }
+    ]
+  },
+  "cost": {
+    "total_usd": null,
+    "dev_usd": 29.069822499999994,
+    "review_usd": null,
+    "dev_invocations": 3,
+    "review_invocations": 6,
+    "agents": [
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 15.276316749999994,
+        "duration_seconds": 1907.7444375000196,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.00629
+          },
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 15.270026749999994
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 7.996303750000001,
+        "duration_seconds": 766.3107168750139,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 7.996303750000001
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "dev",
+        "profile": "claude-opus",
+        "cost_usd": 5.7972019999999995,
+        "duration_seconds": 386.1715824579587,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-opus-4-8",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 5.7972019999999995
+          }
+        ],
+        "model_used": "opus"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 61.04864815265561,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 61.04864815265561,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      },
+      {
+        "role": "review",
+        "profile": "claude-sonnet",
+        "cost_usd": 1.3744560499999998,
+        "duration_seconds": 61.04864815265561,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 0.039152000000000006
+          },
+          {
+            "model": "claude-sonnet-5",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 1.33530405
+          }
+        ],
+        "model_used": "sonnet"
+      },
+      {
+        "role": "review",
+        "profile": "openai-gpt-5.5",
+        "cost_usd": null,
+        "duration_seconds": 41.31163322230956,
+        "success": true,
+        "exit_code": 0,
+        "model_used": "gpt-5.5"
+      },
+      {
+        "role": "review",
+        "profile": "google-gemini-3.5-flash",
+        "cost_usd": null,
+        "duration_seconds": 41.31163322230956,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "gemini-3.5-flash",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": null
+          }
+        ],
+        "model_used": "gemini-3.5-flash"
+      },
+      {
+        "role": "review",
+        "profile": "claude-sonnet",
+        "cost_usd": 1.4650839,
+        "duration_seconds": 41.31163322230956,
+        "success": true,
+        "exit_code": 0,
+        "model_usage": [
+          {
+            "model": "claude-sonnet-5",
+            "input_tokens": "[REDACTED]",
+            "output_tokens": "[REDACTED]",
+            "cache_read_tokens": "[REDACTED]",
+            "cache_creation_tokens": "[REDACTED]",
+            "cost_usd": 1.4650839
+          }
+        ],
+        "model_used": "sonnet"
+      }
+    ]
+  },
+  "preflight": {
+    "verdict": "cached",
+    "reason": "The Claude CLI runner has no mechanical write containment today \u2014 runner_claude.py only sets --permission-mode default (prompt-only) for sandbox_mode=read-only and never calls workspace_effect_sandbox_command, unlike runner_gemini.py which wraps and fails closed. This is genuinely unfinished, cross-module work.",
+    "complexity": "large",
+    "complexity_score": 8,
+    "implementation_complexity_score": 8,
+    "validation_complexity_score": 2,
+    "complexity_projection": "max_implementation_validation",
+    "complexity_evidence": [
+      {
+        "rule_id": "implementation_model_score",
+        "signal": "preflight model sized the code-change envelope at 8",
+        "dimension": "implementation"
+      },
+      {
+        "rule_id": "implementation_contract_change",
+        "signal": "contract change forces at least medium implementation complexity (shared-interface blast radius)",
+        "dimension": "implementation"
+      },
+      {
+        "rule_id": "release_blocking_validation",
+        "signal": "acceptance criteria gate a release: 'gate' near 'release' and 'v0.13'",
+        "dimension": "validation"
+      }
+    ],
+    "work_type": "bug",
+    "domains": [
+      "security",
+      "cli",
+      "backend"
+    ],
+    "contract_change": true,
+    "bundle_candidate": false,
+    "cost_usd": 0.5601463999999998,
+    "cached": true,
+    "original_verdict": "PROCEED",
+    "source_run_id": "774a5f80ee4c",
+    "cache_snapshot": {
+      "worktree_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "evaluation_base_branch": "release/v0.13",
+      "evaluation_base_branch_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494"
+    },
+    "cache_validation": {
+      "cached": true,
+      "cached_worktree_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "current_worktree_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "cached_evaluation_base_branch": "release/v0.13",
+      "current_evaluation_base_branch": "release/v0.13",
+      "cached_evaluation_base_branch_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "current_evaluation_base_branch_head": "f1e8e38cd4e8ae73b7f517de6cc3deb3f9015494",
+      "status": "accepted",
+      "reason": "git_state_match"
+    },
+    "degraded": false,
+    "degraded_reason": null,
+    "risk_signals": [],
+    "failure_action": null,
+    "partial_evidence": null,
+    "attempts": [
+      {
+        "profile_name": "preflight",
+        "model": "sonnet",
+        "cost_usd": 0.5601463999999998,
+        "duration_s": 108.38,
+        "success": true,
+        "exit_code": 0
+      }
+    ],
+    "complexity_routing": {
+      "complexity": "large",
+      "complexity_score": 8,
+      "adaptive_enabled": true,
+      "source": "adaptive_assignment",
+      "explicit_overrides": [],
+      "role_sources": {
+        "preflight": "adaptive",
+        "planner": "adaptive",
+        "plan_review": "adaptive",
+        "dev": "adaptive",
+        "code_review": "adaptive"
+      },
+      "assignments": {
+        "preflight": {
+          "model": "gpt-5.4-mini",
+          "source": "builtin",
+          "canonical_id": "openai/gpt-5.4-mini/cli"
+        },
+        "planner": {
+          "model": "gpt-5.5",
+          "source": "forge.yaml",
+          "canonical_id": "openai/gpt-5.5/cli"
+        },
+        "plan_reviewers": [
+          {
+            "model": "opus",
+            "source": "builtin",
+            "canonical_id": "anthropic/opus/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "gpt-5.4",
+            "source": "builtin",
+            "canonical_id": "openai/gpt-5.4/cli"
+          }
+        ],
+        "dev": {
+          "model": "opus",
+          "source": "builtin",
+          "canonical_id": "anthropic/opus/cli"
+        },
+        "code_reviewers": [
+          {
+            "model": "gpt-5.5",
+            "source": "forge.yaml",
+            "canonical_id": "openai/gpt-5.5/cli"
+          },
+          {
+            "model": "gemini-3.5-flash",
+            "source": "forge.yaml",
+            "canonical_id": "google/gemini-3.5-flash/api"
+          },
+          {
+            "model": "sonnet",
+            "source": "builtin",
+            "canonical_id": "anthropic/sonnet/cli"
+          }
+        ]
+      },
+      "rationale": {
+        "dev": "HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 3/10 recent HIGH stories escalated (profile success_rate=0.67 @ HIGH); per-story routing cost target: unset",
+        "preflight": "tier cheap ($8.33)",
+        "planner": "complexity score 8 \u2192 tier strong ($8.33); per-story routing cost target: unset",
+        "plan_review": "3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 8; per-story routing cost target: unset",
+        "code_review": "3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 8; per-story routing cost target: unset",
+        "per_story_routing_cost_target": "unset \u2014 adaptive routes by complexity; no per-story routing cost target enforcement"
+      },
+      "per_story_routing_cost_target": {
+        "target_usd": null,
+        "initial_total_usd": 75.0,
+        "final_total_usd": 75.0,
+        "within_target": true,
+        "downgraded": false,
+        "steps": [],
+        "preferred": {
+          "dev": {
+            "model": "opus",
+            "budget_usd": 8.33
+          },
+          "planner": {
+            "model": "gpt-5.5",
+            "budget_usd": 8.33
+          },
+          "plan_reviewers": [
+            {
+              "model": "opus",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gpt-5.4",
+              "budget_usd": 8.33
+            }
+          ],
+          "code_reviewers": [
+            {
+              "model": "gpt-5.5",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "gemini-3.5-flash",
+              "budget_usd": 8.33
+            },
+            {
+              "model": "sonnet",
+              "budget_usd": 8.33
+            }
+          ],
+          "total_usd": 75.0
+        }
+      },
+      "config_model_routing": {
+        "complexity": "large",
+        "complexity_score": 8,
+        "derived_plan_model": "opus",
+        "derived_dev_model": "opus",
+        "derived_review_pool": [
+          "gemini-3.5-flash",
+          "gpt-5.4",
+          "gpt-5.5"
+        ],
+        "source": "complexity_adaptive"
+      }
+    }
+  },
+  "context_manifests": [
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/runners",
+          "lines": 16
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        }
+      ],
+      "items_dropped": [
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 18
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 17
+        }
+      ]
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/runners",
+          "lines": 16
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        }
+      ],
+      "items_dropped": [
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 18
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 17
+        }
+      ]
+    },
+    {
+      "phase": "dev",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/runners",
+          "lines": 16
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        }
+      ],
+      "items_dropped": [
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 18
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 17
+        }
+      ]
+    },
+    {
+      "phase": "review",
+      "context_budget": 80,
+      "git_sha": null,
+      "items_included": [
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/config",
+          "lines": 11
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/coordinator",
+          "lines": 13
+        },
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_invariants",
+          "type": "invariant",
+          "reason": "invariants for src/theforge/runners",
+          "lines": 16
+        },
+        {
+          "source_path": "src/theforge/coordinator/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "advisory for src/theforge/coordinator",
+          "lines": 24
+        }
+      ],
+      "items_dropped": [
+        {
+          "source_path": "src/theforge/runners/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 18
+        },
+        {
+          "source_path": "src/theforge/config/CONVENTIONS.md",
+          "kind": "claude_advisory",
+          "type": "advisory",
+          "reason": "budget exceeded",
+          "lines": 17
+        }
+      ]
+    }
+  ],
+  "dev_handoffs": [
+    {
+      "iteration": 1,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1907/iter_1.yaml",
+      "handoff": {
+        "summary": "Made Claude CLI dev runs mechanically write-contained to the story worktree by wrapping the launcher in the existing host sandbox (sandbox-exec/bwrap) via workspace_effect_sandbox_command when sandbox_mode != none, failing closed (SANDBOX_UNAVAILABLE) when the host sandbox is unavailable \u2014 matching runner_gemini. Native --permission-mode is retained only as defense-in-depth. Critically, the prior attempt (#920) was reverted (#925) because the sandbox blocked Claude's macOS Keychain auth; I reproduced that failure empirically on the dev host and fixed it by granting the com.apple.SecurityServer mach-lookup + ~/Library/Keychains reads (allow_credential_services), network-outbound + mDNSResponder for API egress, and ~/.claude as a writable state root \u2014 verified end-to-end that the #1443 attack (cd /abs && git add) and sibling writes/reads are blocked while auth, DNS, worktree writes, and ~/.claude writes work. Readiness/audit now distinguish mechanical containment from prompt-only/native: _sandbox_readiness reports Claude/Gemini CLIs as sandboxed only when the host wrapper is available (Codex stays native), and sandbox_containment_mode (mechanical/native/unavailable/none) is surfaced in dev-phase state, audit iteration metrics, and the reviewer prompt.",
+        "commits": [
+          {
+            "sha": "da93e53",
+            "message": "fix(runners): mechanically contain Claude dev runs in the story worktree"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "When sandbox_mode != none, Claude dev runs cannot write to or commit from the project root or sibling worktrees.",
+            "status": "MET",
+            "notes": "runner_claude wraps the launcher in workspace_effect_sandbox_command; empirically confirmed project-root and sibling-worktree writes fail with 'Operation not permitted' under the real generated profile."
+          },
+          {
+            "criterion": "A command like `cd .../theforge && git commit ...` fails mechanically during a contained dev run.",
+            "status": "MET",
+            "notes": "Verified: `cd <project-root> && git add` fails with EPERM under the sandbox profile scoped to the worktree."
+          },
+          {
+            "criterion": "A regression test proves the Claude runner command is wrapped or otherwise confined when host sandbox support exists.",
+            "status": "MET",
+            "notes": "TestClaudeSandboxWrapper: test_workspace_write_wraps_command asserts Popen receives the wrapper (sandbox-exec), not the bare claude argv; test_read_only_also_wraps; wrapper receives allow_credential_services + ~/.claude write roots."
+          },
+          {
+            "criterion": "If containment cannot be provided, the Claude dev runner fails closed rather than running with only cwd/prompt discipline.",
+            "status": "MET",
+            "notes": "test_sandbox_unavailable_fails_closed asserts Popen is never called and a startup_failure SANDBOX_UNAVAILABLE result is returned."
+          },
+          {
+            "criterion": "Audit/review/status output distinguishes mechanically contained runs from prompt-only/native-permission-mode runs.",
+            "status": "MET",
+            "notes": "sandbox_containment_mode + state.dev_containment surfaced in audit dev_loop metrics and the reviewer prompt (MECHANICAL/NATIVE/DISABLED labels); tests in test_coord_sandbox.py and test_auth.py."
+          },
+          {
+            "criterion": "The fix reuses the existing workspace_effect_sandbox_command path Gemini uses.",
+            "status": "MET",
+            "notes": "Reused workspace_effect_sandbox_command; extended it with extra_write_roots + allow_credential_services rather than adding a parallel mechanism."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "The macOS Keychain-auth/DNS behavior (the root cause of the prior #925 revert) can only be validated empirically on the macOS dev host \u2014 CI is Linux, so this specific interaction is not exercised by the gate (known Linux/macOS coverage gap). All containment logic, fail-closed, and readiness/audit changes are unit-tested. Also repurposed one test asserting the old 'launcher invoked directly' contract and set claude lifecycle test fixtures to sandbox_mode=none (mirroring the existing gemini_profile fixture) since they exercise streaming/lifecycle, not containment.",
+        "deferred_items": "none"
+      }
+    },
+    {
+      "iteration": 2,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1907/iter_1.yaml",
+      "handoff": {
+        "summary": "Iteration 1 addresses both P1 review findings on top of the iter-0 mechanical containment. (1) Legitimate `git commit` inside the correctly-scoped worktree was failing EPERM because a linked worktree's private gitdir (<repo>/.git/worktrees/<name>) and shared object store/refs (<repo>/.git) live outside the worktree root and were never write-allowed. Added _git_worktree_write_roots, auto-applied by workspace_effect_sandbox_command for both Claude and Gemini, granting a tight set: the worktree's own private gitdir, shared objects+reflogs+packed-refs, and ONLY the namespace dir of the worktree's own branch ref (e.g. .git/refs/heads/feat). The main checkout's index/HEAD and other branches' refs stay read-only, so `cd <project-root> && git commit` and `git update-ref refs/heads/main` still fail mechanically \u2014 the #1443 vector remains blocked (verified empirically on a real linked worktree: worktree commit exit 0/clean, main-checkout commit blocked, main-ref rewrite blocked, project-root and sibling writes blocked). (2) Added an executable macOS-gated regression test that runs real commands under the generated sandbox-exec profile proving the escape fails and the legit commit succeeds, plus cross-platform structural tests for the git-write-root scoping. Full suite: 5907 passed, 31 skipped; ruff check/format clean on changed files.",
+        "commits": [
+          {
+            "sha": "52062f5",
+            "message": "fix(runners): grant worktree git internals + executable escape test (iter 1)"
+          },
+          {
+            "sha": "da93e53",
+            "message": "fix(runners): mechanically contain Claude dev runs in the story worktree"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "When sandbox_mode != none, Claude dev runs cannot write to or commit from the project root or sibling worktrees.",
+            "status": "MET",
+            "notes": "Wrapping confines writes to the worktree; empirically verified project-root source writes, project-root commits, main-branch-ref rewrites, and sibling-worktree writes all fail under the real profile."
+          },
+          {
+            "criterion": "A command like `cd .../theforge && git commit ...` fails mechanically during a contained dev run.",
+            "status": "MET",
+            "notes": "Main checkout's .git/index stays read-only, so cd <project-root> && git add/commit fails EPERM; covered by the new executable integration test (step 3 assertion)."
+          },
+          {
+            "criterion": "A regression test proves the Claude runner command is wrapped or otherwise confined when host sandbox support exists.",
+            "status": "MET",
+            "notes": "TestClaudeSandboxWrapper asserts wrapping; new test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice executes real commands under the generated sandbox-exec profile and asserts the #1443 escape fails while a legit worktree commit succeeds."
+          },
+          {
+            "criterion": "If containment cannot be provided, the Claude dev runner fails closed rather than running with only cwd/prompt discipline.",
+            "status": "MET",
+            "notes": "runner_claude returns SANDBOX_UNAVAILABLE startup_failure without launching claude; unchanged this iteration."
+          },
+          {
+            "criterion": "Audit/review/status output distinguishes mechanically contained runs from prompt-only/native-permission-mode runs.",
+            "status": "MET",
+            "notes": "sandbox_containment_mode + state.dev_containment surfaced in audit metrics and reviewer prompt; unchanged this iteration."
+          },
+          {
+            "criterion": "The fix reuses the existing workspace_effect_sandbox_command path Gemini uses.",
+            "status": "MET",
+            "notes": "git write-root grant added centrally in workspace_effect_sandbox_command so both Claude and Gemini benefit."
+          }
+        ],
+        "gate_delegated": true,
+        "gate_result": "BLOCKED",
+        "story_deviations": "The git write-root grant is applied centrally in workspace_effect_sandbox_command (affects Gemini too), not only in the Claude path \u2014 Gemini had the identical latent commit-under-sandbox bug, and centralizing avoids duplication. The branch-ref scoping (own-namespace-only) intentionally goes beyond the reviewer's literal 'add commondir' suggestion because granting the whole common .git would have reopened the #1443 main-checkout-commit escape; verified empirically. macOS Keychain/DNS and the git-commit-under-sandbox behavior can only be validated on the macOS dev host (CI is Linux and does not run real claude/sandbox); the git-scoping logic itself has cross-platform structural unit tests.",
+        "deferred_items": "none"
+      }
+    },
+    {
+      "iteration": 3,
+      "source": "structured_output",
+      "path": "/Users/pwickersham/src/theforge/.forge/handoffs/issue-1907/iter_2.yaml",
+      "handoff": {
+        "summary": "Iteration 2 fixes the gate failure the owner flagged. The only failing test was the new executable containment regression (test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice). Root cause: the sandbox profile intentionally grants write to /tmp (agent scratch), and under make gate's scrubbed `env -i` TMPDIR is stripped so pytest's tmp_path resolves under /tmp \u2014 placing the fake project inside a sandbox-writable temp root, making every write-denial assertion vacuously false. It passed in normal unscrubbed runs (tmp_path under /var/folders, which is read-only in the profile), which is why it slipped through. Fix: anchor the test's project tree under /private/var/tmp \u2014 a real, writable, non-TMPDIR-dependent path the profile does NOT grant write to \u2014 with cleanup in a finally. Reproduced the failure under the exact scrubbed gate command and confirmed the fix there, then ran the full gate green (5907 passed, 31 skipped, exit 0). No production code changed; the cycle-1 P1 fixes (git write-root grant in workspace_effect_sandbox_command and the executable escape test) remain in place.",
+        "commits": [
+          {
+            "sha": "3e00dee",
+            "message": "fix(tests): anchor sandbox escape test outside /tmp so it holds under gate scrub"
+          },
+          {
+            "sha": "52062f5",
+            "message": "fix(runners): grant worktree git internals + executable escape test (iter 1)"
+          },
+          {
+            "sha": "da93e53",
+            "message": "fix(runners): mechanically contain Claude dev runs in the story worktree"
+          }
+        ],
+        "acceptance_criteria": [
+          {
+            "criterion": "When sandbox_mode != none, Claude dev runs cannot write to or commit from the project root or sibling worktrees.",
+            "status": "MET",
+            "notes": "Wrapping confines writes to the worktree; the executable regression test now runs under the gate and asserts project-root and sibling writes/commits fail while a legit worktree commit succeeds."
+          },
+          {
+            "criterion": "A command like `cd .../theforge && git commit ...` fails mechanically during a contained dev run.",
+            "status": "MET",
+            "notes": "Main checkout's .git/index stays read-only; assertion 3 of the executable test verifies the project-root commit fails under the real sandbox profile."
+          },
+          {
+            "criterion": "A regression test proves the Claude runner command is wrapped or otherwise confined when host sandbox support exists.",
+            "status": "MET",
+            "notes": "TestClaudeSandboxWrapper asserts wrapping; the macOS-gated integration test executes real commands under the generated sandbox-exec profile and now passes under the scrubbed gate."
+          },
+          {
+            "criterion": "If containment cannot be provided, the Claude dev runner fails closed rather than running with only cwd/prompt discipline.",
+            "status": "MET",
+            "notes": "runner_claude returns SANDBOX_UNAVAILABLE startup_failure without launching claude; unchanged this iteration."
+          },
+          {
+            "criterion": "Audit/review/status output distinguishes mechanically contained runs from prompt-only/native-permission-mode runs.",
+            "status": "MET",
+            "notes": "sandbox_containment_mode + state.dev_containment surfaced in audit metrics and reviewer prompt; unchanged this iteration."
+          },
+          {
+            "criterion": "The fix reuses the existing workspace_effect_sandbox_command path Gemini uses.",
+            "status": "MET",
+            "notes": "git write-root grant added centrally in workspace_effect_sandbox_command so both Claude and Gemini benefit; unchanged this iteration."
+          }
+        ],
+        "gate_result": "PASS",
+        "story_deviations": "The executable regression test anchors its project tree under /private/var/tmp rather than pytest tmp_path \u2014 necessary because the sandbox intentionally grants /tmp write and the scrubbed gate forces tmp_path into /tmp, which would make the containment assertions vacuous. This is macOS-only (the test is already Darwin-gated). No production behavior changed.",
+        "deferred_items": "none"
+      }
+    }
+  ],
+  "dev_prompt_injections": [
+    {
+      "iteration": 1,
+      "finding_ids": []
+    },
+    {
+      "iteration": 2,
+      "finding_ids": [
+        "1c2d15fcfa5d68ea",
+        "17862cbb2e4678eb"
+      ]
+    },
+    {
+      "iteration": 3,
+      "finding_ids": []
+    }
+  ],
+  "reviews": [
+    {
+      "cycle": 1,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded",
+        "claude-sonnet": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "REQUEST_CHANGES",
+      "summary": "[openai-gpt-5.5] Claude now wraps and fails closed, but the original absolute-path write escape is not covered by an executable regression test. | [google-gemini-3.5-flash] The Claude dev runner is now mechanically write-contained to the story worktree using the host sandbox wrapper, with robust fail-closed behavior and clear audit/status reporting. | [claude-sonnet] Mechanical sandbox containment is well-designed for the #1443 attack path, but empirically the write-allow list omits the git worktree's actual gitdir/object-store location, so git commit fails even from the correctly-scoped worktree.",
+      "sanitization_audit": null,
+      "p1_count": 2,
+      "p2_count": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "file": "tests/test_runner_sandbox.py",
+          "line": 99,
+          "description": "The containment regression tests inspect wrapper arguments and profile text but never execute a contained command that attempts the issue's escaped project-root write or commit path, so a sandbox profile that still permits the #1443 write escape would pass the gate.",
+          "reviewers": [
+            "openai-gpt-5.5"
+          ],
+          "reporter": "openai-gpt-5.5"
+        },
+        {
+          "severity": "P1",
+          "file": "src/theforge/runners/sandbox.py",
+          "line": 215,
+          "description": "Running git commit inside the story worktree under the generated sandbox-exec profile fails with Operation not permitted because the profile does not grant write access to the worktree's real gitdir (<project-root>/.git/worktrees/<name>) or the shared object database under <project-root>/.git.",
+          "reviewers": [
+            "claude-sonnet"
+          ],
+          "reporter": "claude-sonnet"
+        }
+      ],
+      "ac_verification": [
+        {
+          "criterion": "When sandbox_mode != none, Claude dev runs cannot write to or commit from the project root or sibling worktrees.",
+          "status": "PARTIAL",
+          "evidence": "src/theforge/runners/runner_claude.py:666 wraps Claude when sandbox_mode is not none, and src/theforge/runners/sandbox.py:246 plus src/theforge/runners/sandbox.py:297 make only the story worktree writable in the generated sandbox command; tests/test_runner_sandbox.py:99-118 only validates wrapper shape and does not execute a project-root or sibling-worktree write/commit escape.; Writes to the project root and sibling worktrees via absolute paths are correctly blocked (src/theforge/runners/sandbox.py write_roots/denied_read_roots), but the criterion's implicit requirement that legitimate worktree commits still succeed is not met \u2014 git commit from inside the worktree itself fails because the worktree's gitdir/object store live under the project root, which is read-only under this profile."
+        },
+        {
+          "criterion": "A command like cd /Users/pwickersham/src/theforge && git commit ... fails mechanically during a contained dev run whose story worktree is /Users/pwickersham/src/theforge/.forge/worktrees/issue-1443.",
+          "status": "PARTIAL",
+          "evidence": "src/theforge/runners/runner_claude.py:667 passes the story worktree as the allowed sandbox root, but there is no test that executes an escaped cd into the project root followed by git add, git commit, or an equivalent write assertion.; Confirmed by design and by the pre-existing test_macos_sandbox_profile_blocks_sibling_worktree_reads_in_practice plus the write_roots restriction; the #1443 attack path itself is blocked."
+        },
+        {
+          "criterion": "A regression test proves the Claude runner command is wrapped or otherwise confined when host sandbox support exists.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:666-695 wraps the Claude argv before Popen, and tests/test_runner_claude.py:683-702 asserts workspace-write mode calls the sandbox wrapper and Popen receives sandbox-exec rather than bare claude.; tests/test_runner_claude.py:683-703 (test_workspace_write_wraps_command) asserts that Popen receives the wrapped command (sandbox-exec) instead of the bare claude argv.; tests/test_runner_claude.py TestClaudeSandboxWrapper::test_workspace_write_wraps_command and test_read_only_also_wraps assert Popen receives the sandbox-exec wrapper, not the bare claude argv."
+        },
+        {
+          "criterion": "If containment cannot be provided, the Claude dev runner fails closed rather than running with only cwd/prompt discipline.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:673-694 returns a startup_failure AgentResult with SANDBOX_UNAVAILABLE before launch when the wrapper is unavailable, and tests/test_runner_claude.py:737-753 asserts Popen is not called and the error string is returned.; src/theforge/runners/runner_claude.py:673-690 returns an AgentResult with success=False and startup_failure=True when the host sandbox is unavailable, and tests/test_runner_claude.py:737-750 (test_sandbox_unavailable_fails_closed) verifies this behavior.; src/theforge/runners/runner_claude.py:666-695 returns AgentResult(success=False, startup_failure=True) with SANDBOX_UNAVAILABLE before Popen when workspace_effect_sandbox_command returns the cmd unchanged; tests/test_runner_claude.py::test_sandbox_unavailable_fails_closed asserts Popen is never called."
+        },
+        {
+          "criterion": "Audit/review/status output distinguishes mechanically contained runs from prompt-only/native-permission-mode runs.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/config/auth.py:94-114 classifies containment as mechanical, native, unavailable, or none; src/theforge/coordinator/dev_phase.py:621-634 records and logs the mode; src/theforge/coordinator/audit.py:452-453 serializes it; src/theforge/task/review_prompts.py:400-411 labels it in review prompts; tests/test_coord_sandbox.py:151-229 and tests/test_auth.py:367-374 cover the state, audit, prompt, and classification behavior.; src/theforge/config/auth.py:94-114 (sandbox_containment_mode) classifies the containment mode, which is recorded in state.dev_containment and DevIterationTelemetry.containment (src/theforge/coordinator/dev_phase.py:622), serialized in src/theforge/coordinator/audit.py:453, and rendered in src/theforge/task/review_prompts.py:398-411. Verified by tests/test_coord_sandbox.py:151-230.; src/theforge/config/auth.py sandbox_containment_mode; state.dev_containment surfaced in src/theforge/coordinator/audit.py:453 and src/theforge/task/review_prompts.py containment labels; tests/test_coord_sandbox.py TestStateAndAuditContainment and TestReviewPromptContainment."
+        },
+        {
+          "criterion": "The fix should reuse the existing workspace containment machinery where possible, likely the same workspace_effect_sandbox_command path Gemini uses for workspace-write containment.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:23 imports workspace_effect_sandbox_command and src/theforge/runners/runner_claude.py:667-672 calls it with Claude-specific state roots and credential access; tests/test_runner_claude.py:704-721 asserts those wrapper arguments are threaded.; src/theforge/runners/runner_claude.py imports and calls workspace_effect_sandbox_command directly (same function extended with extra_write_roots/allow_credential_services rather than a parallel mechanism)."
+        },
+        {
+          "criterion": "When `sandbox_mode != none`, Claude dev runs cannot write to or commit from the project root or sibling worktrees.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:666-672 wraps the command in workspace_effect_sandbox_command when profile.sandbox_mode != 'none'. src/theforge/runners/sandbox.py:338 blocks sibling worktrees via _blocked_worktree_roots(root). tests/test_runner_sandbox.py:225 verifies that sibling worktree reads/writes are blocked."
+        },
+        {
+          "criterion": "A command like `cd /Users/pwickersham/src/theforge && git commit ...` fails mechanically during a contained dev run whose story worktree is `/Users/pwickersham/src/theforge/.forge/worktrees/issue-1443`.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/sandbox.py:215-218 restricts write roots to the worktree, /tmp, /dev, and extra_write_roots (which is ~/.claude and ~/.claude.json). The project root is not in the write roots, so any write or commit to the project root fails mechanically."
+        },
+        {
+          "criterion": "The fix should reuse the existing workspace containment machinery where possible, likely the same `workspace_effect_sandbox_command` path Gemini uses for workspace-write containment.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:667 invokes workspace_effect_sandbox_command from theforge.runners.sandbox."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    },
+    {
+      "cycle": 2,
+      "pool_models": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "successful": [
+        "openai-gpt-5.5",
+        "google-gemini-3.5-flash",
+        "claude-sonnet"
+      ],
+      "failed": [],
+      "failed_detail": {},
+      "synthesized": false,
+      "parse_retries": 0,
+      "transient_retries": {},
+      "transient_outcomes": {
+        "openai-gpt-5.5": "succeeded",
+        "google-gemini-3.5-flash": "succeeded",
+        "claude-sonnet": "succeeded"
+      },
+      "quorum_threshold": 2,
+      "quorum_met": true,
+      "degraded_quorum": false,
+      "degraded_quorum_warning": null,
+      "verdict": "APPROVE",
+      "summary": "[openai-gpt-5.5] Prior P1s are fixed, the latest iteration only adjusts the executable test location, and no blocking regressions were found. | [google-gemini-3.5-flash] The Claude dev runner containment implementation is fully verified, robustly tested, and completely resolves all prior P1 findings. | [claude-sonnet] Iteration 2 fixes both cycle-1 P1s: the executable macOS test now proves a legitimate commit inside the story worktree succeeds while project-root writes/commits and main-ref rewrites still fail, and _git_worktree_write_roots grants only the worktree's own gitdir/objects/branch-namespace (not the whole refs tree or main checkout). Reproduced independently against this review worktree with sandbox-exec: worktree commit succeeded (exit 0), project-root commit and refs/heads/main rewrite both failed with 'Operation not permitted' (exit 128).",
+      "sanitization_audit": null,
+      "p1_count": 0,
+      "p2_count": 0,
+      "findings": [],
+      "ac_verification": [
+        {
+          "criterion": "When sandbox_mode != none, Claude dev runs cannot write to or commit from the project root or sibling worktrees.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:666 wraps Claude whenever sandbox_mode is not none, src/theforge/runners/sandbox.py:433 threads the allowed story worktree into workspace_effect_sandbox_command, and src/theforge/runners/sandbox.py:156 scopes linked-worktree git writes to the worktree's private gitdir plus required shared git internals. tests/test_runner_sandbox.py:371 verifies a legitimate worktree commit succeeds, while tests/test_runner_sandbox.py:378 and tests/test_runner_sandbox.py:394 verify project-root and sibling-worktree writes fail under the generated sandbox profile.; src/theforge/runners/runner_claude.py lines 658-671 wraps the Claude CLI command using workspace_effect_sandbox_command when profile.sandbox_mode != 'none'. tests/test_runner_sandbox.py lines 294-399 (test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice) executes real commands under the generated sandbox-exec profile and asserts that writing/committing to the project root or sibling worktrees fails mechanically.; src/theforge/runners/sandbox.py write_roots (worktree, /tmp, /dev, extra_write_roots) exclude the project root and sibling worktrees; _git_worktree_write_roots (sandbox.py, added in 52062f5) grants only the worktree's own private gitdir + shared objects/logs/packed-refs + its own branch-ref namespace, not the common root or other branches' refs. tests/test_runner_sandbox.py::test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice asserts a project-root source write and a sibling-worktree write both fail (returncode != 0) under the real generated sandbox-exec profile. Independently reproduced against the live issue-1907 worktree: project-root git commit fails with 'Unable to create .../index.lock: Operation not permitted'."
+        },
+        {
+          "criterion": "A command like cd /Users/pwickersham/src/theforge && git commit ... fails mechanically during a contained dev run whose story worktree is /Users/pwickersham/src/theforge/.forge/worktrees/issue-1443.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/sandbox.py:184 grants the story worktree's private gitdir while leaving the main checkout's gitdir root and index outside the write roots, and tests/test_runner_sandbox.py:383 runs the project-root commit escape shape under sandbox-exec and asserts it fails.; tests/test_runner_sandbox.py lines 384-387 (test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice) asserts that a commit from the project root fails under the real sandbox profile.; tests/test_runner_sandbox.py::test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice assertion 3 runs cd {proot} && ... git commit under the real sandbox-exec profile and asserts returncode != 0, plus assertion 4 confirms git update-ref refs/heads/main HEAD also fails and main is unchanged. Independently reproduced against issue-1907: project-root commit and main-ref rewrite both exit 128 with 'Operation not permitted', while the correctly-scoped worktree commit (the cycle-1 regression) now succeeds (exit 0)."
+        },
+        {
+          "criterion": "A regression test proves the Claude runner command is wrapped or otherwise confined when host sandbox support exists.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:667 calls workspace_effect_sandbox_command before subprocess launch, tests/test_runner_claude.py:683 asserts Popen receives the sandbox wrapper rather than bare claude, and tests/test_runner_sandbox.py:357 executes commands under the real generated macOS sandbox profile when sandbox-exec is available.; tests/test_runner_claude.py lines 671-691 (TestClaudeSandboxWrapper.test_workspace_write_wraps_command) asserts that the Claude CLI command is wrapped with sandbox-exec when sandbox_mode != 'none'. tests/test_runner_sandbox.py lines 294-399 (test_macos_sandbox_allows_worktree_commit_but_blocks_escape_in_practice) executes real commands under the generated sandbox-exec profile.; tests/test_runner_claude.py::TestClaudeSandboxWrapper::test_workspace_write_wraps_command asserts Popen receives sandbox-exec, not the bare claude argv; test_read_only_also_wraps; plus the new executable sandbox-exec integration test."
+        },
+        {
+          "criterion": "If containment cannot be provided, the Claude dev runner fails closed rather than running with only cwd/prompt discipline.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:673 detects an unchanged wrapper command and returns a SANDBOX_UNAVAILABLE startup_failure instead of launching Claude, with tests/test_runner_claude.py:737 asserting subprocess.Popen is not called and the result contains SANDBOX_UNAVAILABLE.; src/theforge/runners/runner_claude.py lines 665-698 returns AgentResult with startup_failure=True and SANDBOX_UNAVAILABLE output if the host sandbox is unavailable and sandbox_mode != 'none'. tests/test_runner_claude.py lines 724-739 (test_sandbox_unavailable_fails_closed) asserts that the runner fails closed without launching Claude when the host sandbox is unavailable.; src/theforge/runners/runner_claude.py:673-694 (unchanged this iteration) returns AgentResult(startup_failure=True, output contains SANDBOX_UNAVAILABLE) before Popen when wrapping is unavailable; tests/test_runner_claude.py::test_sandbox_unavailable_fails_closed asserts Popen is never called."
+        },
+        {
+          "criterion": "Audit/review/status output distinguishes mechanically contained runs from prompt-only/native-permission-mode runs.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/config/auth.py:94 classifies containment as mechanical, native, unavailable, or none; src/theforge/coordinator/dev_phase.py:621 records sandboxed and dev_containment at runtime; src/theforge/coordinator/audit.py:452 serializes containment; src/theforge/task/review_prompts.py:398 renders distinct prompt labels; tests/test_coord_sandbox.py:151 verifies state and audit recording, and tests/test_coord_sandbox.py:215 verifies reviewer prompt labels.; src/theforge/config/auth.py lines 94-117 (sandbox_containment_mode) classifies containment as 'mechanical', 'native', 'unavailable', or 'none'. src/theforge/coordinator/dev_phase.py lines 619-620 records state.dev_containment = sandbox_containment_mode(config.dev_profile). src/theforge/coordinator/audit.py line 453 serializes containment in dev iteration metrics. src/theforge/task/review_prompts.py lines 398-411 (build_review_prompt) renders the containment mode label in the reviewer prompt. tests/test_coord_sandbox.py lines 151-232 (TestStateAndAuditContainment and TestReviewPromptContainment) verify that the containment mode is recorded in state, audit, and reviewer prompt.; src/theforge/config/auth.py sandbox_containment_mode; state.dev_containment surfaced in coordinator/audit.py and task/review_prompts.py; tests/test_coord_sandbox.py TestStateAndAuditContainment and TestReviewPromptContainment (unchanged this iteration, still passing)."
+        },
+        {
+          "criterion": "The fix should reuse the existing workspace containment machinery where possible, likely the same workspace_effect_sandbox_command path Gemini uses for workspace-write containment.",
+          "status": "VERIFIED",
+          "evidence": "src/theforge/runners/runner_claude.py:25 imports workspace_effect_sandbox_command, src/theforge/runners/runner_claude.py:667 uses that shared wrapper for Claude, src/theforge/runners/sandbox.py:409 keeps the git write-root grants centralized in workspace_effect_sandbox_command, and src/theforge/runners/runner_gemini.py:109 continues to use the same shared path.; src/theforge/runners/runner_claude.py line 25 imports workspace_effect_sandbox_command from theforge.runners.sandbox. src/theforge/runners/runner_claude.py lines 659-664 invokes workspace_effect_sandbox_command to wrap the Claude CLI command.; workspace_effect_sandbox_command (src/theforge/runners/sandbox.py) is the single shared entry point used by runner_claude.py; the git-write-root grant added in 52062f5 is threaded through this same function, so Gemini's existing wrapping benefits automatically without a parallel mechanism."
+        }
+      ],
+      "criteria_enumerable": true,
+      "criteria_enumerable_rationale": null,
+      "parse_errors": []
+    }
+  ],
+  "reviewer_attempts": [
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "claude-sonnet",
+      "provider": null,
+      "model": "sonnet",
+      "cli": "claude",
+      "canonical_id": "anthropic/sonnet/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 1
+    },
+    {
+      "name": "openai-gpt-5.5",
+      "provider": null,
+      "model": "gpt-5.5",
+      "cli": "codex",
+      "canonical_id": "openai/gpt-5.5/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    },
+    {
+      "name": "google-gemini-3.5-flash",
+      "provider": "google",
+      "model": "gemini-3.5-flash",
+      "cli": null,
+      "canonical_id": "google/gemini-3.5-flash/api",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    },
+    {
+      "name": "claude-sonnet",
+      "provider": null,
+      "model": "sonnet",
+      "cli": "claude",
+      "canonical_id": "anthropic/sonnet/cli",
+      "completed_parseable_verdict": true,
+      "outcome": "completed",
+      "failure_reason": null,
+      "cycle": 2
+    }
+  ],
+  "human_review": null,
+  "plan_review": null,
+  "plan_validation": {
+    "skipped": false,
+    "findings": [],
+    "finding_count": 0
+  },
+  "merge": {
+    "action": "merge-pr",
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1909",
+    "merged": false,
+    "merge_queued": true,
+    "success": true,
+    "error": null,
+    "auto_merge_queued": true,
+    "landing_path": "fresh-merge",
+    "guard_evidence": {
+      "branch": "feat/issue-1907",
+      "pr_url": "https://github.com/fuzzypete/theforge/pull/1909",
+      "merge_queued": true
+    }
+  },
+  "landing": {
+    "outcome": "merge-queued",
+    "landing_path": "fresh-merge",
+    "fresh_pr_created": true,
+    "merged": false,
+    "merge_queued": true,
+    "pr_url": "https://github.com/fuzzypete/theforge/pull/1909",
+    "pr_merged_at": null
+  },
+  "landing_status": "pending_integration",
+  "landing_event": {
+    "landing_status": "pending_integration",
+    "landed": false,
+    "timestamp": "2026-07-23T17:03:58.307293+00:00"
+  },
+  "timeout_escalation": null,
+  "escalation": null,
+  "error": null,
+  "error_type": null,
+  "story_validation": null,
+  "convention_violations": [
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/assignment.py",
+      "detail": "src/theforge/assignment.py has 3293 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/check_config.py",
+      "detail": "src/theforge/cli/check_config.py has 726 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/sprint.py",
+      "detail": "src/theforge/cli/sprint.py has 1283 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/cli/status.py",
+      "detail": "src/theforge/cli/status.py has 1125 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/load.py",
+      "detail": "src/theforge/config/load.py has 1353 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/models.py",
+      "detail": "src/theforge/config/models.py has 874 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/config/types.py",
+      "detail": "src/theforge/config/types.py has 768 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/conventions.py",
+      "detail": "src/theforge/conventions.py has 706 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit.py",
+      "detail": "src/theforge/coordinator/audit.py has 907 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/audit_substrate.py",
+      "detail": "src/theforge/coordinator/audit_substrate.py has 2166 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/completion.py",
+      "detail": "src/theforge/coordinator/completion.py has 1581 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/dev_phase.py",
+      "detail": "src/theforge/coordinator/dev_phase.py has 1410 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/diagnose_flow.py",
+      "detail": "src/theforge/coordinator/diagnose_flow.py has 1160 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/engine.py",
+      "detail": "src/theforge/coordinator/engine.py has 1555 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/plan_flow.py",
+      "detail": "src/theforge/coordinator/plan_flow.py has 1808 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight.py",
+      "detail": "src/theforge/coordinator/preflight.py has 1397 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/preflight_flow.py",
+      "detail": "src/theforge/coordinator/preflight_flow.py has 1054 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_phase.py",
+      "detail": "src/theforge/coordinator/review_phase.py has 2004 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/review_pool.py",
+      "detail": "src/theforge/coordinator/review_pool.py has 1100 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/state.py",
+      "detail": "src/theforge/coordinator/state.py has 840 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/validate_phase.py",
+      "detail": "src/theforge/coordinator/validate_phase.py has 929 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/coordinator/workspace.py",
+      "detail": "src/theforge/coordinator/workspace.py has 872 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/ideate.py",
+      "detail": "src/theforge/ideate.py has 816 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/groom_flow.py",
+      "detail": "src/theforge/intake/groom_flow.py has 616 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/intake/remediation.py",
+      "detail": "src/theforge/intake/remediation.py has 745 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "src/theforge/model_profiles.py has 2750 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/review.py",
+      "detail": "src/theforge/review.py has 1065 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/api.py",
+      "detail": "src/theforge/runners/api.py has 1047 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "src/theforge/runners/cli.py has 730 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/runners/runner_claude.py",
+      "detail": "src/theforge/runners/runner_claude.py has 982 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/schemas.py",
+      "detail": "src/theforge/schemas.py has 665 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/shape_check/heuristics.py",
+      "detail": "src/theforge/shape_check/heuristics.py has 1044 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/audit.py",
+      "detail": "src/theforge/sprint/audit.py has 1206 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/dag.py",
+      "detail": "src/theforge/sprint/dag.py has 673 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/rca.py",
+      "detail": "src/theforge/sprint/rca.py has 1114 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/runner.py",
+      "detail": "src/theforge/sprint/runner.py has 3575 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/shape_gate.py",
+      "detail": "src/theforge/sprint/shape_gate.py has 681 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/sprint/status_reader.py",
+      "detail": "src/theforge/sprint/status_reader.py has 934 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_module_lines",
+      "file": "src/theforge/task/plan_prompts.py",
+      "detail": "src/theforge/task/plan_prompts.py has 685 lines (limit 600)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_assignment.py",
+      "detail": "tests/test_assignment.py has 1571 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_audit_substrate.py",
+      "detail": "tests/test_audit_substrate.py has 1020 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_check_config.py",
+      "detail": "tests/test_check_config.py has 1234 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_setup.py",
+      "detail": "tests/test_cli_setup.py has 1273 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_sprint_status.py",
+      "detail": "tests/test_cli_sprint_status.py has 1423 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cli_status_watch.py",
+      "detail": "tests/test_cli_status_watch.py has 1087 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_config_load.py",
+      "detail": "tests/test_config_load.py has 1244 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_dev_phase_routing.py",
+      "detail": "tests/test_coord_dev_phase_routing.py has 1009 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_merge_pr.py",
+      "detail": "tests/test_coord_merge_pr.py has 1811 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_model_profiles_seam.py",
+      "detail": "tests/test_coord_model_profiles_seam.py has 1155 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_plan_flow_agent.py",
+      "detail": "tests/test_coord_plan_flow_agent.py has 2259 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_preflight_verdict.py",
+      "detail": "tests/test_coord_preflight_verdict.py has 1173 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_phase_pool.py",
+      "detail": "tests/test_coord_review_phase_pool.py has 1016 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_review_pool.py",
+      "detail": "tests/test_coord_review_pool.py has 1324 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_state.py",
+      "detail": "tests/test_coord_state.py has 1165 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coord_workspace_stale.py",
+      "detail": "tests/test_coord_workspace_stale.py has 1084 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_coordinator.py",
+      "detail": "tests/test_coordinator.py has 1376 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_cut_rc_isolation.py",
+      "detail": "tests/test_cut_rc_isolation.py has 1476 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_diagnose_flow.py",
+      "detail": "tests/test_diagnose_flow.py has 1541 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_generate_audit_log.py",
+      "detail": "tests/test_generate_audit_log.py has 1114 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_model_profiles.py",
+      "detail": "tests/test_model_profiles.py has 1182 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_preflight_work_type.py",
+      "detail": "tests/test_preflight_work_type.py has 1146 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_review.py",
+      "detail": "tests/test_review.py has 1106 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_claude.py",
+      "detail": "tests/test_runner_claude.py has 1231 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_runner_stuck_detection.py",
+      "detail": "tests/test_runner_stuck_detection.py has 1098 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_parallel.py",
+      "detail": "tests/test_sprint_parallel.py has 2699 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_rca.py",
+      "detail": "tests/test_sprint_rca.py has 1070 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_resume.py",
+      "detail": "tests/test_sprint_resume.py has 1268 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_sprint_run_id_rollover.py",
+      "detail": "tests/test_sprint_run_id_rollover.py has 1292 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_story_sources.py",
+      "detail": "tests/test_story_sources.py has 1077 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "max_test_file_lines",
+      "file": "tests/test_validate_phase.py",
+      "detail": "tests/test_validate_phase.py has 1413 lines (limit 1000)",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/types.py",
+      "detail": "Circular import detected: theforge.config.types \u2192 theforge.config.models \u2192 theforge.config.types",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/config/defaults.py",
+      "detail": "Circular import detected: theforge.config.defaults \u2192 theforge.config.types \u2192 theforge.config.defaults",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/review.py",
+      "detail": "Circular import detected: theforge.review \u2192 theforge.plan_finding_classifier \u2192 theforge.review",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/model_profiles.py",
+      "detail": "Circular import detected: theforge.model_profiles \u2192 theforge.reviewer_value \u2192 theforge.model_profiles",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/__init__.py",
+      "detail": "Circular import detected: theforge.runners \u2192 theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/api.py",
+      "detail": "Circular import detected: theforge.runners.api \u2192 theforge.runners.adapters.google \u2192 theforge.runners.cli \u2192 theforge.runners.api",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_codex \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/runners/cli.py",
+      "detail": "Circular import detected: theforge.runners.cli \u2192 theforge.runners.runner_gemini \u2192 theforge.runners.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/task/__init__.py",
+      "detail": "Circular import detected: theforge.task \u2192 theforge.task.dev_prompts \u2192 theforge.coordinator.state \u2192 theforge.task",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/sprint/manifest.py",
+      "detail": "Circular import detected: theforge.sprint.manifest \u2192 theforge.sprint.sources \u2192 theforge.sprint.manifest",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/coordinator/notify.py",
+      "detail": "Circular import detected: theforge.coordinator.notify \u2192 theforge.notify_backends \u2192 theforge.coordinator.notify",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "no_circular_imports",
+      "file": "src/theforge/cli/__init__.py",
+      "detail": "Circular import detected: theforge.cli \u2192 theforge.cli.main \u2192 theforge.cli.status \u2192 theforge.cli",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/agent_types.py",
+      "detail": "No test mirror found for src/theforge/agent_types.py (expected tests/test_agent_types.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/artifacts.py",
+      "detail": "No test mirror found for src/theforge/artifacts.py (expected tests/test_artifacts.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/coordinator",
+      "detail": "No test mirror found for package src/theforge/coordinator (expected tests/test_coordinator_*.py or tests/test_coordinator/)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_launchd.py",
+      "detail": "No test mirror found for src/theforge/daemon_launchd.py (expected tests/test_daemon_launchd.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/daemon_state.py",
+      "detail": "No test mirror found for src/theforge/daemon_state.py (expected tests/test_daemon_state.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/ideate.py",
+      "detail": "No test mirror found for src/theforge/ideate.py (expected tests/test_ideate.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/log_level.py",
+      "detail": "No test mirror found for src/theforge/log_level.py (expected tests/test_log_level.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/review_finding_classifier.py",
+      "detail": "No test mirror found for src/theforge/review_finding_classifier.py (expected tests/test_review_finding_classifier.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/root_file_conventions.py",
+      "detail": "No test mirror found for src/theforge/root_file_conventions.py (expected tests/test_root_file_conventions.py)",
+      "blocking": false
+    },
+    {
+      "rule": "test_mirrors_source",
+      "file": "src/theforge/runners",
+      "detail": "No test mirror found for package src/theforge/runners (expected tests/test_runners_*.py or tests/test_runners/)",
+      "blocking": false
+    }
+  ],
+  "finding_registry": [
+    {
+      "finding_id": "1c2d15fcfa5d68ea",
+      "cycle_first_seen": 1,
+      "cycle_last_seen": 1,
+      "file": "tests/test_runner_sandbox.py",
+      "line": 99,
+      "severity": "P1",
+      "description": "The containment regression tests inspect wrapper arguments and profile text but never execute a contained command that attempts the issue's escaped project-root write or commit path, so a sandbox profile that still permits the #1443 write escape would pass the gate.",
+      "reporter": "openai-gpt-5.5",
+      "disposition": "fixed"
+    },
+    {
+      "finding_id": "17862cbb2e4678eb",
+      "cycle_first_seen": 1,
+      "cycle_last_seen": 1,
+      "file": "src/theforge/runners/sandbox.py",
+      "line": 215,
+      "severity": "P1",
+      "description": "Running git commit inside the story worktree under the generated sandbox-exec profile fails with Operation not permitted because the profile does not grant write access to the worktree's real gitdir (<project-root>/.git/worktrees/<name>) or the shared object database under <project-root>/.git.",
+      "reporter": "claude-sonnet",
+      "disposition": "fixed"
+    }
+  ],
+  "non_blocking_p1s": [],
+  "conventions": {
+    "soft": [
+      "Coordinator is pure Python \u2014 no LLM calls for routing or process decisions",
+      "Schema validation is the integrity boundary \u2014 do not relax cross-validation rules",
+      "Keep modules single-purpose; extract instead of growing monolith files",
+      "Keep pure-data types in low-dependency modules with stdlib-only imports",
+      "Separate prompt construction, output parsing, and coordinator control flow",
+      "When adding or modifying data that flows between coordinator phases, instrument the change so the actual values are visible in the audit trail \u2014 diagnosing sprint failures requires tracing real data, not reconstructing it",
+      "Do not create files outside src/, tests/, or docs/. If you need a scratch file for exploration, delete it before committing.",
+      "Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow."
+    ]
+  },
+  "symptom_test_escalations": null,
+  "routing_decision": {
+    "origin": "preflight",
+    "excluded_for_taint": 0,
+    "preflight": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.4-mini",
+        "tier": "cheap",
+        "rationale": "[preflight] tier cheap ($8.33)"
+      }
+    },
+    "planner": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "model": "gpt-5.5",
+        "tier": "strong",
+        "rationale": "[preflight] complexity score 8 \u2192 tier strong ($8.33); per-story routing cost target: unset"
+      }
+    },
+    "dev": {
+      "score": 8,
+      "base_tier_from_score": "strong",
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": 0.8765,
+              "weighted": 0.6667,
+              "runs": 81,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": 0.6667
+            },
+            "domain": {
+              "domains": [
+                "security",
+                "cli",
+                "backend"
+              ],
+              "raw": 0.8,
+              "weighted": 0.8,
+              "runs": 5,
+              "tainted_runs": 0,
+              "floor": "pass",
+              "recency": "windowed",
+              "rate": 0.8,
+              "by_domain": {
+                "security": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "cli": {
+                  "runs": 1,
+                  "raw": 1.0,
+                  "weighted": 1.0,
+                  "tainted_runs": 0
+                },
+                "backend": {
+                  "runs": 4,
+                  "raw": 0.75,
+                  "weighted": 0.75,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": false,
+          "reason": "tier_mismatch"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none",
+          "signals": {
+            "success_rate": {
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "weighting": {
+                "mode": "exponential",
+                "half_life_runs": 50.0,
+                "window": 200
+              },
+              "rate": null
+            },
+            "domain": {
+              "domains": [
+                "security",
+                "cli",
+                "backend"
+              ],
+              "raw": null,
+              "weighted": null,
+              "runs": 0,
+              "tainted_runs": 0,
+              "floor": "fail",
+              "recency": "windowed",
+              "rate": null,
+              "by_domain": {
+                "security": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "cli": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                },
+                "backend": {
+                  "runs": 0,
+                  "raw": null,
+                  "weighted": null,
+                  "tainted_runs": 0
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": false,
+          "reason": "tier_mismatch"
+        }
+      ],
+      "domain_match": {
+        "domains": [
+          "security",
+          "cli",
+          "backend"
+        ],
+        "influenced": false,
+        "complexity_only_head": "claude-opus",
+        "domain_head": "claude-opus",
+        "selected_model_slice": {
+          "domains": [
+            "security",
+            "cli",
+            "backend"
+          ],
+          "raw": 0.8,
+          "weighted": 0.8,
+          "runs": 5,
+          "tainted_runs": 0,
+          "floor": "pass",
+          "recency": "windowed",
+          "rate": 0.8,
+          "by_domain": {
+            "security": {
+              "runs": 0,
+              "raw": null,
+              "weighted": null,
+              "tainted_runs": 0
+            },
+            "cli": {
+              "runs": 1,
+              "raw": 1.0,
+              "weighted": 1.0,
+              "tainted_runs": 0
+            },
+            "backend": {
+              "runs": 4,
+              "raw": 0.75,
+              "weighted": 0.75,
+              "tainted_runs": 0
+            }
+          }
+        },
+        "reason": "domain_signal_did_not_change_selection"
+      },
+      "promotion_check": {
+        "fired": true,
+        "matching_records": 10,
+        "escalations": 3,
+        "outcome": "promoted_to_strong"
+      },
+      "routing_rationale": {
+        "state": "promoted_by",
+        "mechanism": "_check_promotion",
+        "from_tier": "strong",
+        "to_tier": "strong"
+      },
+      "demotion_check": {
+        "mechanism": "dev_tier_demotion",
+        "applicable": false,
+        "fired": false,
+        "checked": null,
+        "reason": "no_dev_tier_demotion_mechanism_v1"
+      },
+      "post_plan_checkpoint": {
+        "fired": false,
+        "decision": "pending",
+        "reason": "checkpoint_runs_after_plan_review"
+      },
+      "exploration": {
+        "mode": "winner",
+        "routing_key": "dev:large:backend+cli+security",
+        "pool": [
+          "claude-sonnet",
+          "claude-opus",
+          "openai-gpt-5.4",
+          "openai-gpt-5.4-mini",
+          "openai-gpt-5.5",
+          "google-gemini-3.5-flash"
+        ],
+        "selected": "claude-opus",
+        "winner": "claude-opus",
+        "reason": "not_cadence_run",
+        "domains": [
+          "backend",
+          "cli",
+          "security"
+        ]
+      },
+      "final": {
+        "model": "opus",
+        "tier": "strong",
+        "rationale": "[preflight] HIGH dev promoted claude-opus (tier strong \u2192 strong) \u2014 3/10 recent HIGH stories escalated (profile success_rate=0.67 @ HIGH); per-story routing cost target: unset"
+      }
+    },
+    "plan_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "claude-opus": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 9,
+            "completed": 8,
+            "raw": 0.8889,
+            "weighted": 0.8935,
+            "rate": 0.8935,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 4,
+            "completed": 4,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "opus",
+          "gemini-3.5-flash",
+          "gpt-5.4"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['anthropic', 'google', 'openai'], complexity score 8; per-story routing cost target: unset"
+      }
+    },
+    "code_review": {
+      "candidate_pool": [
+        {
+          "name": "claude-sonnet",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "claude-opus",
+          "tier": "strong",
+          "included": false,
+          "reason": "anti_self_review"
+        },
+        {
+          "name": "openai-gpt-5.4",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.4-mini",
+          "tier": "cheap",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "openai-gpt-5.5",
+          "tier": "strong",
+          "included": true,
+          "reason": "none"
+        },
+        {
+          "name": "google-gemini-3.5-flash",
+          "tier": "mid",
+          "included": true,
+          "reason": "none"
+        }
+      ],
+      "demotion_check": {
+        "mechanism": "provider_health",
+        "fired": false,
+        "deprioritized": [],
+        "fell_back": [],
+        "reason": "no_unhealthy_candidates"
+      },
+      "completion_check": {
+        "mechanism": "reviewer_completion_rate",
+        "fired": false,
+        "threshold": 0.5,
+        "min_runs": 5,
+        "deprioritized": [],
+        "signals": {
+          "openai-gpt-5.5": {
+            "attempted": 11,
+            "completed": 11,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": 1.0,
+            "floor": "pass",
+            "selected": true
+          },
+          "google-gemini-3.5-flash": {
+            "attempted": 9,
+            "completed": 8,
+            "raw": 0.8889,
+            "weighted": 0.8935,
+            "rate": 0.8935,
+            "floor": "pass",
+            "selected": true
+          },
+          "openai-gpt-5.4": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "openai-gpt-5.4-mini": {
+            "attempted": 0,
+            "completed": 0,
+            "raw": null,
+            "weighted": null,
+            "rate": null,
+            "floor": "fail",
+            "selected": false
+          },
+          "claude-sonnet": {
+            "attempted": 4,
+            "completed": 4,
+            "raw": 1.0,
+            "weighted": 1.0,
+            "rate": null,
+            "floor": "fail",
+            "selected": true
+          }
+        }
+      },
+      "exploration": {
+        "mode": "winner"
+      },
+      "final": {
+        "models": [
+          "gpt-5.5",
+          "gemini-3.5-flash",
+          "sonnet"
+        ],
+        "rationale": "[preflight] 3 reviewer(s), tier strong, providers ['openai', 'google', 'anthropic'], complexity score 8; per-story routing cost target: unset"
+      }
+    }
+  },
+  "trust_checks": [],
+  "trust_status": "unchecked",
+  "phases": {
+    "preflight": {
+      "cost_usd": 0.560146,
+      "duration_s": 108.38,
+      "outcome": "proceed"
+    },
+    "plan": null,
+    "plan_review": null,
+    "dev": {
+      "cost_usd": 29.069822,
+      "duration_s": 3060.23,
+      "iterations": 3,
+      "outcome": "success"
+    },
+    "validate": {
+      "cost_usd": 0.0,
+      "duration_s": 124.38,
+      "outcome": "pass",
+      "gate_debug": [],
+      "gate_diagnostic": []
+    },
+    "review": {
+      "cost_usd": null,
+      "duration_s": 307.08,
+      "cycles": 2,
+      "outcome": "approve",
+      "per_reviewer": {
+        "claude-sonnet": {
+          "cost": 2.83954,
+          "verdict": "APPROVE"
+        },
+        "google-gemini-3.5-flash": {
+          "cost": null,
+          "verdict": "APPROVE"
+        },
+        "openai-gpt-5.5": {
+          "cost": null,
+          "verdict": "APPROVE"
+        }
+      }
+    }
+  },
+  "totals": {
+    "cost_usd": null,
+    "duration_s": 3600.06,
+    "dev_attempts_total": 3,
+    "dev_iterations_productive": 3,
+    "review_cycles_total": 2,
+    "dev_iterations": 3,
+    "review_cycles": 2
+  },
+  "sprint_id": "cb1ed713b3a2",
+  "sprint_name": "issues-1907,1904"
+}


### PR DESCRIPTION
## Summary

- Commits the 11 `.forge/audits/runs/{run_id}.json` canonical run records that have accumulated locally as untracked project memory during recent v0.13 dogfood sprints.
- These paths are already un-ignored by `.gitignore` (`!.forge/audits/runs/**`) — sprint landing just doesn't stage them yet, so they were sitting untracked until manually caught up here.
- Everything else under `.forge/audits/` (`index.sqlite`, `history.jsonl`, diagnose YAMLs, `forge_audit.yaml`) remains gitignored, unchanged.

This is a manual catch-up, not the fix. Relates to #1908, which is the mechanical fix for sprint landing to stage these automatically going forward.

## Test plan

- [x] Every staged file parses as valid JSON
- [x] `git status --porcelain` before commit showed only `.forge/audits/runs/*.json` staged, no ignored paths force-added