### PR TITLE
Gate nested inside a sprint takes 20x wall clock at idle CPU (30s standalone vs 605s nested)

### DIFF
--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -12,11 +12,12 @@ import secrets
 import signal
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 from theforge.log_level import LogLevel
 from theforge.log_util import _log_line
-from theforge.process_group import is_killable_pgid
+from theforge.process_group import KILL_GRACE_SECONDS, is_killable_pgid
 from theforge.workspace_env import build_workspace_env
 
 # Stable reference captured at import time so test patches that replace the
@@ -176,13 +177,33 @@ def resolve_timeout_with_active(
     return base, False
 
 
+def _wait_bounded(proc: subprocess.Popen[str]) -> None:
+    """Wait for *proc*, but never longer than the teardown grace period.
+
+    An unbounded wait after a best-effort kill is only correct if the kill always
+    lands. It does not: a platform sandbox can refuse signal delivery outright,
+    and the wait then lasts for the command's entire natural lifetime — measured
+    at 300s for a ``sleep 300`` that a 0.1s timeout was meant to cut short
+    (#1959). A timeout that cannot bound its own cleanup is not a timeout.
+    """
+    try:
+        proc.wait(timeout=KILL_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:
-    """Best-effort kill for a spawned shell process group.
+    """Best-effort kill for a spawned shell process group, then a bounded wait.
 
     Only ``killpg`` a pgid that denotes a real group (``> 1``); a bogus ``<= 1``
     value would broadcast SIGKILL across the whole session (see
     ``process_group.is_killable_pgid`` / #1793). Fall back to terminating just the
     direct child when the group id is unknown or unkillable.
+
+    A refused ``killpg`` is logged rather than swallowed. It produces no error
+    anywhere else and surfaces only as a teardown that takes the command's full
+    natural lifetime — indistinguishable in a log from "the work was slow", which
+    is why #1959 took a dedicated probe to find.
     """
     try:
         pgid = os.getpgid(proc.pid)
@@ -191,13 +212,82 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
     if is_killable_pgid(pgid):
         try:
             os.killpg(pgid, signal.SIGKILL)
+        except OSError as exc:
+            _log_line("[forge]", f"  ⚠ group kill of pgid={pgid} refused: {exc}")
+        else:
+            _wait_bounded(proc)
             return
-        except OSError:
-            pass
     try:
         proc.terminate()
     except OSError:
         pass
+    _wait_bounded(proc)
+
+
+# Longest we will wait to collect a timed-out command's partial output. Small:
+# the pipes hold what the command already wrote, so a read that has not returned
+# by now is blocked on a writer that is still alive, not on data in flight.
+_DRAIN_TIMEOUT_SECONDS = 2.0
+
+
+def _drain_partial_output(
+    te: subprocess.TimeoutExpired, proc: subprocess.Popen[str]
+) -> tuple[str, bool]:
+    """Collect what a timed-out command emitted, without blocking on its writer.
+
+    Returns ``(output, drained)``. ``drained`` is False when the read did not
+    finish, which also means the reader thread still owns the streams — see
+    below.
+
+    Reading a pipe blocks until every writer holding the other end closes it.
+    After the group kill above that writer should be gone — but when the kill was
+    refused (a platform sandbox denying signal delivery, #1959) it is not, and
+    this read then waits out the command's entire natural lifetime. Measured: a
+    ``sleep 300`` under a 0.1s timeout returned after 300s, with the wait spent
+    here rather than anywhere the timeout could see it. Reading on a daemon
+    thread bounds it — a timeout that cannot bound its own cleanup is not a
+    timeout.
+
+    The thread closes the streams itself once it finishes. That is not tidiness:
+    a blocked ``read()`` holds the buffer lock, so a ``close()`` from this thread
+    would block on that lock and reintroduce the very wait we just bounded, one
+    frame further out.
+    """
+    chunks: list[str] = []
+    for raw in (te.stdout, te.stderr):
+        if raw:
+            chunks.append(raw if isinstance(raw, str) else raw.decode(errors="replace"))
+
+    tail: list[str] = []
+
+    def _read() -> None:
+        for stream in (proc.stdout, proc.stderr):
+            if stream is None:
+                continue
+            try:
+                data = stream.read()
+                if isinstance(data, bytes):
+                    data = data.decode(errors="replace")
+                if isinstance(data, str):
+                    tail.append(data)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                stream.close()
+            except Exception:  # noqa: BLE001, S110
+                pass
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+    reader.join(_DRAIN_TIMEOUT_SECONDS)
+    drained = not reader.is_alive()
+    if not drained:
+        _log_line(
+            "[forge]",
+            "  ⚠ timed-out command still holds its output pipes open "
+            "(its process group survived the kill); reporting partial output",
+        )
+    return "".join(chunks + tail).strip(), drained
 
 
 def _run_shell_detailed(
@@ -221,6 +311,9 @@ def _run_shell_detailed(
         )
     except Exception as e:
         return False, f"ERROR: {e}", None, False
+    # False only while a drain thread still owns the streams, in which case that
+    # thread closes them and this one must not touch them (see _drain_partial_output).
+    owns_streams = True
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
         output = (stdout + stderr).strip()
@@ -230,36 +323,24 @@ def _run_shell_detailed(
         # such as pytest-xdist workers cannot keep writing indefinitely after
         # the shell itself has timed out.
         _kill_process_group(proc)
-        proc.wait()
-        partial_out = ""
-        try:
-            chunks: list[str] = []
-            for raw in (te.stdout, te.stderr):
-                if raw:
-                    chunks.append(raw if isinstance(raw, str) else raw.decode(errors="replace"))
-            if proc.stdout:
-                chunks.append(proc.stdout.read())
-            if proc.stderr:
-                chunks.append(proc.stderr.read())
-            partial_out = "".join(chunks).strip()
-        except Exception:
-            pass
+        partial_out, drained = _drain_partial_output(te, proc)
+        owns_streams = drained
         header = f"TIMEOUT after {timeout}s: {cmd}"
         if partial_out:
             return False, f"{header}\n{partial_out}", None, True
         return False, header, None, True
     except BaseException:
         _kill_process_group(proc)
-        proc.wait()
         raise
     finally:
-        for stream_name in ("stdout", "stderr"):
-            stream = getattr(proc, stream_name, None)
-            if stream is not None:
-                try:
-                    stream.close()
-                except Exception:
-                    pass
+        if owns_streams:
+            for stream_name in ("stdout", "stderr"):
+                stream = getattr(proc, stream_name, None)
+                if stream is not None:
+                    try:
+                        stream.close()
+                    except Exception:
+                        pass
 
 
 def _run_shell(

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -177,8 +177,10 @@ def resolve_timeout_with_active(
     return base, False
 
 
-def _wait_bounded(proc: subprocess.Popen[str]) -> None:
+def _wait_bounded(proc: subprocess.Popen[str]) -> bool:
     """Wait for *proc*, but never longer than the teardown grace period.
+
+    Returns True if it exited within that window.
 
     An unbounded wait after a best-effort kill is only correct if the kill always
     lands. It does not: a platform sandbox can refuse signal delivery outright,
@@ -189,7 +191,8 @@ def _wait_bounded(proc: subprocess.Popen[str]) -> None:
     try:
         proc.wait(timeout=KILL_GRACE_SECONDS)
     except subprocess.TimeoutExpired:
-        pass
+        return False
+    return True
 
 
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:
@@ -217,10 +220,24 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
         else:
             _wait_bounded(proc)
             return
+    # Each wait is guarded by whether the signal before it was actually
+    # delivered. Waiting on a refused signal is the #1959 mistake in miniature:
+    # it buys nothing and costs the grace period every time.
     try:
         proc.terminate()
     except OSError:
         pass
+    else:
+        if _wait_bounded(proc):
+            return
+    # SIGTERM is catchable, so a shell that ignores it survives — and a survivor
+    # holds the output pipes open, which is the read this function's caller then
+    # blocks on (#1959). Escalate to SIGKILL rather than leave that to chance;
+    # this matches process_group.terminate_process_group's escalation.
+    try:
+        proc.kill()
+    except OSError:
+        return
     _wait_bounded(proc)
 
 

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -34,6 +34,15 @@ from typing import Any
 _PROJECT_ROOT_ENV = "FORGE_PROJECT_ROOT"
 _RUN_ID_ENV = "FORGE_DETACHED_RUN_ID"
 
+# How long a teardown waits for a SIGKILL-ed tree to actually be reaped before
+# escalating, and again before giving up. Short on purpose, and it can afford to
+# be: this is not a grace period for a graceful shutdown — SIGKILL is not
+# catchable, so a process that has received one is already dead barring
+# uninterruptible sleep. It is only the window to observe the exit. Two passes
+# bound the whole teardown at 2x this, which keeps it inside the <5s budget the
+# gate's timeout path is asserted against even when every kill is refused.
+KILL_GRACE_SECONDS = 2.0
+
 
 def _log(msg: str) -> None:
     # Local import keeps this module stdlib-only at import time.
@@ -89,13 +98,12 @@ def run_in_process_group(
         register_agent_group(pgid, sandbox_dir=cwd)
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
-    except subprocess.TimeoutExpired:
-        _killpg_for(proc.pid)
-        proc.wait()
-        raise
     except BaseException:
-        _killpg_for(proc.pid)
-        proc.wait()
+        # Covers TimeoutExpired and every other unwind identically: kill the
+        # group, then wait for it *bounded*. An unbounded wait here blocks for
+        # the child's full natural lifetime whenever the group kill did not land
+        # (#1959), turning an enforced timeout into no timeout at all.
+        terminate_process_group(proc)
         raise
     finally:
         if pgid is not None:
@@ -103,12 +111,63 @@ def run_in_process_group(
     return subprocess.CompletedProcess(proc.args, proc.returncode, out, err)
 
 
-def _killpg_for(pid: int) -> None:
+def _killpg_for(pid: int) -> bool:
     """Best-effort ``SIGKILL`` of the process group led by *pid*."""
     try:
-        kill_agent_group(os.getpgid(pid))
+        return kill_agent_group(os.getpgid(pid))
     except OSError:
-        pass
+        return False
+
+
+def _wait_bounded(proc: subprocess.Popen[Any], timeout: float) -> bool:
+    """True if *proc* exited within *timeout* seconds."""
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return False
+    return True
+
+
+def terminate_process_group(
+    proc: subprocess.Popen[Any], *, grace_seconds: float = KILL_GRACE_SECONDS
+) -> None:
+    """Kill the group led by *proc* and wait — bounded — for the tree to die.
+
+    Group kill is best-effort and can fail to land: the macOS seatbelt profile
+    denies ``killpg`` unless it grants signalling descendants, and a group can
+    also be partly gone already. Every caller that reaches here has already
+    decided the tree must die, so the only question is how long we are willing to
+    wait to observe it. Waiting without a bound is the failure mode this exists
+    to prevent — it converts a denied kill into a block for the child's entire
+    natural lifetime, which is how a nested gate spent ten minutes at idle CPU
+    (#1959). So: kill the group, wait briefly, escalate to the direct child, wait
+    briefly again, and log loudly if even that does not settle it — a survivor is
+    a real leak and the log line is the only trace of it, so it must not be
+    swallowed the way the refused kill itself was.
+    """
+    # Only ever wait on a signal that was actually delivered. A refused kill
+    # tells us up front that nothing will change, so waiting out the grace period
+    # for it buys nothing but the latency this function exists to avoid.
+    if _killpg_for(proc.pid) and _wait_bounded(proc, grace_seconds):
+        return
+    # The group kill did not reach the child. Signalling the direct pid is a
+    # weaker guarantee (grandchildren may survive) but it is the one thing a
+    # sandbox that denies cross-group signalling still permits. The same guard
+    # applies as for a pgid, and for the same reason (#1793): a real spawned
+    # child always has pid > 1, while ``os.kill(0, …)`` signals the caller's own
+    # process group and ``os.kill(1, …)`` targets init.
+    if not is_killable_pgid(proc.pid):
+        return
+    try:
+        os.kill(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except OSError as exc:
+        _log(f"  ⚠ direct kill of pid={proc.pid} refused: {exc}")
+    else:
+        if _wait_bounded(proc, grace_seconds):
+            return
+    _log(f"  ⚠ pid={proc.pid} survived teardown; abandoning it rather than blocking on it")
 
 
 # ── pgid registry sidecars ───────────────────────────────────────────
@@ -182,8 +241,11 @@ def is_killable_pgid(pgid: object) -> bool:
     return isinstance(pgid, int) and pgid > 1
 
 
-def kill_agent_group(pgid: int) -> None:
+def kill_agent_group(pgid: int) -> bool:
     """Best-effort ``SIGKILL`` of an entire agent process group.
+
+    Returns True when the group is gone or the signal was delivered, False when
+    there was no group to kill or the kill was refused.
 
     A pgid ``<= 1`` (or a non-int) is treated as "no group to kill" rather than
     passed to ``killpg``: ``os.killpg(1, …)`` is ``kill(-1, …)``, a broadcast
@@ -191,11 +253,21 @@ def kill_agent_group(pgid: int) -> None:
     workers and the CI runner (issue #1793).
     """
     if not is_killable_pgid(pgid):
-        return
+        return False
     try:
         os.killpg(pgid, signal.SIGKILL)
-    except OSError:
-        pass
+    except ProcessLookupError:
+        # Already gone — that is the state we wanted, not a failure.
+        return True
+    except OSError as exc:
+        # Loud on purpose. A refused group kill produces no error anywhere else;
+        # it surfaces only as a teardown that takes the child's full natural
+        # lifetime, which is indistinguishable from "the work was slow" in a log
+        # (#1959). Under macOS seatbelt this is EPERM when the profile does not
+        # grant signalling descendants.
+        _log(f"  ⚠ group kill of pgid={pgid} refused: {exc}")
+        return False
+    return True
 
 
 # ── Orphan reaper ────────────────────────────────────────────────────

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -96,6 +96,9 @@ def run_in_process_group(
         pgid = None
     if pgid is not None:
         register_agent_group(pgid, sandbox_dir=cwd)
+    # Normal completion implies the group went with the child; only a teardown
+    # that could not reach the group flips this.
+    group_killed = True
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
     except BaseException:
@@ -103,12 +106,29 @@ def run_in_process_group(
         # group, then wait for it *bounded*. An unbounded wait here blocks for
         # the child's full natural lifetime whenever the group kill did not land
         # (#1959), turning an enforced timeout into no timeout at all.
-        terminate_process_group(proc)
+        group_killed = terminate_process_group(proc)
         raise
     finally:
         if pgid is not None:
-            unregister_agent_group(pgid)
+            release_group_record(pgid, group_killed=group_killed)
     return subprocess.CompletedProcess(proc.args, proc.returncode, out, err)
+
+
+def release_group_record(pgid: int, *, group_killed: bool) -> None:
+    """Drop the reaper's sidecar, but only once the group is really gone.
+
+    When teardown could reach only the direct child, that child exits while its
+    grandchildren keep running — and unregistering here would erase the one
+    record that lets `reap_orphan_agents` ever kill them. The sidecar is how a
+    surviving group stays reachable, so it outlives a partial teardown.
+    """
+    if not group_killed and group_is_alive(pgid):
+        _log(
+            f"  ⚠ keeping agent sidecar for pgid={pgid}: teardown reached only the "
+            "direct child and the group is still alive"
+        )
+        return
+    unregister_agent_group(pgid)
 
 
 def _killpg_for(pid: int) -> bool:
@@ -149,10 +169,34 @@ def _wait_bounded(proc: subprocess.Popen[Any], timeout: float) -> bool:
     return True
 
 
+def group_is_alive(pgid: int) -> bool:
+    """True while any process remains in *pgid*, using signal 0 as a probe.
+
+    Errs toward "alive" when the answer cannot be obtained (e.g. a sandbox that
+    refuses even a zero signal). The two mistakes are not symmetric: believing a
+    dead group is alive costs one stale sidecar and a no-op reap, while believing
+    a live group is dead drops the only record that can ever kill it.
+    """
+    if not is_killable_pgid(pgid):
+        return False
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
 def terminate_process_group(
     proc: subprocess.Popen[Any], *, grace_seconds: float = KILL_GRACE_SECONDS
-) -> None:
+) -> bool:
     """Kill the group led by *proc* and wait — bounded — for the tree to die.
+
+    Returns True when the kill reached the whole *group*, False when it reached
+    at most the direct child. That distinction is the caller's business, not a
+    detail: a false return means grandchildren may still be running, so the
+    group's reaper sidecar must be kept rather than dropped.
 
     Group kill is best-effort and can fail to land: the macOS seatbelt profile
     denies ``killpg`` unless it grants signalling descendants, and a group can
@@ -169,14 +213,21 @@ def terminate_process_group(
     # Only ever wait on a signal that was actually delivered. A refused kill
     # tells us up front that nothing will change, so waiting out the grace period
     # for it buys nothing but the latency this function exists to avoid.
-    if _killpg_for(proc.pid) and _wait_bounded(proc, grace_seconds):
-        return
-    # The group kill did not reach the child. Signalling the direct pid is a
-    # weaker guarantee (grandchildren may survive) but it is the one thing a
-    # sandbox that denies cross-group signalling still permits.
-    if _kill_pid(proc.pid) and _wait_bounded(proc, grace_seconds):
-        return
-    _log(f"  ⚠ pid={proc.pid} survived teardown; abandoning it rather than blocking on it")
+    if _killpg_for(proc.pid):
+        # SIGKILL reached the group and is uncatchable, so every member is dead
+        # or dying. The bounded wait only observes our own child being reaped.
+        if not _wait_bounded(proc, grace_seconds):
+            _log(f"  ⚠ pid={proc.pid} not reaped after its group was killed")
+        return True
+    # The group kill did not land. Signalling the direct pid is a strictly weaker
+    # guarantee — it cannot reach grandchildren — but it is the one thing a
+    # sandbox that denies cross-group signalling still permits. Report it as what
+    # it is so the caller keeps tracking whatever survived.
+    if _kill_pid(proc.pid):
+        _wait_bounded(proc, grace_seconds)
+    else:
+        _log(f"  ⚠ pid={proc.pid} survived teardown; abandoning it rather than blocking on it")
+    return False
 
 
 # ── pgid registry sidecars ───────────────────────────────────────────

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -119,6 +119,27 @@ def _killpg_for(pid: int) -> bool:
         return False
 
 
+def _kill_pid(pid: int) -> bool:
+    """Best-effort ``SIGKILL`` of a single process; twin of `_killpg_for`.
+
+    Returns True when the process is gone or the signal was delivered. The same
+    guard applies as for a pgid, and for the same reason (#1793): a real spawned
+    child always has pid > 1, while ``os.kill(0, …)`` signals the caller's own
+    process group and ``os.kill(1, …)`` targets init.
+    """
+    if not is_killable_pgid(pid):
+        return False
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        # Already gone — the state we wanted, not a failure.
+        return True
+    except OSError as exc:
+        _log(f"  ⚠ direct kill of pid={pid} refused: {exc}")
+        return False
+    return True
+
+
 def _wait_bounded(proc: subprocess.Popen[Any], timeout: float) -> bool:
     """True if *proc* exited within *timeout* seconds."""
     try:
@@ -152,21 +173,9 @@ def terminate_process_group(
         return
     # The group kill did not reach the child. Signalling the direct pid is a
     # weaker guarantee (grandchildren may survive) but it is the one thing a
-    # sandbox that denies cross-group signalling still permits. The same guard
-    # applies as for a pgid, and for the same reason (#1793): a real spawned
-    # child always has pid > 1, while ``os.kill(0, …)`` signals the caller's own
-    # process group and ``os.kill(1, …)`` targets init.
-    if not is_killable_pgid(proc.pid):
+    # sandbox that denies cross-group signalling still permits.
+    if _kill_pid(proc.pid) and _wait_bounded(proc, grace_seconds):
         return
-    try:
-        os.kill(proc.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        return
-    except OSError as exc:
-        _log(f"  ⚠ direct kill of pid={proc.pid} refused: {exc}")
-    else:
-        if _wait_bounded(proc, grace_seconds):
-            return
     _log(f"  ⚠ pid={proc.pid} survived teardown; abandoning it rather than blocking on it")
 
 

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -761,13 +761,20 @@ def _run_claude(
             startup_failure=True,
         )
 
+    # Flipped whenever a kill fails to reach the whole group, so the finally
+    # below knows the tree may have outlived us and keeps the reaper's record.
+    group_killed = True
+
     def _kill_group() -> None:
         # Kill the whole process group so node/tool grandchildren die too — a
         # bare proc.kill() reaches only the direct child. Fall back to the
         # direct child if the pgid is unknown or already gone.
+        nonlocal group_killed
         if pgid is not None:
-            process_group.kill_agent_group(pgid)
+            if not process_group.kill_agent_group(pgid):
+                group_killed = False
         else:
+            group_killed = False
             try:
                 proc.kill()
             except OSError:
@@ -869,17 +876,21 @@ def _run_claude(
         try:
             proc.wait(timeout=_EXIT_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
-            process_group.terminate_process_group(proc)
+            if not process_group.terminate_process_group(proc):
+                group_killed = False
     except BaseException:
         # SIGTERM→SystemExit, KeyboardInterrupt, or any post-spawn error: kill the
         # whole group so it cannot outlive this process, then re-raise.
         _kill_group()
         raise
     finally:
-        # The group is dead by now (normal exit, an in-loop _kill_group, or the
-        # except above); drop its sidecar so the reaper doesn't chase a dead pgid.
+        # Normally the group is dead by now (clean exit, an in-loop _kill_group,
+        # or the except above) and dropping the sidecar keeps the reaper from
+        # chasing a dead pgid. But when a kill was refused the tree can outlive
+        # us, and the sidecar is the only thing that can still reach it — so
+        # release the record only once the group is actually gone.
         if pgid is not None:
-            process_group.unregister_agent_group(pgid)
+            process_group.release_group_record(pgid, group_killed=group_killed)
 
     if stuck_monitor.should_terminate:
         partial_output = "".join(lines)

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -124,6 +124,14 @@ def _parse_model_usage(result_json: dict[str, Any]) -> tuple[ModelUsage, ...]:
 _CACHE_READ_RATE_MULT = 0.1
 _CACHE_WRITE_RATE_MULT = 1.25
 
+# How long to let the CLI exit on its own once its stream is finished and stdin
+# is closed, before killing it. Distinct from the post-SIGKILL reap window in
+# process_group: this one is a genuine grace period for an orderly shutdown, so
+# it is generous. What it must not be is unbounded — that is what turns a
+# _kill_group() the platform sandbox refused into a wait for the CLI's whole
+# natural lifetime (#1959).
+_EXIT_GRACE_SECONDS = 10.0
+
 # Models whose kill-path cost could not be reconstructed — warned once each so
 # the log makes cost-unknown runs loud rather than silently zero.
 _COST_UNMEASURED_WARNED: set[str] = set()
@@ -853,7 +861,15 @@ def _run_claude(
             proc.stdin.close()
         except (BrokenPipeError, ValueError, OSError):
             pass
-        proc.wait()
+        # Bounded. The stream is finished (result event, timeout, stop, or stuck
+        # kill) and stdin is closed, so a CLI that has not exited by now is not
+        # going to produce anything more. Waiting without a bound here is how a
+        # _kill_group() the platform sandbox refused turns an enforced timeout
+        # into a block for the CLI's full natural lifetime (#1959).
+        try:
+            proc.wait(timeout=_EXIT_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            process_group.terminate_process_group(proc)
     except BaseException:
         # SIGTERM→SystemExit, KeyboardInterrupt, or any post-spawn error: kill the
         # whole group so it cannot outlive this process, then re-raise.

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -761,20 +761,22 @@ def _run_claude(
             startup_failure=True,
         )
 
-    # Flipped whenever a kill fails to reach the whole group, so the finally
-    # below knows the tree may have outlived us and keeps the reaper's record.
-    group_killed = True
+    # Set whenever a kill fails to reach the whole group, so the finally below
+    # knows the tree may have outlived us and keeps the reaper's record. An Event
+    # rather than a bool because _kill_group runs on the watchdog thread as well
+    # as this one; Event carries its own lock, so the flag needs no reasoning
+    # about which writes are atomic.
+    group_kill_failed = threading.Event()
 
     def _kill_group() -> None:
         # Kill the whole process group so node/tool grandchildren die too — a
         # bare proc.kill() reaches only the direct child. Fall back to the
         # direct child if the pgid is unknown or already gone.
-        nonlocal group_killed
         if pgid is not None:
             if not process_group.kill_agent_group(pgid):
-                group_killed = False
+                group_kill_failed.set()
         else:
-            group_killed = False
+            group_kill_failed.set()
             try:
                 proc.kill()
             except OSError:
@@ -877,7 +879,7 @@ def _run_claude(
             proc.wait(timeout=_EXIT_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
             if not process_group.terminate_process_group(proc):
-                group_killed = False
+                group_kill_failed.set()
     except BaseException:
         # SIGTERM→SystemExit, KeyboardInterrupt, or any post-spawn error: kill the
         # whole group so it cannot outlive this process, then re-raise.
@@ -890,7 +892,7 @@ def _run_claude(
         # us, and the sidecar is the only thing that can still reach it — so
         # release the record only once the group is actually gone.
         if pgid is not None:
-            process_group.release_group_record(pgid, group_killed=group_killed)
+            process_group.release_group_record(pgid, group_killed=not group_kill_failed.is_set())
 
     if stuck_monitor.should_terminate:
         partial_output = "".join(lines)

--- a/src/theforge/runners/sandbox.py
+++ b/src/theforge/runners/sandbox.py
@@ -60,12 +60,28 @@ def _escape_subpath(path: Path) -> str:
     return str(path.resolve()).replace("\\", "\\\\").replace('"', '\\"')
 
 
+def _path_exists(path: Path) -> bool:
+    """``path.exists()`` that treats "forbidden to stat" as existing.
+
+    ``Path.exists()`` swallows only ENOENT-class errors; an EPERM — which is what
+    an outer sandbox returns for a path it has masked — propagates and would
+    abort profile construction entirely. A path we are not allowed to stat is
+    still a real path, so report it as present: that keeps it on the deny list
+    (where dropping it would be a containment hole) and on the read list (where
+    dropping it would silently break the wrapped CLI).
+    """
+    try:
+        return path.exists()
+    except OSError:
+        return True
+
+
 def _unique_existing_paths(paths: list[Path] | tuple[Path, ...]) -> tuple[Path, ...]:
     unique: list[Path] = []
     seen: set[Path] = set()
     for path in paths:
         resolved = path.resolve()
-        if resolved in seen or not resolved.exists():
+        if resolved in seen or not _path_exists(resolved):
             continue
         seen.add(resolved)
         unique.append(resolved)
@@ -90,13 +106,28 @@ def _layout_roots(allowed_root: Path) -> tuple[Path | None, Path | None]:
 def _blocked_worktree_roots(allowed_root: Path) -> tuple[Path, ...]:
     root = allowed_root.resolve()
     _, worktrees_dir = _layout_roots(root)
-    if worktrees_dir is None or not worktrees_dir.exists():
+    if worktrees_dir is None or not _path_exists(worktrees_dir):
         return ()
     blocked: list[Path] = []
-    for child in sorted(worktrees_dir.iterdir()):
-        if not child.is_dir():
+    try:
+        children = sorted(worktrees_dir.iterdir())
+    except OSError:
+        return ()
+    for child in children:
+        try:
+            is_dir = child.is_dir()
+        except OSError:
+            # Cannot stat the sibling — block it anyway. Erring toward the deny
+            # list is the safe direction, and letting the error escape would
+            # abort profile construction entirely, dropping the sandbox for a
+            # path we were trying to lock down.
+            is_dir = True
+        if not is_dir:
             continue
-        resolved = child.resolve()
+        try:
+            resolved = child.resolve()
+        except OSError:
+            resolved = child
         if resolved == root:
             continue
         blocked.append(resolved)
@@ -347,12 +378,25 @@ def _macos_profile(
 {deny_rules}
 )
 """
+    # Signal scope: a sandboxed CLI must be able to tear down the tree it
+    # spawned. `(target self)` alone authorises signalling only the calling
+    # process, so `killpg` aimed at a child's process group — which is how every
+    # forge timeout/teardown path kills npm→node→leaf trees — returns EPERM and
+    # silently no-ops. The subprocess then runs to its natural end instead of to
+    # its timeout, which is what made a 30s suite cost 605s of gate wall clock at
+    # idle CPU (#1959). `children` covers descendants and `same-sandbox` covers
+    # the whole inherited-sandbox subtree, so a group kill reaches grandchildren
+    # too. Neither widens the boundary outward: a process outside this sandbox
+    # instance is still unsignallable, so an agent cannot signal the coordinator,
+    # a sibling story's agent, or anything else on the host.
     return f"""(version 1)
 (deny default)
 (import "system.sb")
 (allow process-exec)
 (allow process-fork)
 (allow signal (target self))
+(allow signal (target children))
+(allow signal (target same-sandbox))
 {service_block}
 (allow file-write*
 {write_rules}

--- a/tests/test_coord_gate_exec.py
+++ b/tests/test_coord_gate_exec.py
@@ -930,3 +930,69 @@ def test_run_shell_keyboard_interrupt_ignores_missing_process_group(tmp_path):
     # Bounded, not bare: an unbounded wait here lasts for the command's whole
     # natural lifetime whenever the kill above did not land (#1959).
     proc.wait.assert_called_once_with(timeout=_cu.KILL_GRACE_SECONDS)
+
+
+class _IgnoresSigterm:
+    """Popen stand-in for a process that catches SIGTERM and keeps running.
+
+    The mocks used by the tests above return from ``wait()`` immediately, so they
+    short-circuit before the SIGKILL escalation and cannot observe it. This one
+    stays alive until ``kill()`` — the only thing SIGTERM-ignoring processes
+    respond to, and the reason the escalation exists (a survivor holds the gate's
+    output pipes open, which is the 300s read in #1959).
+    """
+
+    def __init__(self, pid: int = 4321) -> None:
+        self.pid = pid
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_timeouts: list[float | None] = []
+        self._alive = True
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1  # Delivered, and deliberately ignored.
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self._alive = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_timeouts.append(timeout)
+        if self._alive:
+            raise subprocess.TimeoutExpired(cmd="ignores-sigterm", timeout=timeout or 0)
+        return 0
+
+
+def test_kill_process_group_escalates_to_sigkill_when_sigterm_is_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A process that survives terminate() must be killed, not left running."""
+    # Force the no-usable-pgid path so the fallback branch is what runs. Patching
+    # the module-local name rather than os.getpgid keeps the real os module intact.
+    monkeypatch.setattr(_cu, "is_killable_pgid", lambda _pgid: False)
+    proc = _IgnoresSigterm()
+
+    _cu._kill_process_group(proc)
+
+    assert proc.terminate_calls == 1, "SIGTERM should be tried first"
+    assert proc.kill_calls == 1, (
+        "process survived SIGTERM and was never SIGKILL-ed — it would keep the "
+        "gate's output pipes open for its full natural lifetime (#1959)"
+    )
+    assert proc.wait_timeouts == [_cu.KILL_GRACE_SECONDS, _cu.KILL_GRACE_SECONDS], (
+        f"every wait must be bounded by the grace period; got {proc.wait_timeouts}"
+    )
+
+
+def test_kill_process_group_does_not_escalate_when_sigterm_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The escalation is conditional: a process that exits on SIGTERM is left alone."""
+    monkeypatch.setattr(_cu, "is_killable_pgid", lambda _pgid: False)
+    proc = _IgnoresSigterm()
+    proc.terminate = lambda: setattr(proc, "_alive", False)  # type: ignore[method-assign]
+
+    _cu._kill_process_group(proc)
+
+    assert proc.kill_calls == 0, "SIGKILL sent to a process that had already exited"
+    assert proc.wait_timeouts == [_cu.KILL_GRACE_SECONDS]

--- a/tests/test_coord_gate_exec.py
+++ b/tests/test_coord_gate_exec.py
@@ -844,7 +844,9 @@ def test_run_shell_kills_process_group_on_timeout(tmp_path):
     assert mock_popen.call_args.kwargs["start_new_session"] is True
     mock_getpgid.assert_called_once_with(4321)
     mock_killpg.assert_called_once_with(9876, signal.SIGKILL)
-    proc.wait.assert_called_once_with()
+    # Bounded, not bare: an unbounded wait here lasts for the command's whole
+    # natural lifetime whenever the kill above did not land (#1959).
+    proc.wait.assert_called_once_with(timeout=_cu.KILL_GRACE_SECONDS)
 
 
 def test_run_shell_timeout_ignores_missing_process_group(tmp_path):
@@ -862,7 +864,9 @@ def test_run_shell_timeout_ignores_missing_process_group(tmp_path):
     assert ok is False
     assert output == "TIMEOUT after 1s: pytest -n auto --dist worksteal"
     mock_killpg.assert_not_called()
-    proc.wait.assert_called_once_with()
+    # Bounded, not bare: an unbounded wait here lasts for the command's whole
+    # natural lifetime whenever the kill above did not land (#1959).
+    proc.wait.assert_called_once_with(timeout=_cu.KILL_GRACE_SECONDS)
 
 
 def test_run_shell_timeout_refuses_broadcast_pgid(tmp_path):
@@ -884,7 +888,9 @@ def test_run_shell_timeout_refuses_broadcast_pgid(tmp_path):
     mock_getpgid.assert_called_once_with(4321)
     mock_killpg.assert_not_called()
     proc.terminate.assert_called_once_with()
-    proc.wait.assert_called_once_with()
+    # Bounded, not bare: an unbounded wait here lasts for the command's whole
+    # natural lifetime whenever the kill above did not land (#1959).
+    proc.wait.assert_called_once_with(timeout=_cu.KILL_GRACE_SECONDS)
 
 
 def test_run_shell_kills_process_group_on_keyboard_interrupt(tmp_path):
@@ -902,7 +908,9 @@ def test_run_shell_kills_process_group_on_keyboard_interrupt(tmp_path):
 
     mock_getpgid.assert_called_once_with(4321)
     mock_killpg.assert_called_once_with(9876, signal.SIGKILL)
-    proc.wait.assert_called_once_with()
+    # Bounded, not bare: an unbounded wait here lasts for the command's whole
+    # natural lifetime whenever the kill above did not land (#1959).
+    proc.wait.assert_called_once_with(timeout=_cu.KILL_GRACE_SECONDS)
 
 
 def test_run_shell_keyboard_interrupt_ignores_missing_process_group(tmp_path):
@@ -919,4 +927,6 @@ def test_run_shell_keyboard_interrupt_ignores_missing_process_group(tmp_path):
             _cu._run_shell("pytest -n auto --dist worksteal", tmp_path, timeout=1)
 
     mock_killpg.assert_not_called()
-    proc.wait.assert_called_once_with()
+    # Bounded, not bare: an unbounded wait here lasts for the command's whole
+    # natural lifetime whenever the kill above did not land (#1959).
+    proc.wait.assert_called_once_with(timeout=_cu.KILL_GRACE_SECONDS)

--- a/tests/test_sandbox_group_kill.py
+++ b/tests/test_sandbox_group_kill.py
@@ -1,0 +1,274 @@
+"""Group-kill must survive the platform sandbox wrapper.
+
+Every forge timeout and teardown path kills a *process group* (``killpg``), and
+the agent that issues it runs wrapped in the host sandbox. If the sandbox refuses
+that signal the kill no-ops silently: no exception, no log, just a subprocess
+that runs to its natural end instead of to its timeout. That is invisible in a
+transcript and shows up only as wall clock — a 30s suite costing 605s at idle CPU
+(#1959). These tests pin the grant that makes the kill land, and — where the host
+can actually apply a profile — prove it end to end with real processes.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from theforge.runners.sandbox import workspace_effect_sandbox_command
+
+# Spawns a child in its own session (so it leads its own process group — exactly
+# how the runners spawn agent CLIs), killpg's that group, and reports which of
+# the two signal scopes the sandbox permitted.
+_PROBE = """
+import os, signal, subprocess, sys, time
+child = subprocess.Popen(
+    [sys.executable, "-c", "import time; time.sleep(30)"], start_new_session=True
+)
+time.sleep(0.3)
+try:
+    os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+    print("KILLPG_OK")
+except OSError as exc:
+    print("KILLPG_FAIL", exc)
+    try:
+        os.kill(child.pid, signal.SIGKILL)
+    except OSError:
+        pass
+try:
+    child.wait(timeout=5)
+except subprocess.TimeoutExpired:
+    print("CHILD_SURVIVED")
+"""
+
+
+def _macos_profile_for(root: Path) -> str:
+    """The seatbelt profile text the wrapper would apply for *root*."""
+    with (
+        patch("theforge.runners.sandbox._SYSTEM", "Darwin"),
+        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
+    ):
+        wrapped = workspace_effect_sandbox_command(["true"], root)
+    assert wrapped[:2] == ["sandbox-exec", "-p"]
+    return wrapped[2]
+
+
+def _run_sandboxed(cmd: list[str], root: Path) -> subprocess.CompletedProcess[str]:
+    """Run *cmd* under the real host sandbox, skipping when that is not possible.
+
+    Skips rather than fails on a host that cannot apply a profile at all —
+    notably when this suite is itself running inside a sandbox, where nested
+    ``sandbox_apply`` is refused. That is a property of the harness, not of the
+    code under test.
+    """
+    if platform.system() != "Darwin":
+        pytest.skip("seatbelt signal scope is macOS-specific")
+    if shutil.which("sandbox-exec") is None:
+        pytest.skip("sandbox-exec not available on this host")
+    wrapped = workspace_effect_sandbox_command(cmd, root)
+    if wrapped[0] != "sandbox-exec":
+        pytest.skip("host sandbox unavailable; wrapper returned the command unchanged")
+    result = subprocess.run(wrapped, capture_output=True, text=True, timeout=120, check=False)
+    if "sandbox_apply" in result.stderr:
+        pytest.skip("cannot apply a sandbox profile from inside an existing sandbox")
+    return result
+
+
+class TestSignalScopeGrant:
+    """Profile-text assertions — these run on every host, including Linux CI."""
+
+    def test_profile_grants_signalling_descendants(self, tmp_path: Path) -> None:
+        """``(target self)`` alone denies killpg on a child's group — the #1959 cause."""
+        profile = _macos_profile_for(tmp_path)
+        assert "(allow signal (target children))" in profile
+        assert "(allow signal (target same-sandbox))" in profile
+
+    def test_profile_does_not_grant_signalling_arbitrary_processes(self, tmp_path: Path) -> None:
+        """Widening stays inward: an agent still cannot signal the coordinator.
+
+        ``(target others)`` would let a sandboxed agent signal any process the
+        user owns — the coordinator, a sibling story's agent, the operator's
+        shell. The fix must not reach for it.
+        """
+        profile = _macos_profile_for(tmp_path)
+        assert "(target others)" not in profile
+        assert "(allow signal)" not in profile
+
+    def test_signal_grant_does_not_widen_write_boundary(self, tmp_path: Path) -> None:
+        """The signal rules are capability grants, not filesystem ones."""
+        profile = _macos_profile_for(tmp_path)
+        assert "(deny default)" in profile
+        signal_block = "\n".join(
+            line for line in profile.splitlines() if line.startswith("(allow signal")
+        )
+        assert "subpath" not in signal_block
+
+
+class TestGroupKillUnderRealSandbox:
+    """End-to-end with real processes under a real seatbelt profile."""
+
+    def test_profile_compiles(self, tmp_path: Path) -> None:
+        """An unsupported filter would make sandbox-exec reject every agent run."""
+        result = _run_sandboxed(["/usr/bin/true"], tmp_path)
+        assert result.returncode == 0, f"profile rejected by sandbox-exec: {result.stderr}"
+
+    def test_killpg_reaches_a_child_process_group(self, tmp_path: Path) -> None:
+        """The actual bug: killpg on a spawned group must not return EPERM.
+
+        Runs the real interpreter (resolved through the venv symlink, since the
+        profile grants the toolchain roots rather than an arbitrary venv) under a
+        real profile scoped to a throwaway worktree root, and has it spawn and
+        group-kill a child exactly the way the runners do.
+        """
+        interpreter = os.path.realpath(sys.executable)
+        result = _run_sandboxed([interpreter, "-c", _PROBE], tmp_path)
+        assert "KILLPG_OK" in result.stdout, (
+            "group kill was refused inside the sandbox — a timeout in this state "
+            f"silently no-ops and runs to natural completion.\n{result.stdout}\n{result.stderr}"
+        )
+        assert "CHILD_SURVIVED" not in result.stdout
+
+
+def _spawn_sleeper() -> subprocess.Popen[bytes]:
+    return subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", "import time; time.sleep(60)"], start_new_session=True
+    )
+
+
+def _require_signalling_own_children() -> None:
+    """Skip when the *host* forbids signalling our own subprocesses.
+
+    Some sandboxes (including a nested one wrapping the test runner itself) deny
+    signal delivery outright. Nothing about the code under test can be observed
+    in that state, so skip rather than report a failure that is really a property
+    of the harness.
+    """
+    proc = _spawn_sleeper()
+    try:
+        os.kill(proc.pid, 0)
+        os.killpg(os.getpgid(proc.pid), 0)
+    except OSError as exc:
+        pytest.skip(f"host forbids signalling own children ({exc})")
+    finally:
+        try:
+            proc.kill()
+            proc.wait(timeout=5)
+        except OSError:
+            pass
+
+
+class TestTerminateProcessGroup:
+    """The bounded-teardown backstop, exercised with real subprocesses."""
+
+    @pytest.fixture(autouse=True)
+    def _guard(self) -> None:
+        _require_signalling_own_children()
+
+    def _spawn_sleeper(self) -> subprocess.Popen[bytes]:
+        return _spawn_sleeper()
+
+    def test_kills_the_group_and_returns_promptly(self) -> None:
+        from theforge import process_group
+
+        proc = self._spawn_sleeper()
+        try:
+            process_group.terminate_process_group(proc)
+            assert proc.poll() is not None, "sleeper outlived terminate_process_group"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_bounded_when_the_group_kill_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A refused killpg must cost the grace period, not the child's lifetime.
+
+        Simulates the sandbox denial directly: with the group kill neutered, the
+        old code path blocked in an unbounded ``proc.wait()`` for the full 60s
+        sleep. The escalation to the direct child has to bound that.
+        """
+        from theforge import process_group
+
+        monkeypatch.setattr(process_group, "_killpg_for", lambda _pid: False)
+        proc = self._spawn_sleeper()
+        try:
+            process_group.terminate_process_group(proc, grace_seconds=1.0)
+            assert proc.poll() is not None, (
+                "refused group kill did not escalate to the direct child; "
+                "teardown would block for the child's natural lifetime"
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_survivor_is_logged_not_waited_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When nothing lands, give up loudly instead of blocking forever."""
+        from theforge import process_group
+
+        logged: list[str] = []
+        monkeypatch.setattr(process_group, "_killpg_for", lambda _pid: False)
+        monkeypatch.setattr(process_group, "_log", logged.append)
+        monkeypatch.setattr(process_group.os, "kill", _refuse)
+
+        proc = self._spawn_sleeper()
+        try:
+            process_group.terminate_process_group(proc, grace_seconds=0.2)
+            assert proc.poll() is None, "sleeper should still be alive — every kill was refused"
+            assert any("survived teardown" in msg for msg in logged), logged
+        finally:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def _refuse(*_args: object, **_kwargs: object) -> None:
+    raise PermissionError(os.strerror(1))
+
+
+class TestGateTimeoutBoundsItsOwnCleanup:
+    """The gate's shell timeout must cost the timeout, not the command's lifetime.
+
+    Neuters the group kill outright rather than relying on the host to refuse it,
+    so this pins the behaviour on every platform — including one where signalling
+    works and the regression would otherwise be invisible.
+    """
+
+    def test_timeout_returns_promptly_when_the_kill_does_not_land(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from theforge.coordinator import util
+
+        # Record the process instead of killing it: this is the "kill was
+        # refused" state, and it gives the teardown below a handle to clean up.
+        spared: list[subprocess.Popen[str]] = []
+        monkeypatch.setattr(util, "_kill_process_group", spared.append)
+
+        cmd = (
+            "python3 -c \"import sys, time; sys.stdout.write(chr(10).join(['partial'])); "
+            'sys.stdout.write(chr(10)); sys.stdout.flush(); time.sleep(120)"'
+        )
+        start = time.monotonic()
+        try:
+            ok, output = util._run_shell(cmd, tmp_path, timeout=0.2)
+            elapsed = time.monotonic() - start
+
+            assert ok is False
+            assert output.startswith("TIMEOUT after 0.2s:")
+            assert "partial" in output, "output written before the timeout must survive"
+            assert elapsed < 30, (
+                f"timeout cleanup took {elapsed:.1f}s against a 120s command — the "
+                "drain is waiting out the command's natural lifetime (#1959)"
+            )
+        finally:
+            for proc in spared:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                except OSError:
+                    pass

--- a/tests/test_sandbox_group_kill.py
+++ b/tests/test_sandbox_group_kill.py
@@ -208,27 +208,67 @@ class TestTerminateProcessGroup:
                 proc.kill()
                 proc.wait(timeout=5)
 
+
+class TestSurvivorIsAbandonedNotAwaited:
+    """Deliberately outside TestTerminateProcessGroup's signalling guard.
+
+    Both kill seams are stubbed out, so nothing here needs signal delivery to
+    actually work — which means this runs on every host, including one that
+    denies signalling entirely. That matters: the skip that protects the tests
+    above is what hid a defect in this very test from a local run.
+    """
+
     def test_survivor_is_logged_not_waited_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When nothing lands, give up loudly instead of blocking forever."""
+        """When nothing lands, give up loudly instead of blocking forever.
+
+        Patches the two kill *seams* rather than ``os.kill`` itself. Replacing
+        ``os.kill`` would replace it for everything in the process — including
+        this test's own cleanup below, which would then be refused and leave the
+        teardown blocking on a sleeper it could not kill.
+        """
         from theforge import process_group
 
         logged: list[str] = []
         monkeypatch.setattr(process_group, "_killpg_for", lambda _pid: False)
+        monkeypatch.setattr(process_group, "_kill_pid", lambda _pid: False)
         monkeypatch.setattr(process_group, "_log", logged.append)
-        monkeypatch.setattr(process_group.os, "kill", _refuse)
 
-        proc = self._spawn_sleeper()
+        proc = _spawn_sleeper()
         try:
+            start = time.monotonic()
             process_group.terminate_process_group(proc, grace_seconds=0.2)
+            elapsed = time.monotonic() - start
+
             assert proc.poll() is None, "sleeper should still be alive — every kill was refused"
             assert any("survived teardown" in msg for msg in logged), logged
+            assert elapsed < 5, (
+                f"teardown took {elapsed:.1f}s with both kills refused — it waited on "
+                "signals that were never delivered (#1959)"
+            )
         finally:
-            proc.kill()
-            proc.wait(timeout=5)
+            # Tolerant: on a host that denies signalling, cleanup cannot succeed
+            # and the sleeper exits on its own. Failing here would report the
+            # host's restrictions as a defect in the code under test.
+            try:
+                proc.kill()
+                proc.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
 
 
-def _refuse(*_args: object, **_kwargs: object) -> None:
-    raise PermissionError(os.strerror(1))
+class TestKillPidGuard:
+    """The direct-pid escalation needs the same guard killpg has (#1793)."""
+
+    def test_refuses_targets_that_are_not_a_spawned_child(self) -> None:
+        """``os.kill(0, …)`` signals our own group; ``os.kill(1, …)`` targets init.
+
+        Pure — no process is spawned, so this pins the guard on every host,
+        including ones where signalling is denied outright.
+        """
+        from theforge import process_group
+
+        for bogus in (0, 1, -1, None, "4321"):
+            assert process_group._kill_pid(bogus) is False, f"{bogus!r} must not be signalled"
 
 
 class TestGateTimeoutBoundsItsOwnCleanup:

--- a/tests/test_sandbox_group_kill.py
+++ b/tests/test_sandbox_group_kill.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -312,3 +313,134 @@ class TestGateTimeoutBoundsItsOwnCleanup:
                     proc.wait(timeout=5)
                 except OSError:
                     pass
+
+
+class TestSidecarSurvivesPartialTeardown:
+    """A group that outlives teardown must stay reachable by the orphan reaper.
+
+    When the group kill is refused but the direct child can be signalled, that
+    child dies while its grandchildren keep running. Dropping the pgid sidecar at
+    that moment erases the only record `reap_orphan_agents` could ever use to
+    kill them, so the survivors become permanently untracked — holding their
+    workspace-write sandbox grant with nothing left to reclaim it.
+
+    Both kill seams are stubbed, so none of this needs working signal delivery
+    and it runs on every host.
+    """
+
+    # Child spawns a grandchild, records its pid, then hangs — the npm→node→leaf
+    # shape the whole group-kill mechanism exists for, in miniature.
+    _SPAWNS_GRANDCHILD = (
+        "import subprocess,sys,time,pathlib;"
+        "gc=subprocess.Popen([sys.executable,'-c','import time;time.sleep(20)']);"
+        "pathlib.Path(sys.argv[1]).write_text(str(gc.pid));"
+        "time.sleep(20)"
+    )
+
+    def _sidecars(self, project_root: Path) -> list[Path]:
+        return sorted((project_root / ".forge" / "runs" / "agents").glob("*.json"))
+
+    def _run_until_timeout(
+        self, project_root: Path, pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from theforge import process_group
+
+        monkeypatch.setenv("FORGE_PROJECT_ROOT", str(project_root))
+        with pytest.raises(subprocess.TimeoutExpired):
+            process_group.run_in_process_group(
+                [sys.executable, "-c", self._SPAWNS_GRANDCHILD, str(pidfile)],
+                timeout=1.0,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_sidecar_kept_when_teardown_reached_only_the_direct_child(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from theforge import process_group
+
+        # The exact defect state: killpg refused, direct-pid kill accepted.
+        monkeypatch.setattr(process_group, "_killpg_for", lambda _pid: False)
+        monkeypatch.setattr(process_group, "_kill_pid", lambda _pid: True)
+
+        pidfile = tmp_path / "gc.pid"
+        try:
+            self._run_until_timeout(tmp_path, pidfile, monkeypatch)
+            assert self._sidecars(tmp_path), (
+                "sidecar was dropped while the group may still be alive — the "
+                "surviving tree is now invisible to reap_orphan_agents"
+            )
+        finally:
+            _reap_tree(pidfile)
+
+    def test_sidecar_released_when_the_group_kill_lands(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The other half: a landed group kill must not leak sidecars.
+
+        Without this, "keep the record when unsure" quietly degrades into "never
+        clean up", and the reaper accumulates entries pointing at pgids the OS is
+        free to recycle.
+        """
+        from theforge import process_group
+
+        killed: list[int] = []
+
+        def _kill_group_for_real(pid: int) -> bool:
+            killed.append(pid)
+            try:
+                os.killpg(os.getpgid(pid), signal.SIGKILL)
+            except OSError:
+                pass
+            return True  # report the group as killed, as a granted killpg would
+
+        monkeypatch.setattr(process_group, "_killpg_for", _kill_group_for_real)
+
+        pidfile = tmp_path / "gc.pid"
+        try:
+            self._run_until_timeout(tmp_path, pidfile, monkeypatch)
+            assert killed, "teardown never attempted the group kill"
+            assert not self._sidecars(tmp_path), (
+                "sidecar outlived a successful group kill — records would "
+                "accumulate pointing at pgids the OS can recycle"
+            )
+        finally:
+            _reap_tree(pidfile)
+
+    def test_normal_completion_releases_the_sidecar(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No teardown at all is the common case and must not leak either."""
+        from theforge import process_group
+
+        monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+        result = process_group.run_in_process_group(
+            [sys.executable, "-c", "print('ok')"], capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        assert not self._sidecars(tmp_path)
+
+
+class TestGroupIsAliveGuard:
+    def test_refuses_pgids_that_cannot_denote_a_real_group(self) -> None:
+        """Same #1793 guard: a probe on pgid 0/1 would ask about the wrong group."""
+        from theforge import process_group
+
+        for bogus in (0, 1, -1, None, "4321"):
+            assert process_group.group_is_alive(bogus) is False, f"{bogus!r} is not a group"
+
+
+def _reap_tree(pidfile: Path) -> None:
+    """Best-effort cleanup of a child/grandchild left alive by a stubbed kill.
+
+    Tolerant by design: on a host that denies signalling nothing here can
+    succeed, and the sleepers exit on their own well inside the suite's runtime.
+    """
+    try:
+        gc_pid = int(pidfile.read_text().strip())
+    except (OSError, ValueError):
+        return
+    try:
+        os.kill(gc_pid, signal.SIGKILL)
+    except OSError:
+        pass


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior sidecar-retention P1 is resolved, the latest iteration introduces no blocking regressions, and the targeted timeout/sandbox tests pass. | [google-gemini-3.5-flash] The implementation successfully resolves the macOS seatbelt signal-delivery restriction and bounds all process teardown waits to prevent idle CPU hangs. | [claude-sonnet] Prior P1 (sidecar dropped after a partial teardown that could reach only the direct child) remains fixed; this iteration is a pure test/hygiene pass (SIGKILL-escalation test added and verified non-vacuous, group_killed converted from a plain bool to a threading.Event) with no production logic change in util.py or process_group.py and no regressions found in runner_claude.py's Event conversion.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $35.90
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Gate nested inside a sprint takes 20x wall clock at idle CPU (30s standalone vs 605s nested) (GitHub Issue #1959)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1959