### PR TITLE
Unmeasured cost is coerced to zero at every aggregation, so unpriced work is reported as free

### DIFF
--- a/src/theforge/cli/audit.py
+++ b/src/theforge/cli/audit.py
@@ -9,6 +9,20 @@ import yaml
 
 from theforge.coordinator.util import _fmt_duration
 
+_UNKNOWN_COST = "unknown"
+
+
+def _cost_str(value: object, *, width: int = 0) -> str:
+    """Render an audit cost field, keeping an unmeasured ``None`` unmeasured.
+
+    The audit stores ``None`` for spend a transport could not measure. Printing
+    it as ``$0.0000`` would present unpriced work as free, so it renders as
+    ``unknown`` instead (#1992).
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"${float(value):>{width}.4f}" if width else f"${float(value):.4f}"
+    return f"{_UNKNOWN_COST:>{width + 1}}" if width else _UNKNOWN_COST
+
 
 def _cmd_audit_ideate(audit: dict) -> int:
     """Print a human-readable summary of an ideation audit record."""
@@ -44,7 +58,7 @@ def _cmd_audit_ideate(audit: dict) -> int:
 
     cost = audit.get("cost", {})
     print()
-    print(f"  Cost:  ${cost.get('total_usd', 0):.4f}")
+    print(f"  Cost:  {_cost_str(cost.get('total_usd'))}")
 
     rounds = audit.get("rounds", [])
     if rounds:
@@ -101,9 +115,9 @@ def cmd_audit(args: object) -> int:
     if preflight:
         pf_verdict = preflight.get("verdict", "?")
         pf_reason = preflight.get("reason", "")
-        pf_cost = preflight.get("cost_usd", 0.0) or 0.0
+        pf_cost = preflight.get("cost_usd")
         print()
-        print(f"  Preflight: {pf_verdict} (${pf_cost:.4f})")
+        print(f"  Preflight: {pf_verdict} ({_cost_str(pf_cost)})")
         if pf_reason:
             print(f"    Reason: {pf_reason}")
 
@@ -138,11 +152,11 @@ def cmd_audit(args: object) -> int:
     # Cost summary
     print()
     print("  Cost")
-    print(f"    Total:  ${cost.get('total_usd', 0):.4f}")
+    print(f"    Total:  {_cost_str(cost.get('total_usd'))}")
     dev_inv = cost.get("dev_invocations", 0)
     rev_inv = cost.get("review_invocations", 0)
-    print(f"    Dev:    ${cost.get('dev_usd', 0):.4f}  ({dev_inv} invocation(s))")
-    print(f"    Review: ${cost.get('review_usd', 0):.4f}  ({rev_inv} invocation(s))")
+    print(f"    Dev:    {_cost_str(cost.get('dev_usd'))}  ({dev_inv} invocation(s))")
+    print(f"    Review: {_cost_str(cost.get('review_usd'))}  ({rev_inv} invocation(s))")
 
     # Per-agent breakdown
     agents = cost.get("agents", [])
@@ -153,10 +167,10 @@ def cmd_audit(args: object) -> int:
         for a in agents:
             role = a.get("role", "?")
             profile = a.get("profile", "?")
-            cost_usd = a.get("cost_usd", 0.0) or 0.0
+            cost_usd = a.get("cost_usd")
             dur = a.get("duration_seconds")
             dur_str = _fmt_duration(dur) if dur is not None else "—"
-            print(f"  {role:<10} {profile:<20} ${cost_usd:>11.4f}  {dur_str:>10}")
+            print(f"  {role:<10} {profile:<20} {_cost_str(cost_usd, width=11)}  {dur_str:>10}")
 
     # Reviews
     if reviews:

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -8,6 +8,8 @@ import sys
 import textwrap
 from pathlib import Path
 
+from theforge.coordinator.util import _fmt_cost_total
+
 #: Width of the STATUS column — wide enough for the longest status label
 #: ("interrupted") so a killed story does not push the row out of alignment.
 _STATUS_WIDTH = 11
@@ -128,6 +130,10 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     terminal_outcome: str | None = None
     terminal_cause: str | None = None
     total_cost_usd: float | None = None
+    # False once any story's cost is known to be unmeasured — the header then
+    # reports the measured lower bound as such instead of as the sprint cost.
+    cost_complete: bool = True
+    cost_measured_usd: float | None = None
     duration_seconds: float | None = None
     sprint_phase: str | None = None
     base_branch: str | None = None
@@ -202,13 +208,24 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
                 summary_data = yaml.safe_load(f) or {}
             sp = summary_data.get("sprint", {})
             total_cost_usd = sp.get("total_cost_usd")
+            cost_complete = sp.get("cost_complete", True) is not False
+            _measured = sp.get("total_cost_measured_usd")
+            cost_measured_usd = _measured if isinstance(_measured, (int, float)) else None
             duration_seconds = sp.get("duration_seconds")
         except Exception:
             pass
 
-    # For live/crashed sprints compute total cost from story entries.
-    if total_cost_usd is None and entries:
-        total_cost_usd = sum(getattr(e, "cost_usd", 0.0) for e in entries)
+    # For live/crashed sprints compute total cost from story entries. A story
+    # whose cost is unknown makes the sprint total incomplete: sum only the
+    # measured ones and report the result as a lower bound (#1992).
+    if total_cost_usd is None and cost_complete and entries:
+        _entry_costs = [getattr(e, "cost_usd", 0.0) for e in entries]
+        _measured_sum = sum(c for c in _entry_costs if c is not None)
+        if all(c is not None for c in _entry_costs):
+            total_cost_usd = _measured_sum
+        else:
+            cost_complete = False
+            cost_measured_usd = _measured_sum
 
     # ── Header ───────────────────────────────────────────────────────────
     if is_live:
@@ -227,6 +244,8 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
         header_parts.append(f"phase: {sprint_phase}")
     if total_cost_usd is not None:
         header_parts.append(f"cost: ${total_cost_usd:.2f}")
+    elif not cost_complete:
+        header_parts.append(f"cost: {_fmt_cost_total(None, cost_measured_usd)}")
     if duration_seconds is not None:
         if is_live:
             header_parts.append(f"elapsed: {int(duration_seconds // 60)}m")
@@ -405,7 +424,12 @@ def _print_story_line(
     model_str = model if model else "—"
     if len(model_str) > 24:
         model_str = model_str[:24]
-    cost_str = f"${cost_usd:.2f}" if cost_usd else "   —"
+    if cost_usd is None:
+        # Cost-unknown must not render like "no spend": the story ran on a
+        # transport that reported no cost (#1992).
+        cost_str = "unknown"
+    else:
+        cost_str = f"${cost_usd:.2f}" if cost_usd else "   —"
     elapsed_str = _format_story_elapsed(elapsed_s)
 
     prefix = " " * indent

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -218,7 +218,11 @@ def _historical_row_from_substrate(record: dict) -> tuple[float, str, str, str, 
         stopped = sprint_block.get("stopped_reason")
         status_str = "stopped" if stopped else "completed"
         cost_usd = sprint_block.get("total_cost_usd")
-        if cost_usd is None:
+        if cost_usd is None and sprint_block.get("cost_complete") is not False:
+            # A sprint that recorded cost_complete=False has a null total on
+            # purpose: at least one story's spend was never measured. Falling
+            # back to a numeric subtotal would report it as the sprint's cost
+            # (#1992).
             cost_usd = (record.get("totals") or {}).get("cost_usd")
         dur_s = sprint_block.get("duration_seconds")
         if dur_s is None:
@@ -245,7 +249,12 @@ def _historical_row_from_substrate(record: dict) -> tuple[float, str, str, str, 
         if dur_s is None and isinstance(timing, dict):
             dur_s = timing.get("duration_seconds")
 
-    cost_str = f"${cost_usd:.2f}" if isinstance(cost_usd, (int, float)) else "—"
+    if isinstance(cost_usd, (int, float)):
+        cost_str = f"${cost_usd:.2f}"
+    elif sprint_block is not None and sprint_block.get("cost_complete") is False:
+        cost_str = "unknown"
+    else:
+        cost_str = "—"
     if isinstance(dur_s, (int, float)) and dur_s > 0:
         elapsed_str = f"{int(dur_s // 60)}m"
     else:

--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -254,6 +254,8 @@ def render_frame(
     for e in entries:
         slug = getattr(e, "slug", "") or ""
         path = getattr(e, "path", slug) or slug
+        # Unknown cost contributes no measurable delta; treated as 0 for the
+        # ΔCOST column only, never reported as the story's cost (#1992).
         cost = float(getattr(e, "cost_usd", 0.0) or 0.0)
         prev = prev_costs.get(slug, cost)
         delta = cost - prev

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -18,6 +18,7 @@ from .audit_substrate import MIGRATION_HELPERS
 from .landing_record import build_landing_record
 from .state import CoordinatorResult, CoordinatorState
 from .trust_status import derive_trust_status
+from .util import _round_cost as _util_round_cost
 
 # Per-run audit-record schema version and the reader-side migration registry
 # are owned by audit_substrate (the reader). They are re-exported here so
@@ -39,7 +40,7 @@ def _round_cost(value: float | None) -> float | None:
     from a genuinely free run and corrupts every cost-based view built on the
     audit substrate.
     """
-    return round(value, 6) if value is not None else None
+    return _util_round_cost(value, 6)
 
 
 def _branch_has_unmerged_commits(project_root: Path, branch: str, base: str) -> bool:
@@ -555,7 +556,7 @@ def _serialize_review_iteration_metrics(state: CoordinatorState) -> list[dict]:
             "repeated_findings_by_severity": item.repeated_findings_by_severity,
             "novel_findings": item.novel_findings,
             "restated_findings": item.restated_findings,
-            "cost_usd": round(item.cost_usd, 6),
+            "cost_usd": _round_cost(item.cost_usd),
             "duration_s": round(item.duration_s, 2),
         }
         for item in state.review_iteration_telemetry

--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -20,7 +20,7 @@ from .logging import StructuredLogger
 from .notify import _ntfy_done_notify
 from .run_setup import delete_merge_state, load_merge_state, save_merge_state
 from .state import CoordinatorResult, CoordinatorState, CycleHistory, MergeStepState, Phase
-from .util import _fmt_duration, _log, _log_verbose, _run_shell
+from .util import _fmt_cost_total, _fmt_duration, _log, _log_verbose, _round_cost, _run_shell
 from .workspace import _deindex_forge_artifacts, _merge_branch
 from .worktree_state import check_worktree_git_consistency
 
@@ -387,7 +387,7 @@ def _create_pr(
         f"## Review\n\n"
         f"- **Verdict:** APPROVE ({p1_count} P1, {p2_count} P2)\n"
         f"- **Reviewers:** {reviewer_names}\n"
-        f"- **Cost:** ${state.total_cost:.2f}\n"
+        f"- **Cost:** {_fmt_cost_total(state.total_cost_measured, state.total_cost)}\n"
         f"- **Dev iterations:** {state.dev_iteration}\n"
         f"- **Tests:** N/A\n\n"
         f"## Findings\n\n"
@@ -1578,7 +1578,7 @@ def _finalize_approve(
     auto_merge: bool,
     notify: bool,
     logger: "StructuredLogger | None",
-    review_cost: float,
+    review_cost: float | None,
     review_elapsed: float,
     message: str,
     run_id: str = "",
@@ -1620,11 +1620,14 @@ def _finalize_approve(
             "phase_end",
             phase="REVIEW",
             outcome="approve",
-            cost_usd=round(review_cost, 6),
+            cost_usd=_round_cost(review_cost),
             duration_s=round(review_elapsed, 2),
         )
     _task_elapsed = time.monotonic() - task_start
-    _log(f"✓ DONE   total=${state.total_cost:.2f}  {_fmt_duration(_task_elapsed)}")
+    _log(
+        f"✓ DONE   total={_fmt_cost_total(state.total_cost_measured, state.total_cost)}"
+        f"  {_fmt_duration(_task_elapsed)}"
+    )
     _ntfy_done_notify(
         task, state, config, notify, parsed_review.summary, _task_elapsed, branch_name
     )

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -48,11 +48,13 @@ from .state import (
     RetryReason,
 )
 from .util import (
+    _fmt_cost,
     _fmt_duration,
     _log,
     _log_phase,
     _log_verbose,
     resolve_timeout_with_active,
+    sum_costs,
 )
 from .worktree_state import check_worktree_git_consistency
 
@@ -472,11 +474,10 @@ def record_dev_iteration_telemetry(
     duration_attempts = state.dev_durations[-attempt_count:]
     dev_result = dev_attempts[-1]
     duration_s = sum(duration_attempts)
-    cost_usd = (
-        sum(result.cost_usd or 0.0 for result in dev_attempts)
-        if any(result.cost_usd is not None for result in dev_attempts)
-        else None
-    )
+    # None-aware: a MIX of measured and unmeasured attempts is still unknown —
+    # summing only the measured ones would report a partial subtotal as if it
+    # were this iteration's cost (#1992).
+    cost_usd = sum_costs(result.cost_usd for result in dev_attempts)
     baseline = state.last_dev_start_commit or "HEAD"
     files_changed = _git_lines(workspace_path, ["diff", "--name-only", baseline, "HEAD"])
     dirty_files = [
@@ -1062,12 +1063,8 @@ def _run_dev_phase(
         state.dev_session_id = dev_result.session_id or state.dev_session_id
     save_sessions(workspace_path, state.dev_session_id, state.reviewer_session_ids)
     log_agent_result(dev_result, "DEV")
-    _dev_cost_total = sum(result.cost_usd or 0.0 for result in _dev_results_this_iteration)
-    _dev_cost_str = (
-        "${:.2f}".format(_dev_cost_total)
-        if any(result.cost_usd is not None for result in _dev_results_this_iteration)
-        else "unknown"
-    )
+    _dev_cost_total = sum_costs(result.cost_usd for result in _dev_results_this_iteration)
+    _dev_cost_str = _fmt_cost(_dev_cost_total)
     # Glyph reflects the actual outcome: a killed or crashed iteration must not
     # be rendered with the success glyph one line above the failure it caused.
     _dev_glyph = "✓" if dev_result.success else "✗"
@@ -1077,7 +1074,7 @@ def _run_dev_phase(
             "phase_end",
             phase="DEV",
             outcome="success" if dev_result.success else "failure",
-            cost_usd=_dev_cost_total if _dev_cost_str != "unknown" else None,
+            cost_usd=_dev_cost_total,
             duration_s=round(_dev_elapsed, 2),
         )
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -81,6 +81,7 @@ from .util import (
     _log,
     _log_phase,
     _log_verbose,
+    _round_cost,
 )
 from .workspace import _base_branch_lands_locally, _create_workspace, pull_base_branch
 from .workspace_scrub import _scrub_forge_history
@@ -428,7 +429,7 @@ def _coordinator_loop(
                     {
                         "phase": "DEV",
                         "iteration": state.dev_iteration,
-                        "cost_usd": state.total_cost,
+                        "cost_usd": state.total_cost_measured,
                         "complexity": state.preflight_complexity,
                         "complexity_score": state.preflight_complexity_score,
                         "current_model": config.dev_profile.model,
@@ -474,7 +475,7 @@ def _coordinator_loop(
                     {
                         "phase": "DEV",
                         "iteration": state.dev_iteration,
-                        "cost_usd": state.total_cost,
+                        "cost_usd": state.total_cost_measured,
                         "complexity": state.preflight_complexity,
                         "complexity_score": state.preflight_complexity_score,
                         "current_model": config.dev_profile.model,
@@ -940,7 +941,7 @@ def run_task(
             logger._safe_emit(
                 "run_end",
                 outcome=_run_end_outcome(result),
-                total_cost_usd=round(state.total_cost, 6),
+                total_cost_usd=_round_cost(state.total_cost_measured),
                 total_duration_s=round(_total_elapsed, 2),
             )
             return result
@@ -1030,7 +1031,7 @@ def run_task(
             logger._safe_emit(
                 "run_end",
                 outcome=_run_end_outcome(result),
-                total_cost_usd=round(state.total_cost, 6),
+                total_cost_usd=_round_cost(state.total_cost_measured),
                 total_duration_s=round(time.monotonic() - _task_start, 2),
             )
             return result
@@ -1148,7 +1149,7 @@ def run_task(
         logger._safe_emit(
             "run_end",
             outcome=_run_end_outcome(result),
-            total_cost_usd=round(state.total_cost, 6),
+            total_cost_usd=_round_cost(state.total_cost_measured),
             total_duration_s=round(_total_elapsed, 2),
         )
 
@@ -1439,7 +1440,7 @@ def _run_resume_coordinator(
         logger._safe_emit(
             "run_end",
             outcome=_run_end_outcome(result),
-            total_cost_usd=round(state.total_cost, 6),
+            total_cost_usd=_round_cost(state.total_cost_measured),
             total_duration_s=round(_total_elapsed, 2),
         )
         _record_run_memory(config, task, state, result)

--- a/src/theforge/coordinator/hooks.py
+++ b/src/theforge/coordinator/hooks.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .util import _round_cost
+
 if TYPE_CHECKING:
     from theforge.config import ForgeConfig
     from theforge.task import TaskStory
@@ -278,7 +280,7 @@ def build_post_run_payload(
         "summary": summary,
         "cycles": state.review_cycle,
         "dev_iterations": len(state.dev_results),
-        "total_cost_usd": round(state.total_cost, 4),
+        "total_cost_usd": _round_cost(state.total_cost_measured, 4),
         "duration_seconds": round(duration_seconds, 1),
         "findings": findings,
         "gate_decisions": list(state.gate_decisions),
@@ -311,7 +313,7 @@ def build_post_sprint_payload(
     stories: list[dict],
     run_id: str,
     config: ForgeConfig,
-    total_cost_usd: float = 0.0,
+    total_cost_usd: float | None = 0.0,
     duration_seconds: float = 0.0,
 ) -> dict:
     """Payload for post_sprint hook."""
@@ -320,7 +322,7 @@ def build_post_sprint_payload(
         "project": config.project,
         "sprint": sprint_name,
         "run_id": run_id,
-        "total_cost_usd": round(total_cost_usd, 4),
+        "total_cost_usd": _round_cost(total_cost_usd, 4),
         "duration_seconds": round(duration_seconds, 1),
         "stories": stories,
     }

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -21,27 +21,34 @@ from .trust_status import derive_trust_status, is_tainted
 
 def _extract_reviewers(
     state: CoordinatorState,
-) -> dict[str, tuple[int, int, float]]:
+) -> dict[str, tuple[int, int, float | None]]:
     """Per-reviewer ``(cycles, findings, cost)`` from cycle metadata + telemetry.
 
     Findings are the per-cycle aggregate (shared view across reviewers); cost
     is split evenly across successful reviewers in each cycle. Attribution is
     approximate but reasonable without per-reviewer telemetry.
     """
-    out: dict[str, tuple[int, int, float]] = {}
+    out: dict[str, tuple[int, int, float | None]] = {}
     meta_list = state.review_cycle_metadata or []
     tele_list = state.review_iteration_telemetry or []
     for idx, meta in enumerate(meta_list):
         tele = tele_list[idx] if idx < len(tele_list) else None
         findings = sum(int(v) for v in tele.findings_by_severity.values()) if tele else 0
-        cost = float(tele.cost_usd) if tele else 0.0
+        # An unmeasured cycle cost stays None all the way into the profile fold
+        # (_update_review handles it): splitting $0.00 across reviewers would
+        # teach the router that a cost-unmeasured transport is free (#1992).
+        cost = (float(tele.cost_usd) if tele.cost_usd is not None else None) if tele else 0.0
         participants = list(meta.successful or [])
         if not participants:
             continue
-        per_head_cost = cost / len(participants) if participants else 0.0
+        per_head_cost = (cost / len(participants)) if cost is not None else None
         for name in participants:
             prev = out.get(name, (0, 0, 0.0))
-            out[name] = (prev[0] + 1, prev[1] + findings, prev[2] + per_head_cost)
+            prev_cost = prev[2]
+            new_cost = (
+                None if per_head_cost is None or prev_cost is None else prev_cost + per_head_cost
+            )
+            out[name] = (prev[0] + 1, prev[1] + findings, new_cost)
     return out
 
 

--- a/src/theforge/coordinator/notify.py
+++ b/src/theforge/coordinator/notify.py
@@ -78,7 +78,8 @@ def _escalate_notify(
     branch = state.branch_name or ""
     first_line = (
         f"{state.review_cycle} cycles exhausted"
-        f" — ${state.total_cost:.2f}  {_cu._fmt_duration(elapsed)}"
+        f" — {_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)}"
+        f"  {_cu._fmt_duration(elapsed)}"
     )
     body = "\n".join([first_line, detail, f"Branch: {branch}"])
     if config.notifications.ntfy is not None:
@@ -114,7 +115,7 @@ def _ntfy_crash_notify(
     body = "\n".join(
         [
             f"{phase_name} (iter {state.dev_iteration})",
-            f"Cost at crash: ${state.total_cost:.2f}",
+            f"Cost at crash: {_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)}",
             f"Uptime: {_cu._fmt_duration(uptime_seconds)}",
         ]
     )
@@ -145,7 +146,8 @@ def _ntfy_done_notify(
         return
     body = "\n".join(
         [
-            f"APPROVE \u2014 ${state.total_cost:.2f}  {_cu._fmt_duration(elapsed)}",
+            f"APPROVE \u2014 {_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)}"
+            f"  {_cu._fmt_duration(elapsed)}",
             (summary or "Approved and merged.")[:120],
             f"Branch: {branch_name}",
         ]
@@ -197,7 +199,7 @@ def _human_review(
     _cu._log(f"  Summary:   {parsed_review.summary}")
     _cu._log(f"  Workspace: {workspace_path}")
     _cu._log(f"  Branch:    {branch_name}")
-    _cu._log(f"  Cost:      ${state.total_cost:.3f}")
+    _cu._log(f"  Cost:      {_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)}")
     _cu._log("")
     _cu._log("Options:")
     _cu._log("  [a]pprove  → DONE (ready to merge)")
@@ -298,7 +300,7 @@ def _escalate_gate_interactive(
         _cu._log(f"  Reviewers: {verdicts_str}")
     if gate_result:
         _cu._log(f"  Gate:     {gate_result}")
-    _cu._log(f"  Cost:     ${state.total_cost:.3f}")
+    _cu._log(f"  Cost:     {_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)}")
     _cu._log(f"  Dev iter: {state.dev_iteration}  Review cycles: {state.review_cycle}")
     _cu._log("")
     _cu._log("  Choose:")

--- a/src/theforge/coordinator/pending_hitl.py
+++ b/src/theforge/coordinator/pending_hitl.py
@@ -42,7 +42,8 @@ def _pending_human_review(
     timeout_seconds = config.notifications.human_review_timeout_seconds
 
     reason = (
-        f"{parsed_review.verdict} ({p1} P1, {p2} P2) — ${state.total_cost:.2f} "
+        f"{parsed_review.verdict} ({p1} P1, {p2} P2) — "
+        f"{_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)} "
         f"{_cu._fmt_duration(elapsed)}\n{parsed_review.summary[:120]}\nBranch: {branch_name}"
     )
 

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -79,7 +79,14 @@ from .preflight_evidence import render_partial_evidence
 from .remote_gates import _plan_review_remote
 from .reviewer_progress import ReviewerProgressChannel
 from .state import CoordinatorResult, CoordinatorState, Phase, PlanFindingRecord
-from .util import _fmt_cost, _fmt_duration, _log_phase, resolve_timeout_with_active
+from .util import (
+    _fmt_cost,
+    _fmt_duration,
+    _log_phase,
+    _round_cost,
+    resolve_timeout_with_active,
+    sum_costs,
+)
 
 if TYPE_CHECKING:
     from theforge.agent_types import AgentResult
@@ -686,7 +693,7 @@ def _run_plan_phase(
             {
                 "phase": "PLAN",
                 "iteration": 0,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 **_cu.live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),
@@ -747,7 +754,7 @@ def _run_plan_phase(
             {
                 "phase": "PLAN",
                 "iteration": 0,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 **_cu.live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),
@@ -845,7 +852,7 @@ def _run_plan_phase(
                 "phase_end",
                 phase="PLAN",
                 outcome="success",
-                cost_usd=round(plan_result.cost_usd or 0.0, 6),
+                cost_usd=_round_cost(plan_result.cost_usd),
                 duration_s=round(_plan_elapsed, 2),
             )
 
@@ -1023,7 +1030,7 @@ def _run_plan_agent_review(
             reviewer_names=_pool_names,
             phase="PLAN_REVIEW",
             iteration=_attempt,
-            cost_usd=state.total_cost,
+            cost_usd=state.total_cost_measured,
             complexity=state.preflight_complexity,
             complexity_score=state.preflight_complexity_score,
             state_update_fn=state_update_fn,
@@ -1283,7 +1290,7 @@ def _run_plan_agent_review(
                 message=state.error,
             )
 
-        _total_pr_cost = sum(r.cost_usd or 0.0 for r in pr_results)
+        _total_pr_cost = sum_costs(r.cost_usd for r in pr_results)
 
         # ── Plan finding identity tracking ────────────────────────────────
         # Snapshot registry before this cycle so new inserts don't interfere.
@@ -1385,7 +1392,7 @@ def _run_plan_agent_review(
                     "phase_end",
                     phase="PLAN_REVIEW",
                     outcome="approve",
-                    cost_usd=round(_total_pr_cost, 6),
+                    cost_usd=_round_cost(_total_pr_cost),
                     duration_s=round(_pr_elapsed, 2),
                     plan_regen_disposition=state.plan_regen_disposition,
                 )
@@ -1426,7 +1433,7 @@ def _run_plan_agent_review(
                     "phase_end",
                     phase="PLAN_REVIEW",
                     outcome="advisory",
-                    cost_usd=round(_total_pr_cost, 6),
+                    cost_usd=_round_cost(_total_pr_cost),
                     duration_s=round(_pr_elapsed, 2),
                 )
             _write_log_artifact(state.log_dir, "plan.md", plan_text)
@@ -1453,7 +1460,7 @@ def _run_plan_agent_review(
                 "phase_end",
                 phase="PLAN_REVIEW",
                 outcome="reject",
-                cost_usd=round(_total_pr_cost, 6),
+                cost_usd=_round_cost(_total_pr_cost),
                 duration_s=round(_pr_elapsed, 2),
                 plan_regen_disposition=state.plan_regen_disposition,
             )

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -63,7 +63,7 @@ from .preflight import (
 from .preflight_cache import capture_preflight_cache_snapshot
 from .preflight_evidence import build_partial_evidence
 from .state import CoordinatorResult, CoordinatorState, Phase
-from .util import _fmt_duration, _log_phase
+from .util import _fmt_cost_total, _fmt_duration, _log_phase, _round_cost
 from .validation_complexity import (
     DIMENSION_IMPLEMENTATION,
     VALIDATION_BASELINE_SCORE,
@@ -271,7 +271,7 @@ def _run_preflight_phase(
             {
                 "phase": "PREFLIGHT",
                 "iteration": 0,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 "current_model": preflight_profile.model,
             }
         )
@@ -505,7 +505,7 @@ def _run_preflight_phase(
             {
                 "phase": "PREFLIGHT",
                 "iteration": 0,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 # Fired before the parse step computes preflight_complexity_score,
                 # so the score may still be None. live_complexity_fields omits the
                 # key in that case, preserving any score an earlier phase set on a
@@ -878,7 +878,7 @@ def _run_preflight_phase(
             {
                 "phase": "PREFLIGHT",
                 "iteration": 0,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 # Fired after the parse step; by now preflight_complexity_score is
                 # set whenever the agent emitted a numeric score, so the score
                 # reaches live state immediately for stories that never enter DEV.
@@ -1047,7 +1047,7 @@ def _handle_preflight_verdict(
             logger._safe_emit(
                 "run_end",
                 outcome="infrastructure_abort",
-                total_cost_usd=round(state.total_cost, 6),
+                total_cost_usd=_round_cost(state.total_cost_measured),
                 total_duration_s=round(time.monotonic() - task_start, 2),
             )
         # No _escalate_notify: an escalation notification asserts that the story
@@ -1107,12 +1107,15 @@ def _handle_preflight_verdict(
 
         state.phase = Phase.DONE
         elapsed = time.monotonic() - task_start
-        _log(f"✓ DONE   total=${state.total_cost:.2f}  {_fmt_duration(elapsed)}")
+        _log(
+            f"✓ DONE   total={_fmt_cost_total(state.total_cost_measured, state.total_cost)}"
+            f"  {_fmt_duration(elapsed)}"
+        )
         if logger:
             logger._safe_emit(
                 "run_end",
                 outcome="already_done",
-                total_cost_usd=round(state.total_cost, 6),
+                total_cost_usd=_round_cost(state.total_cost_measured),
                 total_duration_s=round(elapsed, 2),
             )
         _ntfy_done_notify(
@@ -1145,7 +1148,7 @@ def _handle_preflight_verdict(
             logger._safe_emit(
                 "run_end",
                 outcome="escalate",
-                total_cost_usd=round(state.total_cost, 6),
+                total_cost_usd=_round_cost(state.total_cost_measured),
                 total_duration_s=round(time.monotonic() - task_start, 2),
             )
         _escalate_notify(task, state, notify, config)

--- a/src/theforge/coordinator/remote_gates.py
+++ b/src/theforge/coordinator/remote_gates.py
@@ -188,7 +188,8 @@ def _remote_human_review(
 
     title = f"TheForge: review needed \u2014 {task.slug}"
     body_lines = [
-        f"{parsed_review.verdict} ({p1} P1, {p2} P2) \u2014 ${state.total_cost:.2f}  "
+        f"{parsed_review.verdict} ({p1} P1, {p2} P2) \u2014 "
+        f"{_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)}  "
         f"{_cu._fmt_duration(elapsed)}",
         parsed_review.summary[:120],
         f"Branch: {branch_name}",

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -80,12 +80,16 @@ from .state import (
     ReviewIterationTelemetry,
 )
 from .util import (
+    _fmt_cost,
+    _fmt_cost_total,
     _fmt_duration,
     _log,
     _log_phase,
     _log_verbose,
+    _round_cost,
     _run_shell,
     live_complexity_fields,
+    sum_costs,
 )
 
 
@@ -237,7 +241,7 @@ def _run_escalate_gate(
                     auto_merge=auto_merge,
                     notify=notify,
                     logger=logger,
-                    review_cost=state.total_review_cost,
+                    review_cost=state.total_review_cost_measured,
                     review_elapsed=0.0,
                     message=(
                         f"Task '{task.name}' completed. "
@@ -310,7 +314,7 @@ def _run_escalate_gate(
             auto_merge=auto_merge,
             notify=notify,
             logger=None,
-            review_cost=state.total_review_cost,
+            review_cost=state.total_review_cost_measured,
             review_elapsed=0.0,
             message=(
                 f"Task '{task.name}' completed. "
@@ -368,7 +372,7 @@ def _record_review_iteration_telemetry(
     state: CoordinatorState,
     parsed_review: ReviewResult,
     *,
-    review_cost: float,
+    review_cost: float | None,
     review_elapsed: float,
     max_iterations: int,
 ) -> None:
@@ -583,7 +587,7 @@ def _log_review_findings(
     parsed_review: ReviewResult,
     p1_count: int,
     p2_count: int,
-    review_cost: float,
+    review_cost: float | None,
     logger: StructuredLogger | None,
     task: TaskStory,
 ) -> None:
@@ -610,7 +614,7 @@ def _log_review_findings(
             verdict=parsed_review.verdict,
             p1_count=p1_count,
             p2_count=p2_count,
-            cost_usd=round(review_cost, 6),
+            cost_usd=_round_cost(review_cost),
         )
 
 
@@ -625,7 +629,7 @@ def _handle_interactive_review_decision(
     *,
     auto_merge: bool,
     notify: bool,
-    review_cost: float,
+    review_cost: float | None,
     review_elapsed: float,
     run_id: str,
     exhausted_cycles: bool,
@@ -983,7 +987,7 @@ def _run_review_phase(
             {
                 "phase": "REVIEW",
                 "iteration": state.review_cycle + 1,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 **live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),
@@ -1019,7 +1023,10 @@ def _run_review_phase(
         parse_retries=0,
     )
     state.review_cycle_metadata.append(meta)
-    _review_cost_before_cycle = sum(r.cost_usd or 0.0 for r in state.review_agent_results)
+    # Snapshot the result COUNT, not a coerced dollar subtotal: this cycle's
+    # cost is the sum over the results this cycle appends, and that sum stays
+    # None-aware (an unmeasured attempt makes the cycle cost unknown).
+    _review_results_before_cycle = len(state.review_agent_results)
 
     from . import scope_guard  # noqa: PLC0415
     from .workspace_hygiene import (  # noqa: PLC0415
@@ -1268,7 +1275,7 @@ def _run_review_phase(
             {
                 "phase": "REVIEW",
                 "iteration": state.review_cycle,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 **live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),
@@ -1285,8 +1292,8 @@ def _run_review_phase(
                 },
             }
         )
-    _review_cost = (
-        sum(r.cost_usd or 0.0 for r in state.review_agent_results) - _review_cost_before_cycle
+    _review_cost = sum_costs(
+        r.cost_usd for r in state.review_agent_results[_review_results_before_cycle:]
     )
 
     # ── Finding classification (in-process) ───────────────────────────────
@@ -1608,7 +1615,7 @@ def _run_review_phase(
         )
         _log(
             f"  ✓ REVIEW   {_verdict_label}  {_p1_count} P1  {_p2_count} P2"
-            f"  ${_review_cost:.2f}  {_fmt_duration(_review_elapsed)}"
+            f"  {_fmt_cost(_review_cost)}  {_fmt_duration(_review_elapsed)}"
         )
         _append_cycle_history(state, parsed_review)
         # ── P2 cleanup (post-APPROVE advisory iterations) ──────────────
@@ -1629,7 +1636,7 @@ def _run_review_phase(
                     "phase_end",
                     phase="REVIEW",
                     outcome="approve_p2_cleanup",
-                    cost_usd=round(_review_cost, 6),
+                    cost_usd=_round_cost(_review_cost),
                     duration_s=round(_review_elapsed, 2),
                 )
                 logger._safe_emit(
@@ -1712,7 +1719,7 @@ def _run_review_phase(
     _persistent_tag = " (persistent-P1)" if _is_persistent_p1 else ""
     _log(
         f"  ✗ REVIEW   REQUEST_CHANGES  {_p1_count} P1{_persistent_tag}  {_p2_count} P2"
-        f"  ${_review_cost:.2f}  {_fmt_duration(_review_elapsed)}"
+        f"  {_fmt_cost(_review_cost)}  {_fmt_duration(_review_elapsed)}"
     )
 
     # Escalate dev model on persistent P1 (only when explicitly enabled via forge.yaml)
@@ -1807,7 +1814,7 @@ def _run_review_phase(
             "phase_end",
             phase="REVIEW",
             outcome="request_changes",
-            cost_usd=round(_review_cost, 6),
+            cost_usd=_round_cost(_review_cost),
             duration_s=round(_review_elapsed, 2),
         )
     _append_cycle_history(state, parsed_review)
@@ -1947,7 +1954,7 @@ def _run_review_only_phase(
 
     _ro_p1 = sum(1 for f in parsed_review.findings if f.severity == "P1")
     _ro_p2 = sum(1 for f in parsed_review.findings if f.severity == "P2")
-    _ro_cost = sum(r.cost_usd or 0.0 for r in state.review_agent_results)
+    _ro_cost = sum_costs(r.cost_usd for r in state.review_agent_results)
     _ro_elapsed = _pool_elapsed
 
     _log_review_findings(parsed_review, _ro_p1, _ro_p2, _ro_cost, logger, task)
@@ -1955,20 +1962,23 @@ def _run_review_only_phase(
     if parsed_review.verdict == "APPROVE":
         state.phase = Phase.DONE
         _dur = _fmt_duration(_ro_elapsed)
-        _log(f"  ✓ REVIEW   APPROVE  {_ro_p1} P1  {_ro_p2} P2  ${_ro_cost:.2f}  {_dur}")
-        _log(f"✓ DONE   total=${state.total_cost:.2f}  {_fmt_duration(_ro_elapsed)}")
+        _log(f"  ✓ REVIEW   APPROVE  {_ro_p1} P1  {_ro_p2} P2  {_fmt_cost(_ro_cost)}  {_dur}")
+        _log(
+            f"✓ DONE   total={_fmt_cost_total(state.total_cost_measured, state.total_cost)}"
+            f"  {_fmt_duration(_ro_elapsed)}"
+        )
         if logger:
             logger._safe_emit(
                 "phase_end",
                 phase="REVIEW",
                 outcome="approve",
-                cost_usd=round(_ro_cost, 6),
+                cost_usd=_round_cost(_ro_cost),
                 duration_s=round(_ro_elapsed, 2),
             )
             logger._safe_emit(
                 "run_end",
                 outcome="done",
-                total_cost_usd=round(state.total_cost, 6),
+                total_cost_usd=_round_cost(state.total_cost_measured),
                 total_duration_s=round(time.monotonic() - task_start, 2),
             )
         _ntfy_done_notify(
@@ -1989,7 +1999,7 @@ def _run_review_only_phase(
     )
     _log(
         f"  ✗ REVIEW   REQUEST_CHANGES  {_ro_p1} P1  {_ro_p2} P2"
-        f"  ${_ro_cost:.2f}  {_fmt_duration(_ro_elapsed)}"
+        f"  {_fmt_cost(_ro_cost)}  {_fmt_duration(_ro_elapsed)}"
     )
     _log(f"✗ ESCALATE   {state.error}")
     if logger:
@@ -1997,14 +2007,14 @@ def _run_review_only_phase(
             "phase_end",
             phase="REVIEW",
             outcome="escalate",
-            cost_usd=round(_ro_cost, 6),
+            cost_usd=_round_cost(_ro_cost),
             duration_s=round(_ro_elapsed, 2),
         )
         logger._safe_emit("escalate", reason=state.error, phase="REVIEW")
         logger._safe_emit(
             "run_end",
             outcome="escalate",
-            total_cost_usd=round(state.total_cost, 6),
+            total_cost_usd=_round_cost(state.total_cost_measured),
             total_duration_s=round(time.monotonic() - task_start, 2),
         )
     _escalate_notify(task, state, notify, config)

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -743,7 +743,7 @@ def _run_review_pool(
         reviewer_names=[p.name for p in pool],
         phase="REVIEW",
         iteration=state.review_cycle + 1,
-        cost_usd=state.total_cost,
+        cost_usd=state.total_cost_measured,
         complexity=state.preflight_complexity,
         complexity_score=state.preflight_complexity_score,
         state_update_fn=state_update_fn,

--- a/src/theforge/coordinator/signals.py
+++ b/src/theforge/coordinator/signals.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from .log_tee import _end_run_log_tee, _safe_signal
 from .state import RetryReason
+from .util import _round_cost
 
 if TYPE_CHECKING:
     from theforge.config import ForgeConfig
@@ -49,7 +50,7 @@ def _make_sigterm_handler(
         if state is not None:
             extra["phase_at_crash"] = state.phase.name if state.phase is not None else "UNKNOWN"
             extra["iteration_at_crash"] = state.dev_iteration
-            extra["cost_at_crash"] = round(state.total_cost, 6)
+            extra["cost_at_crash"] = _round_cost(state.total_cost_measured)
         extra["last_event"] = logger.last_event
         logger._safe_emit("run_end", outcome="crashed", **extra)
         if state is not None and task is not None and config is not None:

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -269,7 +269,9 @@ class ReviewIterationTelemetry:
 
     iteration: int
     max_iterations: int
-    cost_usd: float
+    # None = the transport could not measure this cycle's cost. Never coerce it
+    # to 0.0 — unmeasured spend is not free spend (#1992).
+    cost_usd: float | None
     duration_s: float
     verdict: str
     findings_by_severity: dict[str, int]

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -13,6 +13,7 @@ import signal
 import subprocess
 import sys
 import threading
+from collections.abc import Iterable
 from pathlib import Path
 
 from theforge.log_level import LogLevel
@@ -101,6 +102,45 @@ def _log_verbose(msg: str) -> None:
 def _fmt_cost(cost: float | None) -> str:
     """Format a cost value as '$1.23', or 'unknown' when cost is None."""
     return f"${cost:.2f}" if cost is not None else "unknown"
+
+
+def sum_costs(values: Iterable[float | None]) -> float | None:
+    """Sum optional costs, returning ``None`` if *any* contributor is unmeasured.
+
+    ``None`` means "the transport could not measure this spend", which is a
+    different statement from ``0.0`` ("this was free"). Coercing the former to
+    the latter reports unpriced work as free, so a single unmeasured addend
+    makes the whole aggregate cost-unknown. An empty iterable is genuinely no
+    spend, so ``0.0``.
+    """
+    total = 0.0
+    for value in values:
+        if value is None:
+            return None
+        total += value
+    return total
+
+
+def _fmt_cost_total(total: float | None, subtotal: float | None = None) -> str:
+    """Render an aggregate cost for an operator.
+
+    A fully measured aggregate renders as ``$1.23``. An aggregate with any
+    unmeasured component renders as ``unknown`` — never as a dollar figure,
+    which would present a partial total as a complete one. When a measured
+    subtotal is available it is shown as an explicit lower bound
+    (``unknown (>= $0.99 measured)``) so the operator sees both that money was
+    spent and that the figure is incomplete.
+    """
+    if total is not None:
+        return f"${total:.2f}"
+    if subtotal:
+        return f"unknown (>= ${subtotal:.2f} measured)"
+    return "unknown"
+
+
+def _round_cost(value: float | None, digits: int = 6) -> float | None:
+    """Round an optional cost, preserving an unmeasured ``None`` as ``None``."""
+    return round(value, digits) if value is not None else None
 
 
 def _log_phase(phase: object, detail: str = "") -> None:

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -592,7 +592,7 @@ def _run_validate_phase(
             {
                 "phase": "VALIDATE",
                 "iteration": state.dev_iteration,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
             }
         )
     if logger:
@@ -792,7 +792,7 @@ def _run_validate_phase(
             {
                 "phase": "VALIDATE",
                 "iteration": state.dev_iteration,
-                "cost_usd": state.total_cost,
+                "cost_usd": state.total_cost_measured,
                 **_cu.live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),

--- a/src/theforge/detach.py
+++ b/src/theforge/detach.py
@@ -289,6 +289,12 @@ def read_run_status(run_id: str, slug: str, project_root: Path) -> dict:
             content = log_path.read_text(encoding="utf-8", errors="replace")
             for line in reversed(content.splitlines()):
                 if "Total cost:" in line or "total_cost" in line:
+                    # A total rendered as "unknown (>= $X measured)" is a lower
+                    # bound, not the run's cost. Scraping the dollar figure out
+                    # of it would re-present unpriced work as a complete total,
+                    # so the cost stays unknown (#1992).
+                    if "unknown" in line:
+                        break
                     m = re.search(r"\$([0-9]+\.[0-9]+)", line)
                     if m:
                         cost_usd = float(m.group(1))

--- a/src/theforge/ideate.py
+++ b/src/theforge/ideate.py
@@ -48,7 +48,9 @@ class IdeationResult:
     rounds: list[IdeationRound]
     final_synthesis: str  # final synthesized spec text
     residual_divergence: list[str]  # items needing human executive decision
-    total_cost_usd: float
+    # None = at least one contributing agent call's cost was unmeasured; the
+    # ideation total is unknown, not zero (#1992).
+    total_cost_usd: float | None
     human_decision_required: bool
 
 
@@ -364,10 +366,28 @@ def _log(msg: str) -> None:
     print(f"[forge] {msg}", file=sys.stderr, flush=True)
 
 
+def _accumulate_cost(total: float | None, cost: float | None) -> float | None:
+    """Add an optional agent cost to a running ideation total.
+
+    ``None`` means the transport could not measure that call's cost, which is
+    not the same statement as "it was free". Once any contributing call is
+    unmeasured the running total is unknown, so it stays ``None`` rather than
+    silently reporting the measured remainder as the ideation cost (#1992).
+    """
+    if total is None or cost is None:
+        return None
+    return total + cost
+
+
+def _fmt_ideation_cost(total: float | None) -> str:
+    """Render an ideation total as ``$1.23``, or ``unknown`` when unmeasured."""
+    return f"${total:.2f}" if total is not None else "unknown"
+
+
 def _failed_result(
     msg: str,
     rounds: list[IdeationRound],
-    total_cost: float,
+    total_cost: float | None,
 ) -> IdeationResult:
     """Return a failed IdeationResult with an error message in final_synthesis."""
     return IdeationResult(
@@ -386,7 +406,7 @@ def _run_single_model_ideation(
     working_dir: Path,
     config: ForgeConfig,
     brief: str,
-) -> "IdeationResult | tuple[str, list[str], list[IdeationRound], float]":
+) -> "IdeationResult | tuple[str, list[str], list[IdeationRound], float | None]":
     """Single-model fast path: one combined Phase 1 + synthesis call.
 
     Intentional design deviation from the spec's "Phase 1 only" wording:
@@ -402,7 +422,7 @@ def _run_single_model_ideation(
     (final_synthesis, residual_divergence, all_rounds, total_cost) on success.
     """
     all_rounds: list[IdeationRound] = []
-    total_cost = 0.0
+    total_cost: float | None = 0.0
 
     _log(f"▸ IDEATE   {pool[0].name}  round=1")
     _log("  ▸ Phase 1   generating spec (single-model)...")
@@ -416,7 +436,7 @@ def _run_single_model_ideation(
         plain_text=True,
     )
     agent_elapsed = time.monotonic() - agent_start
-    total_cost += result.cost_usd or 0.0
+    total_cost = _accumulate_cost(total_cost, result.cost_usd)
     _log(f"  ↳ {pool[0].name} done ({agent_elapsed:.0f}s)")
     if not result.success:
         _log(f"  ✗ {pool[0].name} failed: {result.output[:120]}")
@@ -470,7 +490,7 @@ def _run_multi_model_ideation(
     brief: str,
     synthesis_profile: object,
     max_rounds: int,
-) -> "IdeationResult | tuple[str, list[str], list[IdeationRound], float]":
+) -> "IdeationResult | tuple[str, list[str], list[IdeationRound], float | None]":
     """Multi-model deliberation: Phase 1 → Phase 2 → Phase 3 → loop.
 
     Returns a failed IdeationResult on error, or
@@ -478,7 +498,7 @@ def _run_multi_model_ideation(
     """
     pool_names = "+".join(p.name for p in pool)
     all_rounds: list[IdeationRound] = []
-    total_cost = 0.0
+    total_cost: float | None = 0.0
     current_brief = brief
     residual_divergence: list[str] = []
     final_synthesis = ""
@@ -508,7 +528,7 @@ def _run_multi_model_ideation(
         # Accumulate all pool costs before checking failures so partial runs
         # are fully accounted for in total_cost_usd.
         for r in p1_results:
-            total_cost += r.cost_usd or 0.0
+            total_cost = _accumulate_cost(total_cost, r.cost_usd)
         failed_p1 = next(
             ((profile, r) for profile, r in zip(pool, p1_results) if not r.success), None
         )
@@ -541,7 +561,7 @@ def _run_multi_model_ideation(
         p2_elapsed = time.monotonic() - p2_start
         # Accumulate all pool costs before checking failures.
         for r in p2_results:
-            total_cost += r.cost_usd or 0.0
+            total_cost = _accumulate_cost(total_cost, r.cost_usd)
         failed_p2 = next(
             ((profile, r) for profile, r in zip(pool, p2_results) if not r.success), None
         )
@@ -574,7 +594,7 @@ def _run_multi_model_ideation(
         )
         synth_elapsed = time.monotonic() - synth_start
         _log(f"  ↳ synthesis done ({synth_elapsed:.0f}s)")
-        total_cost += synth_result.cost_usd or 0.0
+        total_cost = _accumulate_cost(total_cost, synth_result.cost_usd)
 
         if not synth_result.success:
             _log(f"  ✗ synthesis failed: {synth_result.output[:120]}")
@@ -749,7 +769,7 @@ def run_ideation(
     mins, secs = divmod(int(elapsed_total), 60)
     dur_str = f"{mins}m {secs:02d}s" if mins else f"{secs}s"
     spec_label = str(written_path) if written_path else "(no output)"
-    _log(f"✓ IDEATE   story written: {spec_label}  ${total_cost:.2f}  {dur_str}")
+    _log(f"✓ IDEATE   story written: {spec_label}  {_fmt_ideation_cost(total_cost)}  {dur_str}")
     if human_decision_required:
         _log(
             f"⚠ {len(residual_divergence)} item(s) require human decision "

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -207,7 +207,7 @@ class RunOutcome:
     planner_cli: str | None = None
     planner_cost_usd: float | None = None  # None = cost unmeasured
     planner_attempts: list[RoleAttempt] = field(default_factory=list)
-    reviewers: dict[str, tuple[int, int, float]] = field(default_factory=dict)
+    reviewers: dict[str, tuple[int, int, float | None]] = field(default_factory=dict)
     # Every reviewer invocation this run, including failures (#1388). Unlike
     # ``reviewers`` (which is survivorship-biased — only reviewers that returned a
     # parseable verdict appear), this list carries an entry for each attempt so the

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -16,6 +16,31 @@ from .launch_guard import REASON_RECONCILE_PRIOR_DONE, REASON_STRANDED_WORKTREE
 from .manifest import ResolvedSprint, SprintManifest, SprintResult
 
 
+def _optional_cost(value: object) -> float | None:
+    """Round a cost for a sprint record, preserving an unmeasured ``None``.
+
+    A ``None`` cost means the story had at least one phase whose spend the
+    transport could not measure. Rounding it to ``0.0`` would record unpriced
+    work as free in sprint-audit.yaml and sprint-summary.yaml (#1992).
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return round(float(value), 4)
+    return None
+
+
+def _state_reported_cost(state: object) -> float | None:
+    """Per-story cost from a coordinator state, preserving cost-unknown.
+
+    Reads ``total_cost_measured`` — the None-preserving aggregate — so a story
+    with any unmeasured phase is recorded as cost-unknown instead of as the
+    measured remainder. Falls back to ``total_cost`` only for duck-typed states
+    that predate the measured aggregate.
+    """
+    if hasattr(state, "total_cost_measured"):
+        return _optional_cost(state.total_cost_measured)
+    return _optional_cost(getattr(state, "total_cost", None))
+
+
 def _review_usage(state: object) -> tuple[int, int | None, bool]:
     """Return ``(cycles_spent, cycle_cap, budget_exhausted)`` for a story's review budget.
 
@@ -348,7 +373,7 @@ def _load_story_summary_entry_from_audit(
         "outcome": final_phase,
         "outcome_source": outcome_source,
         "verdict": verdict,
-        "cost_usd": round(float(cost_block.get("total_usd", 0.0)), 4)
+        "cost_usd": _optional_cost(cost_block.get("total_usd"))
         if isinstance(cost_block, dict)
         else 0.0,
         "story_run_id": audit_data.get("run_id"),
@@ -547,7 +572,7 @@ def _write_sprint_audit(
                 "path": display_key,
                 "outcome": outcome,
                 "outcome_source": outcome_source,
-                "cost_usd": round(res.state.total_cost, 4),
+                "cost_usd": _state_reported_cost(res.state),
                 "preflight": preflight,
                 "preflight_original_verdict": getattr(
                     res.state, "preflight_cached_original_verdict", None
@@ -608,10 +633,14 @@ def _write_sprint_audit(
             if snapshot:
                 last_cost = snapshot.get("last_cost")
                 if (
-                    not entry.get("cost_usd")
+                    entry.get("cost_usd") is not None
+                    and not entry.get("cost_usd")
                     and isinstance(last_cost, (int, float))
                     and last_cost > 0
                 ):
+                    # Only fills in a genuine zero. A cost-unknown (None) entry
+                    # stays unknown — a live snapshot subtotal is not the
+                    # story's total (#1992).
                     entry["cost_usd"] = round(float(last_cost), 4)
                 last_phase_val = snapshot.get("last_phase")
                 if last_phase_val:
@@ -692,7 +721,15 @@ def _write_sprint_audit(
             "budget_usd": manifest.budget_usd,
             "max_parallel": manifest.max_parallel,
             "sprint_id": sprint_id,
-            "total_cost_usd": round(result.total_cost_usd, 4),
+            # ``None`` when any story's cost was unmeasured: a sprint total over
+            # partially unpriced work is a different statement from a complete
+            # one and must not render as a confident figure (#1992). The measured
+            # lower bound stays available under ``total_cost_measured_usd``.
+            "total_cost_usd": (
+                round(result.total_cost_usd, 4) if getattr(result, "cost_complete", True) else None
+            ),
+            "total_cost_measured_usd": round(result.total_cost_usd, 4),
+            "cost_complete": bool(getattr(result, "cost_complete", True)),
             "budget_note": "Costs reflect Claude invocations only; Codex/Gemini report $0.00",
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -857,7 +894,7 @@ def _write_sprint_summary(
             if outcome == "ALREADY_DONE" and preflight == "ALREADY_DONE":
                 outcome_source = "preflight_verdict"
             _snapshot = live_telemetry_snapshots.get(slug)
-            _entry_cost = round(res.state.total_cost, 4)
+            _entry_cost = _state_reported_cost(res.state)
             _last_phase_val: str | None = None
             if _snapshot:
                 _snap_cost = _snapshot.get("last_cost")
@@ -1049,9 +1086,9 @@ def _write_sprint_summary(
         effective_succeeded = canonical_counts["succeeded"]
         effective_failed = canonical_counts["failed"]
         effective_skipped = canonical_counts["skipped"]
-        effective_cost_usd = round(
-            sum(getattr(e, "cost_usd", 0.0) for e in story_state.stories()), 4
-        )
+        _canonical_costs = [getattr(e, "cost_usd", 0.0) for e in story_state.stories()]
+        effective_cost_complete = all(c is not None for c in _canonical_costs)
+        effective_cost_usd = round(sum(c for c in _canonical_costs if c is not None), 4)
         # Inject any shape-gate-skipped stories (and other canonical-only
         # entries that aren't in canonical_refs) so the summary surfaces them.
         canonical_slugs_in_entries = {e.get("slug") for e in spec_entries if e.get("slug")}
@@ -1078,7 +1115,9 @@ def _write_sprint_summary(
             )
     else:
         effective_specs_total = len(spec_entries)
-        effective_cost_usd = round(sum(e.get("cost_usd", 0.0) for e in spec_entries), 4)
+        _entry_costs = [e.get("cost_usd", 0.0) for e in spec_entries]
+        effective_cost_complete = all(c is not None for c in _entry_costs)
+        effective_cost_usd = round(sum(c for c in _entry_costs if c is not None), 4)
         effective_succeeded = sum(1 for e in spec_entries if e.get("outcome") == "DONE")
         effective_failed = sum(
             1
@@ -1111,7 +1150,12 @@ def _write_sprint_summary(
             "run_id": run_id,
             "sprint_id": sprint_id,
             "run_log": f"run-{run_id}.log" if run_id else None,
-            "total_cost_usd": effective_cost_usd,
+            # Null when any story's cost is unknown; the measured lower bound is
+            # reported separately so an incomplete total is never mistaken for a
+            # complete one (#1992).
+            "total_cost_usd": effective_cost_usd if effective_cost_complete else None,
+            "total_cost_measured_usd": effective_cost_usd,
+            "cost_complete": effective_cost_complete,
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "duration_seconds": round(duration, 1),

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -730,6 +730,11 @@ def _write_sprint_audit(
             ),
             "total_cost_measured_usd": round(result.total_cost_usd, 4),
             "cost_complete": bool(getattr(result, "cost_complete", True)),
+            # Which work is unpriced, not merely that some is — the budget check
+            # refuses on this list, so it must be traceable (#1992).
+            "unmeasured_spend_sources": list(
+                getattr(result, "unmeasured_spend_sources", ()) or []
+            ),
             "budget_note": "Costs reflect Claude invocations only; Codex/Gemini report $0.00",
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -1142,6 +1147,13 @@ def _write_sprint_summary(
         accumulated_for_state,
     )
 
+    # Intake remediation spends the sprint budget outside any story's entry, so
+    # an unmeasured intake pass makes the sprint total incomplete even when every
+    # per-story cost is known (#1992).
+    _unmeasured_sources = list(getattr(result, "unmeasured_spend_sources", ()) or [])
+    if _unmeasured_sources:
+        effective_cost_complete = False
+
     summary = {
         "sprint": {
             "name": manifest.name,
@@ -1156,6 +1168,7 @@ def _write_sprint_summary(
             "total_cost_usd": effective_cost_usd if effective_cost_complete else None,
             "total_cost_measured_usd": effective_cost_usd,
             "cost_complete": effective_cost_complete,
+            "unmeasured_spend_sources": _unmeasured_sources,
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "duration_seconds": round(duration, 1),

--- a/src/theforge/sprint/budget.py
+++ b/src/theforge/sprint/budget.py
@@ -1,0 +1,104 @@
+"""Sprint budget enforcement decisions.
+
+Pure, stdlib-only: given what the sprint has measurably spent and which spend it
+could not measure, decide whether the next story may be dispatched. Extracted
+from ``runner.py`` so the policy is testable without a live sprint.
+
+The load-bearing rule is that a cap can only be enforced against a number that
+means what it says. ``accumulated_cost`` is a sum over measured spend; when a
+transport reports no cost, that story contributes ``0.0`` to the sum while
+having spent an unknown amount. Comparing that understated total against the
+cap would certify a budget the sprint cannot actually show it is within, and
+the understatement correlates with which transport served a story — so the
+error is systematic, not noise (#1992). When any spend is unmeasured the check
+therefore fails closed: it refuses to dispatch further work rather than
+dispatch it against a number it knows is a lower bound.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+#: How many unmeasured sources to name in an operator-facing message before
+#: eliding the rest. The full list lives in the sprint's structured records.
+_MAX_NAMED_SOURCES = 5
+
+
+@dataclass(frozen=True)
+class BudgetBlock:
+    """A decision to stop dispatching, with the operator-facing wording.
+
+    ``kind`` is ``"exhausted"`` (measured spend met or passed the cap) or
+    ``"unverifiable"`` (spend is unknown, so the cap cannot be evaluated).
+    """
+
+    kind: str
+    detail: str
+
+    @property
+    def story_reason(self) -> str:
+        """Reason recorded on each story skipped by this decision."""
+        label = "budget exhausted" if self.kind == "exhausted" else "budget unverifiable"
+        return f"{label} ({self.detail})"
+
+    @property
+    def stopped_reason(self) -> str:
+        """Sprint-level ``stopped_reason`` recorded in the summary and audit."""
+        label = "Budget exhausted" if self.kind == "exhausted" else "Budget unverifiable"
+        return f"{label} ({self.detail})"
+
+    def notification_title(self, sprint_name: str) -> str:
+        label = "budget exceeded" if self.kind == "exhausted" else "budget unverifiable"
+        return f'TheForge: {label} — "{sprint_name}"'
+
+
+def describe_unmeasured_spend(sources: Sequence[str]) -> str:
+    """Render the unmeasured-spend sources for an operator message."""
+    named = list(sources[:_MAX_NAMED_SOURCES])
+    elided = len(sources) - len(named)
+    rendered = ", ".join(named)
+    if elided > 0:
+        rendered = f"{rendered}, +{elided} more"
+    return rendered
+
+
+def evaluate_budget(
+    *,
+    accumulated_cost: float,
+    prior_cost: float,
+    budget_usd: float,
+    unmeasured_spend: Sequence[str],
+) -> BudgetBlock | None:
+    """Return the reason to stop dispatching, or ``None`` to proceed.
+
+    ``unmeasured_spend`` names every source whose spend this sprint could not
+    measure (completed stories, intake remediation passes). It being non-empty
+    means ``accumulated_cost`` is a lower bound.
+
+    Exhaustion is checked first: when the measured lower bound alone already
+    meets the cap, that is a definite answer and stays worded exactly as before,
+    whether or not other spend was unmeasured. Otherwise, unmeasured spend makes
+    the comparison unanswerable and the sprint stops rather than launching more
+    work against a total it knows is understated.
+    """
+    cumulative = prior_cost + accumulated_cost
+    if cumulative >= budget_usd:
+        return BudgetBlock(
+            kind="exhausted",
+            detail=(
+                f"sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} = "
+                f"${cumulative:.2f} >= ${budget_usd:.2f}"
+            ),
+        )
+    if unmeasured_spend:
+        return BudgetBlock(
+            kind="unverifiable",
+            detail=(
+                f"spend unmeasured for {len(unmeasured_spend)} source(s) "
+                f"[{describe_unmeasured_spend(unmeasured_spend)}]; "
+                f"measured ${cumulative:.2f} of ${budget_usd:.2f} cap is a lower bound, "
+                "so the cap cannot be verified"
+            ),
+        )
+    return None

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -60,6 +60,9 @@ class SprintResult:
     specs_skipped: int  # ALREADY_DONE or budget-stopped
     total_cost_usd: float
     budget_usd: float
+    # False when at least one story's cost could not be measured. ``total_cost_usd``
+    # is then only a measured lower bound, not the sprint's cost (#1992).
+    cost_complete: bool = True
     results: list[tuple[str, CoordinatorResult]] = field(default_factory=list)
     stopped_reason: str | None = None  # why sprint stopped early, if it did
 

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -63,6 +63,10 @@ class SprintResult:
     # False when at least one story's cost could not be measured. ``total_cost_usd``
     # is then only a measured lower bound, not the sprint's cost (#1992).
     cost_complete: bool = True
+    # Every spend source this sprint could not measure (story slugs, intake
+    # passes). Recorded so an operator can trace WHICH work is unpriced rather
+    # than only that the total is incomplete.
+    unmeasured_spend_sources: tuple[str, ...] = ()
     results: list[tuple[str, CoordinatorResult]] = field(default_factory=list)
     stopped_reason: str | None = None  # why sprint stopped early, if it did
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -38,6 +38,7 @@ from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
 from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from ..coordinator.util import (
+    _fmt_cost_total,
     _fmt_duration,
     _generate_run_id,
     resolve_timeout,
@@ -626,6 +627,34 @@ def emit_inline_remediation_event(
         logger.warning(msg)
 
 
+def _optional_cost(raw: object) -> float | None:
+    """Coerce a persisted ``cost_usd`` to float, preserving an unmeasured ``None``.
+
+    ``None`` records "the transport could not measure this spend", which is a
+    different fact from ``0.0``. Numeric arithmetic (budget checks, carry-forward
+    sums) may treat unknown as a zero-valued lower bound, but anything that
+    *reports* a story's cost must keep the distinction (#1992).
+    """
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return float(raw)
+    return None
+
+
+def _story_reported_cost(state: object, adjustment: float = 0.0) -> float | None:
+    """Per-story reported cost: measured total plus adjustment, or ``None``.
+
+    Uses ``CoordinatorState.total_cost_measured`` so a story with any unmeasured
+    phase is reported as cost-unknown instead of as the measured remainder.
+    """
+    if hasattr(state, "total_cost_measured"):
+        measured = state.total_cost_measured
+    else:
+        measured = getattr(state, "total_cost", None)
+    if not isinstance(measured, (int, float)) or isinstance(measured, bool):
+        return None
+    return round(float(measured) + adjustment, 4)
+
+
 def _intake_outcome_cost(outcome: IntakeOutcome) -> float:
     """Return the agent cost recorded in an intake outcome's audit block.
 
@@ -795,7 +824,13 @@ def derive_worker_timeout(
 
 
 def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
-    """Read carry-forward cost for a same-sprint re-exec from sprint-audit.yaml."""
+    """Read carry-forward cost for a same-sprint re-exec from sprint-audit.yaml.
+
+    ``total_cost_usd`` is null when the prior generation had a story whose cost
+    was unmeasured (#1992). Carry-forward is arithmetic, so it falls back to the
+    measured lower bound rather than dropping the prior spend entirely — the
+    cost-unknown signal itself is carried by the per-story entries.
+    """
     if not sprint_id or not os.environ.get("FORGE_PREV_RUN_ID"):
         return 0.0
     audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
@@ -807,7 +842,10 @@ def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
         sprint_block = data.get("sprint", {})
         if sprint_block.get("sprint_id") != sprint_id:
             return 0.0
-        return float(sprint_block.get("total_cost_usd", 0.0))
+        total = sprint_block.get("total_cost_usd")
+        if total is None:
+            total = sprint_block.get("total_cost_measured_usd", 0.0)
+        return float(total or 0.0)
     except (OSError, ValueError, TypeError):
         return 0.0
 
@@ -2111,7 +2149,7 @@ def _classify_and_record(
         dag.mark_skipped(task.slug)
 
     if story_state is not None:
-        _transition_fields: dict = {"cost_usd": result.state.total_cost}
+        _transition_fields: dict = {"cost_usd": _story_reported_cost(result.state)}
         if is_landed:
             _transition_fields["landed"] = True
         story_state.transition(task.slug, outcome=outcome, **_transition_fields)
@@ -2588,7 +2626,7 @@ def run_sprint(
                 _prior_slug,
                 _prior.get("path", _prior_slug),
                 outcome=_mapped_outcome,
-                cost_usd=float(_prior.get("cost_usd", 0.0) or 0.0),
+                cost_usd=_optional_cost(_prior.get("cost_usd")),
                 canonical_ref=_prior.get("canonical_ref"),
                 detail=_prior_detail,
             )
@@ -2750,10 +2788,7 @@ def run_sprint(
             "outcome": outcome,
             "outcome_source": outcome_source,
             "verdict": None,
-            "cost_usd": round(
-                float(result.state.total_cost) + story_cost_adjustments.get(slug, 0.0),
-                4,
-            ),
+            "cost_usd": _story_reported_cost(result.state, story_cost_adjustments.get(slug, 0.0)),
             "story_run_id": run_id,
             "preflight": preflight,
             "preflight_original_verdict": getattr(
@@ -3202,7 +3237,7 @@ def run_sprint(
                 "outcome": "ALREADY_DONE",
                 "outcome_source": "resume_skip_merged",
                 "verdict": prior_entry.get("verdict"),
-                "cost_usd": float(prior_entry.get("cost_usd", 0.0) or 0.0),
+                "cost_usd": _optional_cost(prior_entry.get("cost_usd")),
                 "story_run_id": prior_entry.get("story_run_id", run_id),
                 "preflight": prior_entry.get("preflight"),
                 "preflight_original_verdict": prior_entry.get("preflight_original_verdict"),
@@ -4103,10 +4138,12 @@ def run_sprint(
                 spec_str = slug_to_spec[slug]
                 results.append((spec_str, result))
 
-                spec_cost = result.state.total_cost
+                spec_cost = result.state.total_cost_measured
                 icon = "✓" if result.success else "✗"
                 dur = _fmt_duration(elapsed)
-                _log(f"{icon} {slug}   ${spec_cost:.2f}  {dur}")
+                _log(
+                    f"{icon} {slug}   {_fmt_cost_total(spec_cost, result.state.total_cost)}  {dur}"
+                )
 
                 # Auth circuit breaker (#1952): the launch gate proves the
                 # credential was usable at t=0, but an interactive sign-in can
@@ -4184,7 +4221,7 @@ def run_sprint(
                         slug,
                         status=_done_status,
                         phase=result.phase.name,
-                        cost_usd=result.state.total_cost,
+                        cost_usd=_story_reported_cost(result.state),
                     )
 
                 _classify_outcome = _classify_and_record(
@@ -4193,7 +4230,7 @@ def run_sprint(
                 _terminal_model = _terminal_story_model(result)
                 _outcome_fields: dict[str, object] = {
                     "phase": result.phase.name,
-                    "cost_usd": result.state.total_cost,
+                    "cost_usd": _story_reported_cost(result.state),
                 }
                 if _terminal_model is not None:
                     _outcome_fields["current_model"] = _terminal_model
@@ -4346,6 +4383,10 @@ def run_sprint(
         entry = _story_state.get(slug)
         if entry is None:
             return
+        if entry.cost_usd is None:
+            # Unknown + known is still unknown: adding measured intake spend to a
+            # cost-unknown story must not turn it into a confident figure (#1992).
+            return
         _story_state.transition(slug, cost_usd=entry.cost_usd + extra)
 
     for _slug, _outcome in (intake_outcomes or {}).items():
@@ -4376,6 +4417,11 @@ def run_sprint(
         )
 
     final_cost = accumulated_cost + prior_cost
+    # A sprint total is only a total when every story's cost was measured. When
+    # any story ran on a transport that reported no cost, ``final_cost`` is a
+    # measured lower bound and every surface must say so rather than present it
+    # as the sprint's cost (#1992).
+    _cost_complete = all(e.cost_usd is not None for e in _story_state.stories())
     # Banner, summary, notifications, and SprintResult all project from the
     # same canonical structure — by construction they cannot disagree.
     _canonical_counts = _story_state.counts()
@@ -4394,21 +4440,26 @@ def run_sprint(
         specs_skipped=specs_skipped,
         total_cost_usd=final_cost,
         budget_usd=resolved.budget_usd,
+        cost_complete=_cost_complete,
         results=results,
         stopped_reason=stopped_reason,
     )
 
     _sprint_elapsed = (datetime.datetime.now(datetime.timezone.utc) - started_at).total_seconds()
     _sprint_dur = _fmt_duration(_sprint_elapsed)
+    _sprint_cost_str = _fmt_cost_total(final_cost if _cost_complete else None, final_cost)
     _log(
         f"Sprint complete: {specs_succeeded} succeeded, {specs_failed} failed, "
-        f"{specs_skipped} skipped. Total: ${final_cost:.2f}  {_sprint_dur}"
+        f"{specs_skipped} skipped. "
+        f"Total: {_sprint_cost_str}"
+        f"  {_sprint_dur}"
     )
     _sprint_outcome = "done" if specs_failed == 0 and stopped_reason is None else "partial"
     _sprint_logger.emit(
         "run_end",
         outcome=_sprint_outcome,
-        total_cost_usd=round(final_cost, 6),
+        total_cost_usd=round(final_cost, 6) if _cost_complete else None,
+        total_cost_measured_usd=round(final_cost, 6),
         total_duration_s=round(_sprint_elapsed, 2),
     )
     if notify:
@@ -4429,7 +4480,7 @@ def run_sprint(
                     f"{canonical_total} stories: {specs_succeeded} succeeded "
                     f"\u00b7 {specs_failed} failed \u00b7 {specs_skipped} skipped"
                 ),
-                f"Total cost: ${final_cost:.2f}   Duration: {_sprint_dur}",
+                f"Total cost: {_sprint_cost_str}   Duration: {_sprint_dur}",
             ]
             if stopped_reason:
                 _ntfy_body_lines.append(f"Stopped: {stopped_reason}")
@@ -4448,7 +4499,7 @@ def run_sprint(
                     f"{canonical_total} stories: {specs_succeeded} succeeded "
                     f"\u00b7 {specs_failed} failed \u00b7 {specs_skipped} skipped"
                 ),
-                f"Total cost: ${final_cost:.2f}   Duration: {_fmt_duration(_sprint_elapsed)}",
+                f"Total cost: {_sprint_cost_str}   Duration: {_fmt_duration(_sprint_elapsed)}",
             ]
             if stopped_reason:
                 _sc_body_lines.append(f"Stopped: {stopped_reason}")
@@ -4581,7 +4632,7 @@ def run_sprint(
             stories=_stories,
             run_id=_sprint_run_id,
             config=config,
-            total_cost_usd=final_cost,
+            total_cost_usd=final_cost if _cost_complete else None,
             duration_seconds=_sprint_elapsed,
         )
         _run_hook(

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -62,6 +62,7 @@ from .audit import (
     persist_accumulated_story_state,
 )
 from .auth_gate import enforce_sprint_auth_readiness
+from .budget import evaluate_budget
 from .ci_checks import failing_required_pr_checks, poll_required_checks
 from .collision import (
     compute_bundle_assignments,
@@ -662,16 +663,27 @@ def _intake_outcome_cost(outcome: IntakeOutcome) -> float:
     outside CoordinatorState.total_cost. Sprint cost rollups must consult
     this seam so reported sprint totals reflect actual spend.
     """
+    return _intake_outcome_cost_measured(outcome) or 0.0
+
+
+def _intake_outcome_cost_measured(outcome: IntakeOutcome) -> float | None:
+    """Intake agent cost, or ``None`` when an agent ran without reporting cost.
+
+    ``attempted`` is what separates "no agent ran, so genuinely free" from "an
+    agent ran on a transport that reported no cost". Only the latter is
+    cost-unknown; collapsing it to ``0.0`` would let unpriced intake spend pass
+    the sprint budget check as if it were free (#1992).
+    """
     agent = outcome.audit.get("agent") if isinstance(outcome.audit, dict) else None
     if not isinstance(agent, dict):
         return 0.0
     raw = agent.get("cost_usd")
     if raw is None:
-        return 0.0
+        return None if agent.get("attempted") else 0.0
     try:
         return float(raw)
     except (TypeError, ValueError):
-        return 0.0
+        return None
 
 
 def _intake_finding_codes(outcome: IntakeOutcome) -> list[str]:
@@ -848,6 +860,32 @@ def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
         return float(total or 0.0)
     except (OSError, ValueError, TypeError):
         return 0.0
+
+
+def _prior_sprint_cost_incomplete(project_root: Path, sprint_id: str | None) -> bool:
+    """Return True when the prior generation recorded an incomplete sprint cost.
+
+    A carried total from a generation that could not measure all of its spend is
+    itself a lower bound; the budget check must know that before enforcing a cap
+    against it (#1992). Absent/unreadable records report False — the pre-#1992
+    shape simply carries no completeness claim.
+    """
+    if not sprint_id:
+        return False
+    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
+    if not audit_path.exists():
+        return False
+    try:
+        with open(audit_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        sprint_block = data.get("sprint", {})
+        if not isinstance(sprint_block, dict):
+            return False
+        if sprint_block.get("sprint_id") != sprint_id:
+            return False
+        return sprint_block.get("cost_complete") is False
+    except (OSError, yaml.YAMLError, AttributeError):
+        return False
 
 
 def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
@@ -2505,10 +2543,21 @@ def run_sprint(
 
     started_at = datetime.datetime.now(datetime.timezone.utc)
     accumulated_cost = 0.0
+    # Every source of spend this sprint could not measure, in the order it was
+    # discovered ("issue-1945" for a story, "intake:issue-1946" for a
+    # remediation pass, "carried:..." for spend inherited on resume). While this is
+    # non-empty, ``accumulated_cost`` is a measured LOWER BOUND, not the
+    # sprint's spend — the budget check must refuse to certify a cap it cannot
+    # evaluate rather than dispatch more work against an understated total
+    # (#1992). Guarded by ``cost_lock`` alongside ``accumulated_cost``.
+    unmeasured_spend: list[str] = []
     # Entry-level intake remediation runs in the CLI before run_sprint and
     # spends the same sprint-authorized budget; fold its agent cost into
     # the sprint total so operator-visible accounting matches actual spend.
     if entry_intake_outcomes:
+        for _issue_num, _entry_outcome in entry_intake_outcomes.items():
+            if _intake_outcome_cost_measured(_entry_outcome) is None:
+                unmeasured_spend.append(f"entry-intake:issue-{_issue_num}")
         _entry_intake_cost = sum(_intake_outcome_cost(o) for o in entry_intake_outcomes.values())
         if _entry_intake_cost > 0.0:
             accumulated_cost += _entry_intake_cost
@@ -2581,6 +2630,12 @@ def run_sprint(
             _prior_slug = _prior.get("slug")
             if not _prior_slug:
                 continue
+            # An earlier generation's unpriced story is still unpriced spend
+            # this sprint carries. Without re-flagging it here, a --resume would
+            # start with an empty ledger and enforce the cap against a carried
+            # lower bound as if it were complete (#1992).
+            if "cost_usd" in _prior and _prior.get("cost_usd") is None:
+                unmeasured_spend.append(f"carried:{_prior_slug}")
             _prior_outcome = (_prior.get("outcome") or "").upper()
             if _prior_slug in _current_run_slugs and _prior_outcome not in _succeeded_outcomes:
                 _defer_prior_cost(_prior_slug, _prior)
@@ -2675,6 +2730,10 @@ def run_sprint(
         )
         if prior_cost > 0.0:
             _log(f"Resuming with prior cost: ${prior_cost:.2f}")
+        if _prior_sprint_cost_incomplete(config.project_root, _sprint_id):
+            # The carried total came from a generation that recorded incomplete
+            # cost, so it is a lower bound too (#1992).
+            unmeasured_spend.append("carried:prior-generation")
         if recovered_prior_started_at is not None and recovered_prior_started_at < started_at:
             started_at = recovered_prior_started_at
         _log("Triaging specs...")
@@ -2906,6 +2965,9 @@ def run_sprint(
     # Intake remediation agent spend (auto_fix LLM rewrites) must roll up
     # into the sprint total. Without this, sprint.total_cost_usd silently
     # excludes every dollar spent on intake auto-fix attempts.
+    for _intake_slug, _intake_outcome in intake_outcomes.items():
+        if _intake_outcome_cost_measured(_intake_outcome) is None:
+            unmeasured_spend.append(f"intake:{_intake_slug}")
     _intake_remediation_cost = sum(_intake_outcome_cost(o) for o in intake_outcomes.values())
     if _intake_remediation_cost > 0.0:
         accumulated_cost += _intake_remediation_cost
@@ -3713,28 +3775,25 @@ def run_sprint(
                     break
 
                 with cost_lock:
-                    cumulative = prior_cost + accumulated_cost
-                if cumulative >= resolved.budget_usd:
-                    dag.mark_skipped(task.slug)
-                    _budget_reason = (
-                        "budget exhausted "
-                        f"(sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} = "
-                        f"${cumulative:.2f} >= ${resolved.budget_usd:.2f})"
+                    _budget_decision = evaluate_budget(
+                        accumulated_cost=accumulated_cost,
+                        prior_cost=prior_cost,
+                        budget_usd=resolved.budget_usd,
+                        unmeasured_spend=list(unmeasured_spend),
                     )
+                if _budget_decision is not None:
+                    dag.mark_skipped(task.slug)
+                    _budget_reason = _budget_decision.story_reason
                     _set_outcome(task.slug, StoryOutcome.SKIPPED, reason=_budget_reason)
                     if stopped_reason is None:
-                        _budget_math = (
-                            f"sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} = "
-                            f"${cumulative:.2f} >= ${resolved.budget_usd:.2f}"
-                        )
-                        stopped_reason = f"Budget exhausted ({_budget_math})"
+                        stopped_reason = _budget_decision.stopped_reason
                         if notify and config.notifications.backend not in ("ntfy", "none"):
                             from ..notify_backends import send_notifications
 
                             send_notifications(
                                 config,
-                                f'TheForge: budget exceeded \u2014 "{resolved.name}"',
-                                f"{_budget_math} \u2014 remaining stories skipped",
+                                _budget_decision.notification_title(resolved.name),
+                                f"{_budget_decision.detail} \u2014 remaining stories skipped",
                             )
                     _log(f"SKIPPED {task.slug} ({_budget_reason})")
                     _record_current_story_entry(task.slug, "SKIPPED", error=_budget_reason)
@@ -4133,6 +4192,11 @@ def run_sprint(
                 story_times[slug] = (t0, t1)
 
                 with cost_lock:
+                    # The budget can only ever be enforced against measured
+                    # spend. Record the shortfall alongside it so the dispatch
+                    # check knows the running total is a lower bound (#1992).
+                    if result.state.total_cost_measured is None:
+                        unmeasured_spend.append(slug)
                     accumulated_cost += result.state.total_cost
 
                 spec_str = slug_to_spec[slug]
@@ -4420,8 +4484,11 @@ def run_sprint(
     # A sprint total is only a total when every story's cost was measured. When
     # any story ran on a transport that reported no cost, ``final_cost`` is a
     # measured lower bound and every surface must say so rather than present it
-    # as the sprint's cost (#1992).
-    _cost_complete = all(e.cost_usd is not None for e in _story_state.stories())
+    # as the sprint's cost (#1992). Intake remediation spends the same budget
+    # outside any story's CoordinatorState, so its unmeasured passes count too.
+    _cost_complete = not unmeasured_spend and all(
+        e.cost_usd is not None for e in _story_state.stories()
+    )
     # Banner, summary, notifications, and SprintResult all project from the
     # same canonical structure — by construction they cannot disagree.
     _canonical_counts = _story_state.counts()
@@ -4441,6 +4508,7 @@ def run_sprint(
         total_cost_usd=final_cost,
         budget_usd=resolved.budget_usd,
         cost_complete=_cost_complete,
+        unmeasured_spend_sources=tuple(unmeasured_spend),
         results=results,
         stopped_reason=stopped_reason,
     )

--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -81,7 +81,7 @@ class SprintStateWriter:
                     story.get("path", slug),
                     outcome=story.get("status") or story.get("outcome") or "waiting",
                     phase=story.get("phase"),
-                    cost_usd=float(story.get("cost_usd", 0.0) or 0.0),
+                    cost_usd=_story_cost(story),
                     bundle_candidate=bool(story.get("bundle_candidate", False)),
                     blocked_by=list(story.get("blocked_by") or []),
                     complexity=story.get("complexity"),
@@ -186,6 +186,19 @@ class SprintStateWriter:
                 pass
 
 
+def _story_cost(story: dict) -> float | None:
+    """Read a story dict's ``cost_usd``, preserving an unmeasured ``None``.
+
+    ``None`` means the transport could not measure that story's spend. Coercing
+    it to 0.0 here would report unpriced work as free on every surface that
+    reads the live state file (#1992).
+    """
+    raw = story.get("cost_usd", 0.0)
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return float(raw)
+    return None if raw is None else 0.0
+
+
 def _load_existing_state(state_path: Path) -> dict | None:
     """Read an existing state file when possible."""
     if not state_path.exists():
@@ -223,7 +236,11 @@ def _has_accumulated_live_state(data: dict | None) -> bool:
         outcome = story.get("outcome", story.get("status"))
         if outcome not in seed_outcomes:
             return True
-        if float(story.get("cost_usd", 0.0) or 0.0) > 0.0:
+        _cost = story.get("cost_usd")
+        if _cost is None and "cost_usd" in story:
+            # Cost-unknown is recorded spend the seed file never has.
+            return True
+        if isinstance(_cost, (int, float)) and float(_cost) > 0.0:
             return True
     return False
 

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -19,7 +19,8 @@ class StoryStatusEntry:
     path: str
     status: str  # "done" | "running" | "waiting" | "blocked" | "failed" | "skipped"
     phase: str | None
-    cost_usd: float
+    # None = the story's cost could not be measured (unknown, not zero) (#1992).
+    cost_usd: float | None
     blocked_by: list[str] = field(default_factory=list)
     bundle_candidate: bool = False
     elapsed_seconds: float | None = None
@@ -187,6 +188,18 @@ def _already_done_detail(outcome_source: object, reason: str | None = None) -> s
     if reason:
         return f"Preflight verdict: {reason}"
     return "ALREADY_DONE"
+
+
+def _story_cost_usd(story: dict) -> float | None:
+    """Read a story row's ``cost_usd``, preserving an unmeasured ``None``.
+
+    ``None`` means at least one phase's spend was never measured. Rendering it
+    as ``$0.00`` would present unpriced work as free (#1992).
+    """
+    raw = story.get("cost_usd", 0.0)
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return float(raw)
+    return None
 
 
 def _outcome_to_status(outcome: str) -> str:
@@ -784,7 +797,7 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
         slug = story.get("slug", "")
         path = story.get("path", slug)
         outcome = story.get("outcome", "SKIPPED")
-        cost_usd = float(story.get("cost_usd", 0.0))
+        cost_usd = _story_cost_usd(story)
 
         status = _outcome_to_status(outcome)
         phase = _terminal_phase(
@@ -937,7 +950,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                 path=story.get("path", slug),
                 status=status_val,
                 phase=phase_display,
-                cost_usd=float(story.get("cost_usd", 0.0)),
+                cost_usd=_story_cost_usd(story),
                 blocked_by=blocked_by_val,
                 bundle_candidate=bool(story.get("bundle_candidate", False)),
                 elapsed_seconds=_elapsed_seconds_from_live_story(story),
@@ -975,7 +988,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                         depends_on,
                         _nonempty_str(story.get("last_phase")),
                     ),
-                    cost_usd=float(story.get("cost_usd", 0.0)),
+                    cost_usd=_story_cost_usd(story),
                     blocked_by=depends_on,
                     bundle_candidate=False,
                     elapsed_seconds=_elapsed_seconds_from_bounds(

--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -203,7 +203,9 @@ class StoryStateEntry:
     path: str
     outcome: StoryOutcome = StoryOutcome.WAITING
     phase: str | None = None
-    cost_usd: float = 0.0
+    # None = at least one contributing phase's cost was unmeasured, so this
+    # story's cost is unknown — never coerce it to 0.0 (#1992).
+    cost_usd: float | None = 0.0
     bundle_candidate: bool = False
     blocked_by: list[str] = field(default_factory=list)
     complexity: str | None = None
@@ -292,7 +294,7 @@ class SprintStoryState:
         *,
         outcome: StoryOutcome | str = StoryOutcome.WAITING,
         phase: str | None = None,
-        cost_usd: float = 0.0,
+        cost_usd: float | None = 0.0,
         bundle_candidate: bool = False,
         blocked_by: list[str] | None = None,
         complexity: str | None = None,
@@ -318,7 +320,12 @@ class SprintStoryState:
             entry.path = path
             if phase is not None:
                 entry.phase = phase
-            entry.cost_usd = cost_usd if cost_usd else entry.cost_usd
+            if cost_usd is None:
+                # Cost-unknown is a real state, not a missing value: it must not
+                # be silently replaced by a previously recorded number.
+                entry.cost_usd = None
+            elif cost_usd:
+                entry.cost_usd = cost_usd
             entry.bundle_candidate = bundle_candidate
             if blocked_by is not None:
                 entry.blocked_by = list(blocked_by)
@@ -391,8 +398,11 @@ class SprintStoryState:
             for k, v in fields.items():
                 if k == "phase" and isinstance(v, (str, type(None))):
                     entry.phase = v  # type: ignore[assignment]
-                elif k == "cost_usd" and isinstance(v, (int, float)):
-                    entry.cost_usd = float(v)
+                elif k == "cost_usd":
+                    if isinstance(v, (int, float)) and not isinstance(v, bool):
+                        entry.cost_usd = float(v)
+                    elif v is None:
+                        entry.cost_usd = None
                 elif k == "blocked_by" and isinstance(v, list):
                     entry.blocked_by = list(v)
                 elif k == "complexity":
@@ -466,7 +476,12 @@ class SprintStoryState:
                 d.get("path", slug),
                 outcome=d.get("outcome") or d.get("status") or "waiting",
                 phase=d.get("phase"),
-                cost_usd=float(d.get("cost_usd", 0.0)),
+                cost_usd=(
+                    float(d["cost_usd"])
+                    if isinstance(d.get("cost_usd"), (int, float))
+                    and not isinstance(d.get("cost_usd"), bool)
+                    else (0.0 if "cost_usd" not in d else None)
+                ),
                 bundle_candidate=bool(d.get("bundle_candidate", False)),
                 blocked_by=list(d.get("blocked_by") or []),
                 complexity=d.get("complexity"),

--- a/tests/test_coord_merge_pr.py
+++ b/tests/test_coord_merge_pr.py
@@ -147,6 +147,7 @@ class TestMergePrFunction:
 
         state = MagicMock()
         state.total_cost = 1.5
+        state.total_cost_measured = 1.5
         state.dev_iteration = 1
         state.cycle_history = []
         state.cycle_history_total = 0
@@ -260,6 +261,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         calls: list[list[str]] = []
@@ -326,6 +328,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         current_head = "newnewnewnewnewnewnewnewnewnewnewnewnewn"
@@ -399,6 +402,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         call_counts = {"fetch": 0, "rebase": 0, "push": 0}
@@ -457,6 +461,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         call_counts = {"fetch": 0, "rebase": 0, "push": 0, "merge": 0}
@@ -519,6 +524,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         arming_stderr = (
@@ -560,6 +566,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         def _fake_run(cmd, **kwargs):
@@ -592,6 +599,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         call_counts = {"fetch": 0, "rebase": 0, "push": 0, "merge": 0}
@@ -643,6 +651,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         gh_calls: list[list[str]] = []
@@ -681,6 +690,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         gh_calls: list[list[str]] = []
@@ -715,6 +725,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         gh_calls: list[list[str]] = []
@@ -749,6 +760,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         commands: list[list[str]] = []
@@ -796,6 +808,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         commands: list[list[str]] = []
@@ -834,6 +847,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         def _fake_run(cmd, **kwargs):
@@ -870,6 +884,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         def _fake_run(cmd, **kwargs):
@@ -916,6 +931,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         gh_calls: list[list[str]] = []
@@ -951,6 +967,7 @@ class TestMergePrFunction:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         merge_cwds: list[Path] = []
@@ -1410,6 +1427,7 @@ class TestPrBodyContent:
         )
         state = MagicMock()
         state.total_cost = 2.75
+        state.total_cost_measured = 2.75
         state.dev_iteration = 3
 
         pr_bodies: list[str] = []
@@ -1458,6 +1476,7 @@ class TestPrBodyContent:
         )
         state = MagicMock()
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         pr_bodies: list[str] = []
@@ -1504,6 +1523,7 @@ class TestCreatePrReopenedBranch:
         review = _make_review_result()
         state = MagicMock()
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         current_head = "newnewnewnewnewnewnewnewnewnewnewnewnewn"
@@ -1560,6 +1580,7 @@ class TestCreatePrReopenedBranch:
         review = _make_review_result()
         state = MagicMock()
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         head_sha = "abc1234abc1234abc1234abc1234abc1234abc1"
@@ -1701,6 +1722,7 @@ class TestFastForwardAfterMerge:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         ff_calls: list[list[str]] = []
@@ -1755,6 +1777,7 @@ class TestFastForwardAfterMerge:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         cleanup_calls: list[list[str]] = []
@@ -1798,6 +1821,7 @@ class TestFastForwardAfterMerge:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         ff_calls: list[list[str]] = []
@@ -1848,6 +1872,7 @@ class TestFastForwardAfterMerge:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         cleanup_calls: list[list[str]] = []
@@ -1907,6 +1932,7 @@ class TestFastForwardAfterMerge:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         def _fake_run(cmd, **kwargs):
@@ -1962,6 +1988,7 @@ class TestFastForwardAfterMerge:
         state = MagicMock()
         state.review_results = [review]
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
 
         def _fake_run(cmd, **kwargs):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -338,6 +338,7 @@ def test_state_update_fn_called_in_run_sprint(tmp_path: Path) -> None:
     mock_result = MagicMock()
     mock_result.success = True
     mock_result.state.total_cost = 0.0
+    mock_result.state.total_cost_measured = 0.0
     mock_result.state.preflight_verdict = None
     mock_result.state.log_dir = None
     mock_result.state.review_cycle_metadata = []

--- a/tests/test_ideate_flow.py
+++ b/tests/test_ideate_flow.py
@@ -805,7 +805,12 @@ test_target: tests/
 
 
 def test_none_cost_usd_does_not_crash_accumulation(tmp_path: Path) -> None:
-    """cost_usd=None from a pool agent must not crash total_cost accumulation."""
+    """cost_usd=None from a pool agent makes the ideation total cost-unknown.
+
+    Contract change (#1992): an unmeasured agent cost is no longer coerced to
+    $0.00. The run still completes, but its total is reported as unknown rather
+    than as the measured remainder of the other calls.
+    """
     config = _make_config(tmp_path, [_REVIEWER_A, _REVIEWER_B], _SYNTH_PROFILE)
 
     def pool_with_none_cost(*, prompt, profiles, working_dir, **kwargs):
@@ -828,8 +833,8 @@ def test_none_cost_usd_does_not_crash_accumulation(tmp_path: Path) -> None:
     ):
         result = run_ideation(config, "Build a feature", None, max_rounds=1)
 
-    assert result.total_cost_usd is not None
-    assert result.total_cost_usd >= 0.0
+    assert result.success
+    assert result.total_cost_usd is None
 
 
 def test_plain_text_forwarded_to_run_agent_pool(tmp_path: Path) -> None:

--- a/tests/test_notify_backends.py
+++ b/tests/test_notify_backends.py
@@ -305,6 +305,7 @@ def test_escalate_notify_calls_send_notifications_when_ntfy_is_none():
     state = MagicMock()
     state.review_cycle = 2
     state.total_cost = 1.50
+    state.total_cost_measured = 1.50
     state.error = "Too many cycles"
     state.branch_name = "feat/test"
     state.started_at = None

--- a/tests/test_operator_action_lifecycle.py
+++ b/tests/test_operator_action_lifecycle.py
@@ -99,6 +99,7 @@ def _capture_pr_body(config, task) -> str:
     review = _make_review_result()
     state = MagicMock()
     state.total_cost = 1.0
+    state.total_cost_measured = 1.0
     state.dev_iteration = 1
 
     bodies: list[str] = []
@@ -162,6 +163,7 @@ class TestNoAutoCloseForOperatorAction:
         review = _make_review_result()
         state = MagicMock()
         state.total_cost = 1.0
+        state.total_cost_measured = 1.0
         state.dev_iteration = 1
         bodies: list[str] = []
 

--- a/tests/test_unmeasured_cost_reporting.py
+++ b/tests/test_unmeasured_cost_reporting.py
@@ -525,3 +525,274 @@ class TestPullRequestBody:
         state.dev_durations.append(10.0)
         body = self._capture_pr_body(tmp_path, state)
         assert "- **Cost:** $0.50" in body
+
+
+class TestBudgetEnforcement:
+    """The cap can only be enforced against a number that means what it says.
+
+    ``accumulated_cost`` sums measured spend, so a story whose transport
+    reported no cost contributes ``0.0`` while having spent an unknown amount.
+    Comparing that understated total against the cap would certify a budget the
+    sprint cannot show it is within, so the check fails closed instead (#1992).
+    """
+
+    def test_measured_spend_under_cap_dispatches(self) -> None:
+        from theforge.sprint.budget import evaluate_budget
+
+        assert (
+            evaluate_budget(
+                accumulated_cost=1.0,
+                prior_cost=0.5,
+                budget_usd=10.0,
+                unmeasured_spend=[],
+            )
+            is None
+        )
+
+    def test_measured_spend_over_cap_still_reports_exhausted(self) -> None:
+        from theforge.sprint.budget import evaluate_budget
+
+        block = evaluate_budget(
+            accumulated_cost=0.0,
+            prior_cost=6.0,
+            budget_usd=5.0,
+            unmeasured_spend=[],
+        )
+        assert block is not None
+        assert block.kind == "exhausted"
+        # Wording is load-bearing for existing operator surfaces and tests.
+        assert block.stopped_reason == (
+            "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
+
+    def test_exhaustion_wins_over_unverifiable(self) -> None:
+        """A definite over-cap answer stays definite even with unmeasured spend."""
+        from theforge.sprint.budget import evaluate_budget
+
+        block = evaluate_budget(
+            accumulated_cost=6.0,
+            prior_cost=0.0,
+            budget_usd=5.0,
+            unmeasured_spend=["issue-1945"],
+        )
+        assert block is not None
+        assert block.kind == "exhausted"
+
+    def test_unmeasured_spend_under_cap_blocks_dispatch(self) -> None:
+        from theforge.sprint.budget import evaluate_budget
+
+        block = evaluate_budget(
+            accumulated_cost=MEASURED_REVIEW_COST,
+            prior_cost=0.0,
+            budget_usd=10.0,
+            unmeasured_spend=["issue-1945"],
+        )
+        assert block is not None
+        assert block.kind == "unverifiable"
+        assert "issue-1945" in block.story_reason
+        assert "lower bound" in block.story_reason
+        assert block.stopped_reason.startswith("Budget unverifiable")
+
+    def test_unmeasured_source_list_is_elided_not_dropped(self) -> None:
+        from theforge.sprint.budget import describe_unmeasured_spend
+
+        rendered = describe_unmeasured_spend([f"issue-{n}" for n in range(8)])
+        assert rendered.startswith("issue-0, issue-1")
+        assert "+3 more" in rendered
+
+    def test_intake_agent_without_reported_cost_is_unmeasured_not_free(self) -> None:
+        """An intake auto-fix that ran on an unpriced transport is not free."""
+        from theforge.sprint.runner import _intake_outcome_cost, _intake_outcome_cost_measured
+
+        class _Outcome:
+            def __init__(self, agent: dict) -> None:
+                self.audit = {"agent": agent}
+
+        attempted_unpriced = _Outcome({"attempted": True, "cost_usd": None})
+        assert _intake_outcome_cost_measured(attempted_unpriced) is None
+        # The numeric accessor still yields a usable lower bound for rollups.
+        assert _intake_outcome_cost(attempted_unpriced) == 0.0
+
+        never_ran = _Outcome({"attempted": False, "cost_usd": None})
+        assert _intake_outcome_cost_measured(never_ran) == 0.0
+
+        priced = _Outcome({"attempted": True, "cost_usd": 0.25})
+        assert _intake_outcome_cost_measured(priced) == 0.25
+
+
+class TestBudgetEnforcementSeam:
+    """End-to-end: an unmeasured story must stop the sprint dispatching more."""
+
+    @staticmethod
+    def _unmeasured_dev_result():
+        from theforge.coordinator.state import CoordinatorResult as _CR
+        from theforge.coordinator.state import CoordinatorState as _CS
+
+        state = _CS()
+        state.preflight_verdict = "PROCEED"
+        state.dev_results.append(_agent_result(None, profile_name="codex-dev"))
+        state.dev_durations.append(60.0)
+        state.review_agent_results.append(
+            _agent_result(MEASURED_REVIEW_COST, profile_name="claude-reviewer")
+        )
+        state.review_durations.append(30.0)
+        return _CR(success=True, phase=Phase.DONE, state=state, message="Done.")
+
+    def test_second_story_is_not_dispatched_after_unmeasured_spend(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.dag import StoryTriage
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+        config = _make_config(tmp_path)
+
+        def _triage(spec_path, *args, **kwargs):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                return_value=self._unmeasured_dev_result(),
+            ) as mock_run:
+                result = run_sprint(config, manifest_path)
+
+        # The budget is nowhere near exhausted at the measured lower bound —
+        # the sprint stops because that bound is not the spend.
+        assert mock_run.call_count == 1
+        assert result.stopped_reason is not None
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert result.specs_skipped == 1
+        assert result.cost_complete is False
+
+    def test_sprint_records_which_spend_was_unmeasured(self, tmp_path: Path) -> None:
+        """Convention 6: the refusal must be traceable to the work that caused it."""
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.dag import StoryTriage
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+        config = _make_config(tmp_path)
+
+        def _triage(spec_path, *args, **kwargs):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                return_value=self._unmeasured_dev_result(),
+            ):
+                result = run_sprint(config, manifest_path)
+
+        assert result.unmeasured_spend_sources  # names the story that ran unpriced
+        audit = yaml.safe_load(
+            (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+        )
+        assert audit["sprint"]["cost_complete"] is False
+        assert audit["sprint"]["total_cost_usd"] is None
+        assert audit["sprint"]["unmeasured_spend_sources"]
+        skipped = [s for s in audit["specs"] if s["outcome"] == "SKIPPED"]
+        assert skipped, audit["specs"]
+        assert "budget unverifiable" in (skipped[0]["error"] or "")
+
+    def test_fully_measured_sprint_dispatches_every_story(self, tmp_path: Path) -> None:
+        """The fail-closed path must not fire when every story reports cost."""
+        from unittest.mock import patch
+
+        from test_sprint_resume import (
+            _make_config,
+            _make_coordinator_result,
+            _make_manifest,
+            _make_spec_file,
+        )
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.dag import StoryTriage
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+        config = _make_config(tmp_path)
+
+        def _triage(spec_path, *args, **kwargs):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                side_effect=lambda *a, **k: _make_coordinator_result(success=True, cost=1.0),
+            ) as mock_run:
+                result = run_sprint(config, manifest_path)
+
+        assert mock_run.call_count == 2
+        assert result.stopped_reason is None
+        assert result.cost_complete is True
+        assert result.unmeasured_spend_sources == ()
+
+    def test_resume_inherits_the_unmeasured_flag_from_the_prior_generation(
+        self, tmp_path: Path
+    ) -> None:
+        """Carried spend from an incomplete generation is a lower bound too."""
+        from theforge.sprint.runner import _prior_sprint_cost_incomplete
+
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True)
+        (audits / "sprint-audit.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "sprint": {
+                        "sprint_id": "sid",
+                        "total_cost_usd": None,
+                        "total_cost_measured_usd": MEASURED_REVIEW_COST,
+                        "cost_complete": False,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert _prior_sprint_cost_incomplete(tmp_path, "sid") is True
+        # A different sprint's record must not leak its incompleteness.
+        assert _prior_sprint_cost_incomplete(tmp_path, "other-sid") is False
+
+    def test_resume_from_a_complete_generation_is_not_flagged(self, tmp_path: Path) -> None:
+        from theforge.sprint.runner import _prior_sprint_cost_incomplete
+
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True)
+        (audits / "sprint-audit.yaml").write_text(
+            yaml.safe_dump(
+                {"sprint": {"sprint_id": "sid", "total_cost_usd": 2.0, "cost_complete": True}}
+            ),
+            encoding="utf-8",
+        )
+        assert _prior_sprint_cost_incomplete(tmp_path, "sid") is False
+        # A pre-#1992 record carries no completeness claim and must not block.
+        (audits / "sprint-audit.yaml").write_text(
+            yaml.safe_dump({"sprint": {"sprint_id": "sid", "total_cost_usd": 2.0}}),
+            encoding="utf-8",
+        )
+        assert _prior_sprint_cost_incomplete(tmp_path, "sid") is False

--- a/tests/test_unmeasured_cost_reporting.py
+++ b/tests/test_unmeasured_cost_reporting.py
@@ -1,0 +1,527 @@
+"""Unmeasured cost must survive aggregation instead of being coerced to zero (#1992).
+
+The motivating shape is story #1945: three dev iterations on a cost-unmeasured
+CLI transport plus a review pool on a transport that does report cost. The story
+was reported as ``$0.99`` — the review pool's share — with nothing indicating the
+dev phase was absent rather than free. These tests pin the seam end to end: state
+aggregation, the operator-facing coordinator surfaces, the structured run/audit
+records, and the sprint-level story/summary surfaces.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import yaml
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.hooks import build_post_run_payload, build_post_sprint_payload
+from theforge.coordinator.model_profiles_bridge import _extract_reviewers
+from theforge.coordinator.state import (
+    CoordinatorResult,
+    CoordinatorState,
+    Phase,
+    ReviewCycleMetadata,
+    ReviewIterationTelemetry,
+)
+from theforge.coordinator.util import _fmt_cost_total, _round_cost, sum_costs
+from theforge.runners import AgentResult
+from theforge.sprint.audit import _write_sprint_audit, _write_sprint_summary
+from theforge.sprint.manifest import ResolvedSprint, SprintResult
+from theforge.sprint.state_writer import SprintStateWriter
+from theforge.sprint.status_reader import read_completed_status
+from theforge.sprint.story_state import SprintStoryState, StoryOutcome
+
+MEASURED_REVIEW_COST = 0.99
+
+
+def _agent_result(cost: float | None, *, profile_name: str = "agent") -> AgentResult:
+    return AgentResult(
+        success=True,
+        output="ok",
+        session_id=None,
+        cost_usd=cost,
+        exit_code=0,
+        raw={},
+        profile_name=profile_name,
+    )
+
+
+def _issue_1945_state() -> CoordinatorState:
+    """Three unmeasured dev iterations plus a review pool that reported cost."""
+    state = CoordinatorState()
+    for _ in range(3):
+        state.dev_results.append(_agent_result(None, profile_name="codex-dev"))
+        state.dev_durations.append(120.0)
+    state.review_agent_results.append(
+        _agent_result(MEASURED_REVIEW_COST, profile_name="claude-reviewer")
+    )
+    state.review_durations.append(60.0)
+    return state
+
+
+def _result(state: CoordinatorState) -> CoordinatorResult:
+    return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="done")
+
+
+class TestStateAggregation:
+    def test_measured_total_is_unknown_when_dev_unmeasured(self) -> None:
+        state = _issue_1945_state()
+        # The legacy coercing accessor still yields the review-only subtotal —
+        # it is a lower bound, not the story's cost.
+        assert state.total_cost == MEASURED_REVIEW_COST
+        assert state.total_cost_measured is None
+        assert state.total_dev_cost_measured is None
+        assert state.total_review_cost_measured == MEASURED_REVIEW_COST
+
+    def test_fully_measured_total_is_unchanged(self) -> None:
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(0.25))
+        state.dev_durations.append(10.0)
+        state.review_agent_results.append(_agent_result(0.75))
+        state.review_durations.append(10.0)
+        assert state.total_cost_measured == 1.0
+        assert state.total_cost == 1.0
+
+    def test_sum_costs_treats_a_mix_as_unknown(self) -> None:
+        assert sum_costs([0.5, 0.25]) == 0.75
+        assert sum_costs([0.5, None]) is None
+        assert sum_costs([]) == 0.0
+        # A genuinely free run is still free, not unknown.
+        assert sum_costs([0.0, 0.0]) == 0.0
+
+    def test_round_cost_preserves_none(self) -> None:
+        assert _round_cost(None) is None
+        assert _round_cost(0.123456789) == 0.123457
+
+
+class TestOperatorRendering:
+    def test_partial_total_never_renders_as_a_plain_dollar_figure(self) -> None:
+        rendered = _fmt_cost_total(None, MEASURED_REVIEW_COST)
+        assert rendered != f"${MEASURED_REVIEW_COST:.2f}"
+        assert rendered.startswith("unknown")
+        # The measured spend stays visible as an explicit lower bound.
+        assert "0.99" in rendered
+
+    def test_unknown_with_no_measured_spend(self) -> None:
+        assert _fmt_cost_total(None, 0.0) == "unknown"
+        assert _fmt_cost_total(None) == "unknown"
+
+    def test_measured_total_renders_as_dollars(self) -> None:
+        assert _fmt_cost_total(1.5, 1.5) == "$1.50"
+
+
+class TestStructuredRecords:
+    def test_audit_totals_null_for_partially_unmeasured_story(self, tmp_path: Path) -> None:
+        state = _issue_1945_state()
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _result(state))
+        assert log["totals"]["cost_usd"] is None
+        assert log["cost"]["total_usd"] is None
+        assert log["cost"]["dev_usd"] is None
+        # The phase that WAS measured keeps its measured value.
+        assert log["cost"]["review_usd"] == MEASURED_REVIEW_COST
+
+    def test_review_iteration_telemetry_cost_stays_null(self, tmp_path: Path) -> None:
+        state = _issue_1945_state()
+        state.review_iteration_telemetry.append(
+            ReviewIterationTelemetry(
+                iteration=1,
+                max_iterations=3,
+                cost_usd=None,
+                duration_s=12.0,
+                verdict="APPROVE",
+                findings_by_severity={"P1": 0, "P2": 0},
+                new_findings_by_severity={"P1": 0, "P2": 0},
+                repeated_findings_by_severity={"P1": 0, "P2": 0},
+                novel_findings=0,
+                restated_findings=0,
+            )
+        )
+        log = generate_audit_log(_make_config(tmp_path), _make_task(tmp_path), _result(state))
+        assert log["iterations"]["review_loop"][0]["cost_usd"] is None
+
+    def test_post_run_hook_payload_reports_unknown_cost(self, tmp_path: Path) -> None:
+        state = _issue_1945_state()
+        payload = build_post_run_payload(
+            state,
+            _make_config(tmp_path),
+            _make_task(tmp_path),
+            _result(state),
+            run_id="run-1992",
+            duration_seconds=90.0,
+        )
+        assert payload["total_cost_usd"] is None
+
+    def test_post_sprint_hook_payload_passes_none_through(self, tmp_path: Path) -> None:
+        payload = build_post_sprint_payload(
+            sprint_name="s",
+            stories=[],
+            run_id="run-1992",
+            config=_make_config(tmp_path),
+            total_cost_usd=None,
+            duration_seconds=1.0,
+        )
+        assert payload["total_cost_usd"] is None
+
+    def test_profile_fold_receives_unmeasured_reviewer_cost(self) -> None:
+        """Routing evidence must not learn that an unpriced reviewer was free."""
+        state = CoordinatorState()
+        state.review_cycle_metadata.append(
+            ReviewCycleMetadata(
+                pool_models=["codex-reviewer"],
+                successful=["codex-reviewer"],
+                failed=[],
+                synthesized=False,
+                parse_retries=0,
+            )
+        )
+        state.review_iteration_telemetry.append(
+            ReviewIterationTelemetry(
+                iteration=1,
+                max_iterations=3,
+                cost_usd=None,
+                duration_s=10.0,
+                verdict="APPROVE",
+                findings_by_severity={"P1": 0, "P2": 0},
+                new_findings_by_severity={"P1": 0, "P2": 0},
+                repeated_findings_by_severity={"P1": 0, "P2": 0},
+                novel_findings=0,
+                restated_findings=0,
+            )
+        )
+        cycles, findings, cost = _extract_reviewers(state)["codex-reviewer"]
+        assert cycles == 1
+        assert findings == 0
+        assert cost is None
+
+
+class TestSprintStorySurfaces:
+    def test_story_state_round_trips_unknown_cost(self) -> None:
+        state = SprintStoryState()
+        state.register("issue-1945", "Issue #1945")
+        state.transition("issue-1945", outcome=StoryOutcome.DONE, cost_usd=None)
+        assert state.get("issue-1945").cost_usd is None
+        restored = SprintStoryState.from_dict(state.as_dict())
+        assert restored.get("issue-1945").cost_usd is None
+
+    def test_state_writer_persists_null_cost(self, tmp_path: Path) -> None:
+        writer = SprintStateWriter("run-1992", tmp_path, "s", sprint_id="sid")
+        writer.init([{"slug": "issue-1945", "path": "Issue #1945", "status": "running"}])
+        writer.update("issue-1945", status="running", cost_usd=None)
+        data = yaml.safe_load((tmp_path / ".forge" / "runs" / "run-1992.state").read_text())
+        assert data["stories"][0]["cost_usd"] is None
+
+    def test_completed_status_entry_keeps_cost_unknown(self, tmp_path: Path) -> None:
+        summary = tmp_path / "sprint-summary.yaml"
+        summary.write_text(
+            yaml.safe_dump(
+                {
+                    "sprint": {"name": "s", "total_cost_usd": None, "cost_complete": False},
+                    "stories": [
+                        {
+                            "slug": "issue-1945",
+                            "path": "Issue #1945",
+                            "outcome": "DONE",
+                            "cost_usd": None,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        entries = read_completed_status(summary)
+        assert [e.cost_usd for e in entries] == [None]
+
+    def test_story_row_renders_unknown_not_a_dash(self, capsys) -> None:
+        """A cost-unknown story must not render like a story that spent nothing."""
+        from theforge.cli.sprint_status import _print_story_line
+
+        entry = type(
+            "E",
+            (),
+            {
+                "slug": "issue-1945",
+                "path": "Issue #1945",
+                "status": "done",
+                "phase": "DONE",
+                "stage": "",
+                "cost_usd": None,
+                "elapsed_seconds": 60.0,
+                "detail": "",
+                "complexity": None,
+                "complexity_score": None,
+                "model": None,
+            },
+        )()
+        _print_story_line(entry, {"done": "✓"}, 0)
+        rendered = capsys.readouterr().out
+        assert "unknown" in rendered
+        assert "$" not in rendered
+
+
+def _resolved_sprint() -> ResolvedSprint:
+    return ResolvedSprint(name="test-sprint", budget_usd=10.0, stories=[], max_parallel=1)
+
+
+class TestSprintTotals:
+    def test_sprint_audit_total_is_null_when_a_story_cost_is_unknown(self, tmp_path: Path) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        result = SprintResult(
+            name="test-sprint",
+            specs_total=1,
+            specs_succeeded=1,
+            specs_failed=0,
+            specs_skipped=0,
+            total_cost_usd=MEASURED_REVIEW_COST,
+            budget_usd=10.0,
+            cost_complete=False,
+            results=[],
+        )
+        _write_sprint_audit(
+            manifest=_resolved_sprint(),
+            result=result,
+            canonical_refs=[],
+            started_at=now,
+            finished_at=now,
+            duration=0.0,
+            project_root=tmp_path,
+        )
+        audit = yaml.safe_load((tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text())
+        assert audit["sprint"]["total_cost_usd"] is None
+        assert audit["sprint"]["cost_complete"] is False
+        assert audit["sprint"]["total_cost_measured_usd"] == MEASURED_REVIEW_COST
+
+    def test_sprint_summary_total_is_null_when_a_story_cost_is_unknown(
+        self, tmp_path: Path
+    ) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        story_state = SprintStoryState()
+        story_state.register("issue-1945", "Issue #1945")
+        story_state.transition("issue-1945", outcome=StoryOutcome.DONE, cost_usd=None)
+        story_state.register("issue-1946", "Issue #1946")
+        story_state.transition("issue-1946", outcome=StoryOutcome.DONE, cost_usd=0.5)
+        result = SprintResult(
+            name="test-sprint",
+            specs_total=2,
+            specs_succeeded=2,
+            specs_failed=0,
+            specs_skipped=0,
+            total_cost_usd=0.5,
+            budget_usd=10.0,
+            cost_complete=False,
+            results=[],
+        )
+        _write_sprint_summary(
+            manifest=_resolved_sprint(),
+            result=result,
+            canonical_refs=[],
+            started_at=now,
+            finished_at=now,
+            duration=0.0,
+            sprint_log_dir=tmp_path / "logs",
+            project_root=tmp_path,
+            story_state=story_state,
+        )
+        summary = yaml.safe_load((tmp_path / "logs" / "sprint-summary.yaml").read_text())
+        assert summary["sprint"]["total_cost_usd"] is None
+        assert summary["sprint"]["cost_complete"] is False
+        assert summary["sprint"]["total_cost_measured_usd"] == 0.5
+
+    def test_fully_measured_sprint_still_reports_a_total(self, tmp_path: Path) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        story_state = SprintStoryState()
+        story_state.register("issue-1946", "Issue #1946")
+        story_state.transition("issue-1946", outcome=StoryOutcome.DONE, cost_usd=0.5)
+        result = SprintResult(
+            name="test-sprint",
+            specs_total=1,
+            specs_succeeded=1,
+            specs_failed=0,
+            specs_skipped=0,
+            total_cost_usd=0.5,
+            budget_usd=10.0,
+            results=[],
+        )
+        _write_sprint_summary(
+            manifest=_resolved_sprint(),
+            result=result,
+            canonical_refs=[],
+            started_at=now,
+            finished_at=now,
+            duration=0.0,
+            sprint_log_dir=tmp_path / "logs",
+            project_root=tmp_path,
+            story_state=story_state,
+        )
+        summary = yaml.safe_load((tmp_path / "logs" / "sprint-summary.yaml").read_text())
+        assert summary["sprint"]["total_cost_usd"] == 0.5
+        assert summary["sprint"]["cost_complete"] is True
+
+
+class TestCliRenderers:
+    def test_forge_audit_renders_unknown_instead_of_zero(self) -> None:
+        from theforge.cli.audit import _cost_str
+
+        assert _cost_str(None) == "unknown"
+        assert _cost_str(0.0) == "$0.0000"
+        assert _cost_str(1.5) == "$1.5000"
+
+    def test_recent_runs_row_shows_unknown_for_incomplete_sprint(self) -> None:
+        from theforge.cli.status import _historical_row_from_substrate
+
+        record = {
+            "run_id": "abc123",
+            "timing": {"started_at": "2026-07-26T00:00:00", "duration_seconds": 60},
+            "sprint": {
+                "total_cost_usd": None,
+                "cost_complete": False,
+                "total_cost_measured_usd": MEASURED_REVIEW_COST,
+                "duration_seconds": 60,
+            },
+            "totals": {"cost_usd": MEASURED_REVIEW_COST},
+        }
+        row = _historical_row_from_substrate(record)
+        assert row is not None
+        assert row[4] == "unknown"
+
+    def test_recent_runs_row_still_shows_a_measured_sprint_total(self) -> None:
+        from theforge.cli.status import _historical_row_from_substrate
+
+        record = {
+            "run_id": "abc123",
+            "timing": {"started_at": "2026-07-26T00:00:00", "duration_seconds": 60},
+            "sprint": {
+                "total_cost_usd": 2.5,
+                "cost_complete": True,
+                "duration_seconds": 60,
+            },
+        }
+        row = _historical_row_from_substrate(record)
+        assert row is not None
+        assert row[4] == "$2.50"
+
+    def test_run_status_does_not_scrape_a_lower_bound_as_the_total(self, tmp_path: Path) -> None:
+        """`forge status` must not recover a dollar figure from an unknown total."""
+        from theforge import detach
+
+        log_dir = tmp_path / ".forge" / "logs" / "issue-1945"
+        log_dir.mkdir(parents=True)
+        (log_dir / "run-run1992.log").write_text(
+            "[forge] Total cost: unknown (>= $0.99 measured)   Duration: 13m\n",
+            encoding="utf-8",
+        )
+        status = detach.read_run_status("run1992", "issue-1945", tmp_path)
+        assert status["cost_usd"] is None
+
+
+class TestPhaseAggregationSeams:
+    def test_dev_iteration_with_mixed_attempts_records_unknown_cost(self, tmp_path: Path) -> None:
+        """A retry that reported cost does not make the whole iteration measured."""
+        from unittest.mock import patch
+
+        from theforge.coordinator.dev_phase import record_dev_iteration_telemetry
+
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(None, profile_name="codex-dev"))
+        state.dev_durations.append(100.0)
+        state.dev_results.append(_agent_result(0.42, profile_name="api-fallback"))
+        state.dev_durations.append(50.0)
+        state.pending_dev_transport_retry_count = 1
+
+        with patch("theforge.coordinator.dev_phase._git_lines", return_value=[]):
+            record_dev_iteration_telemetry(
+                state,
+                tmp_path,
+                max_iterations=3,
+                gate_result="PASS",
+            )
+
+        assert state.dev_iteration_telemetry[-1].cost_usd is None
+
+    def test_dev_iteration_with_all_measured_attempts_sums_them(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        from theforge.coordinator.dev_phase import record_dev_iteration_telemetry
+
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(0.10))
+        state.dev_durations.append(100.0)
+        state.dev_results.append(_agent_result(0.42))
+        state.dev_durations.append(50.0)
+        state.pending_dev_transport_retry_count = 1
+
+        with patch("theforge.coordinator.dev_phase._git_lines", return_value=[]):
+            record_dev_iteration_telemetry(
+                state,
+                tmp_path,
+                max_iterations=3,
+                gate_result="PASS",
+            )
+
+        assert state.dev_iteration_telemetry[-1].cost_usd == 0.52
+
+
+class TestPullRequestBody:
+    """The PR body is the durable operator-facing record of a story's cost."""
+
+    @staticmethod
+    def _capture_pr_body(tmp_path: Path, state: CoordinatorState) -> str:
+        from unittest.mock import MagicMock, patch
+
+        from test_operator_action_lifecycle import (
+            _make_issue_task,
+            _make_merge_pr_config,
+            _make_review_result,
+        )
+
+        from theforge.coordinator import completion
+
+        bodies: list[str] = []
+
+        def _sub(returncode: int, stdout: str = "") -> MagicMock:
+            proc = MagicMock()
+            proc.returncode = returncode
+            proc.stdout = stdout
+            proc.stderr = ""
+            return proc
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list):
+                if cmd[:2] == ["gh", "issue"] and "labels" in cmd:
+                    import json
+
+                    return _sub(0, stdout=json.dumps({"labels": []}))
+                if cmd[:3] == ["git", "rev-list", "--count"]:
+                    return _sub(0, stdout="1\n")
+                if "pr" in cmd and "list" in cmd:
+                    return _sub(0, stdout="[]")
+                for i, arg in enumerate(cmd):
+                    if arg == "--body" and i + 1 < len(cmd):
+                        bodies.append(cmd[i + 1])
+            return _sub(0, stdout="https://github.com/x/y/pull/10")
+
+        config = _make_merge_pr_config(tmp_path)
+        task = _make_issue_task(tmp_path, 1945)
+        with patch("theforge.coordinator.completion.subprocess.run", side_effect=_fake_run):
+            result = completion._create_pr(
+                config, task, "forge/issue-1945", _make_review_result(), state
+            )
+        assert result["success"] is True, result
+        assert len(bodies) == 1, bodies
+        return bodies[0]
+
+    def test_pr_body_reports_unknown_cost_for_partially_unmeasured_story(
+        self, tmp_path: Path
+    ) -> None:
+        body = self._capture_pr_body(tmp_path, _issue_1945_state())
+        assert "- **Cost:** unknown" in body
+        assert "- **Cost:** $0.99" not in body
+
+    def test_pr_body_reports_a_measured_cost_unchanged(self, tmp_path: Path) -> None:
+        state = CoordinatorState()
+        state.dev_results.append(_agent_result(0.5))
+        state.dev_durations.append(10.0)
+        body = self._capture_pr_body(tmp_path, state)
+        assert "- **Cost:** $0.50" in body


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior budget-enforcement P1 is resolved, and I found no blocking regressions in the current change. | [google-gemini-3.5-flash] The unmeasured cost preservation and budget fail-closed enforcement are beautifully implemented and fully verified by comprehensive tests. | [claude-sonnet] Iteration 1 correctly fixes the cycle-1 P1: sprint budget enforcement now fails closed via the new pure evaluate_budget() decision function when any spend is unmeasured, with unit tests and an end-to-end seam test (story 2 never dispatched after story 1 runs unpriced). No regressions found in the touched files; full suite (6148 tests) passes and ruff is clean.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $36.39
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Unmeasured cost is coerced to zero at every aggregation, so unpriced work is reported as free (GitHub Issue #1992)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1992