### PR TITLE
Preflight cache key omits story content, so a re-scoped story reuses the old body's verdict

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -961,6 +961,7 @@ def run_task(
                 cached_preflight_state,
                 config=config,
                 workspace_path=workspace_path,
+                story_content=story_content,
             )
             state.preflight_cache_validation = cache_validation
             if cache_valid:
@@ -1273,6 +1274,7 @@ def _run_resume_coordinator(
             cached_preflight_state,
             config=config,
             workspace_path=workspace_path,
+            story_content=story_content,
         )
         state.preflight_cache_validation = cache_validation
         if cache_valid:

--- a/src/theforge/coordinator/preflight_cache.py
+++ b/src/theforge/coordinator/preflight_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -19,12 +20,22 @@ def _git_rev_parse(cwd: Path, rev: str) -> str | None:
     return value or None
 
 
+def _story_content_hash(story_content: str) -> str:
+    return hashlib.sha256(story_content.encode("utf-8")).hexdigest()
+
+
 def capture_preflight_cache_snapshot(
     *,
     config: "ForgeConfig",
     workspace_path: Path,
+    story_content: str,
 ) -> dict[str, str]:
-    """Return the git-state fingerprint that makes a preflight verdict reusable."""
+    """Return the fingerprint that makes a preflight verdict reusable.
+
+    A preflight verdict is a judgement about a specific story text evaluated
+    against a specific tree state, so both must be captured for the cached
+    verdict to be validly reusable.
+    """
     snapshot: dict[str, str] = {}
 
     worktree_head = _git_rev_parse(workspace_path, "HEAD")
@@ -37,6 +48,8 @@ def capture_preflight_cache_snapshot(
     if base_branch_head is not None:
         snapshot["evaluation_base_branch_head"] = base_branch_head
 
+    snapshot["story_content_hash"] = _story_content_hash(story_content)
+
     return snapshot
 
 
@@ -45,12 +58,14 @@ def validate_preflight_cache(
     *,
     config: "ForgeConfig",
     workspace_path: Path,
+    story_content: str,
 ) -> tuple[bool, dict[str, Any]]:
-    """Return whether cached preflight can be reused for the current git state."""
+    """Return whether cached preflight can be reused for the current state."""
     snapshot = dict(getattr(cached_state, "preflight_cache_snapshot", {}) or {})
     current_worktree_head = _git_rev_parse(workspace_path, "HEAD")
     current_base_branch = config.workspace.base_branch
     current_base_branch_head = _git_rev_parse(config.project_root, current_base_branch)
+    current_story_content_hash = _story_content_hash(story_content)
 
     validation: dict[str, Any] = {
         "cached": bool(snapshot),
@@ -60,6 +75,8 @@ def validate_preflight_cache(
         "current_evaluation_base_branch": current_base_branch,
         "cached_evaluation_base_branch_head": snapshot.get("evaluation_base_branch_head"),
         "current_evaluation_base_branch_head": current_base_branch_head,
+        "cached_story_content_hash": snapshot.get("story_content_hash"),
+        "current_story_content_hash": current_story_content_hash,
     }
 
     if not snapshot:
@@ -71,6 +88,7 @@ def validate_preflight_cache(
         snapshot.get("worktree_head"),
         snapshot.get("evaluation_base_branch"),
         snapshot.get("evaluation_base_branch_head"),
+        snapshot.get("story_content_hash"),
         current_worktree_head,
         current_base_branch_head,
     )
@@ -92,6 +110,11 @@ def validate_preflight_cache(
     if snapshot["evaluation_base_branch_head"] != current_base_branch_head:
         validation["status"] = "invalidated"
         validation["reason"] = "evaluation_base_branch_head_changed"
+        return False, validation
+
+    if snapshot["story_content_hash"] != current_story_content_hash:
+        validation["status"] = "invalidated"
+        validation["reason"] = "story_content_changed"
         return False, validation
 
     validation["status"] = "accepted"

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -877,6 +877,7 @@ def _run_preflight_phase(
         "cache_snapshot": capture_preflight_cache_snapshot(
             config=config,
             workspace_path=workspace_path,
+            story_content=story_content,
         ),
         "criteria_checked": state.preflight_criteria_checked,
         "symptom_verification": dict(state.preflight_symptom_verification or {}),

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -34,7 +34,10 @@ from theforge.config import (  # noqa: E402
     AssignmentConfig,
 )
 from theforge.coordinator.engine import run_task  # noqa: E402
+from theforge.coordinator.preflight_cache import _story_content_hash  # noqa: E402
 from theforge.coordinator.state import CoordinatorState  # noqa: E402
+
+_STORY_CONTENT_HASH = _story_content_hash("# Test Spec\n\nImplement the thing.")
 
 
 def _cached_proceed_state_with_complexity(complexity: str = "medium") -> CoordinatorState:
@@ -49,6 +52,7 @@ def _cached_proceed_state_with_complexity(complexity: str = "medium") -> Coordin
         "worktree_head": "OK",
         "evaluation_base_branch": "main",
         "evaluation_base_branch_head": "OK",
+        "story_content_hash": _STORY_CONTENT_HASH,
     }
     return state
 

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -15,7 +15,10 @@ import pytest
 from coord_test_helpers import _make_agent_result, _make_config, _make_task
 
 from theforge.coordinator.engine import run_from_dev, run_task
+from theforge.coordinator.preflight_cache import _story_content_hash
 from theforge.coordinator.state import CoordinatorState, Phase
+
+_TEST_STORY_CONTENT_HASH = _story_content_hash("# Test Spec\n\nImplement the thing.")
 
 
 def _with_cache_snapshot(state: CoordinatorState) -> CoordinatorState:
@@ -23,6 +26,7 @@ def _with_cache_snapshot(state: CoordinatorState) -> CoordinatorState:
         "worktree_head": "OK",
         "evaluation_base_branch": "main",
         "evaluation_base_branch_head": "OK",
+        "story_content_hash": _TEST_STORY_CONTENT_HASH,
     }
     return state
 
@@ -207,6 +211,7 @@ class TestCachedPreflightVerdictDispatch:
                 "worktree_head": "old-head",
                 "evaluation_base_branch": "main",
                 "evaluation_base_branch_head": "base-head",
+                "story_content_hash": _TEST_STORY_CONTENT_HASH,
             },
         )
 
@@ -256,6 +261,73 @@ criteria_checked: []
         assert result.state.preflight_cache_validation["status"] == "invalidated"
         assert result.state.preflight_cache_validation["reason"] == "worktree_head_changed"
 
+    def test_rewritten_story_body_invalidates_cache_despite_unchanged_git_state(self, tmp_path):
+        """A re-scoped story must not reuse a preflight verdict from its old text.
+
+        Regression for the issue #1904 near miss: git state alone (worktree head,
+        base branch, base branch head) matched a cached ALREADY_DONE verdict while
+        the story body had been rewritten. The cache must invalidate on content
+        change even when neither branch head has moved.
+        """
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        # Re-scope the story after the cached verdict was recorded.
+        task.story_path.write_text(
+            "# Test Spec\n\nImplement a completely different thing.", encoding="utf-8"
+        )
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        cached_state = replace(
+            CoordinatorState(),
+            preflight_verdict="ALREADY_DONE",
+            preflight_reason="Stale cached verdict from superseded story text.",
+            preflight_complexity="medium",
+            preflight_sufficiency="implementation_ready",
+            preflight_work_type="feature",
+            preflight_cache_snapshot={
+                "worktree_head": "OK",
+                "evaluation_base_branch": "main",
+                "evaluation_base_branch_head": "OK",
+                "story_content_hash": _TEST_STORY_CONTENT_HASH,
+            },
+        )
+
+        fresh_preflight = _make_agent_result(
+            output="""\
+```yaml
+verdict: PROCEED
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+reason: "Story rewritten; reevaluated."
+criteria_checked: []
+```
+""",
+            profile_name="preflight",
+        )
+
+        with (
+            patch("theforge.coordinator.util._run_shell", side_effect=_shell_with_matching_cache),
+            patch(
+                "theforge.coordinator.preflight_flow.run_agent",
+                return_value=fresh_preflight,
+            ) as mock_preflight,
+        ):
+            result = run_task(
+                config,
+                task,
+                cached_preflight_state=cached_state,
+                stop_phase=Phase.PREFLIGHT,
+            )
+
+        assert result.success is True
+        assert mock_preflight.call_count == 1
+        assert result.state.preflight_cached is False
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_cache_validation["status"] == "invalidated"
+        assert result.state.preflight_cache_validation["reason"] == "story_content_changed"
+
 
 class TestResumeStaleCacheRerunsPreflight:
     """Regression: resume path must re-run preflight when the cache is invalid.
@@ -285,6 +357,7 @@ class TestResumeStaleCacheRerunsPreflight:
                 "worktree_head": "old-head",
                 "evaluation_base_branch": "main",
                 "evaluation_base_branch_head": "old-base-head",
+                "story_content_hash": _TEST_STORY_CONTENT_HASH,
             },
         )
 

--- a/tests/test_coord_preflight_escalation.py
+++ b/tests/test_coord_preflight_escalation.py
@@ -31,11 +31,14 @@ from theforge.coordinator.preflight import (
     _escalate_dev_model,
     _has_persistent_p1,
 )
+from theforge.coordinator.preflight_cache import _story_content_hash
 from theforge.coordinator.state import CoordinatorState, Phase
 from theforge.review import ReviewFinding
 from theforge.task import TaskStory
 
 # ── Dev model escalation tests ────────────────────────────────────────
+
+_STORY_CONTENT_HASH = _story_content_hash("# Test Spec\n\nImplement the thing.")
 
 
 def _make_review_finding(
@@ -54,6 +57,7 @@ def _with_cache_snapshot(state: CoordinatorState) -> CoordinatorState:
         "worktree_head": "OK",
         "evaluation_base_branch": "main",
         "evaluation_base_branch_head": "OK",
+        "story_content_hash": _STORY_CONTENT_HASH,
     }
     return state
 

--- a/tests/test_coord_preflight_verdict.py
+++ b/tests/test_coord_preflight_verdict.py
@@ -34,6 +34,7 @@ from theforge.coordinator.preflight import (
     _parse_preflight_complexity,
     _parse_preflight_warnings,
 )
+from theforge.coordinator.preflight_cache import _story_content_hash
 from theforge.coordinator.state import CoordinatorState, Phase
 
 # ── Preflight phase tests ─────────────────────────────────────────────
@@ -922,6 +923,7 @@ criteria_checked: []
             "worktree_head": "OK",
             "evaluation_base_branch": "main",
             "evaluation_base_branch_head": "OK",
+            "story_content_hash": _story_content_hash(task.story_path.read_text(encoding="utf-8")),
         }
 
         with (

--- a/tests/test_coord_resume_cached_already_done.py
+++ b/tests/test_coord_resume_cached_already_done.py
@@ -21,8 +21,11 @@ from unittest.mock import patch
 from coord_test_helpers import _make_agent_result, _make_config, patch_gate_shell
 
 from theforge.coordinator.engine import run_from_dev, run_from_review
+from theforge.coordinator.preflight_cache import _story_content_hash
 from theforge.coordinator.state import CoordinatorState, Phase
 from theforge.task import TaskStory
+
+_STORY_CONTENT_HASH = _story_content_hash("# Test\n\nDo the thing.")
 
 
 def _make_already_done_cached_state() -> CoordinatorState:
@@ -40,6 +43,7 @@ def _make_already_done_cached_state() -> CoordinatorState:
         "worktree_head": "OK",
         "evaluation_base_branch": "main",
         "evaluation_base_branch_head": "OK",
+        "story_content_hash": _STORY_CONTENT_HASH,
     }
     state.run_id = "prior-run-id"
     return state

--- a/tests/test_coord_resume_none_preflight.py
+++ b/tests/test_coord_resume_none_preflight.py
@@ -22,8 +22,11 @@ from coord_test_helpers import (
 )
 
 from theforge.coordinator.engine import run_from_dev, run_from_review, run_task
+from theforge.coordinator.preflight_cache import _story_content_hash
 from theforge.coordinator.state import CoordinatorState
 from theforge.task import TaskStory
+
+_STORY_CONTENT_HASH = _story_content_hash("# Test\n\nDo the thing.")
 
 
 def _make_cached_state(
@@ -44,6 +47,7 @@ def _make_cached_state(
         "worktree_head": "OK",
         "evaluation_base_branch": "main",
         "evaluation_base_branch_head": "OK",
+        "story_content_hash": _STORY_CONTENT_HASH,
     }
     state.run_id = "prior-run-id"
     return state


### PR DESCRIPTION
## Summary

The change is safe to merge; the cache now keys on story content as well as git state, and the regression path is covered.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.68
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight cache key omits story content, so a re-scoped story reuses the old body's verdict (GitHub Issue #1912)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1912