### PR TITLE
Patient gate runs under the orchestrator's interpreter, not the project's pinned Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Patient gates run under the project's pinned Python, not the orchestrator's
+  (#1934):** `{forge_python}` now expands to a new required
+  `workspace.python_interpreter` setting instead of TheForge's own
+  `sys.executable`, and a worktree `.venv` whose `pyvenv.cfg` does not record
+  that interpreter is deleted and reprovisioned before setup runs. Gate
+  subprocess environments only prefer `.venv/bin` when it matches the pin. A
+  story's gate result therefore no longer depends on which Python TheForge
+  happens to be installed under, or on whether a stale virtualenv survived from
+  an earlier run.
+  **Operator action:** projects whose `setup_command` uses `{forge_python}` must
+  add `workspace.python_interpreter` (e.g. `"python3.12"`) to `forge.yaml`;
+  config load now fails closed without it rather than silently substituting the
+  orchestrator's interpreter.
+
 - **Base-branch audit commits are published, not left local (#1950):** the
   sprint now pushes its `chore(audit): record sprint run audits` commit to
   `origin/<base_branch>` and verifies the base branch is no longer ahead;

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -284,6 +284,13 @@ overrides:
 workspace:
   create_command: "git worktree add .forge/worktrees/{slug} -b forge/{slug} main"
   setup_command: "pip install -e ."    # optional: run once after worktree creation
+                                      # {forge_python} expands to python_interpreter
+  python_interpreter: "python3.12"    # interpreter this project develops against;
+                                      # required when setup_command uses {forge_python}.
+                                      # Worktree virtualenvs built from a different
+                                      # interpreter are deleted and reprovisioned, so
+                                      # the gate never inherits whichever Python
+                                      # TheForge itself happens to be installed under.
   path_pattern: ".forge/worktrees/{slug}"
   branch_pattern: "forge/{slug}"
   base_branch: "main"                 # default: "main"

--- a/src/theforge/config/_loaders.py
+++ b/src/theforge/config/_loaders.py
@@ -78,6 +78,20 @@ def _parse_workspace(ws_data: dict[str, Any]) -> WorkspaceConfig:
                 "merge_strategy must be one of "
                 f"{sorted(_valid_strategies)}, got {merge_strategy!r}"
             )
+
+    setup_command = ws_data.get("setup_command", DEFAULT_WORKSPACE.setup_command)
+    raw_interpreter = ws_data.get("python_interpreter", DEFAULT_WORKSPACE.python_interpreter)
+    python_interpreter = str(raw_interpreter).strip() if raw_interpreter is not None else None
+    python_interpreter = python_interpreter or None
+    if setup_command and "{forge_python}" in setup_command and not python_interpreter:
+        raise ValueError(
+            "workspace.setup_command uses {forge_python} but workspace.python_interpreter "
+            "is not set. Declare the interpreter this project develops against (e.g. "
+            'python_interpreter: "python3.12") — TheForge will not substitute its own '
+            "interpreter, because the orchestrator's runtime must not decide which Python "
+            "the project's gate runs under."
+        )
+
     return WorkspaceConfig(
         create_command=ws_data.get("create_command", DEFAULT_WORKSPACE.create_command),
         path_pattern=ws_data.get("path_pattern", DEFAULT_WORKSPACE.path_pattern),
@@ -87,7 +101,8 @@ def _parse_workspace(ws_data: dict[str, Any]) -> WorkspaceConfig:
             "stale_worktree_days", DEFAULT_WORKSPACE.stale_worktree_days
         ),
         auto_push=auto_push,
-        setup_command=ws_data.get("setup_command", DEFAULT_WORKSPACE.setup_command),
+        setup_command=setup_command,
+        python_interpreter=python_interpreter,
         on_approve=on_approve,
         merge_strategy=merge_strategy,
         pr_labels=tuple(ws_data.get("pr_labels", [])),

--- a/src/theforge/config/defaults.py
+++ b/src/theforge/config/defaults.py
@@ -77,6 +77,9 @@ workspace:
   create_command: "git worktree add .forge/worktrees/{slug} -b forge/{slug} {base_branch}"
   # Optional: run once in the new workspace after creation (e.g. install deps).
   # setup_command: "pip install -e ."
+  # Required when setup_command uses {forge_python}: the interpreter this project
+  # develops against. TheForge never substitutes its own interpreter here.
+  # python_interpreter: "python3.12"
   path_pattern: ".forge/worktrees/{slug}"
   branch_pattern: "forge/{slug}"
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -304,6 +304,11 @@ class WorkspaceConfig:
     stale_worktree_days: int = 1  # remove worktrees older than N days; 0 = always remove
     auto_push: bool = False  # push base_branch to origin after successful auto-merge
     setup_command: str | None = None  # optional command run once after workspace creation
+    # Interpreter the patient project develops against, e.g. "python3.12" or an
+    # absolute path. Substituted for {forge_python} in setup_command and used to
+    # validate worktree virtualenvs. Deliberately has no default: falling back to
+    # the orchestrator's own interpreter is the defect this field exists to close.
+    python_interpreter: str | None = None
     on_approve: str = "none"  # "merge" | "pr" | "merge-pr" | "none"; alias: "ask" → "pr"
     merge_strategy: str = "squash"  # merge | squash | rebase (used by on_approve="merge-pr")
     pr_labels: tuple[str, ...] = ()  # labels to apply when on_approve="pr" or "merge-pr"

--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -96,6 +96,7 @@ def run_gate_full(
         gate_cmd,
         workspace_path,
         timeout=gate_timeout,
+        expected_python=config.workspace.python_interpreter,
     )
 
     if iter_num is not None:
@@ -175,6 +176,7 @@ def _run_gate_debug_command(
         debug_cmd,
         workspace_path,
         timeout=debug_timeout,
+        expected_python=config.workspace.python_interpreter,
     )
     if output.startswith("TIMEOUT") and exit_code is None:
         _cu._log(f"  Gate debug command timed out after {debug_timeout}s")

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -308,12 +308,21 @@ def _drain_partial_output(
 
 
 def _run_shell_detailed(
-    cmd: str, cwd: Path, timeout: int = 120, env: dict[str, str] | None = None
+    cmd: str,
+    cwd: Path,
+    timeout: int = 120,
+    env: dict[str, str] | None = None,
+    expected_python: str | None = None,
 ) -> tuple[bool, str, int | None, bool]:
     """Run a shell command. Returns (success, combined output, exit_code, timed_out).
 
     On abnormal exit, kills the entire process group so child processes (e.g.
     pytest-xdist workers) don't outlive the shell and consume unbounded memory.
+
+    ``expected_python`` is the patient project's pinned interpreter; when given,
+    a worktree virtualenv is only put on PATH if it was built from that
+    interpreter. Ignored when ``env`` is supplied, since the caller then owns
+    the environment.
     """
     try:
         proc = subprocess.Popen(
@@ -323,7 +332,11 @@ def _run_shell_detailed(
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(cwd),
-            env=env if env is not None else build_workspace_env(cwd),
+            env=(
+                env
+                if env is not None
+                else build_workspace_env(cwd, expected_python=expected_python)
+            ),
             start_new_session=True,
         )
     except Exception as e:
@@ -361,7 +374,11 @@ def _run_shell_detailed(
 
 
 def _run_shell(
-    cmd: str, cwd: Path, timeout: int = 120, env: dict[str, str] | None = None
+    cmd: str,
+    cwd: Path,
+    timeout: int = 120,
+    env: dict[str, str] | None = None,
+    expected_python: str | None = None,
 ) -> tuple[bool, str]:
     """Run a shell command. Returns (success, combined output)."""
     ok, output, _exit_code, _timed_out = _run_shell_detailed(
@@ -369,6 +386,7 @@ def _run_shell(
         cwd,
         timeout=timeout,
         env=env,
+        expected_python=expected_python,
     )
     return ok, output
 

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -15,6 +15,7 @@ from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.config import ForgeConfig
 from theforge.detach import find_run_id_for_pid as _find_run_id_for_pid
 from theforge.task import TaskStory
+from theforge.workspace_env import read_venv_base_executable, venv_matches_interpreter
 
 from . import util as _cu
 from .gate import _run_gate
@@ -90,13 +91,62 @@ def _propagate_claude_memory(project_root: Path, workspace_path: Path) -> None:
         _cu._log(f"⚠ WORKSPACE  failed to propagate Claude memory: {exc}")
 
 
-def _resolve_setup_command(cmd: str) -> str:
-    """Replace {forge_python} with the shell-safe path to the running interpreter.
+def _resolve_setup_command(cmd: str, python_interpreter: str | None = None) -> str:
+    """Replace {forge_python} with the shell-safe patient-project interpreter.
+
+    The value comes from ``workspace.python_interpreter``, never from
+    ``sys.executable``: the interpreter the orchestrator happens to be installed
+    under must not decide which Python the patient project's gate runs on.
+    Config load rejects a ``{forge_python}`` template without the pin, so a
+    missing value here is a programming error and raises rather than silently
+    falling back.
 
     Uses shlex.quote so that paths containing spaces or shell-sensitive characters
     do not break shell=True invocations.
     """
-    return cmd.replace("{forge_python}", shlex.quote(sys.executable))
+    if "{forge_python}" not in cmd:
+        return cmd
+    if not python_interpreter:
+        raise ValueError(
+            "setup_command uses {forge_python} but no workspace.python_interpreter was "
+            "supplied — refusing to substitute the orchestrator's own interpreter"
+        )
+    return cmd.replace("{forge_python}", shlex.quote(python_interpreter))
+
+
+def _invalidate_stale_venv(workspace_path: Path, python_interpreter: str | None) -> str | None:
+    """Remove a worktree virtualenv not built from the project-pinned interpreter.
+
+    Setup commands guard venv creation with ``test -d .venv ||``, and gate
+    commands routinely invoke ``.venv/bin/...`` directly, so an existing
+    virtualenv left by a differently-built orchestrator would decide the gate's
+    runtime no matter what the pin says. Removing it lets the guard rebuild it
+    under the pin, which also reruns dependency installation.
+
+    Returns an error message when a stale virtualenv could not be removed —
+    continuing would run the gate under the wrong interpreter — or None.
+    """
+    if not python_interpreter:
+        return None
+    venv_path = workspace_path / ".venv"
+    if not venv_path.is_dir():
+        return None
+    if venv_matches_interpreter(venv_path, python_interpreter):
+        return None
+
+    recorded = read_venv_base_executable(venv_path) or "unknown"
+    _cu._log(
+        f"⚠ WORKSPACE  existing .venv was built from {recorded}, not the project-pinned "
+        f"{python_interpreter} — removing so it is reprovisioned under the pin"
+    )
+    try:
+        shutil.rmtree(venv_path)
+    except OSError as exc:
+        return (
+            f"Could not remove stale virtualenv {venv_path} built from {recorded} "
+            f"(pinned interpreter: {python_interpreter}): {exc}"
+        )
+    return None
 
 
 def _read_last_setup_command(workspace_path: Path) -> str | None:
@@ -115,41 +165,66 @@ def _write_last_setup_command(workspace_path: Path, cmd: str) -> None:
     (forge_dir / "last_setup_command").write_text(cmd, encoding="utf-8")
 
 
-def _run_setup_split(setup_command: str, workspace_path: Path) -> tuple[bool, str]:
+def _run_setup_split(
+    setup_command: str,
+    workspace_path: Path,
+    python_interpreter: str | None = None,
+) -> tuple[bool, str]:
     """Run workspace setup, splitting venv creation from install.
 
     Matches {forge_python} template before substitution to avoid parsing
     shlex.quote() output; falls back to legacy form; then runs verbatim.
+
+    ``python_interpreter`` is the patient project's pinned interpreter. A
+    virtualenv already present in the worktree is validated against it before
+    anything runs, so a stale one cannot survive the ``test -d .venv`` guard.
     """
     last_setup_command = _read_last_setup_command(workspace_path)
     if last_setup_command is not None and last_setup_command != setup_command:
         _cu._log("⚠ WORKSPACE  setup_command changed — re-running install")
 
+    stale_err = _invalidate_stale_venv(workspace_path, python_interpreter)
+    if stale_err is not None:
+        return False, stale_err
+
     m = _VENV_GUARD_TEMPLATE_RE.search(setup_command)
     if m:
         install_cmd = m.group(1).strip()
-        python_exe = shlex.quote(sys.executable)
-        ok, out = _cu._run_shell(f"test -d .venv || {python_exe} -m venv .venv", workspace_path)
+        if not python_interpreter:
+            raise ValueError(
+                "setup_command uses {forge_python} but no workspace.python_interpreter was "
+                "supplied — refusing to substitute the orchestrator's own interpreter"
+            )
+        python_exe = shlex.quote(python_interpreter)
+        ok, out = _cu._run_shell(
+            f"test -d .venv || {python_exe} -m venv .venv",
+            workspace_path,
+            expected_python=python_interpreter,
+        )
         if not ok:
             return ok, out
-        ok, out = _cu._run_shell(install_cmd, workspace_path)
+        ok, out = _cu._run_shell(install_cmd, workspace_path, expected_python=python_interpreter)
         if ok:
             _write_last_setup_command(workspace_path, setup_command)
         return ok, out
 
-    cmd = _resolve_setup_command(setup_command)
+    cmd = _resolve_setup_command(setup_command, python_interpreter)
     m = _VENV_GUARD_RE.search(cmd)
     if not m:
-        ok, out = _cu._run_shell(cmd, workspace_path)
+        ok, out = _cu._run_shell(cmd, workspace_path, expected_python=python_interpreter)
         if ok:
             _write_last_setup_command(workspace_path, setup_command)
         return ok, out
     python_exe = m.group(1)
     install_cmd = m.group(2).strip()
-    ok, out = _cu._run_shell(f"test -d .venv || {python_exe} -m venv .venv", workspace_path)
+    ok, out = _cu._run_shell(
+        f"test -d .venv || {python_exe} -m venv .venv",
+        workspace_path,
+        expected_python=python_interpreter,
+    )
     if not ok:
         return ok, out
-    ok, out = _cu._run_shell(install_cmd, workspace_path)
+    ok, out = _cu._run_shell(install_cmd, workspace_path, expected_python=python_interpreter)
     if ok:
         _write_last_setup_command(workspace_path, setup_command)
     return ok, out
@@ -863,7 +938,11 @@ def _create_workspace(
                 return None, None, rebase_err
             if config.workspace.setup_command:
                 _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
-                ok_s, out_s = _run_setup_split(config.workspace.setup_command, workspace_path)
+                ok_s, out_s = _run_setup_split(
+                    config.workspace.setup_command,
+                    workspace_path,
+                    config.workspace.python_interpreter,
+                )
                 if not ok_s:
                     return None, None, f"Workspace setup command failed: {out_s}"
             _deindex_forge_artifacts(workspace_path, purge=True)
@@ -900,7 +979,11 @@ def _create_workspace(
                     return None, None, rebase_err
                 if config.workspace.setup_command:
                     _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
-                    ok_s, out_s = _run_setup_split(config.workspace.setup_command, existing_wt)
+                    ok_s, out_s = _run_setup_split(
+                        config.workspace.setup_command,
+                        existing_wt,
+                        config.workspace.python_interpreter,
+                    )
                     if not ok_s:
                         return None, None, f"Workspace setup command failed: {out_s}"
                 _deindex_forge_artifacts(existing_wt, purge=True)
@@ -933,7 +1016,11 @@ def _create_workspace(
                 return None, None, rebase_err
             if config.workspace.setup_command:
                 _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
-                ok_s, out_s = _run_setup_split(config.workspace.setup_command, workspace_path)
+                ok_s, out_s = _run_setup_split(
+                    config.workspace.setup_command,
+                    workspace_path,
+                    config.workspace.python_interpreter,
+                )
                 if not ok_s:
                     return None, None, f"Workspace setup command failed: {out_s}"
             _deindex_forge_artifacts(workspace_path, purge=True)
@@ -960,7 +1047,11 @@ def _create_workspace(
 
     if config.workspace.setup_command:
         _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
-        ok, output = _run_setup_split(config.workspace.setup_command, workspace_path)
+        ok, output = _run_setup_split(
+            config.workspace.setup_command,
+            workspace_path,
+            config.workspace.python_interpreter,
+        )
         if not ok:
             return None, None, f"Workspace setup command failed: {output}"
 

--- a/src/theforge/gate_diagnostics.py
+++ b/src/theforge/gate_diagnostics.py
@@ -98,7 +98,11 @@ def run_gate_diagnostic_pass(
     )
     _cu._log(f"  Running gate diagnostic pass after timeout: {diagnostic_cmd}")
 
-    env = build_workspace_env(workspace_path, extra={"PYTHONFAULTHANDLER": "1"})
+    env = build_workspace_env(
+        workspace_path,
+        extra={"PYTHONFAULTHANDLER": "1"},
+        expected_python=config.workspace.python_interpreter,
+    )
     _ok, output, exit_code, timed_out = _cu._run_shell_detailed(
         diagnostic_cmd,
         workspace_path,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -784,7 +784,9 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
         if config.workspace.setup_command:
             _log(f"Running baseline workspace setup: {config.workspace.setup_command}")
             setup_ok, setup_out = coordinator_workspace._run_setup_split(
-                config.workspace.setup_command, baseline_worktree
+                config.workspace.setup_command,
+                baseline_worktree,
+                config.workspace.python_interpreter,
             )
             if not setup_ok:
                 duration = time.monotonic() - started_monotonic

--- a/src/theforge/workspace_env.py
+++ b/src/theforge/workspace_env.py
@@ -1,10 +1,112 @@
-"""Workspace subprocess environment helpers."""
+"""Workspace subprocess environment helpers.
+
+Stdlib-only by design: this module is imported by runners, the coordinator, and
+gate diagnostics, so it must not pull in configuration or provider machinery.
+"""
 
 from __future__ import annotations
 
+import logging
 import os
+import shlex
+import shutil
+import subprocess
+from functools import lru_cache
 from pathlib import Path
 from typing import Mapping
+
+log = logging.getLogger("theforge.workspace_env")
+
+_INTERPRETER_PROBE_TIMEOUT_SECONDS = 15
+
+# ``sys._base_executable`` resolves through nested virtualenvs to the real
+# interpreter; ``sys.executable`` inside a venv points at the venv's own shim.
+# ``venv`` records the former in pyvenv.cfg, so the pin must be probed the same
+# way or every comparison against a venv-hosted interpreter would spuriously
+# mismatch.
+_BASE_EXECUTABLE_PROBE = (
+    "import sys; print(getattr(sys, '_base_executable', None) or sys.executable)"
+)
+
+
+def read_venv_base_executable(venv_path: Path) -> str | None:
+    """Return the base interpreter a virtualenv was created from, if recorded.
+
+    Reads ``pyvenv.cfg``'s ``executable`` key, falling back to the first token of
+    ``command`` for virtualenvs written without it. Returns None when the file is
+    absent or records neither — callers must treat that as "cannot prove a
+    match", not as a match.
+    """
+    try:
+        text = (venv_path / "pyvenv.cfg").read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    executable: str | None = None
+    command_exe: str | None = None
+    for line in text.splitlines():
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        name = key.strip().lower()
+        val = value.strip()
+        if not val:
+            continue
+        if name == "executable":
+            executable = val
+        elif name == "command":
+            try:
+                tokens = shlex.split(val)
+            except ValueError:
+                tokens = val.split()
+            if tokens:
+                command_exe = tokens[0]
+    return executable or command_exe
+
+
+@lru_cache(maxsize=32)
+def resolve_base_executable(python_command: str) -> str | None:
+    """Resolve an interpreter command to the real path of its base interpreter.
+
+    ``python_command`` may be a bare name resolved through PATH (``python3.12``),
+    a launcher shim, or an absolute path — including one inside a virtualenv.
+    The interpreter is probed once per process so the result is comparable with
+    what ``venv`` writes into pyvenv.cfg. Returns None when the command does not
+    resolve to an existing file.
+    """
+    candidate = shutil.which(python_command) or python_command
+    if not os.path.exists(candidate):
+        return None
+    try:
+        probe = subprocess.run(
+            [candidate, "-c", _BASE_EXECUTABLE_PROBE],
+            capture_output=True,
+            text=True,
+            timeout=_INTERPRETER_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return os.path.realpath(candidate)
+    resolved = probe.stdout.strip()
+    if probe.returncode == 0 and resolved:
+        return os.path.realpath(resolved)
+    return os.path.realpath(candidate)
+
+
+def venv_matches_interpreter(venv_path: Path, expected_python: str) -> bool:
+    """Whether ``venv_path`` was provably created from ``expected_python``.
+
+    Fails closed: anything that cannot be proven — no pyvenv.cfg, no recorded
+    interpreter, an unresolvable pin — is a mismatch. A virtualenv whose
+    provenance is unknown must not be allowed to decide which Python a gate runs
+    under.
+    """
+    recorded = read_venv_base_executable(venv_path)
+    if not recorded:
+        return False
+    expected = resolve_base_executable(expected_python)
+    if not expected:
+        return False
+    return os.path.realpath(recorded) == expected
 
 
 def build_workspace_env(
@@ -12,13 +114,33 @@ def build_workspace_env(
     base_env: Mapping[str, str] | None = None,
     *,
     extra: Mapping[str, str] | None = None,
+    expected_python: str | None = None,
 ) -> dict[str, str]:
-    """Build an environment that prefers the workspace virtualenv when present."""
+    """Build an environment that prefers the workspace virtualenv when present.
+
+    ``expected_python`` is the patient project's pinned interpreter. When given,
+    an existing ``.venv`` is only put on PATH if it was built from that
+    interpreter; otherwise it is left unpreferred so a virtualenv provisioned by
+    a differently-built orchestrator cannot silently change the runtime. Callers
+    that have no pin available omit it and keep the historical behavior.
+    """
     env = dict(base_env or os.environ)
     venv_path = workspace_path / ".venv"
     venv_bin = venv_path / "bin"
 
-    if venv_bin.exists():
+    prefer_venv = venv_bin.exists()
+    if prefer_venv and expected_python is not None:
+        if not venv_matches_interpreter(venv_path, expected_python):
+            log.warning(
+                "workspace virtualenv at %s was not built from the pinned interpreter %r "
+                "(recorded: %s) — not preferring it on PATH",
+                venv_path,
+                expected_python,
+                read_venv_base_executable(venv_path) or "unknown",
+            )
+            prefer_venv = False
+
+    if prefer_venv:
         path_entries = env.get("PATH", "").split(os.pathsep) if env.get("PATH") else []
         filtered_entries = [
             entry

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -9,6 +9,7 @@ import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from coord_test_helpers import (
     _PREFLIGHT_RESULT,
     APPROVE_REVIEW,
@@ -984,8 +985,32 @@ class TestRunSetupSplit:
         assert out == "venv error"
         assert len(calls) == 1  # install was not called
 
-    def test_forge_python_placeholder_replaced_with_sys_executable(self, tmp_path):
-        """{forge_python} in setup_command is replaced with sys.executable before running."""
+    def test_forge_python_placeholder_replaced_with_configured_interpreter(self, tmp_path):
+        """{forge_python} is replaced with the configured project pin, not sys.executable."""
+        import sys
+
+        from theforge.coordinator.workspace import _run_setup_split
+
+        pinned = "/opt/project-pythons/3.12/bin/python3.12"
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && pip install -e .)"
+        calls = []
+
+        def fake_shell(cmd_arg, cwd, **kw):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path, pinned)
+
+        assert ok is True
+        assert len(calls) == 2
+        # venv creation uses the project pin, not the orchestrator's interpreter
+        assert pinned in calls[0]
+        assert sys.executable not in calls[0]
+        assert "{forge_python}" not in calls[0]
+
+    def test_forge_python_without_configured_interpreter_is_rejected(self, tmp_path):
+        """A {forge_python} template with no pin raises rather than using sys.executable."""
         import sys
 
         from theforge.coordinator.workspace import _run_setup_split
@@ -998,22 +1023,22 @@ class TestRunSetupSplit:
             return (True, "ok")
 
         with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
-            ok, out = _run_setup_split(cmd, tmp_path)
+            with pytest.raises(ValueError, match="python_interpreter"):
+                _run_setup_split(cmd, tmp_path)
 
-        assert ok is True
-        assert len(calls) == 2
-        # venv creation uses sys.executable, not the literal placeholder
-        assert sys.executable in calls[0]
-        assert "{forge_python}" not in calls[0]
+        assert calls == []
+        assert sys.executable  # the orchestrator interpreter exists but must not be used
 
     def test_resolve_setup_command_replaces_placeholder(self):
-        """_resolve_setup_command swaps {forge_python} for the absolute interpreter path."""
+        """_resolve_setup_command swaps {forge_python} for the configured interpreter."""
         import sys
 
         from theforge.coordinator.workspace import _resolve_setup_command
 
-        result = _resolve_setup_command("test -d .venv || ({forge_python} -m venv .venv)")
-        assert sys.executable in result
+        pinned = "/opt/project-pythons/3.12/bin/python3.12"
+        result = _resolve_setup_command("test -d .venv || ({forge_python} -m venv .venv)", pinned)
+        assert pinned in result
+        assert sys.executable not in result
         assert "{forge_python}" not in result
 
     def test_resolve_setup_command_noop_without_placeholder(self):
@@ -1024,7 +1049,7 @@ class TestRunSetupSplit:
         assert _resolve_setup_command(cmd) == cmd
 
     def test_forge_python_with_spaces_in_path_is_shell_quoted(self, tmp_path):
-        """sys.executable with spaces is shell-quoted; command is still split (not verbatim)."""
+        """A pin with spaces is shell-quoted; command is still split (not verbatim)."""
         from theforge.coordinator.workspace import _run_setup_split
 
         spaced_exe = "/home/my user/.pyenv/versions/3.12.12/bin/python3.12"
@@ -1035,12 +1060,8 @@ class TestRunSetupSplit:
             calls.append(cmd_arg)
             return (True, "ok")
 
-        with (
-            patch("theforge.coordinator.workspace.sys") as mock_sys,
-            patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell),
-        ):
-            mock_sys.executable = spaced_exe
-            ok, out = _run_setup_split(cmd, tmp_path)
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path, spaced_exe)
 
         assert ok is True
         # Template matched before substitution — command was split, not run verbatim
@@ -1066,12 +1087,8 @@ class TestRunSetupSplit:
             calls.append(cmd_arg)
             return (True, "ok")
 
-        with (
-            patch("theforge.coordinator.workspace.sys") as mock_sys,
-            patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell),
-        ):
-            mock_sys.executable = tricky_exe
-            ok, out = _run_setup_split(cmd, tmp_path)
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, out = _run_setup_split(cmd, tmp_path, tricky_exe)
 
         assert ok is True
         # Must have split into two calls, not fallen back to verbatim (one call)
@@ -1084,9 +1101,7 @@ class TestRunSetupSplit:
         from theforge.coordinator.workspace import _resolve_setup_command
 
         spaced_exe = "/home/my user/.pyenv/bin/python3"
-        with patch("theforge.coordinator.workspace.sys") as mock_sys:
-            mock_sys.executable = spaced_exe
-            result = _resolve_setup_command("{forge_python} -m venv .venv")
+        result = _resolve_setup_command("{forge_python} -m venv .venv", spaced_exe)
 
         assert "'/home/my user/.pyenv/bin/python3'" in result
         assert "{forge_python}" not in result

--- a/tests/test_coord_workspace_venv.py
+++ b/tests/test_coord_workspace_venv.py
@@ -18,7 +18,7 @@ class TestRunSetupSplitVenvBehavior:
             return (True, "ok")
 
         with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
-            ok, out = _run_setup_split(cmd, tmp_path)
+            ok, out = _run_setup_split(cmd, tmp_path, "/opt/project-pythons/3.12/bin/python3.12")
 
         assert ok is True
         assert len(calls) == 2
@@ -107,7 +107,9 @@ class TestCreateWorkspaceReuseRunsSetup:
 
         assert err is None
         assert workspace_path == workspace
-        mock_setup.assert_called_once_with(config.workspace.setup_command, workspace)
+        mock_setup.assert_called_once_with(
+            config.workspace.setup_command, workspace, config.workspace.python_interpreter
+        )
         mock_deindex.assert_called_once_with(workspace, purge=True)
 
 

--- a/tests/test_workspace_python_pin.py
+++ b/tests/test_workspace_python_pin.py
@@ -1,0 +1,314 @@
+"""Tests for the patient project's pinned gate interpreter.
+
+The gate must run under the interpreter the project declares, never under
+whichever Python TheForge itself happens to be installed under, and never under
+whatever interpreter a leftover worktree virtualenv was built from.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from theforge.config import load_config
+from theforge.coordinator.workspace import _invalidate_stale_venv, _run_setup_split
+from theforge.workspace_env import (
+    build_workspace_env,
+    read_venv_base_executable,
+    resolve_base_executable,
+    venv_matches_interpreter,
+)
+
+_OTHER_PYTHON = "/opt/some-other-runtime/bin/python3.14"
+
+
+def _base_executable() -> str:
+    """The real interpreter behind this test run, as ``venv`` would record it."""
+    return os.path.realpath(getattr(sys, "_base_executable", None) or sys.executable)
+
+
+def _fake_venv(root: Path, *, executable: str | None = None, command: str | None = None) -> Path:
+    """Create a .venv skeleton with the given pyvenv.cfg provenance keys."""
+    venv = root / ".venv"
+    (venv / "bin").mkdir(parents=True, exist_ok=True)
+    lines = ["home = /irrelevant", "version = 3.12.12"]
+    if executable is not None:
+        lines.append(f"executable = {executable}")
+    if command is not None:
+        lines.append(f"command = {command}")
+    (venv / "pyvenv.cfg").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return venv
+
+
+def _write_config(data: dict, tmp_dir: Path) -> Path:
+    config_path = tmp_dir / "forge.yaml"
+    config_path.write_text(yaml.dump(data), encoding="utf-8")
+    return config_path
+
+
+class TestReadVenvBaseExecutable:
+    def test_reads_executable_key(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable="/usr/bin/python3.12")
+        assert read_venv_base_executable(venv) == "/usr/bin/python3.12"
+
+    def test_falls_back_to_command_first_token(self, tmp_path):
+        venv = _fake_venv(tmp_path, command="/usr/bin/python3.12 -m venv /tmp/x")
+        assert read_venv_base_executable(venv) == "/usr/bin/python3.12"
+
+    def test_command_with_spaces_is_shell_split(self, tmp_path):
+        venv = _fake_venv(tmp_path, command="'/opt/my python/bin/python3' -m venv /tmp/x")
+        assert read_venv_base_executable(venv) == "/opt/my python/bin/python3"
+
+    def test_missing_pyvenv_cfg_is_unknown(self, tmp_path):
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+        assert read_venv_base_executable(tmp_path / ".venv") is None
+
+    def test_cfg_without_provenance_keys_is_unknown(self, tmp_path):
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "pyvenv.cfg").write_text("home = /x\nversion = 3.12.12\n", encoding="utf-8")
+        assert read_venv_base_executable(venv) is None
+
+
+class TestVenvMatchesInterpreter:
+    def test_matches_when_built_from_the_pin(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_base_executable())
+        assert venv_matches_interpreter(venv, sys.executable) is True
+
+    def test_mismatch_when_built_from_another_interpreter(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+        assert venv_matches_interpreter(venv, sys.executable) is False
+
+    def test_unknown_provenance_fails_closed(self, tmp_path):
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+        assert venv_matches_interpreter(tmp_path / ".venv", sys.executable) is False
+
+    def test_unresolvable_pin_fails_closed(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_base_executable())
+        assert venv_matches_interpreter(venv, "/nonexistent/bin/python3.99") is False
+
+    def test_resolve_base_executable_of_missing_command_is_none(self):
+        assert resolve_base_executable("/nonexistent/bin/python3.99") is None
+
+
+class TestBuildWorkspaceEnvPinAware:
+    def test_matching_venv_is_preferred(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_base_executable())
+
+        env = build_workspace_env(tmp_path, {"PATH": "/usr/bin"}, expected_python=sys.executable)
+
+        assert env["PATH"].split(os.pathsep)[0] == str(venv / "bin")
+        assert env["VIRTUAL_ENV"] == str(venv)
+
+    def test_stale_venv_is_not_put_on_path(self, tmp_path):
+        _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+
+        env = build_workspace_env(tmp_path, {"PATH": "/usr/bin"}, expected_python=sys.executable)
+
+        assert env["PATH"] == "/usr/bin"
+        assert "VIRTUAL_ENV" not in env
+
+    def test_venv_with_unknown_provenance_is_not_put_on_path(self, tmp_path):
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+
+        env = build_workspace_env(tmp_path, {"PATH": "/usr/bin"}, expected_python=sys.executable)
+
+        assert env["PATH"] == "/usr/bin"
+
+    def test_without_a_pin_the_venv_is_preferred_as_before(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+
+        env = build_workspace_env(tmp_path, {"PATH": "/usr/bin"})
+
+        assert env["PATH"].split(os.pathsep)[0] == str(venv / "bin")
+
+
+class TestInvalidateStaleVenv:
+    def test_removes_venv_built_from_another_interpreter(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+
+        assert _invalidate_stale_venv(tmp_path, sys.executable) is None
+        assert not venv.exists()
+
+    def test_keeps_venv_built_from_the_pin(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_base_executable())
+
+        assert _invalidate_stale_venv(tmp_path, sys.executable) is None
+        assert venv.exists()
+
+    def test_no_pin_leaves_the_venv_alone(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+
+        assert _invalidate_stale_venv(tmp_path, None) is None
+        assert venv.exists()
+
+    def test_missing_venv_is_a_noop(self, tmp_path):
+        assert _invalidate_stale_venv(tmp_path, sys.executable) is None
+
+    def test_removal_failure_is_reported_not_swallowed(self, tmp_path):
+        _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+
+        with patch(
+            "theforge.coordinator.workspace.shutil.rmtree",
+            side_effect=OSError("permission denied"),
+        ):
+            err = _invalidate_stale_venv(tmp_path, sys.executable)
+
+        assert err is not None
+        assert "permission denied" in err
+
+
+class TestRunSetupSplitReprovisionsStaleVenv:
+    def test_stale_venv_is_removed_before_the_guard_runs(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && .venv/bin/pip install -e .)"
+        calls: list[str] = []
+
+        def fake_shell(cmd_arg, cwd, **kw):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell):
+            ok, _out = _run_setup_split(cmd, tmp_path, sys.executable)
+
+        assert ok is True
+        assert not venv.exists()  # guard will now actually create it under the pin
+        assert len(calls) == 2
+
+    def test_matching_venv_survives_setup(self, tmp_path):
+        venv = _fake_venv(tmp_path, executable=_base_executable())
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && .venv/bin/pip install -e .)"
+
+        with patch("theforge.coordinator.workspace._cu._run_shell", return_value=(True, "ok")):
+            ok, _out = _run_setup_split(cmd, tmp_path, sys.executable)
+
+        assert ok is True
+        assert venv.exists()
+
+    def test_unremovable_stale_venv_fails_setup_closed(self, tmp_path):
+        _fake_venv(tmp_path, executable=_OTHER_PYTHON)
+        cmd = "test -d .venv || ({forge_python} -m venv .venv && .venv/bin/pip install -e .)"
+        calls: list[str] = []
+
+        def fake_shell(cmd_arg, cwd, **kw):
+            calls.append(cmd_arg)
+            return (True, "ok")
+
+        with (
+            patch(
+                "theforge.coordinator.workspace.shutil.rmtree",
+                side_effect=OSError("permission denied"),
+            ),
+            patch("theforge.coordinator.workspace._cu._run_shell", side_effect=fake_shell),
+        ):
+            ok, out = _run_setup_split(cmd, tmp_path, sys.executable)
+
+        assert ok is False
+        assert "stale virtualenv" in out
+        assert calls == []  # nothing ran under the wrong interpreter
+
+
+class TestWorkspaceConfigPin:
+    def test_pin_is_parsed(self, tmp_path):
+        config_path = _write_config(
+            {
+                "workspace": {
+                    "setup_command": "test -d .venv || {forge_python} -m venv .venv",
+                    "python_interpreter": "python3.12",
+                }
+            },
+            tmp_path,
+        )
+
+        config = load_config(config_path)
+
+        assert config.workspace.python_interpreter == "python3.12"
+
+    def test_forge_python_without_a_pin_is_rejected(self, tmp_path):
+        config_path = _write_config(
+            {"workspace": {"setup_command": "test -d .venv || {forge_python} -m venv .venv"}},
+            tmp_path,
+        )
+
+        with pytest.raises(ValueError, match="python_interpreter"):
+            load_config(config_path)
+
+    def test_blank_pin_is_rejected_like_a_missing_one(self, tmp_path):
+        config_path = _write_config(
+            {
+                "workspace": {
+                    "setup_command": "{forge_python} -m venv .venv",
+                    "python_interpreter": "   ",
+                }
+            },
+            tmp_path,
+        )
+
+        with pytest.raises(ValueError, match="python_interpreter"):
+            load_config(config_path)
+
+    def test_setup_command_without_the_placeholder_needs_no_pin(self, tmp_path):
+        config_path = _write_config({"workspace": {"setup_command": "pip install -e ."}}, tmp_path)
+
+        config = load_config(config_path)
+
+        assert config.workspace.python_interpreter is None
+
+    def test_default_config_has_no_pin(self, tmp_path):
+        config = load_config(_write_config({}, tmp_path))
+
+        assert config.workspace.python_interpreter is None
+
+
+class TestGateRunsUnderThePin:
+    def _config(self, tmp_path, pin):
+        workspace: dict[str, object] = {
+            "setup_command": "test -d .venv || {forge_python} -m venv .venv"
+        }
+        if pin is not None:
+            workspace["python_interpreter"] = pin
+        return load_config(
+            _write_config(
+                {"workspace": workspace, "validation": {"gate_command": "make gate"}},
+                tmp_path,
+            )
+        )
+
+    def test_gate_command_is_run_with_the_pin(self, tmp_path):
+        from theforge.coordinator.gate import run_gate_full
+
+        config = self._config(tmp_path, "python3.12")
+        seen: dict[str, object] = {}
+
+        def fake_run(cmd, cwd, timeout=120, env=None, expected_python=None):
+            seen["expected_python"] = expected_python
+            return (True, "ok", 0, False)
+
+        with patch("theforge.coordinator.gate._cu._run_shell_detailed", side_effect=fake_run):
+            decision, error, _tail, _cmd, _exit = run_gate_full(config, tmp_path)
+
+        assert error is None
+        assert decision == "PASS"
+        assert seen["expected_python"] == "python3.12"
+
+    def test_gate_falls_back_to_no_pin_when_project_declares_none(self, tmp_path):
+        from theforge.coordinator.gate import run_gate_full
+
+        config = load_config(
+            _write_config({"validation": {"gate_command": "make gate"}}, tmp_path)
+        )
+        seen: dict[str, object] = {"expected_python": "unset"}
+
+        def fake_run(cmd, cwd, timeout=120, env=None, expected_python=None):
+            seen["expected_python"] = expected_python
+            return (True, "ok", 0, False)
+
+        with patch("theforge.coordinator.gate._cu._run_shell_detailed", side_effect=fake_run):
+            run_gate_full(config, tmp_path)
+
+        assert seen["expected_python"] is None

--- a/tests/test_workspace_python_pin.py
+++ b/tests/test_workspace_python_pin.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from coord_test_helpers import patch_gate_shell
 
 from theforge.config import load_config
 from theforge.coordinator.workspace import _invalidate_stale_venv, _run_setup_split
@@ -289,7 +290,7 @@ class TestGateRunsUnderThePin:
             seen["expected_python"] = expected_python
             return (True, "ok", 0, False)
 
-        with patch("theforge.coordinator.gate._cu._run_shell_detailed", side_effect=fake_run):
+        with patch_gate_shell(side_effect=fake_run):
             decision, error, _tail, _cmd, _exit = run_gate_full(config, tmp_path)
 
         assert error is None
@@ -308,7 +309,7 @@ class TestGateRunsUnderThePin:
             seen["expected_python"] = expected_python
             return (True, "ok", 0, False)
 
-        with patch("theforge.coordinator.gate._cu._run_shell_detailed", side_effect=fake_run):
+        with patch_gate_shell(side_effect=fake_run):
             run_gate_full(config, tmp_path)
 
         assert seen["expected_python"] is None


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change pins gate setup and gate subprocess environment resolution to workspace.python_interpreter, with focused tests for missing pins and stale virtualenvs. | [google-gemini-3.5-flash] The implementation successfully pins the patient project's gate runtime to its own declared interpreter, invalidates stale virtualenvs, and prevents inheritance of the orchestrator's Python.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.77
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Patient gate runs under the orchestrator's interpreter, not the project's pinned Python (GitHub Issue #1934)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1934