### PR TITLE
forge post-merge cleanup fast-forwards the operator's checkout to origin/base_branch, silently corrupting a checked-out release branch

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -854,20 +854,54 @@ def _step_cleanup(
 ) -> None:
     """Best-effort local cleanup after a successful remote PR merge."""
     try:
-        subprocess.run(
-            ["git", "fetch", "origin"],
+        branch_proc = subprocess.run(
+            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
             capture_output=True,
             text=True,
             cwd=str(project_root),
-            timeout=60,
+            timeout=15,
         )
-        subprocess.run(
-            ["git", "merge", "--ff-only", f"origin/{base_branch}"],
-            capture_output=True,
-            text=True,
-            cwd=str(project_root),
-            timeout=30,
-        )
+        current_branch = branch_proc.stdout.strip()
+        if branch_proc.returncode != 0 or not current_branch:
+            err = (
+                branch_proc.stderr.strip() or branch_proc.stdout.strip() or "unknown branch state"
+            )
+            _log(
+                "Warning: skipped local base branch sync after merge because forge "
+                f"could not determine the checked-out branch in {project_root}: {err}"
+            )
+            _pr_log.warning(
+                "local base_branch fast-forward skipped: could not determine checked-out "
+                "branch in %s: %s",
+                project_root,
+                err,
+            )
+        elif current_branch != base_branch:
+            _log(
+                "Warning: skipped local base branch sync after merge because checked-out "
+                f"branch '{current_branch}' does not match configured base '{base_branch}'"
+            )
+            _pr_log.warning(
+                "local base_branch fast-forward skipped: checked-out branch %s does not "
+                "match configured base %s",
+                current_branch,
+                base_branch,
+            )
+        else:
+            subprocess.run(
+                ["git", "fetch", "origin"],
+                capture_output=True,
+                text=True,
+                cwd=str(project_root),
+                timeout=60,
+            )
+            subprocess.run(
+                ["git", "merge", "--ff-only", f"origin/{base_branch}"],
+                capture_output=True,
+                text=True,
+                cwd=str(project_root),
+                timeout=30,
+            )
     except Exception as exc:
         _pr_log.warning("local base_branch fast-forward failed (non-fatal): %s", exc)
 

--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -853,6 +853,22 @@ def _step_cleanup(
     delete_remote_branch: bool,
 ) -> None:
     """Best-effort local cleanup after a successful remote PR merge."""
+
+    def _warn_base_sync_failure(cmd: list[str], proc: subprocess.CompletedProcess[str]) -> None:
+        err = proc.stderr.strip() or proc.stdout.strip() or "unknown error"
+        cmd_str = shlex.join(cmd)
+        _log(
+            "Warning: local base branch sync after merge failed for "
+            f"`{cmd_str}` (exit {proc.returncode}): {err}"
+        )
+        _pr_log.warning(
+            "local base_branch fast-forward command failed in %s: cmd=%s exit=%d err=%s",
+            project_root,
+            cmd,
+            proc.returncode,
+            err,
+        )
+
     try:
         branch_proc = subprocess.run(
             ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
@@ -888,20 +904,27 @@ def _step_cleanup(
                 base_branch,
             )
         else:
-            subprocess.run(
-                ["git", "fetch", "origin"],
+            fetch_cmd = ["git", "fetch", "origin"]
+            fetch_proc = subprocess.run(
+                fetch_cmd,
                 capture_output=True,
                 text=True,
                 cwd=str(project_root),
                 timeout=60,
             )
-            subprocess.run(
-                ["git", "merge", "--ff-only", f"origin/{base_branch}"],
-                capture_output=True,
-                text=True,
-                cwd=str(project_root),
-                timeout=30,
-            )
+            if fetch_proc.returncode != 0:
+                _warn_base_sync_failure(fetch_cmd, fetch_proc)
+            else:
+                merge_cmd = ["git", "merge", "--ff-only", f"origin/{base_branch}"]
+                merge_proc = subprocess.run(
+                    merge_cmd,
+                    capture_output=True,
+                    text=True,
+                    cwd=str(project_root),
+                    timeout=30,
+                )
+                if merge_proc.returncode != 0:
+                    _warn_base_sync_failure(merge_cmd, merge_proc)
     except Exception as exc:
         _pr_log.warning("local base_branch fast-forward failed (non-fatal): %s", exc)
 

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -1900,6 +1900,116 @@ class TestFastForwardAfterMerge:
         assert any(cmd[:3] == ["git", "branch", "-D"] for cmd in cleanup_calls)
         assert any(cmd[:4] == ["git", "push", "origin", "--delete"] for cmd in cleanup_calls)
 
+    def test_cleanup_warns_when_base_fetch_fails(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd == [
+                "git",
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "HEAD",
+            ]:
+                return _make_subprocess_result(0, stdout="main\n")
+            if isinstance(cmd, list) and cmd == ["git", "fetch", "origin"]:
+                return _make_subprocess_result(1, stderr="fetch failed")
+            if isinstance(cmd, list) and cmd == ["git", "merge", "--ff-only", "origin/main"]:
+                raise AssertionError(f"unexpected merge command after failed fetch: {cmd}")
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="MERGED")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch("theforge.coordinator.completion._log") as mock_log,
+            patch("theforge.coordinator.completion._pr_log.warning") as mock_warning,
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/x/y/pull/9",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["merged"] is True
+        mock_log.assert_any_call(
+            "Warning: local base branch sync after merge failed for "
+            "`git fetch origin` (exit 1): fetch failed"
+        )
+        mock_warning.assert_any_call(
+            "local base_branch fast-forward command failed in %s: cmd=%s exit=%d err=%s",
+            tmp_path,
+            ["git", "fetch", "origin"],
+            1,
+            "fetch failed",
+        )
+
+    def test_cleanup_warns_when_base_fast_forward_merge_fails(self, tmp_path: Path) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd == [
+                "git",
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "HEAD",
+            ]:
+                return _make_subprocess_result(0, stdout="main\n")
+            if isinstance(cmd, list) and cmd == ["git", "fetch", "origin"]:
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd == ["git", "merge", "--ff-only", "origin/main"]:
+                return _make_subprocess_result(1, stderr="non-fast-forward")
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="MERGED")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch("theforge.coordinator.completion._log") as mock_log,
+            patch("theforge.coordinator.completion._pr_log.warning") as mock_warning,
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/x/y/pull/10",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["merged"] is True
+        mock_log.assert_any_call(
+            "Warning: local base branch sync after merge failed for "
+            "`git merge --ff-only origin/main` (exit 1): non-fast-forward"
+        )
+        mock_warning.assert_any_call(
+            "local base_branch fast-forward command failed in %s: cmd=%s exit=%d err=%s",
+            tmp_path,
+            ["git", "merge", "--ff-only", "origin/main"],
+            1,
+            "non-fast-forward",
+        )
+
     def test_finalize_approve_keeps_done_for_merge_queued(self, tmp_path: Path) -> None:
         """land_story returns landing_status='pending_integration' when PR merge is queued."""
         from theforge.coordinator.completion import land_story

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -1706,6 +1706,14 @@ class TestFastForwardAfterMerge:
         ff_calls: list[list[str]] = []
 
         def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd == [
+                "git",
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "HEAD",
+            ]:
+                return _make_subprocess_result(0, stdout="main\n")
             if isinstance(cmd, list) and "fetch" in cmd and "merge" not in cmd:
                 if cmd == ["git", "fetch", "origin"]:
                     ff_calls.append(cmd)
@@ -1777,6 +1785,117 @@ class TestFastForwardAfterMerge:
             result = _merge_pr(config, task, "forge/test-task", review, state)
 
         assert result["merged"] is True
+        assert any(cmd[:4] == ["git", "worktree", "remove", "--force"] for cmd in cleanup_calls)
+        assert any(cmd[:3] == ["git", "branch", "-D"] for cmd in cleanup_calls)
+        assert any(cmd[:4] == ["git", "push", "origin", "--delete"] for cmd in cleanup_calls)
+
+    def test_cleanup_fast_forwards_local_base_only_when_project_root_is_on_base(
+        self, tmp_path: Path
+    ) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        ff_calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd == [
+                "git",
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "HEAD",
+            ]:
+                return _make_subprocess_result(0, stdout="main\n")
+            if isinstance(cmd, list) and (
+                cmd == ["git", "fetch", "origin"]
+                or cmd == ["git", "merge", "--ff-only", "origin/main"]
+            ):
+                ff_calls.append(cmd)
+                return _make_subprocess_result(0)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="MERGED")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/x/y/pull/8",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["merged"] is True
+        assert ["git", "fetch", "origin"] in ff_calls
+        assert ["git", "merge", "--ff-only", "origin/main"] in ff_calls
+
+    def test_cleanup_skips_base_fast_forward_when_project_root_is_on_different_branch(
+        self, tmp_path: Path
+    ) -> None:
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_task(tmp_path)
+        review = _make_review_result()
+        state = MagicMock()
+        state.review_results = [review]
+        state.total_cost = 1.0
+        state.dev_iteration = 1
+
+        cleanup_calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd == [
+                "git",
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "HEAD",
+            ]:
+                return _make_subprocess_result(0, stdout="release/v0.13\n")
+            if isinstance(cmd, list) and (
+                cmd[:4] == ["git", "worktree", "remove", "--force"]
+                or cmd[:3] == ["git", "branch", "-D"]
+                or cmd[:4] == ["git", "push", "origin", "--delete"]
+            ):
+                cleanup_calls.append(cmd)
+            if isinstance(cmd, list) and cmd[:3] == ["gh", "pr", "view"]:
+                return _make_subprocess_result(0, stdout="MERGED")
+            if isinstance(cmd, list) and (
+                cmd == ["git", "fetch", "origin"]
+                or cmd == ["git", "merge", "--ff-only", "origin/main"]
+            ):
+                raise AssertionError(f"unexpected base sync command: {cmd}")
+            return _make_subprocess_result(0)
+
+        with (
+            patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run),
+            patch("theforge.coordinator.completion._log") as mock_log,
+            patch(
+                "theforge.coordinator.completion._create_pr",
+                return_value={
+                    "action": "pr",
+                    "pr_url": "https://github.com/x/y/pull/8",
+                    "success": True,
+                    "error": None,
+                },
+            ),
+        ):
+            result = _merge_pr(config, task, "forge/test-task", review, state)
+
+        assert result["merged"] is True
+        mock_log.assert_any_call(
+            "Warning: skipped local base branch sync after merge because checked-out "
+            "branch 'release/v0.13' does not match configured base 'main'"
+        )
         assert any(cmd[:4] == ["git", "worktree", "remove", "--force"] for cmd in cleanup_calls)
         assert any(cmd[:3] == ["git", "branch", "-D"] for cmd in cleanup_calls)
         assert any(cmd[:4] == ["git", "push", "origin", "--delete"] for cmd in cleanup_calls)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The checkout-branch guard and operator-visible failure warnings are covered, including the prior P1 fetch/merge warning gap. | [claude-opus] Cycle-1 P1 resolved: fetch/merge nonzero exits now surface an operator-visible warning via _warn_base_sync_failure with tests for both failure paths; branch-guard logic and symptom coverage remain intact, no regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.28
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge post-merge cleanup fast-forwards the operator's checkout to origin/base_branch, silently corrupting a checked-out release branch (GitHub Issue #1928)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1928