### PR TITLE
End-of-sprint audit push races the sprint's own merges and fails terminally without retry

### DIFF
--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -120,6 +120,31 @@ RC_NUM=n scripts/cut-rc.sh X.Y.Z
   the operator explicitly asks to merge. Surface the gate/review state, then
   merge.
 
+### End-of-sprint audit publish (issue #2006)
+
+The last thing a sprint does is commit `.forge/audits/runs/*` in the project-root
+checkout and push the base branch. A push rejected because the base branch moved
+— usually the merge of this sprint's *own* story PR — is reconciled (`git fetch`
++ `git rebase origin/<base>`) and retried up to three times before the sprint
+fails.
+
+If you find audit commits sitting local, read
+`.forge/audit-publish-state.json` in the project root rather than guessing which
+of the failure modes you hit — the `state` field says which:
+
+| `state` | Meaning | Remedy |
+| --- | --- | --- |
+| `published` | Commit reached `origin/<base>`. | none |
+| `clean` | Nothing was pending this run. | none |
+| `local_only` | Publish deliberately skipped (`auto_push` off on a locally-landing run). | push `<base>` yourself before any run that diffs against `origin/<base>` |
+| `committed_unpublished` | The run died between the commit and the push. | fetch, rebase, push |
+| `push_refused` | Remote refused the push through all retries; `detail` has git's output. | inspect the remote, then fetch/rebase/push |
+| `reconcile_failed` | The fetch or rebase itself failed (e.g. conflicting audit records); any partial rebase was aborted. | resolve by hand |
+| `verify_failed` | Push reported success but `<base>` is still ahead. | fetch, rebase, push |
+
+A *stale* file (state `published`/`clean`) next to unpushed audit commits means
+the run ended before it ever reached the publish step.
+
 ## 6. Dogfood substrate model
 
 - Two runtimes that must stay **disjoint**: the *orchestrator* is the released

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import os
 import shlex
@@ -103,6 +104,32 @@ _STORY_RUN_AUDIT_DIR = ".forge/audits/runs"
 _STORY_RUN_AUDIT_COMMIT_CMD = (
     f'git commit -m "chore(audit): record sprint run audits" -- {_STORY_RUN_AUDIT_DIR}'
 )
+
+# Where the outcome of the publish step is recorded. Lives under .forge/ (which
+# .gitignore denies wholesale), so writing it never dirties the base-branch
+# checkout the sprint is publishing from.
+_STORY_RUN_AUDIT_PUBLISH_STATE_PATH = ".forge/audit-publish-state.json"
+
+# A push rejected because the base branch moved is reconciled and retried. Three
+# attempts covers the sprint's own merges landing while the push is in flight;
+# beyond that the remote is being advanced by something other than this run and
+# looping longer just delays the operator's answer.
+_STORY_RUN_AUDIT_PUSH_ATTEMPTS = 3
+
+# Publish end states, recorded to ``_STORY_RUN_AUDIT_PUBLISH_STATE_PATH`` and
+# carried on ``StoryRunAuditPublishError.state``. They exist so that an operator
+# looking at local-only audit commits can tell *which* thing happened: the run
+# never got here (no/stale record), it got here and the remote refused
+# (``push_refused``), or publishing was deliberately skipped (``local_only``).
+AUDIT_PUBLISH_CLEAN = "clean"
+AUDIT_PUBLISH_COMMITTED = "committed_unpublished"
+AUDIT_PUBLISH_PUBLISHED = "published"
+AUDIT_PUBLISH_LOCAL_ONLY = "local_only"
+AUDIT_PUBLISH_COMMIT_FAILED = "commit_failed"
+AUDIT_PUBLISH_PUSH_REFUSED = "push_refused"
+AUDIT_PUBLISH_RECONCILE_FAILED = "reconcile_failed"
+AUDIT_PUBLISH_VERIFY_FAILED = "verify_failed"
+
 run_agent = None
 log_agent_result = None
 
@@ -111,6 +138,75 @@ def _log(msg: str) -> None:
     # Worker-slug prefixing (parallel attribution) is applied centrally by
     # ``_log_line``; do not prepend it here or it would double-tag.
     _log_line("[sprint]", msg)
+
+
+class StoryRunAuditPublishError(RuntimeError):
+    """Canonical story run audits could not be published to the base branch.
+
+    ``state`` is one of the ``AUDIT_PUBLISH_*`` constants and names the end
+    state the checkout was left in. It is a ``RuntimeError`` subclass because
+    the sprint entry point already treats a publish failure as fatal; the extra
+    attribute only makes the *kind* of failure legible to callers and tests.
+    """
+
+    def __init__(self, message: str, *, state: str) -> None:
+        super().__init__(message)
+        self.state = state
+
+
+def _record_audit_publish_state(
+    project_root: Path,
+    base_branch: str,
+    state: str,
+    detail: str | None = None,
+) -> None:
+    """Record the publish end state next to the checkout it describes.
+
+    Best-effort: a sprint must not fail because this marker could not be
+    written, and the marker must never mask the error it is describing.
+    """
+    path = project_root / _STORY_RUN_AUDIT_PUBLISH_STATE_PATH
+    payload = {
+        "state": state,
+        "base_branch": base_branch,
+        "recorded_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "detail": detail,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:  # pragma: no cover — filesystem-level failure
+        _log(f"Warning: could not record story run audit publish state: {exc}")
+
+
+def _reconcile_base_with_origin(project_root: Path, base_branch: str) -> None:
+    """Fetch origin and rebase the local base branch onto its current head.
+
+    Raises ``StoryRunAuditPublishError`` when the reconcile itself cannot be
+    completed, aborting any partial rebase so the checkout is left usable.
+    """
+    from ..coordinator import util as _cu  # noqa: PLC0415
+
+    quoted_base = shlex.quote(base_branch)
+    ok_fetch, fetch_out = _cu._run_shell(f"git fetch origin {quoted_base}", project_root)
+    if not ok_fetch:
+        raise StoryRunAuditPublishError(
+            f"Failed to fetch origin/{base_branch} while publishing story run audits: "
+            f"{fetch_out.strip()}",
+            state=AUDIT_PUBLISH_RECONCILE_FAILED,
+        )
+
+    ok_rebase, rebase_out = _cu._run_shell(
+        f"git rebase origin/{quoted_base}",
+        project_root,
+    )
+    if not ok_rebase:
+        _cu._run_shell("git rebase --abort", project_root)
+        raise StoryRunAuditPublishError(
+            f"Failed to rebase '{base_branch}' onto origin/{base_branch} while publishing "
+            f"story run audits: {rebase_out.strip()}",
+            state=AUDIT_PUBLISH_RECONCILE_FAILED,
+        )
 
 
 def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: bool) -> None:
@@ -128,6 +224,15 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
     opted out of pushing them. Pushing a branch publishes all of its ancestors,
     so a push here would then also publish those local merges. In that one
     configuration the commit stays local and the fact is warned about instead.
+
+    A rejected push is not a failure of this step so much as a statement about
+    where the remote is: the sprint's own merges are what usually advance the
+    base branch, so a run that landed stories is the *normal* case for the local
+    branch being behind. So a rejection is reconciled (fetch + rebase onto the
+    current remote head) and retried, and only exhausting that raises. Whichever
+    end state the checkout lands in is recorded to
+    ``.forge/audit-publish-state.json`` so it survives to where the state is
+    observed.
     """
     from ..coordinator import util as _cu  # noqa: PLC0415
 
@@ -141,20 +246,41 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
         project_root,
     )
     if not ok_status:
-        raise RuntimeError(f"Failed to inspect story run audits: {status_out}")
+        raise StoryRunAuditPublishError(
+            f"Failed to inspect story run audits: {status_out}",
+            state=AUDIT_PUBLISH_COMMIT_FAILED,
+        )
     if not status_out.strip():
+        # Nothing pending. Record it so a marker from an earlier run cannot be
+        # mistaken for this one's outcome.
+        _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_CLEAN)
         return
 
     ok_add, add_out = _cu._run_shell(f"git add -- {quoted_audit_dir}", project_root)
     if not ok_add:
-        raise RuntimeError(f"Failed to stage story run audits: {add_out}")
+        raise StoryRunAuditPublishError(
+            f"Failed to stage story run audits: {add_out}",
+            state=AUDIT_PUBLISH_COMMIT_FAILED,
+        )
 
     ok_commit, commit_out = _cu._run_shell(_STORY_RUN_AUDIT_COMMIT_CMD, project_root)
     if not ok_commit:
-        raise RuntimeError(f"Failed to commit story run audits: {commit_out}")
+        raise StoryRunAuditPublishError(
+            f"Failed to commit story run audits: {commit_out}",
+            state=AUDIT_PUBLISH_COMMIT_FAILED,
+        )
     _log("Committed canonical story run audit records to the base branch checkout.")
+    # Written before the push so that a crash mid-publish is distinguishable
+    # from a run that never reached this function at all.
+    _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_COMMITTED)
 
     if not publish:
+        _record_audit_publish_state(
+            project_root,
+            base_branch,
+            AUDIT_PUBLISH_LOCAL_ONLY,
+            detail="workspace.auto_push is off for a run that lands stories locally",
+        )
         _log(
             f"⚠ SPRINT  story run audit records remain local: this run merges stories into "
             f"'{base_branch}' with workspace.auto_push off, so pushing would also publish those "
@@ -164,35 +290,76 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
         return
 
     quoted_base = shlex.quote(base_branch)
-    ok_push, push_out = _cu._run_shell(
-        f"git push origin {quoted_base}",
-        project_root,
-    )
-    if not ok_push:
-        raise RuntimeError(
-            f"Failed to push story run audits to origin/{base_branch}: {push_out.strip()}"
+    push_out = ""
+    for attempt in range(1, _STORY_RUN_AUDIT_PUSH_ATTEMPTS + 1):
+        ok_push, push_out = _cu._run_shell(
+            f"git push origin {quoted_base}",
+            project_root,
         )
+        if ok_push:
+            break
+        if attempt == _STORY_RUN_AUDIT_PUSH_ATTEMPTS:
+            _record_audit_publish_state(
+                project_root,
+                base_branch,
+                AUDIT_PUBLISH_PUSH_REFUSED,
+                detail=push_out.strip(),
+            )
+            raise StoryRunAuditPublishError(
+                f"Failed to push story run audits to origin/{base_branch} after "
+                f"{_STORY_RUN_AUDIT_PUSH_ATTEMPTS} attempts (fetch + rebase between "
+                f"attempts): {push_out.strip()}",
+                state=AUDIT_PUBLISH_PUSH_REFUSED,
+            )
+        _log(
+            f"Push of story run audits to origin/{base_branch} was refused "
+            f"(attempt {attempt}/{_STORY_RUN_AUDIT_PUSH_ATTEMPTS}); reconciling with the "
+            f"current remote head and retrying."
+        )
+        try:
+            _reconcile_base_with_origin(project_root, base_branch)
+        except StoryRunAuditPublishError as exc:
+            _record_audit_publish_state(
+                project_root,
+                base_branch,
+                exc.state,
+                detail=str(exc),
+            )
+            raise
 
     ok_ahead, ahead_out = _cu._run_shell(
         f"git rev-list --count origin/{quoted_base}..{quoted_base}",
         project_root,
     )
     if not ok_ahead:
-        raise RuntimeError(
+        message = (
             f"Failed to verify story run audits reached origin/{base_branch}: {ahead_out.strip()}"
         )
+        _record_audit_publish_state(
+            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
+        )
+        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED)
     try:
         ahead = int(ahead_out.strip())
     except ValueError:
-        raise RuntimeError(
+        message = (
             f"Failed to verify story run audits reached origin/{base_branch}: "
             f"unexpected rev-list output {ahead_out.strip()!r}"
-        ) from None
+        )
+        _record_audit_publish_state(
+            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
+        )
+        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED) from None
     if ahead > 0:
-        raise RuntimeError(
+        message = (
             f"Story run audits were committed but '{base_branch}' is still {ahead} commit(s) "
             f"ahead of origin/{base_branch} after push. Publish or reset it before rerunning."
         )
+        _record_audit_publish_state(
+            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
+        )
+        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED)
+    _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_PUBLISHED)
     _log(f"Pushed canonical story run audit records to origin/{base_branch}.")
 
 
@@ -4374,7 +4541,13 @@ def run_sprint(
             publish=_base_branch_tracks_origin(config, lands_locally=_sprint_lands_locally),
         )
     except RuntimeError as exc:
-        _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}")
+        _state = getattr(exc, "state", None)
+        _state_suffix = (
+            f" [state={_state}; recorded in {_STORY_RUN_AUDIT_PUBLISH_STATE_PATH}]"
+            if _state
+            else ""
+        )
+        _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}{_state_suffix}")
         raise
 
     # ── POST_SPRINT hook ──────────────────────────────────────────────

--- a/tests/test_sprint_audit_publish.py
+++ b/tests/test_sprint_audit_publish.py
@@ -1,0 +1,228 @@
+"""Tests for publishing canonical story run audit records at end of sprint.
+
+The publish step pushes the audit commit to the base branch. Because the
+sprint's own merges are what usually advance that branch, a non-fast-forward
+rejection is the ordinary case for a run that landed stories — it must be
+reconciled and retried rather than raised as terminal. These tests drive the
+real git plumbing (a bare "origin" plus two clones) so the reconcile is
+exercised end to end, and assert the recorded publish end state.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from theforge.sprint.runner import (
+    _STORY_RUN_AUDIT_PUBLISH_STATE_PATH,
+    AUDIT_PUBLISH_CLEAN,
+    AUDIT_PUBLISH_LOCAL_ONLY,
+    AUDIT_PUBLISH_PUBLISHED,
+    AUDIT_PUBLISH_PUSH_REFUSED,
+    AUDIT_PUBLISH_RECONCILE_FAILED,
+    StoryRunAuditPublishError,
+    _commit_story_run_audits,
+)
+
+BASE = "release/v0.13"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def _configure(repo: Path) -> None:
+    _git(repo, "config", "user.email", "forge@example.com")
+    _git(repo, "config", "user.name", "Forge Test")
+
+
+def _write_audit(repo: Path, name: str) -> None:
+    audit_dir = repo / ".forge" / "audits" / "runs"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    (audit_dir / name).write_text(json.dumps({"run": name}) + "\n", encoding="utf-8")
+
+
+@pytest.fixture()
+def origin_and_clone(tmp_path: Path) -> tuple[Path, Path]:
+    """A bare origin with ``BASE`` checked out in a clone, audits unignored."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "--bare", "--initial-branch", BASE)
+
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(seed, "init", "--initial-branch", BASE)
+    _configure(seed)
+    (seed / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(seed, "add", "README.md")
+    _git(seed, "commit", "-m", "seed")
+    _git(seed, "remote", "add", "origin", str(origin))
+    _git(seed, "push", "-u", "origin", BASE)
+
+    clone = tmp_path / "project"
+    _git(tmp_path, "clone", str(origin), str(clone))
+    _configure(clone)
+    return origin, clone
+
+
+def _read_state(project_root: Path) -> dict:
+    return json.loads(
+        (project_root / _STORY_RUN_AUDIT_PUBLISH_STATE_PATH).read_text(encoding="utf-8")
+    )
+
+
+def _advance_origin(tmp_path: Path, origin: Path, message: str) -> None:
+    """Land an unrelated commit on origin's base branch, as a merged PR would."""
+    other = tmp_path / f"other-{message}"
+    _git(tmp_path, "clone", str(origin), str(other))
+    _configure(other)
+    (other / f"{message}.txt").write_text(message + "\n", encoding="utf-8")
+    _git(other, "add", ".")
+    _git(other, "commit", "-m", message)
+    _git(other, "push", "origin", BASE)
+
+
+def test_publish_pushes_audits_when_remote_is_unchanged(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-a.json")
+
+    _commit_story_run_audits(clone, BASE, publish=True)
+
+    assert "run-a.json" in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
+
+
+def test_publish_reconciles_when_the_base_branch_advanced(
+    tmp_path: Path, origin_and_clone: tuple[Path, Path]
+) -> None:
+    """The sprint's own merge landing mid-run must not strand the audit commit."""
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-b.json")
+    # The base branch moves after the clone's last fetch — the merge of the PR
+    # for the story this sprint just landed.
+    _advance_origin(tmp_path, origin, "story-merge")
+
+    _commit_story_run_audits(clone, BASE, publish=True)
+
+    tree = _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    assert "run-b.json" in tree
+    # The reconcile rebased onto the mover rather than discarding it.
+    assert "story-merge.txt" in tree
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
+    assert _git(clone, "rev-list", "--count", f"origin/{BASE}..{BASE}") == "0"
+
+
+def test_publish_raises_with_push_refused_state_when_retries_are_exhausted(
+    monkeypatch: pytest.MonkeyPatch, origin_and_clone: tuple[Path, Path]
+) -> None:
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-c.json")
+
+    from theforge.coordinator import util as _cu
+
+    real_run_shell = _cu._run_shell
+
+    def fake_run_shell(cmd: str, cwd: Path, *args: object, **kwargs: object):
+        if cmd.startswith("git push origin"):
+            return False, "! [rejected] (fetch first)"
+        return real_run_shell(cmd, cwd, *args, **kwargs)
+
+    monkeypatch.setattr(_cu, "_run_shell", fake_run_shell)
+
+    with pytest.raises(StoryRunAuditPublishError) as excinfo:
+        _commit_story_run_audits(clone, BASE, publish=True)
+
+    assert excinfo.value.state == AUDIT_PUBLISH_PUSH_REFUSED
+    assert "3 attempts" in str(excinfo.value)
+    state = _read_state(clone)
+    assert state["state"] == AUDIT_PUBLISH_PUSH_REFUSED
+    assert "rejected" in state["detail"]
+    # The audit commit is still local — the caller must exit nonzero.
+    assert _git(clone, "log", "-1", "--pretty=%s") == "chore(audit): record sprint run audits"
+
+
+def test_publish_reports_reconcile_failure_distinctly(
+    monkeypatch: pytest.MonkeyPatch, origin_and_clone: tuple[Path, Path]
+) -> None:
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-d.json")
+
+    from theforge.coordinator import util as _cu
+
+    real_run_shell = _cu._run_shell
+
+    def fake_run_shell(cmd: str, cwd: Path, *args: object, **kwargs: object):
+        if cmd.startswith("git push origin"):
+            return False, "! [rejected] (fetch first)"
+        if cmd.startswith("git fetch origin"):
+            return False, "fatal: could not read from remote repository"
+        return real_run_shell(cmd, cwd, *args, **kwargs)
+
+    monkeypatch.setattr(_cu, "_run_shell", fake_run_shell)
+
+    with pytest.raises(StoryRunAuditPublishError) as excinfo:
+        _commit_story_run_audits(clone, BASE, publish=True)
+
+    assert excinfo.value.state == AUDIT_PUBLISH_RECONCILE_FAILED
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_RECONCILE_FAILED
+
+
+def test_publish_aborts_a_conflicted_rebase_before_raising(
+    tmp_path: Path, origin_and_clone: tuple[Path, Path]
+) -> None:
+    """A conflicting reconcile leaves no half-finished rebase in the checkout."""
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-e.json")
+
+    other = tmp_path / "conflicting"
+    _git(tmp_path, "clone", str(origin), str(other))
+    _configure(other)
+    _write_audit(other, "run-e.json")
+    (other / ".forge" / "audits" / "runs" / "run-e.json").write_text(
+        '{"run": "different"}\n', encoding="utf-8"
+    )
+    _git(other, "add", "--", ".forge/audits/runs")
+    _git(other, "commit", "-m", "conflicting audit")
+    _git(other, "push", "origin", BASE)
+
+    with pytest.raises(StoryRunAuditPublishError) as excinfo:
+        _commit_story_run_audits(clone, BASE, publish=True)
+
+    assert excinfo.value.state == AUDIT_PUBLISH_RECONCILE_FAILED
+    assert not (clone / ".git" / "rebase-merge").exists()
+    assert not (clone / ".git" / "rebase-apply").exists()
+
+
+def test_publish_disabled_records_local_only_state(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-f.json")
+
+    _commit_story_run_audits(clone, BASE, publish=False)
+
+    assert "run-f.json" not in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_LOCAL_ONLY
+
+
+def test_publish_records_clean_state_when_no_audits_are_pending(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    """A stale marker from an earlier run must not be read as this run's outcome."""
+    _origin, clone = origin_and_clone
+
+    _commit_story_run_audits(clone, BASE, publish=True)
+
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_CLEAN


### PR DESCRIPTION
## Summary

The audit publish retry/reconcile path is wired into the sprint runtime, covers the reported non-fast-forward race with a real git test, and records distinct operator-visible end states.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.48
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

End-of-sprint audit push races the sprint's own merges and fails terminally without retry (GitHub Issue #2006)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2006