### PR TITLE
Base-branch audit commits can remain local and contaminate later story PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Base-branch audit commits are published, not left local (#1950):** the
-  sprint now pushes its `chore(audit): record sprint run audits` commit to
-  `origin/<base_branch>` and verifies the base branch is no longer ahead;
-  failure raises instead of logging a warning, so the sprint exits nonzero
-  rather than reporting success over divergent state. Workspace preparation
-  also fails closed when the base branch carries commits absent from origin —
-  on the fresh, reused, reattach, and resume paths alike — because a worktree
-  cut from such a checkout makes GitHub attribute that content to whichever
-  story happens to be running. The purely informational `_check_behind_origin`
-  helper is gone; the ahead-only case it could not detect is exactly the one
-  that contaminated PR diffs.
+- **Base-branch audit commits are published, not left local (#1950):** with
+  `workspace.auto_push` on, the sprint now pushes its `chore(audit): record
+  sprint run audits` commit to `origin/<base_branch>` and verifies the base
+  branch is no longer ahead; failure raises instead of logging a warning, so
+  the sprint exits nonzero rather than reporting success over divergent state.
+  Workspace preparation also fails closed when the base branch carries commits
+  absent from origin — on the fresh, reused, reattach, and resume paths alike —
+  because a worktree cut from such a checkout makes GitHub attribute that
+  content to whichever story happens to be running. Both behaviors are scoped
+  to `auto_push`: without it, `on_approve: merge` lands stories into the local
+  base checkout by design, so the branch is expected to run ahead of origin and
+  the sprint warns that the audit records stay local rather than pushing them
+  (a branch push would carry those local merges too). The purely informational
+  `_check_behind_origin` helper is gone; the ahead-only case it could not
+  detect is exactly the one that contaminated PR diffs.
 
 - **Failing-test extraction no longer silently assumes pytest (#1738):** the
   gate-failure retry path extracted failing-test identifiers using pytest's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Base-branch audit commits are published, not left local (#1950):** the
+  sprint now pushes its `chore(audit): record sprint run audits` commit to
+  `origin/<base_branch>` and verifies the base branch is no longer ahead;
+  failure raises instead of logging a warning, so the sprint exits nonzero
+  rather than reporting success over divergent state. Workspace preparation
+  also fails closed when the base branch carries commits absent from origin —
+  on the fresh, reused, reattach, and resume paths alike — because a worktree
+  cut from such a checkout makes GitHub attribute that content to whichever
+  story happens to be running. The purely informational `_check_behind_origin`
+  helper is gone; the ahead-only case it could not detect is exactly the one
+  that contaminated PR diffs.
+
 - **Failing-test extraction no longer silently assumes pytest (#1738):** the
   gate-failure retry path extracted failing-test identifiers using pytest's
   summary grammar only, so a project whose gate speaks another toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,22 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Base-branch audit commits are published, not left local (#1950):** with
-  `workspace.auto_push` on, the sprint now pushes its `chore(audit): record
-  sprint run audits` commit to `origin/<base_branch>` and verifies the base
-  branch is no longer ahead; failure raises instead of logging a warning, so
-  the sprint exits nonzero rather than reporting success over divergent state.
+- **Base-branch audit commits are published, not left local (#1950):** the
+  sprint now pushes its `chore(audit): record sprint run audits` commit to
+  `origin/<base_branch>` and verifies the base branch is no longer ahead;
+  failure raises instead of logging a warning, so the sprint exits nonzero
+  rather than reporting success over divergent state.
   Workspace preparation also fails closed when the base branch carries commits
   absent from origin — on the fresh, reused, reattach, and resume paths alike —
   because a worktree cut from such a checkout makes GitHub attribute that
   content to whichever story happens to be running. Both behaviors stand down
-  in exactly one case: when the run lands stories by merging into the local base
-  checkout (`on_approve: merge`, or the `--auto-merge` override) *and* has
-  `auto_push` off. There the branch is expected to run ahead of origin, so the
-  sprint warns that the audit records stay local rather than pushing them (a
-  branch push would carry those local merges too). Under `on_approve: pr` and
-  `merge-pr` nothing merges locally, so the guard and the push apply regardless
-  of `auto_push`. The purely informational
+  in exactly one case: when the run merges stories into the local base checkout
+  *and* has `auto_push` off. There the branch is expected to run ahead of
+  origin, so the sprint warns that the audit records stay local rather than
+  pushing them (a branch push would carry those local merges too). Under
+  `on_approve: pr` and `merge-pr` nothing merges locally, so the guard and the
+  push apply regardless of `auto_push`. Whether a run merges locally is decided
+  sprint-wide rather than per story, since `--auto-merge` and dependency-parent
+  stories both force a local merge that leaves the base branch ahead when the
+  *next* story's worktree is cut. The purely informational
   `_check_behind_origin` helper is gone; the ahead-only case it could not
   detect is exactly the one that contaminated PR diffs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Workspace preparation also fails closed when the base branch carries commits
   absent from origin — on the fresh, reused, reattach, and resume paths alike —
   because a worktree cut from such a checkout makes GitHub attribute that
-  content to whichever story happens to be running. Both behaviors are scoped
-  to `auto_push`: without it, `on_approve: merge` lands stories into the local
-  base checkout by design, so the branch is expected to run ahead of origin and
-  the sprint warns that the audit records stay local rather than pushing them
-  (a branch push would carry those local merges too). The purely informational
+  content to whichever story happens to be running. Both behaviors stand down
+  in exactly one case: when the run lands stories by merging into the local base
+  checkout (`on_approve: merge`, or the `--auto-merge` override) *and* has
+  `auto_push` off. There the branch is expected to run ahead of origin, so the
+  sprint warns that the audit records stay local rather than pushing them (a
+  branch push would carry those local merges too). Under `on_approve: pr` and
+  `merge-pr` nothing merges locally, so the guard and the push apply regardless
+  of `auto_push`. The purely informational
   `_check_behind_origin` helper is gone; the ahead-only case it could not
   detect is exactly the one that contaminated PR diffs.
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -82,7 +82,7 @@ from .util import (
     _log_phase,
     _log_verbose,
 )
-from .workspace import _check_behind_origin, _create_workspace
+from .workspace import _create_workspace, pull_base_branch
 from .workspace_scrub import _scrub_forge_history
 
 # ── Lazy runner symbols ───────────────────────────────────────────────
@@ -1245,7 +1245,10 @@ def _run_resume_coordinator(
     """
     _ensure_runners()
     if not no_pull:
-        _check_behind_origin(config)
+        # Blocking, unlike the informational behind-origin check this replaced:
+        # the reused worktree is about to be rebased onto the base branch, so an
+        # unpublished commit there would be absorbed into this story's diff.
+        pull_base_branch(config)
     setup = _setup_resume_entry(
         config,
         task,

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -885,7 +885,9 @@ def run_task(
         _log_phase(state.phase, task.slug)
         logger._safe_emit("phase_start", phase="WORKSPACE", iteration=0)
 
-        workspace_path, branch_name, err = _create_workspace(config, task, no_pull=no_pull)
+        workspace_path, branch_name, err = _create_workspace(
+            config, task, no_pull=no_pull, auto_merge=auto_merge
+        )
         if err:
             state.phase = Phase.ESCALATE
             state.error = err
@@ -1248,7 +1250,7 @@ def _run_resume_coordinator(
         # Blocking, unlike the informational behind-origin check this replaced:
         # the reused worktree is about to be rebased onto the base branch, so an
         # unpublished commit there would be absorbed into this story's diff.
-        pull_base_branch(config)
+        pull_base_branch(config, auto_merge=auto_merge)
     setup = _setup_resume_entry(
         config,
         task,

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -82,7 +82,7 @@ from .util import (
     _log_phase,
     _log_verbose,
 )
-from .workspace import _create_workspace, pull_base_branch
+from .workspace import _base_branch_lands_locally, _create_workspace, pull_base_branch
 from .workspace_scrub import _scrub_forge_history
 
 # ── Lazy runner symbols ───────────────────────────────────────────────
@@ -754,6 +754,7 @@ def run_task(
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
+    base_lands_locally: bool | None = None,
 ) -> CoordinatorResult:
     """Execute the full coordinator state machine for a single task.
 
@@ -770,6 +771,12 @@ def run_task(
             finalizing DONE or ESCALATE. When False (default), behave as before.
         auto_merge: When True, merge the feature branch into base_branch after
             a successful APPROVE. Does NOT merge on ESCALATE or ALREADY_DONE.
+        base_lands_locally: Override for the base-branch publication guard —
+            whether *any* story in the surrounding run merges into the local
+            base checkout. Defaults to deriving it from this task's own
+            auto_merge and config, which is right for a standalone run but not
+            inside a sprint, where an earlier story may have merged locally
+            while this one did not.
     """
     _ensure_runners()
     state = _fresh_run_state()
@@ -886,7 +893,14 @@ def run_task(
         logger._safe_emit("phase_start", phase="WORKSPACE", iteration=0)
 
         workspace_path, branch_name, err = _create_workspace(
-            config, task, no_pull=no_pull, auto_merge=auto_merge
+            config,
+            task,
+            no_pull=no_pull,
+            lands_locally=(
+                base_lands_locally
+                if base_lands_locally is not None
+                else _base_branch_lands_locally(config, auto_merge=auto_merge)
+            ),
         )
         if err:
             state.phase = Phase.ESCALATE
@@ -1239,6 +1253,7 @@ def _run_resume_coordinator(
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
+    base_lands_locally: bool | None = None,
 ) -> CoordinatorResult:
     """Shared body for run_from_review and run_from_dev.
 
@@ -1250,7 +1265,14 @@ def _run_resume_coordinator(
         # Blocking, unlike the informational behind-origin check this replaced:
         # the reused worktree is about to be rebased onto the base branch, so an
         # unpublished commit there would be absorbed into this story's diff.
-        pull_base_branch(config, auto_merge=auto_merge)
+        pull_base_branch(
+            config,
+            lands_locally=(
+                base_lands_locally
+                if base_lands_locally is not None
+                else _base_branch_lands_locally(config, auto_merge=auto_merge)
+            ),
+        )
     setup = _setup_resume_entry(
         config,
         task,
@@ -1441,6 +1463,7 @@ def run_from_review(
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
+    base_lands_locally: bool | None = None,
 ) -> CoordinatorResult:
     """Start at REVIEW on an existing worktree, then iterate DEV→VALIDATE→REVIEW as needed.
 
@@ -1475,6 +1498,7 @@ def run_from_review(
         cached_preflight_state=cached_preflight_state,
         defer_landing=defer_landing,
         stop_event=stop_event,
+        base_lands_locally=base_lands_locally,
     )
 
 
@@ -1493,6 +1517,7 @@ def run_from_dev(
     cached_preflight_state: CoordinatorState | None = None,
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
+    base_lands_locally: bool | None = None,
 ) -> CoordinatorResult:
     """Start at DEV on an existing worktree, skipping WORKSPACE and PREFLIGHT.
 
@@ -1524,6 +1549,7 @@ def run_from_dev(
         cached_preflight_state=cached_preflight_state,
         defer_landing=defer_landing,
         stop_event=stop_event,
+        base_lands_locally=base_lands_locally,
     )
 
 

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -590,6 +590,20 @@ def _branch_sync_delta(config: ForgeConfig, base_branch: str) -> tuple[int | Non
     return None, None
 
 
+def _base_branch_tracks_origin(config: ForgeConfig) -> bool:
+    """Whether the project-root base branch is expected to match origin.
+
+    ``workspace.auto_push`` is the operator's declaration on this. With it off,
+    ``_merge_branch`` lands stories by merging into the local base checkout and
+    deliberately does not push (see the ``auto_push`` guard there), so the
+    branch running ahead of origin is the configured steady state — treating it
+    as drift would abort every multi-story sprint after the first landing.
+    With it on — which ``on_approve: merge-pr`` requires at config load — every
+    landing reaches the remote, so local-only commits are unowned state.
+    """
+    return config.workspace.auto_push
+
+
 def _assert_base_branch_published(config: ForgeConfig, base_branch: str) -> None:
     """Fail closed when the local base branch carries commits absent from origin.
 
@@ -599,7 +613,14 @@ def _assert_base_branch_published(config: ForgeConfig, base_branch: str) -> None
     commit-based review is the evaluation mechanism, that is a correctness
     failure, not a cosmetic one. ``git pull --ff-only`` succeeds trivially in
     this state, so the delta has to be checked explicitly.
+
+    Only applies when the base branch is supposed to track origin — see
+    ``_base_branch_tracks_origin``. Under a local-merge workflow with pushing
+    disabled, an ahead-only base branch is the configured steady state, and
+    aborting on it would break every multi-story sprint.
     """
+    if not _base_branch_tracks_origin(config):
+        return
     ahead, _behind = _branch_sync_delta(config, base_branch)
     if ahead is None or ahead <= 0:
         return

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -590,21 +590,46 @@ def _branch_sync_delta(config: ForgeConfig, base_branch: str) -> tuple[int | Non
     return None, None
 
 
-def _base_branch_tracks_origin(config: ForgeConfig) -> bool:
+def _base_branch_lands_locally(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
+    """Whether this run merges landed stories into the project-root base checkout.
+
+    Mirrors the effective-``on_approve`` resolution in ``completion.py``: the
+    ``--auto-merge`` CLI flag forces ``"merge"`` regardless of configuration,
+    so the config value alone cannot answer this — that runtime override is why
+    keying the publication rule off ``auto_push`` misclassified workflows.
+    """
+    return auto_merge or config.workspace.on_approve == "merge"
+
+
+def _base_branch_tracks_origin(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
     """Whether the project-root base branch is expected to match origin.
 
-    ``workspace.auto_push`` is the operator's declaration on this. With it off,
-    ``_merge_branch`` lands stories by merging into the local base checkout and
-    deliberately does not push (see the ``auto_push`` guard there), so the
-    branch running ahead of origin is the configured steady state — treating it
-    as drift would abort every multi-story sprint after the first landing.
-    With it on — which ``on_approve: merge-pr`` requires at config load — every
-    landing reaches the remote, so local-only commits are unowned state.
+    Two independent questions decide this, and conflating them is what made the
+    earlier ``auto_push``-only rule wrong in both directions:
+
+    1. Does anything land on the local base branch at all? Only the ``"merge"``
+       landing path (``_merge_branch``) does. Under ``on_approve: pr`` and
+       ``merge-pr`` the forge never merges into the local checkout, so any
+       commit the base branch carries beyond origin is unowned drift — and
+       those are precisely the workflows that publish story branches, where a
+       contaminated base makes GitHub attribute the extra content to whichever
+       story is running.
+    2. If stories do land locally, are those merges published? ``_merge_branch``
+       pushes only when ``workspace.auto_push`` is set. Without it, the branch
+       running ahead of origin is the configured steady state, and treating it
+       as drift would abort every multi-story sprint after the first landing.
+
+    So the base branch is expected to track origin unless this run lands stories
+    locally *and* has opted out of pushing them.
     """
+    if not _base_branch_lands_locally(config, auto_merge=auto_merge):
+        return True
     return config.workspace.auto_push
 
 
-def _assert_base_branch_published(config: ForgeConfig, base_branch: str) -> None:
+def _assert_base_branch_published(
+    config: ForgeConfig, base_branch: str, *, auto_merge: bool = False
+) -> None:
     """Fail closed when the local base branch carries commits absent from origin.
 
     A worktree cut from an ahead-only base branch inherits those commits, and
@@ -619,7 +644,7 @@ def _assert_base_branch_published(config: ForgeConfig, base_branch: str) -> None
     disabled, an ahead-only base branch is the configured steady state, and
     aborting on it would break every multi-story sprint.
     """
-    if not _base_branch_tracks_origin(config):
+    if not _base_branch_tracks_origin(config, auto_merge=auto_merge):
         return
     ahead, _behind = _branch_sync_delta(config, base_branch)
     if ahead is None or ahead <= 0:
@@ -687,11 +712,15 @@ def _recover_base_branch_sync(
     )
 
 
-def pull_base_branch(config: ForgeConfig) -> bool:
+def pull_base_branch(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
     """Pull the base branch once before parallel workspace creation.
     Uses --ff-only (checked out) or fetch origin base:base (not checked out).
     Re-execs if src/theforge source changes. Raises RuntimeError if base
-    branch diverged from origin or origin is unreachable.
+    branch diverged from origin, origin is unreachable, or the base branch
+    carries unpublished commits in a workflow where it must track origin.
+
+    ``auto_merge`` is the run's CLI override, needed because it forces the
+    local-merge landing path independently of ``workspace.on_approve``.
     """
     base_branch = config.workspace.base_branch
 
@@ -720,7 +749,7 @@ def pull_base_branch(config: ForgeConfig) -> bool:
         _cu._log(f"✓ WORKSPACE  pulled latest {base_branch}")
         # A successful ff-only pull says nothing about unpublished local commits:
         # ahead-only is exactly the state that pull reports as clean.
-        _assert_base_branch_published(config, base_branch)
+        _assert_base_branch_published(config, base_branch, auto_merge=auto_merge)
     else:
         _cu._log(f"⚠ WORKSPACE  pull failed (non-ff / offline): {pull_out.strip()}")
         if ahead is not None and behind is not None and ahead > 0 and behind > 0:
@@ -753,7 +782,7 @@ def pull_base_branch(config: ForgeConfig) -> bool:
     return True
 
 
-def _sync_base_before_worktree_use(config: ForgeConfig) -> str | None:
+def _sync_base_before_worktree_use(config: ForgeConfig, *, auto_merge: bool = False) -> str | None:
     """Blocking base-branch sync shared by fresh, reused, and reattach paths.
 
     Returns an error message instead of raising so ``_create_workspace`` can
@@ -762,7 +791,7 @@ def _sync_base_before_worktree_use(config: ForgeConfig) -> str | None:
     blocked and so let worktrees be advanced from an unpublished base branch.
     """
     try:
-        pull_base_branch(config)
+        pull_base_branch(config, auto_merge=auto_merge)
     except RuntimeError as exc:
         return str(exc)
     return None
@@ -781,9 +810,14 @@ def _rebase_reused_worktree(workspace_path: Path, base_branch: str) -> str | Non
 
 
 def _create_workspace(
-    config: ForgeConfig, task: TaskStory, *, no_pull: bool = False
+    config: ForgeConfig, task: TaskStory, *, no_pull: bool = False, auto_merge: bool = False
 ) -> tuple[Path | None, str | None, str | None]:
-    """Create an isolated workspace. Returns (path, branch, error)."""
+    """Create an isolated workspace. Returns (path, branch, error).
+
+    ``auto_merge`` is forwarded to the base-branch publication guard: it forces
+    the local-merge landing path, under which the base branch is expected to
+    run ahead of origin.
+    """
     slug = task.slug
     cmd = config.workspace.create_command.format(
         slug=slug,
@@ -802,7 +836,11 @@ def _create_workspace(
             _remove_worktree(workspace_path, branch_name, config.project_root, info_line)
         else:
             _cu._log(f"↻ WORKSPACE  reusing existing worktree: {workspace_path}")
-            if not no_pull and (sync_err := _sync_base_before_worktree_use(config)) is not None:
+            if (
+                not no_pull
+                and (sync_err := _sync_base_before_worktree_use(config, auto_merge=auto_merge))
+                is not None
+            ):
                 return None, None, sync_err
             rebase_err = _rebase_reused_worktree(workspace_path, config.workspace.base_branch)
             if rebase_err is not None:
@@ -816,7 +854,10 @@ def _create_workspace(
             _propagate_claude_memory(config.project_root, workspace_path)
             return workspace_path, branch_name, None
 
-    if not no_pull and (sync_err := _sync_base_before_worktree_use(config)) is not None:
+    if (
+        not no_pull
+        and (sync_err := _sync_base_before_worktree_use(config, auto_merge=auto_merge)) is not None
+    ):
         return None, None, sync_err
 
     _cu._log(f"Creating workspace: {cmd}")
@@ -836,7 +877,7 @@ def _create_workspace(
             if existing_wt.exists():
                 _cu._log(f"↻ WORKSPACE  reusing existing worktree (registered): {existing_wt}")
                 if not no_pull:
-                    sync_err = _sync_base_before_worktree_use(config)
+                    sync_err = _sync_base_before_worktree_use(config, auto_merge=auto_merge)
                     if sync_err is not None:
                         return None, None, sync_err
                 rebase_err = _rebase_reused_worktree(existing_wt, config.workspace.base_branch)
@@ -863,7 +904,11 @@ def _create_workspace(
 
         if commits_ahead:
             _cu._log(f"↻ WORKSPACE  branch has commits, reattaching worktree: {branch_name}")
-            if not no_pull and (sync_err := _sync_base_before_worktree_use(config)) is not None:
+            if (
+                not no_pull
+                and (sync_err := _sync_base_before_worktree_use(config, auto_merge=auto_merge))
+                is not None
+            ):
                 return None, None, sync_err
             ok_add, add_out = _cu._run_shell(
                 f"git worktree add {workspace_path} {branch_name}", config.project_root

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -544,25 +544,6 @@ def sweep_orphan_worktrees(project_root: Path, config: ForgeConfig) -> None:
         _remove_worktree(candidate, branch_name, project_root, "sweep: merged or branch gone")
 
 
-def _check_behind_origin(config: ForgeConfig) -> None:
-    """Log an informational note if base_branch is behind origin.
-    Silently skips if rev-list fails. Purely informational — never blocks.
-    """
-    base_branch = config.workspace.base_branch
-    ok, out = _cu._run_shell(
-        f"git rev-list --count {base_branch}..origin/{base_branch}",
-        config.project_root,
-    )
-    if not ok:
-        return
-    try:
-        count = int(out.strip())
-    except ValueError:
-        return
-    if count > 0:
-        _cu._log(f"ℹ WORKSPACE  {base_branch} is {count} commit(s) behind origin/{base_branch}")
-
-
 _FORGE_ARTIFACTS = (".forge/handoff.yaml", ".forge/trajectory.yaml", ".forge/last_setup_command")
 
 
@@ -607,6 +588,26 @@ def _branch_sync_delta(config: ForgeConfig, base_branch: str) -> tuple[int | Non
     except Exception:
         pass
     return None, None
+
+
+def _assert_base_branch_published(config: ForgeConfig, base_branch: str) -> None:
+    """Fail closed when the local base branch carries commits absent from origin.
+
+    A worktree cut from an ahead-only base branch inherits those commits, and
+    GitHub diffs the resulting PR against origin/<base> — so the unpublished
+    content is attributed to whichever story happens to be running. Since
+    commit-based review is the evaluation mechanism, that is a correctness
+    failure, not a cosmetic one. ``git pull --ff-only`` succeeds trivially in
+    this state, so the delta has to be checked explicitly.
+    """
+    ahead, _behind = _branch_sync_delta(config, base_branch)
+    if ahead is None or ahead <= 0:
+        return
+    raise RuntimeError(
+        f"WORKSPACE abort: base branch '{base_branch}' has {ahead} local commit(s) not on "
+        f"origin/{base_branch}. Worktrees cut from it would attribute that content to the "
+        f"running story. Run: git push origin {base_branch}"
+    )
 
 
 def _recover_base_branch_sync(
@@ -696,6 +697,9 @@ def pull_base_branch(config: ForgeConfig) -> bool:
             )
     if ok_pull:
         _cu._log(f"✓ WORKSPACE  pulled latest {base_branch}")
+        # A successful ff-only pull says nothing about unpublished local commits:
+        # ahead-only is exactly the state that pull reports as clean.
+        _assert_base_branch_published(config, base_branch)
     else:
         _cu._log(f"⚠ WORKSPACE  pull failed (non-ff / offline): {pull_out.strip()}")
         if ahead is not None and behind is not None and ahead > 0 and behind > 0:
@@ -726,6 +730,21 @@ def pull_base_branch(config: ForgeConfig) -> bool:
             )
 
     return True
+
+
+def _sync_base_before_worktree_use(config: ForgeConfig) -> str | None:
+    """Blocking base-branch sync shared by fresh, reused, and reattach paths.
+
+    Returns an error message instead of raising so ``_create_workspace`` can
+    surface it through its (path, branch, error) contract. Replaces the old
+    informational ``_check_behind_origin`` call on the reuse paths, which never
+    blocked and so let worktrees be advanced from an unpublished base branch.
+    """
+    try:
+        pull_base_branch(config)
+    except RuntimeError as exc:
+        return str(exc)
+    return None
 
 
 def _rebase_reused_worktree(workspace_path: Path, base_branch: str) -> str | None:
@@ -762,8 +781,8 @@ def _create_workspace(
             _remove_worktree(workspace_path, branch_name, config.project_root, info_line)
         else:
             _cu._log(f"↻ WORKSPACE  reusing existing worktree: {workspace_path}")
-            if not no_pull:
-                _check_behind_origin(config)
+            if not no_pull and (sync_err := _sync_base_before_worktree_use(config)) is not None:
+                return None, None, sync_err
             rebase_err = _rebase_reused_worktree(workspace_path, config.workspace.base_branch)
             if rebase_err is not None:
                 return None, None, rebase_err
@@ -776,11 +795,8 @@ def _create_workspace(
             _propagate_claude_memory(config.project_root, workspace_path)
             return workspace_path, branch_name, None
 
-    if not no_pull:
-        try:
-            pull_base_branch(config)
-        except RuntimeError as exc:
-            return None, None, str(exc)
+    if not no_pull and (sync_err := _sync_base_before_worktree_use(config)) is not None:
+        return None, None, sync_err
 
     _cu._log(f"Creating workspace: {cmd}")
     ok, output = _cu._run_shell(cmd, config.project_root)
@@ -799,7 +815,9 @@ def _create_workspace(
             if existing_wt.exists():
                 _cu._log(f"↻ WORKSPACE  reusing existing worktree (registered): {existing_wt}")
                 if not no_pull:
-                    _check_behind_origin(config)
+                    sync_err = _sync_base_before_worktree_use(config)
+                    if sync_err is not None:
+                        return None, None, sync_err
                 rebase_err = _rebase_reused_worktree(existing_wt, config.workspace.base_branch)
                 if rebase_err is not None:
                     return None, None, rebase_err
@@ -824,8 +842,8 @@ def _create_workspace(
 
         if commits_ahead:
             _cu._log(f"↻ WORKSPACE  branch has commits, reattaching worktree: {branch_name}")
-            if not no_pull:
-                _check_behind_origin(config)
+            if not no_pull and (sync_err := _sync_base_before_worktree_use(config)) is not None:
+                return None, None, sync_err
             ok_add, add_out = _cu._run_shell(
                 f"git worktree add {workspace_path} {branch_name}", config.project_root
             )

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -591,17 +591,22 @@ def _branch_sync_delta(config: ForgeConfig, base_branch: str) -> tuple[int | Non
 
 
 def _base_branch_lands_locally(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
-    """Whether this run merges landed stories into the project-root base checkout.
+    """Whether a run merges landed stories into the project-root base checkout.
 
     Mirrors the effective-``on_approve`` resolution in ``completion.py``: the
     ``--auto-merge`` CLI flag forces ``"merge"`` regardless of configuration,
     so the config value alone cannot answer this — that runtime override is why
     keying the publication rule off ``auto_push`` misclassified workflows.
+
+    This is the *default* derivation for a single run. Callers that know more —
+    notably the sprint runner, which also merges dependency-parent stories
+    locally whether or not ``--auto-merge`` was passed — compute the answer
+    themselves and pass it as ``lands_locally``.
     """
     return auto_merge or config.workspace.on_approve == "merge"
 
 
-def _base_branch_tracks_origin(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
+def _base_branch_tracks_origin(config: ForgeConfig, *, lands_locally: bool) -> bool:
     """Whether the project-root base branch is expected to match origin.
 
     Two independent questions decide this, and conflating them is what made the
@@ -619,16 +624,18 @@ def _base_branch_tracks_origin(config: ForgeConfig, *, auto_merge: bool = False)
        running ahead of origin is the configured steady state, and treating it
        as drift would abort every multi-story sprint after the first landing.
 
-    So the base branch is expected to track origin unless this run lands stories
-    locally *and* has opted out of pushing them.
+    So the base branch is expected to track origin unless the run lands stories
+    locally *and* has opted out of pushing them. ``lands_locally`` answers (1)
+    and is supplied by the caller — see ``_base_branch_lands_locally`` for the
+    default derivation and why the sprint runner overrides it.
     """
-    if not _base_branch_lands_locally(config, auto_merge=auto_merge):
+    if not lands_locally:
         return True
     return config.workspace.auto_push
 
 
 def _assert_base_branch_published(
-    config: ForgeConfig, base_branch: str, *, auto_merge: bool = False
+    config: ForgeConfig, base_branch: str, *, lands_locally: bool
 ) -> None:
     """Fail closed when the local base branch carries commits absent from origin.
 
@@ -644,7 +651,7 @@ def _assert_base_branch_published(
     disabled, an ahead-only base branch is the configured steady state, and
     aborting on it would break every multi-story sprint.
     """
-    if not _base_branch_tracks_origin(config, auto_merge=auto_merge):
+    if not _base_branch_tracks_origin(config, lands_locally=lands_locally):
         return
     ahead, _behind = _branch_sync_delta(config, base_branch)
     if ahead is None or ahead <= 0:
@@ -712,17 +719,22 @@ def _recover_base_branch_sync(
     )
 
 
-def pull_base_branch(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
+def pull_base_branch(config: ForgeConfig, *, lands_locally: bool | None = None) -> bool:
     """Pull the base branch once before parallel workspace creation.
     Uses --ff-only (checked out) or fetch origin base:base (not checked out).
     Re-execs if src/theforge source changes. Raises RuntimeError if base
     branch diverged from origin, origin is unreachable, or the base branch
     carries unpublished commits in a workflow where it must track origin.
 
-    ``auto_merge`` is the run's CLI override, needed because it forces the
-    local-merge landing path independently of ``workspace.on_approve``.
+    ``lands_locally`` says whether this run merges stories into the local base
+    checkout, which decides whether an ahead-only branch is drift or the
+    configured steady state. ``None`` derives it from config alone — correct
+    for direct/single-story callers, but the sprint runner passes its own
+    DAG-aware value.
     """
     base_branch = config.workspace.base_branch
+    if lands_locally is None:
+        lands_locally = _base_branch_lands_locally(config)
 
     ok_before, tree_before = _cu._run_shell("git rev-parse HEAD:src/theforge", config.project_root)
     if not ok_before:
@@ -749,7 +761,7 @@ def pull_base_branch(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
         _cu._log(f"✓ WORKSPACE  pulled latest {base_branch}")
         # A successful ff-only pull says nothing about unpublished local commits:
         # ahead-only is exactly the state that pull reports as clean.
-        _assert_base_branch_published(config, base_branch, auto_merge=auto_merge)
+        _assert_base_branch_published(config, base_branch, lands_locally=lands_locally)
     else:
         _cu._log(f"⚠ WORKSPACE  pull failed (non-ff / offline): {pull_out.strip()}")
         if ahead is not None and behind is not None and ahead > 0 and behind > 0:
@@ -782,7 +794,9 @@ def pull_base_branch(config: ForgeConfig, *, auto_merge: bool = False) -> bool:
     return True
 
 
-def _sync_base_before_worktree_use(config: ForgeConfig, *, auto_merge: bool = False) -> str | None:
+def _sync_base_before_worktree_use(
+    config: ForgeConfig, *, lands_locally: bool | None = None
+) -> str | None:
     """Blocking base-branch sync shared by fresh, reused, and reattach paths.
 
     Returns an error message instead of raising so ``_create_workspace`` can
@@ -791,7 +805,7 @@ def _sync_base_before_worktree_use(config: ForgeConfig, *, auto_merge: bool = Fa
     blocked and so let worktrees be advanced from an unpublished base branch.
     """
     try:
-        pull_base_branch(config, auto_merge=auto_merge)
+        pull_base_branch(config, lands_locally=lands_locally)
     except RuntimeError as exc:
         return str(exc)
     return None
@@ -810,13 +824,17 @@ def _rebase_reused_worktree(workspace_path: Path, base_branch: str) -> str | Non
 
 
 def _create_workspace(
-    config: ForgeConfig, task: TaskStory, *, no_pull: bool = False, auto_merge: bool = False
+    config: ForgeConfig,
+    task: TaskStory,
+    *,
+    no_pull: bool = False,
+    lands_locally: bool | None = None,
 ) -> tuple[Path | None, str | None, str | None]:
     """Create an isolated workspace. Returns (path, branch, error).
 
-    ``auto_merge`` is forwarded to the base-branch publication guard: it forces
-    the local-merge landing path, under which the base branch is expected to
-    run ahead of origin.
+    ``lands_locally`` is forwarded to the base-branch publication guard: when
+    this run merges stories into the local base checkout, the branch is
+    expected to run ahead of origin and the guard stands down.
     """
     slug = task.slug
     cmd = config.workspace.create_command.format(
@@ -836,12 +854,10 @@ def _create_workspace(
             _remove_worktree(workspace_path, branch_name, config.project_root, info_line)
         else:
             _cu._log(f"↻ WORKSPACE  reusing existing worktree: {workspace_path}")
-            if (
-                not no_pull
-                and (sync_err := _sync_base_before_worktree_use(config, auto_merge=auto_merge))
-                is not None
-            ):
-                return None, None, sync_err
+            if not no_pull:
+                sync_err = _sync_base_before_worktree_use(config, lands_locally=lands_locally)
+                if sync_err is not None:
+                    return None, None, sync_err
             rebase_err = _rebase_reused_worktree(workspace_path, config.workspace.base_branch)
             if rebase_err is not None:
                 return None, None, rebase_err
@@ -854,11 +870,10 @@ def _create_workspace(
             _propagate_claude_memory(config.project_root, workspace_path)
             return workspace_path, branch_name, None
 
-    if (
-        not no_pull
-        and (sync_err := _sync_base_before_worktree_use(config, auto_merge=auto_merge)) is not None
-    ):
-        return None, None, sync_err
+    if not no_pull:
+        sync_err = _sync_base_before_worktree_use(config, lands_locally=lands_locally)
+        if sync_err is not None:
+            return None, None, sync_err
 
     _cu._log(f"Creating workspace: {cmd}")
     ok, output = _cu._run_shell(cmd, config.project_root)
@@ -877,7 +892,7 @@ def _create_workspace(
             if existing_wt.exists():
                 _cu._log(f"↻ WORKSPACE  reusing existing worktree (registered): {existing_wt}")
                 if not no_pull:
-                    sync_err = _sync_base_before_worktree_use(config, auto_merge=auto_merge)
+                    sync_err = _sync_base_before_worktree_use(config, lands_locally=lands_locally)
                     if sync_err is not None:
                         return None, None, sync_err
                 rebase_err = _rebase_reused_worktree(existing_wt, config.workspace.base_branch)
@@ -904,12 +919,10 @@ def _create_workspace(
 
         if commits_ahead:
             _cu._log(f"↻ WORKSPACE  branch has commits, reattaching worktree: {branch_name}")
-            if (
-                not no_pull
-                and (sync_err := _sync_base_before_worktree_use(config, auto_merge=auto_merge))
-                is not None
-            ):
-                return None, None, sync_err
+            if not no_pull:
+                sync_err = _sync_base_before_worktree_use(config, lands_locally=lands_locally)
+                if sync_err is not None:
+                    return None, None, sync_err
             ok_add, add_out = _cu._run_shell(
                 f"git worktree add {workspace_path} {branch_name}", config.project_root
             )

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -114,9 +114,10 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
     the operation — this pushes it to origin and verifies the base branch is no
     longer ahead, raising loudly if either step fails.
 
-    ``publish`` mirrors ``workspace.auto_push``. Pushing a branch publishes all
-    of its ancestors, so with auto_push off a push here would also publish the
-    local story merges the operator opted out of sending to the remote. In that
+    ``publish`` comes from ``_base_branch_tracks_origin``: it is false only when
+    this run lands stories by merging into the local base checkout *and* has
+    opted out of pushing them. Pushing a branch publishes all of its ancestors,
+    so a push here would then also publish those local merges. In that one
     configuration the commit stays local and the fact is warned about instead.
     """
     from ..coordinator import util as _cu  # noqa: PLC0415
@@ -146,9 +147,10 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
 
     if not publish:
         _log(
-            f"⚠ SPRINT  story run audit records remain local: workspace.auto_push is off, so "
-            f"'{base_branch}' is not pushed. Publish it before cutting worktrees from a clone "
-            f"that expects origin/{base_branch} to be current."
+            f"⚠ SPRINT  story run audit records remain local: this run merges stories into "
+            f"'{base_branch}' with workspace.auto_push off, so pushing would also publish those "
+            f"local merges. Push '{base_branch}' yourself before any workflow that diffs a story "
+            f"branch against origin/{base_branch}."
         )
         return
 
@@ -1874,7 +1876,7 @@ def run_sprint(
         pass
 
     if not no_pull and _project_root_is_git_checkout(config.project_root):
-        coordinator_workspace.pull_base_branch(config)
+        coordinator_workspace.pull_base_branch(config, auto_merge=auto_merge)
 
     baseline_started_at = datetime.datetime.now(datetime.timezone.utc)
     baseline_gate = _run_baseline_gate(config, resolved)
@@ -3625,7 +3627,7 @@ def run_sprint(
         _commit_story_run_audits(
             config.project_root,
             config.workspace.base_branch,
-            publish=_base_branch_tracks_origin(config),
+            publish=_base_branch_tracks_origin(config, auto_merge=auto_merge),
         )
     except RuntimeError as exc:
         _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}")

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1116,6 +1116,7 @@ def _run_fresh(
     preflight_states: dict[str, CoordinatorState] | None = None,
     *,
     stop_event: "threading.Event | None" = None,
+    base_lands_locally: bool | None = None,
 ) -> CoordinatorResult:
     """Run a fresh story, optionally splitting at PLAN_REVIEW for overlap gating."""
     if plan_gate is None:
@@ -1149,6 +1150,7 @@ def _run_fresh(
                 cached_preflight_state=(preflight_states or {}).get(task.slug),
                 defer_landing=True,
                 stop_event=stop_event,
+                base_lands_locally=base_lands_locally,
             )
         return run_task(
             config,
@@ -1162,6 +1164,7 @@ def _run_fresh(
             cached_preflight_state=(preflight_states or {}).get(task.slug),
             defer_landing=True,
             stop_event=stop_event,
+            base_lands_locally=base_lands_locally,
         )
 
     # Phase 1: run through PLAN only
@@ -1169,7 +1172,7 @@ def _run_fresh(
         config,
         task,
         interactive=interactive,
-        auto_merge=False,
+        auto_merge=effective_auto_merge,
         notify=notify,
         sprint_name=sprint_name,
         state_update_fn=state_update_fn,
@@ -1178,6 +1181,7 @@ def _run_fresh(
         cached_preflight_state=(preflight_states or {}).get(task.slug),
         defer_landing=True,
         stop_event=stop_event,
+        base_lands_locally=base_lands_locally,
     )
 
     if not plan_result.success:
@@ -1214,6 +1218,7 @@ def _run_fresh(
         cached_preflight_state=(preflight_states or {}).get(task.slug),
         defer_landing=True,
         stop_event=stop_event,
+        base_lands_locally=base_lands_locally,
     )
 
 
@@ -1232,6 +1237,7 @@ def _run_single_story(
     plan_gate: "threading.Event | None" = None,
     preflight_states: dict[str, CoordinatorState] | None = None,
     stop_event: "threading.Event | None" = None,
+    base_lands_locally: bool | None = None,
 ) -> "tuple[TaskStory, CoordinatorResult, float, datetime.datetime, datetime.datetime]":
     """Execute a single story and return (task, result, elapsed, started_at, finished_at).
 
@@ -1267,6 +1273,7 @@ def _run_single_story(
                     cached_preflight_state=(preflight_states or {}).get(task.slug),
                     defer_landing=True,
                     stop_event=stop_event,
+                    base_lands_locally=base_lands_locally,
                 )
             elif triage.action == "dev" and triage.worktree_path is not None:
                 result = run_from_dev(
@@ -1282,6 +1289,7 @@ def _run_single_story(
                     cached_preflight_state=(preflight_states or {}).get(task.slug),
                     defer_landing=True,
                     stop_event=stop_event,
+                    base_lands_locally=base_lands_locally,
                 )
             else:
                 result = _run_fresh(
@@ -1297,6 +1305,7 @@ def _run_single_story(
                     plan_gate,
                     preflight_states,
                     stop_event=stop_event,
+                    base_lands_locally=base_lands_locally,
                 )
         else:
             result = _run_fresh(
@@ -1312,6 +1321,7 @@ def _run_single_story(
                 plan_gate,
                 preflight_states,
                 stop_event=stop_event,
+                base_lands_locally=base_lands_locally,
             )
     except Exception as exc:
         _log(f"ERROR {task.slug}: worker thread raised {type(exc).__name__}: {exc}")
@@ -1748,6 +1758,19 @@ def run_sprint(
     }
     dependent_slugs = {dep for task, _src, _ref in task_entries for dep in task.depends_on}
 
+    # Does ANY story in this sprint merge into the project-root base checkout?
+    # This is a sprint-wide question, not a per-story one: story N merging
+    # locally leaves the base branch ahead of origin when story N+1's worktree
+    # is cut, so every story's workspace guard needs the sprint's answer, not
+    # its own effective_auto_merge. Parallel mode never eager-merges (see the
+    # effective_am computation below, which forces False when max_parallel > 1);
+    # sequential mode merges for --auto-merge and, independently of it, for any
+    # story other stories depend on.
+    _sprint_lands_locally = coordinator_workspace._base_branch_lands_locally(
+        config,
+        auto_merge=(max_parallel <= 1 and (auto_merge or bool(dependent_slugs))),
+    )
+
     total = len(task_entries)
     noun = "stories" if total != 1 else "story"
     # Substrate provenance: name the runtime executing this sprint so the
@@ -1876,7 +1899,7 @@ def run_sprint(
         pass
 
     if not no_pull and _project_root_is_git_checkout(config.project_root):
-        coordinator_workspace.pull_base_branch(config, auto_merge=auto_merge)
+        coordinator_workspace.pull_base_branch(config, lands_locally=_sprint_lands_locally)
 
     baseline_started_at = datetime.datetime.now(datetime.timezone.utc)
     baseline_gate = _run_baseline_gate(config, resolved)
@@ -3001,6 +3024,9 @@ def run_sprint(
                     gate,
                     preflight_states,
                     stop_evt,
+                    # Keyword, not positional: stop_evt must stay the last
+                    # positional argument for callers that index args[-1].
+                    base_lands_locally=_sprint_lands_locally,
                 )
                 active[task.slug] = fut
                 story_deadlines[task.slug] = time.monotonic() + float(
@@ -3627,7 +3653,7 @@ def run_sprint(
         _commit_story_run_audits(
             config.project_root,
             config.workspace.base_branch,
-            publish=_base_branch_tracks_origin(config, auto_merge=auto_merge),
+            publish=_base_branch_tracks_origin(config, lands_locally=_sprint_lands_locally),
         )
     except RuntimeError as exc:
         _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}")

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -104,7 +104,7 @@ def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
 
 
-def _commit_story_run_audits(project_root: Path, base_branch: str) -> None:
+def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: bool) -> None:
     """Commit and publish canonical per-run audit JSON emitted during a sprint.
 
     The sprint writes these records to the project-root base-branch checkout on
@@ -113,6 +113,11 @@ def _commit_story_run_audits(project_root: Path, base_branch: str) -> None:
     JSON to whichever story happens to be running. So the commit is only half
     the operation — this pushes it to origin and verifies the base branch is no
     longer ahead, raising loudly if either step fails.
+
+    ``publish`` mirrors ``workspace.auto_push``. Pushing a branch publishes all
+    of its ancestors, so with auto_push off a push here would also publish the
+    local story merges the operator opted out of sending to the remote. In that
+    configuration the commit stays local and the fact is warned about instead.
     """
     from ..coordinator import util as _cu  # noqa: PLC0415
 
@@ -138,6 +143,14 @@ def _commit_story_run_audits(project_root: Path, base_branch: str) -> None:
     if not ok_commit:
         raise RuntimeError(f"Failed to commit story run audits: {commit_out}")
     _log("Committed canonical story run audit records to the base branch checkout.")
+
+    if not publish:
+        _log(
+            f"⚠ SPRINT  story run audit records remain local: workspace.auto_push is off, so "
+            f"'{base_branch}' is not pushed. Publish it before cutting worktrees from a clone "
+            f"that expects origin/{base_branch} to be current."
+        )
+        return
 
     quoted_base = shlex.quote(base_branch)
     ok_push, push_out = _cu._run_shell(
@@ -3606,8 +3619,14 @@ def run_sprint(
     # but the failure is NOT swallowed: a local-only audit commit contaminates
     # every later story PR cut from this checkout, so the sprint must exit
     # nonzero rather than report success over divergent base-branch state.
+    from ..coordinator.workspace import _base_branch_tracks_origin
+
     try:
-        _commit_story_run_audits(config.project_root, config.workspace.base_branch)
+        _commit_story_run_audits(
+            config.project_root,
+            config.workspace.base_branch,
+            publish=_base_branch_tracks_origin(config),
+        )
     except RuntimeError as exc:
         _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}")
         raise

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -104,8 +104,16 @@ def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
 
 
-def _commit_story_run_audits(project_root: Path) -> None:
-    """Commit canonical per-run audit JSON emitted during sprint execution."""
+def _commit_story_run_audits(project_root: Path, base_branch: str) -> None:
+    """Commit and publish canonical per-run audit JSON emitted during a sprint.
+
+    The sprint writes these records to the project-root base-branch checkout on
+    the operator's behalf. A commit that is never pushed is unowned state: later
+    story worktrees are cut from that checkout and GitHub attributes the audit
+    JSON to whichever story happens to be running. So the commit is only half
+    the operation — this pushes it to origin and verifies the base branch is no
+    longer ahead, raising loudly if either step fails.
+    """
     from ..coordinator import util as _cu  # noqa: PLC0415
 
     if not (project_root / ".git").exists():
@@ -130,6 +138,38 @@ def _commit_story_run_audits(project_root: Path) -> None:
     if not ok_commit:
         raise RuntimeError(f"Failed to commit story run audits: {commit_out}")
     _log("Committed canonical story run audit records to the base branch checkout.")
+
+    quoted_base = shlex.quote(base_branch)
+    ok_push, push_out = _cu._run_shell(
+        f"git push origin {quoted_base}",
+        project_root,
+    )
+    if not ok_push:
+        raise RuntimeError(
+            f"Failed to push story run audits to origin/{base_branch}: {push_out.strip()}"
+        )
+
+    ok_ahead, ahead_out = _cu._run_shell(
+        f"git rev-list --count origin/{quoted_base}..{quoted_base}",
+        project_root,
+    )
+    if not ok_ahead:
+        raise RuntimeError(
+            f"Failed to verify story run audits reached origin/{base_branch}: {ahead_out.strip()}"
+        )
+    try:
+        ahead = int(ahead_out.strip())
+    except ValueError:
+        raise RuntimeError(
+            f"Failed to verify story run audits reached origin/{base_branch}: "
+            f"unexpected rev-list output {ahead_out.strip()!r}"
+        ) from None
+    if ahead > 0:
+        raise RuntimeError(
+            f"Story run audits were committed but '{base_branch}' is still {ahead} commit(s) "
+            f"ahead of origin/{base_branch} after push. Publish or reset it before rerunning."
+        )
+    _log(f"Pushed canonical story run audit records to origin/{base_branch}.")
 
 
 def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:
@@ -3562,10 +3602,15 @@ def run_sprint(
     if _state_writer is not None:
         _state_writer.remove()
 
+    # Runs after _state_writer.remove() so sprint state is cleaned up regardless,
+    # but the failure is NOT swallowed: a local-only audit commit contaminates
+    # every later story PR cut from this checkout, so the sprint must exit
+    # nonzero rather than report success over divergent base-branch state.
     try:
-        _commit_story_run_audits(config.project_root)
+        _commit_story_run_audits(config.project_root, config.workspace.base_branch)
     except RuntimeError as exc:
-        _log(f"Warning: canonical story run audit commit failed: {exc}")
+        _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}")
+        raise
 
     # ── POST_SPRINT hook ──────────────────────────────────────────────
     if config.hooks and config.hooks.post_sprint:

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -388,7 +388,7 @@ criteria_checked: []
                 "theforge.coordinator.preflight_flow.run_agent",
                 return_value=fresh_preflight,
             ) as mock_preflight,
-            patch("theforge.coordinator.engine._check_behind_origin"),
+            patch("theforge.coordinator.engine.pull_base_branch"),
         ):
             result = run_from_dev(config, task, workspace, cached_preflight_state=cached_state)
 

--- a/tests/test_coord_seam_timeout_escalation.py
+++ b/tests/test_coord_seam_timeout_escalation.py
@@ -154,7 +154,7 @@ def test_timeout_escalation_seam(mock_shell, mock_dev, mock_preflight, mock_pool
 @patch("theforge.coordinator.preflight_flow.run_agent")
 @patch("theforge.coordinator.dev_phase.run_agent")
 @patch_gate_shell()
-@patch("theforge.coordinator.engine._check_behind_origin")
+@patch("theforge.coordinator.engine.pull_base_branch")
 def test_resume_path_reads_sprint_flag(
     mock_origin, mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
 ):

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -4,10 +4,12 @@ Covers:
 - Fresh workspace: pull succeeds before worktree creation
 - Fresh workspace: pull fails (diverged) -> hard abort, workspace NOT created, error returned
 - Fresh workspace: pull fails (offline/unreachable) -> hard abort, workspace NOT created
-- Base branch ahead of origin (ahead-only) under auto_push -> hard abort on
-  fresh, reused, and reattach paths, even though `git pull --ff-only` succeeds
-- Base branch ahead of origin without auto_push -> allowed; local merges land
-  there by design and must not block subsequent stories in a sprint
+- Base branch ahead of origin (ahead-only) where the branch must track origin
+  -> hard abort on fresh, reused, and reattach paths, even though
+  `git pull --ff-only` succeeds in that state
+- Base branch ahead of origin under a local-merge workflow (on_approve: merge
+  or --auto-merge, without auto_push) -> allowed; stories land there by design
+  and must not block subsequent stories in a sprint
 - no_pull=True: no pull attempted on fresh path
 - no_pull=True: no base-branch sync on resume path
 - Daemon sprint_args dict includes no_pull; _execute_sprint passes it to run_sprint
@@ -23,6 +25,7 @@ from coord_test_helpers import _make_config, _make_task
 
 from theforge.coordinator.workspace import (
     _FORGE_ARTIFACTS,
+    _base_branch_tracks_origin,
     _create_workspace,
     _deindex_forge_artifacts,
     pull_base_branch,
@@ -307,17 +310,23 @@ def _ahead_only_shell(ahead: str = "2", behind: str = "0", *, recorder=None):
     return shell_side_effect
 
 
-def _make_pushing_config(tmp_path):
-    """_make_config with auto_push on: the base branch is expected to track origin.
-
-    With auto_push off, `_merge_branch` lands stories locally without pushing,
-    so an ahead-only base branch is the configured steady state and the guard
-    deliberately stands down — see TestLocalMergeWorkflowNotBlocked.
-    """
+def _make_workspace_config(tmp_path, **workspace_kwargs):
+    """_make_config with workspace field overrides."""
     config = _make_config(tmp_path)
     return dataclasses.replace(
-        config, workspace=dataclasses.replace(config.workspace, auto_push=True)
+        config, workspace=dataclasses.replace(config.workspace, **workspace_kwargs)
     )
+
+
+def _make_pushing_config(tmp_path):
+    """A workflow where the base branch must track origin: PRs, no local merges.
+
+    `on_approve: pr` publishes story branches for GitHub to diff against
+    origin/<base>, and nothing merges into the local base checkout, so any
+    commit it carries beyond origin is drift. Note auto_push stays off — this
+    is exactly the combination the auto_push-only rule wrongly exempted.
+    """
+    return _make_workspace_config(tmp_path, on_approve="pr")
 
 
 class TestBaseBranchAheadOnlyGuard:
@@ -418,22 +427,57 @@ class TestBaseBranchAheadOnlyGuard:
         mock_rebase.assert_not_called()
 
 
+class TestPublicationRuleMatrix:
+    """Two independent questions decide whether an ahead-only base is drift.
+
+    Does anything land on the local base branch (only `on_approve: merge`, or
+    the --auto-merge CLI override, does), and if so are those merges pushed
+    (only with auto_push)? Keying the rule off auto_push alone got both the
+    local-merge workflow and the `on_approve: pr` workflow wrong.
+    """
+
+    def test_pr_workflow_tracks_origin_without_auto_push(self, tmp_path):
+        config = _make_workspace_config(tmp_path, on_approve="pr")
+        assert config.workspace.auto_push is False
+        assert _base_branch_tracks_origin(config) is True
+
+    def test_merge_pr_workflow_tracks_origin(self, tmp_path):
+        config = _make_workspace_config(tmp_path, on_approve="merge-pr", auto_push=True)
+        assert _base_branch_tracks_origin(config) is True
+
+    def test_no_landing_workflow_tracks_origin(self, tmp_path):
+        config = _make_workspace_config(tmp_path, on_approve="none")
+        assert _base_branch_tracks_origin(config) is True
+
+    def test_local_merge_without_push_does_not_track_origin(self, tmp_path):
+        config = _make_workspace_config(tmp_path, on_approve="merge")
+        assert _base_branch_tracks_origin(config) is False
+
+    def test_local_merge_with_push_tracks_origin(self, tmp_path):
+        config = _make_workspace_config(tmp_path, on_approve="merge", auto_push=True)
+        assert _base_branch_tracks_origin(config) is True
+
+    def test_auto_merge_override_forces_local_landing(self, tmp_path):
+        """--auto-merge forces the merge path regardless of configured on_approve."""
+        config = _make_workspace_config(tmp_path, on_approve="pr")
+        assert _base_branch_tracks_origin(config, auto_merge=True) is False
+        assert _base_branch_tracks_origin(config, auto_merge=False) is True
+
+
 class TestLocalMergeWorkflowNotBlocked:
-    """auto_push=false leaves the base branch ahead by design — do not abort.
+    """A local-merge workflow leaves the base branch ahead by design.
 
     `_merge_branch` merges each landed story into the project-root base branch
-    and only pushes when workspace.auto_push is set. Under the default, the
-    branch is legitimately ahead of origin from the first landing onward, so a
-    guard that fired on ahead>0 unconditionally would abort every subsequent
-    story in a multi-story sprint.
+    and only pushes when workspace.auto_push is set. Under `on_approve: merge`
+    without auto_push the branch is legitimately ahead of origin from the first
+    landing onward, so a guard that fired on ahead>0 unconditionally would
+    abort every subsequent story in a multi-story sprint.
     """
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_pull_base_branch_allows_ahead_when_auto_push_off(
-        self, mock_log, mock_shell, tmp_path
-    ):
-        config = _make_config(tmp_path)
+    def test_pull_base_branch_allows_ahead_under_local_merge(self, mock_log, mock_shell, tmp_path):
+        config = _make_workspace_config(tmp_path, on_approve="merge")
         assert config.workspace.auto_push is False
         mock_shell.side_effect = _ahead_only_shell(ahead="3", behind="0")
 
@@ -441,11 +485,22 @@ class TestLocalMergeWorkflowNotBlocked:
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
+    def test_pull_base_branch_allows_ahead_under_auto_merge_override(
+        self, mock_log, mock_shell, tmp_path
+    ):
+        """`forge sprint --auto-merge` merges locally even with on_approve: none."""
+        config = _make_config(tmp_path)
+        mock_shell.side_effect = _ahead_only_shell(ahead="3", behind="0")
+
+        assert pull_base_branch(config, auto_merge=True) is True
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
     def test_second_story_workspace_created_after_local_only_merge(
         self, mock_log, mock_shell, tmp_path
     ):
         """The scenario the unconditional guard broke: story N+1 after a local merge."""
-        config = _make_config(tmp_path)
+        config = _make_workspace_config(tmp_path, on_approve="merge")
         task = _make_task(tmp_path)
         calls: list[str] = []
         base_shell = _ahead_only_shell(ahead="3", behind="0", recorder=calls)
@@ -467,9 +522,36 @@ class TestLocalMergeWorkflowNotBlocked:
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_diverged_abort_still_applies_when_auto_push_off(self, mock_log, mock_shell, tmp_path):
+    def test_auto_merge_reaches_guard_through_create_workspace(
+        self, mock_log, mock_shell, tmp_path
+    ):
+        """The seam: _create_workspace must forward auto_merge, not drop it."""
+        config = _make_workspace_config(tmp_path, on_approve="pr")
+        task = _make_task(tmp_path)
+        calls: list[str] = []
+        base_shell = _ahead_only_shell(ahead="3", behind="0", recorder=calls)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if cmd.startswith("mkdir -p "):
+                calls.append(cmd)
+                (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            return base_shell(cmd, cwd, **kwargs)
+
+        mock_shell.side_effect = shell_side_effect
+
+        _path, _branch, error_without = _create_workspace(config, task, no_pull=False)
+        assert error_without is not None and "not on origin/main" in error_without
+
+        path, _branch, error_with = _create_workspace(config, task, no_pull=False, auto_merge=True)
+        assert error_with is None
+        assert path == tmp_path / task.slug
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_diverged_abort_still_applies_under_local_merge(self, mock_log, mock_shell, tmp_path):
         """Standing down on ahead-only must not disable the pre-existing divergence abort."""
-        config = _make_config(tmp_path)
+        config = _make_workspace_config(tmp_path, on_approve="merge")
 
         def shell_side_effect(cmd, cwd, **kwargs):
             if "rev-parse --abbrev-ref HEAD" in cmd:

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -4,10 +4,10 @@ Covers:
 - Fresh workspace: pull succeeds before worktree creation
 - Fresh workspace: pull fails (diverged) -> hard abort, workspace NOT created, error returned
 - Fresh workspace: pull fails (offline/unreachable) -> hard abort, workspace NOT created
-- Resume path (existing worktree): behind-origin check logs informational note
-- Resume path: rev-list fails -> silently skipped
+- Base branch ahead of origin (ahead-only) -> hard abort on fresh, reused, and
+  reattach paths, even though `git pull --ff-only` succeeds in that state
 - no_pull=True: no pull attempted on fresh path
-- no_pull=True: no behind-origin check on resume path
+- no_pull=True: no base-branch sync on resume path
 - Daemon sprint_args dict includes no_pull; _execute_sprint passes it to run_sprint
 - _deindex_forge_artifacts: runs git rm --cached --ignore-unmatch on all return paths
 """
@@ -20,9 +20,9 @@ from coord_test_helpers import _make_config, _make_task
 
 from theforge.coordinator.workspace import (
     _FORGE_ARTIFACTS,
-    _check_behind_origin,
     _create_workspace,
     _deindex_forge_artifacts,
+    pull_base_branch,
 )
 
 # ── Fresh workspace pull tests ────────────────────────────────────────
@@ -274,59 +274,140 @@ class TestFreshWorkspacePull:
         assert sync_called == [], "no pull/fetch should be called when no_pull=True"
 
 
-# ── Resume path behind-origin check tests ────────────────────────────
+# ── Base branch ahead-only guard tests ───────────────────────────────
 
 
-class TestBehindOriginCheck:
-    """_check_behind_origin logs when base is behind; silently skips on failure."""
+def _ahead_only_shell(ahead: str = "2", behind: str = "0", *, recorder=None):
+    """Shell stub where the base branch is `ahead` commits ahead of origin.
+
+    ``git pull --ff-only`` succeeds trivially in this state — that is precisely
+    what made the old guard miss it — so the stub returns success for the sync.
+    """
+
+    def shell_side_effect(cmd, cwd, **kwargs):
+        if recorder is not None:
+            recorder.append(cmd)
+        if "rev-list --count origin/" in cmd:
+            return (True, f"{ahead}\n")
+        if "rev-list --count" in cmd:
+            return (True, f"{behind}\n")
+        if "rev-parse --abbrev-ref HEAD" in cmd:
+            return (True, "main")
+        if "rev-parse HEAD:src/theforge" in cmd:
+            return (True, "treesha")
+        if "git log" in cmd and "--oneline" in cmd:
+            # Non-empty: keeps an existing worktree out of the stale-removal
+            # path and marks a collided branch as having commits to reattach.
+            return (True, "abc1234 a commit\n")
+        return (True, "")
+
+    return shell_side_effect
+
+
+class TestBaseBranchAheadOnlyGuard:
+    """An ahead-only base branch must block worktree use, not just log."""
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_behind_origin_logs_info(self, mock_log, mock_shell, tmp_path):
-        """When base_branch is N commits behind origin, log an info note."""
+    def test_pull_base_branch_raises_when_ahead_only(self, mock_log, mock_shell, tmp_path):
+        """Successful pull + ahead>0/behind==0 still aborts."""
         config = _make_config(tmp_path)
+        mock_shell.side_effect = _ahead_only_shell(ahead="2", behind="0")
 
-        mock_shell.return_value = (True, "3\n")
-
-        _check_behind_origin(config)
-
-        log_calls = [str(c) for c in mock_log.call_args_list]
-        assert any("3 commit" in c and "behind" in c for c in log_calls)
+        try:
+            pull_base_branch(config)
+        except RuntimeError as exc:
+            assert "2 local commit(s) not on origin/main" in str(exc)
+        else:
+            raise AssertionError("pull_base_branch must abort on an ahead-only base branch")
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_not_behind_no_log(self, mock_log, mock_shell, tmp_path):
-        """When base_branch is 0 commits behind, no info note logged."""
+    def test_pull_base_branch_passes_when_in_sync(self, mock_log, mock_shell, tmp_path):
+        """ahead == 0 is the normal case and must not raise."""
         config = _make_config(tmp_path)
+        mock_shell.side_effect = _ahead_only_shell(ahead="0", behind="0")
 
-        mock_shell.return_value = (True, "0\n")
-
-        _check_behind_origin(config)
-
-        log_calls = [str(c) for c in mock_log.call_args_list]
-        assert not any("behind" in c for c in log_calls)
+        assert pull_base_branch(config) is True
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_rev_list_fails_silent(self, mock_log, mock_shell, tmp_path):
-        """When rev-list command fails, silently skip — no error raised."""
+    def test_fresh_workspace_aborts_before_worktree_add(self, mock_log, mock_shell, tmp_path):
+        """The fresh path returns an error and never runs the create command."""
         config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        calls: list[str] = []
+        mock_shell.side_effect = _ahead_only_shell(recorder=calls)
 
-        mock_shell.return_value = (False, "fatal: ambiguous argument")
+        path, branch, error = _create_workspace(config, task, no_pull=False)
 
-        # Should not raise
-        _check_behind_origin(config)
+        assert path is None and branch is None
+        assert error is not None and "not on origin/main" in error
+        assert not any(cmd.startswith("mkdir -p ") for cmd in calls)
 
-        log_calls = [str(c) for c in mock_log.call_args_list]
-        assert not any("behind" in c for c in log_calls)
+    @patch("theforge.coordinator.workspace._rebase_reused_worktree")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_reused_worktree_aborts_before_rebase(
+        self, mock_log, mock_shell, mock_rebase, tmp_path
+    ):
+        """The reused-worktree path blocks too — it used to only log behind-origin."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+        mock_shell.side_effect = _ahead_only_shell()
+
+        path, branch, error = _create_workspace(config, task, no_pull=False)
+
+        assert path is None and branch is None
+        assert error is not None and "not on origin/main" in error
+        mock_rebase.assert_not_called()
+
+    @patch("theforge.coordinator.workspace._rebase_reused_worktree")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_reattach_path_aborts_before_worktree_add(
+        self, mock_log, mock_shell, mock_rebase, tmp_path
+    ):
+        """Branch-collision reattach blocks before `git worktree add`."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        calls: list[str] = []
+        base_shell = _ahead_only_shell(ahead="0", behind="0", recorder=calls)
+        # First sync succeeds (in-sync) so creation is attempted; the create
+        # command then collides with an existing branch that has commits, and
+        # by the time the reattach path re-syncs the base branch is ahead-only.
+        state = {"synced": 0}
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-list --count origin/" in cmd:
+                calls.append(cmd)
+                state["synced"] += 1
+                return (True, "0\n" if state["synced"] == 1 else "2\n")
+            if cmd.startswith("mkdir -p "):
+                calls.append(cmd)
+                return (False, "fatal: branch already exists")
+            if cmd.startswith("git branch --list"):
+                calls.append(cmd)
+                return (True, "  forge/test-task\n")
+            return base_shell(cmd, cwd, **kwargs)
+
+        mock_shell.side_effect = shell_side_effect
+
+        path, branch, error = _create_workspace(config, task, no_pull=False)
+
+        assert path is None and branch is None
+        assert error is not None and "not on origin/main" in error
+        assert not any("worktree add" in cmd for cmd in calls)
+        mock_rebase.assert_not_called()
 
 
 class TestResumeNoPull:
-    """On resume/reuse paths, no_pull=True suppresses the behind-origin check."""
+    """On resume/reuse paths, no_pull=True suppresses the base-branch sync."""
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_no_pull_skips_behind_origin_check_on_reuse(self, mock_log, mock_shell, tmp_path):
+    def test_no_pull_skips_base_sync_on_reuse(self, mock_log, mock_shell, tmp_path):
         """When no_pull=True and worktree exists (non-stale), no rev-list is run."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
@@ -354,8 +435,8 @@ class TestResumeNoPull:
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_pull_false_runs_behind_origin_check_on_reuse(self, mock_log, mock_shell, tmp_path):
-        """When no_pull=False and worktree exists (non-stale), rev-list is run."""
+    def test_pull_false_runs_base_sync_on_reuse(self, mock_log, mock_shell, tmp_path):
+        """When no_pull=False and worktree exists (non-stale), the sync delta is measured."""
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)
 

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -4,8 +4,10 @@ Covers:
 - Fresh workspace: pull succeeds before worktree creation
 - Fresh workspace: pull fails (diverged) -> hard abort, workspace NOT created, error returned
 - Fresh workspace: pull fails (offline/unreachable) -> hard abort, workspace NOT created
-- Base branch ahead of origin (ahead-only) -> hard abort on fresh, reused, and
-  reattach paths, even though `git pull --ff-only` succeeds in that state
+- Base branch ahead of origin (ahead-only) under auto_push -> hard abort on
+  fresh, reused, and reattach paths, even though `git pull --ff-only` succeeds
+- Base branch ahead of origin without auto_push -> allowed; local merges land
+  there by design and must not block subsequent stories in a sprint
 - no_pull=True: no pull attempted on fresh path
 - no_pull=True: no base-branch sync on resume path
 - Daemon sprint_args dict includes no_pull; _execute_sprint passes it to run_sprint
@@ -14,6 +16,7 @@ Covers:
 
 from __future__ import annotations
 
+import dataclasses
 from unittest.mock import MagicMock, patch
 
 from coord_test_helpers import _make_config, _make_task
@@ -304,6 +307,19 @@ def _ahead_only_shell(ahead: str = "2", behind: str = "0", *, recorder=None):
     return shell_side_effect
 
 
+def _make_pushing_config(tmp_path):
+    """_make_config with auto_push on: the base branch is expected to track origin.
+
+    With auto_push off, `_merge_branch` lands stories locally without pushing,
+    so an ahead-only base branch is the configured steady state and the guard
+    deliberately stands down — see TestLocalMergeWorkflowNotBlocked.
+    """
+    config = _make_config(tmp_path)
+    return dataclasses.replace(
+        config, workspace=dataclasses.replace(config.workspace, auto_push=True)
+    )
+
+
 class TestBaseBranchAheadOnlyGuard:
     """An ahead-only base branch must block worktree use, not just log."""
 
@@ -311,7 +327,7 @@ class TestBaseBranchAheadOnlyGuard:
     @patch("theforge.coordinator.workspace._cu._log")
     def test_pull_base_branch_raises_when_ahead_only(self, mock_log, mock_shell, tmp_path):
         """Successful pull + ahead>0/behind==0 still aborts."""
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
         mock_shell.side_effect = _ahead_only_shell(ahead="2", behind="0")
 
         try:
@@ -325,7 +341,7 @@ class TestBaseBranchAheadOnlyGuard:
     @patch("theforge.coordinator.workspace._cu._log")
     def test_pull_base_branch_passes_when_in_sync(self, mock_log, mock_shell, tmp_path):
         """ahead == 0 is the normal case and must not raise."""
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
         mock_shell.side_effect = _ahead_only_shell(ahead="0", behind="0")
 
         assert pull_base_branch(config) is True
@@ -334,7 +350,7 @@ class TestBaseBranchAheadOnlyGuard:
     @patch("theforge.coordinator.workspace._cu._log")
     def test_fresh_workspace_aborts_before_worktree_add(self, mock_log, mock_shell, tmp_path):
         """The fresh path returns an error and never runs the create command."""
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
         task = _make_task(tmp_path)
         calls: list[str] = []
         mock_shell.side_effect = _ahead_only_shell(recorder=calls)
@@ -352,7 +368,7 @@ class TestBaseBranchAheadOnlyGuard:
         self, mock_log, mock_shell, mock_rebase, tmp_path
     ):
         """The reused-worktree path blocks too — it used to only log behind-origin."""
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
         task = _make_task(tmp_path)
         (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
         mock_shell.side_effect = _ahead_only_shell()
@@ -370,7 +386,7 @@ class TestBaseBranchAheadOnlyGuard:
         self, mock_log, mock_shell, mock_rebase, tmp_path
     ):
         """Branch-collision reattach blocks before `git worktree add`."""
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
         task = _make_task(tmp_path)
         calls: list[str] = []
         base_shell = _ahead_only_shell(ahead="0", behind="0", recorder=calls)
@@ -400,6 +416,78 @@ class TestBaseBranchAheadOnlyGuard:
         assert error is not None and "not on origin/main" in error
         assert not any("worktree add" in cmd for cmd in calls)
         mock_rebase.assert_not_called()
+
+
+class TestLocalMergeWorkflowNotBlocked:
+    """auto_push=false leaves the base branch ahead by design — do not abort.
+
+    `_merge_branch` merges each landed story into the project-root base branch
+    and only pushes when workspace.auto_push is set. Under the default, the
+    branch is legitimately ahead of origin from the first landing onward, so a
+    guard that fired on ahead>0 unconditionally would abort every subsequent
+    story in a multi-story sprint.
+    """
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_pull_base_branch_allows_ahead_when_auto_push_off(
+        self, mock_log, mock_shell, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        assert config.workspace.auto_push is False
+        mock_shell.side_effect = _ahead_only_shell(ahead="3", behind="0")
+
+        assert pull_base_branch(config) is True
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_second_story_workspace_created_after_local_only_merge(
+        self, mock_log, mock_shell, tmp_path
+    ):
+        """The scenario the unconditional guard broke: story N+1 after a local merge."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        calls: list[str] = []
+        base_shell = _ahead_only_shell(ahead="3", behind="0", recorder=calls)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if cmd.startswith("mkdir -p "):
+                calls.append(cmd)
+                (tmp_path / task.slug).mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            return base_shell(cmd, cwd, **kwargs)
+
+        mock_shell.side_effect = shell_side_effect
+
+        path, branch, error = _create_workspace(config, task, no_pull=False)
+
+        assert error is None
+        assert path == tmp_path / task.slug
+        assert any(cmd.startswith("mkdir -p ") for cmd in calls)
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_diverged_abort_still_applies_when_auto_push_off(self, mock_log, mock_shell, tmp_path):
+        """Standing down on ahead-only must not disable the pre-existing divergence abort."""
+        config = _make_config(tmp_path)
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "main")
+            if "pull --ff-only" in cmd:
+                return (False, "fatal: Not possible to fast-forward, aborting.")
+            if "rev-list --count" in cmd:
+                return (True, "2\n")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        try:
+            pull_base_branch(config)
+        except RuntimeError as exc:
+            assert "diverged" in str(exc)
+        else:
+            raise AssertionError("divergence must still abort regardless of auto_push")
 
 
 class TestResumeNoPull:

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -30,6 +30,9 @@ from theforge.coordinator.workspace import (
     _deindex_forge_artifacts,
     pull_base_branch,
 )
+from theforge.coordinator.workspace import (
+    _base_branch_lands_locally as _lands,
+)
 
 # ── Fresh workspace pull tests ────────────────────────────────────────
 
@@ -439,29 +442,31 @@ class TestPublicationRuleMatrix:
     def test_pr_workflow_tracks_origin_without_auto_push(self, tmp_path):
         config = _make_workspace_config(tmp_path, on_approve="pr")
         assert config.workspace.auto_push is False
-        assert _base_branch_tracks_origin(config) is True
+        assert _base_branch_tracks_origin(config, lands_locally=_lands(config)) is True
 
     def test_merge_pr_workflow_tracks_origin(self, tmp_path):
         config = _make_workspace_config(tmp_path, on_approve="merge-pr", auto_push=True)
-        assert _base_branch_tracks_origin(config) is True
+        assert _base_branch_tracks_origin(config, lands_locally=_lands(config)) is True
 
     def test_no_landing_workflow_tracks_origin(self, tmp_path):
         config = _make_workspace_config(tmp_path, on_approve="none")
-        assert _base_branch_tracks_origin(config) is True
+        assert _base_branch_tracks_origin(config, lands_locally=_lands(config)) is True
 
     def test_local_merge_without_push_does_not_track_origin(self, tmp_path):
         config = _make_workspace_config(tmp_path, on_approve="merge")
-        assert _base_branch_tracks_origin(config) is False
+        assert _base_branch_tracks_origin(config, lands_locally=_lands(config)) is False
 
     def test_local_merge_with_push_tracks_origin(self, tmp_path):
         config = _make_workspace_config(tmp_path, on_approve="merge", auto_push=True)
-        assert _base_branch_tracks_origin(config) is True
+        assert _base_branch_tracks_origin(config, lands_locally=_lands(config)) is True
 
     def test_auto_merge_override_forces_local_landing(self, tmp_path):
         """--auto-merge forces the merge path regardless of configured on_approve."""
         config = _make_workspace_config(tmp_path, on_approve="pr")
-        assert _base_branch_tracks_origin(config, auto_merge=True) is False
-        assert _base_branch_tracks_origin(config, auto_merge=False) is True
+        assert _lands(config, auto_merge=True) is True
+        assert _lands(config, auto_merge=False) is False
+        assert _base_branch_tracks_origin(config, lands_locally=True) is False
+        assert _base_branch_tracks_origin(config, lands_locally=False) is True
 
 
 class TestLocalMergeWorkflowNotBlocked:
@@ -492,7 +497,7 @@ class TestLocalMergeWorkflowNotBlocked:
         config = _make_config(tmp_path)
         mock_shell.side_effect = _ahead_only_shell(ahead="3", behind="0")
 
-        assert pull_base_branch(config, auto_merge=True) is True
+        assert pull_base_branch(config, lands_locally=True) is True
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
@@ -522,10 +527,10 @@ class TestLocalMergeWorkflowNotBlocked:
 
     @patch("theforge.coordinator.workspace._cu._run_shell")
     @patch("theforge.coordinator.workspace._cu._log")
-    def test_auto_merge_reaches_guard_through_create_workspace(
+    def test_lands_locally_reaches_guard_through_create_workspace(
         self, mock_log, mock_shell, tmp_path
     ):
-        """The seam: _create_workspace must forward auto_merge, not drop it."""
+        """The seam: _create_workspace must forward lands_locally, not drop it."""
         config = _make_workspace_config(tmp_path, on_approve="pr")
         task = _make_task(tmp_path)
         calls: list[str] = []
@@ -543,7 +548,9 @@ class TestLocalMergeWorkflowNotBlocked:
         _path, _branch, error_without = _create_workspace(config, task, no_pull=False)
         assert error_without is not None and "not on origin/main" in error_without
 
-        path, _branch, error_with = _create_workspace(config, task, no_pull=False, auto_merge=True)
+        path, _branch, error_with = _create_workspace(
+            config, task, no_pull=False, lands_locally=True
+        )
         assert error_with is None
         assert path == tmp_path / task.slug
 

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -446,6 +446,14 @@ class TestStaleWorktree:
                 return (True, "feat/test-task")
             if "git status --porcelain" in cmd:
                 return (True, "?? scratch.txt")
+            # Reuse now runs the blocking base-branch sync, not a bare
+            # behind-origin probe, so the fetch + ahead/behind delta appear here.
+            if "rev-parse HEAD:src/theforge" in cmd:
+                return (True, "treesha")
+            if "git fetch origin main:main" in cmd:
+                return (True, "")
+            if "git rev-list --count origin/main..main" in cmd:
+                return (True, "0")
             if "git rev-list --count main..origin/main" in cmd:
                 return (True, "0")
             if "git rm -f --cached --ignore-unmatch" in cmd:

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from coord_test_helpers import _make_config, _make_task
 
 from theforge.coordinator.context_scope import plan_file_list
@@ -352,7 +353,7 @@ def test_run_resume_coordinator_rebases_before_loop_and_continues(tmp_path):
 
     with (
         patch("theforge.coordinator.engine._ensure_runners"),
-        patch("theforge.coordinator.engine._check_behind_origin"),
+        patch("theforge.coordinator.engine.pull_base_branch"),
         patch("theforge.coordinator.engine._setup_resume_entry", return_value=setup),
         patch("theforge.coordinator.engine._make_story_log_dir", return_value=tmp_path / "logs"),
         patch("theforge.coordinator.engine._run_log_context") as mock_ctx,
@@ -385,6 +386,91 @@ def test_run_resume_coordinator_rebases_before_loop_and_continues(tmp_path):
     )
 
 
+def test_run_resume_coordinator_aborts_when_base_branch_unpublished(tmp_path):
+    """The resume entry uses the blocking base sync, not the old advisory check.
+
+    A reused worktree is about to be rebased onto the base branch, so an
+    unpublished commit there would be absorbed into this story's diff. The
+    RuntimeError must propagate rather than be logged and stepped over.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    with (
+        patch("theforge.coordinator.engine._ensure_runners"),
+        patch(
+            "theforge.coordinator.engine.pull_base_branch",
+            side_effect=RuntimeError("WORKSPACE abort: base branch 'main' has 1 local commit(s)"),
+        ) as mock_pull,
+        patch("theforge.coordinator.engine._setup_resume_entry") as mock_setup,
+        pytest.raises(RuntimeError, match="has 1 local commit"),
+    ):
+        _run_resume_coordinator(
+            config,
+            task,
+            workspace,
+            initial_phase=Phase.DEV,
+            skip_dev_first_iter=False,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            run_id="run-1",
+            sprint_name=None,
+            state_update_fn=None,
+        )
+
+    mock_pull.assert_called_once_with(config)
+    mock_setup.assert_not_called()
+
+
+def test_run_resume_coordinator_skips_base_sync_when_no_pull(tmp_path):
+    """no_pull=True still suppresses the base-branch sync entirely."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    state = MagicMock()
+    state.workspace_path = workspace
+    state.log_dir = None
+    logger = MagicMock()
+    setup = (state, logger, "forge/test-task", "story", 123.0)
+    loop_result = CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="done")
+
+    with (
+        patch("theforge.coordinator.engine._ensure_runners"),
+        patch("theforge.coordinator.engine.pull_base_branch") as mock_pull,
+        patch("theforge.coordinator.engine._setup_resume_entry", return_value=setup),
+        patch("theforge.coordinator.engine._make_story_log_dir", return_value=tmp_path / "logs"),
+        patch("theforge.coordinator.engine._run_log_context") as mock_ctx,
+        patch("theforge.coordinator.engine._rebase_onto_main", return_value=(True, "")),
+        patch("theforge.coordinator.engine._coordinator_loop", return_value=loop_result),
+        patch("theforge.coordinator.engine._fire_post_run_hook"),
+    ):
+        mock_ctx.return_value.__enter__.return_value = None
+        mock_ctx.return_value.__exit__.return_value = None
+        _run_resume_coordinator(
+            config,
+            task,
+            workspace,
+            initial_phase=Phase.DEV,
+            skip_dev_first_iter=False,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            run_id="run-1",
+            sprint_name=None,
+            state_update_fn=None,
+            no_pull=True,
+        )
+
+    mock_pull.assert_not_called()
+
+
 def test_run_resume_coordinator_escalates_when_rebase_fails(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -399,7 +485,7 @@ def test_run_resume_coordinator_escalates_when_rebase_fails(tmp_path):
 
     with (
         patch("theforge.coordinator.engine._ensure_runners"),
-        patch("theforge.coordinator.engine._check_behind_origin"),
+        patch("theforge.coordinator.engine.pull_base_branch"),
         patch("theforge.coordinator.engine._setup_resume_entry", return_value=setup),
         patch("theforge.coordinator.engine._make_story_log_dir", return_value=tmp_path / "logs"),
         patch("theforge.coordinator.engine._run_log_context") as mock_ctx,

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -422,7 +422,7 @@ def test_run_resume_coordinator_aborts_when_base_branch_unpublished(tmp_path):
             state_update_fn=None,
         )
 
-    mock_pull.assert_called_once_with(config)
+    mock_pull.assert_called_once_with(config, auto_merge=False)
     mock_setup.assert_not_called()
 
 

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -422,7 +422,7 @@ def test_run_resume_coordinator_aborts_when_base_branch_unpublished(tmp_path):
             state_update_fn=None,
         )
 
-    mock_pull.assert_called_once_with(config, auto_merge=False)
+    mock_pull.assert_called_once_with(config, lands_locally=False)
     mock_setup.assert_not_called()
 
 

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2646,6 +2646,8 @@ class TestSprintRunAuditCommit:
                 return (True, "")
             if cmd == commit_cmd:
                 return (True, "")
+            if cmd == "git rev-list --count origin/main..main":
+                return (True, "0\n")
             return (True, "")
 
         with (
@@ -2659,15 +2661,15 @@ class TestSprintRunAuditCommit:
             sprint = run_sprint(config, manifest_path, auto_merge=True)
 
         assert sprint.specs_succeeded == 1
-        audit_shell_calls = [
-            call
-            for call in shell_calls
-            if ".forge/audits/runs" in call[0] or "chore(audit)" in call[0]
-        ]
-        assert audit_shell_calls == [
+        # Slice from the audit status probe: the publish sequence is the tail of
+        # the run, and rev-list also appears earlier from workspace base sync.
+        start = shell_calls.index(("git status --porcelain -- .forge/audits/runs", tmp_path))
+        assert shell_calls[start:] == [
             ("git status --porcelain -- .forge/audits/runs", tmp_path),
             ("git add -- .forge/audits/runs", tmp_path),
             (commit_cmd, tmp_path),
+            ("git push origin main", tmp_path),
+            ("git rev-list --count origin/main..main", tmp_path),
         ]
 
     def test_run_sprint_skips_audit_commit_when_project_root_is_clean(
@@ -2712,7 +2714,7 @@ class TestSprintRunAuditCommit:
         ]
         assert audit_shell_calls == [("git status --porcelain -- .forge/audits/runs", tmp_path)]
 
-    def test_run_sprint_warns_when_audit_commit_fails_after_state_cleanup(
+    def test_run_sprint_raises_when_audit_publish_fails_after_state_cleanup(
         self, tmp_path: Path
     ) -> None:
         _make_spec_file(tmp_path, "Story A", "story-a")
@@ -2739,7 +2741,9 @@ class TestSprintRunAuditCommit:
             if cmd == "git add -- .forge/audits/runs":
                 return (True, "")
             if cmd == commit_cmd:
-                return (False, "commit failed")
+                return (True, "")
+            if cmd == "git push origin main":
+                return (False, "rejected: non-fast-forward")
             return (True, "")
 
         with (
@@ -2750,13 +2754,52 @@ class TestSprintRunAuditCommit:
             ),
             patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
             patch("theforge.sprint.runner._log", side_effect=warnings.append),
+            pytest.raises(RuntimeError, match="Failed to push story run audits"),
         ):
-            sprint = run_sprint(config, manifest_path, auto_merge=True)
+            run_sprint(config, manifest_path, auto_merge=True)
 
-        assert sprint.specs_succeeded == 1
+        # Cleanup still ran before the raise, but the sprint does not report success.
         assert not any((tmp_path / ".forge" / "runs").glob("*.state"))
-        assert any("canonical story run audit commit failed" in warning for warning in warnings)
-        assert (commit_cmd, tmp_path) in shell_calls
+        assert any("canonical story run audit publish failed" in warning for warning in warnings)
+        assert ("git push origin main", tmp_path) in shell_calls
+
+    def test_run_sprint_raises_when_base_still_ahead_after_push(self, tmp_path: Path) -> None:
+        """A push that reports success but leaves the base ahead is still a failure."""
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md"],
+            budget=10.0,
+            max_parallel=1,
+        )
+        (tmp_path / ".git").mkdir()
+        config = _make_config(tmp_path)
+
+        result = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        result.landing_status = "pending_integration"
+        result.merge = {"action": "merge", "pending": True}
+        warnings: list[str] = []
+
+        def fake_shell(cmd, cwd, **kwargs):  # noqa: ANN001
+            if cmd == "git status --porcelain -- .forge/audits/runs":
+                return (True, "?? .forge/audits/runs/run-123.json")
+            if cmd == "git rev-list --count origin/main..main":
+                return (True, "1\n")
+            return (True, "")
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch(
+                "theforge.coordinator.completion._merge_branch",
+                return_value={"merged": True, "success": True, "action": "merge"},
+            ),
+            patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
+            patch("theforge.sprint.runner._log", side_effect=warnings.append),
+            pytest.raises(RuntimeError, match="still 1 commit"),
+        ):
+            run_sprint(config, manifest_path, auto_merge=True)
+
+        assert any("canonical story run audit publish failed" in warning for warning in warnings)
 
 
 def test_integration_lock_serializes(tmp_path: Path) -> None:

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -26,7 +26,7 @@ from theforge.review import ReviewResult
 from theforge.sprint import load_sprint_manifest, run_sprint
 from theforge.sprint.dag import StoryDAG, build_dag
 from theforge.sprint.lock import integration_lock
-from theforge.sprint.runner import _classify_and_record
+from theforge.sprint.runner import _classify_and_record, _run_fresh
 from theforge.task import TaskStory
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -2618,6 +2618,100 @@ class TestImmediateIntegrationLanding:
         assert result.success is False
         assert result.phase is Phase.MERGE_FAILED
         assert result.landing_status == "failed"
+
+
+class TestRunFreshPlanGatedForwarding:
+    """The plan-gated split path must forward both landing-related flags.
+
+    Phase 1 of the split is the call whose WORKSPACE step actually cuts the
+    story's worktree, so dropping either flag there reintroduces a false abort
+    on a base branch that a local-merge workflow legitimately left ahead.
+    """
+
+    def _run(self, tmp_path: Path, *, effective_auto_merge: bool, base_lands_locally: bool):
+        task = TaskStory(name="Story A", slug="story-a", story_path=None, story_text="body")
+        gate = threading.Event()
+        gate.set()  # scheduler already released; do not block the test
+
+        plan_result = _make_coordinator_result(success=True, cost=0.0)
+        plan_result.state.workspace_path = tmp_path / "story-a"
+        dev_result = _make_coordinator_result(success=True, cost=0.0)
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=plan_result) as mock_run_task,
+            patch(
+                "theforge.sprint.runner.run_from_dev", return_value=dev_result
+            ) as mock_run_from_dev,
+        ):
+            _run_fresh(
+                _make_config(tmp_path),
+                task,
+                "sprint-run-1",
+                "Sprint",
+                False,
+                False,
+                effective_auto_merge,
+                None,
+                False,
+                gate,
+                None,
+                base_lands_locally=base_lands_locally,
+            )
+        return mock_run_task, mock_run_from_dev
+
+    def test_phase1_run_task_forwards_effective_auto_merge(self, tmp_path: Path) -> None:
+        mock_run_task, _ = self._run(tmp_path, effective_auto_merge=True, base_lands_locally=True)
+        assert mock_run_task.call_args.kwargs["auto_merge"] is True
+
+    def test_phase1_run_task_forwards_base_lands_locally(self, tmp_path: Path) -> None:
+        mock_run_task, _ = self._run(tmp_path, effective_auto_merge=False, base_lands_locally=True)
+        # effective_auto_merge is False for this story, but an earlier story in
+        # the sprint merged locally — the guard must hear about it anyway.
+        assert mock_run_task.call_args.kwargs["auto_merge"] is False
+        assert mock_run_task.call_args.kwargs["base_lands_locally"] is True
+
+    def test_phase2_run_from_dev_forwards_both(self, tmp_path: Path) -> None:
+        _, mock_run_from_dev = self._run(
+            tmp_path, effective_auto_merge=True, base_lands_locally=True
+        )
+        assert mock_run_from_dev.call_args.kwargs["auto_merge"] is True
+        assert mock_run_from_dev.call_args.kwargs["base_lands_locally"] is True
+
+
+class TestSprintLandsLocallyResolution:
+    """run_sprint answers the local-landing question sprint-wide, once."""
+
+    def _lands_locally_seen(self, tmp_path: Path, *, max_parallel: int, auto_merge: bool):
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path, ["story-a.md"], budget=10.0, max_parallel=max_parallel
+        )
+        (tmp_path / ".git").mkdir()
+        config = _make_workspace_config(tmp_path, on_approve="pr")
+        seen: dict = {}
+
+        def fake_pull(_config, *, lands_locally=None):
+            seen["lands_locally"] = lands_locally
+            raise RuntimeError("stop after base sync")
+
+        with (
+            patch("theforge.sprint.runner._project_root_is_git_checkout", return_value=True),
+            patch("theforge.coordinator.workspace.pull_base_branch", side_effect=fake_pull),
+            pytest.raises(RuntimeError, match="stop after base sync"),
+        ):
+            run_sprint(config, manifest_path, auto_merge=auto_merge)
+        return seen["lands_locally"]
+
+    def test_sequential_auto_merge_lands_locally(self, tmp_path: Path) -> None:
+        """--auto-merge in sequential mode merges into the local base checkout."""
+        assert self._lands_locally_seen(tmp_path, max_parallel=1, auto_merge=True) is True
+
+    def test_parallel_auto_merge_does_not_land_locally(self, tmp_path: Path) -> None:
+        """Parallel mode forces effective_am False, so nothing merges locally."""
+        assert self._lands_locally_seen(tmp_path, max_parallel=2, auto_merge=True) is False
+
+    def test_sequential_without_auto_merge_does_not_land_locally(self, tmp_path: Path) -> None:
+        assert self._lands_locally_seen(tmp_path, max_parallel=1, auto_merge=False) is False
 
 
 def _make_workspace_config(tmp_path: Path, **workspace_kwargs):

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2620,12 +2620,22 @@ class TestImmediateIntegrationLanding:
         assert result.landing_status == "failed"
 
 
-def _make_pushing_config(tmp_path: Path):
-    """_make_config with auto_push on — the base branch is expected to track origin."""
+def _make_workspace_config(tmp_path: Path, **workspace_kwargs):
+    """_make_config with workspace field overrides."""
     config = _make_config(tmp_path)
     return dataclasses.replace(
-        config, workspace=dataclasses.replace(config.workspace, auto_push=True)
+        config, workspace=dataclasses.replace(config.workspace, **workspace_kwargs)
     )
+
+
+def _make_pushing_config(tmp_path: Path):
+    """These sprints run with auto_merge=True, so auto_push decides publication.
+
+    --auto-merge forces the local-merge landing path; with auto_push on, those
+    merges reach the remote, so the base branch is expected to track origin and
+    the audit commit must be pushed.
+    """
+    return _make_workspace_config(tmp_path, auto_push=True)
 
 
 class TestSprintRunAuditCommit:
@@ -2809,8 +2819,53 @@ class TestSprintRunAuditCommit:
 
         assert any("canonical story run audit publish failed" in warning for warning in warnings)
 
-    def test_run_sprint_commits_without_push_when_auto_push_off(self, tmp_path: Path) -> None:
-        """auto_push=false: pushing the base would publish local merges the operator declined.
+    def test_run_sprint_publishes_audits_under_pr_workflow_without_auto_push(
+        self, tmp_path: Path
+    ) -> None:
+        """on_approve: pr + auto_push: false must still push the audit commit.
+
+        Nothing merges into the local base branch under a PR workflow, so there
+        are no local merges a push could over-publish — and story branches are
+        pushed for GitHub to diff against origin/<base>, which is exactly where
+        an unpublished audit commit shows up as content of the wrong story.
+        """
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md"],
+            budget=10.0,
+            max_parallel=1,
+        )
+        (tmp_path / ".git").mkdir()
+        config = _make_workspace_config(tmp_path, on_approve="pr")
+        assert config.workspace.auto_push is False
+
+        result = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        commit_cmd = 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs'
+        shell_calls: list[str] = []
+        logs: list[str] = []
+
+        def fake_shell(cmd, cwd, **kwargs):  # noqa: ANN001
+            shell_calls.append(cmd)
+            if cmd == "git status --porcelain -- .forge/audits/runs":
+                return (True, "?? .forge/audits/runs/run-123.json")
+            if cmd == "git rev-list --count origin/main..main":
+                return (True, "0\n")
+            return (True, "")
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
+            patch("theforge.sprint.runner._log", side_effect=logs.append),
+        ):
+            run_sprint(config, manifest_path)
+
+        assert commit_cmd in shell_calls
+        assert "git push origin main" in shell_calls
+        assert not any("remain local" in line for line in logs)
+
+    def test_run_sprint_commits_without_push_under_local_merge(self, tmp_path: Path) -> None:
+        """Local-merge landing without auto_push: pushing would over-publish.
 
         A branch push carries all its ancestors, so the audit commit cannot be
         published in isolation. The records stay local and the sprint warns.
@@ -2853,7 +2908,7 @@ class TestSprintRunAuditCommit:
         assert sprint.specs_succeeded == 1
         assert commit_cmd in shell_calls
         assert "git push origin main" not in shell_calls
-        assert any("remain local" in line and "auto_push is off" in line for line in logs)
+        assert any("remain local" in line and "workspace.auto_push off" in line for line in logs)
 
 
 def test_integration_lock_serializes(tmp_path: Path) -> None:

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2620,6 +2620,14 @@ class TestImmediateIntegrationLanding:
         assert result.landing_status == "failed"
 
 
+def _make_pushing_config(tmp_path: Path):
+    """_make_config with auto_push on — the base branch is expected to track origin."""
+    config = _make_config(tmp_path)
+    return dataclasses.replace(
+        config, workspace=dataclasses.replace(config.workspace, auto_push=True)
+    )
+
+
 class TestSprintRunAuditCommit:
     def test_run_sprint_commits_story_run_audits_from_project_root(self, tmp_path: Path) -> None:
         _make_spec_file(tmp_path, "Story A", "story-a")
@@ -2630,7 +2638,7 @@ class TestSprintRunAuditCommit:
             max_parallel=1,
         )
         (tmp_path / ".git").mkdir()
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
 
         result = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result.landing_status = "pending_integration"
@@ -2683,7 +2691,7 @@ class TestSprintRunAuditCommit:
             max_parallel=1,
         )
         (tmp_path / ".git").mkdir()
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
 
         result = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result.landing_status = "pending_integration"
@@ -2725,7 +2733,7 @@ class TestSprintRunAuditCommit:
             max_parallel=1,
         )
         (tmp_path / ".git").mkdir()
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
 
         result = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result.landing_status = "pending_integration"
@@ -2773,7 +2781,7 @@ class TestSprintRunAuditCommit:
             max_parallel=1,
         )
         (tmp_path / ".git").mkdir()
-        config = _make_config(tmp_path)
+        config = _make_pushing_config(tmp_path)
 
         result = _make_coordinator_result(success=True, cost=1.0, merged=False)
         result.landing_status = "pending_integration"
@@ -2800,6 +2808,52 @@ class TestSprintRunAuditCommit:
             run_sprint(config, manifest_path, auto_merge=True)
 
         assert any("canonical story run audit publish failed" in warning for warning in warnings)
+
+    def test_run_sprint_commits_without_push_when_auto_push_off(self, tmp_path: Path) -> None:
+        """auto_push=false: pushing the base would publish local merges the operator declined.
+
+        A branch push carries all its ancestors, so the audit commit cannot be
+        published in isolation. The records stay local and the sprint warns.
+        """
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md"],
+            budget=10.0,
+            max_parallel=1,
+        )
+        (tmp_path / ".git").mkdir()
+        config = _make_config(tmp_path)
+        assert config.workspace.auto_push is False
+
+        result = _make_coordinator_result(success=True, cost=1.0, merged=False)
+        result.landing_status = "pending_integration"
+        result.merge = {"action": "merge", "pending": True}
+        commit_cmd = 'git commit -m "chore(audit): record sprint run audits" -- .forge/audits/runs'
+        shell_calls: list[str] = []
+        logs: list[str] = []
+
+        def fake_shell(cmd, cwd, **kwargs):  # noqa: ANN001
+            shell_calls.append(cmd)
+            if cmd == "git status --porcelain -- .forge/audits/runs":
+                return (True, "?? .forge/audits/runs/run-123.json")
+            return (True, "")
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch(
+                "theforge.coordinator.completion._merge_branch",
+                return_value={"merged": True, "success": True, "action": "merge"},
+            ),
+            patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
+            patch("theforge.sprint.runner._log", side_effect=logs.append),
+        ):
+            sprint = run_sprint(config, manifest_path, auto_merge=True)
+
+        assert sprint.specs_succeeded == 1
+        assert commit_cmd in shell_calls
+        assert "git push origin main" not in shell_calls
+        assert any("remain local" in line and "auto_push is off" in line for line in logs)
 
 
 def test_integration_lock_serializes(tmp_path: Path) -> None:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -323,7 +323,7 @@ def test_run_sprint_pulls_base_branch_before_baseline_by_default(tmp_path: Path)
     resolved = _make_empty_resolved()
     call_order: list[str] = []
 
-    def _fake_pull(_config: ForgeConfig) -> None:
+    def _fake_pull(_config: ForgeConfig, *, auto_merge: bool = False) -> None:
         call_order.append("pull")
 
     def _fake_baseline(_config: ForgeConfig, _resolved: ResolvedSprint) -> dict[str, object]:
@@ -354,7 +354,7 @@ def test_run_sprint_pulls_base_branch_before_baseline_by_default(tmp_path: Path)
             run_sprint(config, resolved)
 
     assert call_order == ["pull", "baseline"]
-    mock_pull.assert_called_once_with(config)
+    mock_pull.assert_called_once_with(config, auto_merge=False)
 
 
 def test_run_sprint_no_pull_skips_prebaseline_pull(tmp_path: Path) -> None:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -323,7 +323,7 @@ def test_run_sprint_pulls_base_branch_before_baseline_by_default(tmp_path: Path)
     resolved = _make_empty_resolved()
     call_order: list[str] = []
 
-    def _fake_pull(_config: ForgeConfig, *, auto_merge: bool = False) -> None:
+    def _fake_pull(_config: ForgeConfig, *, lands_locally: bool | None = None) -> None:
         call_order.append("pull")
 
     def _fake_baseline(_config: ForgeConfig, _resolved: ResolvedSprint) -> dict[str, object]:
@@ -354,7 +354,7 @@ def test_run_sprint_pulls_base_branch_before_baseline_by_default(tmp_path: Path)
             run_sprint(config, resolved)
 
     assert call_order == ["pull", "baseline"]
-    mock_pull.assert_called_once_with(config, auto_merge=False)
+    mock_pull.assert_called_once_with(config, lands_locally=False)
 
 
 def test_run_sprint_no_pull_skips_prebaseline_pull(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior P1s are resolved: audit commits are published or visibly warned in the local-merge exception, ahead-only base branches block PR-style worktree creation, and the plan-gated fresh path now forwards the effective landing context. | [google-gemini-3.5-flash] All prior P1 findings are fully resolved, and the base-branch publication guard is robustly implemented and tested. | [claude-sonnet] All three prior P1s are resolved: the auto_push-only rule (Cycle 1) was replaced by the two-question lands-locally/tracks-origin split (Cycle 2), and the per-story auto_merge mismatch (Cycle 3) is now resolved by a sprint-wide _sprint_lands_locally computed once in run_sprint and threaded as an explicit base_lands_locally override through every run_task/run_from_dev/run_from_review/_run_resume_coordinator call site, including the plan-gated Phase-1 call that previously hardcoded auto_merge=False. Verified the sprint-wide formula against the actual per-story effective_on_approve resolution in completion.py (both the --auto-merge/dependent_slugs sequential case and the config.workspace.on_approve=='merge' case, which applies unconditionally even in parallel mode) — no gap found. 250 targeted tests pass; 2 unrelated failures elsewhere in the suite are sandbox multiprocessing semaphore permission errors, not caused by this diff.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $32.74
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Base-branch audit commits can remain local and contaminate later story PRs (GitHub Issue #1950)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1950