### PR TITLE
Record the reviewer-record invariant and the stale-ref review trap (#1989)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -226,6 +226,30 @@ and re-run via the forge process once the next step is chosen.
 
 Source: `feedback_never_fix_gate.md`
 
+### Review the commit you pushed, not the ref you assume
+
+Pushing `HEAD:branch` from a detached worktree updates the remote ref and the
+remote-tracking ref, but **not** the local branch ref. `git show branch:file`,
+`git worktree add <path> branch`, and anything else resolving the local name then
+silently serve an older commit. Reviewing a pushed change off the stale local ref
+reads code that is not under review, and the findings that come back are about
+nothing.
+
+This has already produced a near-miss: a reported defect on an open PR was
+derived from a superseded commit, and an independent review agent hit the same
+trap on the same branch. Before reviewing or verifying a pushed change, confirm
+what you are actually reading:
+
+```bash
+git rev-parse --short HEAD origin/<branch>
+```
+
+Prefer explicit SHAs or `origin/<branch>` for review worktrees, and after a
+detached-worktree push, fast-forward the local ref
+(`git update-ref refs/heads/<branch> refs/remotes/origin/<branch>`) so the two
+cannot drift. A line-number mismatch against another reviewer's citations is a
+symptom of this, not a disagreement.
+
 ### Manual PR intervention changes merge state
 
 Force-pushes clear GitHub auto-merge, and `gh pr create` does not arm

--- a/src/theforge/coordinator/CONVENTIONS.md
+++ b/src/theforge/coordinator/CONVENTIONS.md
@@ -21,6 +21,39 @@ escalates, or completes.
 - Workspace and gate handling must be conservative: prefer failing closed over
   silently continuing with an invalid repository, branch, or validation result.
 
+## The reviewer record is reviewer-only
+
+`state.review_results`, `state.review_cycle_metadata`, and
+`state.review_iteration_telemetry` carry an implicit contract: **an entry in them
+means a reviewer pool ran and produced a verdict.** They are parallel lists, read
+by index and by tail, and several consumers depend on that contract without
+checking it:
+
+- `model_profiles_bridge._extract_reviewers` pairs metadata with telemetry *by
+  index* to attribute findings and cost per model, and persists the result to
+  `model_profiles.yaml`, where adaptive routing reads it.
+- `audit.review_cycles_total` feeds `adaptive_iterations._extract_review_used`,
+  which percentiles it to set a future `max_review_cycles`.
+- The persistent-P1 lookback reads `review_results[-2]` expecting the previous
+  *reviewer* verdict; dev-model escalation hangs off that comparison.
+- `audit_render.build_reviews` zips metadata against results to render cycles.
+
+A coordinator-raised finding — a gate failure or a hard convention violation
+observed in VALIDATE — is **not** a reviewer verdict, however similar it looks.
+Record it in its own channel (`state.validate_blocks`, via
+`validate_phase.record_validate_block`), never in the three lists above.
+
+This is not hypothetical: #1981 first shipped the return path by writing a
+synthetic REQUEST_CHANGES into the reviewer record, which invented a model named
+`coordinator` holding the real reviewer's cost, zeroed the reviewer that actually
+ran, taught the router that gate failures mean reviewers need more cycles, and
+disabled persistent-P1 detection for the following cycle. Mirroring the review
+loop-back's *control flow* was right; mirroring its *data structures* was the
+defect. Sharing the review-cycle **budget** is likewise fine — it is the same
+currency — but the budget counters are split for the same reason
+(`reviewer_cycles_run` for reviewer demand, `review_cycles_spent` for budget
+consumed), so a coordinator-opened cycle never reads as reviewer demand.
+
 ## Adaptive routing symmetry invariant
 
 Adaptive routing (`assignment.py`) learns from run history to move a story's dev


### PR DESCRIPTION
Closes #1989.

Docs only — no code change, no behaviour change.

Two lessons from #1981 that neither the code nor the git history preserves, both of which already caused real errors during that PR.

## The reviewer-record invariant (`src/theforge/coordinator/CONVENTIONS.md`)

`review_results`, `review_cycle_metadata`, and `review_iteration_telemetry` carry an implicit contract: an entry means a reviewer pool ran. Four consumers depend on it without checking — per-model attribution feeding `model_profiles.yaml`, the adaptive review-cycle learner, the persistent-P1 lookback at `review_results[-2]`, and audit rendering.

The first revision of #1981 carried a coordinator-raised finding in those lists and broke all four: it invented a model named `coordinator` holding the real reviewer's cost, zeroed the reviewer that actually ran, taught the router that gate failures mean reviewers need more cycles, and disabled persistent-P1 detection for the next cycle. The merged code routes those findings to `state.validate_blocks` instead — but nothing in the code says why that channel exists, which leaves the obvious reuse easy to repeat.

The entry names each consumer, states the incident, and draws the line the fix settled on: sharing the review-cycle **budget** is correct — it is the same currency — while writing into the reviewer **record** is not.

## The stale-ref review trap (`CONVENTIONS.md`, git hygiene)

Pushing `HEAD:branch` from a detached worktree updates the remote ref but not the local branch ref, so `git show branch:file` and `git worktree add <path> branch` silently serve a superseded commit.

During #1981 review this produced a reported defect derived from the wrong commit, and an independent review agent hit the same trap on the same branch. The entry gives the one-line check that detects it and the fix that prevents it, and notes that a line-number mismatch against another reviewer's citations is a symptom rather than a disagreement.

## Verification

`make gate` exits 0. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)