### PR TITLE
Patient gate runs under the orchestrator's interpreter, not the project's pinned Python

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -15,7 +15,11 @@ from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.config import ForgeConfig
 from theforge.detach import find_run_id_for_pid as _find_run_id_for_pid
 from theforge.task import TaskStory
-from theforge.workspace_env import resolve_workspace_python, workspace_venv_matches_python
+from theforge.workspace_env import (
+    maybe_resolve_workspace_python,
+    resolve_workspace_python,
+    workspace_venv_matches_python,
+)
 
 from . import util as _cu
 from .gate import _run_gate
@@ -97,8 +101,11 @@ def _resolve_setup_command(cmd: str, workspace_path: Path) -> str:
     Uses shlex.quote so that paths containing spaces or shell-sensitive characters
     do not break shell=True invocations.
     """
-    resolved = resolve_workspace_python(workspace_path)
-    return cmd.replace("{forge_python}", shlex.quote(str(resolved.executable)))
+    if "{forge_python}" not in cmd:
+        return cmd
+    resolved = maybe_resolve_workspace_python(workspace_path)
+    executable = resolved.executable if resolved is not None else Path(sys.executable)
+    return cmd.replace("{forge_python}", shlex.quote(str(executable)))
 
 
 def _read_last_setup_command(workspace_path: Path) -> str | None:
@@ -130,10 +137,14 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
     m = _VENV_GUARD_TEMPLATE_RE.search(setup_command)
     if m:
         install_cmd = m.group(1).strip()
-        resolved_python = resolve_workspace_python(workspace_path)
-        python_exe = shlex.quote(str(resolved_python.executable))
-        if (workspace_path / ".venv").exists() and not workspace_venv_matches_python(
-            workspace_path, resolved_python
+        resolved_python = maybe_resolve_workspace_python(workspace_path)
+        python_exe = shlex.quote(
+            str(resolved_python.executable if resolved_python is not None else Path(sys.executable))
+        )
+        if (
+            resolved_python is not None
+            and (workspace_path / ".venv").exists()
+            and not workspace_venv_matches_python(workspace_path, resolved_python)
         ):
             _cu._log("⚠ WORKSPACE  removing stale .venv pinned to a different Python")
             shutil.rmtree(workspace_path / ".venv")
@@ -152,11 +163,18 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
         if ok:
             _write_last_setup_command(workspace_path, setup_command)
         return ok, out
-    python_exe = m.group(1)
+    legacy_python_exe = m.group(1)
     install_cmd = m.group(2).strip()
-    resolved_python = resolve_workspace_python(workspace_path)
-    if (workspace_path / ".venv").exists() and not workspace_venv_matches_python(
-        workspace_path, resolved_python
+    resolved_python = maybe_resolve_workspace_python(workspace_path)
+    python_exe = (
+        shlex.quote(str(resolved_python.executable))
+        if resolved_python is not None
+        else legacy_python_exe
+    )
+    if (
+        resolved_python is not None
+        and (workspace_path / ".venv").exists()
+        and not workspace_venv_matches_python(workspace_path, resolved_python)
     ):
         _cu._log("⚠ WORKSPACE  removing stale .venv pinned to a different Python")
         shutil.rmtree(workspace_path / ".venv")

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -15,6 +15,7 @@ from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.config import ForgeConfig
 from theforge.detach import find_run_id_for_pid as _find_run_id_for_pid
 from theforge.task import TaskStory
+from theforge.workspace_env import resolve_workspace_python, workspace_venv_matches_python
 
 from . import util as _cu
 from .gate import _run_gate
@@ -90,13 +91,14 @@ def _propagate_claude_memory(project_root: Path, workspace_path: Path) -> None:
         _cu._log(f"⚠ WORKSPACE  failed to propagate Claude memory: {exc}")
 
 
-def _resolve_setup_command(cmd: str) -> str:
-    """Replace {forge_python} with the shell-safe path to the running interpreter.
+def _resolve_setup_command(cmd: str, workspace_path: Path) -> str:
+    """Replace {forge_python} with the shell-safe path to the pinned interpreter.
 
     Uses shlex.quote so that paths containing spaces or shell-sensitive characters
     do not break shell=True invocations.
     """
-    return cmd.replace("{forge_python}", shlex.quote(sys.executable))
+    resolved = resolve_workspace_python(workspace_path)
+    return cmd.replace("{forge_python}", shlex.quote(str(resolved.executable)))
 
 
 def _read_last_setup_command(workspace_path: Path) -> str | None:
@@ -128,7 +130,13 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
     m = _VENV_GUARD_TEMPLATE_RE.search(setup_command)
     if m:
         install_cmd = m.group(1).strip()
-        python_exe = shlex.quote(sys.executable)
+        resolved_python = resolve_workspace_python(workspace_path)
+        python_exe = shlex.quote(str(resolved_python.executable))
+        if (workspace_path / ".venv").exists() and not workspace_venv_matches_python(
+            workspace_path, resolved_python
+        ):
+            _cu._log("⚠ WORKSPACE  removing stale .venv pinned to a different Python")
+            shutil.rmtree(workspace_path / ".venv")
         ok, out = _cu._run_shell(f"test -d .venv || {python_exe} -m venv .venv", workspace_path)
         if not ok:
             return ok, out
@@ -137,7 +145,7 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
             _write_last_setup_command(workspace_path, setup_command)
         return ok, out
 
-    cmd = _resolve_setup_command(setup_command)
+    cmd = _resolve_setup_command(setup_command, workspace_path)
     m = _VENV_GUARD_RE.search(cmd)
     if not m:
         ok, out = _cu._run_shell(cmd, workspace_path)
@@ -146,6 +154,12 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
         return ok, out
     python_exe = m.group(1)
     install_cmd = m.group(2).strip()
+    resolved_python = resolve_workspace_python(workspace_path)
+    if (workspace_path / ".venv").exists() and not workspace_venv_matches_python(
+        workspace_path, resolved_python
+    ):
+        _cu._log("⚠ WORKSPACE  removing stale .venv pinned to a different Python")
+        shutil.rmtree(workspace_path / ".venv")
     ok, out = _cu._run_shell(f"test -d .venv || {python_exe} -m venv .venv", workspace_path)
     if not ok:
         return ok, out

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -17,7 +17,6 @@ from theforge.detach import find_run_id_for_pid as _find_run_id_for_pid
 from theforge.task import TaskStory
 from theforge.workspace_env import (
     maybe_resolve_workspace_python,
-    resolve_workspace_python,
     workspace_venv_matches_python,
 )
 
@@ -138,9 +137,10 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
     if m:
         install_cmd = m.group(1).strip()
         resolved_python = maybe_resolve_workspace_python(workspace_path)
-        python_exe = shlex.quote(
-            str(resolved_python.executable if resolved_python is not None else Path(sys.executable))
+        python_path = (
+            resolved_python.executable if resolved_python is not None else Path(sys.executable)
         )
+        python_exe = shlex.quote(str(python_path))
         if (
             resolved_python is not None
             and (workspace_path / ".venv").exists()

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -107,6 +107,16 @@ def _resolve_setup_command(cmd: str, workspace_path: Path) -> str:
     return cmd.replace("{forge_python}", shlex.quote(str(executable)))
 
 
+def _log_unpinned_python_fallback(workspace_path: Path) -> None:
+    """Record when gate setup falls back to the ambient interpreter."""
+    _cu._log(
+        "⚠ WORKSPACE  "
+        f"{workspace_path} has no .python-version; "
+        f"gate setup is using ambient Python {sys.executable}. "
+        "Add a workspace .python-version pin to enable pinned-interpreter gate setup."
+    )
+
+
 def _read_last_setup_command(workspace_path: Path) -> str | None:
     """Read the last setup_command run in this workspace, if any."""
     path = workspace_path / ".forge" / "last_setup_command"
@@ -138,6 +148,8 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
         if m:
             install_cmd = m.group(1).strip()
             resolved_python = maybe_resolve_workspace_python(workspace_path)
+            if resolved_python is None:
+                _log_unpinned_python_fallback(workspace_path)
             python_path = (
                 resolved_python.executable if resolved_python is not None else Path(sys.executable)
             )
@@ -169,6 +181,8 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
         legacy_python_exe = m.group(1)
         install_cmd = m.group(2).strip()
         resolved_python = maybe_resolve_workspace_python(workspace_path)
+        if resolved_python is None:
+            _log_unpinned_python_fallback(workspace_path)
         python_exe = (
             shlex.quote(str(resolved_python.executable))
             if resolved_python is not None

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -129,18 +129,51 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
     Matches {forge_python} template before substitution to avoid parsing
     shlex.quote() output; falls back to legacy form; then runs verbatim.
     """
-    last_setup_command = _read_last_setup_command(workspace_path)
-    if last_setup_command is not None and last_setup_command != setup_command:
-        _cu._log("⚠ WORKSPACE  setup_command changed — re-running install")
+    try:
+        last_setup_command = _read_last_setup_command(workspace_path)
+        if last_setup_command is not None and last_setup_command != setup_command:
+            _cu._log("⚠ WORKSPACE  setup_command changed — re-running install")
 
-    m = _VENV_GUARD_TEMPLATE_RE.search(setup_command)
-    if m:
-        install_cmd = m.group(1).strip()
+        m = _VENV_GUARD_TEMPLATE_RE.search(setup_command)
+        if m:
+            install_cmd = m.group(1).strip()
+            resolved_python = maybe_resolve_workspace_python(workspace_path)
+            python_path = (
+                resolved_python.executable if resolved_python is not None else Path(sys.executable)
+            )
+            python_exe = shlex.quote(str(python_path))
+            if (
+                resolved_python is not None
+                and (workspace_path / ".venv").exists()
+                and not workspace_venv_matches_python(workspace_path, resolved_python)
+            ):
+                _cu._log("⚠ WORKSPACE  removing stale .venv pinned to a different Python")
+                shutil.rmtree(workspace_path / ".venv")
+            ok, out = _cu._run_shell(
+                f"test -d .venv || {python_exe} -m venv .venv", workspace_path
+            )
+            if not ok:
+                return ok, out
+            ok, out = _cu._run_shell(install_cmd, workspace_path)
+            if ok:
+                _write_last_setup_command(workspace_path, setup_command)
+            return ok, out
+
+        cmd = _resolve_setup_command(setup_command, workspace_path)
+        m = _VENV_GUARD_RE.search(cmd)
+        if not m:
+            ok, out = _cu._run_shell(cmd, workspace_path)
+            if ok:
+                _write_last_setup_command(workspace_path, setup_command)
+            return ok, out
+        legacy_python_exe = m.group(1)
+        install_cmd = m.group(2).strip()
         resolved_python = maybe_resolve_workspace_python(workspace_path)
-        python_path = (
-            resolved_python.executable if resolved_python is not None else Path(sys.executable)
+        python_exe = (
+            shlex.quote(str(resolved_python.executable))
+            if resolved_python is not None
+            else legacy_python_exe
         )
-        python_exe = shlex.quote(str(python_path))
         if (
             resolved_python is not None
             and (workspace_path / ".venv").exists()
@@ -155,36 +188,8 @@ def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, st
         if ok:
             _write_last_setup_command(workspace_path, setup_command)
         return ok, out
-
-    cmd = _resolve_setup_command(setup_command, workspace_path)
-    m = _VENV_GUARD_RE.search(cmd)
-    if not m:
-        ok, out = _cu._run_shell(cmd, workspace_path)
-        if ok:
-            _write_last_setup_command(workspace_path, setup_command)
-        return ok, out
-    legacy_python_exe = m.group(1)
-    install_cmd = m.group(2).strip()
-    resolved_python = maybe_resolve_workspace_python(workspace_path)
-    python_exe = (
-        shlex.quote(str(resolved_python.executable))
-        if resolved_python is not None
-        else legacy_python_exe
-    )
-    if (
-        resolved_python is not None
-        and (workspace_path / ".venv").exists()
-        and not workspace_venv_matches_python(workspace_path, resolved_python)
-    ):
-        _cu._log("⚠ WORKSPACE  removing stale .venv pinned to a different Python")
-        shutil.rmtree(workspace_path / ".venv")
-    ok, out = _cu._run_shell(f"test -d .venv || {python_exe} -m venv .venv", workspace_path)
-    if not ok:
-        return ok, out
-    ok, out = _cu._run_shell(install_cmd, workspace_path)
-    if ok:
-        _write_last_setup_command(workspace_path, setup_command)
-    return ok, out
+    except ValueError as exc:
+        return False, str(exc)
 
 
 def _resolve_merge_conflicts(

--- a/src/theforge/workspace_env.py
+++ b/src/theforge/workspace_env.py
@@ -45,6 +45,11 @@ def _read_workspace_python_pin(workspace_path: Path) -> str | None:
     raise ValueError(f"Workspace {workspace_path} has an empty .python-version pin.")
 
 
+def workspace_has_python_pin(workspace_path: Path) -> bool:
+    """Return True when the workspace declares a .python-version pin."""
+    return _read_workspace_python_pin(workspace_path) is not None
+
+
 def _candidate_python_names(pin: str) -> list[str]:
     version_parts = pin.split(".")
     candidates = [f"python{pin}"]
@@ -177,9 +182,12 @@ def workspace_venv_is_usable(
     if not cfg:
         return False
 
-    resolved = resolved_python if resolved_python is not None else maybe_resolve_workspace_python(
-        workspace_path
-    )
+    if resolved_python is not None:
+        resolved = resolved_python
+    elif workspace_has_python_pin(workspace_path):
+        resolved = resolve_workspace_python(workspace_path)
+    else:
+        resolved = None
     if resolved is None:
         return True
     return workspace_venv_matches_python(workspace_path, resolved)

--- a/src/theforge/workspace_env.py
+++ b/src/theforge/workspace_env.py
@@ -31,16 +31,12 @@ def _parse_version(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
 
-def _read_workspace_python_pin(workspace_path: Path) -> str:
+def _read_workspace_python_pin(workspace_path: Path) -> str | None:
     pin_path = workspace_path / ".python-version"
     try:
         raw = pin_path.read_text(encoding="utf-8")
-    except FileNotFoundError as exc:
-        raise ValueError(
-            "Workspace "
-            f"{workspace_path} is missing .python-version; "
-            "gate setup requires a pinned Python interpreter."
-        ) from exc
+    except FileNotFoundError:
+        return None
 
     for line in raw.splitlines():
         pin = line.split("#", 1)[0].strip()
@@ -76,9 +72,8 @@ def _read_python_version(executable: str) -> str:
     return proc.stdout.strip()
 
 
-def resolve_workspace_python(workspace_path: Path) -> WorkspacePython:
-    """Resolve the interpreter pinned by workspace .python-version from PATH."""
-    pin = _read_workspace_python_pin(workspace_path)
+def _resolve_workspace_python_pin(workspace_path: Path, pin: str) -> WorkspacePython:
+    """Resolve a validated workspace Python pin from PATH."""
     pinned_parts = _parse_version(pin.removeprefix("python"))
 
     for candidate_name in _candidate_python_names(pin):
@@ -103,16 +98,28 @@ def resolve_workspace_python(workspace_path: Path) -> WorkspacePython:
     )
 
 
+def resolve_workspace_python(workspace_path: Path) -> WorkspacePython:
+    """Resolve the interpreter pinned by workspace .python-version from PATH."""
+    pin = _read_workspace_python_pin(workspace_path)
+    if pin is None:
+        raise ValueError(
+            "Workspace "
+            f"{workspace_path} is missing .python-version; "
+            "gate setup requires a pinned Python interpreter."
+        )
+    return _resolve_workspace_python_pin(workspace_path, pin)
+
+
 def maybe_resolve_workspace_python(workspace_path: Path) -> WorkspacePython | None:
     """Best-effort workspace interpreter resolution.
 
-    Returns None when the workspace has no usable .python-version pin so callers
-    can conservatively fall back instead of crashing on unpinned worktrees.
+    Returns None only when the workspace has no .python-version pin. Declared
+    pins still fail closed when they are invalid or unresolved.
     """
-    try:
-        return resolve_workspace_python(workspace_path)
-    except ValueError:
+    pin = _read_workspace_python_pin(workspace_path)
+    if pin is None:
         return None
+    return resolve_workspace_python(workspace_path)
 
 
 def read_workspace_venv_config(workspace_path: Path) -> dict[str, str]:
@@ -162,6 +169,22 @@ def workspace_venv_matches_python(
     return False
 
 
+def workspace_venv_is_usable(
+    workspace_path: Path, resolved_python: WorkspacePython | None = None
+) -> bool:
+    """Return True when workspace .venv can safely drive subprocess execution."""
+    cfg = read_workspace_venv_config(workspace_path)
+    if not cfg:
+        return False
+
+    resolved = resolved_python if resolved_python is not None else maybe_resolve_workspace_python(
+        workspace_path
+    )
+    if resolved is None:
+        return True
+    return workspace_venv_matches_python(workspace_path, resolved)
+
+
 def build_workspace_env(
     workspace_path: Path,
     base_env: Mapping[str, str] | None = None,
@@ -173,7 +196,7 @@ def build_workspace_env(
     venv_path = workspace_path / ".venv"
     venv_bin = venv_path / "bin"
 
-    if venv_bin.exists() and workspace_venv_matches_python(workspace_path):
+    if venv_bin.exists() and workspace_venv_is_usable(workspace_path):
         path_entries = env.get("PATH", "").split(os.pathsep) if env.get("PATH") else []
         filtered_entries = [
             entry

--- a/src/theforge/workspace_env.py
+++ b/src/theforge/workspace_env.py
@@ -3,8 +3,149 @@
 from __future__ import annotations
 
 import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
+
+
+@dataclass(frozen=True)
+class WorkspacePython:
+    """Resolved workspace interpreter and validated pinned version."""
+
+    executable: Path
+    version: str
+    version_parts: tuple[int, ...]
+
+
+_PINNED_VERSION_RE = re.compile(r"^\d+\.\d+(?:\.\d+)?$")
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    if not _PINNED_VERSION_RE.fullmatch(version):
+        raise ValueError(
+            f"Workspace .python-version must pin major.minor or major.minor.patch, got {version!r}"
+        )
+    return tuple(int(part) for part in version.split("."))
+
+
+def _read_workspace_python_pin(workspace_path: Path) -> str:
+    pin_path = workspace_path / ".python-version"
+    try:
+        raw = pin_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ValueError(
+            "Workspace "
+            f"{workspace_path} is missing .python-version; "
+            "gate setup requires a pinned Python interpreter."
+        ) from exc
+
+    for line in raw.splitlines():
+        pin = line.split("#", 1)[0].strip()
+        if pin:
+            return pin
+    raise ValueError(f"Workspace {workspace_path} has an empty .python-version pin.")
+
+
+def _candidate_python_names(pin: str) -> list[str]:
+    version_parts = pin.split(".")
+    candidates = [f"python{pin}"]
+    if len(version_parts) == 3:
+        candidates.append(f"python{'.'.join(version_parts[:2])}")
+    candidates.extend(["python3", "python"])
+    return list(dict.fromkeys(candidates))
+
+
+def _read_python_version(executable: str) -> str:
+    proc = subprocess.run(
+        [
+            executable,
+            "-c",
+            "import sys; "
+            "print(f'{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}')",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        raise ValueError(f"Failed to inspect Python interpreter {executable!r}: {stderr}")
+    return proc.stdout.strip()
+
+
+def resolve_workspace_python(workspace_path: Path) -> WorkspacePython:
+    """Resolve the interpreter pinned by workspace .python-version from PATH."""
+    pin = _read_workspace_python_pin(workspace_path)
+    pinned_parts = _parse_version(pin.removeprefix("python"))
+
+    for candidate_name in _candidate_python_names(pin):
+        candidate = candidate_name if "/" in candidate_name else shutil.which(candidate_name)
+        if not candidate:
+            continue
+        actual_version = _read_python_version(candidate)
+        actual_parts = tuple(int(part) for part in actual_version.split("."))
+        if actual_parts[: len(pinned_parts)] != pinned_parts:
+            continue
+        return WorkspacePython(
+            executable=Path(candidate).resolve(),
+            version=actual_version,
+            version_parts=actual_parts,
+        )
+
+    searched = ", ".join(_candidate_python_names(pin))
+    raise ValueError(
+        "Workspace "
+        f"{workspace_path} pins Python {pin!r}, but no matching interpreter "
+        f"was found on PATH ({searched})."
+    )
+
+
+def read_workspace_venv_config(workspace_path: Path) -> dict[str, str]:
+    """Read workspace .venv/pyvenv.cfg into a normalized key/value mapping."""
+    cfg_path = workspace_path / ".venv" / "pyvenv.cfg"
+    try:
+        raw = cfg_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+
+    parsed: dict[str, str] = {}
+    for line in raw.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        parsed[key.strip().lower()] = value.strip()
+    return parsed
+
+
+def workspace_venv_matches_python(
+    workspace_path: Path, resolved_python: WorkspacePython | None = None
+) -> bool:
+    """Return True when workspace .venv provenance matches the pinned interpreter."""
+    resolved = resolved_python or resolve_workspace_python(workspace_path)
+    cfg = read_workspace_venv_config(workspace_path)
+    if not cfg:
+        return False
+
+    cfg_version = cfg.get("version")
+    try:
+        cfg_version_parts = _parse_version(cfg_version) if cfg_version else ()
+    except ValueError:
+        return False
+    if cfg_version_parts != resolved.version_parts:
+        return False
+
+    cfg_executable = cfg.get("executable")
+    if cfg_executable:
+        return Path(cfg_executable).resolve() == resolved.executable
+
+    cfg_home = cfg.get("home")
+    if cfg_home:
+        return Path(cfg_home).resolve() == resolved.executable.parent
+
+    return False
 
 
 def build_workspace_env(
@@ -13,12 +154,12 @@ def build_workspace_env(
     *,
     extra: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
-    """Build an environment that prefers the workspace virtualenv when present."""
+    """Build an environment that prefers a matching workspace virtualenv when present."""
     env = dict(base_env or os.environ)
     venv_path = workspace_path / ".venv"
     venv_bin = venv_path / "bin"
 
-    if venv_bin.exists():
+    if venv_bin.exists() and workspace_venv_matches_python(workspace_path):
         path_entries = env.get("PATH", "").split(os.pathsep) if env.get("PATH") else []
         filtered_entries = [
             entry

--- a/src/theforge/workspace_env.py
+++ b/src/theforge/workspace_env.py
@@ -103,6 +103,18 @@ def resolve_workspace_python(workspace_path: Path) -> WorkspacePython:
     )
 
 
+def maybe_resolve_workspace_python(workspace_path: Path) -> WorkspacePython | None:
+    """Best-effort workspace interpreter resolution.
+
+    Returns None when the workspace has no usable .python-version pin so callers
+    can conservatively fall back instead of crashing on unpinned worktrees.
+    """
+    try:
+        return resolve_workspace_python(workspace_path)
+    except ValueError:
+        return None
+
+
 def read_workspace_venv_config(workspace_path: Path) -> dict[str, str]:
     """Read workspace .venv/pyvenv.cfg into a normalized key/value mapping."""
     cfg_path = workspace_path / ".venv" / "pyvenv.cfg"
@@ -124,7 +136,9 @@ def workspace_venv_matches_python(
     workspace_path: Path, resolved_python: WorkspacePython | None = None
 ) -> bool:
     """Return True when workspace .venv provenance matches the pinned interpreter."""
-    resolved = resolved_python or resolve_workspace_python(workspace_path)
+    resolved = resolved_python or maybe_resolve_workspace_python(workspace_path)
+    if resolved is None:
+        return False
     cfg = read_workspace_venv_config(workspace_path)
     if not cfg:
         return False

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -11,7 +11,6 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-
 from coord_test_helpers import (
     _PREFLIGHT_RESULT,
     APPROVE_REVIEW,

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -961,7 +961,7 @@ class TestRunSetupSplit:
         assert ok is True
         assert len(calls) == 2
         assert "test -d .venv" in calls[0]
-        assert "python -m venv" in calls[0]
+        assert "python3.12" in calls[0]
         # Second call is just the install command, not the venv creation
         assert "pip install -e ." in calls[1]
         assert "python -m venv" not in calls[1]
@@ -1039,7 +1039,7 @@ class TestRunSetupSplit:
             return (True, "ok")
 
         with (
-            patch("theforge.coordinator.workspace.resolve_workspace_python") as mock_resolve,
+            patch("theforge.coordinator.workspace.maybe_resolve_workspace_python") as mock_resolve,
             patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell),
         ):
             mock_resolve.return_value = SimpleNamespace(executable=Path(spaced_exe))
@@ -1070,7 +1070,7 @@ class TestRunSetupSplit:
             return (True, "ok")
 
         with (
-            patch("theforge.coordinator.workspace.resolve_workspace_python") as mock_resolve,
+            patch("theforge.coordinator.workspace.maybe_resolve_workspace_python") as mock_resolve,
             patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell),
         ):
             mock_resolve.return_value = SimpleNamespace(executable=Path(tricky_exe))
@@ -1087,7 +1087,7 @@ class TestRunSetupSplit:
         from theforge.coordinator.workspace import _resolve_setup_command
 
         spaced_exe = "/home/my user/.pyenv/bin/python3"
-        with patch("theforge.coordinator.workspace.resolve_workspace_python") as mock_resolve:
+        with patch("theforge.coordinator.workspace.maybe_resolve_workspace_python") as mock_resolve:
             mock_resolve.return_value = SimpleNamespace(executable=Path(spaced_exe))
             result = _resolve_setup_command("{forge_python} -m venv .venv", Path("/tmp/workspace"))
 

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from coord_test_helpers import (
@@ -34,6 +35,7 @@ from theforge.config import (
 from theforge.coordinator.engine import run_task
 from theforge.coordinator.state import Phase
 from theforge.coordinator.workspace import _create_workspace, _is_stale_worktree, _remove_worktree
+from theforge.workspace_env import resolve_workspace_python
 
 # ── Shared helper ─────────────────────────────────────────────────
 
@@ -57,6 +59,10 @@ def _make_stale_config(tmp_path: Path, stale_worktree_days: int = 1) -> ForgeCon
         synthesis_profile=None,
         retry=RetryPolicy(),
     )
+
+
+def _write_workspace_pin(workspace_path: Path) -> None:
+    (workspace_path / ".python-version").write_text("3.12.12\n", encoding="utf-8")
 
 
 # ── Stale worktree tests ──────────────────────────────────────────
@@ -924,6 +930,7 @@ class TestRunSetupSplit:
         """When command doesn't match the venv guard pattern, runs it verbatim."""
         from theforge.coordinator.workspace import _run_setup_split
 
+        _write_workspace_pin(tmp_path)
         calls = []
 
         def fake_shell(cmd, cwd, **kw):
@@ -940,6 +947,7 @@ class TestRunSetupSplit:
         """When command matches venv guard, venv creation and install run separately."""
         from theforge.coordinator.workspace import _run_setup_split
 
+        _write_workspace_pin(tmp_path)
         cmd = "test -d .venv || (python -m venv .venv && pip install -e .)"
         calls = []
 
@@ -962,6 +970,7 @@ class TestRunSetupSplit:
         """If venv creation fails, the install command is not run."""
         from theforge.coordinator.workspace import _run_setup_split
 
+        _write_workspace_pin(tmp_path)
         cmd = "test -d .venv || (python -m venv .venv && pip install -e .)"
         calls = []
 
@@ -976,12 +985,11 @@ class TestRunSetupSplit:
         assert out == "venv error"
         assert len(calls) == 1  # install was not called
 
-    def test_forge_python_placeholder_replaced_with_sys_executable(self, tmp_path):
-        """{forge_python} in setup_command is replaced with sys.executable before running."""
-        import sys
-
+    def test_forge_python_placeholder_replaced_with_workspace_pin(self, tmp_path):
+        """{forge_python} in setup_command is replaced with the pinned workspace Python."""
         from theforge.coordinator.workspace import _run_setup_split
 
+        _write_workspace_pin(tmp_path)
         cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e .)"
         calls = []
 
@@ -994,29 +1002,32 @@ class TestRunSetupSplit:
 
         assert ok is True
         assert len(calls) == 2
-        # venv creation uses sys.executable, not the literal placeholder
-        assert sys.executable in calls[0]
+        assert str(resolve_workspace_python(tmp_path).executable) in calls[0]
         assert "{forge_python}" not in calls[0]
 
-    def test_resolve_setup_command_replaces_placeholder(self):
-        """_resolve_setup_command swaps {forge_python} for the absolute interpreter path."""
-        import sys
+    def test_resolve_setup_command_replaces_placeholder(self, tmp_path):
+        """_resolve_setup_command swaps {forge_python} for the pinned interpreter path."""
 
         from theforge.coordinator.workspace import _resolve_setup_command
 
-        result = _resolve_setup_command("test -d .venv || ({forge_python} -m venv .venv)")
-        assert sys.executable in result
+        _write_workspace_pin(tmp_path)
+        result = _resolve_setup_command(
+            "test -d .venv || ({forge_python} -m venv .venv)",
+            tmp_path,
+        )
+        assert str(resolve_workspace_python(tmp_path).executable) in result
         assert "{forge_python}" not in result
 
-    def test_resolve_setup_command_noop_without_placeholder(self):
+    def test_resolve_setup_command_noop_without_placeholder(self, tmp_path):
         """_resolve_setup_command is a no-op when {forge_python} is absent."""
         from theforge.coordinator.workspace import _resolve_setup_command
 
         cmd = "test -d .venv || (python -m venv .venv && pip install -e .)"
-        assert _resolve_setup_command(cmd) == cmd
+        _write_workspace_pin(tmp_path)
+        assert _resolve_setup_command(cmd, tmp_path) == cmd
 
     def test_forge_python_with_spaces_in_path_is_shell_quoted(self, tmp_path):
-        """sys.executable with spaces is shell-quoted; command is still split (not verbatim)."""
+        """Pinned interpreter with spaces is shell-quoted; command is still split."""
         from theforge.coordinator.workspace import _run_setup_split
 
         spaced_exe = "/home/my user/.pyenv/versions/3.12.12/bin/python3.12"
@@ -1028,10 +1039,10 @@ class TestRunSetupSplit:
             return (True, "ok")
 
         with (
-            patch("theforge.coordinator.workspace.sys") as mock_sys,
+            patch("theforge.coordinator.workspace.resolve_workspace_python") as mock_resolve,
             patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell),
         ):
-            mock_sys.executable = spaced_exe
+            mock_resolve.return_value = SimpleNamespace(executable=Path(spaced_exe))
             ok, out = _run_setup_split(cmd, tmp_path)
 
         assert ok is True
@@ -1059,10 +1070,10 @@ class TestRunSetupSplit:
             return (True, "ok")
 
         with (
-            patch("theforge.coordinator.workspace.sys") as mock_sys,
+            patch("theforge.coordinator.workspace.resolve_workspace_python") as mock_resolve,
             patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell),
         ):
-            mock_sys.executable = tricky_exe
+            mock_resolve.return_value = SimpleNamespace(executable=Path(tricky_exe))
             ok, out = _run_setup_split(cmd, tmp_path)
 
         assert ok is True
@@ -1076,9 +1087,9 @@ class TestRunSetupSplit:
         from theforge.coordinator.workspace import _resolve_setup_command
 
         spaced_exe = "/home/my user/.pyenv/bin/python3"
-        with patch("theforge.coordinator.workspace.sys") as mock_sys:
-            mock_sys.executable = spaced_exe
-            result = _resolve_setup_command("{forge_python} -m venv .venv")
+        with patch("theforge.coordinator.workspace.resolve_workspace_python") as mock_resolve:
+            mock_resolve.return_value = SimpleNamespace(executable=Path(spaced_exe))
+            result = _resolve_setup_command("{forge_python} -m venv .venv", Path("/tmp/workspace"))
 
         assert "'/home/my user/.pyenv/bin/python3'" in result
         assert "{forge_python}" not in result

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from coord_test_helpers import (
     _PREFLIGHT_RESULT,
     APPROVE_REVIEW,
@@ -61,8 +63,8 @@ def _make_stale_config(tmp_path: Path, stale_worktree_days: int = 1) -> ForgeCon
     )
 
 
-def _write_workspace_pin(workspace_path: Path) -> None:
-    (workspace_path / ".python-version").write_text("3.12.12\n", encoding="utf-8")
+def _write_workspace_pin(workspace_path: Path, version: str = "3.12.12") -> None:
+    (workspace_path / ".python-version").write_text(f"{version}\n", encoding="utf-8")
 
 
 # ── Stale worktree tests ──────────────────────────────────────────
@@ -1026,6 +1028,15 @@ class TestRunSetupSplit:
         _write_workspace_pin(tmp_path)
         assert _resolve_setup_command(cmd, tmp_path) == cmd
 
+    def test_resolve_setup_command_raises_for_unresolved_declared_pin(self, tmp_path):
+        """A declared but unresolved pin fails closed instead of falling back."""
+        from theforge.coordinator.workspace import _resolve_setup_command
+
+        _write_workspace_pin(tmp_path, "3.99.1")
+
+        with pytest.raises(ValueError, match=r"pins Python '3\.99\.1'"):
+            _resolve_setup_command("{forge_python} -m venv .venv", tmp_path)
+
     def test_forge_python_with_spaces_in_path_is_shell_quoted(self, tmp_path):
         """Pinned interpreter with spaces is shell-quoted; command is still split."""
         from theforge.coordinator.workspace import _run_setup_split
@@ -1081,6 +1092,20 @@ class TestRunSetupSplit:
         assert len(calls) == 2
         # The quoted token must appear in the venv creation command
         assert shlex.quote(tricky_exe) in calls[0]
+
+    def test_declared_unresolved_pin_fails_before_shelling_out(self, tmp_path):
+        """A declared but unresolved pin stops setup instead of using ambient Python."""
+        from theforge.coordinator.workspace import _run_setup_split
+
+        _write_workspace_pin(tmp_path, "3.99.1")
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e .)"
+
+        with patch("theforge.coordinator.workspace._cu._run_shell") as mock_shell:
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is False
+        assert "pins Python '3.99.1'" in out
+        mock_shell.assert_not_called()
 
     def test_resolve_setup_command_quotes_spaced_path(self):
         """_resolve_setup_command wraps a space-containing path in single quotes."""

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -1087,7 +1087,9 @@ class TestRunSetupSplit:
         from theforge.coordinator.workspace import _resolve_setup_command
 
         spaced_exe = "/home/my user/.pyenv/bin/python3"
-        with patch("theforge.coordinator.workspace.maybe_resolve_workspace_python") as mock_resolve:
+        with patch(
+            "theforge.coordinator.workspace.maybe_resolve_workspace_python"
+        ) as mock_resolve:
             mock_resolve.return_value = SimpleNamespace(executable=Path(spaced_exe))
             result = _resolve_setup_command("{forge_python} -m venv .venv", Path("/tmp/workspace"))
 

--- a/tests/test_coord_workspace_venv.py
+++ b/tests/test_coord_workspace_venv.py
@@ -64,6 +64,19 @@ class TestRunSetupSplitVenvBehavior:
         assert calls[0] == "test -d .venv || python -m venv .venv"
         assert calls[1] == "pip install -e '.[all]'"
 
+    def test_legacy_guard_without_pin_logs_ambient_python_fallback(self, tmp_path):
+        cmd = "test -d .venv || (python -m venv .venv && pip install -e '.[all]')"
+
+        with (
+            patch("theforge.coordinator.workspace._cu._run_shell", return_value=(True, "ok")),
+            patch("theforge.coordinator.workspace._cu._log") as mock_log,
+        ):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert any("has no .python-version" in str(call) for call in mock_log.call_args_list)
+        assert any("ambient Python" in str(call) for call in mock_log.call_args_list)
+
     def test_template_guard_reprovisions_stale_venv(self, tmp_path):
         _write_workspace_pin(tmp_path)
         venv_bin = tmp_path / ".venv" / "bin"
@@ -110,6 +123,19 @@ class TestRunSetupSplitVenvBehavior:
         assert len(calls) == 2
         assert calls[0] == f"test -d .venv || {sys.executable} -m venv .venv"
         assert calls[1] == "pip install -e '.[all]'"
+
+    def test_template_guard_without_pin_logs_ambient_python_fallback(self, tmp_path):
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e '.[all]')"
+
+        with (
+            patch("theforge.coordinator.workspace._cu._run_shell", return_value=(True, "ok")),
+            patch("theforge.coordinator.workspace._cu._log") as mock_log,
+        ):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert any("has no .python-version" in str(call) for call in mock_log.call_args_list)
+        assert any("ambient Python" in str(call) for call in mock_log.call_args_list)
 
 
 class TestRunSetupSplitCommandTracking:

--- a/tests/test_coord_workspace_venv.py
+++ b/tests/test_coord_workspace_venv.py
@@ -8,8 +8,13 @@ from coord_test_helpers import _make_config, _make_task
 from theforge.coordinator.workspace import _FORGE_ARTIFACTS, _create_workspace, _run_setup_split
 
 
+def _write_workspace_pin(workspace_path) -> None:
+    (workspace_path / ".python-version").write_text("3.12.12\n", encoding="utf-8")
+
+
 class TestRunSetupSplitVenvBehavior:
     def test_template_guard_always_runs_install_even_when_venv_exists(self, tmp_path):
+        _write_workspace_pin(tmp_path)
         cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e '.[all]')"
         calls = []
 
@@ -26,6 +31,7 @@ class TestRunSetupSplitVenvBehavior:
         assert calls[1] == "pip install -e '.[all]'"
 
     def test_legacy_guard_always_runs_install_even_when_venv_exists(self, tmp_path):
+        _write_workspace_pin(tmp_path)
         cmd = "test -d .venv || (python -m venv .venv && pip install -e '.[all]')"
         calls = []
 
@@ -41,11 +47,43 @@ class TestRunSetupSplitVenvBehavior:
         assert calls[0] == "test -d .venv || python -m venv .venv"
         assert calls[1] == "pip install -e '.[all]'"
 
+    def test_template_guard_reprovisions_stale_venv(self, tmp_path):
+        _write_workspace_pin(tmp_path)
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (tmp_path / ".venv" / "pyvenv.cfg").write_text(
+            "\n".join(
+                [
+                    "home = /Users/example/.pyenv/versions/3.11.9/bin",
+                    "include-system-site-packages = false",
+                    "version = 3.11.9",
+                    "executable = /Users/example/.pyenv/versions/3.11.9/bin/python3.11",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e '.[all]')"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kwargs):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert not (tmp_path / ".venv" / "pyvenv.cfg").exists()
+        assert len(calls) == 2
+        assert "python3.12" in calls[0]
+
 
 class TestRunSetupSplitCommandTracking:
     @patch("theforge.coordinator.workspace._cu._log")
     @patch("theforge.coordinator.workspace._cu._run_shell")
     def test_logs_and_records_changed_setup_command(self, mock_shell, mock_log, tmp_path):
+        _write_workspace_pin(tmp_path)
         forge_dir = tmp_path / ".forge"
         forge_dir.mkdir()
         (forge_dir / "last_setup_command").write_text("pip install -e .", encoding="utf-8")
@@ -61,6 +99,7 @@ class TestRunSetupSplitCommandTracking:
     @patch("theforge.coordinator.workspace._cu._log")
     @patch("theforge.coordinator.workspace._cu._run_shell")
     def test_no_log_when_setup_command_unchanged(self, mock_shell, mock_log, tmp_path):
+        _write_workspace_pin(tmp_path)
         forge_dir = tmp_path / ".forge"
         forge_dir.mkdir()
         cmd = "pip install -e '.[all]'"

--- a/tests/test_coord_workspace_venv.py
+++ b/tests/test_coord_workspace_venv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import replace
 from unittest.mock import patch
 
@@ -32,6 +33,22 @@ class TestRunSetupSplitVenvBehavior:
 
     def test_legacy_guard_always_runs_install_even_when_venv_exists(self, tmp_path):
         _write_workspace_pin(tmp_path)
+        cmd = "test -d .venv || (python -m venv .venv && pip install -e '.[all]')"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kwargs):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert len(calls) == 2
+        assert "python3.12" in calls[0]
+        assert calls[1] == "pip install -e '.[all]'"
+
+    def test_legacy_guard_without_pin_keeps_original_python_token(self, tmp_path):
         cmd = "test -d .venv || (python -m venv .venv && pip install -e '.[all]')"
         calls = []
 
@@ -77,6 +94,22 @@ class TestRunSetupSplitVenvBehavior:
         assert not (tmp_path / ".venv" / "pyvenv.cfg").exists()
         assert len(calls) == 2
         assert "python3.12" in calls[0]
+
+    def test_template_guard_without_pin_falls_back_to_orchestrator_python(self, tmp_path):
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e '.[all]')"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kwargs):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path)
+
+        assert ok is True
+        assert len(calls) == 2
+        assert calls[0] == f"test -d .venv || {sys.executable} -m venv .venv"
+        assert calls[1] == "pip install -e '.[all]'"
 
 
 class TestRunSetupSplitCommandTracking:

--- a/tests/test_run_shell_timeout.py
+++ b/tests/test_run_shell_timeout.py
@@ -71,14 +71,21 @@ class TestRunShellTimeout:
 
 def test_run_shell_defaults_to_workspace_venv_env(tmp_path: Path) -> None:
     venv_bin = tmp_path / ".venv" / "bin"
-    venv_bin.mkdir(parents=True)
+    venv_bin.mkdir(parents=True, exist_ok=True)
+    expected_env = {
+        "PATH": os.pathsep.join([str(venv_bin), "/usr/bin"]),
+        "VIRTUAL_ENV": str(tmp_path / ".venv"),
+    }
     proc = MagicMock()
     proc.communicate.return_value = ("ok\n", "")
     proc.returncode = 0
     proc.stdout = MagicMock()
     proc.stderr = MagicMock()
 
-    with patch("theforge.coordinator.util.subprocess.Popen", return_value=proc) as mock_popen:
+    with (
+        patch("theforge.coordinator.util.build_workspace_env", return_value=expected_env),
+        patch("theforge.coordinator.util.subprocess.Popen", return_value=proc) as mock_popen,
+    ):
         ok, output = coord_util._run_shell("python -V", tmp_path)
 
     env_passed = mock_popen.call_args[1]["env"]

--- a/tests/test_runner_claude.py
+++ b/tests/test_runner_claude.py
@@ -276,12 +276,21 @@ class TestRunAgentClaude:
     def test_uses_workspace_venv_env(self, dev_profile: ModelProfile, tmp_path: Path) -> None:
         """Claude subprocess env prefers the worktree virtualenv."""
         venv_bin = tmp_path / ".venv" / "bin"
-        venv_bin.mkdir(parents=True)
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        expected_env = {
+            "PATH": os.pathsep.join([str(venv_bin), "/usr/bin"]),
+            "VIRTUAL_ENV": str(tmp_path / ".venv"),
+            "API_KEY": "secret",
+        }
         mock_proc = _make_stream_mock([_result_line(result="done")])
 
-        with patch(
-            "theforge.runners.runner_claude.subprocess.Popen", return_value=mock_proc
-        ) as mock_popen:
+        with (
+            patch("theforge.runners.runner_claude.build_workspace_env", return_value=expected_env),
+            patch(
+                "theforge.runners.runner_claude.subprocess.Popen",
+                return_value=mock_proc,
+            ) as mock_popen,
+        ):
             run_agent(
                 prompt="test",
                 profile=dev_profile,

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -12,6 +12,7 @@ import pytest
 
 from theforge.config import ModelProfile
 from theforge.runners.runner_codex import _run_codex
+from theforge.workspace_env import resolve_workspace_python
 
 # Spawn seam patched by the argv-construction tests below.
 _RUN_TARGET = "theforge.runners.runner_codex.process_group.run_in_process_group"
@@ -44,6 +45,25 @@ def _make_subprocess_mock(returncode: int = 0) -> MagicMock:
 def _extract_codex_cmd(mock_run: MagicMock) -> list[str]:
     """Return the cmd list from the process_group.run_in_process_group call."""
     return mock_run.call_args[0][0]
+
+
+def _write_matching_workspace_venv(tmp_path: Path) -> None:
+    (tmp_path / ".python-version").write_text("3.12.12\n", encoding="utf-8")
+    resolved = resolve_workspace_python(tmp_path)
+    cfg = tmp_path / ".venv" / "pyvenv.cfg"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        "\n".join(
+            [
+                f"home = {resolved.executable.parent}",
+                "include-system-site-packages = false",
+                f"version = {resolved.version}",
+                f"executable = {resolved.executable}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 class TestCodexSandboxFlag:
@@ -159,8 +179,9 @@ class TestCodexSandboxFlag:
     def test_uses_workspace_venv_env(self, tmp_path: Path) -> None:
         """Codex subprocess env prefers the worktree virtualenv."""
         profile = _make_profile(sandbox_mode="none")
+        _write_matching_workspace_venv(tmp_path)
         venv_bin = tmp_path / ".venv" / "bin"
-        venv_bin.mkdir(parents=True)
+        venv_bin.mkdir(parents=True, exist_ok=True)
         mock_proc = _make_subprocess_mock()
 
         with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):

--- a/tests/test_runner_gemini.py
+++ b/tests/test_runner_gemini.py
@@ -140,12 +140,21 @@ class TestGeminiSandboxWrapper:
         """Gemini subprocess env prefers the worktree virtualenv."""
         profile = _make_profile(sandbox_mode="none")
         venv_bin = tmp_path / ".venv" / "bin"
-        venv_bin.mkdir(parents=True)
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        expected_env = {
+            "PATH": os.pathsep.join([str(venv_bin), "/usr/bin"]),
+            "VIRTUAL_ENV": str(tmp_path / ".venv"),
+            "GOOGLE_API_KEY": "secret",
+        }
         mock_proc = _make_subprocess_mock()
 
-        with patch(
-            "theforge.runners.runner_gemini.subprocess.run", return_value=mock_proc
-        ) as mock_run:
+        with (
+            patch("theforge.runners.runner_gemini.build_workspace_env", return_value=expected_env),
+            patch(
+                "theforge.runners.runner_gemini.subprocess.run",
+                return_value=mock_proc,
+            ) as mock_run,
+        ):
             _run_gemini(
                 prompt="debug run",
                 profile=profile,

--- a/tests/test_sprint_baseline_gate.py
+++ b/tests/test_sprint_baseline_gate.py
@@ -94,6 +94,7 @@ def _init_repo(tmp_path: Path) -> tuple[ForgeConfig, ResolvedSprint, str]:
     _git(tmp_path, "init", "-b", "main")
     _git(tmp_path, "config", "user.name", "Test User")
     _git(tmp_path, "config", "user.email", "test@example.com")
+    (tmp_path / ".python-version").write_text("3.12.12\n", encoding="utf-8")
     (tmp_path / "baseline.txt").write_text("BASELINE\n", encoding="utf-8")
     base_commit = _commit_all(tmp_path, "base")
     _git(tmp_path, "checkout", "-b", "feat/test")

--- a/tests/test_tool_runtime.py
+++ b/tests/test_tool_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from unittest.mock import patch
 
 from theforge.runners.tool_runtime import (
     MAX_TOOL_OUTPUT_BYTES,
@@ -153,7 +154,11 @@ class TestBash:
 
     def test_bash_uses_workspace_venv_env(self, tmp_path, monkeypatch):
         venv_bin = tmp_path / ".venv" / "bin"
-        venv_bin.mkdir(parents=True)
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        expected_env = {
+            "PATH": os.pathsep.join([str(venv_bin), "/usr/bin"]),
+            "VIRTUAL_ENV": str(tmp_path / ".venv"),
+        }
         captured_env = {}
 
         def fake_run(*args, **kwargs):
@@ -163,8 +168,8 @@ class TestBash:
             )
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-
-        result = _handle_bash(command="python -V", working_dir=tmp_path)
+        with patch("theforge.runners.tool_runtime.build_workspace_env", return_value=expected_env):
+            result = _handle_bash(command="python -V", working_dir=tmp_path)
 
         assert "Exit code: 0" in result
         assert captured_env["PATH"].split(os.pathsep)[0] == str(venv_bin)

--- a/tests/test_workspace_env.py
+++ b/tests/test_workspace_env.py
@@ -4,16 +4,93 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
-from theforge.workspace_env import build_workspace_env
+import pytest
+
+from theforge.workspace_env import (
+    WorkspacePython,
+    build_workspace_env,
+    resolve_workspace_python,
+    workspace_venv_matches_python,
+)
+
+
+def _write_workspace_pin(workspace: Path, version: str = "3.12.12") -> None:
+    (workspace / ".python-version").write_text(f"{version}\n", encoding="utf-8")
+
+
+def _write_pyvenv_cfg(
+    workspace: Path,
+    *,
+    version: str,
+    executable: str,
+    home: str | None = None,
+) -> None:
+    home_value = home or str(Path(executable).parent)
+    cfg = workspace / ".venv" / "pyvenv.cfg"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        "\n".join(
+            [
+                f"home = {home_value}",
+                "include-system-site-packages = false",
+                f"version = {version}",
+                f"executable = {executable}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _resolved_python() -> WorkspacePython:
+    return WorkspacePython(
+        executable=Path("/tmp/toolchain/python3.12").resolve(),
+        version="3.12.12",
+        version_parts=(3, 12, 12),
+    )
+
+
+def test_resolve_workspace_python_uses_pinned_interpreter(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path)
+    expected = "/tmp/toolchain/python3.12"
+
+    with (
+        patch("theforge.workspace_env.shutil.which") as mock_which,
+        patch("theforge.workspace_env._read_python_version") as mock_version,
+    ):
+        mock_which.side_effect = lambda name: expected if name == "python3.12" else None
+        mock_version.return_value = "3.12.12"
+        resolved = resolve_workspace_python(tmp_path)
+
+    assert resolved.version == "3.12.12"
+    assert resolved.executable.name == "python3.12"
+    assert resolved.executable == Path(expected).resolve()
+
+
+def test_resolve_workspace_python_requires_repo_pin(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match=r"missing \.python-version"):
+        resolve_workspace_python(tmp_path)
+
+
+def test_resolve_workspace_python_rejects_non_pinned_value(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path, "3.12-dev")
+
+    with pytest.raises(ValueError, match=r"must pin major\.minor or major\.minor\.patch"):
+        resolve_workspace_python(tmp_path)
 
 
 def test_build_workspace_env_prepends_venv_and_sets_virtual_env(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path)
+    resolved = _resolved_python()
     venv_bin = tmp_path / ".venv" / "bin"
     venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(tmp_path, version=resolved.version, executable=str(resolved.executable))
     base_env = {"PATH": "/usr/bin:/bin", "PYTHONHOME": "/opt/python"}
 
-    env = build_workspace_env(tmp_path, base_env)
+    with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
+        env = build_workspace_env(tmp_path, base_env)
 
     assert env["PATH"].split(os.pathsep)[0] == str(venv_bin)
     assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
@@ -29,8 +106,11 @@ def test_build_workspace_env_without_venv_preserves_base_env(tmp_path: Path) -> 
 
 
 def test_build_workspace_env_strips_pyenv_path_entries(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path)
+    resolved = _resolved_python()
     venv_bin = tmp_path / ".venv" / "bin"
     venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(tmp_path, version=resolved.version, executable=str(resolved.executable))
     base_env = {
         "PATH": os.pathsep.join(
             [
@@ -42,14 +122,18 @@ def test_build_workspace_env_strips_pyenv_path_entries(tmp_path: Path) -> None:
         )
     }
 
-    env = build_workspace_env(tmp_path, base_env)
+    with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
+        env = build_workspace_env(tmp_path, base_env)
 
     assert env["PATH"].split(os.pathsep) == [str(venv_bin), "/usr/local/bin", "/usr/bin"]
 
 
 def test_build_workspace_env_drops_python_leak_variables(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path)
+    resolved = _resolved_python()
     venv_bin = tmp_path / ".venv" / "bin"
     venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(tmp_path, version=resolved.version, executable=str(resolved.executable))
     base_env = {
         "PATH": "/usr/bin",
         "PYTHONHOME": "/opt/python",
@@ -57,7 +141,8 @@ def test_build_workspace_env_drops_python_leak_variables(tmp_path: Path) -> None
         "__PYVENV_LAUNCHER__": "/usr/bin/python",
     }
 
-    env = build_workspace_env(tmp_path, base_env)
+    with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
+        env = build_workspace_env(tmp_path, base_env)
 
     assert "PYTHONHOME" not in env
     assert "PYTHONPATH" not in env
@@ -65,9 +150,70 @@ def test_build_workspace_env_drops_python_leak_variables(tmp_path: Path) -> None
 
 
 def test_build_workspace_env_merges_extra_last(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path)
+    resolved = _resolved_python()
     venv_bin = tmp_path / ".venv" / "bin"
     venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(tmp_path, version=resolved.version, executable=str(resolved.executable))
 
-    env = build_workspace_env(tmp_path, {"PATH": "/usr/bin"}, extra={"VIRTUAL_ENV": "override"})
+    with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
+        env = build_workspace_env(
+            tmp_path,
+            {"PATH": "/usr/bin"},
+            extra={"VIRTUAL_ENV": "override"},
+        )
 
     assert env["VIRTUAL_ENV"] == "override"
+
+
+def test_workspace_venv_matches_python_rejects_stale_interpreter(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path)
+    resolved = _resolved_python()
+    stale_executable = "/tmp/toolchain/python3.11"
+    _write_pyvenv_cfg(tmp_path, version="3.11.9", executable=stale_executable)
+
+    with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
+        assert workspace_venv_matches_python(tmp_path) is False
+
+
+def test_workspace_venv_matches_python_accepts_matching_home_without_executable(
+    tmp_path: Path,
+) -> None:
+    _write_workspace_pin(tmp_path)
+    resolved = _resolved_python()
+    cfg = tmp_path / ".venv" / "pyvenv.cfg"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        "\n".join(
+            [
+                f"home = {resolved.executable.parent}",
+                "include-system-site-packages = false",
+                f"version = {resolved.version}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
+        assert workspace_venv_matches_python(tmp_path) is True
+
+
+def test_build_workspace_env_ignores_stale_venv_on_path(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path)
+    resolved = _resolved_python()
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(
+        tmp_path,
+        version="3.11.9",
+        executable="/Users/example/.pyenv/versions/3.11.9/bin/python3.11",
+    )
+    base_env = {"PATH": "/usr/local/bin:/usr/bin", "PYTHONHOME": "/opt/python"}
+
+    with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
+        env = build_workspace_env(tmp_path, base_env)
+
+    assert env["PATH"] == "/usr/local/bin:/usr/bin"
+    assert "VIRTUAL_ENV" not in env
+    assert env["PYTHONHOME"] == "/opt/python"

--- a/tests/test_workspace_env.py
+++ b/tests/test_workspace_env.py
@@ -11,6 +11,7 @@ import pytest
 from theforge.workspace_env import (
     WorkspacePython,
     build_workspace_env,
+    maybe_resolve_workspace_python,
     resolve_workspace_python,
     workspace_venv_matches_python,
 )
@@ -72,6 +73,10 @@ def test_resolve_workspace_python_uses_pinned_interpreter(tmp_path: Path) -> Non
 def test_resolve_workspace_python_requires_repo_pin(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match=r"missing \.python-version"):
         resolve_workspace_python(tmp_path)
+
+
+def test_maybe_resolve_workspace_python_returns_none_without_pin(tmp_path: Path) -> None:
+    assert maybe_resolve_workspace_python(tmp_path) is None
 
 
 def test_resolve_workspace_python_rejects_non_pinned_value(tmp_path: Path) -> None:
@@ -213,6 +218,23 @@ def test_build_workspace_env_ignores_stale_venv_on_path(tmp_path: Path) -> None:
 
     with patch("theforge.workspace_env.resolve_workspace_python", return_value=resolved):
         env = build_workspace_env(tmp_path, base_env)
+
+    assert env["PATH"] == "/usr/local/bin:/usr/bin"
+    assert "VIRTUAL_ENV" not in env
+    assert env["PYTHONHOME"] == "/opt/python"
+
+
+def test_build_workspace_env_ignores_existing_venv_when_pin_missing(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(
+        tmp_path,
+        version="3.11.9",
+        executable="/Users/example/.pyenv/versions/3.11.9/bin/python3.11",
+    )
+    base_env = {"PATH": "/usr/local/bin:/usr/bin", "PYTHONHOME": "/opt/python"}
+
+    env = build_workspace_env(tmp_path, base_env)
 
     assert env["PATH"] == "/usr/local/bin:/usr/bin"
     assert "VIRTUAL_ENV" not in env

--- a/tests/test_workspace_env.py
+++ b/tests/test_workspace_env.py
@@ -13,6 +13,7 @@ from theforge.workspace_env import (
     build_workspace_env,
     maybe_resolve_workspace_python,
     resolve_workspace_python,
+    workspace_venv_is_usable,
     workspace_venv_matches_python,
 )
 
@@ -77,6 +78,15 @@ def test_resolve_workspace_python_requires_repo_pin(tmp_path: Path) -> None:
 
 def test_maybe_resolve_workspace_python_returns_none_without_pin(tmp_path: Path) -> None:
     assert maybe_resolve_workspace_python(tmp_path) is None
+
+
+def test_maybe_resolve_workspace_python_raises_when_declared_pin_is_unresolved(
+    tmp_path: Path,
+) -> None:
+    _write_workspace_pin(tmp_path, "3.99.1")
+
+    with pytest.raises(ValueError, match=r"pins Python '3\.99\.1'"):
+        maybe_resolve_workspace_python(tmp_path)
 
 
 def test_resolve_workspace_python_rejects_non_pinned_value(tmp_path: Path) -> None:
@@ -236,6 +246,32 @@ def test_build_workspace_env_ignores_existing_venv_when_pin_missing(tmp_path: Pa
 
     env = build_workspace_env(tmp_path, base_env)
 
-    assert env["PATH"] == "/usr/local/bin:/usr/bin"
-    assert "VIRTUAL_ENV" not in env
-    assert env["PYTHONHOME"] == "/opt/python"
+    assert env["PATH"].split(os.pathsep)[0] == str(venv_bin)
+    assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+    assert "PYTHONHOME" not in env
+
+
+def test_workspace_venv_is_usable_without_pin_when_cfg_exists(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(
+        tmp_path,
+        version="3.11.9",
+        executable="/Users/example/.pyenv/versions/3.11.9/bin/python3.11",
+    )
+
+    assert workspace_venv_is_usable(tmp_path) is True
+
+
+def test_build_workspace_env_raises_for_unresolved_declared_pin(tmp_path: Path) -> None:
+    _write_workspace_pin(tmp_path, "3.99.1")
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    _write_pyvenv_cfg(
+        tmp_path,
+        version="3.99.1",
+        executable="/tmp/toolchain/python3.99",
+    )
+
+    with pytest.raises(ValueError, match=r"pins Python '3\.99\.1'"):
+        build_workspace_env(tmp_path, {"PATH": "/usr/local/bin:/usr/bin"})


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior P1 issues are resolved: pinned setup uses the workspace interpreter, unpinned worktrees no longer crash, stale pinned virtualenvs are rejected, and unresolved declared pins fail closed. | [claude-opus] Cycle-4 change (commit 4e119e3) adds an operator-visible warning when a worktree has no .python-version and gate setup falls back to ambient Python, closing the prior operator-handoff gap without altering the resolution logic. All prior P1s remain resolved: missing pin no longer crashes and falls back with a logged warning, declared-but-unresolvable pins fail closed (ValueError → (False, msg), no shell-out), the legacy guard honors the pinned interpreter, and build_workspace_env preserves venv activation for unpinned worktrees via workspace_venv_is_usable. No new regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $8.06
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Patient gate runs under the orchestrator's interpreter, not the project's pinned Python (GitHub Issue #1934)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1934