### PR TITLE
Narrow supported Python to 3.12 end-to-end, keeping the CI matrix switchable for later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # Single supported interpreter. Widening multi-version support is a
+        # one-line edit to this list — add the matching contexts to
+        # GATE_CONTEXTS in scripts/apply-branch-protection.sh and re-apply
+        # protection, or the new checks are never required.
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TheForge
 
 [![CI](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml/badge.svg)](https://github.com/fuzzypete/theforge/actions/workflows/ci.yml)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12-blue)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Version](https://img.shields.io/github/v/tag/fuzzypete/theforge?sort=semver&label=version&color=orange)](CHANGELOG.md)
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -11,7 +11,7 @@ feature branch.
 
 ## What you need
 
-1. **Python 3.11+**
+1. **Python 3.12+**
 2. **At least one AI CLI** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
    is recommended to start. Codex and Gemini are optional.
 3. **A git repository** with tests

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -50,14 +50,14 @@ python -c "import theforge"       # verify import works
 
 ### Wrong Python version
 
-**Cause:** TheForge requires Python 3.11+.
+**Cause:** TheForge requires Python 3.12+.
 
 **Fix:**
 ```bash
-python --version                  # must be 3.11+
+python --version                  # must be 3.12+
 # Use pyenv or conda to switch Python versions if needed
-pyenv install 3.11.9
-pyenv local 3.11.9
+pyenv install 3.12.8
+pyenv local 3.12.8
 pip install -e ".[dev]"
 ```
 

--- a/examples/hello-forge/README.md
+++ b/examples/hello-forge/README.md
@@ -10,7 +10,7 @@ Use this example to answer three questions quickly:
 
 ## Prerequisites
 
-- Python 3.11+
+- Python 3.12+
 - Claude Code CLI installed and authenticated
 - TheForge installed from the repo root
 - `pytest` available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.13.0rc9"
 description = "Deterministic multi-LLM development orchestrator"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = ["pyyaml>=6.0", "python-dotenv>=1.0"]
 authors = [{name = "Peter Wickersham"}]
 urls = {Homepage = "https://github.com/fuzzypete/theforge", Repository = "https://github.com/fuzzypete/theforge"}
@@ -34,7 +34,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 99
 
 [tool.ruff.lint]

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -3,9 +3,13 @@
 # branch so GitHub's enablePullRequestAutoMerge mutation works and CI is
 # required before a merge.
 #
-# Usage: scripts/apply-branch-protection.sh [--dry-run] <repo> <branch>
+# Usage: scripts/apply-branch-protection.sh [--dry-run] [--force] <repo> <branch>
 #
 # Behavior:
+#   - Refuse any branch outside release/* unless --force is given. The PUT
+#     below is a WHOLESALE replacement shaped for release branches; pointed at
+#     a branch with richer protection it silently deletes the rules it does not
+#     name. See the guard and the PROTECTION_BODY note for the full rationale.
 #   - Always PUT the protection ruleset — this brings the branch up to the
 #     required state whether or not it was already protected. (An earlier
 #     revision preserved existing protection untouched; that left branches
@@ -21,21 +25,24 @@
 set -uo pipefail
 
 DRY_RUN=false
+FORCE=false
 ARGS=()
 for arg in "$@"; do
     case "$arg" in
         --dry-run) DRY_RUN=true ;;
+        --force) FORCE=true ;;
         *) ARGS+=("$arg") ;;
     esac
 done
 
 if [[ "${#ARGS[@]}" -ne 2 ]]; then
-    echo "Usage: $0 [--dry-run] <repo> <branch>" >&2
+    echo "Usage: $0 [--dry-run] [--force] <repo> <branch>" >&2
     exit 2
 fi
 
 REPO="${ARGS[0]}"
 BRANCH="${ARGS[1]}"
+
 # required_status_checks.contexts must name the CI checks that must pass before
 # a merge. Two reasons this must be non-empty (an empty [] fails both):
 #   1. Auto-merge arming: GitHub's enablePullRequestAutoMerge mutation needs
@@ -55,17 +62,45 @@ BRANCH="${ARGS[1]}"
 # status that never arrives; producing a context that is not required leaves a
 # merge ungated. Change both files together and re-apply protection.
 GATE_CONTEXTS='["gate (3.12)"]'
-# NOTE: this body is the COMPLETE ruleset for a release branch, and the PUT
-# replaces protection wholesale — every rule not named here is cleared. In
-# particular required_pull_request_reviews:null disables "require a pull
-# request before merging". That is correct for release/* branches (cut-rc.sh's
-# only callers, all already in this shape), but it makes the script UNSAFE to
-# point at main, which carries a required_pull_request_reviews block this body
-# would silently drop. Narrow main's contexts with the granular endpoint
-# instead, which touches nothing else:
-#   echo '{"strict":false,"contexts":'"$GATE_CONTEXTS"'}' | gh api --method PATCH \
-#     repos/<repo>/branches/main/protection/required_status_checks --input -
+# This body is the COMPLETE ruleset for a release branch: the PUT replaces
+# protection wholesale, so every rule not named here is cleared. Note
+# required_pull_request_reviews:null in particular — it disables "require a
+# pull request before merging". The guard below is what keeps that from
+# reaching a branch where it would be destructive.
 PROTECTION_BODY='{"required_status_checks":{"strict":false,"contexts":'"$GATE_CONTEXTS"'},"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
+
+# Mechanical guard: this ruleset is only safe on release/* branches.
+#
+# Release branches are already exactly this shape — cut-rc.sh has been applying
+# this same body to them — so the wholesale PUT is faithful there. Other
+# branches are not: main carries a required_pull_request_reviews block, and
+# PUTting this body at it silently disables "require a pull request before
+# merging" on the default branch. No error, no diff, nothing to notice.
+#
+# This is not hypothetical. During the #2012 sprint a review instructed "run
+# apply-branch-protection.sh for each protected branch"; following that
+# literally would have stripped main's PR requirement. A comment saying so was
+# already present and did not prevent it, so the constraint is enforced here
+# instead of described.
+#
+# Guarded before the --dry-run branch so a preview reports the refusal too,
+# rather than printing a PUT that a real run would reject. cut-rc.sh always
+# passes release/v<major>.<minor>, so this can never fire on the RC path.
+#
+# --force covers the deliberate case: bringing a genuinely new release-line
+# branch up to this shape. To change ONLY the required contexts on some other
+# branch, use the granular endpoint named in the refusal message instead.
+if [[ "$FORCE" != true && "$BRANCH" != release/* ]]; then
+    echo "[forge] ✗ refusing to apply the release-branch ruleset to '$BRANCH'" >&2
+    echo "[forge]   This PUT replaces protection wholesale and would clear every" >&2
+    echo "[forge]   rule it does not name (notably required_pull_request_reviews," >&2
+    echo "[forge]   i.e. 'require a pull request before merging')." >&2
+    echo "[forge]   To change ONLY the required checks, use the granular endpoint:" >&2
+    echo "[forge]     echo '{\"strict\":false,\"contexts\":$GATE_CONTEXTS}' | gh api --method PATCH \\" >&2
+    echo "[forge]       repos/$REPO/branches/$BRANCH/protection/required_status_checks --input -" >&2
+    echo "[forge]   Re-run with --force if replacing the whole ruleset is intended." >&2
+    exit 2
+fi
 
 if [[ "$DRY_RUN" == true ]]; then
     echo "+ (dry-run) gh api --method PUT repos/$REPO/branches/$BRANCH/protection --input -"

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -55,6 +55,16 @@ BRANCH="${ARGS[1]}"
 # status that never arrives; producing a context that is not required leaves a
 # merge ungated. Change both files together and re-apply protection.
 GATE_CONTEXTS='["gate (3.12)"]'
+# NOTE: this body is the COMPLETE ruleset for a release branch, and the PUT
+# replaces protection wholesale — every rule not named here is cleared. In
+# particular required_pull_request_reviews:null disables "require a pull
+# request before merging". That is correct for release/* branches (cut-rc.sh's
+# only callers, all already in this shape), but it makes the script UNSAFE to
+# point at main, which carries a required_pull_request_reviews block this body
+# would silently drop. Narrow main's contexts with the granular endpoint
+# instead, which touches nothing else:
+#   echo '{"strict":false,"contexts":'"$GATE_CONTEXTS"'}' | gh api --method PATCH \
+#     repos/<repo>/branches/main/protection/required_status_checks --input -
 PROTECTION_BODY='{"required_status_checks":{"strict":false,"contexts":'"$GATE_CONTEXTS"'},"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
 
 if [[ "$DRY_RUN" == true ]]; then

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -48,11 +48,13 @@ BRANCH="${ARGS[1]}"
 #      release branch with a red gate — a protection hole on the hardened line.
 #
 # These context names are the check names produced by .github/workflows/ci.yml:
-# its `gate` job runs a matrix over python-version ["3.11","3.12","3.13"],
-# yielding checks "gate (3.11)", "gate (3.12)", "gate (3.13)". If the ci.yml
-# job name or the python-version matrix changes, update GATE_CONTEXTS to match
-# or auto-merge arming will silently break again.
-GATE_CONTEXTS='["gate (3.11)","gate (3.12)","gate (3.13)"]'
+# its `gate` job runs a matrix over python-version ["3.12"], yielding the check
+# "gate (3.12)". If the ci.yml job name or the python-version matrix changes,
+# update GATE_CONTEXTS to match or auto-merge arming will silently break again.
+# Requiring a context the matrix does not produce leaves every PR waiting on a
+# status that never arrives; producing a context that is not required leaves a
+# merge ungated. Change both files together and re-apply protection.
+GATE_CONTEXTS='["gate (3.12)"]'
 PROTECTION_BODY='{"required_status_checks":{"strict":false,"contexts":'"$GATE_CONTEXTS"'},"enforce_admins":null,"required_pull_request_reviews":null,"restrictions":null,"allow_force_pushes":false,"allow_deletions":false}'
 
 if [[ "$DRY_RUN" == true ]]; then

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "apply-branch-protection.sh"
@@ -85,9 +88,7 @@ def test_dry_run_does_not_call_gh(sandbox):
     assert "PUT repos/fuzzypete/theforge/branches/release/v0.10/protection" in result.stdout
     # The dry-run body must carry the gate contexts so operators eyeballing the
     # planned PUT see the required checks.
-    assert '"gate (3.11)"' in result.stdout
     assert '"gate (3.12)"' in result.stdout
-    assert '"gate (3.13)"' in result.stdout
     # The log file must NOT exist — the fake `gh` was never invoked.
     assert not log.exists(), f"gh was called in dry-run: {log.read_text()}"
 
@@ -126,27 +127,90 @@ def test_put_body_requires_gate_status_checks(sandbox):
         "required_status_checks must not be null or GitHub refuses to arm auto-merge"
     )
     assert checks["contexts"] == [
-        "gate (3.11)",
         "gate (3.12)",
-        "gate (3.13)",
     ], "contexts must match the ci.yml gate matrix so CI is required before merge"
 
 
+def _ci_matrix_versions() -> list:
+    """The python-version entries ci.yml's `gate` job expands into checks."""
+    ci = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
+    return ci["jobs"]["gate"]["strategy"]["matrix"]["python-version"]
+
+
+def _script_gate_contexts() -> list:
+    """The contexts apply-branch-protection.sh requires, parsed from the script."""
+    match = re.search(r"^GATE_CONTEXTS='(.+)'$", SCRIPT.read_text(), re.MULTILINE)
+    assert match, "apply-branch-protection.sh must define GATE_CONTEXTS on one line"
+    return json.loads(match.group(1))
+
+
+def test_ci_matrix_versions_are_quoted_strings():
+    """Matrix entries must be strings, or YAML eats the trailing zero.
+
+    Unquoted `3.10` parses as the float 3.1, and GitHub then reports the check
+    as "gate (3.1)" — a context name nothing requires. Quoting is what keeps
+    the derived contexts below honest.
+    """
+    versions = _ci_matrix_versions()
+    assert versions, "ci.yml must keep a non-empty python-version matrix"
+    for version in versions:
+        assert isinstance(version, str), (
+            f"python-version entry {version!r} must be quoted in ci.yml"
+        )
+
+
 def test_gate_contexts_match_ci_matrix():
-    """Pin the required contexts to the ci.yml gate matrix.
+    """Pin the required contexts to the ci.yml gate matrix, in both directions.
 
     The context names GitHub reports are "<job> (<matrix value>)". This test
-    guards the coupling the script comment documents: if ci.yml's python-version
-    matrix drifts from the contexts hard-coded in the script, auto-merge arming
-    silently breaks, so fail loudly here instead.
+    guards the coupling the script comment documents. Both directions matter:
+    a required context the matrix never produces leaves every PR waiting on a
+    status that never arrives (auto-merge stops working repo-wide), and a
+    matrix entry nothing requires lets a merge land with that leg red.
+
+    Deriving both sides rather than hard-coding a version list means widening
+    the matrix later is an edit to ci.yml plus GATE_CONTEXTS, with no test
+    churn — and forgetting either half still fails loudly here.
     """
-    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
-    script = SCRIPT.read_text()
-    for version in ("3.11", "3.12", "3.13"):
-        assert f'"{version}"' in ci, f"ci.yml no longer runs python {version}"
-        assert f"gate ({version})" in script, (
-            f"script must require the 'gate ({version})' status check"
-        )
+    expected = [f"gate ({version})" for version in _ci_matrix_versions()]
+
+    assert _script_gate_contexts() == expected, (
+        "apply-branch-protection.sh GATE_CONTEXTS must name exactly the checks "
+        "ci.yml's gate matrix produces"
+    )
+
+
+def test_requires_python_floor_matches_ci_matrix():
+    """The declared support floor must be a version CI actually exercises.
+
+    The point of narrowing to 3.12 was to stop declaring support for
+    interpreters nothing verifies. If requires-python drops below the lowest
+    matrix entry the claim goes unverified again.
+    """
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    requires = pyproject["project"]["requires-python"]
+    lowest = min(_ci_matrix_versions(), key=lambda v: tuple(int(p) for p in v.split(".")))
+
+    assert requires == f">={lowest}", (
+        f"requires-python is {requires!r} but the lowest CI matrix entry is "
+        f"{lowest!r}; the declared floor must be a version CI exercises"
+    )
+
+
+def test_ruff_target_version_matches_requires_python():
+    """ruff's target-version must track the declared floor.
+
+    A stale target-version silently lints for an older interpreter than the
+    project claims to support.
+    """
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    requires = pyproject["project"]["requires-python"]
+    target = pyproject["tool"]["ruff"]["target-version"]
+
+    expected = "py" + requires.removeprefix(">=").replace(".", "")
+    assert target == expected, (
+        f"ruff target-version is {target!r} but requires-python is {requires!r}"
+    )
 
 
 def test_put_failure_warns_and_continues(sandbox):

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -249,3 +249,82 @@ def test_cut_rc_invokes_helper_with_release_branch():
     assert "apply-branch-protection.sh" in cut_rc
     assert '"$RELEASE_BRANCH"' in cut_rc
     assert '[[ "$DRY_RUN" == true ]] && PROTECT_ARGS+=("--dry-run")' in cut_rc
+
+
+def test_cut_rc_release_branch_satisfies_the_release_guard():
+    """The RC path must never trip the release/* guard.
+
+    cut-rc.sh runs under `set -e` and does NOT swallow this helper's exit code
+    (pinned by test_cut_rc_isolation.py), so a refusal would abort the cut. The
+    guard is safe only because RELEASE_BRANCH is always release/-prefixed —
+    pin that derivation here rather than trusting it.
+    """
+    cut_rc = (REPO_ROOT / "scripts" / "cut-rc.sh").read_text()
+    assert 'RELEASE_BRANCH="release/v' in cut_rc, (
+        "cut-rc.sh must derive a release/-prefixed branch or the helper's "
+        "release/* guard would abort the cut"
+    )
+
+
+def test_refuses_non_release_branch_by_default(sandbox):
+    """The wholesale PUT must not reach a branch it would silently damage.
+
+    PROTECTION_BODY sets required_pull_request_reviews:null, so applying it to
+    main would disable 'require a pull request before merging' with no error
+    and nothing in a diff to notice. Refuse instead of PUTting.
+    """
+    log = _write_fake_gh(sandbox, put_exit=0)
+
+    result = _run("fuzzypete/theforge", "main")
+
+    assert result.returncode == 2, result.stdout
+    assert "refusing to apply the release-branch ruleset to 'main'" in result.stderr
+    # The refusal must be actionable: name the rule at risk, and hand over the
+    # granular endpoint that changes contexts without touching anything else.
+    assert "required_pull_request_reviews" in result.stderr
+    assert "protection/required_status_checks" in result.stderr
+    assert "--force" in result.stderr
+    assert not log.exists(), f"gh was called for a refused branch: {log.read_text()}"
+
+
+def test_dry_run_also_refuses_non_release_branch(sandbox):
+    """--dry-run must report the refusal, not preview a PUT that would fail.
+
+    A dry-run that prints a plausible PUT body for main would tell the operator
+    the command is fine when the real run rejects it.
+    """
+    log = _write_fake_gh(sandbox, put_exit=0)
+
+    result = _run("--dry-run", "fuzzypete/theforge", "main")
+
+    assert result.returncode == 2, result.stdout
+    assert "refusing to apply the release-branch ruleset" in result.stderr
+    assert "would apply branch protection" not in result.stdout
+    assert not log.exists(), f"gh was called in a refused dry-run: {log.read_text()}"
+
+
+def test_force_allows_non_release_branch(sandbox):
+    """--force is the deliberate escape hatch (e.g. a new release-line branch)."""
+    log = _write_fake_gh(sandbox, put_exit=0)
+
+    result = _run("--force", "fuzzypete/theforge", "some-other-branch")
+
+    assert result.returncode == 0, result.stderr
+    assert "branch protected; auto-merge enabled" in result.stdout
+    calls = log.read_text().strip().splitlines()
+    assert len(calls) == 1 and "PUT" in calls[0], f"expected a single PUT, got: {calls}"
+    # --force must not alter the body it applies.
+    put_body = json.loads((sandbox / "gh.put_body.json").read_text())
+    assert put_body["required_status_checks"]["contexts"] == ["gate (3.12)"]
+
+
+def test_release_branches_are_unaffected_by_the_guard(sandbox):
+    """Every release/* form the RC ladder produces must pass the guard."""
+    for branch in ("release/v0.10", "release/v0.13", "release/v1.0"):
+        log = _write_fake_gh(sandbox, put_exit=0)
+
+        result = _run("fuzzypete/theforge", branch)
+
+        assert result.returncode == 0, f"{branch}: {result.stderr}"
+        assert "refusing" not in result.stderr, f"{branch} must not be refused"
+        log.unlink()


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The 3.12 narrowing is consistent end-to-end, the prior branch-protection context bug is addressed, and I found no blocking regressions. | [google-gemini-3.5-flash] The Python 3.12 narrowing is fully implemented end-to-end, with robust tests and a mechanical guard protecting main from accidental branch protection overrides.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** unknown (>= $5.84 measured)
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `.github/workflows/guard-release-mechanics.yml:70`** The error message in the release-mechanics guard workflow hardcodes release/v0.11 as the target branch, which is stale guidance.

## Story

Narrow supported Python to 3.12 end-to-end, keeping the CI matrix switchable for later (GitHub Issue #2012)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2012