### PR TITLE
Mid-sprint re-exec drops prior cost from both the budget cap and the reported total

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -644,6 +644,56 @@ def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
         return 0.0
 
 
+def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
+    """Parse timestamps persisted in accumulated sprint story state."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _read_prior_sprint_accounting(
+    project_root: Path,
+    sprint_id: str | None,
+) -> tuple[float, datetime.datetime | None, dict[str, dict]]:
+    """Recover prior same-sprint cost/timing from progressive story state."""
+    if not sprint_id:
+        return 0.0, None, {}
+
+    from .audit import _load_accumulated_stories  # noqa: PLC0415
+
+    recovered_entries: dict[str, dict] = {}
+    recovered_cost = 0.0
+    earliest_started_at: datetime.datetime | None = None
+    for raw_entry in _load_accumulated_stories(sprint_id, project_root):
+        if not isinstance(raw_entry, dict):
+            continue
+        canonical_ref = raw_entry.get("canonical_ref")
+        if not isinstance(canonical_ref, str) or not canonical_ref:
+            continue
+        entry = dict(raw_entry)
+        recovered_entries[canonical_ref] = entry
+        try:
+            recovered_cost += float(entry.get("cost_usd", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            pass
+        started_at = _parse_accumulated_story_timestamp(entry.get("started_at"))
+        if started_at is not None and (
+            earliest_started_at is None or started_at < earliest_started_at
+        ):
+            earliest_started_at = started_at
+
+    if recovered_entries:
+        return round(recovered_cost, 4), earliest_started_at, recovered_entries
+
+    if os.environ.get("FORGE_PREV_RUN_ID"):
+        return _read_prior_sprint_cost(project_root, sprint_id), None, {}
+
+    return 0.0, None, {}
+
+
 def _project_root_is_git_checkout(project_root: Path) -> bool:
     """Return True when the project root is inside a git checkout."""
 
@@ -2163,13 +2213,19 @@ def run_sprint(
     # Derive slug_to_spec from unified context mapping
     slug_to_spec: dict[str, str] = {slug: ctx[2] for slug, ctx in slug_to_context.items()}
 
+    recovered_prior_started_at: datetime.datetime | None = None
+    recovered_prior_entries_by_ref: dict[str, dict] = {}
     # Resume mode (and re-exec, treated as resume-equivalent): triage all stories
     # and carry forward prior costs.
     triages: dict[str, StoryTriage] = {}
     if reconcile:
-        prior_cost = _read_prior_sprint_cost(config.project_root, _sprint_id)
+        prior_cost, recovered_prior_started_at, recovered_prior_entries_by_ref = (
+            _read_prior_sprint_accounting(config.project_root, _sprint_id)
+        )
         if prior_cost > 0.0:
             _log(f"Resuming with prior cost: ${prior_cost:.2f}")
+        if recovered_prior_started_at is not None and recovered_prior_started_at < started_at:
+            started_at = recovered_prior_started_at
         _log("Triaging specs...")
         for slug, (task, _src, canonical_ref) in slug_to_context.items():
             triage = _triage_spec(canonical_ref, config, config.project_root, task=task)
@@ -2219,6 +2275,88 @@ def run_sprint(
     # that would otherwise be null in audit YAML and sprint summary YAML.
     current_story_entries_by_ref: dict[str, dict] = {}
 
+    story_cost_adjustments: dict[str, float] = {}
+
+    def _persist_accumulated_story_entries() -> None:
+        if _sprint_id is None:
+            return
+        accumulated_by_ref = {
+            ref: dict(entry) for ref, entry in recovered_prior_entries_by_ref.items()
+        }
+        for canonical_ref, entry in current_story_entries_by_ref.items():
+            accumulated_by_ref[canonical_ref] = {"canonical_ref": canonical_ref, **entry}
+        persist_accumulated_story_state(
+            _sprint_id,
+            resolved.name,
+            config.project_root,
+            list(accumulated_by_ref.values()),
+        )
+
+    def _persist_current_story_result(
+        slug: str,
+        result: CoordinatorResult,
+        *,
+        started_at: datetime.datetime,
+        finished_at: datetime.datetime,
+    ) -> None:
+        task_ctx = slug_to_context.get(slug)
+        if task_ctx is None:
+            return
+        task, _source, canonical_ref = task_ctx
+        display_key = (
+            f"Issue #{canonical_ref.split(':')[1]}"
+            if canonical_ref.startswith("issue:")
+            else canonical_ref
+        )
+        preflight = (
+            "cached"
+            if getattr(result.state, "preflight_cached", False)
+            else (result.state.preflight_verdict or "PROCEED")
+        )
+        outcome = "ALREADY_DONE" if preflight == "ALREADY_DONE" else result.phase.name
+        outcome_source = (
+            "preflight_verdict"
+            if outcome == "ALREADY_DONE" and preflight == "ALREADY_DONE"
+            else None
+        )
+        current_story_entries_by_ref[canonical_ref] = {
+            "path": display_key,
+            "slug": slug,
+            "outcome": outcome,
+            "outcome_source": outcome_source,
+            "verdict": None,
+            "cost_usd": round(
+                float(result.state.total_cost) + story_cost_adjustments.get(slug, 0.0),
+                4,
+            ),
+            "story_run_id": run_id,
+            "preflight": preflight,
+            "preflight_original_verdict": getattr(
+                result.state, "preflight_cached_original_verdict", None
+            ),
+            "preflight_source_run_id": getattr(
+                result.state, "preflight_cached_from_run_id", None
+            ),
+            "error": result.state.error,
+            "error_type": result.state.error_type,
+            "outcome_code": result.state.error_type or outcome.lower(),
+            "merge": result.merge is not None and result.merge.get("merged", False),
+            "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "batch": 0,
+            "depends_on": list(getattr(task, "depends_on", None) or []),
+            "dependency_warnings": list(getattr(task, "dependency_warnings", None) or []),
+            "inferred_dependencies": {
+                "manifest": [
+                    dep
+                    for dep in (getattr(task, "depends_on", None) or [])
+                    if dep not in (getattr(task, "inferred_dependencies", None) or [])
+                ],
+                "github_blockers": list(getattr(task, "inferred_dependencies", None) or []),
+            },
+        }
+        _persist_accumulated_story_entries()
+
     def _record_current_story_entry(
         slug: str,
         outcome: str,
@@ -2266,6 +2404,7 @@ def run_sprint(
         if extras:
             entry.update(extras)
         current_story_entries_by_ref[canonical_ref] = entry
+        _persist_accumulated_story_entries()
 
     # Intake remediation gate: between dependency normalization and the
     # batch preflight spend, run the shared shape + grooming check on the
@@ -2306,6 +2445,15 @@ def run_sprint(
         _log(
             f"Intake remediation cost: ${_intake_remediation_cost:.4f} (rolled into sprint total)"
         )
+    for _slug, _outcome in intake_outcomes.items():
+        story_cost_adjustments[_slug] = (
+            story_cost_adjustments.get(_slug, 0.0) + _intake_outcome_cost(_outcome)
+        )
+    for _issue_num, _outcome in (entry_intake_outcomes or {}).items():
+        _issue_slug = f"issue-{_issue_num}"
+        story_cost_adjustments[_issue_slug] = story_cost_adjustments.get(
+            _issue_slug, 0.0
+        ) + _intake_outcome_cost(_outcome)
     if intake_outcomes:
         terminal_kinds = {IntakeOutcomeKind.DROPPED_SHAPE, IntakeOutcomeKind.DROPPED_AFTER_FIX}
         dropped_slugs_intake = {
@@ -2496,6 +2644,15 @@ def run_sprint(
                 if triage.action == "skip_merged":
                     merged_slugs.add(slug)
                     dag.mark_complete(slug)
+                    _prior_entry = recovered_prior_entries_by_ref.get(canonical_ref)
+                    if _prior_entry is not None:
+                        _already_done_entry = dict(_prior_entry)
+                        _already_done_entry["outcome"] = "ALREADY_DONE"
+                        _already_done_entry["outcome_source"] = "resume_skip_merged"
+                        current_story_entries_by_ref[canonical_ref] = {
+                            k: v for k, v in _already_done_entry.items() if k != "canonical_ref"
+                        }
+                        _persist_accumulated_story_entries()
                     # Preserve preloaded prior-run outcome (e.g., DONE) when
                     # accumulated state already has a stronger terminal —
                     # otherwise mark SKIPPED for the legacy aggregate contract.
@@ -2589,22 +2746,13 @@ def run_sprint(
     # Persist resume-time already-completed stories before any possible re-exec
     # handoff so later generations can recover the full logical sprint history.
     if resume:
-        _prior_accumulated_by_ref: dict[str, dict] = {}
-        if _sprint_id:
-            from .audit import _load_accumulated_stories  # noqa: PLC0415
-
-            _prior_accumulated_by_ref = {
-                story["canonical_ref"]: story
-                for story in _load_accumulated_stories(_sprint_id, config.project_root)
-                if "canonical_ref" in story
-            }
-
         def _already_done_story_entry(
             canonical_ref: str,
             slug: str,
             *,
             depends_on: list[str],
         ) -> dict:
+            prior_entry = recovered_prior_entries_by_ref.get(canonical_ref, {})
             display_key = (
                 f"Issue #{canonical_ref.split(':')[1]}"
                 if canonical_ref.startswith("issue:")
@@ -2616,20 +2764,26 @@ def run_sprint(
                 "slug": slug,
                 "outcome": "ALREADY_DONE",
                 "outcome_source": "resume_skip_merged",
-                "verdict": None,
-                "cost_usd": 0.0,
-                "story_run_id": run_id,
-                "preflight": None,
-                "preflight_original_verdict": None,
-                "preflight_source_run_id": None,
-                "error": None,
-                "error_type": None,
-                "merge": False,
-                "batch": 0,
+                "verdict": prior_entry.get("verdict"),
+                "cost_usd": float(prior_entry.get("cost_usd", 0.0) or 0.0),
+                "story_run_id": prior_entry.get("story_run_id", run_id),
+                "preflight": prior_entry.get("preflight"),
+                "preflight_original_verdict": prior_entry.get("preflight_original_verdict"),
+                "preflight_source_run_id": prior_entry.get("preflight_source_run_id"),
+                "error": prior_entry.get("error"),
+                "error_type": prior_entry.get("error_type"),
+                "merge": bool(prior_entry.get("merge", False)),
+                "started_at": prior_entry.get("started_at"),
+                "finished_at": prior_entry.get("finished_at"),
+                "batch": int(prior_entry.get("batch", 0) or 0),
                 "depends_on": depends_on,
+                "dependency_warnings": list(prior_entry.get("dependency_warnings", [])),
+                "inferred_dependencies": dict(prior_entry.get("inferred_dependencies", {})),
             }
 
-        _resume_accumulated_by_ref: dict[str, dict] = dict(_prior_accumulated_by_ref)
+        _resume_accumulated_by_ref: dict[str, dict] = {
+            ref: dict(entry) for ref, entry in recovered_prior_entries_by_ref.items()
+        }
         for _canonical_ref, _triage in triages.items():
             if _triage.action != "skip_merged":
                 continue
@@ -3390,6 +3544,12 @@ def run_sprint(
                         phase="ESCALATE",
                         last_phase=last_phase,
                     )
+                    _persist_current_story_result(
+                        slug,
+                        _timeout_result,
+                        started_at=story_started_at,
+                        finished_at=timed_out_at,
+                    )
                     dag.mark_skipped(slug)
                 continue
 
@@ -3458,6 +3618,12 @@ def run_sprint(
                         _exc_outcome,
                         phase="ESCALATE",
                         last_phase=last_phase,
+                    )
+                    _persist_current_story_result(
+                        slug,
+                        _exc_result,
+                        started_at=story_started_at,
+                        finished_at=failed_at,
                     )
                     dag.mark_skipped(slug)
                     continue
@@ -3583,6 +3749,12 @@ def run_sprint(
                     _existing_detail["outcome_source"] = "preflight_verdict"
                     _outcome_fields["detail"] = _existing_detail
                 _set_outcome(task.slug, _classify_outcome, **_outcome_fields)
+                _persist_current_story_result(
+                    slug,
+                    result,
+                    started_at=t0,
+                    finished_at=t1,
+                )
 
                 # Dependent stories in parallel mode need scheduler-side local merge
                 # even when on_approve is "none" and auto_merge is False.

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2334,9 +2334,7 @@ def run_sprint(
             "preflight_original_verdict": getattr(
                 result.state, "preflight_cached_original_verdict", None
             ),
-            "preflight_source_run_id": getattr(
-                result.state, "preflight_cached_from_run_id", None
-            ),
+            "preflight_source_run_id": getattr(result.state, "preflight_cached_from_run_id", None),
             "error": result.state.error,
             "error_type": result.state.error_type,
             "outcome_code": result.state.error_type or outcome.lower(),
@@ -2446,9 +2444,9 @@ def run_sprint(
             f"Intake remediation cost: ${_intake_remediation_cost:.4f} (rolled into sprint total)"
         )
     for _slug, _outcome in intake_outcomes.items():
-        story_cost_adjustments[_slug] = (
-            story_cost_adjustments.get(_slug, 0.0) + _intake_outcome_cost(_outcome)
-        )
+        story_cost_adjustments[_slug] = story_cost_adjustments.get(
+            _slug, 0.0
+        ) + _intake_outcome_cost(_outcome)
     for _issue_num, _outcome in (entry_intake_outcomes or {}).items():
         _issue_slug = f"issue-{_issue_num}"
         story_cost_adjustments[_issue_slug] = story_cost_adjustments.get(
@@ -2746,6 +2744,7 @@ def run_sprint(
     # Persist resume-time already-completed stories before any possible re-exec
     # handoff so later generations can recover the full logical sprint history.
     if resume:
+
         def _already_done_story_entry(
             canonical_ref: str,
             slug: str,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2128,6 +2128,26 @@ def run_sprint(
     # operator-facing surface (forge status, banner, summary, notifications).
     # No local counters are kept; counts are projected from this structure.
     _story_state = SprintStoryState()
+    # Pre-restart spend that the canonical story state will not be holding by
+    # the time totals are projected. It is re-attached at wrap-up (see
+    # ``_bump_story_cost``); without it the summary total — which sums the
+    # canonical state — silently drops spend that SprintResult still counts via
+    # ``prior_cost``, so two operator-facing totals disagree about one run.
+    #
+    # Two disjoint ways the canonical state loses it, both only for stories that
+    # re-enter this generation:
+    #   unseeded — a non-succeeded (or unmappable) prior outcome is never
+    #     seeded, because monotonicity would reject the later transition to
+    #     RUNNING. Its cost is therefore always missing.
+    #   seeded-then-overwritten — a succeeded prior outcome IS seeded with its
+    #     cost, but if the story runs again, transition() replaces cost_usd
+    #     with the coordinator's current-generation total. The seed survives
+    #     only for a story that does not re-run (e.g. resume_skip_merged), so
+    #     this one is re-attached conditionally, keyed on whether the story
+    #     actually ran.
+    unseeded_prior_story_cost: dict[str, float] = {}
+    seeded_prior_story_cost: dict[str, float] = {}
+    ran_this_generation: set[str] = set()
     # Pre-populate from prior-run accumulated state so cross-process resume
     # invocations see the full logical sprint in counts and projections.
     # Stories present in the current run are seeded only when their prior
@@ -2143,12 +2163,25 @@ def run_sprint(
 
         _current_run_slugs = set(slug_to_context.keys())
         _succeeded_outcomes = {"DONE", "ALREADY_DONE"}
+
+        def _prior_cost_of(prior: dict) -> float:
+            try:
+                return float(prior.get("cost_usd", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                return 0.0
+
+        def _defer_prior_cost(slug: str, prior: dict) -> None:
+            _cost = _prior_cost_of(prior)
+            if _cost > 0.0:
+                unseeded_prior_story_cost[slug] = unseeded_prior_story_cost.get(slug, 0.0) + _cost
+
         for _prior in _preload(_sprint_id, config.project_root):
             _prior_slug = _prior.get("slug")
             if not _prior_slug:
                 continue
             _prior_outcome = (_prior.get("outcome") or "").upper()
             if _prior_slug in _current_run_slugs and _prior_outcome not in _succeeded_outcomes:
+                _defer_prior_cost(_prior_slug, _prior)
                 continue
             _outcome_map = {
                 "DONE": StoryOutcome.DONE,
@@ -2163,7 +2196,23 @@ def run_sprint(
             }
             _mapped_outcome = _outcome_map.get(_prior_outcome)
             if _mapped_outcome is None:
+                # Same reasoning as the non-succeeded skip above: an outcome
+                # this runner cannot map is still spend that occurred. Only
+                # current-run slugs are deferred — a story absent from this
+                # run has no canonical row for the spend to land on, so
+                # deferring it would drop the value silently instead.
+                if _prior_slug in _current_run_slugs:
+                    _defer_prior_cost(_prior_slug, _prior)
                 continue
+            # Seeded cost is only durable while the story stays put; if it
+            # re-runs, transition() overwrites it with the current generation's
+            # total. Remember it so wrap-up can restore it in that case.
+            if _prior_slug in _current_run_slugs:
+                _seeded_cost = _prior_cost_of(_prior)
+                if _seeded_cost > 0.0:
+                    seeded_prior_story_cost[_prior_slug] = (
+                        seeded_prior_story_cost.get(_prior_slug, 0.0) + _seeded_cost
+                    )
             # Strip per-run terminal artifacts so an accumulated story cannot
             # carry forward a stale review summary or final_outcome from an
             # earlier generation. The current run must write these fresh.
@@ -2302,6 +2351,11 @@ def run_sprint(
         task_ctx = slug_to_context.get(slug)
         if task_ctx is None:
             return
+        # Every terminal path for a dispatched story lands here (completion,
+        # timeout, exception), so this is the reliable record of which stories
+        # actually consumed a coordinator run this generation — and therefore
+        # which ones had a seeded prior cost overwritten by transition().
+        ran_this_generation.add(slug)
         task, _source, canonical_ref = task_ctx
         display_key = (
             f"Issue #{canonical_ref.split(':')[1]}"
@@ -3887,6 +3941,28 @@ def run_sprint(
         _bump_story_cost(_slug, _intake_outcome_cost(_outcome))
     for _issue_num, _outcome in (entry_intake_outcomes or {}).items():
         _bump_story_cost(f"issue-{_issue_num}", _intake_outcome_cost(_outcome))
+
+    # Re-attach pre-restart spend the canonical state is no longer holding, so
+    # the summary total (which sums that state) matches SprintResult's
+    # accumulated + prior_cost. Runs here, after the work loop, for the same
+    # reason the intake attribution above does: transition() overwrites
+    # cost_usd with the coordinator's current-generation total while a story
+    # is running, so any earlier attribution would be discarded.
+    _carried_by_slug: dict[str, float] = dict(unseeded_prior_story_cost)
+    for _seed_slug, _seed_cost in seeded_prior_story_cost.items():
+        # A seeded cost only needs restoring when the story re-ran; otherwise
+        # the seed is still intact and adding it would double-count.
+        if _seed_slug in ran_this_generation:
+            _carried_by_slug[_seed_slug] = _carried_by_slug.get(_seed_slug, 0.0) + _seed_cost
+    for _carried_slug, _carried_cost in _carried_by_slug.items():
+        _bump_story_cost(_carried_slug, _carried_cost)
+    if _carried_by_slug:
+        _carried_total = sum(_carried_by_slug.values())
+        _carried_detail = ", ".join(f"{s}=${c:.4f}" for s, c in sorted(_carried_by_slug.items()))
+        _log(
+            f"Re-attached pre-restart spend to {len(_carried_by_slug)} story/stories: "
+            f"${_carried_total:.4f} ({_carried_detail})"
+        )
 
     final_cost = accumulated_cost + prior_cost
     # Banner, summary, notifications, and SprintResult all project from the

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -1098,6 +1098,187 @@ class TestResumeSprintIntegration:
         assert summary["sprint"]["total_cost_usd"] == pytest.approx(7.5)
         assert by_slug["feature-a"]["cost_usd"] == pytest.approx(6.0)
 
+    def test_reexec_retried_story_keeps_prior_spend_in_summary_total(self, tmp_path: Path) -> None:
+        """A story retried after the re-exec keeps its pre-restart spend.
+
+        The startup preload deliberately does not seed a non-succeeded prior
+        outcome for a story that re-enters the current generation, or the
+        transition to RUNNING would be rejected as non-monotonic. That skip
+        must not take the story's prior *cost* with it: SprintResult counts it
+        via prior_cost, so if the canonical state drops it, sprint-summary.yaml
+        (which sums the canonical state) reports a smaller total than the
+        banner for the same run.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=100.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "FAILED",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                    "started_at": "2026-07-27T01:00:00Z",
+                    "finished_at": "2026-07-27T01:05:00Z",
+                }
+            ],
+        )
+
+        retry_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+            slug="feature-a",
+        )
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=retry_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                return_value=_make_coordinator_result(
+                    success=True, cost=1.5, landing_status="landed"
+                ),
+            ):
+                result = run_sprint(config, manifest_path, reexec=True)
+
+        summary_path = tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml"
+        summary = yaml.safe_load(summary_path.read_text(encoding="utf-8"))
+        by_slug = {story["slug"]: story for story in summary["stories"]}
+
+        # $6.00 spent before the restart + $1.50 spent retrying it.
+        assert result.total_cost_usd == pytest.approx(7.5)
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(7.5)
+        # The two operator-facing totals must agree for the same run.
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(result.total_cost_usd)
+        # Per-row traceability: the retried story owns the whole of its spend.
+        assert by_slug["feature-a"]["cost_usd"] == pytest.approx(7.5)
+        # The retry's own outcome wins — carrying cost must not resurrect the
+        # prior FAILED state.
+        assert by_slug["feature-a"]["outcome"] == "DONE"
+
+    def test_reexec_retried_succeeded_story_keeps_prior_spend_in_summary_total(
+        self, tmp_path: Path
+    ) -> None:
+        """Same defect, other branch: a prior DONE story that re-runs.
+
+        A succeeded prior outcome IS seeded into the canonical state with its
+        cost, so it survives for a story that does not re-run (skip_merged).
+        But when triage retries it — prior generation marked it DONE and the
+        merge never landed, say — transition() overwrites the seeded cost with
+        the current generation's total, losing the prior spend from the summary
+        while SprintResult still counts it.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=100.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                    "started_at": "2026-07-27T01:00:00Z",
+                    "finished_at": "2026-07-27T01:05:00Z",
+                }
+            ],
+        )
+
+        retry_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="full",
+            reason="branch not merged",
+            worktree_path=None,
+            slug="feature-a",
+        )
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=retry_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                return_value=_make_coordinator_result(
+                    success=True, cost=1.5, landing_status="landed"
+                ),
+            ):
+                result = run_sprint(config, manifest_path, reexec=True)
+
+        summary_path = tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml"
+        summary = yaml.safe_load(summary_path.read_text(encoding="utf-8"))
+        by_slug = {story["slug"]: story for story in summary["stories"]}
+
+        assert result.total_cost_usd == pytest.approx(7.5)
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(7.5)
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(result.total_cost_usd)
+        assert by_slug["feature-a"]["cost_usd"] == pytest.approx(7.5)
+
+    def test_reexec_skip_merged_story_does_not_double_count_seeded_cost(
+        self, tmp_path: Path
+    ) -> None:
+        """The seeded-cost restore must not fire for a story that did not re-run.
+
+        Guards the other side of the same conditional: a resume_skip_merged
+        story keeps its seeded prior cost intact, so re-attaching it would
+        report double the money actually spent.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=100.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                    "started_at": "2026-07-27T01:00:00Z",
+                    "finished_at": "2026-07-27T01:05:00Z",
+                }
+            ],
+        )
+
+        merged_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="skip_merged",
+            reason="already merged to main",
+            worktree_path=None,
+            slug="feature-a",
+        )
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=merged_triage):
+            with patch("theforge.sprint.runner.run_task") as mock_run:
+                result = run_sprint(config, manifest_path, reexec=True)
+
+        mock_run.assert_not_called()
+        summary_path = tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml"
+        summary = yaml.safe_load(summary_path.read_text(encoding="utf-8"))
+        by_slug = {story["slug"]: story for story in summary["stories"]}
+
+        # Exactly $6.00 — the prior spend, counted once.
+        assert result.total_cost_usd == pytest.approx(6.0)
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(6.0)
+        assert by_slug["feature-a"]["cost_usd"] == pytest.approx(6.0)
+
     def test_reexec_budget_check_sees_spend_from_before_the_reexec(self, tmp_path: Path) -> None:
         """The dispatch-time check evaluates the carried figure, not $0.00."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -23,13 +23,13 @@ from theforge.config import (
 from theforge.coordinator import audit_substrate
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint import run_sprint
+from theforge.sprint.audit import persist_accumulated_story_state
 from theforge.sprint.dag import StoryTriage, _triage_spec
 from theforge.sprint.lock import acquire_story_locks, release_story_locks
 from theforge.sprint.manifest import ResolvedSprint, _build_task_from_story
 from theforge.sprint.runner import _read_prior_sprint_cost, _run_fresh
 from theforge.sprint.sources import GitHubIssueSource
 from theforge.task import TaskStory
-from theforge.sprint.audit import persist_accumulated_story_state
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -986,12 +986,14 @@ class TestResumeSprintIntegration:
         summary_path = tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml"
         summary = yaml.safe_load(summary_path.read_text(encoding="utf-8"))
         by_slug = {story["slug"]: story for story in summary["stories"]}
+        expected_started_at = prior_started_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        expected_finished_at = prior_finished_at.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         assert summary["sprint"]["total_cost_usd"] == pytest.approx(4.75)
         assert summary["sprint"]["duration_seconds"] >= 80.0
         assert by_slug["feature-a"]["cost_usd"] == pytest.approx(3.5)
-        assert by_slug["feature-a"]["started_at"] == prior_started_at.strftime("%Y-%m-%dT%H:%M:%SZ")
-        assert by_slug["feature-a"]["finished_at"] == prior_finished_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert by_slug["feature-a"]["started_at"] == expected_started_at
+        assert by_slug["feature-a"]["finished_at"] == expected_finished_at
         assert by_slug["feature-a"]["outcome_source"] == "resume_skip_merged"
 
     def test_no_resume_flag_unchanged(self, tmp_path: Path) -> None:

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -29,6 +29,7 @@ from theforge.sprint.manifest import ResolvedSprint, _build_task_from_story
 from theforge.sprint.runner import _read_prior_sprint_cost, _run_fresh
 from theforge.sprint.sources import GitHubIssueSource
 from theforge.task import TaskStory
+from theforge.sprint.audit import persist_accumulated_story_state
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -336,6 +337,34 @@ class TestReadPriorSprintCost:
         monkeypatch.setenv("FORGE_PREV_RUN_ID", "run-prev-123")
 
         assert _read_prior_sprint_cost(tmp_path, sprint_id) == pytest.approx(3.5)
+
+    def test_progressive_state_can_exceed_stale_sprint_audit_during_reexec(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sprint_id = _set_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 1.0)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "DONE",
+                    "cost_usd": 3.5,
+                    "story_run_id": "run-prev",
+                }
+            ],
+        )
+
+        monkeypatch.setenv("FORGE_PREV_RUN_ID", "run-prev-123")
+
+        # Legacy helper still exposes sprint-audit.yaml; integration tests below
+        # verify run_sprint now prefers progressive state for real re-exec
+        # accounting.
+        assert _read_prior_sprint_cost(tmp_path, sprint_id) == pytest.approx(1.0)
 
     def test_triage_same_tip_missing_worktree_with_prior_approve_skips_when_squash_merged(
         self, tmp_path: Path
@@ -843,6 +872,127 @@ class TestResumeSprintIntegration:
         assert audit_data["specs"][0]["error"] == (
             "budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
         )
+
+    def test_resume_prior_state_cost_exceeds_budget_without_sprint_audit(
+        self, tmp_path: Path
+    ) -> None:
+        """Budget checks use progressive prior story state during re-exec."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=5.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                    "started_at": "2026-07-27T01:00:00Z",
+                    "finished_at": "2026-07-27T01:05:00Z",
+                }
+            ],
+        )
+
+        full_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+        )
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=full_triage):
+            with patch("theforge.sprint.runner.run_task") as mock_run:
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint(config, manifest_path, resume=True)
+
+        mock_run.assert_not_called()
+        assert result.specs_skipped == 1
+        assert (
+            result.stopped_reason
+            == "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
+        audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+        audit_data = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+        assert audit_data["specs"][0]["error"] == (
+            "budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
+
+    def test_reexec_summary_preserves_prior_story_accounting_from_progressive_state(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-exec summary keeps prior cost/timing and spans pre-reexec duration."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=10.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        prior_started_at = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=90)
+        ).replace(microsecond=0)
+        prior_finished_at = prior_started_at + datetime.timedelta(seconds=30)
+
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "DONE",
+                    "cost_usd": 3.5,
+                    "story_run_id": "run-prev",
+                    "started_at": prior_started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "finished_at": prior_finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }
+            ],
+        )
+
+        merged_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="skip_merged",
+            reason="already merged to main",
+            worktree_path=None,
+            slug="feature-a",
+        )
+        full_triage = StoryTriage(
+            story_path="feature-b.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+            slug="feature-b",
+        )
+
+        def triage_side_effect(spec_path, config, project_root, *, task=None):
+            return merged_triage if "feature-a" in spec_path else full_triage
+
+        coord_result = _make_coordinator_result(success=True, cost=1.25, landing_status="landed")
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect):
+            with patch("theforge.sprint.runner.run_task", return_value=coord_result):
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint(config, manifest_path, reexec=True)
+
+        assert result.total_cost_usd == pytest.approx(4.75)
+
+        summary_path = tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml"
+        summary = yaml.safe_load(summary_path.read_text(encoding="utf-8"))
+        by_slug = {story["slug"]: story for story in summary["stories"]}
+
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(4.75)
+        assert summary["sprint"]["duration_seconds"] >= 80.0
+        assert by_slug["feature-a"]["cost_usd"] == pytest.approx(3.5)
+        assert by_slug["feature-a"]["started_at"] == prior_started_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert by_slug["feature-a"]["finished_at"] == prior_finished_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert by_slug["feature-a"]["outcome_source"] == "resume_skip_merged"
 
     def test_no_resume_flag_unchanged(self, tmp_path: Path) -> None:
         """Without --resume, behavior is unchanged (run_task called normally)."""

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -84,6 +84,21 @@ def _make_manifest(tmp_path: Path, specs: list[str], budget: float = 10.0) -> Pa
     return manifest_path
 
 
+def _make_gen1_manifest(tmp_path: Path, budget: float = 10.0) -> Path:
+    """First-generation manifest on its own path.
+
+    Must not reuse ``sprint.yaml`` — the second generation reads that path, and
+    overwriting it would silently shrink the sprint rather than exercising a
+    re-exec of the same one.
+    """
+    manifest_path = tmp_path / "sprint-gen1.yaml"
+    manifest_path.write_text(
+        yaml.dump({"name": "Test Sprint", "budget_usd": budget, "specs": ["feature-a.md"]}),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
 def _set_sprint_id(
     tmp_path: Path,
     sprint_name: str = "Test Sprint",
@@ -995,6 +1010,136 @@ class TestResumeSprintIntegration:
         assert by_slug["feature-a"]["started_at"] == expected_started_at
         assert by_slug["feature-a"]["finished_at"] == expected_finished_at
         assert by_slug["feature-a"]["outcome_source"] == "resume_skip_merged"
+
+    def test_fresh_sprint_persists_progressive_story_state_for_later_reexec(
+        self, tmp_path: Path
+    ) -> None:
+        """A fresh generation writes per-story accounting as it proceeds.
+
+        This is the half of the carry-forward that makes re-exec recovery
+        possible at all: sprint-audit.yaml only exists once a sprint has
+        finished, so the generation that later re-execs must have left its
+        in-flight accounting on progressive state while it was still running.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=10.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        coord_result = _make_coordinator_result(success=True, cost=3.5, landing_status="landed")
+
+        with patch("theforge.sprint.runner.run_task", return_value=coord_result):
+            run_sprint(config, manifest_path, resume=False)
+
+        state_path = tmp_path / ".forge" / "sprints" / sprint_id / "state.yaml"
+        assert state_path.exists(), "fresh run must persist progressive story state"
+        stories = yaml.safe_load(state_path.read_text(encoding="utf-8"))["stories"]
+        by_ref = {story["canonical_ref"]: story for story in stories}
+        assert by_ref["feature-a.md"]["cost_usd"] == pytest.approx(3.5)
+        assert by_ref["feature-a.md"]["started_at"]
+        assert by_ref["feature-a.md"]["finished_at"]
+
+    def test_reexec_after_fresh_generation_carries_that_generations_spend(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end: fresh generation, then re-exec, no seeded state.yaml.
+
+        Reproduces the reported failure without hand-authoring the carry-forward
+        artifact — the second generation must recover the first's spend from
+        whatever the first actually wrote, with no sprint-audit.yaml in play.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=10.0)
+        config = _make_config(tmp_path)
+        _set_sprint_id(tmp_path)
+
+        # Generation 1: only feature-a completes, then the process re-execs.
+        gen1_manifest = _make_gen1_manifest(tmp_path, budget=10.0)
+        with patch(
+            "theforge.sprint.runner.run_task",
+            return_value=_make_coordinator_result(success=True, cost=6.0, landing_status="landed"),
+        ):
+            run_sprint(config, gen1_manifest, resume=False)
+
+        merged_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="skip_merged",
+            reason="already merged to main",
+            worktree_path=None,
+            slug="feature-a",
+        )
+        full_triage = StoryTriage(
+            story_path="feature-b.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+            slug="feature-b",
+        )
+
+        def triage_side_effect(spec_path, config, project_root, *, task=None):
+            return merged_triage if "feature-a" in spec_path else full_triage
+
+        # Generation 2: re-exec of the same sprint picks up where gen 1 left off.
+        with patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                return_value=_make_coordinator_result(
+                    success=True, cost=1.5, landing_status="landed"
+                ),
+            ):
+                result = run_sprint(config, manifest_path, reexec=True)
+
+        # $6.00 from before the re-exec is still counted, not dropped.
+        assert result.total_cost_usd == pytest.approx(7.5)
+
+        summary_path = tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml"
+        summary = yaml.safe_load(summary_path.read_text(encoding="utf-8"))
+        by_slug = {story["slug"]: story for story in summary["stories"]}
+        assert summary["sprint"]["total_cost_usd"] == pytest.approx(7.5)
+        assert by_slug["feature-a"]["cost_usd"] == pytest.approx(6.0)
+
+    def test_reexec_budget_check_sees_spend_from_before_the_reexec(self, tmp_path: Path) -> None:
+        """The dispatch-time check evaluates the carried figure, not $0.00."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=5.0)
+        config = _make_config(tmp_path)
+        _set_sprint_id(tmp_path)
+
+        gen1_manifest = _make_gen1_manifest(tmp_path, budget=100.0)
+        with patch(
+            "theforge.sprint.runner.run_task",
+            return_value=_make_coordinator_result(success=True, cost=6.0, landing_status="landed"),
+        ):
+            run_sprint(config, gen1_manifest, resume=False)
+
+        merged_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="skip_merged",
+            reason="already merged to main",
+            worktree_path=None,
+            slug="feature-a",
+        )
+        full_triage = StoryTriage(
+            story_path="feature-b.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+            slug="feature-b",
+        )
+
+        def triage_side_effect(spec_path, config, project_root, *, task=None):
+            return merged_triage if "feature-a" in spec_path else full_triage
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect):
+            with patch("theforge.sprint.runner.run_task") as mock_run:
+                result = run_sprint(config, manifest_path, reexec=True)
+
+        # feature-b must not dispatch: $0.00 + carried $6.00 already exceeds $5.
+        mock_run.assert_not_called()
+        assert result.stopped_reason == (
+            "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
 
     def test_no_resume_flag_unchanged(self, tmp_path: Path) -> None:
         """Without --resume, behavior is unchanged (run_task called normally)."""


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 is resolved; focused sprint resume coverage passes and I found no blocking regressions in the touched paths. | [google-gemini-3.5-flash] The prior P1 finding is fully resolved, and the re-exec carry-forward logic is robustly covered by end-to-end integration tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $9.21
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Mid-sprint re-exec drops prior cost from both the budget cap and the reported total (GitHub Issue #1972)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1972