### PR TITLE
forge diagnose emits a Diagnosis section the intake gate rejects when no hypothesis is ruled out

### DIFF
--- a/docs/reference/bug-shape.md
+++ b/docs/reference/bug-shape.md
@@ -24,11 +24,6 @@ Each component is written as a bolded bullet lead-in under the
 - Satisfies: bolded bullet lead-in or heading inside "## Diagnosis"
 - Example: - **Evidence:** run id `1ff6b0bb7992`, story #1102 — resume log shows the false skip.
 
-### Ruled out
-
-- Satisfies: bolded bullet lead-in or heading listing eliminated hypotheses
-- Example: - **Ruled out:** workspace creation actually succeeds (verified in logs) — not the cause.
-
 ### Confirmed cause
 
 - Satisfies: bolded bullet lead-in or heading; its value may be a specific claim or an honest non-assertion ("unknown", "not yet identified")
@@ -54,7 +49,6 @@ that starts from this skeleton passes the shape gate by construction.
 
 - **Observed symptom:** sprint resume false-skips zero-delta APPROVE stories, reporting them merged when no commit landed.
 - **Evidence:** run id `1ff6b0bb7992`, story #1102 — resume log shows the false skip.
-- **Ruled out:** workspace creation actually succeeds (verified in logs) — not the cause.
 - **Confirmed cause:** `_is_already_merged` requires at least one commit ahead, so a zero-delta APPROVE is misclassified as unmerged.
 - **Affected code path:** `sprint.runner._is_already_merged`.
 - **Fix-success criterion:** resume identifies a zero-delta APPROVE story as already merged.

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -128,8 +128,8 @@ class DiagnosisArtifact:
     """Structured diagnosis output from an investigative agent.
 
     All fields required by the diagnose AC: observed symptom, reproduction or
-    evidence, hypotheses tested and ruled out, confirmed cause, affected code
-    path, and fix-success criterion.
+    evidence, hypotheses tested, confirmed cause, affected code path, and
+    fix-success criterion.
     """
 
     issue_number: int
@@ -259,7 +259,7 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
     """Render a DiagnosisArtifact as a Markdown ``## Diagnosis`` section.
 
     Output format intentionally matches the headings expected by the shape gate
-    (DIAGNOSIS_HEADING_PATTERN / DIAGNOSIS_REQUIRED_COMPONENTS in shape_check)
+    (DIAGNOSIS_HEADING_PATTERN / required Diagnosis labels in shape_check)
     so a landed artifact makes the issue fix-ready.
 
     Raises ``ValueError`` when the artifact carries no substantive content.
@@ -308,8 +308,7 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
     )
     if artifact.hypotheses:
         for h in artifact.hypotheses:
-            # Underscore→space so the rendered section contains the literal
-            # tokens the sprint shape gate scans for ("ruled out" etc.).
+            # Underscore→space so status values render as readable prose.
             display_status = h.status.replace("_", " ")
             lines.append(f"- **[{display_status}]** {h.statement.strip()}")
             if h.evidence.strip():

--- a/src/theforge/intake/groom_flow.py
+++ b/src/theforge/intake/groom_flow.py
@@ -4,9 +4,9 @@ Operates on a single typed issue (bug, enhancement/task, etc.) and produces
 a proposed body restructure that satisfies the shape gate for its type.
 
 Enforces the three-state bug invariant from ADR-0001: bugs without a
-diagnosis are refused; bugs whose diagnosis documents ruled-out hypotheses
-but lacks a confirmed cause may be normalized but MUST NOT transition to
-the ``ready`` label; only bugs with a confirmed cause are eligible for
+diagnosis are refused; bugs whose diagnosis is complete but lacks an
+asserted confirmed cause may be normalized but MUST NOT transition to the
+``ready`` label; only bugs with a confirmed cause are eligible for
 ``ready``.
 
 Stdlib + ``shape_check``/``intake`` modules only — no provider SDK imports.

--- a/src/theforge/shape_check/diagnosis_spec.py
+++ b/src/theforge/shape_check/diagnosis_spec.py
@@ -88,12 +88,6 @@ REQUIRED_DIAGNOSIS_COMPONENTS: tuple[DiagnosisComponent, ...] = (
         example="run id `1ff6b0bb7992`, story #1102 — resume log shows the false skip.",
     ),
     DiagnosisComponent(
-        key="ruled_out",
-        label="Ruled out",
-        satisfies="bolded bullet lead-in or heading listing eliminated hypotheses",
-        example="workspace creation actually succeeds (verified in logs) — not the cause.",
-    ),
-    DiagnosisComponent(
         key="confirmed_cause",
         label="Confirmed cause",
         satisfies=(

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -445,12 +445,10 @@ _UNRESOLVED_CAUSE_RE = re.compile(
     r"(?:not\s+yet\s+identified|unknown|tbd|investigating|n/?a)\b",
     re.IGNORECASE,
 )
-_RULED_OUT_RE = re.compile(r"ruled\s+out", re.IGNORECASE)
 
 
 def _diagnosis_cause_unknown(body: str) -> bool:
-    """Return True when the Diagnosis section documents ruled-out hypotheses
-    but the confirmed cause is explicitly still open.
+    """Return True when the Diagnosis section's confirmed cause is still open.
 
     This is the admissible "investigation-ready" state: the bug is not
     malformed (it has been investigated), but it is not implementation-runnable
@@ -458,8 +456,6 @@ def _diagnosis_cause_unknown(body: str) -> bool:
     """
     section = extract_section(body, DIAGNOSIS_HEADING_PATTERN)
     if section is None:
-        return False
-    if not _RULED_OUT_RE.search(section):
         return False
     return bool(_UNRESOLVED_CAUSE_RE.search(section))
 
@@ -470,27 +466,26 @@ def check_bug_missing_diagnosis(title: str, body: str, labels: Iterable[str]) ->
     - No Diagnosis section → BLOCKING ``needs_diagnosis``: the body is
       symptom-only and would let an implementer hypothesize a cause that
       reviewers cannot verify against. This is the original failure mode.
-    - Diagnosis section present, hypotheses ruled out, but confirmed cause
-      explicitly unresolved → ADVISORY ``diagnosis_cause_unknown``. The
-      issue is admissible (well-formed) but the verdict-derivation layer
-      lifts it to its own verdict so the sprint gate keeps it out of
-      implementation runs.
+    - Diagnosis section present and complete, but confirmed cause explicitly
+      unresolved → ADVISORY ``diagnosis_cause_unknown``. The issue is
+      admissible (well-formed) but the verdict-derivation layer lifts it to
+      its own verdict so the sprint gate keeps it out of implementation runs.
     - Complete Diagnosis section → no Reason; bug is implementation-runnable.
     """
     if not is_bug_format_issue(body, labels):
         return None
     ok, missing = diagnosis_completeness(body)
     if ok:
-        # All six tokens present, but the confirmed cause line may still be
-        # explicitly unresolved ("not yet identified", etc.) — that's the
-        # admissible-but-not-runnable state.
+        # All required Diagnosis labels are present, but the confirmed-cause
+        # line may still be explicitly unresolved ("not yet identified",
+        # etc.) — that's the admissible-but-not-runnable state.
         if _diagnosis_cause_unknown(body):
             return Reason(
                 code="diagnosis_cause_unknown",
                 severity=Severity.ADVISORY,
                 detail=(
-                    "Bug Diagnosis section documents ruled-out hypotheses but no "
-                    "confirmed cause — investigation-ready but not "
+                    "Bug Diagnosis section is complete but no confirmed cause is "
+                    "asserted — investigation-ready but not "
                     "implementation-runnable."
                 ),
             )
@@ -519,8 +514,8 @@ def check_bug_missing_diagnosis(title: str, body: str, labels: Iterable[str]) ->
             code="diagnosis_cause_unknown",
             severity=Severity.ADVISORY,
             detail=(
-                "Bug Diagnosis section documents ruled-out hypotheses but no confirmed "
-                "cause — investigation-ready but not implementation-runnable."
+                "Bug Diagnosis section is complete but no confirmed cause is asserted "
+                "— investigation-ready but not implementation-runnable."
             ),
         )
     return Reason(

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -35,22 +35,41 @@ from theforge.task.diagnose_prompts import (
 )
 
 
-def _agent_yaml_output(*, confirmed: bool = True, partial: bool = False) -> str:
+def _agent_yaml_output(
+    *, hypothesis_statuses: tuple[str, ...] = ("ruled_out", "confirmed")
+) -> str:
+    confirmed = "confirmed" in hypothesis_statuses
+    hypotheses = []
+    template = (
+        (
+            "DAG scheduler skips dependents when blocker fails",
+            "Logs show no failed blockers in this run",
+        ),
+        (
+            "Worker pool size off-by-one",
+            "scheduler.py:142 reserves N-1 slots when N requested",
+        ),
+    )
+    for idx, status in enumerate(hypothesis_statuses):
+        statement, evidence = (
+            template[idx]
+            if idx < len(template)
+            else (
+                f"Hypothesis {idx + 1}",
+                f"evidence {idx + 1}",
+            )
+        )
+        hypotheses.append(
+            {
+                "statement": statement,
+                "status": status,
+                "evidence": evidence,
+            }
+        )
     payload = {
         "observed_symptom": "Sprint flow drops the third story silently",
         "reproduction_or_evidence": "Run forge sprint --issues 1,2,3 — story 3 never starts",
-        "hypotheses": [
-            {
-                "statement": "DAG scheduler skips dependents when blocker fails",
-                "status": "ruled_out",
-                "evidence": "Logs show no failed blockers in this run",
-            },
-            {
-                "statement": "Worker pool size off-by-one",
-                "status": "confirmed" if confirmed else "inconclusive",
-                "evidence": "scheduler.py:142 reserves N-1 slots when N requested",
-            },
-        ],
+        "hypotheses": hypotheses,
         "confirmed_cause": (
             "Worker pool reserves N-1 slots in scheduler.py:142" if confirmed else ""
         ),
@@ -160,7 +179,9 @@ class TestParseDiagnoseOutput:
 
     def test_partial_flag_propagates(self):
         artifact = parse_diagnose_output(
-            _agent_yaml_output(confirmed=False), issue_number=1, partial=True
+            _agent_yaml_output(hypothesis_statuses=("ruled_out", "inconclusive")),
+            issue_number=1,
+            partial=True,
         )
         assert artifact is not None
         assert artifact.partial is True
@@ -385,7 +406,9 @@ class TestDiagnoseFlow:
             "body": "y",
             "state": "OPEN",
         }
-        mock_agent.return_value = _fake_agent_result(_agent_yaml_output(confirmed=False))
+        mock_agent.return_value = _fake_agent_result(
+            _agent_yaml_output(hypothesis_statuses=("ruled_out", "inconclusive"))
+        )
         mock_post.return_value = "https://example/comment"
 
         from theforge.coordinator.diagnose_flow import run_diagnose_flow
@@ -456,7 +479,9 @@ class TestDiagnoseFlow:
             "body": original_body,
             "state": "OPEN",
         }
-        mock_agent.return_value = _fake_agent_result(_agent_yaml_output())
+        mock_agent.return_value = _fake_agent_result(
+            _agent_yaml_output(hypothesis_statuses=("confirmed",))
+        )
 
         # No explicit output_destination — exercise the default contract.
         result = run_diagnose_flow(

--- a/tests/test_diagnosis_spec.py
+++ b/tests/test_diagnosis_spec.py
@@ -38,7 +38,6 @@ _COMPLIANT_BODY = textwrap.dedent(
 
     - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
     - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
-    - **Ruled out.** Workspace creation actually succeeds (verified in logs).
     - **Confirmed cause.** `_is_already_merged` requires at least one commit ahead.
     - **Affected code path.** sprint.runner._is_already_merged.
     - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.
@@ -54,7 +53,6 @@ _LABEL_MISMATCH_BODY = textwrap.dedent(
 
     - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
     - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
-    - **Ruled out.** Workspace creation actually succeeds (verified in logs).
     - **Root cause.** `_is_already_merged` requires at least one commit ahead.
     - **Affected code path.** sprint.runner._is_already_merged.
     - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.

--- a/tests/test_fix_readiness.py
+++ b/tests/test_fix_readiness.py
@@ -32,7 +32,6 @@ DIAGNOSIS_BODY = textwrap.dedent(
 
     - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
     - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
-    - **Ruled out.** Workspace creation actually succeeds (verified in logs).
     - **Confirmed cause.** `_is_already_merged` requires at least one commit ahead.
     - **Affected code path.** sprint.runner._is_already_merged.
     - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.
@@ -64,7 +63,6 @@ class TestDiagnosisCompleteness:
         assert ok is False
         # Partial section flags the specific missing tokens, not the whole section.
         expected_missing = (
-            "ruled out",
             "confirmed cause",
             "affected code path",
             "fix-success criterion",
@@ -92,7 +90,6 @@ class TestCheckBugMissingDiagnosis:
         assert reason is not None
         # The detail now names the exact literal labels a producer must hit,
         # each with its example, and links the full shape reference (#1629 AC3).
-        assert "**Ruled out:**" in reason.detail
         assert "**Confirmed cause:**" in reason.detail
         assert "**Affected code path:**" in reason.detail
         assert "docs/reference/bug-shape.md" in reason.detail
@@ -159,7 +156,6 @@ def _investigation_ready_body(cause_value: str) -> str:
 
         - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
         - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
-        - **Ruled out.** Workspace creation actually succeeds (verified in logs).
         - **Confirmed cause.** {cause_value}
         - **Affected code path.** sprint.runner._is_already_merged.
         - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.

--- a/tests/test_shape_verdict_diagnosis_split.py
+++ b/tests/test_shape_verdict_diagnosis_split.py
@@ -4,7 +4,7 @@ Drives three bug bodies through ``apply_shape_gate`` to assert the verdict
 each lands on per ADR-0001:
 
 1. No Diagnosis section → ``needs_diagnosis`` (skipped, blocking).
-2. Diagnosis with hypotheses ruled out but cause unknown →
+2. Diagnosis with complete required labels but cause unknown →
    ``diagnosis_cause_unknown`` (skipped from implementation sprints, but
    admissible — not malformed).
 3. Complete Diagnosis with confirmed cause → ``runnable``.
@@ -40,7 +40,6 @@ CAUSE_UNKNOWN_BODY = textwrap.dedent(
 
     - **Observed symptom.** Exit code flips between 0 and 1.
     - **Evidence.** Run id `abcd1234`, log lines 42-55.
-    - **Ruled out.** Network flake (verified offline), gate cache (cleared).
     - **Confirmed cause.** Not yet identified — investigating provider retry path.
     - **Affected code path.** unknown; suspected coordinator/runner.py.
     - **Fix-success criterion.** Exit code is deterministic across 100 runs.
@@ -59,7 +58,6 @@ COMPLETE_DIAGNOSIS_BODY = textwrap.dedent(
 
     - **Observed symptom.** Sprint resume false-skips zero-delta APPROVE stories.
     - **Evidence.** Run id `1ff6b0bb7992`, story #1102.
-    - **Ruled out.** Workspace creation actually succeeds (verified in logs).
     - **Confirmed cause.** `_is_already_merged` requires at least one commit ahead.
     - **Affected code path.** sprint.runner._is_already_merged.
     - **Fix-success criterion.** Resume identifies zero-delta APPROVE as merged.


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change removes the unconditional ruled-out token from the shared Diagnosis contract and verifies the diagnose-to-shape-gate seam with a no-ruled-out artifact. | [claude-opus] Removes the conditionally-supplied ruled out component from the shared Diagnosis spec so diagnose output is unconditionally fix-ready; single-source derivation, docs regeneration, and the strengthened confirmed-only seam test all hold up.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.86
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge diagnose emits a Diagnosis section the intake gate rejects when no hypothesis is ruled out (GitHub Issue #1904)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1904