### PR TITLE
bug: forge status --watch blanks whole board (all stories waiting/$0.00, sprint_id null) after a story completes mid-sprint

### DIFF
--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -186,6 +186,48 @@ class SprintStateWriter:
                 pass
 
 
+def _load_existing_state(state_path: Path) -> dict | None:
+    """Read an existing state file when possible."""
+    if not state_path.exists():
+        return None
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _has_accumulated_live_state(data: dict | None) -> bool:
+    """Return True once the bootstrap file has been superseded by live state.
+
+    Bootstrap writes are only allowed while the on-disk file is still the seed
+    view: unresolved sprint id and story rows that have not advanced beyond the
+    initial waiting/skipped placeholders. Once the live writer has resolved the
+    sprint id or moved any story forward, a later bootstrap invocation must stay
+    inert so watch-mode data cannot regress.
+    """
+    if not isinstance(data, dict):
+        return False
+    if data.get("sprint_id") is not None:
+        return True
+
+    stories = data.get("stories")
+    if not isinstance(stories, list):
+        return False
+
+    seed_outcomes = {"waiting", "skipped"}
+    for story in stories:
+        if not isinstance(story, dict):
+            continue
+        outcome = story.get("outcome", story.get("status"))
+        if outcome not in seed_outcomes:
+            return True
+        if float(story.get("cost_usd", 0.0) or 0.0) > 0.0:
+            return True
+    return False
+
+
 def write_bootstrap_state(
     run_id: str,
     project_root: Path,
@@ -212,6 +254,10 @@ def write_bootstrap_state(
     """
     state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
     state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_state = _load_existing_state(state_path)
+    if _has_accumulated_live_state(existing_state):
+        return state_path
 
     stories: list[dict] = []
     seen_slugs: set[str] = set()

--- a/tests/test_sprint_status_bootstrap_window.py
+++ b/tests/test_sprint_status_bootstrap_window.py
@@ -148,6 +148,68 @@ def test_sprint_state_writer_inherits_bootstrap_metadata(tmp_path: Path) -> None
     assert data["max_parallel"] == 4
 
 
+def test_bootstrap_reentry_preserves_accumulated_live_state(tmp_path: Path) -> None:
+    """A later bootstrap call must not blank an already-live sprint state file."""
+    from theforge.sprint.state_writer import SprintStateWriter, write_bootstrap_state
+
+    run_id = "run-reseed-guard"
+    write_bootstrap_state(
+        run_id,
+        tmp_path,
+        sprint_name="my-sprint",
+        sprint_phase="starting",
+        base_branch="main",
+        budget_usd=42.0,
+        max_parallel=2,
+        issues=[{"number": 7}, {"number": 8}],
+    )
+
+    writer = SprintStateWriter(
+        run_id,
+        tmp_path,
+        "my-sprint",
+        sprint_id="sprint-123",
+        sprint_phase="executing",
+        base_branch="main",
+        budget_usd=42.0,
+        max_parallel=2,
+    )
+    writer.init(
+        [
+            {"slug": "issue-7", "path": "Issue #7", "status": "running"},
+            {"slug": "issue-8", "path": "Issue #8", "status": "waiting"},
+        ]
+    )
+    writer.update(
+        "issue-7",
+        status="done",
+        cost_usd=32.45,
+        detail={"merged_pr": 1795},
+    )
+
+    write_bootstrap_state(
+        run_id,
+        tmp_path,
+        sprint_name="my-sprint",
+        sprint_phase="starting",
+        base_branch="main",
+        budget_usd=42.0,
+        max_parallel=2,
+        issues=[{"number": 7}, {"number": 8}],
+    )
+
+    state_path = tmp_path / ".forge" / "runs" / f"{run_id}.state"
+    data = yaml.safe_load(state_path.read_text(encoding="utf-8"))
+    stories_by_slug = {story["slug"]: story for story in data["stories"]}
+
+    assert data["sprint_id"] == "sprint-123"
+    assert data["sprint_phase"] == "executing"
+    assert stories_by_slug["issue-7"]["status"] == "done"
+    assert stories_by_slug["issue-7"]["cost_usd"] == 32.45
+    assert stories_by_slug["issue-7"]["detail"]["merged_pr"] == 1795
+    assert stories_by_slug["issue-8"]["status"] == "waiting"
+
+
 def test_display_sprint_status_renders_bootstrap_window(tmp_path: Path) -> None:
     """display_sprint_status renders issue rows + phase + base_branch + budget
     + parallel from a bootstrap state file alone (no preflight, no per-story


### PR DESCRIPTION
## Summary

The bootstrap reseed guard is on the runtime write path and the regression test covers the observed mid-sprint reset signature.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $0.40
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

bug: forge status --watch blanks whole board (all stories waiting/$0.00, sprint_id null) after a story completes mid-sprint (GitHub Issue #1801)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1801