### PR TITLE
Mid-run re-exec re-enters sprint startup, re-running pre-work checks against a live sprint

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -284,6 +284,9 @@ def _cmd_sprint(args: object) -> int:
             )
         except Exception:
             prior_outcomes = None
+    # Stories this same process (the pid survives ``os.execv``) still has agents
+    # running for. They are this run's own live work, not foreign state.
+    in_flight_slugs = _resolve_live_story_slugs(config, slugs) if reexec else set()
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
         slugs=slugs,
         config=config,
@@ -291,6 +294,7 @@ def _cmd_sprint(args: object) -> int:
         allow_drop=reexec,
         force=force,
         prior_outcomes=prior_outcomes,
+        live_slugs=in_flight_slugs,
     )
     if launch_error is not None:
         return launch_error
@@ -365,6 +369,7 @@ def _cmd_sprint(args: object) -> int:
             run_id=run_id,
             dropped_slugs=dropped_slugs,
             force=force,
+            live_story_slugs=in_flight_slugs,
         )
     except KeyboardInterrupt:
         # Ctrl-C is a deliberate termination, not a crash — record it as such
@@ -401,6 +406,7 @@ def _acquire_launch_locks(
     allow_drop: bool = False,
     force: bool = False,
     prior_outcomes: dict[str, str] | None = None,
+    live_slugs: set[str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     return acquire_launch_story_locks(
         slugs=slugs,
@@ -409,7 +415,27 @@ def _acquire_launch_locks(
         allow_drop=allow_drop,
         force=force,
         prior_outcomes=prior_outcomes,
+        live_slugs=live_slugs,
     )
+
+
+def _resolve_live_story_slugs(config: object, slugs: list[str]) -> set[str]:
+    """Stories of this same process still executing across a re-exec boundary.
+
+    Thin CLI seam over :mod:`theforge.sprint.live_stories` — the ownership
+    decision itself lives in the sprint package. Best-effort: a resolution
+    failure degrades to today's behaviour rather than failing the launch.
+    """
+    try:
+        from theforge.sprint.live_stories import resolve_live_story_slugs  # noqa: PLC0415
+
+        return resolve_live_story_slugs(
+            slugs,
+            project_root=config.project_root,
+            path_pattern=config.workspace.path_pattern,
+        )
+    except Exception:
+        return set()
 
 
 def _resolve_prior_outcomes(config: object, sprint_name: str) -> dict[str, str]:
@@ -1129,6 +1155,8 @@ def _run_query_mode(
     # flattening them into fresh collisions. Best-effort — a miss degrades to
     # today's behavior.
     prior_outcomes = _resolve_prior_outcomes(config, resolved.name) if reexec else None
+    # Stories this same process still has live agents for (see manifest mode).
+    in_flight_slugs = _resolve_live_story_slugs(config, slugs) if reexec else set()
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
         slugs=slugs,
         config=config,
@@ -1136,6 +1164,7 @@ def _run_query_mode(
         allow_drop=reexec,
         force=force,
         prior_outcomes=prior_outcomes,
+        live_slugs=in_flight_slugs,
     )
     if launch_error is not None:
         return launch_error
@@ -1218,6 +1247,7 @@ def _run_query_mode(
             skipped_issues=skipped_issues,
             entry_intake_outcomes=entry_intake_outcomes,
             force=force,
+            live_story_slugs=in_flight_slugs,
         )
     except KeyboardInterrupt:
         # Ctrl-C is a deliberate termination, not a crash — record it as such

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -575,11 +575,25 @@ def _find_worktree_for_branch(branch: str, project_root: Path) -> Path | None:
     return None
 
 
-def sweep_orphan_worktrees(project_root: Path, config: ForgeConfig) -> None:
-    """Remove orphaned or safely-removable worktrees under .forge/worktrees/."""
+def sweep_orphan_worktrees(
+    project_root: Path,
+    config: ForgeConfig,
+    *,
+    protected_slugs: set[str] | None = None,
+) -> None:
+    """Remove orphaned or safely-removable worktrees under .forge/worktrees/.
+
+    ``protected_slugs`` names worktrees the caller knows are live work of the
+    current run — after a mid-run re-exec, the surviving agent process groups
+    (see :mod:`theforge.sprint.live_stories`). Liveness is not derivable from the
+    git state this sweep inspects: an agent that has not committed yet leaves a
+    clean tree 0 commits ahead of base, which is indistinguishable here from an
+    abandoned worktree. The caller knows; the sweep does not. So it is told.
+    """
     worktrees_root = project_root / ".forge" / "worktrees"
     if not worktrees_root.exists():
         return
+    protected = set(protected_slugs or ())
 
     ok, output = _cu._run_shell("git worktree list --porcelain", project_root)
     registered: dict[Path, str | None] = {}
@@ -602,6 +616,12 @@ def sweep_orphan_worktrees(project_root: Path, config: ForgeConfig) -> None:
         if not candidate.is_dir():
             continue
         slug = candidate.name
+        if slug in protected:
+            _cu._log(
+                f"⚠ WORKSPACE  preserving worktree {slug} — live agent from this "
+                "sprint is still running in it"
+            )
+            continue
         if (lock_dir / f"{slug}.lock").exists():
             continue
         if (candidate / ESCALATED_MARKER_PATH).exists():

--- a/src/theforge/sprint/gate_timeout_resolver.py
+++ b/src/theforge/sprint/gate_timeout_resolver.py
@@ -26,6 +26,8 @@ class GateTimeoutResolution:
     gate_cpu_cores: int
     max_parallel: int
     reason: str
+    running_stories: int = 0
+    actual_parallel: int = 0
 
 
 def resolve_effective_gate_timeout(
@@ -34,20 +36,32 @@ def resolve_effective_gate_timeout(
     host_cores: int,
     gate_cpu_cores: int | None,
     mode: str,
+    running_stories: int = 0,
 ) -> GateTimeoutResolution:
     """Resolve the effective gate timeout given contention conditions.
 
     Formula:
         gate_demand_cores = gate_cpu_cores or host_cores
-        demand            = gate_demand_cores * max_parallel
+        actual_parallel   = max_parallel + running_stories
+        demand            = gate_demand_cores * actual_parallel
         factor            = max(1.0, demand / host_cores)
         effective         = baseline if mode == "fixed" else ceil(baseline * factor)
         overcommit        = demand > host_cores * 1.5
+
+    ``running_stories`` is the count of stories already executing when the
+    timeout is resolved — non-zero only on a continuation (a mid-run re-exec
+    inherits live agent process groups). Those agents contend with the gate just
+    as this generation's own workers do, and a limit derived from configured
+    ``--parallel`` alone under-counts them: exceeding a timeout that ignored half
+    the load is a measurement of contention, not evidence that the tree is
+    broken. At the default ``0`` the formula is exactly the fresh-start one.
     """
     safe_host = max(1, host_cores)
     safe_parallel = max(1, max_parallel)
+    safe_running = max(0, int(running_stories or 0))
+    actual_parallel = safe_parallel + safe_running
     gate_demand_cores = gate_cpu_cores if gate_cpu_cores and gate_cpu_cores > 0 else safe_host
-    demand = gate_demand_cores * safe_parallel
+    demand = gate_demand_cores * actual_parallel
     factor = max(1.0, demand / safe_host)
     normalized_mode = str(mode)
     if normalized_mode not in VALID_GATE_TIMEOUT_SCALES:
@@ -59,10 +73,13 @@ def resolve_effective_gate_timeout(
     else:
         effective = int(math.ceil(baseline * factor))
     overcommit = demand > safe_host * 1.5
+    # Field order is appended-to, never reordered: the reason line is an
+    # operator-facing diagnostic that is grepped and asserted on by prefix.
     reason = (
         f"baseline={baseline}s mode={normalized_mode} parallel={safe_parallel} "
         f"gate_cpu_cores={gate_demand_cores} host_cores={safe_host} "
-        f"demand={demand} factor={factor:.2f} effective={effective}s"
+        f"demand={demand} factor={factor:.2f} effective={effective}s "
+        f"running_stories={safe_running} actual_parallel={actual_parallel}"
     )
     return GateTimeoutResolution(
         effective_timeout=effective,
@@ -74,4 +91,6 @@ def resolve_effective_gate_timeout(
         gate_cpu_cores=gate_demand_cores,
         max_parallel=safe_parallel,
         reason=reason,
+        running_stories=safe_running,
+        actual_parallel=actual_parallel,
     )

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -31,6 +31,11 @@ REASON_LOCK_HELD = "story-lock-held-by-other-process"
 # as a fresh ``active-worktree-collision`` and re-consumed.
 REASON_RECONCILE_PRIOR_DONE = "reconciled-prior-generation-done"
 REASON_STRANDED_WORKTREE = "stranded-prior-generation-worktree"
+# A story of *this* sprint generation whose agent process group is still running
+# across the re-exec boundary (the pid survives ``os.execv``). Its worktree is
+# this run's own live work, not a foreign collision: it is neither re-dispatched
+# (that would run two agents in one worktree) nor dropped/swept.
+REASON_IN_FLIGHT = "in-flight-current-sprint"
 
 # Prior-generation outcome strings (upper-cased) that mean the story succeeded
 # and its worktree should be reconciled/preserved rather than treated as a fresh
@@ -46,6 +51,7 @@ def acquire_launch_story_locks(
     allow_drop: bool = False,
     force: bool = False,
     prior_outcomes: dict[str, str] | None = None,
+    live_slugs: set[str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     """Acquire launch-time story locks after checking for active worktrees.
 
@@ -67,6 +73,13 @@ def acquire_launch_story_locks(
     individually recorded in ``dropped_slugs`` and the remaining, unconflicted
     stories have their locks acquired normally.
 
+    ``live_slugs`` names the stories this same process still has in flight across
+    a re-exec boundary (see :mod:`theforge.sprint.live_stories`). They are
+    recorded as ``REASON_IN_FLIGHT`` — excluded from dispatch, because their
+    original agent is still running in that worktree, and excluded from every
+    reconciliation that would treat the worktree as foreign (collision
+    classification, lock sweeping).
+
     Invariants the callers rely on:
 
     - Every slug in the returned ``dropped_slugs`` is *not* counted in
@@ -76,18 +89,35 @@ def acquire_launch_story_locks(
       non-None exit code.  In particular, the non-re-exec path never returns a
       partial lock set: if any story conflicts, no locks are returned.
     """
+    # ── In-flight stories: this process's own live work, untouchable ────
+    #
+    # Resolved before every other check so no reconciliation step — escalation
+    # scan, lock sweep, worktree collision classification — ever gets to look at
+    # a worktree whose agent is still running inside it.
+    in_flight_slugs = [s for s in slugs if s in (live_slugs or set())]
+    dropped: dict[str, str] = {s: REASON_IN_FLIGHT for s in in_flight_slugs}
+    if in_flight_slugs:
+        print(
+            f"[forge] IN-FLIGHT {', '.join(in_flight_slugs)}: agent process group "
+            "from this sprint survived the re-exec; preserving the live worktree and "
+            "not re-dispatching.",
+            file=sys.stderr,
+            flush=True,
+        )
+
     # ── Escalated worktrees: always preserved, on every launch path ─────
+    considered = [s for s in slugs if s not in dropped]
     if resume:
         escalated_slugs: list[str] = []
     else:
         escalated_slugs = check_escalated_worktrees(
-            slugs,
+            considered,
             config.workspace.path_pattern,
             config.workspace.branch_pattern,
             config.workspace.base_branch,
             config.project_root,
         )
-    dropped: dict[str, str] = {s: REASON_PRESERVED_ESCALATED for s in escalated_slugs}
+    dropped.update({s: REASON_PRESERVED_ESCALATED for s in escalated_slugs})
     schedulable = [s for s in slugs if s not in dropped]
 
     if escalated_slugs:
@@ -98,7 +128,10 @@ def acquire_launch_story_locks(
             flush=True,
         )
 
-    reaped_lock_paths = sweep_story_locks(config.project_root)
+    # A live story's lock file is unlocked (``os.execv`` closes the flock fd), so
+    # the generic sweep would read it as stale and delete it — and the worktree
+    # sweep then loses the marker that says the directory is claimed. Keep it.
+    reaped_lock_paths = sweep_story_locks(config.project_root, exclude_slugs=set(in_flight_slugs))
     if reaped_lock_paths:
         print(
             f"[forge] Reaped {len(reaped_lock_paths)} stale story lock file(s) at sprint launch.",
@@ -153,6 +186,10 @@ def acquire_launch_story_locks(
     stranded_slugs: list[str] = []
     collision_slugs: list[str] = []
     for slug in active_worktrees:
+        if slug in dropped:
+            # Already classified (in-flight / escalated). A later, coarser
+            # classification must never overwrite a more specific one.
+            continue
         prior_outcome = prior_outcomes.get(slug)
         if prior_outcome in _PRIOR_SUCCEEDED_OUTCOMES:
             dropped[slug] = REASON_RECONCILE_PRIOR_DONE

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -31,10 +31,11 @@ REASON_LOCK_HELD = "story-lock-held-by-other-process"
 # as a fresh ``active-worktree-collision`` and re-consumed.
 REASON_RECONCILE_PRIOR_DONE = "reconciled-prior-generation-done"
 REASON_STRANDED_WORKTREE = "stranded-prior-generation-worktree"
-# A story of *this* sprint generation whose agent process group is still running
-# across the re-exec boundary (the pid survives ``os.execv``). Its worktree is
-# this run's own live work, not a foreign collision: it is neither re-dispatched
-# (that would run two agents in one worktree) nor dropped/swept.
+# Not a drop reason: the deferral marker for a story of *this* sprint generation
+# whose agent process group is still running across the re-exec boundary (the pid
+# survives ``os.execv``). Its worktree is this run's own live work, not a foreign
+# collision. The runner surfaces this string on the story's live status while it
+# waits for the inherited agent to finish, then resumes the story.
 REASON_IN_FLIGHT = "in-flight-current-sprint"
 
 # Prior-generation outcome strings (upper-cased) that mean the story succeeded
@@ -75,10 +76,11 @@ def acquire_launch_story_locks(
 
     ``live_slugs`` names the stories this same process still has in flight across
     a re-exec boundary (see :mod:`theforge.sprint.live_stories`). They are
-    recorded as ``REASON_IN_FLIGHT`` — excluded from dispatch, because their
-    original agent is still running in that worktree, and excluded from every
-    reconciliation that would treat the worktree as foreign (collision
-    classification, lock sweeping).
+    excluded from every reconciliation that would treat their worktree as foreign
+    (escalation scan, collision classification, lock sweeping) but remain
+    schedulable and keep their launch lock: the runner defers each one until its
+    inherited agent exits and then resumes it. Dropping them instead would strand
+    the story, since no other process can adopt an agent group this pid owns.
 
     Invariants the callers rely on:
 
@@ -91,22 +93,25 @@ def acquire_launch_story_locks(
     """
     # ── In-flight stories: this process's own live work, untouchable ────
     #
-    # Resolved before every other check so no reconciliation step — escalation
-    # scan, lock sweep, worktree collision classification — ever gets to look at
-    # a worktree whose agent is still running inside it.
+    # Identified before every other check so no reconciliation step — escalation
+    # scan, worktree collision classification, lock sweep — ever gets to look at
+    # a worktree whose agent is still running inside it. They are NOT dropped:
+    # the story stays scheduled and keeps its launch lock, because this process
+    # is the only one that can still finish it (the runner waits for the
+    # inherited agent, then resumes the story through triage).
     in_flight_slugs = [s for s in slugs if s in (live_slugs or set())]
-    dropped: dict[str, str] = {s: REASON_IN_FLIGHT for s in in_flight_slugs}
+    dropped: dict[str, str] = {}
     if in_flight_slugs:
         print(
             f"[forge] IN-FLIGHT {', '.join(in_flight_slugs)}: agent process group "
             "from this sprint survived the re-exec; preserving the live worktree and "
-            "not re-dispatching.",
+            "deferring the story until its agent finishes.",
             file=sys.stderr,
             flush=True,
         )
 
     # ── Escalated worktrees: always preserved, on every launch path ─────
-    considered = [s for s in slugs if s not in dropped]
+    considered = [s for s in slugs if s not in in_flight_slugs]
     if resume:
         escalated_slugs: list[str] = []
     else:
@@ -177,7 +182,7 @@ def acquire_launch_story_locks(
     # story is reconciled instead of being flattened into a launch collision.
     prior_outcomes = prior_outcomes or {}
     active_worktrees = check_active_worktrees(
-        schedulable,
+        [s for s in schedulable if s not in in_flight_slugs],
         config.workspace.path_pattern,
         config.workspace.base_branch,
         config.project_root,
@@ -186,9 +191,9 @@ def acquire_launch_story_locks(
     stranded_slugs: list[str] = []
     collision_slugs: list[str] = []
     for slug in active_worktrees:
-        if slug in dropped:
-            # Already classified (in-flight / escalated). A later, coarser
-            # classification must never overwrite a more specific one.
+        if slug in dropped or slug in in_flight_slugs:
+            # Already classified (escalated), or live work of this same run. A
+            # later, coarser classification must never overwrite either.
             continue
         prior_outcome = prior_outcomes.get(slug)
         if prior_outcome in _PRIOR_SUCCEEDED_OUTCOMES:

--- a/src/theforge/sprint/live_stories.py
+++ b/src/theforge/sprint/live_stories.py
@@ -1,0 +1,113 @@
+"""Identify the stories this sprint process still has in flight.
+
+A mid-run re-exec (``os.execv`` after ``workspace.pull_base_branch`` observes new
+source) replaces the process *image* but keeps the process *identity*: the pid is
+unchanged, and the agent process groups the pre-exec image spawned are still
+running. Those groups are recorded in ``.forge/runs/agents/{owner_pid}-{pgid}.json``
+by :func:`theforge.process_group.register_agent_group`, together with the
+``sandbox_dir`` the agent was launched in — which for a story agent is its
+worktree.
+
+That pairing is what lets a re-exec'd process recognise its own work: a sidecar
+whose ``owner_pid`` is *this* pid and whose group is still alive names a story
+that is still executing right now. Such a story is not foreign state to be
+reconciled — it must not be re-dispatched, its worktree must not be swept, and
+its presence is the evidence that startup-only checks (the baseline gate) no
+longer hold their precondition.
+
+Stdlib-only apart from :mod:`theforge.process_group` (itself stdlib-only), per
+convention 4.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+from theforge.process_group import group_is_alive
+
+__all__ = ["resolve_live_story_slugs"]
+
+
+def _agent_sidecars(project_root: Path) -> list[Path]:
+    agents_dir = Path(project_root) / ".forge" / "runs" / "agents"
+    if not agents_dir.exists():
+        return []
+    try:
+        return sorted(agents_dir.glob("*.json"))
+    except OSError:
+        return []
+
+
+def _slug_for_sandbox(sandbox: Path, worktree_to_slug: dict[Path, str]) -> str | None:
+    """Map an agent sandbox dir onto the slug whose worktree contains it."""
+    for candidate in (sandbox, *sandbox.parents):
+        slug = worktree_to_slug.get(candidate)
+        if slug is not None:
+            return slug
+    return None
+
+
+def resolve_live_story_slugs(
+    slugs: Iterable[str],
+    *,
+    project_root: Path,
+    path_pattern: str,
+    owner_pid: int | None = None,
+    is_group_alive=group_is_alive,
+) -> set[str]:
+    """Return the subset of *slugs* still being executed by this process.
+
+    A slug qualifies when an agent-group sidecar exists that (a) records
+    ``owner_pid`` equal to this process's pid — the pid survives ``os.execv``, so
+    this is exactly "spawned by me, before the re-exec" — and (b) names a process
+    group that is still alive, launched inside that slug's worktree.
+
+    Best-effort by construction: an unreadable or malformed sidecar is ignored
+    rather than raised on. The cost of a miss is today's behaviour (the story is
+    treated as foreign), so this must never fail a launch.
+    """
+    slug_list = [s for s in slugs if s]
+    if not slug_list:
+        return set()
+
+    root = Path(project_root)
+    worktree_to_slug: dict[Path, str] = {}
+    for slug in slug_list:
+        try:
+            worktree = (root / path_pattern.format(slug=slug)).resolve()
+        except (KeyError, IndexError, OSError, ValueError):
+            continue
+        worktree_to_slug[worktree] = slug
+
+    if not worktree_to_slug:
+        return set()
+
+    my_pid = os.getpid() if owner_pid is None else int(owner_pid)
+    live: set[str] = set()
+    for sidecar in _agent_sidecars(root):
+        try:
+            data = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if data.get("owner_pid") != my_pid:
+            # Another process's group: not this sprint generation's work.
+            continue
+        pgid = data.get("pgid")
+        sandbox_raw = data.get("sandbox_dir")
+        if not isinstance(pgid, int) or not sandbox_raw:
+            continue
+        try:
+            sandbox = Path(str(sandbox_raw)).resolve()
+        except OSError:
+            continue
+        slug = _slug_for_sandbox(sandbox, worktree_to_slug)
+        if slug is None or slug in live:
+            continue
+        if is_group_alive(pgid):
+            live.add(slug)
+    return live

--- a/src/theforge/sprint/live_stories.py
+++ b/src/theforge/sprint/live_stories.py
@@ -1,4 +1,4 @@
-"""Identify the stories this sprint process still has in flight.
+"""Agent process groups this sprint inherited across a mid-run re-exec.
 
 A mid-run re-exec (``os.execv`` after ``workspace.pull_base_branch`` observes new
 source) replaces the process *image* but keeps the process *identity*: the pid is
@@ -11,9 +11,14 @@ worktree.
 That pairing is what lets a re-exec'd process recognise its own work: a sidecar
 whose ``owner_pid`` is *this* pid and whose group is still alive names a story
 that is still executing right now. Such a story is not foreign state to be
-reconciled — it must not be re-dispatched, its worktree must not be swept, and
-its presence is the evidence that startup-only checks (the baseline gate) no
-longer hold their precondition.
+reconciled — its worktree must not be swept, its outcome is not yet knowable, and
+it must not be re-dispatched *while the inherited agent runs*. It is also not
+abandoned: the new process image waits for that group to finish
+(:func:`await_inherited_agents`), reclaims it if it overruns
+(:func:`reclaim_inherited_agents`), and then resumes the story through the normal
+triage path. Nothing else will ever pick it up — the sidecar's owner is this pid,
+so the moment this process exits, a later invocation's orphan reaper sees a dead
+owner and kills the group.
 
 Stdlib-only apart from :mod:`theforge.process_group` (itself stdlib-only), per
 convention 4.
@@ -23,12 +28,29 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterable
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
-from theforge.process_group import group_is_alive
+from theforge.process_group import group_is_alive, kill_agent_group
 
-__all__ = ["resolve_live_story_slugs"]
+__all__ = [
+    "InheritedAgentGroup",
+    "await_inherited_agents",
+    "reclaim_inherited_agents",
+    "resolve_inherited_agents",
+    "resolve_live_story_slugs",
+]
+
+
+@dataclass(frozen=True)
+class InheritedAgentGroup:
+    """One agent process group this process spawned before the re-exec."""
+
+    slug: str
+    pgid: int
+    sidecar: Path
 
 
 def _agent_sidecars(project_root: Path) -> list[Path]:
@@ -50,43 +72,46 @@ def _slug_for_sandbox(sandbox: Path, worktree_to_slug: dict[Path, str]) -> str |
     return None
 
 
-def resolve_live_story_slugs(
+def _worktree_index(slugs: Iterable[str], root: Path, path_pattern: str) -> dict[Path, str]:
+    index: dict[Path, str] = {}
+    for slug in slugs:
+        if not slug:
+            continue
+        try:
+            index[(root / path_pattern.format(slug=slug)).resolve()] = slug
+        except (KeyError, IndexError, OSError, ValueError):
+            continue
+    return index
+
+
+def resolve_inherited_agents(
     slugs: Iterable[str],
     *,
     project_root: Path,
     path_pattern: str,
     owner_pid: int | None = None,
-    is_group_alive=group_is_alive,
-) -> set[str]:
-    """Return the subset of *slugs* still being executed by this process.
+    only_live: bool = True,
+    is_group_alive: Callable[[int], bool] = group_is_alive,
+) -> list[InheritedAgentGroup]:
+    """Agent groups spawned by this process for any of *slugs*.
 
-    A slug qualifies when an agent-group sidecar exists that (a) records
-    ``owner_pid`` equal to this process's pid — the pid survives ``os.execv``, so
-    this is exactly "spawned by me, before the re-exec" — and (b) names a process
-    group that is still alive, launched inside that slug's worktree.
+    A group qualifies when its sidecar records ``owner_pid`` equal to this
+    process's pid — the pid survives ``os.execv``, so this is exactly "spawned by
+    me, before the re-exec" — and its ``sandbox_dir`` lies inside that slug's
+    worktree. With ``only_live`` (the default) dead groups are filtered out;
+    pass ``False`` to reach their sidecar records for cleanup.
 
     Best-effort by construction: an unreadable or malformed sidecar is ignored
     rather than raised on. The cost of a miss is today's behaviour (the story is
     treated as foreign), so this must never fail a launch.
     """
-    slug_list = [s for s in slugs if s]
-    if not slug_list:
-        return set()
-
     root = Path(project_root)
-    worktree_to_slug: dict[Path, str] = {}
-    for slug in slug_list:
-        try:
-            worktree = (root / path_pattern.format(slug=slug)).resolve()
-        except (KeyError, IndexError, OSError, ValueError):
-            continue
-        worktree_to_slug[worktree] = slug
-
+    worktree_to_slug = _worktree_index(slugs, root, path_pattern)
     if not worktree_to_slug:
-        return set()
+        return []
 
     my_pid = os.getpid() if owner_pid is None else int(owner_pid)
-    live: set[str] = set()
+    found: list[InheritedAgentGroup] = []
     for sidecar in _agent_sidecars(root):
         try:
             data = json.loads(sidecar.read_text(encoding="utf-8"))
@@ -106,8 +131,142 @@ def resolve_live_story_slugs(
         except OSError:
             continue
         slug = _slug_for_sandbox(sandbox, worktree_to_slug)
-        if slug is None or slug in live:
+        if slug is None:
             continue
-        if is_group_alive(pgid):
-            live.add(slug)
-    return live
+        if only_live and not is_group_alive(pgid):
+            continue
+        found.append(InheritedAgentGroup(slug=slug, pgid=pgid, sidecar=sidecar))
+    return found
+
+
+def resolve_live_story_slugs(
+    slugs: Iterable[str],
+    *,
+    project_root: Path,
+    path_pattern: str,
+    owner_pid: int | None = None,
+    is_group_alive: Callable[[int], bool] = group_is_alive,
+) -> set[str]:
+    """The subset of *slugs* whose inherited agent group is still running."""
+    return {
+        group.slug
+        for group in resolve_inherited_agents(
+            slugs,
+            project_root=project_root,
+            path_pattern=path_pattern,
+            owner_pid=owner_pid,
+            is_group_alive=is_group_alive,
+        )
+    }
+
+
+def _discard_records(groups: Iterable[InheritedAgentGroup]) -> None:
+    """Drop sidecars for groups that are finished with.
+
+    The image that registered them is gone, so nothing else will ever unregister
+    them; left behind, they are indistinguishable from a live record and invite a
+    later reaper to act on a recycled pgid.
+    """
+    for group in groups:
+        try:
+            group.sidecar.unlink()
+        except OSError:
+            pass
+
+
+def await_inherited_agents(
+    slug: str,
+    *,
+    project_root: Path,
+    path_pattern: str,
+    timeout: float,
+    poll_interval: float = 2.0,
+    owner_pid: int | None = None,
+    is_group_alive: Callable[[int], bool] = group_is_alive,
+    stop_event=None,
+    log: Callable[[str], None] | None = None,
+) -> bool:
+    """Block until no inherited agent group for *slug* is alive.
+
+    Returns True when the story's inherited work has finished (or was never
+    running), False when *timeout* elapsed or *stop_event* was set with a group
+    still alive — in which case the caller must decide what to do with the
+    survivor rather than dispatch a second agent into the same worktree.
+
+    Their sidecar records are dropped once the groups are gone, so the pgids
+    cannot be revisited by a later reaper.
+    """
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    waited = False
+    while True:
+        groups = resolve_inherited_agents(
+            [slug],
+            project_root=project_root,
+            path_pattern=path_pattern,
+            owner_pid=owner_pid,
+            is_group_alive=is_group_alive,
+        )
+        if not groups:
+            if waited and log is not None:
+                log(f"IN-FLIGHT {slug}: inherited agent finished; resuming the story")
+            _discard_records(
+                resolve_inherited_agents(
+                    [slug],
+                    project_root=project_root,
+                    path_pattern=path_pattern,
+                    owner_pid=owner_pid,
+                    only_live=False,
+                    is_group_alive=is_group_alive,
+                )
+            )
+            return True
+        if stop_event is not None and stop_event.is_set():
+            return False
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        if not waited and log is not None:
+            pgids = ", ".join(str(g.pgid) for g in groups)
+            log(
+                f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s for the agent process "
+                f"group(s) {pgids} inherited across the re-exec to finish before resuming"
+            )
+        waited = True
+        time.sleep(min(max(0.01, poll_interval), remaining))
+
+
+def reclaim_inherited_agents(
+    slug: str,
+    *,
+    project_root: Path,
+    path_pattern: str,
+    owner_pid: int | None = None,
+    is_group_alive: Callable[[int], bool] = group_is_alive,
+    kill_group: Callable[[int], bool] = kill_agent_group,
+) -> list[int]:
+    """Kill any still-live inherited groups for *slug*; return the pgids killed.
+
+    Used when the wait for an inherited agent overruns: the story cannot be
+    resumed while another agent is writing to its worktree, and leaving the group
+    running would hand it to the next invocation's orphan reaper anyway.
+    """
+    live = resolve_inherited_agents(
+        [slug],
+        project_root=project_root,
+        path_pattern=path_pattern,
+        owner_pid=owner_pid,
+        is_group_alive=is_group_alive,
+    )
+    for group in live:
+        kill_group(group.pgid)
+    _discard_records(
+        resolve_inherited_agents(
+            [slug],
+            project_root=project_root,
+            path_pattern=path_pattern,
+            owner_pid=owner_pid,
+            only_live=False,
+            is_group_alive=is_group_alive,
+        )
+    )
+    return [group.pgid for group in live]

--- a/src/theforge/sprint/lock.py
+++ b/src/theforge/sprint/lock.py
@@ -416,6 +416,7 @@ def sweep_story_locks(
     project_root: Path,
     *,
     slugs: list[str] | None = None,
+    exclude_slugs: set[str] | None = None,
 ) -> list[Path]:
     """Remove unlocked story lock files at sprint launch.
 
@@ -423,6 +424,12 @@ def sweep_story_locks(
     at sprint launch is stale and is removed, regardless of whether its recorded
     PID is dead, recycled, or still alive. Live holders keep their flock and are
     left in place for the conflict gate to inspect precisely.
+
+    ``exclude_slugs`` names stories whose lock file must survive the sweep even
+    though nothing holds its flock. That combination is not a contradiction after
+    a mid-run re-exec: ``os.execv`` closes the lock fd (and so releases the
+    flock) while the story's agent process group keeps running, so an unheld lock
+    is exactly what a live story looks like from the new process image.
     """
     lock_dir = project_root / ".forge" / "locks"
     if not lock_dir.exists():
@@ -432,6 +439,9 @@ def sweep_story_locks(
         lock_paths = sorted(lock_dir.glob("*.lock"))
     else:
         lock_paths = [lock_dir / f"{slug}.lock" for slug in slugs]
+    if exclude_slugs:
+        excluded_names = {f"{slug}.lock" for slug in exclude_slugs}
+        lock_paths = [p for p in lock_paths if p.name not in excluded_names]
 
     removed: list[Path] = []
     for lock_path in lock_paths:

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -77,6 +77,7 @@ from .dag import (
 from .display import _print_worker_status, _story_header
 from .gate_timeout_resolver import resolve_effective_gate_timeout
 from .launch_guard import (
+    REASON_IN_FLIGHT,
     REASON_RECONCILE_PRIOR_DONE,
     REASON_STRANDED_WORKTREE,
 )
@@ -924,6 +925,62 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
             check=False,
         )
         shutil.rmtree(temp_root, ignore_errors=True)
+
+
+def _continuation_evidence(
+    *,
+    reexec: bool,
+    live_story_slugs: set[str],
+) -> str | None:
+    """Describe why this launch is a continuation of in-flight work, or None.
+
+    A re-exec is not, on its own, evidence that work is in flight: the source
+    change can be observed by the sprint's *own* first pull, before any story has
+    started, and such a launch is still a genuine start. What distinguishes a
+    continuation is observed live work — agent process groups this same pid
+    spawned before the re-exec and that are still running. Startup-only checks
+    are skipped on exactly that evidence, never on the re-exec flag alone, so a
+    launch that has not started anything keeps its full startup sequence.
+
+    Deliberately narrow: prior *recorded* outcomes are not used as evidence,
+    because a sprint id is stable across separate invocations of the same sprint
+    and would make an unrelated later run skip its baseline gate.
+    """
+    if not reexec or not live_story_slugs:
+        return None
+    return (
+        "agent process groups still running for "
+        f"{', '.join(sorted(live_story_slugs))} after the re-exec"
+    )
+
+
+def _skipped_baseline_gate(config: ForgeConfig, evidence: str) -> dict[str, object]:
+    """The baseline-gate record for a run that legitimately did not run it.
+
+    The baseline gate answers one question — was the merge base green *before any
+    dev work started* — and a continuation cannot ask it: work has started, and
+    the host is busy running it, so a failure would report a conclusion about the
+    code drawn from a measurement of our own load. Skipping is recorded
+    explicitly, with its evidence, rather than silently omitted.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return {
+        "status": "skipped",
+        "passed": True,
+        "exit_code": 0,
+        "duration_seconds": 0.0,
+        "started_at": now,
+        "finished_at": now,
+        "merge_base": None,
+        "command": config.validation.gate_command,
+        "skip_reason": "reexec_continuation",
+        "skip_evidence": evidence,
+        "message": (
+            "Baseline gate skipped: this process is continuing an in-flight sprint "
+            f"after a mid-run re-exec ({evidence}); the gate's precondition — no dev "
+            "work started — no longer holds"
+        ),
+    }
 
 
 def _agent_cost_tracking_warnings(config: ForgeConfig) -> list[str]:
@@ -1855,6 +1912,7 @@ def run_sprint(
     skipped_issues: "list | None" = None,
     entry_intake_outcomes: "dict[int, IntakeOutcome] | None" = None,
     force: bool = False,
+    live_story_slugs: "set[str] | None" = None,
 ) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -1883,6 +1941,12 @@ def run_sprint(
             resume-equivalent for merged-state reconciliation: every manifest
             story is triaged against merged state before dispatch so a story
             whose PR already landed is never re-entered through WORKSPACE.
+        live_story_slugs: Stories of this same sprint generation whose agent
+            process groups survived the re-exec (resolved by the CLI via
+            ``theforge.sprint.live_stories``). Their worktrees are this run's own
+            live work — protected from the orphan sweep — and their existence is
+            the evidence that startup-only checks (the baseline gate) no longer
+            hold their precondition.
 
     Returns:
         SprintResult with per-story outcomes and aggregate stats.
@@ -1904,6 +1968,12 @@ def run_sprint(
     # resume-equivalent for all reconciliation/skip paths.
     reconcile = resume or reexec
 
+    # Stories still executing from before the re-exec. Everything downstream that
+    # would otherwise treat their state as foreign — the orphan worktree sweep,
+    # the baseline gate's "nothing has started yet" precondition, the gate-timeout
+    # load model — is told about them explicitly.
+    _live_story_slugs: set[str] = {s for s in (live_story_slugs or set()) if s}
+
     # Establish that the agents are reachable BEFORE committing wall clock or
     # budget to them (#1952). This runs ahead of the baseline gate, the base
     # pull, and every worktree touch, so a dead credential costs seconds and
@@ -1912,7 +1982,7 @@ def run_sprint(
 
     # Defensive scrub for the root checkout used by sprint commands.
     _scrub_root_forge_artifacts(config)
-    sweep_orphan_worktrees(config.project_root, config)
+    sweep_orphan_worktrees(config.project_root, config, protected_slugs=_live_story_slugs)
 
     max_parallel = (
         resolved.max_parallel if resolved.max_parallel is not None else config.sprint.max_parallel
@@ -1985,12 +2055,17 @@ def run_sprint(
         # not an operator misconfiguration. Fall back to the safe default
         # rather than raising on incidental mock attribute access.
         _mode = "adaptive"
+    # A fresh start contends only with its own configured parallelism. A
+    # continuation additionally contends with the agents it inherited, so the
+    # derived limit must count them — otherwise the gate is measured against a
+    # load model that describes a different run than the one executing.
     _gate_timeout_resolution = resolve_effective_gate_timeout(
         baseline=_baseline_gate_timeout,
         max_parallel=max_parallel,
         host_cores=_host_cores,
         gate_cpu_cores=_gate_cpu_cores,
         mode=_mode,
+        running_stories=len(_live_story_slugs),
     )
     if _gate_timeout_resolution is not None:
         print(
@@ -2000,7 +2075,7 @@ def run_sprint(
         )
     if _gate_timeout_resolution is not None and _gate_timeout_resolution.overcommit:
         _gpc = _gate_timeout_resolution.gate_cpu_cores
-        _mp = _gate_timeout_resolution.max_parallel
+        _mp = _gate_timeout_resolution.actual_parallel or _gate_timeout_resolution.max_parallel
         _hc = _gate_timeout_resolution.host_cores
         print(
             f"[sprint] WARNING: gate CPU demand ({_gpc} cores × parallel {_mp} = "
@@ -2070,7 +2145,20 @@ def run_sprint(
         coordinator_workspace.pull_base_branch(config, lands_locally=_sprint_lands_locally)
 
     baseline_started_at = datetime.datetime.now(datetime.timezone.utc)
-    baseline_gate = _run_baseline_gate(config, resolved)
+    _continuation_reason = _continuation_evidence(
+        reexec=reexec,
+        live_story_slugs=_live_story_slugs,
+    )
+    if _continuation_reason is not None:
+        baseline_gate = _skipped_baseline_gate(config, _continuation_reason)
+        _sprint_logger.emit(
+            "baseline_gate_skipped",
+            reason="reexec_continuation",
+            evidence=_continuation_reason,
+            live_stories=sorted(_live_story_slugs),
+        )
+    else:
+        baseline_gate = _run_baseline_gate(config, resolved)
     resolved.baseline_gate = baseline_gate
     _log(str(baseline_gate.get("message", "Baseline gate check completed")))
     if not bool(baseline_gate.get("passed", False)):
@@ -2774,6 +2862,26 @@ def run_sprint(
                     "outcome_source": "reexec_reconcile",
                 },
             )
+        elif reason == REASON_IN_FLIGHT:
+            # This story's own agent is still running in its worktree, spawned by
+            # this same pid before the re-exec. Re-dispatching it would put two
+            # agents in one worktree; calling it a collision would delete the
+            # work. It is neither: it is in flight. Record it as PRESERVED (the
+            # skipped bucket — the run neither ran it nor failed it) so the
+            # sprint continues with the rest of its stories.
+            _log(
+                f"IN-FLIGHT {slug} (live agent survived the re-exec; worktree preserved, "
+                "not re-dispatched)"
+            )
+            dag.mark_skipped(slug)
+            _set_outcome(slug, StoryOutcome.PRESERVED, reason=reason)
+            _record_current_story_entry(
+                slug,
+                "PRESERVED",
+                error=reason,
+                error_type="dropped",
+                extras={"drop_reason": reason, "outcome_source": "reexec_in_flight"},
+            )
         elif reason == REASON_STRANDED_WORKTREE:
             # A prior-generation worktree exists but the story did not succeed:
             # recoverable stranded sprint state. Keep it DROPPED but retain the
@@ -2902,6 +3010,15 @@ def run_sprint(
                 _detail = {
                     "final_outcome": "ALREADY_DONE",
                     "outcome_source": "reexec_reconcile",
+                }
+            elif _drop_reason == REASON_IN_FLIGHT:
+                # Live work of this same sprint, still executing outside this
+                # process image — surface it as preserved, not failed.
+                _status = "preserved"
+                _blocked_by = [f"in flight: {_drop_reason}"]
+                _detail = {
+                    "final_outcome": "PRESERVED",
+                    "outcome_source": "reexec_in_flight",
                 }
             elif _drop_reason == REASON_STRANDED_WORKTREE:
                 # Recoverable stranded prior-generation sprint state — name it

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1463,6 +1463,104 @@ def _run_single_story(
     return task, result, elapsed, started_at, finished_at
 
 
+def _run_inherited_story(
+    config: ForgeConfig,
+    task: TaskStory,
+    triage: "StoryTriage | None",
+    sprint_run_id: str,
+    sprint_name: str,
+    interactive: bool,
+    notify: bool,
+    resume: bool,
+    effective_auto_merge: bool,
+    state_update_fn: "Callable[[dict], None] | None",
+    no_pull: bool = False,
+    plan_gate: "threading.Event | None" = None,
+    preflight_states: dict[str, CoordinatorState] | None = None,
+    stop_event: "threading.Event | None" = None,
+    base_lands_locally: bool | None = None,
+    *,
+    canonical_ref: str,
+    quiesce_timeout: float,
+) -> "tuple[TaskStory, CoordinatorResult, float, datetime.datetime, datetime.datetime]":
+    """Resume a story whose agent process group survived a mid-run re-exec.
+
+    Occupies a worker slot exactly like a normal dispatch — which is honest, the
+    story *is* consuming one — and does three things before handing off to
+    :func:`_run_single_story`:
+
+    1. Waits for the inherited agent group to finish. Two agents must never write
+       to one worktree, and nothing else can adopt this group: its sidecar names
+       this pid as owner, so the moment this process exits a later invocation's
+       orphan reaper will kill it.
+    2. Reclaims the group if the wait overruns, so an agent that is wedged cannot
+       hold the story hostage past the worker timeout.
+    3. Triages the worktree *then*, not at sprint start — the re-entry point
+       (review / dev / fresh) is only knowable once the agent has stopped
+       writing.
+
+    The worker deadline the scheduler enforces covers this whole call, so
+    ``quiesce_timeout`` is deliberately a fraction of it: the story must still
+    have time to actually run after the wait.
+    """
+    from .live_stories import await_inherited_agents, reclaim_inherited_agents  # noqa: PLC0415
+
+    quiesced = await_inherited_agents(
+        task.slug,
+        project_root=config.project_root,
+        path_pattern=config.workspace.path_pattern,
+        timeout=quiesce_timeout,
+        stop_event=stop_event,
+        log=_log,
+    )
+    if not quiesced:
+        killed = reclaim_inherited_agents(
+            task.slug,
+            project_root=config.project_root,
+            path_pattern=config.workspace.path_pattern,
+        )
+        _log(
+            f"IN-FLIGHT {task.slug}: inherited agent still running after "
+            f"{int(quiesce_timeout)}s — terminated process group(s) "
+            f"{', '.join(str(p) for p in killed) or 'none'} and resuming from whatever "
+            "it committed"
+        )
+
+    fresh_triage = triage
+    if fresh_triage is None:
+        try:
+            fresh_triage = _triage_spec(canonical_ref, config, config.project_root, task=task)
+            _log(
+                f"IN-FLIGHT {task.slug}: resuming "
+                f"{fresh_triage.action.upper().replace('_', ' ')} ({fresh_triage.reason})"
+            )
+        except Exception as exc:
+            # Triage is an optimisation over "start over"; losing it must not
+            # lose the story.
+            _log(f"WARN {task.slug}: could not triage inherited worktree ({exc}); running fresh")
+            fresh_triage = None
+
+    return _run_single_story(
+        config,
+        task,
+        fresh_triage,
+        sprint_run_id,
+        sprint_name,
+        interactive,
+        notify,
+        # Resume semantics, regardless of the sprint-level --resume flag: the
+        # triage above is the whole point of this path.
+        True,
+        effective_auto_merge,
+        state_update_fn,
+        no_pull,
+        plan_gate,
+        preflight_states,
+        stop_event,
+        base_lands_locally=base_lands_locally,
+    )
+
+
 def _make_worker_phase_fn(
     slug: str,
     worker_phases: dict[str, str],
@@ -1944,9 +2042,12 @@ def run_sprint(
         live_story_slugs: Stories of this same sprint generation whose agent
             process groups survived the re-exec (resolved by the CLI via
             ``theforge.sprint.live_stories``). Their worktrees are this run's own
-            live work — protected from the orphan sweep — and their existence is
-            the evidence that startup-only checks (the baseline gate) no longer
-            hold their precondition.
+            live work: protected from the orphan sweep, excluded from the passes
+            that would collide with a running agent, and dispatched through the
+            deferred path that waits for that agent and then resumes the story —
+            this process is the only one that can still finish them. Their
+            existence is also the evidence that startup-only checks (the baseline
+            gate) no longer hold their precondition.
 
     Returns:
         SprintResult with per-story outcomes and aggregate stats.
@@ -1995,6 +2096,14 @@ def run_sprint(
         task.slug: (task, source, canonical_ref) for task, source, canonical_ref in task_entries
     }
     dependent_slugs = {dep for task, _src, _ref in task_entries for dep in task.depends_on}
+
+    # Stories of this sprint whose agent survived the re-exec. They stay in the
+    # DAG and are dispatched like any other story, but through the deferred path
+    # (``_run_inherited_story``): wait for the inherited agent, then resume from
+    # whatever it left behind. Excluded only from the work that would collide
+    # with a running agent — startup triage, intake, batch preflight — because
+    # each of those reads or writes a worktree that is being mutated right now.
+    _inflight_slugs: set[str] = {s for s in _live_story_slugs if s in slug_to_context}
 
     # Does ANY story in this sprint merge into the project-root base checkout?
     # This is a sprint-wide question, not a per-story one: story N merging
@@ -2365,6 +2474,13 @@ def run_sprint(
             started_at = recovered_prior_started_at
         _log("Triaging specs...")
         for slug, (task, _src, canonical_ref) in slug_to_context.items():
+            if slug in _inflight_slugs:
+                # Triage reads the worktree to decide the re-entry point, and
+                # this one is being written to by a running agent right now — any
+                # verdict taken here describes a half-finished state. Defer it to
+                # dispatch, after the inherited agent has stopped.
+                _log(f"  {slug:<20} DEFERRED (agent still running; triage after it finishes)")
+                continue
             triage = _triage_spec(canonical_ref, config, config.project_root, task=task)
             triages[canonical_ref] = triage
             _log(
@@ -2565,9 +2681,18 @@ def run_sprint(
     # conflicts) are handled by the dropped-slug loop further below and must
     # never consume preflight or worker budget in this generation. Exclude them
     # from every spend/dispatch path here alongside reconcile-skipped stories.
+    #
+    # In-flight stories are excluded from these two passes as well, for a
+    # different reason: they are still scheduled, but an agent is writing to
+    # their worktree right now, so intake and preflight would be reasoning about
+    # (and spending on) a story already being worked.
     _dropped_exclusion = {s for s in (dropped_slugs or {}) if s in slug_to_context}
     _no_dispatch_slugs = skip_slugs | _dropped_exclusion
-    dispatch_tasks = [t for t in normalized.tasks if t.slug not in _no_dispatch_slugs]
+    dispatch_tasks = [
+        t
+        for t in normalized.tasks
+        if t.slug not in _no_dispatch_slugs and t.slug not in _inflight_slugs
+    ]
 
     intake_outcomes = _run_intake_remediation_pass(
         config=config,
@@ -2702,7 +2827,11 @@ def run_sprint(
     # against their stale worktree, or spending budget on an already-dropped
     # story).
     _no_dispatch_slugs = skip_slugs | {s for s in (dropped_slugs or {}) if s in slug_to_context}
-    preflight_tasks = [t for t in normalized.tasks if t.slug not in _no_dispatch_slugs]
+    preflight_tasks = [
+        t
+        for t in normalized.tasks
+        if t.slug not in _no_dispatch_slugs and t.slug not in _inflight_slugs
+    ]
     preflight_states = run_batch_preflight(
         preflight_tasks,
         config,
@@ -2862,26 +2991,6 @@ def run_sprint(
                     "outcome_source": "reexec_reconcile",
                 },
             )
-        elif reason == REASON_IN_FLIGHT:
-            # This story's own agent is still running in its worktree, spawned by
-            # this same pid before the re-exec. Re-dispatching it would put two
-            # agents in one worktree; calling it a collision would delete the
-            # work. It is neither: it is in flight. Record it as PRESERVED (the
-            # skipped bucket — the run neither ran it nor failed it) so the
-            # sprint continues with the rest of its stories.
-            _log(
-                f"IN-FLIGHT {slug} (live agent survived the re-exec; worktree preserved, "
-                "not re-dispatched)"
-            )
-            dag.mark_skipped(slug)
-            _set_outcome(slug, StoryOutcome.PRESERVED, reason=reason)
-            _record_current_story_entry(
-                slug,
-                "PRESERVED",
-                error=reason,
-                error_type="dropped",
-                extras={"drop_reason": reason, "outcome_source": "reexec_in_flight"},
-            )
         elif reason == REASON_STRANDED_WORKTREE:
             # A prior-generation worktree exists but the story did not succeed:
             # recoverable stranded sprint state. Keep it DROPPED but retain the
@@ -3011,15 +3120,6 @@ def run_sprint(
                     "final_outcome": "ALREADY_DONE",
                     "outcome_source": "reexec_reconcile",
                 }
-            elif _drop_reason == REASON_IN_FLIGHT:
-                # Live work of this same sprint, still executing outside this
-                # process image — surface it as preserved, not failed.
-                _status = "preserved"
-                _blocked_by = [f"in flight: {_drop_reason}"]
-                _detail = {
-                    "final_outcome": "PRESERVED",
-                    "outcome_source": "reexec_in_flight",
-                }
             elif _drop_reason == REASON_STRANDED_WORKTREE:
                 # Recoverable stranded prior-generation sprint state — name it
                 # distinctly rather than as a generic drop.
@@ -3039,6 +3139,13 @@ def run_sprint(
             elif _triage and _triage.action == "skip":
                 _status = "skipped"
                 _detail = {"final_outcome": "SKIPPED"}
+            elif _slug in _inflight_slugs:
+                # Still running from before the re-exec: this run will wait for
+                # that agent and then resume the story, so it is waiting work —
+                # not a drop, and not something an operator should read as idle.
+                _status = "waiting"
+                _blocked_by = [f"in flight: {REASON_IN_FLIGHT}"]
+                _detail = {"in_flight": True, "in_flight_reason": REASON_IN_FLIGHT}
             elif _blocked_by:
                 _status = "blocked"
                 _detail = {}
@@ -3440,6 +3547,12 @@ def run_sprint(
 
                 spec_str = slug_to_spec[task.slug]
                 triage = triages.get(spec_str) if resume else None
+                # A story whose agent survived the re-exec is dispatched through
+                # the deferred path: it waits for that agent, triages what it
+                # left, and resumes — so it reaches a real terminal outcome in
+                # this run instead of being abandoned to the next invocation's
+                # orphan reaper.
+                _inherited = task.slug in _inflight_slugs
                 batch_assignments[task.slug] = batch_number
                 _submission_counter[0] += 1
                 print(
@@ -3454,9 +3567,11 @@ def run_sprint(
                         started_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     )
 
-                # Create plan gate for fresh parallel runs
+                # Create plan gate for fresh parallel runs. An inherited story
+                # re-enters through triage and never emits PLAN_DONE, so gating
+                # it would block the scheduler on a signal that never comes.
                 gate: threading.Event | None = None
-                if use_plan_gates and triage is None:
+                if use_plan_gates and triage is None and not _inherited:
                     gate = threading.Event()
                     plan_gates[task.slug] = gate
 
@@ -3472,8 +3587,20 @@ def run_sprint(
                 )
                 stop_evt = threading.Event()
                 stop_events[task.slug] = stop_evt
+                _dispatch_kwargs: dict = {"base_lands_locally": _sprint_lands_locally}
+                if _inherited:
+                    _dispatch_fn = _run_inherited_story
+                    _dispatch_kwargs["canonical_ref"] = spec_str
+                    # Half the worker budget to wait for the inherited agent,
+                    # leaving the other half to actually resume the story before
+                    # the scheduler's deadline expires the worker.
+                    _dispatch_kwargs["quiesce_timeout"] = (
+                        float(story_worker_timeouts[task.slug]) / 2.0
+                    )
+                else:
+                    _dispatch_fn = _run_single_story
                 fut = pool.submit(
-                    _run_single_story,
+                    _dispatch_fn,
                     worker_config,
                     task,
                     triage,
@@ -3490,7 +3617,7 @@ def run_sprint(
                     stop_evt,
                     # Keyword, not positional: stop_evt must stay the last
                     # positional argument for callers that index args[-1].
-                    base_lands_locally=_sprint_lands_locally,
+                    **_dispatch_kwargs,
                 )
                 active[task.slug] = fut
                 story_deadlines[task.slug] = time.monotonic() + float(

--- a/tests/test_sprint_gate_timeout_reexec_load.py
+++ b/tests/test_sprint_gate_timeout_reexec_load.py
@@ -32,7 +32,6 @@ from theforge.config import (
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint import run_sprint
 from theforge.sprint.gate_timeout_resolver import resolve_effective_gate_timeout
-from theforge.sprint.launch_guard import REASON_IN_FLIGHT
 
 # ── Pure resolver: running_stories is additive load ──────────────────
 
@@ -192,7 +191,6 @@ def test_continuation_timeout_counts_inherited_running_stories(tmp_path: Path, c
             manifest_path,
             reexec=True,
             live_story_slugs={"story-a"},
-            dropped_slugs={"story-a": REASON_IN_FLIGHT},
         )
 
     err = capsys.readouterr().err

--- a/tests/test_sprint_gate_timeout_reexec_load.py
+++ b/tests/test_sprint_gate_timeout_reexec_load.py
@@ -1,0 +1,202 @@
+"""Gate-timeout derivation must model the load actually present.
+
+Issue #2003: the effective gate timeout is derived from the sprint's *configured*
+``--parallel``. On a mid-run re-exec the process additionally inherits the agent
+groups still running from before, so the real concurrency is higher than the
+model — and a gate that then exceeds its limit is reported as a broken merge
+base, which is a conclusion about the code drawn from a measurement of our own
+load.
+
+Fresh-start derivation must be unchanged; continuation-time derivation must count
+the inherited load and say so in the operator-facing diagnostic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    SprintConfig,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.sprint import run_sprint
+from theforge.sprint.gate_timeout_resolver import resolve_effective_gate_timeout
+from theforge.sprint.launch_guard import REASON_IN_FLIGHT
+
+# ── Pure resolver: running_stories is additive load ──────────────────
+
+
+def test_running_stories_defaults_to_fresh_start_math() -> None:
+    """Omitting running_stories reproduces the pre-existing derivation exactly."""
+    fresh = resolve_effective_gate_timeout(
+        baseline=60, max_parallel=2, host_cores=10, gate_cpu_cores=10, mode="adaptive"
+    )
+    explicit_zero = resolve_effective_gate_timeout(
+        baseline=60,
+        max_parallel=2,
+        host_cores=10,
+        gate_cpu_cores=10,
+        mode="adaptive",
+        running_stories=0,
+    )
+    # The incident's own startup line: parallel=2, gate_cpu=10, host=10 → 120s.
+    assert fresh.effective_timeout == 120
+    assert fresh.factor == 2.0
+    assert fresh.running_stories == 0
+    assert fresh.actual_parallel == 2
+    assert explicit_zero == fresh
+
+
+def test_running_stories_raises_demand_and_timeout() -> None:
+    """Two inherited agents alongside parallel=2 is a load of four, not two."""
+    r = resolve_effective_gate_timeout(
+        baseline=60,
+        max_parallel=2,
+        host_cores=10,
+        gate_cpu_cores=10,
+        mode="adaptive",
+        running_stories=2,
+    )
+    assert r.actual_parallel == 4
+    assert r.factor == 4.0
+    assert r.effective_timeout == 240
+    assert r.overcommit is True
+    # Configured parallelism is still reported as itself — the two numbers are
+    # different facts and the diagnostic keeps both.
+    assert r.max_parallel == 2
+    assert "running_stories=2 actual_parallel=4" in r.reason
+
+
+def test_fixed_mode_ignores_inherited_load() -> None:
+    """``fixed`` means fixed: an operator pin is not overridden by contention."""
+    r = resolve_effective_gate_timeout(
+        baseline=60,
+        max_parallel=2,
+        host_cores=10,
+        gate_cpu_cores=10,
+        mode="fixed",
+        running_stories=3,
+    )
+    assert r.effective_timeout == 60
+    assert r.running_stories == 3
+
+
+# ── Seam: runner supplies the actual load ────────────────────────────
+
+
+def _make_config(tmp_path: Path, *, gate_timeout: int, gate_cpu_cores: int) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=replace(
+            DEFAULT_VALIDATION,
+            gate_timeout=gate_timeout,
+            gate_cpu_cores=gate_cpu_cores,
+            gate_timeout_scale="adaptive",
+        ),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=1, max_review_cycles=1),
+        sprint=SprintConfig(max_parallel=1),
+    )
+
+
+def _make_manifest(tmp_path: Path, slugs: list[str], max_parallel: int) -> Path:
+    for slug in slugs:
+        (tmp_path / f"{slug}.md").write_text(
+            f"---\nname: {slug}\nslug: {slug}\n---\n# {slug}\n", encoding="utf-8"
+        )
+    path = tmp_path / "sprint.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "name": "Load Sprint",
+                "budget_usd": 10.0,
+                "stories": [f"{s}.md" for s in slugs],
+                "max_parallel": max_parallel,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _ok_result() -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    pf = MagicMock()
+    pf.cost_usd = 0.0
+    state.preflight_result = pf
+    return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok")
+
+
+def test_fresh_start_timeout_derives_from_configured_parallel(tmp_path: Path, capsys) -> None:
+    """No inherited load on a fresh start: the diagnostic says so and the
+    effective timeout is the configured-parallelism one."""
+    manifest_path = _make_manifest(tmp_path, ["story-a"], max_parallel=2)
+    config = _make_config(tmp_path, gate_timeout=60, gate_cpu_cores=10)
+
+    captured: dict = {}
+
+    def fake_run_task(cfg, task, **kwargs):  # type: ignore[no-untyped-def]
+        captured["gate_timeout"] = cfg.validation.gate_timeout
+        return _ok_result()
+
+    with (
+        patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+        patch("os.cpu_count", return_value=10),
+    ):
+        run_sprint(config, manifest_path)
+
+    err = capsys.readouterr().err
+    assert "running_stories=0 actual_parallel=2" in err
+    assert captured["gate_timeout"] == 120
+
+
+def test_continuation_timeout_counts_inherited_running_stories(tmp_path: Path, capsys) -> None:
+    """On a re-exec, the surviving agent counts toward the derived limit."""
+    manifest_path = _make_manifest(tmp_path, ["story-a", "story-b"], max_parallel=2)
+    config = _make_config(tmp_path, gate_timeout=60, gate_cpu_cores=10)
+
+    captured: dict = {}
+
+    def fake_run_task(cfg, task, **kwargs):  # type: ignore[no-untyped-def]
+        captured["gate_timeout"] = cfg.validation.gate_timeout
+        return _ok_result()
+
+    with (
+        patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("os.cpu_count", return_value=10),
+    ):
+        run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            live_story_slugs={"story-a"},
+            dropped_slugs={"story-a": REASON_IN_FLIGHT},
+        )
+
+    err = capsys.readouterr().err
+    assert "running_stories=1 actual_parallel=3" in err
+    # 60s baseline × (10 cores × 3) / 10 host cores = 180s, not the 120s a model
+    # blind to the inherited agent would have produced.
+    assert captured["gate_timeout"] == 180

--- a/tests/test_sprint_reexec_continuation.py
+++ b/tests/test_sprint_reexec_continuation.py
@@ -1,0 +1,471 @@
+"""Seam tests for mid-run re-exec treated as continuation, not re-launch.
+
+Issue #2003: a re-exec (``os.execv`` after the workspace pull observes new
+source) re-entered full sprint startup against a *live* sprint. Three startup
+behaviours then fired with their preconditions no longer holding: a running
+story was reclassified as a foreign active-worktree collision and dropped, its
+worktree was swept, and the baseline gate — whose contract is "before any dev
+work started" — ran while agents were consuming the host and timed out.
+
+These tests pin the continuation semantics at the seams that produced each
+symptom: launch-guard classification, the orphan worktree sweep, and the
+runner's baseline-gate decision.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.coordinator.workspace import sweep_orphan_worktrees
+from theforge.sprint import run_sprint
+from theforge.sprint.dag import StoryTriage
+from theforge.sprint.launch_guard import (
+    REASON_ACTIVE_WORKTREE,
+    REASON_IN_FLIGHT,
+    acquire_launch_story_locks,
+)
+from theforge.sprint.live_stories import resolve_live_story_slugs
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_spec_file(tmp_path: Path, name: str, slug: str) -> Path:
+    spec = tmp_path / f"{slug}.md"
+    spec.write_text(
+        f"---\nname: {name}\nslug: {slug}\n---\n# {name}\nDo the thing.",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _make_manifest(tmp_path: Path, specs: list[str], budget: float = 10.0) -> Path:
+    manifest_path = tmp_path / "sprint.yaml"
+    manifest_path.write_text(
+        yaml.dump({"name": "Test Sprint", "budget_usd": budget, "specs": specs}),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _make_coordinator_result(cost: float = 1.0) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    mock_preflight = MagicMock()
+    mock_preflight.cost_usd = cost
+    state.preflight_result = mock_preflight
+    return CoordinatorResult(
+        success=True,
+        phase=Phase.DONE,
+        state=state,
+        message="Done.",
+        landing_status="landed",
+    )
+
+
+def _triage_full(spec_path, config, project_root, *, task=None):
+    return StoryTriage(
+        story_path=spec_path,
+        action="full",
+        reason="x",
+        worktree_path=None,
+        slug=Path(spec_path).stem,
+    )
+
+
+# ── live-story identity ──────────────────────────────────────────────
+
+
+def _write_agent_sidecar(
+    project_root: Path,
+    *,
+    owner_pid: int,
+    pgid: int,
+    sandbox_dir: Path | None,
+) -> Path:
+    agents_dir = project_root / ".forge" / "runs" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    path = agents_dir / f"{owner_pid}-{pgid}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "owner_pid": owner_pid,
+                "pgid": pgid,
+                "run_id": "run-prev",
+                "sandbox_dir": str(sandbox_dir) if sandbox_dir else None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_live_story_slugs_recognises_this_process_own_running_agent(tmp_path: Path) -> None:
+    """A sidecar owned by this pid whose group is alive names a live story.
+
+    The pid survives ``os.execv``, so "owner_pid == my pid" is exactly the
+    identity relation a re-exec'd process needs to recognise its own work. The
+    group used here is this test process's own — genuinely alive, no stubbing.
+    """
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    (worktrees / "issue-1992").mkdir(parents=True)
+
+    _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=os.getpgrp(),
+        sandbox_dir=worktrees / "issue-1945",
+    )
+
+    live = resolve_live_story_slugs(
+        ["issue-1945", "issue-1992"],
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+    )
+    assert live == {"issue-1945"}
+
+
+def test_live_story_slugs_ignores_other_processes_and_dead_groups(tmp_path: Path) -> None:
+    """Foreign owners and dead groups are not this generation's live work."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    (worktrees / "issue-1992").mkdir(parents=True)
+
+    # Another process's sidecar — alive group, but not our sprint.
+    _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid() + 1,
+        pgid=os.getpgrp(),
+        sandbox_dir=worktrees / "issue-1945",
+    )
+    # Ours, but the group is gone.
+    _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=os.getpgrp(),
+        sandbox_dir=worktrees / "issue-1992",
+    )
+
+    live = resolve_live_story_slugs(
+        ["issue-1945", "issue-1992"],
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        is_group_alive=lambda _pgid: False,
+    )
+    assert live == set()
+
+
+# ── launch-guard classification ──────────────────────────────────────
+
+
+def test_reexec_classifies_own_live_worktree_as_in_flight_not_collision(
+    tmp_path: Path,
+) -> None:
+    """The issue-1945 symptom: a live story must not become a collision drop.
+
+    Its worktree is active (commits ahead of base) and it has no prior-generation
+    recorded outcome — the exact combination that used to fall through to
+    ``REASON_ACTIVE_WORKTREE``, print "DROPPED … continuing", and leave the
+    worktree unclaimed for the sweep to delete.
+    """
+    config = _make_config(tmp_path)
+    lock_dir = tmp_path / ".forge" / "locks"
+    lock_dir.mkdir(parents=True)
+    live_lock = lock_dir / "issue-1945.lock"
+    live_lock.write_text("999999|Mon|fingerprint", encoding="utf-8")
+
+    with (
+        patch(
+            "theforge.sprint.launch_guard.check_active_worktrees",
+            return_value=["issue-1945"],
+        ) as mock_active,
+        patch("theforge.sprint.launch_guard.check_escalated_worktrees", return_value=[]),
+    ):
+        locked_fds, exit_code, dropped = acquire_launch_story_locks(
+            slugs=["issue-1945", "issue-1992"],
+            config=config,
+            resume=False,
+            allow_drop=True,
+            live_slugs={"issue-1945"},
+        )
+
+    try:
+        assert exit_code is None
+        assert dropped["issue-1945"] == REASON_IN_FLIGHT
+        assert REASON_ACTIVE_WORKTREE not in dropped.values()
+        # The live slug is never even offered to the worktree collision check.
+        assert "issue-1945" not in mock_active.call_args.args[0]
+        # Its lock file survives the launch sweep — that file is what tells the
+        # worktree sweep the directory is claimed.
+        assert live_lock.exists()
+        # The remaining story is scheduled normally.
+        assert "issue-1992" not in dropped
+        assert len(locked_fds) == 1
+    finally:
+        from theforge.sprint.lock import release_story_locks
+
+        release_story_locks(locked_fds)
+
+
+# ── orphan worktree sweep ────────────────────────────────────────────
+
+
+def test_orphan_sweep_preserves_protected_live_worktree(tmp_path: Path) -> None:
+    """A live sprint-owned worktree is skipped by the sweep; others are not.
+
+    The directory here holds only Forge-owned artifacts, which is the shape the
+    sweep removes unconditionally — so surviving is attributable to the
+    protection, not to some other guard.
+    """
+    config = _make_config(tmp_path)
+    worktrees = tmp_path / ".forge" / "worktrees"
+    for slug in ("issue-1945", "issue-1899"):
+        (worktrees / slug / ".forge").mkdir(parents=True)
+
+    sweep_orphan_worktrees(tmp_path, config, protected_slugs={"issue-1945"})
+
+    assert (worktrees / "issue-1945").exists()
+    assert not (worktrees / "issue-1899").exists()
+
+
+def test_runner_passes_live_slugs_to_orphan_sweep(tmp_path: Path) -> None:
+    """The runner must hand its live-story set to the sweep, not just to itself."""
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-b.md"])
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.runner.sweep_orphan_worktrees") as mock_sweep,
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            live_story_slugs={"feature-a"},
+            dropped_slugs={"feature-a": REASON_IN_FLIGHT},
+        )
+
+    assert mock_sweep.call_args.kwargs["protected_slugs"] == {"feature-a"}
+
+
+# ── baseline gate: a startup-only check ──────────────────────────────
+
+
+def test_reexec_with_live_story_skips_baseline_gate_and_continues(tmp_path: Path) -> None:
+    """The whole failure, end to end: live story preserved, gate not re-run.
+
+    Given the incident's inputs — one story still running, one still to do — the
+    re-exec must not run the baseline gate (its precondition, "no dev work
+    started", is false), must not drop the live story, and must carry on
+    scheduling the remaining work.
+    """
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight", return_value={}
+        ) as mock_batch_preflight,
+        patch(
+            "theforge.sprint.runner.run_task", return_value=_make_coordinator_result()
+        ) as mock_run_task,
+    ):
+        result = run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            live_story_slugs={"feature-a"},
+            dropped_slugs={"feature-a": REASON_IN_FLIGHT},
+        )
+
+    # (a) The startup-only check did not run against a live sprint.
+    mock_gate.assert_not_called()
+
+    # (b) The live story was neither re-dispatched (two agents, one worktree) nor
+    # counted as a failure.
+    dispatched = [c.args[1].slug for c in mock_run_task.call_args_list]
+    assert dispatched == ["feature-b"]
+    assert "feature-a" not in [t.slug for t in mock_batch_preflight.call_args.args[0]]
+    assert result.specs_failed == 0
+    assert result.specs_skipped == 1
+
+    # (c) The sprint continued and finished the remaining work.
+    assert result.specs_succeeded == 1
+
+    # (d) The skip and its evidence are recorded, not silent.
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
+    )
+    by_slug = {s["slug"]: s for s in summary["stories"]}
+    assert by_slug["feature-a"]["outcome"] == "PRESERVED"
+    audit = yaml.safe_load((tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text())
+    baseline = audit["baseline_check"]
+    assert baseline["status"] == "skipped"
+    assert baseline["skip_reason"] == "reexec_continuation"
+    assert "feature-a" in baseline["skip_evidence"]
+
+
+def test_reexec_before_any_work_still_runs_baseline_gate(tmp_path: Path) -> None:
+    """A re-exec is not by itself proof that work started.
+
+    The sprint's own first pull can trigger the re-exec before any story runs;
+    that launch is still a genuine start, and skipping the baseline gate there
+    would lose the check entirely rather than defer it.
+    """
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        run_sprint(config, manifest_path, reexec=True)
+
+    mock_gate.assert_called_once()
+
+
+def test_fresh_start_still_runs_baseline_gate(tmp_path: Path) -> None:
+    """Non-re-exec launches are untouched by the continuation carve-out."""
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        run_sprint(config, manifest_path)
+
+    mock_gate.assert_called_once()
+
+
+# ── CLI wiring ───────────────────────────────────────────────────────
+
+
+def test_cli_threads_live_story_slugs_into_launch_and_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI resolves live stories once on re-exec and hands them to both
+    consumers — the launch guard (classification) and run_sprint (sweep
+    protection, gate decision)."""
+    import argparse
+
+    from theforge import detach as _detach_mod
+    from theforge.cli import sprint as sprint_cli
+
+    manifest_path = _make_manifest(tmp_path, ["issue-1945.md"])
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+
+    fake_config = SimpleNamespace(
+        project_root=tmp_path,
+        project="test",
+        workspace=SimpleNamespace(path_pattern=".forge/worktrees/{slug}"),
+    )
+
+    worktree = tmp_path / ".forge" / "worktrees" / "issue-1945"
+    worktree.mkdir(parents=True)
+    _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=os.getpgrp(),
+        sandbox_dir=worktree,
+    )
+
+    args = argparse.Namespace(
+        manifest=str(manifest_path),
+        milestone=None,
+        label=None,
+        issues=None,
+        config=str(config_path),
+        base_branch=None,
+        name=None,
+        fg=False,
+        detach=False,
+        dry_run=False,
+        verbose=False,
+        auto_merge=False,
+        interactive=False,
+        resume=False,
+        no_pull=False,
+        parallel=None,
+        force=False,
+        no_notify=True,
+    )
+
+    monkeypatch.setenv("FORGE_DETACHED", "1")
+    monkeypatch.setenv("FORGE_DETACHED_RUN_ID", "child-run-id")
+    monkeypatch.setenv("FORGE_PREV_RUN_ID", "prev-run-id")
+
+    fake_result = MagicMock()
+    fake_result.specs_failed = 0
+
+    with (
+        patch("theforge.cli.sprint.load_config", return_value=fake_config),
+        patch("theforge.cli.sprint.apply_base_branch_override", return_value=fake_config),
+        patch("theforge.cli.sprint._find_config", return_value=config_path),
+        patch("theforge.cli.sprint.parse_manifest_slugs", return_value=["issue-1945"]),
+        patch(
+            "theforge.cli.sprint._acquire_launch_locks",
+            return_value=([], None, {"issue-1945": REASON_IN_FLIGHT}),
+        ) as mock_locks,
+        patch("theforge.cli.sprint.reacquire_story_locks_in_daemon", return_value=[]),
+        patch("theforge.cli.sprint.release_story_locks"),
+        patch("theforge.cli.sprint.run_sprint", return_value=fake_result) as mock_run_sprint,
+        patch.object(_detach_mod, "install_cleanup_handler"),
+        patch.object(_detach_mod, "write_run_ended"),
+        patch.object(_detach_mod, "remove_pid"),
+    ):
+        rc = sprint_cli.cmd_sprint(args)
+
+    assert rc == 0
+    assert mock_locks.call_args.kwargs["live_slugs"] == {"issue-1945"}
+    assert mock_run_sprint.call_args.kwargs["live_story_slugs"] == {"issue-1945"}

--- a/tests/test_sprint_reexec_continuation.py
+++ b/tests/test_sprint_reexec_continuation.py
@@ -38,10 +38,17 @@ from theforge.sprint import run_sprint
 from theforge.sprint.dag import StoryTriage
 from theforge.sprint.launch_guard import (
     REASON_ACTIVE_WORKTREE,
-    REASON_IN_FLIGHT,
     acquire_launch_story_locks,
 )
-from theforge.sprint.live_stories import resolve_live_story_slugs
+from theforge.sprint.live_stories import (
+    await_inherited_agents,
+    reclaim_inherited_agents,
+    resolve_live_story_slugs,
+)
+
+# Beyond any pid this platform hands out, so ``killpg(pgid, 0)`` is reliably
+# "no such group" — a group that has certainly finished.
+_DEAD_PGID = 999999
 
 
 def _make_config(tmp_path: Path) -> ForgeConfig:
@@ -188,10 +195,84 @@ def test_live_story_slugs_ignores_other_processes_and_dead_groups(tmp_path: Path
     assert live == set()
 
 
+# ── waiting for, and reclaiming, an inherited agent ──────────────────
+
+
+def test_await_inherited_agents_returns_when_group_exits(tmp_path: Path) -> None:
+    """The wait ends when the inherited group does, and clears its record."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=4242, sandbox_dir=worktrees / "issue-1945"
+    )
+
+    alive = iter([True, True, False, False])
+
+    quiesced = await_inherited_agents(
+        "issue-1945",
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        timeout=30,
+        poll_interval=0.01,
+        is_group_alive=lambda _pgid: next(alive, False),
+    )
+
+    assert quiesced is True
+    # The image that registered it is gone, so nothing else would ever clear it.
+    assert not sidecar.exists()
+
+
+def test_await_inherited_agents_reports_overrun_without_killing(tmp_path: Path) -> None:
+    """A wait that times out returns False and leaves the group alone.
+
+    Killing is the caller's decision — the wait must not silently destroy work.
+    """
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=4242, sandbox_dir=worktrees / "issue-1945"
+    )
+
+    quiesced = await_inherited_agents(
+        "issue-1945",
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        timeout=0.05,
+        poll_interval=0.01,
+        is_group_alive=lambda _pgid: True,
+    )
+
+    assert quiesced is False
+    assert sidecar.exists()
+
+
+def test_reclaim_inherited_agents_kills_survivor_and_clears_record(tmp_path: Path) -> None:
+    """An agent that overruns is terminated, so no second agent shares its
+    worktree and no later reaper inherits the pgid."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=4242, sandbox_dir=worktrees / "issue-1945"
+    )
+    killed: list[int] = []
+
+    reclaimed = reclaim_inherited_agents(
+        "issue-1945",
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        is_group_alive=lambda _pgid: True,
+        kill_group=lambda pgid: (killed.append(pgid), True)[1],
+    )
+
+    assert reclaimed == [4242]
+    assert killed == [4242]
+    assert not sidecar.exists()
+
+
 # ── launch-guard classification ──────────────────────────────────────
 
 
-def test_reexec_classifies_own_live_worktree_as_in_flight_not_collision(
+def test_reexec_keeps_own_live_worktree_scheduled_not_dropped(
     tmp_path: Path,
 ) -> None:
     """The issue-1945 symptom: a live story must not become a collision drop.
@@ -199,7 +280,9 @@ def test_reexec_classifies_own_live_worktree_as_in_flight_not_collision(
     Its worktree is active (commits ahead of base) and it has no prior-generation
     recorded outcome — the exact combination that used to fall through to
     ``REASON_ACTIVE_WORKTREE``, print "DROPPED … continuing", and leave the
-    worktree unclaimed for the sweep to delete.
+    worktree unclaimed for the sweep to delete. It must come back *scheduled*
+    (with its launch lock held): only this process can finish it, so dropping it
+    would strand the story just as surely as deleting the worktree.
     """
     config = _make_config(tmp_path)
     lock_dir = tmp_path / ".forge" / "locks"
@@ -224,16 +307,15 @@ def test_reexec_classifies_own_live_worktree_as_in_flight_not_collision(
 
     try:
         assert exit_code is None
-        assert dropped["issue-1945"] == REASON_IN_FLIGHT
+        # Not dropped at all — for any reason, least of all a self-collision.
+        assert "issue-1945" not in dropped
         assert REASON_ACTIVE_WORKTREE not in dropped.values()
         # The live slug is never even offered to the worktree collision check.
         assert "issue-1945" not in mock_active.call_args.args[0]
-        # Its lock file survives the launch sweep — that file is what tells the
-        # worktree sweep the directory is claimed.
+        # Both stories are scheduled and hold launch locks.
         assert live_lock.exists()
-        # The remaining story is scheduled normally.
         assert "issue-1992" not in dropped
-        assert len(locked_fds) == 1
+        assert len(locked_fds) == 2
     finally:
         from theforge.sprint.lock import release_story_locks
 
@@ -280,7 +362,6 @@ def test_runner_passes_live_slugs_to_orphan_sweep(tmp_path: Path) -> None:
             manifest_path,
             reexec=True,
             live_story_slugs={"feature-a"},
-            dropped_slugs={"feature-a": REASON_IN_FLIGHT},
         )
 
     assert mock_sweep.call_args.kwargs["protected_slugs"] == {"feature-a"}
@@ -289,22 +370,31 @@ def test_runner_passes_live_slugs_to_orphan_sweep(tmp_path: Path) -> None:
 # ── baseline gate: a startup-only check ──────────────────────────────
 
 
-def test_reexec_with_live_story_skips_baseline_gate_and_continues(tmp_path: Path) -> None:
-    """The whole failure, end to end: live story preserved, gate not re-run.
+def test_reexec_with_live_story_skips_baseline_gate_and_resumes_it(tmp_path: Path) -> None:
+    """The whole failure, end to end: gate not re-run, live story resumed.
 
     Given the incident's inputs — one story still running, one still to do — the
     re-exec must not run the baseline gate (its precondition, "no dev work
-    started", is false), must not drop the live story, and must carry on
-    scheduling the remaining work.
+    started", is false), must not drop the live story, and must carry the live
+    story through to a terminal outcome in this run rather than abandoning it.
+    The sidecar names this pid as owner, so nothing else ever could: once this
+    process exits, the next invocation's orphan reaper kills the group.
     """
     _make_spec_file(tmp_path, "Feature A", "feature-a")
     _make_spec_file(tmp_path, "Feature B", "feature-b")
     manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
     config = _make_config(tmp_path)
 
+    # feature-a's inherited agent has already exited (pgid beyond any real pid),
+    # so the deferred dispatch waits, observes it gone, and resumes immediately.
+    (tmp_path / "feature-a").mkdir()
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=_DEAD_PGID, sandbox_dir=tmp_path / "feature-a"
+    )
+
     with (
         patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
-        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full) as mock_triage,
         patch(
             "theforge.sprint.runner.run_batch_preflight", return_value={}
         ) as mock_batch_preflight,
@@ -317,29 +407,38 @@ def test_reexec_with_live_story_skips_baseline_gate_and_continues(tmp_path: Path
             manifest_path,
             reexec=True,
             live_story_slugs={"feature-a"},
-            dropped_slugs={"feature-a": REASON_IN_FLIGHT},
         )
 
     # (a) The startup-only check did not run against a live sprint.
     mock_gate.assert_not_called()
 
-    # (b) The live story was neither re-dispatched (two agents, one worktree) nor
-    # counted as a failure.
+    # (b) The live story was not dropped: it ran, and it reached a terminal
+    # success like any other story. Both stories are accounted for.
     dispatched = [c.args[1].slug for c in mock_run_task.call_args_list]
-    assert dispatched == ["feature-b"]
-    assert "feature-a" not in [t.slug for t in mock_batch_preflight.call_args.args[0]]
+    assert sorted(dispatched) == ["feature-a", "feature-b"]
+    assert result.specs_succeeded == 2
     assert result.specs_failed == 0
-    assert result.specs_skipped == 1
+    assert result.specs_skipped == 0
 
-    # (c) The sprint continued and finished the remaining work.
-    assert result.specs_succeeded == 1
+    # (c) It did not consume the passes that would have collided with the agent
+    # still writing to its worktree.
+    assert "feature-a" not in [t.slug for t in mock_batch_preflight.call_args.args[0]]
+    # Its triage happened at dispatch (after the wait), not in the startup sweep
+    # that ran while the agent was still writing.
+    triaged_refs = [c.args[0] for c in mock_triage.call_args_list]
+    assert triaged_refs[0] == "feature-b.md"
+    assert triaged_refs.count("feature-a.md") == 1
 
-    # (d) The skip and its evidence are recorded, not silent.
+    # (d) The inherited group's record is cleaned up, so no later reaper acts on
+    # a pgid this run has already settled.
+    assert not sidecar.exists()
+
+    # (e) The gate skip and its evidence are recorded, not silent.
     summary = yaml.safe_load(
         (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
     )
     by_slug = {s["slug"]: s for s in summary["stories"]}
-    assert by_slug["feature-a"]["outcome"] == "PRESERVED"
+    assert by_slug["feature-a"]["outcome"] == "DONE"
     audit = yaml.safe_load((tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text())
     baseline = audit["baseline_check"]
     assert baseline["status"] == "skipped"
@@ -455,7 +554,8 @@ def test_cli_threads_live_story_slugs_into_launch_and_runner(
         patch("theforge.cli.sprint.parse_manifest_slugs", return_value=["issue-1945"]),
         patch(
             "theforge.cli.sprint._acquire_launch_locks",
-            return_value=([], None, {"issue-1945": REASON_IN_FLIGHT}),
+            # The guard keeps an in-flight story scheduled: nothing is dropped.
+            return_value=([], None, {}),
         ) as mock_locks,
         patch("theforge.cli.sprint.reacquire_story_locks_in_daemon", return_value=[]),
         patch("theforge.cli.sprint.release_story_locks"),


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1 is resolved: live in-flight stories are no longer preserved and abandoned, and targeted continuation tests pass. | [google-gemini-3.5-flash] The implementation successfully treats mid-run re-execs as continuations, skipping the baseline gate, preserving live worktrees, and resuming in-flight stories. | [claude-sonnet] The Cycle 1 P1 (in-flight story marked PRESERVED and abandoned to the next invocation's orphan reaper) is fixed: the runner now waits for the inherited agent group, reclaims it on overrun, re-triages the worktree, and resumes the story through the normal review/dev/fresh path to a genuine terminal outcome, verified end-to-end by test_reexec_with_live_story_skips_baseline_gate_and_resumes_it (specs_succeeded == 2, sidecar cleared). No regressions found in the touched files.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $22.52
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Mid-run re-exec re-enters sprint startup, re-running pre-work checks against a live sprint (GitHub Issue #2003)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2003