### PR TITLE
docs: controller runbook + AGENTS.md as AI-agnostic master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,32 @@
-# Codex Guidance for TheForge
+# Agent Guidance for TheForge
 
-This file is reserved for Codex-specific guidance in this repository.
+This is the **canonical, AI-agnostic entry point** for any AI agent working in
+this repository — Claude Code, Codex, Gemini CLI, or otherwise. `CLAUDE.md` and
+`GEMINI.md` are thin redirects to this file; keep shared guidance here so every
+agent reads the same source.
 
-See `CONVENTIONS.md` for all project conventions, architecture, testing rules, and workflow.
+## Start here
 
-Directory-level `CONVENTIONS.md` files under `src/theforge/` provide subsystem-local guidance. When working inside `coordinator/`, `runners/`, `sprint/`, `task/`, `config/`, or `cli/`, read the nearest local `CONVENTIONS.md` in addition to the root conventions file.
+- **`CONVENTIONS.md`** — all project conventions, architecture, testing rules,
+  and workflow. Read it before writing code.
+- Directory-level `CONVENTIONS.md` files under `src/theforge/` provide
+  subsystem-local guidance. When working inside `coordinator/`, `runners/`,
+  `sprint/`, `task/`, `config/`, or `cli/`, read the nearest local
+  `CONVENTIONS.md` in addition to the root conventions file.
+- **`docs/guides/controller-runbook.md`** — read this **first** when you are
+  *operating* TheForge rather than developing it: running or diagnosing sprints,
+  cutting release candidates, or filing issues from sprint failures. It holds
+  the commands, the flags that matter, and the traps (e.g. the `base_branch`
+  fast-forward that can corrupt a checked-out release branch).
 
-## Codex-specific notes
+## Notes for all agents
 
-- No Codex-specific guidance currently differs from the shared project conventions.
-- Do not modify `CLAUDE.md` or `AGENTS.md` unless the story explicitly requires it.
+- No AI-specific guidance currently differs from this shared source.
+- Do not modify `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md` unless the task
+  explicitly requires it.
+- The `# ── TheForge ──` marker block in this repo's `.gitignore`/`.gitattributes`
+  is the canonical template emitted by `forge init` — the single source of truth
+  is `src/theforge/cli/init_commands.py` (`_gitignore_block` /
+  `_gitattributes_block`). Do not hand-edit the marker block; change the template
+  builders and re-sync. See `CONTRIBUTING.md` → "Git Policy" and
+  `docs/plans/forge-storage-layout.md`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,8 +1,8 @@
-# Claude Guidance for TheForge
+# Gemini Guidance for TheForge
 
 The shared, AI-agnostic guidance for this repository lives in **`AGENTS.md`** —
-**read it first.** Everything that applies to Claude applies through `AGENTS.md`;
-there is no Claude-specific guidance that differs from it today.
+**read it first.** Everything that applies to Gemini applies through `AGENTS.md`;
+there is no Gemini-specific guidance that differs from it today.
 
 Quick pointers (all detailed in `AGENTS.md`):
 

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -1,0 +1,138 @@
+# Controller Runbook — Operating TheForge
+
+This is the operational cheat-sheet for a **controller session**: the operator's
+right-hand for running and diagnosing sprints, cutting release candidates, and
+filing issues from sprint failures. Read it before you run anything.
+
+It complements — does not restate — two other docs:
+
+- **`CONVENTIONS.md`** holds the *doctrine* (dogfood floor, forward-port model,
+  what goes in repo vs. operator memory). Cross-links below point into it.
+- **`docs/guides/cli-reference.md`** holds the *full* flag reference. This
+  runbook only calls out the operationally load-bearing flags and the traps.
+
+If a fact keeps getting re-learned across sessions, it belongs **here** (or in
+`CONVENTIONS.md`), not in one AI's private memory.
+
+---
+
+## 1. Running a sprint
+
+```bash
+forge sprint --verbose --issues N,N,N --budget 50 --parallel 3
+```
+
+- `--resume` re-enters an existing run. **Always `--resume`** rather than
+  deleting worktrees and re-running fresh (unless explicitly asked to start
+  clean).
+- **`--base-branch <branch>`** overrides `workspace.base_branch` for this run
+  without editing `forge.yaml`. Set it to the branch fixes should land on. When
+  dogfooding a release line (checkout on `release/vX.Y`), pass
+  `--base-branch release/vX.Y` — otherwise fixes land on `main`, and worse (see
+  §3).
+- **Confirm with the operator per-invocation before launching.** Sprints spend
+  money; "fix it" is not authorization to spend.
+
+## 2. Branch & forward-port model
+
+- Fixes land on the **base branch**. `forward-port.yml` then auto-carries every
+  `release/*` merge into `main` as a real merge-commit PR (GitHub App token,
+  auto-merge on green CI). `main` stays a strict **superset** of every release
+  line.
+- **Never commit directly to `main`.** All changes go through a
+  branch/worktree + PR.
+- After any *manual* PR intervention, re-arm auto-merge — a force-push clears it:
+  ```bash
+  gh pr merge <N> --auto --squash --delete-branch
+  ```
+
+## 3. The `base_branch` trap (issue #1928) — read this
+
+`workspace.base_branch` defaults to `main`. After every merged PR, forge's
+"best-effort local cleanup" (`coordinator/completion.py`) runs, in the
+**project-root checkout**:
+
+```
+git fetch origin
+git merge --ff-only origin/<base_branch>
+```
+
+If you are checked out on a **release branch** while `base_branch` is still
+`main`, that fast-forward silently drags your release branch up to
+`origin/main` — importing main's dev version, its `[Unreleased]` changelog, and
+main's forward-port merge commits. It corrupts the release branch **with no
+error** (the step swallows failures as "non-fatal").
+
+Until #1928 lands:
+
+- Keep `--base-branch` matching the branch you have checked out, **or** don't
+  sit on a release branch in the project root while a sprint runs.
+- Symptom to watch for: `git show release/vX.Y:pyproject.toml` reads main's dev
+  version instead of the branch's `rc` version.
+
+## 4. Cutting a release candidate
+
+```bash
+RC_NUM=n scripts/cut-rc.sh X.Y.Z
+```
+
+- Reads the current version on the release branch, **overwrites** it to
+  `X.Y.Zrcn`, runs the gate, commits, tags, pushes, and configures branch
+  protection so auto-merge works. A stale version on the branch is therefore
+  harmless — cut-rc overwrites it.
+- `cut-rc.sh` only `pull --ff-only`s the *release* branch and creates it from
+  `main` when it doesn't exist yet; it **never** merges `main` into an existing
+  release branch. (So cut-rc is never the cause of a release branch picking up
+  main's history — see §3 for what is.)
+- `--resume` skips bump/commit/tag/push when the tag already exists on origin.
+- **Floor doctrine:** cut when the release is "solid enough to be the dev
+  substrate for the next release," not when every issue is closed. Non-floor
+  bugs roll to the next minor. See `CONVENTIONS.md` → dogfood floor.
+
+## 5. Merge gate
+
+- **PASS gate + review APPROVE before anything merges to `main`** — even when
+  the operator explicitly asks to merge. Surface the gate/review state, then
+  merge.
+
+## 6. Dogfood substrate model
+
+- Two runtimes that must stay **disjoint**: the *orchestrator* is the released
+  `rc` tag in an isolated venv (plain `forge`), pinned; the *patient* is
+  `main`/the working tree with its own deps. Don't editable-install main as the
+  orchestrator, and don't cherry-pick schema changes between them.
+- Pin dogfood to the **latest tag**; re-cut `rcN` as fixes land or the lag
+  returns one version up. See `CONVENTIONS.md` → dogfooding config.
+
+## 7. Filing issues from sprint failures
+
+- **Bugs:** observed behavior + expected behavior only. `EXPECTED` must state a
+  **category-level rule that generalizes** beyond the trigger, written as
+  flowing prose — no bulleted rule-lists (the preflight parses those as feature
+  ACs), no provider/model names, no "Acceptance is…" section. Add a
+  **Diagnosis** section whenever you have an RCA: observed symptom, evidence
+  (with `file:line`), ruled-out hypotheses, confirmed cause, affected code path,
+  fix-success criterion. Symptom bugs don't enter a sprint without that
+  diagnosis, and reviewers verify **symptom resolution**, not just
+  implementation correctness.
+- **Features / enhancements:** need an `## Acceptance criteria` section and a
+  concrete example (sample output / before-after). Body = WHAT/WHY, not HOW.
+- **Label and milestone at creation** (`gh issue create --label bug --milestone
+  vX.Y.Z`) or the shape gate / triage skips it. When reporting a filed issue,
+  include full intake state: labels, milestone, sprint-gate readiness.
+
+---
+
+## Where knowledge goes
+
+| Kind of fact | Home |
+|---|---|
+| How the tool works — commands, flags, branch model, traps, procedures | **this runbook** |
+| Project doctrine, conventions, architecture, dogfood policy | **`CONVENTIONS.md`** |
+| Operator-personal working style — confirm-before-spend, timezone, tone | **AI user memory** (not the repo) |
+
+Repo docs serve every AI (Claude, Codex, Gemini) because each one's context file
+(`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) redirects to `AGENTS.md`, which points
+here. A fact that lives only in one AI's private memory does not survive a switch
+to another AI — or often to the next session. Put durable operational knowledge
+here.

--- a/tests/test_claude_docs.py
+++ b/tests/test_claude_docs.py
@@ -29,24 +29,27 @@ def test_subsystem_claude_docs_point_to_conventions() -> None:
 
 
 def test_root_agent_docs_point_to_conventions() -> None:
-    for filename, notes_heading in (
-        ("CLAUDE.md", "## Claude-specific notes"),
-        ("AGENTS.md", "## Codex-specific notes"),
-    ):
-        text = (ROOT / filename).read_text()
-        assert (
-            "See `CONVENTIONS.md` for all project conventions, architecture, testing "
-            "rules, and workflow." in text
-        )
-        assert (
-            "Directory-level `CONVENTIONS.md` files under `src/theforge/` provide "
-            "subsystem-local guidance." in text
-        )
-        assert notes_heading in text
-        assert (
-            "Do not modify `CLAUDE.md` or `AGENTS.md` unless the story explicitly "
-            "requires it." in text
-        )
+    # AGENTS.md is the AI-agnostic master; CLAUDE.md and GEMINI.md redirect to it.
+    def _norm(name: str) -> str:
+        return " ".join((ROOT / name).read_text().split())
+
+    agents = _norm("AGENTS.md")
+    assert "CONVENTIONS.md" in agents
+    assert (
+        "Directory-level `CONVENTIONS.md` files under `src/theforge/` provide "
+        "subsystem-local guidance." in agents
+    )
+    assert "docs/guides/controller-runbook.md" in agents
+    assert (
+        "Do not modify `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md` unless the task "
+        "explicitly requires it." in agents
+    )
+
+    for filename in ("CLAUDE.md", "GEMINI.md"):
+        text = _norm(filename)
+        assert "`AGENTS.md`" in text, f"{filename} must redirect to AGENTS.md"
+        assert "CONVENTIONS.md" in text
+        assert "docs/guides/controller-runbook.md" in text
 
 
 def test_root_conventions_doc_exists_and_records_shared_guidance() -> None:


### PR DESCRIPTION
## Why

Tool-level operational facts keep getting re-learned every controller session (the `--base-branch` override, cut-rc mechanics, the `base_branch` fast-forward that corrupts a checked-out release branch). They had no home: too tool-specific for one AI's private memory, not a dev convention for `CONVENTIONS.md`.

## What

- **`AGENTS.md`** is now the canonical, AI-agnostic entry point for every agent (Claude, Codex, Gemini).
- **`CLAUDE.md`** and **`GEMINI.md`** are thin redirects to `AGENTS.md`, so all three AIs boot from one source. (Claude Code reads `CLAUDE.md`, Codex reads `AGENTS.md`, Gemini CLI reads `GEMINI.md`.)
- **`docs/guides/controller-runbook.md`** (new) captures the operator runbook: sprint invocation + `--base-branch`, the branch/forward-port model, the `base_branch` trap (#1928), cutting RCs, the merge gate, the dogfood substrate model, and filing issues from sprint failures. It cross-links to `CONVENTIONS.md` (doctrine) and `docs/guides/cli-reference.md` (full flags) rather than restating them.

## Notes

- Pure docs; no code paths touched.
- The runbook references #1928 (the `base_branch` fast-forward corruption bug) as the live trap to work around until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)