### PR TITLE
ALREADY_DONE / git_state_match acceptance leaves the tracking issue open with no comment or disposition, yet counts as landed

### DIFF
--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -102,11 +102,17 @@ def display_sprint_digest(run_id: str, project_root: Path) -> int:
     sprint_block = summary.get("sprint") if isinstance(summary.get("sprint"), dict) else {}
     stories = [s for s in (summary.get("stories") or []) if isinstance(s, dict)]
 
-    landed = [s for s in stories if _outcome(s) in DONE_OUTCOMES]
+    # A no-merge ALREADY_DONE acceptance succeeded but shipped no change. It
+    # must not be reported as a landed change (issue #1937), so split it into a
+    # distinct ALREADY SATISFIED bucket. It still counts as succeeded, so it is
+    # excluded from ``non_done`` and never triggers the recovery sections.
+    already_satisfied = [s for s in stories if _is_already_satisfied(s)]
+    landed = [s for s in stories if _outcome(s) in DONE_OUTCOMES and not _is_already_satisfied(s)]
     non_done = [s for s in stories if _outcome(s) not in DONE_OUTCOMES]
 
     _print_header(sprint_block, run_id)
     _print_landed(landed, len(stories))
+    _print_already_satisfied(already_satisfied)
 
     # Shape-gate skip categories (issue #1453) are independent of story
     # outcomes: a sprint can land every runnable story yet still have skipped a
@@ -162,6 +168,45 @@ def _print_landed(landed: list[dict], total: int) -> None:
         return
     for story in landed:
         print(f"  ✓ {_story_row(story)}")
+
+
+def _print_already_satisfied(stories: list[dict]) -> None:
+    """Render no-op ALREADY_DONE acceptances distinctly from landed changes.
+
+    These stories succeeded without shipping a change — preflight determined the
+    spec was already satisfied and no PR merged. Reporting them under LANDED
+    would present a no-op acceptance as equivalent to a merged land (issue
+    #1937), so they get their own bucket with the preflight reason as detail.
+    """
+    if not stories:
+        return
+    print()
+    print(f"ALREADY SATISFIED ({len(stories)})")
+    for story in stories:
+        print(f"  ✓ {_story_row(story)}")
+        reason = str(story.get("preflight_reason") or "").strip()
+        if reason:
+            print(f"       no change needed — {reason}")
+
+
+def _is_already_satisfied(story: dict) -> bool:
+    """True when a story is a no-merge, preflight-verdict ALREADY_DONE acceptance.
+
+    Distinguishes a no-op acceptance (working tree already satisfied the spec,
+    no PR) from a real landed change. A merged story — even one classified
+    ALREADY_DONE via the resume-skip-merged path — is excluded because it either
+    carries a merge boolean or a structured landing record.
+    """
+    if _outcome(story) != "ALREADY_DONE":
+        return False
+    if str(story.get("outcome_source") or "") != "preflight_verdict":
+        return False
+    if story.get("merge"):
+        return False
+    landing = story.get("landing")
+    if isinstance(landing, dict) and landing.get("merged"):
+        return False
+    return True
 
 
 def _print_shape_gate_skips(summary: dict) -> None:

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -378,6 +378,9 @@ def _load_story_summary_entry_from_audit(
         else 0.0,
         "story_run_id": audit_data.get("run_id"),
         "preflight": preflight_verdict,
+        "preflight_reason": (
+            preflight_block.get("reason") if isinstance(preflight_block, dict) else None
+        ),
         "preflight_original_verdict": (
             preflight_block.get("original_verdict") if isinstance(preflight_block, dict) else None
         ),
@@ -574,6 +577,7 @@ def _write_sprint_audit(
                 "outcome_source": outcome_source,
                 "cost_usd": _state_reported_cost(res.state),
                 "preflight": preflight,
+                "preflight_reason": getattr(res.state, "preflight_reason", None),
                 "preflight_original_verdict": getattr(
                     res.state, "preflight_cached_original_verdict", None
                 ),
@@ -922,6 +926,7 @@ def _write_sprint_summary(
                 "dev_model": _dev_model,
                 "story_run_id": getattr(res.state, "run_id", None) or run_id,
                 "preflight": preflight,
+                "preflight_reason": getattr(res.state, "preflight_reason", None),
                 "preflight_original_verdict": getattr(
                     res.state, "preflight_cached_original_verdict", None
                 ),

--- a/src/theforge/sprint/sources.py
+++ b/src/theforge/sprint/sources.py
@@ -23,6 +23,7 @@ from ..task import (
 from ..task.story import FrontmatterParseResult, _parse_frontmatter_block
 from .manifest import _build_task_from_story
 from .reopen_context import analyze_reopen_contract, append_reopen_context
+from .shape_gate import OPERATOR_ACTION_LABEL
 
 if TYPE_CHECKING:
     from ..config import ForgeConfig
@@ -79,6 +80,41 @@ def _derive_type_from_labels(labels: list[str], issue_number: int) -> tuple[str 
     )
     _log.warning(warning)
     return None, [warning]
+
+
+def classify_already_done_disposition(state: object) -> str:
+    """Classify why a no-merge ALREADY_DONE acceptance needs no code change.
+
+    Returns one of:
+
+    * ``"already_implemented"`` — the working tree already contains the change
+      the spec asks for. Resolves to a ``completed`` close.
+    * ``"premise_obsolete"`` — the spec's premise no longer exists in the
+      codebase, so the requested change is not applicable. Resolves to a
+      ``not planned`` close.
+    * ``"ambiguous"`` — the two dispositions cannot be told apart from the
+      structured preflight state. The decision is routed to the operator rather
+      than guessed.
+
+    The only mechanical signal available is the structured symptom-verification
+    record preflight writes for bug-typed stories (``preflight_symptom_verification``).
+    Everything else (feature/refactor stories, git-state cache hits) is
+    genuinely ambiguous and must go to the operator.
+    """
+    symptom = getattr(state, "preflight_symptom_verification", None) or {}
+    if not isinstance(symptom, dict):
+        return "ambiguous"
+    status = str(symptom.get("status") or "").strip().lower()
+    reproduces_now = symptom.get("reproduces_now")
+    # A verified-resolved symptom that no longer reproduces means the fix is
+    # present in the code — already implemented.
+    if status == "verified_resolved" and reproduces_now is False:
+        return "already_implemented"
+    # A symptom that was never reproducible against the current baseline means
+    # the bug's premise is gone — premise obsolete.
+    if status == "not_reproduced" and reproduces_now is False:
+        return "premise_obsolete"
+    return "ambiguous"
 
 
 class IssueClosedError(RuntimeError):
@@ -405,13 +441,27 @@ class GitHubIssueSource:
         result: "CoordinatorResult",
         config: "ForgeConfig",
     ) -> None:
-        """Close the issue when on_approve is 'merge' and the merge succeeded."""
+        """Resolve the tracking issue when a story completes successfully.
+
+        Two terminal shapes reach here in merge mode:
+
+        * a merged land — close the issue with the review summary (unchanged);
+        * a no-merge ALREADY_DONE acceptance — the working tree already
+          satisfied the spec, so no PR shipped. Post a durable comment stating
+          the determination and its evidence, then either close with the
+          resolved disposition or route the issue to the operator-action queue
+          when the disposition is ambiguous. Without this branch the issue would
+          be left silently open (issue #1937).
+        """
         if config.workspace.on_approve != "merge":
             return
-        # Only close if actually merged
-        if result.merge is None or not result.merge.get("merged", False):
-            return
         if task.github_issue is None:
+            return
+
+        merged = result.merge is not None and result.merge.get("merged", False)
+        if not merged:
+            if getattr(result.state, "preflight_verdict", None) == "ALREADY_DONE":
+                self._resolve_already_done_issue(task, result, config)
             return
 
         summary = ""
@@ -442,6 +492,101 @@ class GitHubIssueSource:
             _log.warning(
                 "gh issue close #%s failed (exit %d): %s", task.github_issue, proc.returncode, err
             )
+
+    def _resolve_already_done_issue(
+        self,
+        task: TaskStory,
+        result: "CoordinatorResult",
+        config: "ForgeConfig",
+    ) -> None:
+        """Post the ALREADY_DONE determination and resolve/route the issue.
+
+        Always leaves a durable, operator-visible comment carrying the
+        determination and its evidence. Then, depending on the disposition:
+
+        * ``already_implemented`` — close with ``--reason completed``;
+        * ``premise_obsolete`` — close with ``--reason "not planned"``;
+        * ``ambiguous`` — leave the issue open, comment, and add the
+          ``operator-action`` label so it surfaces in the operator-action queue.
+        """
+        number = task.github_issue
+        assert number is not None  # guarded by caller
+        project_root = config.project_root
+        reason = (getattr(result.state, "preflight_reason", None) or "").strip()
+        if not reason:
+            reason = "(no reason recorded)"
+        disposition = classify_already_done_disposition(result.state)
+
+        header = (
+            "TheForge accepted this issue without a code change: preflight determined "
+            "the spec is already satisfied (verdict: ALREADY_DONE). No pull request was "
+            "opened because the working tree already meets the spec."
+        )
+        evidence = f"Evidence: {reason}"
+
+        if disposition == "already_implemented":
+            body = (
+                f"{header}\n\n{evidence}\n\n"
+                "Disposition: already implemented — the change this issue asks for is "
+                "already present in the codebase. Closing as completed."
+            )
+            self._run_issue_gh(
+                ["issue", "close", str(number), "--comment", body, "--reason", "completed"],
+                project_root,
+                f"issue close #{number}",
+            )
+        elif disposition == "premise_obsolete":
+            body = (
+                f"{header}\n\n{evidence}\n\n"
+                "Disposition: premise obsolete — the premise this issue depends on is "
+                "no longer present in the codebase. Closing as not planned."
+            )
+            self._run_issue_gh(
+                ["issue", "close", str(number), "--comment", body, "--reason", "not planned"],
+                project_root,
+                f"issue close #{number}",
+            )
+        else:
+            body = (
+                f"{header}\n\n{evidence}\n\n"
+                "Disposition is ambiguous (already-implemented vs. premise-obsolete). "
+                f"Routing to the operator-action queue via the '{OPERATOR_ACTION_LABEL}' "
+                "label and leaving this issue open for an operator to resolve."
+            )
+            self._run_issue_gh(
+                ["issue", "comment", str(number), "--body", body],
+                project_root,
+                f"issue comment #{number}",
+            )
+            self._run_issue_gh(
+                ["issue", "edit", str(number), "--add-label", OPERATOR_ACTION_LABEL],
+                project_root,
+                f"issue edit #{number}",
+            )
+
+    @staticmethod
+    def _run_issue_gh(args: list[str], project_root: Path, failure_desc: str) -> bool:
+        """Run a ``gh`` subcommand, logging (never raising) on failure.
+
+        Returns True on success. Failures are logged with ``failure_desc`` so an
+        operator can correlate a stuck issue with the failed resolution attempt.
+        """
+        try:
+            proc = subprocess.run(
+                ["gh", *args],
+                capture_output=True,
+                text=True,
+                cwd=str(project_root),
+                timeout=30,
+            )
+        except Exception as exc:
+            _log.warning("gh %s failed: %s", failure_desc, exc)
+            return False
+        if proc.returncode != 0:
+            err = proc.stderr.strip() or proc.stdout.strip()
+            _log.warning("gh %s failed (exit %d): %s", failure_desc, proc.returncode, err)
+            return False
+        return True
 
     def on_escalate(
         self,

--- a/tests/test_cli_sprint_digest.py
+++ b/tests/test_cli_sprint_digest.py
@@ -326,6 +326,66 @@ def test_next_omits_citation_when_action_names_its_story(tmp_path: Path) -> None
 # ── All-DONE tighter digest ───────────────────────────────────────────────────
 
 
+def _already_satisfied_story(num: int) -> dict:
+    """A no-merge, preflight-verdict ALREADY_DONE acceptance (issue #1937)."""
+    return {
+        "slug": f"issue-{num}",
+        "path": f"Issue #{num}",
+        "outcome": "ALREADY_DONE",
+        "outcome_source": "preflight_verdict",
+        "preflight_reason": "Working tree already satisfies the spec; git_state_match.",
+        "merge": False,
+        "landing": None,
+        "cost_usd": 0.05,
+        "started_at": "2026-05-08T00:00:00Z",
+        "finished_at": "2026-05-08T00:01:00Z",
+    }
+
+
+def test_preflight_already_done_split_from_landed(tmp_path: Path) -> None:
+    """A no-op ALREADY_DONE acceptance renders under ALREADY SATISFIED, not LANDED."""
+    name = "already-satisfied"
+    run_id = "runAS"
+    stories = [
+        _landed_story(1, 1.0),
+        _already_satisfied_story(1879),
+    ]
+    _write_summary(tmp_path, name, run_id, stories)
+    output = _render(tmp_path, run_id)
+
+    # The merged land is the only LANDED story — the no-op acceptance is excluded.
+    assert "LANDED (1 of 2)" in output
+    assert "ALREADY SATISFIED (1)" in output
+    assert "#1879" in output
+    assert "no change needed" in output
+    assert "git_state_match" in output
+    # No recovery sections: a no-op acceptance still succeeded.
+    assert "FAILED" not in output
+    assert "forge rca" not in output
+
+
+def test_resume_skip_merged_already_done_stays_landed(tmp_path: Path) -> None:
+    """An ALREADY_DONE story that actually merged stays in LANDED, not split out."""
+    name = "merged-already-done"
+    run_id = "runMAD"
+    merged_already_done = {
+        "slug": "issue-42",
+        "path": "Issue #42",
+        "outcome": "ALREADY_DONE",
+        "outcome_source": "resume_skip_merged",
+        "merge": True,
+        "cost_usd": 2.0,
+        "started_at": "2026-05-08T00:00:00Z",
+        "finished_at": "2026-05-08T00:10:00Z",
+    }
+    stories = [_landed_story(1, 1.0), merged_already_done]
+    _write_summary(tmp_path, name, run_id, stories)
+    output = _render(tmp_path, run_id)
+
+    assert "LANDED (2 of 2)" in output
+    assert "ALREADY SATISFIED" not in output
+
+
 def test_all_done_renders_landed_only(tmp_path: Path) -> None:
     name = "all-done"
     run_id = "runAD"

--- a/tests/test_status_reader_already_done_source.py
+++ b/tests/test_status_reader_already_done_source.py
@@ -215,6 +215,7 @@ def test_write_sprint_audit_carries_outcome_source_for_both_paths(
     preflight_state = MagicMock()
     preflight_state.preflight_cached = False
     preflight_state.preflight_verdict = "ALREADY_DONE"
+    preflight_state.preflight_reason = "Spec already satisfied."
     preflight_state.preflight_cached_original_verdict = None
     preflight_state.preflight_cached_from_run_id = None
     preflight_state.total_cost = 0.05

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -462,6 +463,153 @@ class TestGitHubIssueSource:
         mock_log.warning.assert_called_once()
         msg = mock_log.warning.call_args[0][0]
         assert "comment" in msg
+
+    def _already_done_result(
+        self,
+        *,
+        reason: str = "Working tree already satisfies the spec.",
+        symptom: dict | None = None,
+        work_type: str = "feature",
+    ) -> SimpleNamespace:
+        """A no-merge ALREADY_DONE CoordinatorResult stand-in."""
+        state = SimpleNamespace(
+            preflight_verdict="ALREADY_DONE",
+            preflight_reason=reason,
+            preflight_work_type=work_type,
+            preflight_symptom_verification=symptom or {},
+            review_results=[],
+        )
+        return SimpleNamespace(success=True, merge=None, state=state)
+
+    def _merge_config(self, tmp_path: Path):
+        config = MagicMock()
+        config.workspace.on_approve = "merge"
+        config.project_root = tmp_path
+        return config
+
+    def test_already_done_already_implemented_closes_completed(self, tmp_path: Path) -> None:
+        """A verified-resolved symptom closes the issue with --reason completed."""
+        task = TaskStory(name="Test", slug="test", github_issue=1879)
+        result = self._already_done_result(
+            reason="Symptom no longer reproduces at HEAD.",
+            symptom={"status": "verified_resolved", "reproduces_now": False},
+            work_type="bug",
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            GitHubIssueSource().on_complete(task, result, self._merge_config(tmp_path))
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "close" in cmd
+        assert "1879" in cmd
+        assert "--reason" in cmd
+        assert "completed" in cmd
+        # Comment carries the determination and its evidence.
+        comment = cmd[cmd.index("--comment") + 1]
+        assert "ALREADY_DONE" in comment
+        assert "Symptom no longer reproduces at HEAD." in comment
+
+    def test_already_done_premise_obsolete_closes_not_planned(self, tmp_path: Path) -> None:
+        """A never-reproduced symptom closes the issue with --reason 'not planned'."""
+        task = TaskStory(name="Test", slug="test", github_issue=1880)
+        result = self._already_done_result(
+            reason="Bug premise absent from baseline.",
+            symptom={"status": "not_reproduced", "reproduces_now": False},
+            work_type="bug",
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            GitHubIssueSource().on_complete(task, result, self._merge_config(tmp_path))
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "close" in cmd
+        assert "--reason" in cmd
+        assert "not planned" in cmd
+
+    def test_already_done_ambiguous_routes_to_operator(self, tmp_path: Path) -> None:
+        """An ambiguous disposition comments and adds the operator-action label, no close."""
+        task = TaskStory(name="Test", slug="test", github_issue=1881)
+        result = self._already_done_result(reason="Spec appears satisfied.", symptom={})
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            GitHubIssueSource().on_complete(task, result, self._merge_config(tmp_path))
+
+        assert mock_run.call_count == 2
+        comment_cmd = mock_run.call_args_list[0][0][0]
+        label_cmd = mock_run.call_args_list[1][0][0]
+        # First: a durable comment with determination + evidence, no close.
+        assert "comment" in comment_cmd
+        assert "close" not in comment_cmd
+        body = comment_cmd[comment_cmd.index("--body") + 1]
+        assert "ALREADY_DONE" in body
+        assert "Spec appears satisfied." in body
+        # Second: route to the operator-action queue via the label vocabulary.
+        assert "edit" in label_cmd
+        assert "--add-label" in label_cmd
+        assert "operator-action" in label_cmd
+
+    def test_already_done_noop_when_not_merge_mode(self, tmp_path: Path) -> None:
+        """ALREADY_DONE resolution is gated on merge mode like the close path."""
+        task = TaskStory(name="Test", slug="test", github_issue=1882)
+        result = self._already_done_result()
+        config = MagicMock()
+        config.workspace.on_approve = "pr"
+        config.project_root = tmp_path
+        with patch("subprocess.run") as mock_run:
+            GitHubIssueSource().on_complete(task, result, config)
+        mock_run.assert_not_called()
+
+    def test_merged_land_still_uses_close_path(self, tmp_path: Path) -> None:
+        """A real merge still closes with the review summary, never the ALREADY_DONE path."""
+        task = TaskStory(name="Test", slug="test", github_issue=1883)
+        state = SimpleNamespace(
+            preflight_verdict="ALREADY_DONE",  # even if preflight said ALREADY_DONE
+            preflight_reason="x",
+            review_results=[SimpleNamespace(summary="Shipped it")],
+        )
+        result = SimpleNamespace(success=True, merge={"merged": True}, state=state)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            GitHubIssueSource().on_complete(task, result, self._merge_config(tmp_path))
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "close" in cmd
+        assert "--reason" not in cmd  # merged close uses the legacy no-reason form
+        comment = cmd[cmd.index("--comment") + 1]
+        assert "Completed by TheForge" in comment
+
+    def test_classify_disposition(self) -> None:
+        from theforge.sprint.sources import classify_already_done_disposition
+
+        assert (
+            classify_already_done_disposition(
+                SimpleNamespace(
+                    preflight_symptom_verification={
+                        "status": "verified_resolved",
+                        "reproduces_now": False,
+                    }
+                )
+            )
+            == "already_implemented"
+        )
+        assert (
+            classify_already_done_disposition(
+                SimpleNamespace(
+                    preflight_symptom_verification={
+                        "status": "not_reproduced",
+                        "reproduces_now": False,
+                    }
+                )
+            )
+            == "premise_obsolete"
+        )
+        assert (
+            classify_already_done_disposition(SimpleNamespace(preflight_symptom_verification={}))
+            == "ambiguous"
+        )
 
     def test_fetch_raises_on_malformed_json(self, tmp_path: Path) -> None:
         """Malformed JSON from gh is wrapped in a clear RuntimeError."""


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the no-merge ALREADY_DONE issue-resolution and sprint-digest visibility requirements. | [google-gemini-3.5-flash] The ALREADY_DONE acceptance flow is fully resolved, with tracking issues properly commented, closed, or routed, and sprint digests distinctly reporting no-op acceptances.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** unknown (>= $1.26 measured)
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

ALREADY_DONE / git_state_match acceptance leaves the tracking issue open with no comment or disposition, yet counts as landed (GitHub Issue #1937)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1937