### PR TITLE
Merge-wait does not distinguish terminally-failed checks from slow ones: waits the full timeout on a doomed PR and reports it as a queue timeout

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -292,6 +292,8 @@ workspace:
   pr_labels: []                       # labels applied when on_approve is "pr" or "merge-pr"
   pr_draft: false                     # create PR as draft when on_approve is "pr"
   merge_wait_timeout_seconds: 3600    # max wait for queued merge-pr landing
+                                      # (only pending checks consume it; a PR whose
+                                      #  required checks have failed is abandoned at once)
 
 # ── Validation gate ────────────────────────────────────────
 validation:

--- a/src/theforge/sprint/ci_checks.py
+++ b/src/theforge/sprint/ci_checks.py
@@ -18,6 +18,8 @@ _FAIL_CONCLUSIONS = {
     "action_required",
     "startup_failure",
     "stale",
+    # GraphQL StatusContext state for a hard-errored legacy status.
+    "error",
 }
 _PENDING_STATUSES = {"queued", "in_progress", "pending", "waiting", "requested"}
 
@@ -100,18 +102,24 @@ def _summarize_required_checks(
     )
 
 
-def poll_required_checks(project_root: Path, base_branch: str, timeout_seconds: int) -> dict:
+def _resolve_owner_repo(project_root: Path) -> str:
     repo = _gh_json(project_root, ["repo", "view", "--json", "nameWithOwner"])
     owner_repo = repo["nameWithOwner"] if isinstance(repo, dict) else None
     if not isinstance(owner_repo, str) or not owner_repo:
         raise RuntimeError("Unable to resolve GitHub repository owner/name")
+    return owner_repo
 
-    sha_raw = _gh_text(
-        project_root, ["api", f"repos/{owner_repo}/branches/{base_branch}", "--jq", ".commit.sha"]
-    )
-    sha = json.loads(sha_raw) if sha_raw.startswith('"') else sha_raw
+
+def _required_check_contexts(
+    project_root: Path, owner_repo: str, base_branch: str
+) -> list[str] | None:
+    """Required status-check contexts for ``base_branch``.
+
+    Returns ``None`` when branch protection (or its required-checks block) does
+    not exist, which callers must treat as "unknown", not as "none failing".
+    """
     try:
-        required_checks_raw = _gh_json(
+        raw = _gh_json(
             project_root,
             [
                 "api",
@@ -122,22 +130,89 @@ def poll_required_checks(project_root: Path, base_branch: str, timeout_seconds: 
         )
     except RuntimeError as exc:
         if "404" in str(exc) or "Not Found" in str(exc):
-            return {
-                "status": "skipped",
-                "sha": sha,
-                "failing_checks": [],
-                "message": (
-                    f"Required status checks not configured for {base_branch}; "
-                    f"skipping CI gate for {sha}."
-                ),
-            }
+            return None
         raise
+    return [c for c in raw if isinstance(c, str)] if isinstance(raw, list) else []
 
-    required_checks = (
-        [c for c in required_checks_raw if isinstance(c, str)]
-        if isinstance(required_checks_raw, list)
-        else []
+
+def _normalize_rollup(rollup: object) -> tuple[list[dict], list[dict]]:
+    """Split a ``statusCheckRollup`` payload into check-run / legacy-status shapes.
+
+    The rollup comes from GraphQL, so its enums are upper-case
+    (``COMPLETED``/``FAILURE``); the REST-shaped summarizer expects the
+    lower-case spellings. Normalizing here keeps a single conclusion table.
+    """
+
+    def _lower(value: object) -> str | None:
+        return value.lower() if isinstance(value, str) else None
+
+    check_runs: list[dict] = []
+    statuses: list[dict] = []
+    for entry in rollup if isinstance(rollup, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        context = entry.get("context")
+        if entry.get("__typename") == "StatusContext" or (
+            not isinstance(name, str) and isinstance(context, str)
+        ):
+            if isinstance(context, str):
+                statuses.append({"context": context, "state": _lower(entry.get("state"))})
+        elif isinstance(name, str):
+            check_runs.append(
+                {
+                    "name": name,
+                    "status": _lower(entry.get("status")),
+                    "conclusion": _lower(entry.get("conclusion")),
+                }
+            )
+    return check_runs, statuses
+
+
+def failing_required_pr_checks(project_root: Path, pr_url: str, base_branch: str) -> list[str]:
+    """Names of ``pr_url``'s required checks that have terminally failed.
+
+    Returns an empty list when nothing is decided-red *and* when the required
+    check set or the PR's rollup cannot be resolved: an un-answerable probe must
+    leave the caller waiting rather than abandon a PR on missing information.
+    """
+    try:
+        owner_repo = _resolve_owner_repo(project_root)
+        required_checks = _required_check_contexts(project_root, owner_repo, base_branch)
+        if not required_checks:
+            return []
+        rollup = _gh_json(
+            project_root,
+            ["pr", "view", pr_url, "--json", "statusCheckRollup", "--jq", ".statusCheckRollup"],
+        )
+    except Exception as exc:  # gh missing, network flake, unparseable payload
+        log.debug("Unable to resolve required check status for %s: %s", pr_url, exc)
+        return []
+
+    check_runs, statuses = _normalize_rollup(rollup)
+    _, failing, _ = _summarize_required_checks(required_checks, check_runs, statuses)
+    return failing
+
+
+def poll_required_checks(project_root: Path, base_branch: str, timeout_seconds: int) -> dict:
+    owner_repo = _resolve_owner_repo(project_root)
+
+    sha_raw = _gh_text(
+        project_root, ["api", f"repos/{owner_repo}/branches/{base_branch}", "--jq", ".commit.sha"]
     )
+    sha = json.loads(sha_raw) if sha_raw.startswith('"') else sha_raw
+    required_checks = _required_check_contexts(project_root, owner_repo, base_branch)
+    if required_checks is None:
+        return {
+            "status": "skipped",
+            "sha": sha,
+            "failing_checks": [],
+            "message": (
+                f"Required status checks not configured for {base_branch}; "
+                f"skipping CI gate for {sha}."
+            ),
+        }
+
     if not required_checks:
         return {
             "status": "skipped",

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -893,6 +893,32 @@ def _detect_partial_value(story: dict, audit: dict) -> list[str]:
     return values
 
 
+def _merge_failed_action(story: dict, ref: str) -> str:
+    """Next step for a failed landing, branched on the evidenced cause.
+
+    A merge can fail for reasons that call for opposite operator responses, and
+    the recorded error text is the evidence that distinguishes them. Naming a
+    merge conflict unconditionally (the prior behavior) is wrong whenever the PR
+    was mergeable and merely red, or merely slow — issue #1946.
+    """
+    error = (_nonempty(story.get("error")) or "").lower()
+    if "required checks failed" in error:
+        return (
+            f"fix the required checks named in {ref}'s merge failure, then re-run the "
+            "gate and land it — the PR was abandoned decided-red, not blocked by a "
+            "conflict or a wait budget"
+        )
+    if "timed out" in error:
+        return (
+            f"inspect {ref}'s queued PR: its required checks were still pending when the "
+            "merge wait expired — raise merge_wait_timeout_seconds or land it manually "
+            "once the checks settle"
+        )
+    if "conflict" in error:
+        return f"resolve the merge conflict for {ref} and re-run the merge"
+    return f"inspect {ref}'s PR for the merge failure cause recorded above, then re-run the merge"
+
+
 def _recommend_actions(primary: str, contributing: list[str], story: dict) -> list[str]:
     """Map primary class + contributing factors to actionable next steps."""
     ref = _story_ref(story)
@@ -913,7 +939,7 @@ def _recommend_actions(primary: str, contributing: list[str], story: dict) -> li
             "not a code defect requiring LLM diagnosis"
         ),
         "intake_shape": f"reshape the {ref} issue body to satisfy the intake gate, then re-run",
-        "merge_failed": f"resolve the merge conflict for {ref} and re-run the merge",
+        "merge_failed": _merge_failed_action(story, ref),
         "merge_arming_failed": (
             f"configure branch protection so auto-merge can arm, or merge {ref} manually"
         ),
@@ -946,9 +972,13 @@ def _recommend_actions(primary: str, contributing: list[str], story: dict) -> li
         actions.append("wire the provider fallback so the next failure recovers automatically")
     if "operator_gate_timeout" in contributing:
         actions.append("shorten or auto-resolve the operator decision gate that timed out")
-    if "dev_iteration_limit" in contributing and primary != "iteration_exhaustion":
+    # A story that reached the merge queue produced a reviewed, PR-worthy commit;
+    # its landing failed for a post-review reason. Iteration-budget advice there
+    # names a cause the evidence contradicts (issue #1946).
+    iteration_advice_applies = primary not in {"iteration_exhaustion", "merge_failed"}
+    if "dev_iteration_limit" in contributing and iteration_advice_applies:
         actions.append("raise the dev iteration budget or narrow the story scope")
-    if "review_iteration_limit" in contributing and primary != "iteration_exhaustion":
+    if "review_iteration_limit" in contributing and iteration_advice_applies:
         actions.append("raise the review iteration budget or reduce review churn")
 
     return actions

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -60,7 +60,7 @@ from .audit import (
     persist_accumulated_story_state,
 )
 from .auth_gate import enforce_sprint_auth_readiness
-from .ci_checks import poll_required_checks
+from .ci_checks import failing_required_pr_checks, poll_required_checks
 from .collision import (
     compute_bundle_assignments,
     compute_synthetic_edges,
@@ -1474,13 +1474,27 @@ def _snapshot_last_known(
     return snapshot
 
 
+def _failing_required_pr_checks(pr_url: str, project_root: Path, base_branch: str) -> list[str]:
+    """Required checks on ``pr_url`` that have reached a terminal failing state.
+
+    Thin seam over :mod:`theforge.sprint.ci_checks` so the queued-PR wait can be
+    tested without a live ``gh``. Never raises: an unanswerable probe returns no
+    failures, which keeps the caller waiting instead of abandoning a PR whose
+    check state we could not read.
+    """
+    try:
+        return failing_required_pr_checks(project_root, pr_url, base_branch)
+    except Exception:  # pragma: no cover - ci_checks already fails soft
+        return []
+
+
 def _poll_queued_pr(
     pr_url: str,
     project_root: Path,
     timeout_seconds: int,
     base_branch: str | None = None,
 ) -> dict[str, str]:
-    """Poll GitHub until a queued PR is merged, closed, or times out.
+    """Poll GitHub until a queued PR is merged, closed, red, or times out.
 
     When ``base_branch`` is supplied, "merged" is only reported once GitHub
     reports MERGED *and* the PR's merge commit is reachable on
@@ -1488,6 +1502,12 @@ def _poll_queued_pr(
     several seconds before the merge commit propagates to the base ref;
     releasing a collision-serialized dependent on the GitHub state alone
     re-creates the race the collision DAG existed to prevent (issue #1402).
+
+    A still-open PR is also probed for terminally-failed required checks each
+    iteration. A decided-red PR can never merge, so waiting on it only burns the
+    merge-wait budget and then misreports the outcome as a queue timeout (issue
+    #1946); such a PR returns ``checks_failed`` immediately, carrying the names
+    of the failing checks. The wait budget is reserved for *pending* checks.
     """
     deadline = time.monotonic() + timeout_seconds
     while True:
@@ -1511,10 +1531,35 @@ def _poll_queued_pr(
                     return {"status": "merged"}
             elif state == "CLOSED":
                 return {"status": "closed"}
+            elif base_branch is not None:
+                failing = _failing_required_pr_checks(pr_url, project_root, base_branch)
+                if failing:
+                    return {
+                        "status": "checks_failed",
+                        "failing_checks": ", ".join(failing),
+                    }
 
         if time.monotonic() >= deadline:
             return {"status": "timeout"}
         time.sleep(30)
+
+
+def _queued_pr_failure_message(
+    poll_result: dict[str, str], pr_url: str, timeout_seconds: int
+) -> str:
+    """Render the merge-failure cause for a non-merged queued-PR poll result.
+
+    The cause string is the only evidence downstream RCA has, so each terminal
+    status gets its own wording: "timed out" is reserved for an actual deadline
+    expiry, and a decided-red PR names the required checks that failed.
+    """
+    status = poll_result.get("status", "unknown")
+    if status == "checks_failed":
+        failing = poll_result.get("failing_checks") or "unknown"
+        return f"Queued PR required checks failed ({failing}): {pr_url}"
+    if status == "timeout":
+        return f"Queued PR timed out after {timeout_seconds}s: {pr_url}"
+    return f"Queued PR {status}: {pr_url}"
 
 
 def _merge_visible_on_base(pr_url: str, project_root: Path, base_branch: str) -> bool:
@@ -2991,13 +3036,11 @@ def run_sprint(
                                 mark_merge_failed as _mark_mf,
                             )
 
-                            if poll_result["status"] == "timeout":
-                                _err = (
-                                    f"Queued PR timed out after "
-                                    f"{config.workspace.merge_wait_timeout_seconds}s: {dep_pr_url}"
-                                )
-                            else:
-                                _err = f"Queued PR {poll_result['status']}: {dep_pr_url}"
+                            _err = _queued_pr_failure_message(
+                                poll_result,
+                                dep_pr_url,
+                                config.workspace.merge_wait_timeout_seconds,
+                            )
                             _mark_mf(
                                 dep_result.state,
                                 dep_result,
@@ -3204,13 +3247,9 @@ def run_sprint(
                             mark_merge_failed as _mark_mf,
                         )
 
-                        if _qp_poll["status"] == "timeout":
-                            _err = (
-                                f"Queued PR timed out after "
-                                f"{config.workspace.merge_wait_timeout_seconds}s: {_qp_pr_url}"
-                            )
-                        else:
-                            _err = f"Queued PR {_qp_poll['status']}: {_qp_pr_url}"
+                        _err = _queued_pr_failure_message(
+                            _qp_poll, _qp_pr_url, config.workspace.merge_wait_timeout_seconds
+                        )
                         _mark_mf(_qp_result.state, _qp_result, _err, _qp_result.state.branch_name)
                         _set_outcome(
                             _qp_slug, StoryOutcome.MERGE_FAILED, phase=_qp_result.phase.name
@@ -3645,13 +3684,9 @@ def run_sprint(
                     mark_merge_failed as _mark_mf,
                 )
 
-                if poll_result["status"] == "timeout":
-                    _err = (
-                        f"Queued PR timed out after "
-                        f"{config.workspace.merge_wait_timeout_seconds}s: {pr_url}"
-                    )
-                else:
-                    _err = f"Queued PR {poll_result['status']}: {pr_url}"
+                _err = _queued_pr_failure_message(
+                    poll_result, pr_url, config.workspace.merge_wait_timeout_seconds
+                )
                 _mark_mf(result.state, result, _err, result.state.branch_name)
                 _set_outcome(slug, StoryOutcome.MERGE_FAILED, phase=result.phase.name)
                 _log(f"✗ {slug}: queued PR {poll_result['status']} during sprint wrap-up")

--- a/tests/test_ci_checks.py
+++ b/tests/test_ci_checks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-from theforge.sprint.ci_checks import poll_required_checks
+from theforge.sprint.ci_checks import failing_required_pr_checks, poll_required_checks
 
 
 class _Proc:
@@ -110,3 +110,74 @@ def test_poll_required_checks_polls_until_success(tmp_path: Path) -> None:
 
     assert result["status"] == "pass"
     sleep.assert_called_once_with(15)
+
+
+def _pr_check_responses(rollup: str) -> list[_Proc]:
+    """gh calls made by failing_required_pr_checks, in order."""
+    return [
+        _Proc('{"nameWithOwner":"acme/repo"}'),
+        _Proc('["gate","lint"]'),
+        _Proc(rollup),
+    ]
+
+
+def test_failing_required_pr_checks_reports_terminal_failures(tmp_path: Path) -> None:
+    rollup = (
+        '[{"__typename":"CheckRun","name":"gate","status":"COMPLETED","conclusion":"FAILURE"},'
+        '{"__typename":"CheckRun","name":"lint","status":"COMPLETED","conclusion":"SUCCESS"}]'
+    )
+
+    with patch(
+        "theforge.sprint.ci_checks.subprocess.run", side_effect=_pr_check_responses(rollup)
+    ):
+        failing = failing_required_pr_checks(tmp_path, "https://github.com/x/y/pull/1", "main")
+
+    assert failing == ["gate"]
+
+
+def test_failing_required_pr_checks_ignores_pending_and_non_required(tmp_path: Path) -> None:
+    """A required check still running is not a failure, and a failing check that
+    is not required cannot block the merge — neither may abandon the wait."""
+    rollup = (
+        '[{"__typename":"CheckRun","name":"gate","status":"IN_PROGRESS","conclusion":null},'
+        '{"__typename":"CheckRun","name":"lint","status":"COMPLETED","conclusion":"SUCCESS"},'
+        '{"__typename":"CheckRun","name":"optional-bench","status":"COMPLETED",'
+        '"conclusion":"FAILURE"}]'
+    )
+
+    with patch(
+        "theforge.sprint.ci_checks.subprocess.run", side_effect=_pr_check_responses(rollup)
+    ):
+        assert failing_required_pr_checks(tmp_path, "https://github.com/x/y/pull/1", "main") == []
+
+
+def test_failing_required_pr_checks_reads_legacy_status_contexts(tmp_path: Path) -> None:
+    rollup = (
+        '[{"__typename":"StatusContext","context":"gate","state":"ERROR"},'
+        '{"__typename":"CheckRun","name":"lint","status":"COMPLETED","conclusion":"SUCCESS"}]'
+    )
+
+    with patch(
+        "theforge.sprint.ci_checks.subprocess.run", side_effect=_pr_check_responses(rollup)
+    ):
+        failing = failing_required_pr_checks(tmp_path, "https://github.com/x/y/pull/1", "main")
+
+    assert failing == ["gate"]
+
+
+def test_failing_required_pr_checks_returns_empty_when_unresolvable(tmp_path: Path) -> None:
+    """An un-answerable probe must leave the caller waiting rather than abandon a
+    PR whose check state could not be read."""
+
+    with patch("theforge.sprint.ci_checks.subprocess.run", side_effect=OSError("gh missing")):
+        assert failing_required_pr_checks(tmp_path, "https://github.com/x/y/pull/1", "main") == []
+
+
+def test_failing_required_pr_checks_empty_when_branch_unprotected(tmp_path: Path) -> None:
+    responses = [
+        _Proc('{"nameWithOwner":"acme/repo"}'),
+        _Proc("", "gh: Not Found (HTTP 404)", 1),
+    ]
+
+    with patch("theforge.sprint.ci_checks.subprocess.run", side_effect=responses):
+        assert failing_required_pr_checks(tmp_path, "https://github.com/x/y/pull/1", "main") == []

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -1905,6 +1905,109 @@ class TestQueuedMergePolling:
                 "status": "timeout"
             }
 
+    def test_poll_queued_pr_abandons_on_terminally_failed_required_checks(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #1946: a decided-red PR can never merge. Waiting on it burns the
+        whole merge-wait budget and then misreports the cause as a timeout, so the
+        poll must return immediately naming the failing checks."""
+
+        from theforge.sprint.runner import _poll_queued_pr
+
+        with (
+            patch(
+                "theforge.sprint.runner.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="OPEN", stderr=""),
+            ),
+            patch(
+                "theforge.sprint.runner._failing_required_pr_checks",
+                return_value=["gate", "lint"],
+            ),
+            patch("theforge.sprint.runner.time.sleep") as sleep,
+        ):
+            result = _poll_queued_pr(
+                "https://github.com/x/y/pull/1",
+                tmp_path,
+                3600,
+                base_branch="main",
+            )
+
+        assert result == {"status": "checks_failed", "failing_checks": "gate, lint"}
+        sleep.assert_not_called()
+
+    def test_poll_queued_pr_keeps_waiting_while_checks_pending(self, tmp_path: Path) -> None:
+        """Pending checks are exactly what the wait budget is for: no failing
+        required check means keep polling until MERGED (or the deadline)."""
+
+        from theforge.sprint.runner import _poll_queued_pr
+
+        states = ["OPEN", "OPEN", "MERGED"]
+
+        def _fake_run(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout=states.pop(0), stderr="")
+
+        with (
+            patch("theforge.sprint.runner.subprocess.run", side_effect=_fake_run),
+            patch("theforge.sprint.runner._failing_required_pr_checks", return_value=[]) as probe,
+            patch("theforge.sprint.runner.time.sleep") as sleep,
+        ):
+            result = _poll_queued_pr(
+                "https://github.com/x/y/pull/1",
+                tmp_path,
+                3600,
+            )
+
+        assert result == {"status": "merged"}
+        assert sleep.call_count == 2
+        # No base branch → no required-check set to resolve; never probe.
+        probe.assert_not_called()
+
+    def test_poll_queued_pr_timeout_reserved_for_deadline_expiry(self, tmp_path: Path) -> None:
+        """With checks pending (none failing), only the deadline produces a
+        timeout — the status must stay distinguishable from checks_failed."""
+
+        from theforge.sprint.runner import _poll_queued_pr
+
+        monotonic_values = iter([0, 1, 31, 61])
+        with (
+            patch(
+                "theforge.sprint.runner.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="OPEN", stderr=""),
+            ),
+            patch("theforge.sprint.runner._failing_required_pr_checks", return_value=[]),
+            patch("theforge.sprint.runner.time.sleep"),
+            patch(
+                "theforge.sprint.runner.time.monotonic", side_effect=lambda: next(monotonic_values)
+            ),
+        ):
+            result = _poll_queued_pr(
+                "https://github.com/x/y/pull/1",
+                tmp_path,
+                60,
+                base_branch="main",
+            )
+
+        assert result == {"status": "timeout"}
+
+    def test_queued_pr_failure_message_names_the_evidenced_cause(self) -> None:
+        from theforge.sprint.runner import _queued_pr_failure_message
+
+        url = "https://github.com/x/y/pull/7"
+        assert (
+            _queued_pr_failure_message(
+                {"status": "checks_failed", "failing_checks": "gate"}, url, 3600
+            )
+            == f"Queued PR required checks failed (gate): {url}"
+        )
+        assert (
+            _queued_pr_failure_message({"status": "timeout"}, url, 3600)
+            == f"Queued PR timed out after 3600s: {url}"
+        )
+        assert (
+            _queued_pr_failure_message({"status": "closed"}, url, 3600)
+            == f"Queued PR closed: {url}"
+        )
+
     def test_poll_queued_pr_waits_for_origin_main_when_base_branch_set(
         self, tmp_path: Path
     ) -> None:
@@ -2078,6 +2181,94 @@ class TestQueuedMergePolling:
         assert sprint.specs_succeeded == 0
         assert sprint.specs_failed == 1
         assert sprint.specs_skipped == 0
+
+    def test_merge_queued_failed_checks_recorded_as_check_failure(self, tmp_path: Path) -> None:
+        """Issue #1946: a red PR must be recorded with the failing check names as
+        the cause, not with the generic queue-timeout wording."""
+
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            workspace=WorkspaceConfig(
+                create_command="mkdir -p {slug}",
+                path_pattern="{slug}",
+                branch_pattern="forge/{slug}",
+                on_approve="merge-pr",
+                auto_push=True,
+                ci_check_timeout_seconds=60,
+                merge_wait_timeout_seconds=3600,
+            ),
+        )
+
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        mock_preflight = MagicMock()
+        mock_preflight.cost_usd = 1.0
+        state.preflight_result = mock_preflight
+        state.review_results = [
+            ReviewResult(
+                verdict="APPROVE",
+                summary="Looks good.",
+                findings=[],
+                story_matches=True,
+                story_mismatches=[],
+                test_adequate=True,
+                test_gaps=[],
+                parse_errors=[],
+                raw_yaml={},
+            )
+        ]
+        result = CoordinatorResult(
+            success=True,
+            phase=Phase.DONE,
+            state=state,
+            message="Done.",
+            merge={"action": "merge-pr", "pending": True},
+            landing_status="pending_integration",
+        )
+
+        with (
+            patch("theforge.sprint.runner.run_task", return_value=result),
+            patch(
+                "theforge.coordinator.completion._merge_pr",
+                return_value={
+                    "action": "merge-pr",
+                    "pr_url": "https://github.com/x/y/pull/7",
+                    "merged": False,
+                    "merge_queued": True,
+                    "auto_merge_queued": True,
+                    "success": True,
+                    "error": None,
+                },
+            ),
+            patch(
+                "theforge.sprint.runner._poll_queued_pr",
+                return_value={"status": "checks_failed", "failing_checks": "gate"},
+            ),
+            patch(
+                "theforge.sprint.runner.poll_required_checks",
+                return_value={
+                    "status": "pass",
+                    "sha": "deadbeef",
+                    "failing_checks": [],
+                    "message": "ok",
+                },
+            ),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        assert result.landing_status == "failed"
+        assert result.state.error == (
+            "Queued PR required checks failed (gate): https://github.com/x/y/pull/7"
+        )
+        assert "timed out" not in (result.state.error or "")
+        assert sprint.specs_failed == 1
 
     def test_independent_story_runs_while_merge_is_queued(self, tmp_path: Path) -> None:
         _make_spec_file(tmp_path, "Story A", "story-a")

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -1178,3 +1178,69 @@ def test_write_no_overwrite_leaves_existing(tmp_path: Path) -> None:
     # overwrite=True regenerates
     write_sprint_rca(d, overwrite=True)
     assert "sentinel" not in path.read_text()
+
+
+def test_merge_failed_check_failure_guidance_names_the_checks(tmp_path: Path) -> None:
+    """Issue #1946: a PR abandoned decided-red must not be told to resolve a
+    merge conflict or raise an iteration budget — it has evidence against both."""
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-1934",
+                    "outcome": "MERGE_FAILED",
+                    "error": (
+                        "Queued PR required checks failed (gate): https://github.com/x/y/pull/1943"
+                    ),
+                }
+            ]
+        ),
+    )
+    entry = _build(d)["stories"]["issue-1934"]
+    actions = " ".join(entry["recommended_next_actions"]).lower()
+
+    assert entry["primary_failure_class"] == "merge_failed"
+    assert "required checks" in actions
+    assert "merge conflict" not in actions
+    assert "iteration budget" not in actions
+
+
+def test_merge_failed_timeout_guidance_points_at_the_wait_budget(tmp_path: Path) -> None:
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-9",
+                    "outcome": "MERGE_FAILED",
+                    "error": "Queued PR timed out after 3600s: https://github.com/x/y/pull/9",
+                }
+            ]
+        ),
+    )
+    actions = " ".join(_build(d)["stories"]["issue-9"]["recommended_next_actions"]).lower()
+
+    assert "merge_wait_timeout_seconds" in actions
+    assert "merge conflict" not in actions
+
+
+def test_merge_failed_conflict_guidance_preserved(tmp_path: Path) -> None:
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-10",
+                    "outcome": "MERGE_FAILED",
+                    "error": "merge conflict in src/theforge/sprint/runner.py",
+                }
+            ]
+        ),
+    )
+    actions = " ".join(_build(d)["stories"]["issue-10"]["recommended_next_actions"]).lower()
+
+    assert "resolve the merge conflict" in actions


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The queued merge wait now distinguishes terminal check failures from pending checks, records the evidenced cause, and has focused coverage for the observed symptom. | [google-gemini-3.5-flash] The implementation successfully detects terminally-failed required checks on queued PRs, abandons the wait immediately, and provides accurate RCA guidance.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $3.95
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Merge-wait does not distinguish terminally-failed checks from slow ones: waits the full timeout on a doomed PR and reports it as a queue timeout (GitHub Issue #1946)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1946