### PR TITLE
Canonical per-run audit records are never committed — written post-merge to the project root and abandoned

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -90,6 +90,10 @@ from .story_state import (
 )
 
 _UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"codex", "gemini"})
+_STORY_RUN_AUDIT_DIR = ".forge/audits/runs"
+_STORY_RUN_AUDIT_COMMIT_CMD = (
+    f'git commit -m "chore(audit): record sprint run audits" -- {_STORY_RUN_AUDIT_DIR}'
+)
 run_agent = None
 log_agent_result = None
 
@@ -107,7 +111,7 @@ def _commit_story_run_audits(project_root: Path) -> None:
     if not (project_root / ".git").exists():
         return
 
-    audit_dir = Path(".forge/audits/runs")
+    audit_dir = Path(_STORY_RUN_AUDIT_DIR)
     quoted_audit_dir = shlex.quote(audit_dir.as_posix())
     ok_status, status_out = _cu._run_shell(
         f"git status --porcelain -- {quoted_audit_dir}",
@@ -122,10 +126,7 @@ def _commit_story_run_audits(project_root: Path) -> None:
     if not ok_add:
         raise RuntimeError(f"Failed to stage story run audits: {add_out}")
 
-    ok_commit, commit_out = _cu._run_shell(
-        'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs',
-        project_root,
-    )
+    ok_commit, commit_out = _cu._run_shell(_STORY_RUN_AUDIT_COMMIT_CMD, project_root)
     if not ok_commit:
         raise RuntimeError(f"Failed to commit story run audits: {commit_out}")
     _log("Committed canonical story run audit records to the base branch checkout.")

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -97,6 +98,37 @@ def _log(msg: str) -> None:
     # Worker-slug prefixing (parallel attribution) is applied centrally by
     # ``_log_line``; do not prepend it here or it would double-tag.
     _log_line("[sprint]", msg)
+
+
+def _commit_story_run_audits(project_root: Path) -> None:
+    """Commit canonical per-run audit JSON emitted during sprint execution."""
+    from ..coordinator import util as _cu  # noqa: PLC0415
+
+    if not (project_root / ".git").exists():
+        return
+
+    audit_dir = Path(".forge/audits/runs")
+    quoted_audit_dir = shlex.quote(audit_dir.as_posix())
+    ok_status, status_out = _cu._run_shell(
+        f"git status --porcelain -- {quoted_audit_dir}",
+        project_root,
+    )
+    if not ok_status:
+        raise RuntimeError(f"Failed to inspect story run audits: {status_out}")
+    if not status_out.strip():
+        return
+
+    ok_add, add_out = _cu._run_shell(f"git add -- {quoted_audit_dir}", project_root)
+    if not ok_add:
+        raise RuntimeError(f"Failed to stage story run audits: {add_out}")
+
+    ok_commit, commit_out = _cu._run_shell(
+        'git commit -m "chore(audit): record sprint run audits"',
+        project_root,
+    )
+    if not ok_commit:
+        raise RuntimeError(f"Failed to commit story run audits: {commit_out}")
+    _log("Committed canonical story run audit records to the base branch checkout.")
 
 
 def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:
@@ -3525,6 +3557,8 @@ def run_sprint(
                 _log(f"Sprint RCA written: {_rca_path}")
         except Exception as _rca_exc:  # noqa: BLE001 — RCA is best-effort
             _log(f"Warning: sprint RCA generation failed: {_rca_exc}")
+
+    _commit_story_run_audits(config.project_root)
 
     if _state_writer is not None:
         _state_writer.remove()

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -123,7 +123,7 @@ def _commit_story_run_audits(project_root: Path) -> None:
         raise RuntimeError(f"Failed to stage story run audits: {add_out}")
 
     ok_commit, commit_out = _cu._run_shell(
-        'git commit -m "chore(audit): record sprint run audits"',
+        'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs',
         project_root,
     )
     if not ok_commit:
@@ -3558,10 +3558,13 @@ def run_sprint(
         except Exception as _rca_exc:  # noqa: BLE001 — RCA is best-effort
             _log(f"Warning: sprint RCA generation failed: {_rca_exc}")
 
-    _commit_story_run_audits(config.project_root)
-
     if _state_writer is not None:
         _state_writer.remove()
+
+    try:
+        _commit_story_run_audits(config.project_root)
+    except RuntimeError as exc:
+        _log(f"Warning: canonical story run audit commit failed: {exc}")
 
     # ── POST_SPRINT hook ──────────────────────────────────────────────
     if config.hooks and config.hooks.post_sprint:

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2635,6 +2635,7 @@ class TestSprintRunAuditCommit:
         result = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result.landing_status = "pending_integration"
         result.merge = {"action": "merge", "pending": True}
+        commit_cmd = 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs'
         shell_calls: list[tuple[str, Path]] = []
 
         def fake_shell(cmd, cwd, **kwargs):  # noqa: ANN001
@@ -2643,7 +2644,7 @@ class TestSprintRunAuditCommit:
                 return (True, "?? .forge/audits/runs/run-123.json")
             if cmd == "git add -- .forge/audits/runs":
                 return (True, "")
-            if cmd == 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs':
+            if cmd == commit_cmd:
                 return (True, "")
             return (True, "")
 
@@ -2666,10 +2667,7 @@ class TestSprintRunAuditCommit:
         assert audit_shell_calls == [
             ("git status --porcelain -- .forge/audits/runs", tmp_path),
             ("git add -- .forge/audits/runs", tmp_path),
-            (
-                'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs',
-                tmp_path,
-            ),
+            (commit_cmd, tmp_path),
         ]
 
     def test_run_sprint_skips_audit_commit_when_project_root_is_clean(
@@ -2730,6 +2728,7 @@ class TestSprintRunAuditCommit:
         result = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result.landing_status = "pending_integration"
         result.merge = {"action": "merge", "pending": True}
+        commit_cmd = 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs'
         shell_calls: list[tuple[str, Path]] = []
         warnings: list[str] = []
 
@@ -2739,7 +2738,7 @@ class TestSprintRunAuditCommit:
                 return (True, "?? .forge/audits/runs/run-123.json")
             if cmd == "git add -- .forge/audits/runs":
                 return (True, "")
-            if cmd == 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs':
+            if cmd == commit_cmd:
                 return (False, "commit failed")
             return (True, "")
 
@@ -2757,10 +2756,7 @@ class TestSprintRunAuditCommit:
         assert sprint.specs_succeeded == 1
         assert not any((tmp_path / ".forge" / "runs").glob("*.state"))
         assert any("canonical story run audit commit failed" in warning for warning in warnings)
-        assert (
-            'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs',
-            tmp_path,
-        ) in shell_calls
+        assert (commit_cmd, tmp_path) in shell_calls
 
 
 def test_integration_lock_serializes(tmp_path: Path) -> None:

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2620,6 +2620,98 @@ class TestImmediateIntegrationLanding:
         assert result.landing_status == "failed"
 
 
+class TestSprintRunAuditCommit:
+    def test_run_sprint_commits_story_run_audits_from_project_root(self, tmp_path: Path) -> None:
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md"],
+            budget=10.0,
+            max_parallel=1,
+        )
+        (tmp_path / ".git").mkdir()
+        config = _make_config(tmp_path)
+
+        result = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        result.landing_status = "pending_integration"
+        result.merge = {"action": "merge", "pending": True}
+        shell_calls: list[tuple[str, Path]] = []
+
+        def fake_shell(cmd, cwd, **kwargs):  # noqa: ANN001
+            shell_calls.append((cmd, Path(cwd)))
+            if cmd == "git status --porcelain -- .forge/audits/runs":
+                return (True, "?? .forge/audits/runs/run-123.json")
+            if cmd == "git add -- .forge/audits/runs":
+                return (True, "")
+            if cmd == 'git commit -m "chore(audit): record sprint run audits"':
+                return (True, "")
+            return (True, "")
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch(
+                "theforge.coordinator.completion._merge_branch",
+                return_value={"merged": True, "success": True, "action": "merge"},
+            ),
+            patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
+        ):
+            sprint = run_sprint(config, manifest_path, auto_merge=True)
+
+        assert sprint.specs_succeeded == 1
+        audit_shell_calls = [
+            call
+            for call in shell_calls
+            if ".forge/audits/runs" in call[0] or "chore(audit)" in call[0]
+        ]
+        assert audit_shell_calls == [
+            ("git status --porcelain -- .forge/audits/runs", tmp_path),
+            ("git add -- .forge/audits/runs", tmp_path),
+            ('git commit -m "chore(audit): record sprint run audits"', tmp_path),
+        ]
+
+    def test_run_sprint_skips_audit_commit_when_project_root_is_clean(
+        self, tmp_path: Path
+    ) -> None:
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md"],
+            budget=10.0,
+            max_parallel=1,
+        )
+        (tmp_path / ".git").mkdir()
+        config = _make_config(tmp_path)
+
+        result = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        result.landing_status = "pending_integration"
+        result.merge = {"action": "merge", "pending": True}
+        shell_calls: list[tuple[str, Path]] = []
+
+        def fake_shell(cmd, cwd, **kwargs):  # noqa: ANN001
+            shell_calls.append((cmd, Path(cwd)))
+            if cmd == "git status --porcelain -- .forge/audits/runs":
+                return (True, "")
+            return (True, "")
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch(
+                "theforge.coordinator.completion._merge_branch",
+                return_value={"merged": True, "success": True, "action": "merge"},
+            ),
+            patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
+        ):
+            sprint = run_sprint(config, manifest_path, auto_merge=True)
+
+        assert sprint.specs_succeeded == 1
+        audit_shell_calls = [
+            call
+            for call in shell_calls
+            if ".forge/audits/runs" in call[0] or "chore(audit)" in call[0]
+        ]
+        assert audit_shell_calls == [("git status --porcelain -- .forge/audits/runs", tmp_path)]
+
+
 def test_integration_lock_serializes(tmp_path: Path) -> None:
     entered: list[str] = []
     overlap = [False]

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2643,7 +2643,7 @@ class TestSprintRunAuditCommit:
                 return (True, "?? .forge/audits/runs/run-123.json")
             if cmd == "git add -- .forge/audits/runs":
                 return (True, "")
-            if cmd == 'git commit -m "chore(audit): record sprint run audits"':
+            if cmd == 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs':
                 return (True, "")
             return (True, "")
 
@@ -2666,7 +2666,10 @@ class TestSprintRunAuditCommit:
         assert audit_shell_calls == [
             ("git status --porcelain -- .forge/audits/runs", tmp_path),
             ("git add -- .forge/audits/runs", tmp_path),
-            ('git commit -m "chore(audit): record sprint run audits"', tmp_path),
+            (
+                'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs',
+                tmp_path,
+            ),
         ]
 
     def test_run_sprint_skips_audit_commit_when_project_root_is_clean(
@@ -2710,6 +2713,54 @@ class TestSprintRunAuditCommit:
             if ".forge/audits/runs" in call[0] or "chore(audit)" in call[0]
         ]
         assert audit_shell_calls == [("git status --porcelain -- .forge/audits/runs", tmp_path)]
+
+    def test_run_sprint_warns_when_audit_commit_fails_after_state_cleanup(
+        self, tmp_path: Path
+    ) -> None:
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md"],
+            budget=10.0,
+            max_parallel=1,
+        )
+        (tmp_path / ".git").mkdir()
+        config = _make_config(tmp_path)
+
+        result = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        result.landing_status = "pending_integration"
+        result.merge = {"action": "merge", "pending": True}
+        shell_calls: list[tuple[str, Path]] = []
+        warnings: list[str] = []
+
+        def fake_shell(cmd, cwd, **kwargs):  # noqa: ANN001
+            shell_calls.append((cmd, Path(cwd)))
+            if cmd == "git status --porcelain -- .forge/audits/runs":
+                return (True, "?? .forge/audits/runs/run-123.json")
+            if cmd == "git add -- .forge/audits/runs":
+                return (True, "")
+            if cmd == 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs':
+                return (False, "commit failed")
+            return (True, "")
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch(
+                "theforge.coordinator.completion._merge_branch",
+                return_value={"merged": True, "success": True, "action": "merge"},
+            ),
+            patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
+            patch("theforge.sprint.runner._log", side_effect=warnings.append),
+        ):
+            sprint = run_sprint(config, manifest_path, auto_merge=True)
+
+        assert sprint.specs_succeeded == 1
+        assert not any((tmp_path / ".forge" / "runs").glob("*.state"))
+        assert any("canonical story run audit commit failed" in warning for warning in warnings)
+        assert (
+            'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs',
+            tmp_path,
+        ) in shell_calls
 
 
 def test_integration_lock_serializes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The post-sprint audit commit path is invoked from the project root, scoped to canonical run audit records, and covered by focused sprint tests. | [claude-opus] Cycle-1 concerns resolved — the audit commit is now path-scoped to .forge/audits/runs and failures are caught as warnings after state cleanup; AC met and covered by three seam tests including the failure path. No regressions introduced.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.61
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Canonical per-run audit records are never committed — written post-merge to the project root and abandoned (GitHub Issue #1908)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1908