### PR TITLE
Forward-port unconditionally reverts pyproject.toml to main, silently dropping non-version changes

### DIFF
--- a/.github/workflows/forward-port.yml
+++ b/.github/workflows/forward-port.yml
@@ -26,9 +26,18 @@ name: Forward-port release to main
 #   can push to a release branch outside a checked PR.
 # - pyproject.toml and CHANGELOG.md always keep main's version: release-line
 #   commits bump the RC/release version and roll the changelog, and those
-#   must never overwrite main's dev version or its [Unreleased] section.
+#   must never overwrite main's dev version or its [Unreleased] section. That
+#   guard is scoped to the CONTENT, not the files (#2016): reverting the whole
+#   of pyproject.toml also reverted requires-python and the ruff target-version,
+#   silently, while still reporting success. scripts/forward_port_guard.py
+#   restores only [project] version and main's [Unreleased] section, drops the
+#   versioned sections the roll created, and fails the port if anything else
+#   would be discarded.
 # - Any conflict outside those two files aborts the port and files an issue
-#   instead of guessing.
+#   instead of guessing. Conflicts *inside* them are three-way merged with the
+#   release side's version/roll content normalised back to the merge base, so
+#   only genuine conflicts remain — and those abort the port too, rather than
+#   resolving to --ours and dropping the release-line change with it.
 # - "Already ported?" stays a content check (merged tree == main tree) — cheap
 #   and correct regardless of strategy; a merge commit additionally keeps the
 #   ancestry so conflicts don't recur.
@@ -64,6 +73,7 @@ jobs:
         env:
           RELEASE_REF: ${{ github.ref_name }}
         run: |
+          set -o pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin "$RELEASE_REF"
@@ -86,15 +96,55 @@ jobs:
               echo "EOF" >> "$GITHUB_OUTPUT"
               exit 1
             fi
-            # Version files conflict on every rc cut / release bump: keep main's.
-            git checkout --ours -- pyproject.toml CHANGELOG.md
-            git add pyproject.toml CHANGELOG.md
+            # Version files conflict on every rc cut / release bump. Resolving
+            # them with --ours would also revert whatever else the release line
+            # changed in them (#2016), so instead three-way merge each file with
+            # the release side's version/roll content normalised back to the
+            # merge base. Only genuine conflicts survive that, and they abort.
+            for vf in $conflicts; do
+              case "$vf" in
+                pyproject.toml) kind=pyproject ;;
+                CHANGELOG.md) kind=changelog ;;
+                *) continue ;;
+              esac
+              ok=true
+              git show ":1:$vf" > "$RUNNER_TEMP/fp-base" 2>/dev/null || ok=false
+              git show ":2:$vf" > "$RUNNER_TEMP/fp-ours" 2>/dev/null || ok=false
+              git show ":3:$vf" > "$RUNNER_TEMP/fp-theirs" 2>/dev/null || ok=false
+              if [ "$ok" = true ]; then
+                python3 scripts/forward_port_guard.py resolve --kind "$kind" \
+                  --base "$RUNNER_TEMP/fp-base" \
+                  --ours "$RUNNER_TEMP/fp-ours" \
+                  --theirs "$RUNNER_TEMP/fp-theirs" \
+                  --output "$vf" || ok=false
+              else
+                echo "::error::$vf conflicted with no merge-base stage; cannot resolve safely."
+              fi
+              if [ "$ok" != true ]; then
+                git merge --abort
+                echo "conflict_files<<EOF" >> "$GITHUB_OUTPUT"
+                echo "$vf (unresolvable version-file conflict)" >> "$GITHUB_OUTPUT"
+                echo "EOF" >> "$GITHUB_OUTPUT"
+                exit 1
+              fi
+              git add "$vf"
+            done
             git commit --no-edit
           fi
 
           # Even when the merge is clean, never let release-line version bumps
-          # or changelog rolls land on main.
-          git checkout ORIG_HEAD -- pyproject.toml CHANGELOG.md
+          # or changelog rolls land on main — but drop ONLY that content. Every
+          # other release-branch change to these files ports normally, and the
+          # guard fails the port if it would discard anything else (#2016).
+          git show ORIG_HEAD:pyproject.toml > "$RUNNER_TEMP/fp-main-pyproject"
+          git show ORIG_HEAD:CHANGELOG.md > "$RUNNER_TEMP/fp-main-changelog"
+          python3 scripts/forward_port_guard.py protect --kind pyproject \
+            --main "$RUNNER_TEMP/fp-main-pyproject" --merged pyproject.toml \
+            | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          python3 scripts/forward_port_guard.py protect --kind changelog \
+            --main "$RUNNER_TEMP/fp-main-changelog" --merged CHANGELOG.md \
+            | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
           if ! git diff --cached --quiet -- pyproject.toml CHANGELOG.md || ! git diff --quiet -- pyproject.toml CHANGELOG.md; then
             git add pyproject.toml CHANGELOG.md
             git commit --amend --no-edit
@@ -147,7 +197,7 @@ jobs:
           if [ -z "$existing" ]; then
             gh pr create --base main --head "$branch" \
               --title "Forward-port $RELEASE_REF into main" \
-              --body "Automated forward-port of \`$RELEASE_REF\` (@ ${{ github.sha }}) into main. Version files (pyproject.toml, CHANGELOG.md) keep main's copies by design. Opened by forward-port.yml via the forward-port GitHub App so pull_request CI runs with PR-associated checks (#1646)."
+              --body "Automated forward-port of \`$RELEASE_REF\` (@ ${{ github.sha }}) into main. main keeps its own \`[project] version\` and its \`[Unreleased]\` changelog section; every other release-line change to those files is carried, and anything else the guard would drop fails the port instead (#2016). See the run summary for exactly what was excluded. Opened by forward-port.yml via the forward-port GitHub App so pull_request CI runs with PR-associated checks (#1646)."
             existing=$(gh pr list --head "$branch" --base main --state open --json number --jq '.[0].number')
           fi
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -210,6 +210,19 @@ pollutes history and has already caused avoidable merge conflicts in this repo.
 
 Source: `feedback_no_force_add.md`
 
+### Release and CI tooling lives in `scripts/`, not in the package
+
+The "no files outside `src/`, `tests/`, `docs/`" convention carves out `scripts/`
+for tooling that operates *on* the repository rather than shipping with it:
+`cut-rc.sh`, `promote-rc.sh`, `release.sh`, `derive_changelog.py`,
+`apply-branch-protection.sh`, `forward_port_guard.py`. The test is who calls it —
+a Makefile target or a GitHub workflow, never `import theforge`. Such helpers
+must still be unit-tested from `tests/` (see `tests/test_derive_changelog.py`,
+`tests/test_apply_branch_protection.py`, `tests/test_forward_port_guard.py`),
+because the release path breaks in exactly the places nothing exercises. Anything
+importable by the package belongs under `src/`, and scratch files still belong
+nowhere.
+
 ### Do not clean up worktrees or branches blindly
 
 Before deleting a worktree or branch, verify that it has no unique work beyond

--- a/scripts/forward_port_guard.py
+++ b/scripts/forward_port_guard.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Content-scoped protection for the files a forward-port must not fully carry.
+
+`forward-port.yml` merges every `release/*` push into main. Two files always
+differ across that boundary for reasons that must NOT propagate:
+
+  - `pyproject.toml` — the release line bumps `[project] version` to an rc /
+    release version; main keeps its own dev version.
+  - `CHANGELOG.md` — the release line rolls `[Unreleased]` into a versioned
+    section; main keeps `[Unreleased]` accumulating.
+
+The workflow used to defend those two facts by reverting *both files whole* to
+main's copy on every port. That protected the version by discarding everything
+else in the file: #2016 lost `requires-python = ">=3.12"` and
+`[tool.ruff] target-version = "py312"` in transit and still reported success.
+
+This helper scopes the guard to the content it exists for:
+
+  protect  — take the merged tree's file, restore only main's `[project]
+             version` / main's `[Unreleased]` section, and drop the versioned
+             changelog sections the release line rolled. Every other
+             release-branch change survives the port.
+  resolve  — three-way merge a version-file conflict by first normalising the
+             release side's version/roll content back to the merge base, so the
+             only conflicts left are genuine ones (which abort the port).
+
+Both refuse to guess. Anything discarded outside that scope — an unclassifiable
+changelog section, a missing `[project] version`, a merged file the scoped
+rewrite cannot reproduce — exits non-zero with a diagnostic so the port fails
+loudly instead of shipping a partial tree.
+
+Usage:
+    forward_port_guard.py protect --kind {pyproject,changelog} \\
+        --main MAIN_COPY --merged MERGED_FILE [--output PATH]
+    forward_port_guard.py resolve --kind {pyproject,changelog} \\
+        --base BASE --ours OURS --theirs THEIRS --output PATH
+
+Exit 0 on success (a report goes to stdout), 1 on a guard failure, 2 on usage
+errors. Kept pure apart from file IO and the `git merge-file` subprocess in
+`resolve`, so it is unit-testable (see tests/test_forward_port_guard.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+UNRELEASED = "Unreleased"
+
+# `## [Unreleased]` / `## [0.13.0rc9] — 2026-07-25`: the bracketed token is the
+# section key. A `##` heading with no bracket keys on its full text.
+_SECTION_RE = re.compile(r"^##\s+(?!#)(.*)$")
+_BRACKET_KEY_RE = re.compile(r"^\[([^\]]+)\]")
+
+# A release roll only ever adds version-keyed sections. Anything else that a
+# release branch adds is unrelated content and must not be silently dropped.
+_VERSION_KEY_RE = re.compile(r"^v?\d+\.\d+")
+
+# `version = "0.13.0rc9"` inside the `[project]` table.
+_VERSION_LINE_RE = re.compile(r"^version\s*=\s*(.+?)\s*$")
+_TABLE_HEADER_RE = re.compile(r"^\[")
+
+
+class GuardError(Exception):
+    """A drop the guard is not authorised to make — the port must fail."""
+
+
+# --------------------------------------------------------------------------
+# pyproject.toml — protect `[project] version` only
+# --------------------------------------------------------------------------
+
+
+def _project_version_index(lines: list[str]) -> int:
+    """Index of the `version = ...` line inside the `[project]` table, or -1."""
+    in_project = False
+    for index, line in enumerate(lines):
+        if _TABLE_HEADER_RE.match(line):
+            in_project = line.strip() == "[project]"
+            continue
+        if in_project and _VERSION_LINE_RE.match(line):
+            return index
+    return -1
+
+
+def project_version_line(text: str) -> str:
+    """Return the raw `version = ...` line from `[project]`.
+
+    Raises GuardError when the table or the field is absent: without it the
+    guard cannot tell a version bump from any other change, and guessing is
+    exactly the failure mode this helper exists to remove.
+    """
+    lines = text.splitlines()
+    index = _project_version_index(lines)
+    if index < 0:
+        raise GuardError("pyproject.toml has no `version` field in its [project] table")
+    return lines[index]
+
+
+def protect_pyproject(main_text: str, merged_text: str) -> tuple[str, list[str]]:
+    """Merged pyproject with main's `[project] version` restored.
+
+    Everything else in the merged file — dependencies, `requires-python`, tool
+    configuration — is carried through untouched.
+    """
+    main_line = project_version_line(main_text)
+    merged_lines = merged_text.splitlines()
+    index = _project_version_index(merged_lines)
+    if index < 0:
+        raise GuardError("pyproject.toml has no `version` field in its [project] table")
+
+    merged_line = merged_lines[index]
+    report = []
+    if merged_line == main_line:
+        report.append("pyproject.toml: [project] version already matches main; nothing excluded")
+    else:
+        merged_lines[index] = main_line
+        report.append(
+            f"pyproject.toml: excluded the release-line version bump "
+            f"({merged_line.strip()} -> {main_line.strip()}); main keeps its own version"
+        )
+
+    result = _join(merged_lines, merged_text)
+    _verify_pyproject(merged_text, result)
+    report.extend(_carried_report("pyproject.toml", main_text, result))
+    return result, report
+
+
+def _verify_pyproject(merged_text: str, result_text: str) -> None:
+    """Fail unless the result is the merged file with only the version changed.
+
+    A scoped guard that quietly removed anything else would reintroduce #2016
+    in a subtler form, so the rewrite is checked against the merge result
+    rather than trusted.
+    """
+    try:
+        merged = tomllib.loads(merged_text)
+        result = tomllib.loads(result_text)
+    except tomllib.TOMLDecodeError as exc:  # pragma: no cover - malformed input
+        raise GuardError(f"pyproject.toml is not valid TOML after the merge: {exc}") from exc
+
+    merged_project = dict(merged.get("project", {}))
+    result_project = dict(result.get("project", {}))
+    merged_project.pop("version", None)
+    result_project.pop("version", None)
+    merged.pop("project", None)
+    result.pop("project", None)
+
+    if merged_project != result_project or merged != result:
+        removed = _keys_lost(merged_project, result_project) + _keys_lost(merged, result)
+        detail = f" (missing/changed: {', '.join(removed)})" if removed else ""
+        raise GuardError(
+            "the version guard changed pyproject.toml content outside "
+            f"[project] version{detail}; refusing to port a partial file"
+        )
+
+
+def _keys_lost(before: dict, after: dict) -> list[str]:
+    return sorted(key for key, value in before.items() if after.get(key) != value)
+
+
+# --------------------------------------------------------------------------
+# CHANGELOG.md — protect `[Unreleased]` and drop release-roll sections
+# --------------------------------------------------------------------------
+
+
+class Section:
+    """One `## ...` changelog section: its heading line plus the body below it."""
+
+    def __init__(self, heading: str, key: str, body: list[str]) -> None:
+        self.heading = heading
+        self.key = key
+        self.body = body
+
+    @property
+    def lines(self) -> list[str]:
+        return [self.heading, *self.body]
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, Section)
+            and self.heading == other.heading
+            and self.body == other.body
+        )
+
+
+def parse_changelog(text: str) -> tuple[list[str], list[Section]]:
+    """Split a changelog into (preamble lines, sections in file order)."""
+    preamble: list[str] = []
+    sections: list[Section] = []
+    for line in text.splitlines():
+        match = _SECTION_RE.match(line)
+        if match:
+            heading_text = match.group(1).strip()
+            bracket = _BRACKET_KEY_RE.match(heading_text)
+            key = bracket.group(1).strip() if bracket else heading_text
+            sections.append(Section(line, key, []))
+        elif sections:
+            sections[-1].body.append(line)
+        else:
+            preamble.append(line)
+    return preamble, sections
+
+
+def render_changelog(preamble: list[str], sections: list[Section], template: str) -> str:
+    lines = list(preamble)
+    for section in sections:
+        lines.extend(section.lines)
+    return _join(lines, template)
+
+
+def protect_changelog(main_text: str, merged_text: str) -> tuple[str, list[str]]:
+    """Merged changelog with main's `[Unreleased]` restored and rolls dropped.
+
+    Release-roll content is exactly two things: the emptied/rewritten
+    `[Unreleased]` section, and the versioned sections the roll created. Any
+    other section the release line added is unrelated content — it is carried,
+    and if it cannot be classified the port fails rather than dropping it.
+    """
+    _, main_sections = parse_changelog(main_text)
+    merged_preamble, merged_sections = parse_changelog(merged_text)
+
+    main_by_key = {section.key: section for section in main_sections}
+    if UNRELEASED not in main_by_key:
+        raise GuardError(
+            "main's CHANGELOG.md has no `## [Unreleased]` section, so release-roll "
+            "content is not mechanically distinguishable; refusing to guess"
+        )
+
+    kept: list[Section] = []
+    dropped: list[Section] = []
+    # Where main's [Unreleased] goes back: exactly where the merged file had it,
+    # or at the top when the roll removed it outright.
+    unreleased_at: int | None = None
+    for position, section in enumerate(merged_sections):
+        if section.key == UNRELEASED:
+            if unreleased_at is None:
+                unreleased_at = len(kept)
+            dropped.append(section)
+            continue
+        if section.key in main_by_key:
+            kept.append(section)
+        elif _VERSION_KEY_RE.match(section.key):
+            dropped.append(section)
+        else:
+            raise GuardError(
+                f"CHANGELOG.md section `{section.heading.strip()}` (position {position + 1}) "
+                "is absent from main and is not a version section, so it cannot be "
+                "classified as a release roll; refusing to drop it silently"
+            )
+
+    kept.insert(0 if unreleased_at is None else unreleased_at, main_by_key[UNRELEASED])
+
+    result = render_changelog(merged_preamble, kept, merged_text)
+    _verify_changelog(main_text, merged_text, result)
+
+    report = []
+    rolled = [s.key for s in dropped if s.key != UNRELEASED]
+    if rolled:
+        report.append(
+            "CHANGELOG.md: excluded release-roll section(s) "
+            + ", ".join(f"[{key}]" for key in rolled)
+        )
+    merged_unreleased = next((s for s in merged_sections if s.key == UNRELEASED), None)
+    if merged_unreleased is None:
+        report.append("CHANGELOG.md: restored main's [Unreleased] section (the roll emptied it)")
+    elif merged_unreleased != main_by_key[UNRELEASED]:
+        report.append("CHANGELOG.md: kept main's [Unreleased] section over the release line's")
+    if not report:
+        report.append("CHANGELOG.md: no release-roll content to exclude")
+    report.extend(_carried_report("CHANGELOG.md", main_text, result))
+    return result, report
+
+
+def _verify_changelog(main_text: str, merged_text: str, result_text: str) -> None:
+    """Fail unless the result is the merged file minus exactly the roll scope."""
+    _, main_sections = parse_changelog(main_text)
+    merged_preamble, merged_sections = parse_changelog(merged_text)
+    result_preamble, result_sections = parse_changelog(result_text)
+
+    if result_preamble != merged_preamble:
+        raise GuardError(
+            "the changelog guard altered content above the first section heading; "
+            "refusing to port a partial file"
+        )
+
+    main_by_key = {section.key: section for section in main_sections}
+    result_by_key = {section.key: section for section in result_sections}
+
+    for section in merged_sections:
+        if section.key == UNRELEASED or section.key not in main_by_key:
+            continue
+        if result_by_key.get(section.key) != section:
+            raise GuardError(
+                f"the changelog guard dropped or altered section `{section.heading.strip()}`, "
+                "which is neither [Unreleased] nor a release-roll section; "
+                "refusing to port a partial file"
+            )
+
+    if result_by_key.get(UNRELEASED) != main_by_key[UNRELEASED]:
+        raise GuardError("the changelog guard failed to restore main's [Unreleased] section")
+
+    merged_keys = {section.key for section in merged_sections} | {UNRELEASED}
+    invented = sorted(key for key in result_by_key if key not in merged_keys)
+    if invented:
+        raise GuardError(
+            f"the changelog guard invented section(s) absent from the merge: {invented}"
+        )
+
+
+# --------------------------------------------------------------------------
+# shared helpers
+# --------------------------------------------------------------------------
+
+
+def _join(lines: list[str], template: str) -> str:
+    text = "\n".join(lines)
+    if template.endswith("\n") and not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def _carried_report(name: str, main_text: str, result_text: str) -> list[str]:
+    """One line naming how much release-branch change this port actually lands."""
+    diff = [
+        line
+        for line in difflib.unified_diff(
+            main_text.splitlines(), result_text.splitlines(), n=0, lineterm=""
+        )
+        if line[:1] in "+-" and not line.startswith(("+++", "---"))
+    ]
+    if not diff:
+        return [f"{name}: no release-branch change to port"]
+    return [f"{name}: porting {len(diff)} changed line(s) from the release line"]
+
+
+_PROTECTORS = {"pyproject": protect_pyproject, "changelog": protect_changelog}
+
+
+def protect(kind: str, main_text: str, merged_text: str) -> tuple[str, list[str]]:
+    return _PROTECTORS[kind](main_text, merged_text)
+
+
+def resolve(kind: str, base_text: str, ours_text: str, theirs_text: str) -> tuple[str, list[str]]:
+    """Three-way merge a conflicted version file with the roll normalised away.
+
+    The rc bump and the changelog roll conflict on every port. Rewriting the
+    protected scope of *all three* sides to main's copy makes that content
+    identical everywhere, so `git merge-file` sees only genuine release-branch
+    edits — and does not conflict merely because the rc bump sits on the line
+    above one (`requires-python` is adjacent to `version` in practice).
+    Anything that still conflicts is real and propagates as a conflict
+    (GuardError), never as a silent `--ours`.
+    """
+    base_normalised, _ = protect(kind, ours_text, base_text)
+    theirs_normalised, report = protect(kind, ours_text, theirs_text)
+    report = [f"conflict resolution: {line}" for line in report]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        paths = {}
+        for name, text in (
+            ("ours", ours_text),
+            ("base", base_normalised),
+            ("theirs", theirs_normalised),
+        ):
+            path = Path(tmp) / name
+            path.write_text(text)
+            paths[name] = str(path)
+        completed = subprocess.run(
+            [
+                "git",
+                "merge-file",
+                "-p",
+                "-L",
+                "main",
+                "-L",
+                "merge-base (roll normalised)",
+                "-L",
+                "release (roll normalised)",
+                paths["ours"],
+                paths["base"],
+                paths["theirs"],
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    if completed.returncode < 0:  # pragma: no cover - git-level failure
+        raise GuardError(f"git merge-file failed: {completed.stderr.strip()}")
+    if completed.returncode > 0:
+        raise GuardError(
+            f"{completed.returncode} conflict(s) remain after normalising the release-line "
+            "version/roll content — this is a genuine conflict, not a version bump"
+        )
+    return completed.stdout, report
+
+
+def _read(path: str) -> str:
+    return Path(path).read_text()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_protect = sub.add_parser("protect", help="restore main's version/roll scope in place")
+    p_protect.add_argument("--kind", required=True, choices=sorted(_PROTECTORS))
+    p_protect.add_argument("--main", required=True, help="main's copy of the file")
+    p_protect.add_argument("--merged", required=True, help="the merged working-tree file")
+    p_protect.add_argument("--output", help="write here instead of over --merged")
+
+    p_resolve = sub.add_parser("resolve", help="three-way merge a conflicted version file")
+    p_resolve.add_argument("--kind", required=True, choices=sorted(_PROTECTORS))
+    p_resolve.add_argument("--base", required=True, help="merge-base stage (:1:)")
+    p_resolve.add_argument("--ours", required=True, help="main stage (:2:)")
+    p_resolve.add_argument("--theirs", required=True, help="release stage (:3:)")
+    p_resolve.add_argument("--output", required=True)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.command == "protect":
+            result, report = protect(args.kind, _read(args.main), _read(args.merged))
+            destination = args.output or args.merged
+        else:
+            result, report = resolve(
+                args.kind, _read(args.base), _read(args.ours), _read(args.theirs)
+            )
+            destination = args.output
+    except GuardError as exc:
+        print(f"::error::forward-port guard: {exc}", file=sys.stderr)
+        print(f"[forward-port] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    Path(destination).write_text(result)
+    for line in report:
+        print(f"[forward-port] {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_forward_port_guard.py
+++ b/tests/test_forward_port_guard.py
@@ -1,0 +1,354 @@
+"""Tests for scripts/forward_port_guard.py and forward-port.yml's use of it.
+
+The guard exists because forward-port.yml used to revert pyproject.toml and
+CHANGELOG.md wholesale to main's copy on every port (#2016): protecting
+`[project] version` that way also discarded `requires-python` and the ruff
+`target-version`, silently, while the port still reported success.
+
+Covered here:
+  - the release/v0.13 scenario from #2016: main's version survives, the release
+    line's requires-python / ruff target-version port through
+  - changelog rolls are excluded by section, not by reverting the file
+  - anything the guard cannot classify, or would drop outside that scope, is an
+    error rather than a silent drop
+  - conflicted version files are three-way merged, not resolved to --ours
+  - forward-port.yml actually calls the guard and no longer reverts the files
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "forward_port_guard.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "forward-port.yml"
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location("forward_port_guard", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_guard()
+
+
+MAIN_PYPROJECT = """\
+[project]
+name = "theforge"
+version = "0.12.0.dev0"
+requires-python = ">=3.11"
+dependencies = ["pyyaml>=6.0"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 99
+"""
+
+# release/v0.13 at the time of PR #2001: the rc bump plus the two changes #2012
+# made for real reasons, which the old whole-file revert threw away.
+RELEASE_PYPROJECT = """\
+[project]
+name = "theforge"
+version = "0.13.0rc9"
+requires-python = ">=3.12"
+dependencies = ["pyyaml>=6.0"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 99
+"""
+
+MAIN_CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- main-only fix (#999)
+
+## [0.12.0] — 2026-07-01
+
+- shipped earlier
+"""
+
+RELEASE_CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+## [0.13.0rc9] — 2026-07-25
+
+### Fixed
+
+- release-line fix (#1000)
+
+## [0.12.0] — 2026-07-01
+
+- shipped earlier
+"""
+
+
+# --------------------------------------------------------------------------
+# pyproject.toml
+# --------------------------------------------------------------------------
+
+
+def test_release_v013_port_keeps_main_version_and_carries_the_rest():
+    """The #2016 regression, end to end on the real inputs.
+
+    main keeps 0.12.0.dev0; the release line's narrowed floor and ruff target
+    must arrive on main, or the port ships a tree whose CI matrix and declared
+    floor disagree (exactly what test_requires_python_floor_matches_ci_matrix
+    caught on PR #2001).
+    """
+    result, report = guard.protect_pyproject(MAIN_PYPROJECT, RELEASE_PYPROJECT)
+
+    assert 'version = "0.12.0.dev0"' in result
+    assert '"0.13.0rc9"' not in result
+    assert 'requires-python = ">=3.12"' in result
+    assert 'target-version = "py312"' in result
+    assert any("excluded the release-line version bump" in line for line in report)
+
+
+def test_pyproject_with_only_a_version_bump_reports_nothing_else_ported():
+    result, report = guard.protect_pyproject(MAIN_PYPROJECT, MAIN_PYPROJECT)
+
+    assert result == MAIN_PYPROJECT
+    assert any("already matches main" in line for line in report)
+    assert any("no release-branch change to port" in line for line in report)
+
+
+def test_pyproject_dependency_added_on_the_release_line_ports_through():
+    release = RELEASE_PYPROJECT.replace(
+        'dependencies = ["pyyaml>=6.0"]',
+        'dependencies = ["pyyaml>=6.0", "python-dotenv>=1.0"]',
+    )
+
+    result, _ = guard.protect_pyproject(MAIN_PYPROJECT, release)
+
+    assert "python-dotenv>=1.0" in result
+    assert 'version = "0.12.0.dev0"' in result
+
+
+def test_missing_project_version_is_an_error_not_a_guess():
+    with pytest.raises(guard.GuardError, match="no `version` field"):
+        guard.protect_pyproject('[project]\nname = "x"\n', RELEASE_PYPROJECT)
+
+
+def test_version_outside_the_project_table_is_not_mistaken_for_it():
+    """A `version` key in another table must not be rewritten."""
+    merged = RELEASE_PYPROJECT + '\n[tool.other]\nversion = "9.9.9"\n'
+
+    result, _ = guard.protect_pyproject(MAIN_PYPROJECT, merged)
+
+    assert 'version = "9.9.9"' in result
+    assert 'version = "0.12.0.dev0"' in result
+
+
+def test_pyproject_verification_rejects_content_dropped_outside_the_version():
+    """The self-check is what makes 'no silent drops' mechanical.
+
+    If a future edit to the scoped rewrite lost a table, the port must fail
+    rather than open a green PR over a partial file.
+    """
+    doctored = MAIN_PYPROJECT.replace('\n[tool.ruff]\ntarget-version = "py311"\n', "\n")
+
+    with pytest.raises(guard.GuardError, match="outside \\[project\\] version"):
+        guard._verify_pyproject(RELEASE_PYPROJECT, doctored)
+
+
+# --------------------------------------------------------------------------
+# CHANGELOG.md
+# --------------------------------------------------------------------------
+
+
+def test_changelog_roll_is_excluded_by_section_not_by_reverting_the_file():
+    result, report = guard.protect_changelog(MAIN_CHANGELOG, RELEASE_CHANGELOG)
+
+    assert "main-only fix (#999)" in result, "main's [Unreleased] must survive"
+    assert "0.13.0rc9" not in result, "the release roll must not land on main"
+    assert "## [0.12.0] — 2026-07-01" in result
+    assert any("[0.13.0rc9]" in line for line in report)
+
+
+def test_changelog_edits_outside_the_roll_port_through():
+    """An unrelated release-branch changelog edit is release content, not a roll."""
+    release = RELEASE_CHANGELOG.replace("- shipped earlier", "- shipped earlier (corrected)")
+
+    result, _ = guard.protect_changelog(MAIN_CHANGELOG, release)
+
+    assert "- shipped earlier (corrected)" in result
+    assert "main-only fix (#999)" in result
+
+
+def test_changelog_preamble_changes_port_through():
+    release = RELEASE_CHANGELOG.replace("# Changelog", "# Changelog\n\nNow with a preamble.")
+
+    result, _ = guard.protect_changelog(MAIN_CHANGELOG, release)
+
+    assert "Now with a preamble." in result
+
+
+def test_unreleased_is_restored_at_the_top_when_the_roll_removed_it():
+    release = RELEASE_CHANGELOG.replace("## [Unreleased]\n\n", "", 1)
+
+    result, report = guard.protect_changelog(MAIN_CHANGELOG, release)
+
+    sections = [line for line in result.splitlines() if line.startswith("## ")]
+    assert sections[0] == "## [Unreleased]"
+    assert "main-only fix (#999)" in result
+    assert any("restored main's [Unreleased]" in line for line in report)
+
+
+def test_unclassifiable_new_section_is_reported_not_dropped():
+    """A non-version section main lacks cannot be proven to be a roll.
+
+    Dropping it would be exactly the silent loss #2016 is about, so the guard
+    fails the port instead.
+    """
+    release = RELEASE_CHANGELOG.replace(
+        "## [0.12.0] — 2026-07-01",
+        "## Migration notes\n\n- read this\n\n## [0.12.0] — 2026-07-01",
+    )
+
+    with pytest.raises(guard.GuardError, match="cannot be classified"):
+        guard.protect_changelog(MAIN_CHANGELOG, release)
+
+
+def test_main_without_unreleased_refuses_to_guess():
+    main = MAIN_CHANGELOG.replace("## [Unreleased]\n\n### Fixed\n\n- main-only fix (#999)\n\n", "")
+
+    with pytest.raises(guard.GuardError, match="refusing to guess"):
+        guard.protect_changelog(main, RELEASE_CHANGELOG)
+
+
+def test_changelog_verification_rejects_a_dropped_non_roll_section():
+    """A deletion outside the roll scope is an error, not an accepted port."""
+    doctored = MAIN_CHANGELOG  # missing the release line's [0.12.0] edit entirely
+    merged = RELEASE_CHANGELOG.replace("- shipped earlier", "- shipped earlier (corrected)")
+
+    with pytest.raises(guard.GuardError, match="dropped or altered section"):
+        guard._verify_changelog(MAIN_CHANGELOG, merged, doctored)
+
+
+# --------------------------------------------------------------------------
+# conflict resolution
+# --------------------------------------------------------------------------
+
+
+def test_resolve_merges_a_conflicted_pyproject_instead_of_taking_ours():
+    """The rc bump conflicts on every port; --ours would drop the real change.
+
+    base -> ours: main bumped its dev version.
+    base -> theirs: the release line cut an rc AND narrowed requires-python.
+    The resolution must keep main's version and carry the narrowing.
+    """
+    base = MAIN_PYPROJECT.replace('version = "0.12.0.dev0"', 'version = "0.12.0a0"')
+    ours = MAIN_PYPROJECT
+    theirs = RELEASE_PYPROJECT
+
+    result, report = guard.resolve("pyproject", base, ours, theirs)
+
+    assert 'version = "0.12.0.dev0"' in result
+    assert 'requires-python = ">=3.12"' in result
+    assert 'target-version = "py312"' in result
+    assert "<<<<<<<" not in result
+    assert any(line.startswith("conflict resolution:") for line in report)
+
+
+def test_resolve_merges_a_conflicted_changelog_keeping_mains_unreleased():
+    base = MAIN_CHANGELOG.replace("### Fixed\n\n- main-only fix (#999)\n\n", "")
+    ours = MAIN_CHANGELOG
+    theirs = RELEASE_CHANGELOG.replace("- shipped earlier", "- shipped earlier (corrected)")
+
+    result, _ = guard.resolve("changelog", base, ours, theirs)
+
+    assert "main-only fix (#999)" in result
+    assert "- shipped earlier (corrected)" in result
+    assert "0.13.0rc9" not in result
+    assert "<<<<<<<" not in result
+
+
+def test_resolve_reports_a_genuine_conflict_rather_than_picking_a_side():
+    base = MAIN_PYPROJECT
+    ours = MAIN_PYPROJECT.replace("line-length = 99", "line-length = 88")
+    theirs = RELEASE_PYPROJECT.replace("line-length = 99", "line-length = 120")
+
+    with pytest.raises(guard.GuardError, match="genuine conflict"):
+        guard.resolve("pyproject", base, ours, theirs)
+
+
+# --------------------------------------------------------------------------
+# CLI + workflow wiring
+# --------------------------------------------------------------------------
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_protect_rewrites_the_merged_file_in_place(tmp_path):
+    main = tmp_path / "main.toml"
+    merged = tmp_path / "pyproject.toml"
+    main.write_text(MAIN_PYPROJECT)
+    merged.write_text(RELEASE_PYPROJECT)
+
+    result = _run_cli(
+        "protect", "--kind", "pyproject", "--main", str(main), "--merged", str(merged)
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert 'version = "0.12.0.dev0"' in merged.read_text()
+    assert 'requires-python = ">=3.12"' in merged.read_text()
+    assert "[forward-port]" in result.stdout
+
+
+def test_cli_exits_nonzero_and_annotates_on_a_guard_failure(tmp_path):
+    main = tmp_path / "main.md"
+    merged = tmp_path / "CHANGELOG.md"
+    main.write_text("# Changelog\n\n## [0.12.0]\n\n- x\n")
+    merged.write_text(RELEASE_CHANGELOG)
+
+    result = _run_cli(
+        "protect", "--kind", "changelog", "--main", str(main), "--merged", str(merged)
+    )
+
+    assert result.returncode == 1
+    assert "::error::" in result.stderr
+    # The merged file must be left untouched when the guard refuses.
+    assert merged.read_text() == RELEASE_CHANGELOG
+
+
+def test_workflow_no_longer_reverts_the_version_files_wholesale():
+    workflow = WORKFLOW.read_text()
+
+    assert "git checkout ORIG_HEAD -- pyproject.toml CHANGELOG.md" not in workflow, (
+        "the whole-file revert is the #2016 defect; the guard replaces it"
+    )
+    assert "git checkout --ours -- pyproject.toml CHANGELOG.md" not in workflow, (
+        "--ours on a version-file conflict drops release-line changes just as silently"
+    )
+
+
+def test_workflow_invokes_the_guard_for_both_protected_files():
+    workflow = WORKFLOW.read_text()
+
+    assert "scripts/forward_port_guard.py protect --kind pyproject" in workflow
+    assert "scripts/forward_port_guard.py protect --kind changelog" in workflow
+    assert "scripts/forward_port_guard.py resolve --kind" in workflow
+    # A guard failure must fail the step (and so reach the issue/Slack steps)
+    # rather than being swallowed by a pipe into the run summary.
+    assert "set -o pipefail" in workflow


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation scopes forward-port protection to the intended version and changelog-roll content, wires the guard into the workflow, and the focused guard tests pass. | [google-gemini-3.5-flash] The content-scoped forward-port guard is fully implemented, robustly tested, and correctly integrated into the workflow.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** unknown (>= $6.86 measured)
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `scripts/forward_port_guard.py:1`** The new helper script scripts/forward_port_guard.py is created outside the src/, tests/, or docs/ directories.

## Story

Forward-port unconditionally reverts pyproject.toml to main, silently dropping non-version changes (GitHub Issue #2016)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2016