### PR TITLE
groom_how_shaped_ac matches bare substrings — outcome language like "renamed" flags as HOW-shaped, dropping a runnable story at intake

### DIFF
--- a/src/theforge/intake/groom.py
+++ b/src/theforge/intake/groom.py
@@ -48,7 +48,10 @@ _STRONG_HOW_TOKENS: tuple[str, ...] = (
     "subclass",
 )
 
-_STRONG_HOW_RE = re.compile("|".join(re.escape(tok) for tok in _STRONG_HOW_TOKENS), re.IGNORECASE)
+_STRONG_HOW_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(tok) for tok in _STRONG_HOW_TOKENS) + r")\b",
+    re.IGNORECASE,
+)
 
 # An implementation verb operating on a code construct within the same clause.
 # The verb list excludes "import" (see above); the construct list matches the

--- a/src/theforge/intake/groom.py
+++ b/src/theforge/intake/groom.py
@@ -48,8 +48,18 @@ _STRONG_HOW_TOKENS: tuple[str, ...] = (
     "subclass",
 )
 
+def _bounded_token_pattern(tok: str) -> str:
+    """Anchor a token to whole-word boundaries only where the token itself ends
+    in a word character. A trailing \\b after punctuation (e.g. "implementation:")
+    is a no-op that fails to match, since \\b requires a word/non-word transition
+    and punctuation already provides that separation from following text."""
+    left = r"\b" if tok[0].isalnum() or tok[0] == "_" else ""
+    right = r"\b" if tok[-1].isalnum() or tok[-1] == "_" else ""
+    return left + re.escape(tok) + right
+
+
 _STRONG_HOW_RE = re.compile(
-    r"\b(?:" + "|".join(re.escape(tok) for tok in _STRONG_HOW_TOKENS) + r")\b",
+    "|".join(_bounded_token_pattern(tok) for tok in _STRONG_HOW_TOKENS),
     re.IGNORECASE,
 )
 

--- a/src/theforge/intake/groom.py
+++ b/src/theforge/intake/groom.py
@@ -48,6 +48,7 @@ _STRONG_HOW_TOKENS: tuple[str, ...] = (
     "subclass",
 )
 
+
 def _bounded_token_pattern(tok: str) -> str:
     """Anchor a token to whole-word boundaries only where the token itself ends
     in a word character. A trailing \\b after punctuation (e.g. "implementation:")

--- a/tests/test_intake/test_groom.py
+++ b/tests/test_intake/test_groom.py
@@ -76,6 +76,36 @@ def test_groom_still_flags_implement_using_domain_import_machinery():
     assert findings[0].code == "groom_how_shaped_ac"
 
 
+def test_groom_does_not_flag_renamed_entity_outcome_bullet():
+    """Regression for hdp #141: outcome language about a renamed domain entity
+    is not an instruction to rename a code construct."""
+    body = (
+        "## Acceptance criteria\n\n"
+        "- A renamed or closely related exercise still shows its prior "
+        "performance history on the card\n"
+    )
+    assert groom_check("Title", body, ["bug"]) == []
+
+
+def test_groom_does_not_flag_inflected_strong_tokens_in_outcome_prose():
+    """Participle/plural forms of strong tokens ('refactored', 'subclasses')
+    must not trip the substring match when used as outcome/domain language."""
+    body = (
+        "## Acceptance criteria\n\n"
+        "- The refactored module still passes existing tests\n"
+        "- Sport subclasses like tennis show their own leaderboards\n"
+    )
+    assert groom_check("Title", body, ["enhancement"]) == []
+
+
+def test_groom_still_flags_bare_strong_tokens():
+    """Whole-word strong tokens must still flag on their own."""
+    body = "## Acceptance criteria\n\n- Refactor the pipeline for clarity\n"
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"
+
+
 def test_groom_ignores_yaml_example_block_under_example_heading_in_ac():
     body = (
         "## Acceptance criteria\n\n"

--- a/tests/test_intake/test_groom.py
+++ b/tests/test_intake/test_groom.py
@@ -106,6 +106,16 @@ def test_groom_still_flags_bare_strong_tokens():
     assert findings[0].code == "groom_how_shaped_ac"
 
 
+def test_groom_still_flags_punctuation_ended_strong_token():
+    """Regression: the 'implementation:' strong token must still flag even
+    with no nearby code construct — word-boundary anchoring for other tokens
+    must not accidentally suppress this punctuation-ended one."""
+    body = "## Acceptance criteria\n\n- Implementation: use the BatchEmitter module\n"
+    findings = groom_check("Title", body, ["enhancement"])
+    assert len(findings) == 1
+    assert findings[0].code == "groom_how_shaped_ac"
+
+
 def test_groom_ignores_yaml_example_block_under_example_heading_in_ac():
     body = (
         "## Acceptance criteria\n\n"


### PR DESCRIPTION
## Summary

Boundary anchoring resolves the renamed-outcome false positive and the prior Implementation: regression is covered.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.32
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

groom_how_shaped_ac matches bare substrings — outcome language like "renamed" flags as HOW-shaped, dropping a runnable story at intake (GitHub Issue #1758)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1758