### PR TITLE
Sprint that dies on an unhandled exception is reported as completed, with killed stories still shown running

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -273,6 +273,25 @@ For an active sprint run, `forge status` includes the per-story sprint status
 view. The old standalone `forge sprint-status` command is no longer exposed by
 the top-level parser.
 
+### Run dispositions
+
+The bracketed label in the sprint header is derived from how the run actually
+ended — never from the absence of a record:
+
+| Label | Meaning |
+|---|---|
+| `live` | Owning process is alive (PID file present). |
+| `completed` | The sprint returned normally. |
+| `stopped` | Terminated deliberately (`forge stop`, SIGTERM). |
+| `failed` | Terminated on an unhandled exception; the terminating cause is printed on the `cause:` line below the header. |
+| `orphaned` | Marked by `forge runs-clean` — no process, no terminal marker. |
+| `crashed` | State file left behind with no terminal marker at all. |
+
+When the owning process is gone, stories whose last recorded phase said
+`running` are reported as `interrupted` (their last known phase is retained in
+the PHASE column as history). Interrupted work is not progressing — resume the
+sprint rather than waiting on it.
+
 ### Operator-action queue
 
 ```bash

--- a/src/theforge/cli/run.py
+++ b/src/theforge/cli/run.py
@@ -232,6 +232,11 @@ def cmd_run(args: "argparse.Namespace") -> int:
 
     no_pull = getattr(args, "no_pull", False)
 
+    # Terminal disposition is derived from how the run actually ended: a return
+    # out of the block below is an observed ending, anything that propagates is
+    # a failure and must not be recorded as "completed".
+    outcome = "completed"
+    cause: str | None = None
     try:
         if resume:
             triage = _triage_spec(str(story_path), config, config.project_root)
@@ -301,11 +306,15 @@ def cmd_run(args: "argparse.Namespace") -> int:
         print(f"{'=' * 60}", file=sys.stderr)
 
         return 0 if result.success else 1
+    except BaseException as exc:
+        outcome = "failed"
+        cause = _detach.format_exception_cause(exc)
+        raise
     finally:
         # Write terminal marker then remove PID — ensures status is accurate even
         # if run_task raises. SIGTERM handler may have already written "stopped";
         # write_run_ended is a no-op when the file already exists.
-        _detach.write_run_ended(run_id, config.project_root, "completed")
+        _detach.write_run_ended(run_id, config.project_root, outcome, cause=cause)
         _detach.remove_pid(run_id, config.project_root)
 
 

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -17,8 +17,65 @@ from theforge.sprint.lock import release_story_locks
 from theforge.sprint.preflight import reacquire_story_locks_in_daemon
 from theforge.sprint.runner import parse_manifest_slugs
 
+# A run's reported disposition must be derived from how it actually ended, not
+# from the absence of a record saying otherwise. ``_BACKSTOP`` carries the
+# outcome for the atexit fallback registered on the detached path, covering
+# failures that escape before/around the per-mode try/finally blocks below.
+_BACKSTOP: dict[str, str | None] = {"outcome": "completed", "cause": None}
+
+# Cause recorded when a sprint process reaches its terminal marker without
+# either completing run_sprint or catching an exception (SIGINT, SystemExit,
+# BaseException escaping the runner).
+_UNKNOWN_END_CAUSE = "sprint process ended before recording a completion"
+
+
+def _exc_cause(exc: BaseException) -> str:
+    """Return a short single-line description of a terminating exception."""
+    from theforge import detach as _detach_mod
+
+    return _detach_mod.format_exception_cause(exc)
+
+
+def _record_run_failure(cause: str) -> None:
+    """Mark the active sprint process as terminating abnormally."""
+    _BACKSTOP["outcome"] = "failed"
+    _BACKSTOP["cause"] = cause
+
+
+def _backstop_run_ended(run_id: str, project_root: Path) -> None:
+    """atexit fallback: write whatever terminal outcome this process observed.
+
+    A no-op when the per-mode ``finally`` already wrote the marker
+    (``write_run_ended`` does not overwrite an existing file).
+    """
+    from theforge import detach as _detach_mod
+
+    _detach_mod.write_run_ended(
+        run_id,
+        project_root,
+        _BACKSTOP["outcome"] or "failed",
+        cause=_BACKSTOP["cause"],
+    )
+
 
 def cmd_sprint(args: object) -> int:
+    """Run multiple stories via a sprint manifest or GitHub query.
+
+    Thin wrapper around :func:`_cmd_sprint` that records an abnormal
+    termination before the exception leaves the command, so the atexit backstop
+    cannot label a crashed sprint as completed.
+    """
+    try:
+        return _cmd_sprint(args)
+    except KeyboardInterrupt:
+        _BACKSTOP.update({"outcome": "stopped", "cause": "interrupted by operator (SIGINT)"})
+        raise
+    except BaseException as exc:
+        _record_run_failure(_exc_cause(exc))
+        raise
+
+
+def _cmd_sprint(args: object) -> int:
     """Run multiple stories via a sprint manifest or GitHub query."""
     from theforge import daemon as _daemon
     from theforge import detach as _detach
@@ -152,14 +209,15 @@ def cmd_sprint(args: object) -> int:
             # Backstop cleanup for early-return paths (all-skipped, no
             # stories, --detach-not-supported guard) that bypass the
             # try/finally in run_sprint blocks. Idempotent — write_run_ended
-            # is a no-op if the .ended marker already exists.
+            # is a no-op if the .ended marker already exists. Writes the
+            # outcome this process actually observed, so an exception escaping
+            # before the per-mode try/finally is not recorded as "completed".
             import atexit as _atexit
 
             _atexit.register(
-                _detach_mod.write_run_ended,
+                _backstop_run_ended,
                 launch_run_id,
                 config.project_root,
-                "completed",
             )
             _atexit.register(_detach_mod.remove_pid, launch_run_id, config.project_root)
         else:
@@ -289,6 +347,11 @@ def cmd_sprint(args: object) -> int:
             print(f"[daemon] Submit failed: {err}", file=sys.stderr)
             return 1
 
+    # Default to a failed disposition: only a run that returns from run_sprint
+    # has been observed to complete. Anything else (exception, SIGINT,
+    # BaseException) must not be recorded as a completion.
+    outcome = "failed"
+    cause: str | None = _UNKNOWN_END_CAUSE
     try:
         result = run_sprint(
             config,
@@ -303,19 +366,28 @@ def cmd_sprint(args: object) -> int:
             dropped_slugs=dropped_slugs,
             force=force,
         )
+    except KeyboardInterrupt:
+        # Ctrl-C is a deliberate termination, not a crash — record it as such
+        # rather than folding it into the failure bucket.
+        outcome, cause = "stopped", "interrupted by operator (SIGINT)"
+        raise
     except Exception as exc:
         import traceback
 
+        cause = _exc_cause(exc)
+        _record_run_failure(cause)
         print(f"Sprint error: {exc}", file=sys.stderr, flush=True)
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         return 1
+    else:
+        outcome, cause = "completed", None
     finally:
         release_story_locks(locked_fds)
         # Write terminal marker then remove PID — ensures status is accurate even
         # if run_sprint raises. SIGTERM handler may have already written "stopped";
         # write_run_ended is a no-op when the file already exists.
-        _detach.write_run_ended(run_id, config.project_root, "completed")
+        _detach.write_run_ended(run_id, config.project_root, outcome, cause=cause)
         _detach.remove_pid(run_id, config.project_root)
 
     return 0 if result.specs_failed == 0 else 1
@@ -1128,6 +1200,9 @@ def _run_query_mode(
         )
         return 1
 
+    # See the manifest-mode comment: absence of a completion is not completion.
+    outcome = "failed"
+    cause: str | None = _UNKNOWN_END_CAUSE
     try:
         result = run_sprint(
             config,
@@ -1144,17 +1219,26 @@ def _run_query_mode(
             entry_intake_outcomes=entry_intake_outcomes,
             force=force,
         )
+    except KeyboardInterrupt:
+        # Ctrl-C is a deliberate termination, not a crash — record it as such
+        # rather than folding it into the failure bucket.
+        outcome, cause = "stopped", "interrupted by operator (SIGINT)"
+        raise
     except Exception as exc:
         import traceback
 
+        cause = _exc_cause(exc)
+        _record_run_failure(cause)
         print(f"Sprint error: {exc}", file=sys.stderr, flush=True)
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         return 1
+    else:
+        outcome, cause = "completed", None
     finally:
         release_story_locks(locked_fds)
         # Write terminal marker then remove PID — same pattern as manifest mode.
-        _detach.write_run_ended(run_id, config.project_root, "completed")
+        _detach.write_run_ended(run_id, config.project_root, outcome, cause=cause)
         _detach.remove_pid(run_id, config.project_root)
 
     return 0 if result.specs_failed == 0 else 1

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -8,6 +8,10 @@ import sys
 import textwrap
 from pathlib import Path
 
+#: Width of the STATUS column — wide enough for the longest status label
+#: ("interrupted") so a killed story does not push the row out of alignment.
+_STATUS_WIDTH = 11
+
 _ISSUE_REF_RE = re.compile(r"(?:issue-|#)(\d+)")
 _DETAIL_REF_RE = re.compile(r"#(\d+)")
 
@@ -109,6 +113,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     from theforge.sprint.status_reader import (
         find_live_state_path,
         find_sprint_summary,
+        mark_interrupted_entries,
         read_completed_status,
         read_live_status,
     )
@@ -121,6 +126,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     sprint_name = ""
     unexpected_end = False
     terminal_outcome: str | None = None
+    terminal_cause: str | None = None
     total_cost_usd: float | None = None
     duration_seconds: float | None = None
     sprint_phase: str | None = None
@@ -161,10 +167,15 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
         if state_path.exists():
             from theforge import detach as _detach
 
-            terminal_outcome = _detach.read_run_ended(run_id, project_root)
+            record = _detach.read_run_ended_record(run_id, project_root)
+            if record is not None:
+                terminal_outcome, terminal_cause = record
             unexpected_end = terminal_outcome is None
             entries = read_live_status(run_id, project_root)
             if entries is not None:
+                # The owning process is gone: no story can still be advancing,
+                # whatever the last phase written to .state says.
+                entries = mark_interrupted_entries(entries)
                 sprint_name = _read_sprint_name_from_state(state_path)
 
     # For crashed sprints with an unreadable state file, show the banner with
@@ -238,6 +249,10 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
 
     if unexpected_end:
         print("  ⚠  Sprint ended unexpectedly (PID file missing, state file present)")
+    elif terminal_outcome == "failed":
+        print("  ⚠  Sprint terminated abnormally — it did not complete")
+    if terminal_cause:
+        print(f"  cause: {terminal_cause}")
     print()
 
     if not entries:
@@ -253,6 +268,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
         "running": "▸",
         "waiting": "○",
         "failed": "✗",
+        "interrupted": "⚠",
         "skipped": "⊘",
         "blocked": "⊘",
         "operator-action": "⊘",
@@ -261,7 +277,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     # Column header
     stage_width = 20
     header = (
-        f"  {'STORY':<28}  {'STATUS':<8}  {'PHASE':<12}  {'MODEL':<24}  "
+        f"  {'STORY':<28}  {'STATUS':<{_STATUS_WIDTH}}  {'PHASE':<12}  {'MODEL':<24}  "
         f"{'STAGE':<{stage_width}}  {'COMPLEXITY':<10}  {'COST':>7}  {'ELAPSED':>7}  DETAIL"
     )
     print(header)
@@ -418,7 +434,7 @@ def _print_story_line(
         elapsed_cell = elapsed_str if index == 0 else ""
         line = (
             f"{icon_cell} {path_lines[index] if index < len(path_lines) else '':<28}  "
-            f"{status_cell:<8}  "
+            f"{status_cell:<{_STATUS_WIDTH}}  "
             f"{phase_lines[index] if index < len(phase_lines) else '':<12}  "
             f"{model_lines[index] if index < len(model_lines) else '':<24}  "
             f"{stage_lines[index] if index < len(stage_lines) else '':<{stage_width}}  "
@@ -445,7 +461,24 @@ def _detail_column_width(indent: int) -> int:
     terminal_width = shutil.get_terminal_size((140, 20)).columns
     stage_width = 20
     fixed_width = (
-        indent + 2 + 28 + 2 + 8 + 2 + 12 + 2 + 24 + 2 + stage_width + 2 + 10 + 2 + 7 + 2 + 7 + 2
+        indent
+        + 2
+        + 28
+        + 2
+        + _STATUS_WIDTH
+        + 2
+        + 12
+        + 2
+        + 24
+        + 2
+        + stage_width
+        + 2
+        + 10
+        + 2
+        + 7
+        + 2
+        + 7
+        + 2
     )
     return max(20, terminal_width - fixed_width)
 

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -119,12 +119,44 @@ def has_diagnose_marker(run_id: str, project_root: Path) -> bool:
     return (project_root / ".forge" / "runs" / f"{run_id}.diagnose").exists()
 
 
+_CAUSE_MAX_CHARS = 500
+
+
+def _flatten_cause(cause: str) -> str:
+    """Collapse a terminating cause to a single truncated line.
+
+    The ``.ended`` marker is line-oriented (outcome first, cause second), so a
+    multi-line exception message must not smuggle extra lines into the file.
+    """
+    flat = " ".join(cause.split())
+    if len(flat) > _CAUSE_MAX_CHARS:
+        flat = flat[: _CAUSE_MAX_CHARS - 1] + "…"
+    return flat
+
+
+def format_exception_cause(exc: BaseException) -> str:
+    """Return a short single-line description of a terminating exception."""
+    message = " ".join(str(exc).split())
+    if not message:
+        return type(exc).__name__
+    return f"{type(exc).__name__}: {message}"
+
+
 def write_run_ended(
-    run_id: str, project_root: Path, outcome: str = "stopped", *, force: bool = False
+    run_id: str,
+    project_root: Path,
+    outcome: str = "stopped",
+    *,
+    force: bool = False,
+    cause: str | None = None,
 ) -> None:
     """Write .forge/runs/<run_id>.ended with the terminal outcome.
 
-    outcome is a short string: "stopped", "completed", or "orphaned".
+    outcome is a short string: "stopped", "completed", "failed", or "orphaned".
+    ``cause`` is an optional short reason (e.g. the terminating exception
+    message) persisted on a second line so status surfaces can name *why* a run
+    ended abnormally instead of only that it did.
+
     When force=False (default) the file is not overwritten if it already
     exists — the first writer (usually the SIGTERM handler) wins.
     """
@@ -133,19 +165,37 @@ def write_run_ended(
     ended_file = runs_dir / f"{run_id}.ended"
     if not force and ended_file.exists():
         return
+    payload = outcome
+    if cause:
+        payload = f"{outcome}\n{_flatten_cause(cause)}"
     try:
-        ended_file.write_text(outcome, encoding="utf-8")
+        ended_file.write_text(payload, encoding="utf-8")
     except OSError:
         pass
 
 
 def read_run_ended(run_id: str, project_root: Path) -> str | None:
     """Return the terminal outcome recorded in .forge/runs/<run_id>.ended, or None."""
+    record = read_run_ended_record(run_id, project_root)
+    return record[0] if record is not None else None
+
+
+def read_run_ended_record(run_id: str, project_root: Path) -> tuple[str, str | None] | None:
+    """Return ``(outcome, cause)`` from .forge/runs/<run_id>.ended, or None.
+
+    ``cause`` is None for markers written without one (the common
+    stopped/completed case) and for legacy single-line markers.
+    """
     ended_file = project_root / ".forge" / "runs" / f"{run_id}.ended"
     try:
-        return ended_file.read_text(encoding="utf-8").strip() or None
-    except FileNotFoundError:
+        text = ended_file.read_text(encoding="utf-8")
+    except OSError:
         return None
+    lines = [line.strip() for line in text.splitlines()]
+    if not lines or not lines[0]:
+        return None
+    cause = next((line for line in lines[1:] if line), None)
+    return lines[0], cause
 
 
 def _read_pid_file(pid_file: Path) -> tuple[int, str] | None:

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import yaml
@@ -847,6 +847,33 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
         )
 
     return entries
+
+
+#: Statuses that describe work the sprint process was actively advancing. When
+#: that process is gone, none of them can still be true.
+_IN_FLIGHT_STATUSES = {"running"}
+
+
+def mark_interrupted_entries(entries: list[StoryStatusEntry]) -> list[StoryStatusEntry]:
+    """Rewrite in-flight entries for a run whose owning process is gone.
+
+    Live state records the last phase a story reached; nothing rewrites those
+    entries when the sprint process dies, so a killed story keeps reading as
+    ``running``. Work that was interrupted is not work that is progressing —
+    report it as ``interrupted``, preserving the last known phase as history
+    rather than as current progress.
+    """
+    reconciled: list[StoryStatusEntry] = []
+    for entry in entries:
+        if entry.status not in _IN_FLIGHT_STATUSES:
+            reconciled.append(entry)
+            continue
+        last_detail = (entry.detail or "").strip()
+        detail = "interrupted — sprint process is no longer running"
+        if last_detail:
+            detail = f"{detail}; last: {last_detail}"
+        reconciled.append(replace(entry, status="interrupted", detail=detail))
+    return reconciled
 
 
 def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] | None:

--- a/tests/test_sprint_crash_terminal_status.py
+++ b/tests/test_sprint_crash_terminal_status.py
@@ -1,0 +1,499 @@
+"""Terminal disposition of a sprint that dies on an unhandled exception (issue-1979).
+
+A run's reported disposition must be derived from how it actually ended. These
+tests cover the write side (``.ended`` records ``failed`` plus the terminating
+cause) and the read side (per-story state written before the crash is reported
+as interrupted, not running).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from theforge import detach
+from theforge.config import (
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_forge_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        ),
+        preflight_profile=ModelProfile(
+            name="preflight",
+            cli="claude",
+            model="sonnet",
+            budget_usd=0.5,
+            timeout_seconds=120,
+            allowed_tools=("Read",),
+        ),
+        review_pool=[
+            ModelProfile(
+                name="claude-reviewer",
+                provider="anthropic",
+                model="claude-opus-4-6",
+                budget_usd=1.0,
+                timeout_seconds=120,
+                allowed_tools=("Read", "Grep"),
+            )
+        ],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        plan_agent_review=PlanAgentReviewConfig(enabled=False),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _sprint_result():
+    from theforge.sprint import SprintResult
+
+    return SprintResult(
+        name="test",
+        specs_total=1,
+        specs_succeeded=1,
+        specs_failed=0,
+        specs_skipped=0,
+        total_cost_usd=0.0,
+        budget_usd=0.0,
+    )
+
+
+def _query_mode_args() -> argparse.Namespace:
+    return argparse.Namespace(name=None, no_notify=True, fg=True, detach=False)
+
+
+def _run_query_mode(tmp_path: Path, config: ForgeConfig, run_id: str, run_sprint_mock):
+    from theforge.cli.sprint import _run_query_mode as _impl
+
+    task = MagicMock()
+    task.slug = "issue-42"
+    task.depends_on = []
+    resolved = MagicMock()
+    resolved.stories = [(task, MagicMock(), "issue:42")]
+
+    with (
+        patch(
+            "theforge.sprint.query.fetch_issues_for_milestone",
+            return_value=[{"number": 42, "title": "Story"}],
+        ),
+        patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
+        patch("theforge.cli.sprint._acquire_launch_locks", return_value=([], None, {})),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint.run_sprint", **run_sprint_mock),
+        patch("theforge.detach.remove_pid"),
+    ):
+        return _impl(
+            args=_query_mode_args(),
+            config=config,
+            config_path=tmp_path / "forge.yaml",
+            milestone="v1.0",
+            label=None,
+            budget_str="5",
+            dry_run=False,
+            max_parallel=1,
+            auto_merge=False,
+            interactive=False,
+            resume=False,
+            no_pull=False,
+            _daemon=MagicMock(is_daemon_running=MagicMock(return_value=False)),
+            _detach=detach,
+            _generate_run_id=MagicMock(return_value=run_id),
+        )
+
+
+def _make_state_file(tmp_path: Path, run_id: str, sprint_name: str, stories: list[dict]) -> Path:
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    state_path = runs_dir / f"{run_id}.state"
+    with open(state_path, "w", encoding="utf-8") as f:
+        yaml.dump({"sprint_name": sprint_name, "stories": stories}, f)
+    return state_path
+
+
+def _run_sprint_status(tmp_path: Path, run_id: str) -> tuple[int, str]:
+    from theforge.cli.sprint_status import cmd_sprint_status
+
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    fake_config = MagicMock()
+    fake_config.project_root = tmp_path
+
+    args = argparse.Namespace(run_id=run_id)
+    buf = io.StringIO()
+    with (
+        patch("theforge.cli.shared._find_config", return_value=forge_yaml),
+        patch("theforge.config.load_config", return_value=fake_config),
+        # No GitHub access in tests — titles stay unresolved.
+        patch(
+            "theforge.sprint.query.fetch_issues_by_numbers",
+            side_effect=RuntimeError("not found in this repository"),
+        ),
+        patch("sys.stdout", buf),
+    ):
+        code = cmd_sprint_status(args)
+    return code, buf.getvalue()
+
+
+# ── detach: terminal marker carries the cause ────────────────────────────────
+
+
+def test_write_run_ended_persists_cause(tmp_path: Path) -> None:
+    detach.write_run_ended("run1", tmp_path, "failed", cause="Broken baseline: gate FAIL")
+
+    assert detach.read_run_ended("run1", tmp_path) == "failed"
+    assert detach.read_run_ended_record("run1", tmp_path) == (
+        "failed",
+        "Broken baseline: gate FAIL",
+    )
+
+
+def test_write_run_ended_flattens_multiline_cause(tmp_path: Path) -> None:
+    detach.write_run_ended("run2", tmp_path, "failed", cause="line one\nline two")
+
+    outcome, cause = detach.read_run_ended_record("run2", tmp_path)
+    assert outcome == "failed"
+    assert cause == "line one line two"
+
+
+def test_read_run_ended_record_legacy_single_line(tmp_path: Path) -> None:
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True)
+    (runs_dir / "legacy.ended").write_text("completed", encoding="utf-8")
+
+    assert detach.read_run_ended_record("legacy", tmp_path) == ("completed", None)
+    assert detach.read_run_ended_record("missing", tmp_path) is None
+
+
+def test_read_run_status_reports_failed_phase(tmp_path: Path) -> None:
+    detach.write_run_ended("run3", tmp_path, "failed", cause="RuntimeError: boom")
+
+    status = detach.read_run_status("run3", "sprint-slug", tmp_path)
+    assert status["phase"] == "FAILED"
+
+
+# ── write side: sprint CLI records how the run actually ended ────────────────
+
+
+def test_query_mode_records_failed_outcome_with_cause(tmp_path: Path) -> None:
+    config = _make_forge_config(tmp_path)
+
+    rc = _run_query_mode(
+        tmp_path,
+        config,
+        "crash-run",
+        {"side_effect": RuntimeError("Broken baseline: configured gate failed")},
+    )
+
+    assert rc == 1
+    outcome, cause = detach.read_run_ended_record("crash-run", tmp_path)
+    assert outcome == "failed"
+    assert "Broken baseline" in cause
+    assert "RuntimeError" in cause
+
+
+def test_query_mode_records_completed_on_success(tmp_path: Path) -> None:
+    config = _make_forge_config(tmp_path)
+
+    rc = _run_query_mode(tmp_path, config, "ok-run", {"return_value": _sprint_result()})
+
+    assert rc == 0
+    assert detach.read_run_ended_record("ok-run", tmp_path) == ("completed", None)
+
+
+def test_manifest_mode_records_failed_outcome_with_cause(tmp_path: Path) -> None:
+    from theforge.cli import cmd_sprint
+
+    config = _make_forge_config(tmp_path)
+    manifest_path = tmp_path / "sprint.yaml"
+    manifest_path.write_text("stories: []\n", encoding="utf-8")
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project:\n  root: .\n", encoding="utf-8")
+    args = argparse.Namespace(
+        manifest=str(manifest_path),
+        config=str(forge_yaml),
+        fg=True,
+        detach=False,
+        resume=False,
+        milestone=None,
+        label=None,
+        issues=None,
+        budget=None,
+        parallel=None,
+        name=None,
+        dry_run=False,
+        auto_merge=False,
+        interactive=False,
+        verbose=False,
+        no_notify=True,
+        no_pull=False,
+        base_branch=None,
+    )
+
+    captured: dict = {}
+
+    def _capture_write(run_id, project_root, outcome="stopped", *, force=False, cause=None):
+        captured["run_id"] = run_id
+        captured["outcome"] = outcome
+        captured["cause"] = cause
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=config),
+        patch("theforge.cli.sprint.run_sprint", side_effect=RuntimeError("sprint crash")),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint._acquire_launch_locks", return_value=([], None, {})),
+        patch("theforge.detach.remove_pid"),
+        patch("theforge.detach.write_run_ended", side_effect=_capture_write),
+    ):
+        rc = cmd_sprint(args)
+
+    assert rc == 1
+    assert captured["outcome"] == "failed"
+    assert "sprint crash" in captured["cause"]
+
+
+def test_cmd_run_records_failed_outcome_on_exception(tmp_path: Path) -> None:
+    from theforge.cli import cmd_run
+
+    config = _make_forge_config(tmp_path)
+    story = tmp_path / "story.md"
+    story.write_text("# Story\nDo the thing.\n", encoding="utf-8")
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project:\n  root: .\n", encoding="utf-8")
+    args = argparse.Namespace(
+        story=str(story),
+        slug=None,
+        config=str(forge_yaml),
+        plan=None,
+        from_phase=None,
+        until=None,
+        reviewers=None,
+        max_cycles=None,
+        resume=False,
+        dev_model=None,
+        plan_model=None,
+        dry_run=False,
+        interactive=False,
+        auto_merge=False,
+        verbose=False,
+        no_notify=True,
+        fg=True,
+        base_branch=None,
+        no_pull=False,
+    )
+
+    captured: dict = {}
+
+    def _capture_write(run_id, project_root, outcome="stopped", *, force=False, cause=None):
+        captured["outcome"] = outcome
+        captured["cause"] = cause
+
+    with (
+        patch("theforge.cli.run.load_config", return_value=config),
+        patch("theforge.cli.run.run_task", side_effect=RuntimeError("agent crash")),
+        patch("theforge.detach.remove_pid"),
+        patch("theforge.detach.write_run_ended", side_effect=_capture_write),
+    ):
+        with pytest.raises(RuntimeError, match="agent crash"):
+            cmd_run(args)
+
+    assert captured["outcome"] == "failed"
+    assert "agent crash" in captured["cause"]
+
+
+def test_backstop_records_failure_when_exception_escapes_cmd_sprint() -> None:
+    """An exception escaping cmd_sprint must not leave the backstop on "completed"."""
+    import theforge.cli.sprint as sprint_cli
+
+    original = dict(sprint_cli._BACKSTOP)
+    try:
+        sprint_cli._BACKSTOP.update({"outcome": "completed", "cause": None})
+        with patch.object(sprint_cli, "_cmd_sprint", side_effect=RuntimeError("early crash")):
+            with pytest.raises(RuntimeError, match="early crash"):
+                sprint_cli.cmd_sprint(argparse.Namespace())
+        assert sprint_cli._BACKSTOP["outcome"] == "failed"
+        assert "early crash" in (sprint_cli._BACKSTOP["cause"] or "")
+    finally:
+        sprint_cli._BACKSTOP.update(original)
+
+
+def test_backstop_writes_recorded_outcome(tmp_path: Path) -> None:
+    import theforge.cli.sprint as sprint_cli
+
+    original = dict(sprint_cli._BACKSTOP)
+    try:
+        sprint_cli._BACKSTOP.update({"outcome": "failed", "cause": "RuntimeError: boom"})
+        sprint_cli._backstop_run_ended("backstop-run", tmp_path)
+    finally:
+        sprint_cli._BACKSTOP.update(original)
+
+    assert detach.read_run_ended_record("backstop-run", tmp_path) == (
+        "failed",
+        "RuntimeError: boom",
+    )
+
+
+# ── read side: in-flight stories are reported as interrupted ─────────────────
+
+
+def test_mark_interrupted_entries_rewrites_running_stories() -> None:
+    from theforge.sprint.status_reader import StoryStatusEntry, mark_interrupted_entries
+
+    entries = [
+        StoryStatusEntry(
+            slug="issue-1972",
+            path="Issue #1972",
+            status="running",
+            phase="DEV",
+            cost_usd=1.0,
+            detail="running",
+        ),
+        StoryStatusEntry(
+            slug="issue-1946",
+            path="Issue #1946",
+            status="done",
+            phase="DONE",
+            cost_usd=0.5,
+            detail="merged",
+        ),
+    ]
+
+    result = mark_interrupted_entries(entries)
+
+    assert result[0].status == "interrupted"
+    assert result[0].phase == "DEV", "last known phase is preserved as history"
+    assert "interrupted" in result[0].detail
+    assert "last: running" in result[0].detail
+    # Non-in-flight entries are untouched.
+    assert result[1] == entries[1]
+    # Input list is not mutated.
+    assert entries[0].status == "running"
+
+
+def test_crashed_sprint_status_names_cause_and_interrupts_stories(tmp_path: Path) -> None:
+    """Regression for run f13f739e19c3: [completed] with stories still running."""
+    _make_state_file(
+        tmp_path,
+        "f13f739e19c3",
+        "issues-1972,1946,1945,1934",
+        [
+            {
+                "slug": "issue-1945",
+                "path": "Issue #1945",
+                "status": "running",
+                "phase": "WORKSPACE",
+                "cost_usd": 0.0,
+                "bundle_candidate": False,
+                "blocked_by": [],
+            },
+            {
+                "slug": "issue-1972",
+                "path": "Issue #1972",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 3.75,
+                "bundle_candidate": False,
+                "blocked_by": [],
+            },
+        ],
+    )
+    detach.write_run_ended(
+        "f13f739e19c3",
+        tmp_path,
+        "failed",
+        cause="RuntimeError: Broken baseline: configured gate failed on sprint merge base",
+    )
+
+    code, output = _run_sprint_status(tmp_path, "f13f739e19c3")
+
+    assert code == 0
+    assert "[failed]" in output
+    assert "[completed]" not in output
+    assert "Broken baseline" in output
+    assert "interrupted" in output
+    # No story may be described as running by a process that no longer exists.
+    assert " running " not in output.replace("last: running", "")
+
+
+def test_stopped_sprint_stories_are_interrupted_not_running(tmp_path: Path) -> None:
+    _make_state_file(
+        tmp_path,
+        "stopped-1979",
+        "stopped-sprint",
+        [
+            {
+                "slug": "issue-1",
+                "path": "Issue #1",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 0.05,
+                "bundle_candidate": False,
+                "blocked_by": [],
+            }
+        ],
+    )
+    detach.write_run_ended("stopped-1979", tmp_path, "stopped")
+
+    code, output = _run_sprint_status(tmp_path, "stopped-1979")
+
+    assert code == 0
+    assert "[stopped]" in output
+    assert "interrupted" in output
+
+
+def test_live_sprint_still_reports_running(tmp_path: Path) -> None:
+    """Guard: reconciliation must not touch a run whose process is alive."""
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "live-1979.pid").write_text("99999\nlive-sprint\n", encoding="utf-8")
+    _make_state_file(
+        tmp_path,
+        "live-1979",
+        "live-sprint",
+        [
+            {
+                "slug": "issue-1",
+                "path": "Issue #1",
+                "status": "running",
+                "phase": "DEV",
+                "cost_usd": 0.05,
+                "bundle_candidate": False,
+                "blocked_by": [],
+            }
+        ],
+    )
+
+    code, output = _run_sprint_status(tmp_path, "live-1979")
+
+    assert code == 0
+    assert "[live]" in output
+    assert "running" in output
+    assert "interrupted" not in output


### PR DESCRIPTION
## Summary

The submitted commit satisfies the crash-status bug: failed sprint endings carry a cause, dead in-flight stories render interrupted, and both status paths consume the same renderer.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $6.33
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint that dies on an unhandled exception is reported as completed, with killed stories still shown running (GitHub Issue #1979)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1979