### PR TITLE
Codex CLI runs are recorded cost-unmeasured, so any multi-story sprint using a Codex-backed model cannot dispatch

### DIFF
--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -101,17 +101,54 @@ def run_in_process_group(
     group_killed = True
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        # Kill the group first (bounded — see below), then salvage whatever the
+        # child had already written so the caller can still account for work it
+        # paid for. subprocess.run does this; not doing it discarded a timed-out
+        # agent's partial output, including any token usage it had reported.
+        group_killed = terminate_process_group(proc)
+        _attach_partial_output(proc, exc)
+        raise
     except BaseException:
-        # Covers TimeoutExpired and every other unwind identically: kill the
-        # group, then wait for it *bounded*. An unbounded wait here blocks for
-        # the child's full natural lifetime whenever the group kill did not land
-        # (#1959), turning an enforced timeout into no timeout at all.
+        # Every other unwind: kill the group, then wait for it *bounded*. An
+        # unbounded wait here blocks for the child's full natural lifetime
+        # whenever the group kill did not land (#1959), turning an enforced
+        # timeout into no timeout at all.
         group_killed = terminate_process_group(proc)
         raise
     finally:
         if pgid is not None:
             release_group_record(pgid, group_killed=group_killed)
     return subprocess.CompletedProcess(proc.args, proc.returncode, out, err)
+
+
+def _attach_partial_output(
+    proc: subprocess.Popen[Any],
+    exc: subprocess.TimeoutExpired,
+    *,
+    drain_seconds: float = KILL_GRACE_SECONDS,
+) -> None:
+    """Populate ``exc.stdout``/``exc.stderr`` with the killed child's partial output.
+
+    ``Popen.communicate`` does attach partial reads to the ``TimeoutExpired`` it
+    raises, but joins them as bytes even in text mode, so the value is unusable
+    for a ``text=True`` caller. Re-draining after the group kill gives properly
+    decoded text, the same way ``subprocess.run`` does it.
+
+    Bounded on purpose: if the group kill did not land, a survivor still holding
+    the write end would block this drain for the child's full natural lifetime —
+    exactly the failure #1959 exists to prevent. A drain that times out leaves the
+    exception as-is; partial accounting is a best-effort bonus, never a new way to
+    hang teardown.
+    """
+    try:
+        out, err = proc.communicate(timeout=drain_seconds)
+    except (subprocess.TimeoutExpired, ValueError, OSError):
+        return
+    if out is not None:
+        exc.stdout = out
+    if err is not None:
+        exc.stderr = err
 
 
 def release_group_record(pgid: int, *, group_killed: bool) -> None:

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import cast
 
-from theforge.agent_types import AgentResult
+from theforge.agent_types import AgentResult, ModelUsage
 from theforge.log_level import LogLevel
 from theforge.log_util import _log_line
 
@@ -87,22 +87,45 @@ def _run_with_heartbeat(
     return outcome, elapsed
 
 
+def _decode_stream(raw: object) -> str:
+    """Coerce a subprocess stream (str, bytes, or None) to text."""
+    if raw is None:
+        return ""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw)
+
+
 def _handle_exception(
     exc: BaseException,
     *,
     profile: ModelProfile,
     cli_name: str,
+    partial_cost_fn: Callable[[str], tuple[float | None, tuple[ModelUsage, ...]]] | None = None,
 ) -> AgentResult | None:
-    """Handle common subprocess exceptions. Returns AgentResult or None to re-raise."""
+    """Handle common subprocess exceptions. Returns AgentResult or None to re-raise.
+
+    ``partial_cost_fn`` is an opt-in seam for transports that can price the output
+    a killed run had already emitted. It receives the partial stdout salvaged from
+    the ``TimeoutExpired`` and returns ``(cost_usd, model_usage)``; returning
+    ``(None, ())`` keeps the run cost-unknown. Runners that don't pass it (Claude,
+    which reconstructs partial spend from its own stream loop, and Gemini) behave
+    exactly as before.
+    """
     if isinstance(exc, subprocess.TimeoutExpired):
+        cost_usd: float | None = None
+        model_usage: tuple[ModelUsage, ...] = ()
+        if partial_cost_fn is not None:
+            cost_usd, model_usage = partial_cost_fn(_decode_stream(exc.stdout))
         return AgentResult(
             success=False,
             output=f"TIMEOUT: Agent exceeded {profile.timeout_seconds}s limit",
             session_id=None,
-            cost_usd=None,
+            cost_usd=cost_usd,
             exit_code=-1,
             raw={},
             profile_name=profile.name,
+            model_usage=model_usage,
             # A timeout is a distinct, retryable failure kind — classify it so
             # the coordinator can hand back to dev instead of escalating.
             failure_code="timeout",

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -1,7 +1,14 @@
 """Codex (OpenAI) CLI runner.
 
-Invokes `npx @openai/codex exec --full-auto` as a subprocess,
-captures output via a temp file, and returns an AgentResult.
+Invokes `npx @openai/codex exec --json --full-auto` as a subprocess, captures
+agent text via a temp file (`-o`), and returns an AgentResult.
+
+``--json`` puts codex in machine-readable event mode, which is the ONLY way its
+token usage reaches forge: the human transport prints a bare total that cannot be
+priced against an (input, output) table. Recording every run cost-unknown is what
+deadlocked multi-story sprints on the fail-closed budget check (#2019). Usage is
+parsed from ``turn.completed`` events, priced with cached input discounted, and
+salvaged from partial output when a run is killed mid-flight.
 """
 
 from __future__ import annotations
@@ -11,6 +18,8 @@ import os
 import re
 import tempfile
 import time
+from collections.abc import Iterator
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -61,11 +70,21 @@ def build_argv(
     output_file: Path,
     prompt: str,
 ) -> list[str]:
-    """Construct argv for a fresh `codex exec` invocation."""
+    """Construct argv for a fresh `codex exec` invocation.
+
+    ``--json`` puts codex in machine-readable event mode: it streams JSONL thread
+    events on stdout, including a ``turn.completed`` event carrying the turn's
+    token usage split. Without it the only usage figure codex prints is a bare
+    human-readable total, which cannot be priced against an (input, output) table
+    — so every run was recorded cost-unknown and a multi-story sprint deadlocked
+    on the fail-closed budget check (#2019). The ``-o`` last-message file is kept
+    for agent text; ``--json`` only changes what stdout carries.
+    """
     cmd: list[str] = [
         "npx",
         "@openai/codex",
         "exec",
+        "--json",
         "--full-auto",
         "-m",
         profile.model,
@@ -107,12 +126,21 @@ def build_resume_argv(
     the ``--full-auto`` alias is intentionally dropped because it is deprecated
     (codex maps it to ``--sandbox workspace-write``) and would contradict an
     explicit ``read-only`` override.
+
+    ``--json`` is reasserted here for the same reason it is set on the fresh path
+    (#2019): usage is only machine-readable in event mode, and a resumed dev
+    iteration is exactly as billable as the first one. The resume subcommand is
+    known to reject some flags the fresh path accepts (``--sandbox``, above), so
+    the contract test parametrizes resume alongside fresh — a future CLI that
+    stops accepting ``--json`` on resume surfaces there rather than at dogfood
+    time.
     """
     cmd: list[str] = [
         "npx",
         "@openai/codex",
         "exec",
         "resume",
+        "--json",
         "-m",
         profile.model,
     ]
@@ -181,6 +209,177 @@ def _coerce_int(value: Any) -> int | None:
         if digits.isdigit():
             return int(digits)
     return None
+
+
+# ── JSON event stream (`codex exec --json`) ───────────────────────────
+
+
+@dataclass(frozen=True)
+class _CodexUsage:
+    """Token usage recovered from codex ``turn.completed`` events.
+
+    Mirrors codex's own ``TokenUsage`` shape. Two containment relationships hold
+    there and are relied on for pricing:
+
+    * ``cached_input_tokens`` is a SUBSET of ``input_tokens`` (codex's own
+      ``non_cached_input()`` is ``input - cached``), so cached tokens are
+      discounted out of the input total rather than charged on top of it.
+    * ``reasoning_output_tokens`` is a SUBSET of ``output_tokens``, so it is
+      recorded for visibility but NOT added to billable output — doing so would
+      charge reasoning twice and overstate measured spend, which is exactly the
+      dishonesty #1992 set out to remove.
+
+    ``cache_write_input_tokens`` is likewise part of ``input_tokens`` and carries
+    no surcharge on OpenAI pricing, so it is recorded but priced at the normal
+    input rate (i.e. left inside the uncached remainder).
+    """
+
+    input_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_write_input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_output_tokens: int = 0
+
+    def __add__(self, other: "_CodexUsage") -> "_CodexUsage":
+        return _CodexUsage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            cached_input_tokens=self.cached_input_tokens + other.cached_input_tokens,
+            cache_write_input_tokens=(
+                self.cache_write_input_tokens + other.cache_write_input_tokens
+            ),
+            output_tokens=self.output_tokens + other.output_tokens,
+            reasoning_output_tokens=(self.reasoning_output_tokens + other.reasoning_output_tokens),
+        )
+
+
+def _iter_codex_events(stdout: str) -> "Iterator[dict[str, Any]]":
+    """Yield parsed JSONL event objects from a `codex exec --json` stdout stream.
+
+    Non-JSON lines are skipped rather than treated as an error: codex may
+    interleave a plain-text banner or warning, and a partially-written final line
+    is normal in the killed-run path.
+    """
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            continue
+        try:
+            event = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(event, dict):
+            yield event
+
+
+def _first_int(block: dict[str, Any], keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        value = _coerce_int(block.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _parse_usage_block(block: dict[str, Any]) -> _CodexUsage | None:
+    """Parse one codex ``usage`` object; None when it carries no token counts."""
+    input_tokens = _first_int(block, ("input_tokens", "prompt_tokens"))
+    output_tokens = _first_int(block, ("output_tokens", "completion_tokens"))
+    if input_tokens is None and output_tokens is None:
+        return None
+    return _CodexUsage(
+        input_tokens=input_tokens or 0,
+        cached_input_tokens=_first_int(block, ("cached_input_tokens", "cached_tokens")) or 0,
+        cache_write_input_tokens=(
+            _first_int(block, ("cache_write_input_tokens", "cache_creation_input_tokens")) or 0
+        ),
+        output_tokens=output_tokens or 0,
+        reasoning_output_tokens=(
+            _first_int(block, ("reasoning_output_tokens", "reasoning_tokens")) or 0
+        ),
+    )
+
+
+def _usage_from_events(stdout: str) -> _CodexUsage | None:
+    """Sum the ``usage`` of every ``turn.completed`` event in a codex event stream.
+
+    Each ``turn.completed`` reports the usage of the turn that just finished, so
+    turns are summed — the same convention the Claude runner uses for its own
+    per-message usage events. A single-turn ``codex exec`` (the common case) makes
+    sum and last-event identical; the choice only matters for a run that completes
+    several turns in one process, where summing is what "what this process spent"
+    means. Returns None when no turn ever reported usage.
+    """
+    total: _CodexUsage | None = None
+    for event in _iter_codex_events(stdout):
+        if event.get("type") != "turn.completed":
+            continue
+        block = event.get("usage")
+        if not isinstance(block, dict):
+            turn = event.get("turn")
+            block = turn.get("usage") if isinstance(turn, dict) else None
+        if not isinstance(block, dict):
+            continue
+        parsed = _parse_usage_block(block)
+        if parsed is None:
+            continue
+        total = parsed if total is None else total + parsed
+    return total
+
+
+def _agent_text_from_events(stdout: str) -> str | None:
+    """Reconstruct the agent's visible message text from a codex event stream.
+
+    Only used when the ``-o`` last-message file came back empty. Before ``--json``
+    that fallback dumped raw stdout, which under event mode would feed JSONL
+    straight into handoff and review parsing.
+    """
+    texts: list[str] = []
+    for event in _iter_codex_events(stdout):
+        etype = event.get("type")
+        item = event.get("item") if isinstance(event.get("item"), dict) else None
+        if etype in ("item.completed", "item.updated") and item is not None:
+            kind = item.get("type") or item.get("item_type")
+            if kind in ("agent_message", "assistant_message"):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str) and text.strip():
+                    texts.append(text.strip())
+        elif etype in ("agent_message", "assistant_message"):
+            text = event.get("text") or event.get("message")
+            if isinstance(text, str) and text.strip():
+                texts.append(text.strip())
+    if not texts:
+        return None
+    return "\n\n".join(texts)
+
+
+def _error_text_from_events(stdout: str) -> str | None:
+    """Collect error/failure messages from a codex event stream.
+
+    Needed because ``--json`` can carry a failure entirely on stdout as an
+    ``error``/``turn.failed`` event. Without surfacing it into ``AgentResult.output``
+    the CLI→API quota fallback classifier, which pattern-matches that text, would
+    stop seeing rate-limit and quota errors on this transport.
+    """
+    messages: list[str] = []
+    for event in _iter_codex_events(stdout):
+        if event.get("type") not in ("error", "turn.failed", "thread.failed"):
+            continue
+        for candidate in (event.get("message"), event.get("error"), event.get("detail")):
+            if isinstance(candidate, str) and candidate.strip():
+                messages.append(candidate.strip())
+                break
+            if isinstance(candidate, dict):
+                nested = candidate.get("message")
+                if isinstance(nested, str) and nested.strip():
+                    messages.append(nested.strip())
+                    break
+    if not messages:
+        return None
+    return "\n".join(messages)
+
+
+def _looks_like_codex_events(stdout: str) -> bool:
+    """True when stdout is a codex JSONL event stream rather than human text."""
+    return next(_iter_codex_events(stdout), None) is not None
 
 
 def _usage_from_json(result_json: dict[str, Any]) -> tuple[int, int] | None:
@@ -268,7 +467,20 @@ def _extract_codex_cost(
     cannot, ``cost_usd`` is ``None`` (cost-unknown, surfaced loudly) — never
     ``0.0``, so an unmeasured run stays distinct from a genuinely free one.
     """
-    usage = _usage_from_json(result_json) or _usage_from_text(stdout)
+    event_usage = _usage_from_events(stdout)
+    if event_usage is not None:
+        return _price_codex_usage(profile=profile, usage=event_usage)
+
+    # Legacy/defensive fallbacks: a structured-output blob in the -o file, or a
+    # synthetic single-line stdout summary carrying an explicit input+output
+    # split. Neither distinguishes cache tiers, so they price flat — which is why
+    # the line-scan is skipped entirely once stdout is known to be an event
+    # stream. There the event parser is authoritative, and letting the regex match
+    # a JSON usage line instead would silently re-charge cached input at the full
+    # rate, reintroducing the overstatement the split exists to avoid.
+    usage = _usage_from_json(result_json)
+    if usage is None and not _looks_like_codex_events(stdout):
+        usage = _usage_from_text(stdout)
     if usage is None:
         model = profile.model or "?"
         if model not in _COST_UNMEASURED_WARNED:
@@ -279,17 +491,75 @@ def _extract_codex_cost(
             )
         return None, ()
     input_tokens, output_tokens = usage
-    cost = _estimate_cost("openai", profile.model, input_tokens, output_tokens)
+    return _price_codex_usage(
+        profile=profile,
+        usage=_CodexUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+    )
+
+
+def _price_codex_usage(
+    *,
+    profile: ModelProfile,
+    usage: _CodexUsage,
+) -> tuple[float | None, tuple[ModelUsage, ...]]:
+    """Price a recovered codex usage split into (cost_usd, model_usage).
+
+    Cached input is discounted rather than charged at the uncached rate; reasoning
+    output is recorded but not re-billed (it is already inside ``output_tokens``).
+    ``cost_usd`` is None when the model has no pricing entry, but the usage split
+    is still returned so the audit records the measured tokens.
+    """
+    cost = _estimate_cost(
+        "openai",
+        profile.model,
+        usage.input_tokens,
+        usage.output_tokens,
+        cached_input_tokens=usage.cached_input_tokens,
+    )
     model_usage = (
         ModelUsage(
             model=profile.model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cache_read_tokens=0,
-            cache_creation_tokens=0,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_read_tokens=usage.cached_input_tokens,
+            cache_creation_tokens=usage.cache_write_input_tokens,
             cost_usd=cost,
+            thinking_tokens=usage.reasoning_output_tokens,
         ),
     )
+    return cost, model_usage
+
+
+def _partial_codex_cost(
+    *,
+    profile: ModelProfile,
+    stdout: str,
+) -> tuple[float | None, tuple[ModelUsage, ...]]:
+    """Price the usage a killed codex run emitted before it was terminated.
+
+    A timed-out run still cost real money for every turn it completed. Because
+    ``codex exec --json`` emits ``turn.completed`` as each turn lands, the partial
+    stdout salvaged from the timeout usually carries priceable usage. Only when no
+    turn ever reported usage is the run recorded cost-unknown — the honest answer
+    then, but no longer the automatic one.
+    """
+    usage = _usage_from_events(stdout)
+    label = profile.name or profile.model or "?"
+    if usage is None:
+        key = f"partial:{label}:{profile.model}"
+        if key not in _COST_UNMEASURED_WARNED:
+            _COST_UNMEASURED_WARNED.add(key)
+            _log(
+                f"  WARNING: Codex CLI run for {label} was killed before reporting any "
+                "token usage; recording cost-unknown, NOT $0.00."
+            )
+        return None, ()
+    cost, model_usage = _price_codex_usage(profile=profile, usage=usage)
+    if cost is not None:
+        _log(
+            f"  {label} killed mid-run: recovered partial cost ${cost:.4f} from "
+            "codex turn.completed usage (run did not finish)."
+        )
     return cost, model_usage
 
 
@@ -361,7 +631,14 @@ def _run_codex(
     try:
         if outcome.exception:
             result = _handle_exception(
-                outcome.exception, profile=profile, cli_name="npx @openai/codex"
+                outcome.exception,
+                profile=profile,
+                cli_name="npx @openai/codex",
+                # Salvage usage from the partial event stream before declaring a
+                # killed run unmeasurable (#2019).
+                partial_cost_fn=lambda partial: _partial_codex_cost(
+                    profile=profile, stdout=partial
+                ),
             )
             if result:
                 return result
@@ -382,7 +659,25 @@ def _run_codex(
             pass
 
         if not output_text:
-            output_text = proc.stdout or proc.stderr or "(no output)"
+            # Under `--json` stdout is a JSONL event stream, so the old raw-stdout
+            # fallback would feed event objects into handoff/review parsing.
+            # Reconstruct the agent's message from the events instead; fall back to
+            # raw stdout only when it is not an event stream at all.
+            raw_stdout = proc.stdout or ""
+            reconstructed = _agent_text_from_events(raw_stdout)
+            if reconstructed:
+                output_text = reconstructed
+            elif _looks_like_codex_events(raw_stdout):
+                # No agent message means the run failed. Surface the event
+                # stream's error text so the CLI→API quota fallback classifier
+                # can still see rate-limit/quota strings.
+                output_text = (
+                    _error_text_from_events(raw_stdout)
+                    or proc.stderr
+                    or "(no agent message in codex event stream)"
+                )
+            else:
+                output_text = raw_stdout or proc.stderr or "(no output)"
 
         # Try JSON parse for structured response
         result_json: dict[str, Any] = {}

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -131,6 +131,11 @@ _DEFAULT_MAX_ITERATIONS = 75
 
 _MISSING_PRICING_WARNED: set[tuple[str, str]] = set()
 
+# Fraction of the uncached input rate charged for a cache HIT. OpenAI and
+# Anthropic both bill cached input at 10% of the normal input rate; callers that
+# need a different discount pass ``cached_input_rate_mult`` explicitly.
+CACHED_INPUT_RATE_MULT = 0.1
+
 
 def _estimate_cost(
     provider: str,
@@ -139,8 +144,16 @@ def _estimate_cost(
     output_tokens: int,
     *,
     thinking_tokens: int = 0,
+    cached_input_tokens: int = 0,
+    cached_input_rate_mult: float = CACHED_INPUT_RATE_MULT,
 ) -> float | None:
-    """Estimate cost from pricing table; returns None if model unknown."""
+    """Estimate cost from pricing table; returns None if model unknown.
+
+    ``cached_input_tokens`` is the SUBSET of ``input_tokens`` that was served from
+    the provider's prompt cache, and is discounted to ``cached_input_rate_mult`` of
+    the input rate rather than double-counted. Callers that cannot distinguish the
+    cache tier leave it at 0 and get the previous flat-rate behaviour unchanged.
+    """
     price = PRICING_TABLE.get((provider, model))
     if price is None:
         key = (provider, model)
@@ -153,9 +166,15 @@ def _estimate_cost(
             )
             _MISSING_PRICING_WARNED.add(key)
         return None
+    # Clamp rather than trust: a provider reporting more cached tokens than input
+    # tokens would otherwise produce a negative uncached count and understate spend.
+    cached = max(0, min(cached_input_tokens, input_tokens))
+    uncached_input_tokens = input_tokens - cached
     billable_output_tokens = output_tokens + thinking_tokens
-    return ((input_tokens / 1_000_000) * price[0]) + (
-        (billable_output_tokens / 1_000_000) * price[1]
+    return (
+        ((uncached_input_tokens / 1_000_000) * price[0])
+        + ((cached / 1_000_000) * price[0] * cached_input_rate_mult)
+        + ((billable_output_tokens / 1_000_000) * price[1])
     )
 
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -101,7 +101,13 @@ from .story_state import (
     landing_failure_outcome,
 )
 
-_UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"codex", "gemini"})
+# CLI transports whose spend forge cannot measure at all, warned about up front.
+# `codex` left this set in #2019: `codex exec --json` reports a real token split
+# per turn, so codex runs now carry measured cost like the claude transport.
+# Actual per-run measurement failures are still caught downstream by the
+# cost-is-None checks that feed `unmeasured_spend` — this set is only the
+# pre-sprint warning, evaluated over config profiles before any run exists.
+_UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"gemini"})
 _STORY_RUN_AUDIT_DIR = ".forge/audits/runs"
 _STORY_RUN_AUDIT_COMMIT_CMD = (
     f'git commit -m "chore(audit): record sprint run audits" -- {_STORY_RUN_AUDIT_DIR}'

--- a/tests/contract/test_codex_cli_contract.py
+++ b/tests/contract/test_codex_cli_contract.py
@@ -7,6 +7,7 @@ Validates that argv constructed by the runner is accepted by the installed
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -16,7 +17,10 @@ from tests.contract.conftest import assert_cli_accepts_argv
 from theforge.config import ModelProfile
 from theforge.runners import runner_codex
 
-pytestmark = pytest.mark.cli_contract
+# NOTE: the cli_contract marker is applied per-test, not module-wide, because the
+# JSON-mode contract below is asserted against argv and a recorded payload rather
+# than a spawned binary — so it belongs in the default gate (repo invariant: no
+# real provider CLI calls there), while the argv-acceptance test stays opt-in.
 
 
 def _profile(**kwargs) -> ModelProfile:
@@ -110,7 +114,73 @@ def _replace_npx_with_codex(argv: list[str]) -> list[str]:
         ),
     ],
 )
+@pytest.mark.cli_contract
 def test_codex_argv_accepted(shape: str, builder) -> None:
     require_cli("codex")
     argv = _replace_npx_with_codex(builder())
     assert_cli_accepts_argv(f"codex/{shape}", argv)
+
+
+@pytest.mark.parametrize(
+    "shape,builder",
+    [
+        (
+            "exec_fresh",
+            lambda: runner_codex.build_argv(
+                profile=_profile(),
+                working_dir=Path("/tmp"),
+                output_file=Path("/tmp/contract-out.txt"),
+                prompt="contract-check",
+            ),
+        ),
+        (
+            "exec_resume",
+            lambda: runner_codex.build_resume_argv(
+                profile=_profile(),
+                output_file=Path("/tmp/contract-out.txt"),
+                session_id="00000000-0000-0000-0000-000000000000",
+            ),
+        ),
+    ],
+)
+def test_codex_invoked_in_json_event_mode(shape: str, builder) -> None:
+    """Forge must ask codex for machine-readable events on BOTH paths (#2019).
+
+    Cost measurement depends entirely on the `turn.completed` usage event, which
+    only exists in `--json` mode. Parametrizing resume alongside fresh is
+    deliberate: the resume subcommand already rejects flags the fresh path accepts
+    (`--sandbox`), so a future CLI that also stops accepting `--json` there would
+    otherwise silently return codex to cost-blind on resumed dev iterations.
+    """
+    argv = builder()
+    assert "--json" in argv
+
+
+# Codex `turn.completed.usage` fields observed on the real CLI. The parser must
+# accept this shape without depending on any human-readable summary text.
+_OBSERVED_TURN_COMPLETED = {
+    "type": "turn.completed",
+    "usage": {
+        "input_tokens": 12892,
+        "cached_input_tokens": 9088,
+        "cache_write_input_tokens": 0,
+        "output_tokens": 21,
+        "reasoning_output_tokens": 14,
+    },
+}
+
+
+def test_parser_accepts_observed_turn_completed_usage_shape() -> None:
+    """Lock the event shape the extraction path is built against.
+
+    Runs without the real binary on purpose (repo invariant: no real provider CLI
+    calls in the default gate). What it pins is the payload contract — if codex
+    renames these fields, this fails here rather than as silent cost-unknown.
+    """
+    usage = runner_codex._usage_from_events(json.dumps(_OBSERVED_TURN_COMPLETED))
+    assert usage is not None
+    assert usage.input_tokens == 12892
+    assert usage.cached_input_tokens == 9088
+    assert usage.cache_write_input_tokens == 0
+    assert usage.output_tokens == 21
+    assert usage.reasoning_output_tokens == 14

--- a/tests/fake_bin/npx
+++ b/tests/fake_bin/npx
@@ -5,6 +5,21 @@ Routes to fake codex or gemini behaviour based on the package argument.
 
 Codex (FAKE_CODEX_MODE):
   happy         — write "Task complete." to the -o output file, exit 0 (default)
+  json_usage    — emit the `codex exec --json` JSONL event stream (thread.started,
+                  item.completed agent_message, turn.completed with a real token
+                  usage split incl. cached/cache-write/reasoning) on stdout AND
+                  write the last message to -o, exit 0
+  json_two_turns
+                — like json_usage but with TWO turn.completed events, so tests can
+                  pin how multi-turn usage is accumulated
+  json_no_output_file
+                — emit the JSONL event stream but leave -o empty, so the runner
+                  must reconstruct agent text from the events rather than dumping
+                  raw JSONL into handoff/review parsing
+  json_partial_hang
+                — emit a turn.completed usage event, flush, then hang past the
+                  runner timeout, so the killed-run partial-cost path can be
+                  exercised end to end
   usage         — write a JSON blob with a token `usage` block to the -o file
   usage_stdout  — write plain text to the -o file, print a SINGLE-LINE token
                   summary carrying an input+output split to stdout (a synthetic
@@ -52,6 +67,51 @@ if "@openai/codex" in args:
                 fh.write(output_text + "\n")
         else:
             print(output_text)
+        sys.exit(0)
+    # Token split mirroring a real `codex exec --json` turn.completed event:
+    # cached_input_tokens is a SUBSET of input_tokens, reasoning_output_tokens a
+    # SUBSET of output_tokens.
+    _TURN_USAGE = {
+        "input_tokens": 12892,
+        "cached_input_tokens": 9088,
+        "cache_write_input_tokens": 256,
+        "output_tokens": 2100,
+        "reasoning_output_tokens": 1400,
+    }
+
+    def _emit_events(turns=1, agent_text="Task complete."):
+        print(json.dumps({"type": "thread.started", "thread_id": "th_fake"}))
+        print(
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"id": "i1", "type": "agent_message", "text": agent_text},
+                }
+            )
+        )
+        for _ in range(turns):
+            print(json.dumps({"type": "turn.completed", "usage": dict(_TURN_USAGE)}))
+        sys.stdout.flush()
+
+    if mode in ("json_usage", "json_two_turns", "json_no_output_file", "json_partial_hang"):
+        # Event mode only exists because forge asked for it. Fail loudly rather
+        # than emitting JSONL a real CLI would not have produced.
+        if "--json" not in args:
+            sys.stderr.write("fake npx(codex): event mode requested without --json\n")
+            sys.exit(2)
+    if mode in ("json_usage", "json_two_turns", "json_no_output_file"):
+        if output_file and mode != "json_no_output_file":
+            with open(output_file, "w") as fh:
+                fh.write("Task complete.\n")
+        _emit_events(turns=2 if mode == "json_two_turns" else 1)
+        sys.exit(0)
+    if mode == "json_partial_hang":
+        _emit_events(turns=1)
+        # Hang past the runner timeout so the kill path fires with usage already
+        # on the wire.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            time.sleep(0.1)
         sys.exit(0)
     if mode == "usage":
         blob = {

--- a/tests/test_config_auto_api_fallback.py
+++ b/tests/test_config_auto_api_fallback.py
@@ -152,6 +152,42 @@ plan_agent_review:
 
 
 def test_sprint_warning_mentions_tracked_api_fallback(tmp_path):
+    """An untracked CLI with an auto-paired API fallback says the fallback IS tracked.
+
+    Uses the gemini transport rather than codex: since #2019 codex reports real
+    per-turn token usage (`codex exec --json`) and so is no longer in the
+    untracked set, which means it no longer reaches this warning branch at all.
+    Gemini has no measured-usage transport yet and is the remaining subject.
+    """
+    cfg_path = _write(
+        tmp_path,
+        """
+models:
+  - gemini-cli/gemini-2.5-pro
+plan:
+  enabled: true
+  cli: gemini
+  model: gemini-2.5-pro
+""",
+    )
+    with _auth_ok, _import_ok:
+        cfg = load_config(cfg_path)
+
+    warnings = _agent_cost_tracking_warnings(cfg)
+    assert any(
+        "API fallback to google/gemini-2.5-pro will be tracked if it triggers" in warning
+        for warning in warnings
+    )
+    assert any("planner" in warning for warning in warnings)
+
+
+def test_sprint_warning_omits_codex_now_that_usage_is_measured(tmp_path):
+    """Codex must not appear in the pre-sprint untracked-cost warnings (#2019).
+
+    The warning was the config-time half of a behaviour whose runtime half
+    deadlocked multi-story sprints: every codex pass recorded cost-unknown, so the
+    first budget check refused to dispatch anything.
+    """
     cfg_path = _write(
         tmp_path,
         """
@@ -166,12 +202,7 @@ plan:
     with _auth_ok, _import_ok:
         cfg = load_config(cfg_path)
 
-    warnings = _agent_cost_tracking_warnings(cfg)
-    assert any(
-        "API fallback to openai/gpt-5.4 will be tracked if it triggers" in warning
-        for warning in warnings
-    )
-    assert any("planner" in warning for warning in warnings)
+    assert not [w for w in _agent_cost_tracking_warnings(cfg) if "codex" in w]
 
 
 def test_models_null_still_raises_clean_schema_error_with_legacy_plan_agent_review(tmp_path):

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -238,6 +238,38 @@ class TestRunInProcessGroup:
             "grandchild survived group timeout kill"
         )
 
+    def test_timeout_preserves_partial_stdout_as_text(self, tmp_path: Path) -> None:
+        """Output written before the kill survives on the exception, decoded (#2019).
+
+        The raised TimeoutExpired previously carried either nothing or bytes-joined
+        garbage in text mode, so a killed agent's already-reported token usage was
+        unrecoverable and the run could only be recorded cost-unknown.
+        """
+        script = "import sys,time;print('partial line');sys.stdout.flush();time.sleep(30)"
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            process_group.run_in_process_group(
+                [sys.executable, "-c", script],
+                timeout=1.5,
+                capture_output=True,
+                text=True,
+            )
+        assert isinstance(excinfo.value.stdout, str)
+        assert "partial line" in excinfo.value.stdout
+
+    def test_timeout_drain_is_bounded(self, tmp_path: Path) -> None:
+        """A timeout must not become an unbounded wait on a surviving writer (#1959)."""
+        script = "import sys,time;print('x');sys.stdout.flush();time.sleep(30)"
+        start = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            process_group.run_in_process_group(
+                [sys.executable, "-c", script],
+                timeout=1.0,
+                capture_output=True,
+                text=True,
+            )
+        # timeout + two bounded grace windows, with slack for a loaded CI box.
+        assert time.monotonic() - start < 1.0 + 4 * process_group.KILL_GRACE_SECONDS + 5.0
+
 
 # ---------------------------------------------------------------------------
 # Runner-level group kill (real fake-CLI subprocess trees)

--- a/tests/test_runner_api_local.py
+++ b/tests/test_runner_api_local.py
@@ -686,6 +686,34 @@ def test_estimate_cost_for_gpt_5_4_variants():
     assert _estimate_cost("openai", "gpt-5.4-pro", 1_000_000, 500_000) == pytest.approx(75.0)
 
 
+def test_estimate_cost_discounts_cached_input_tokens():
+    """Cached input is a subset of input_tokens, billed at 10% of the input rate."""
+    from theforge.runners.schema_utils import _estimate_cost
+
+    # gpt-5.4-mini: (0.25, 2.00)/Mtok. 1M input of which 800k cached.
+    expected = (0.2 * 0.25) + (0.8 * 0.25 * 0.1) + (0.5 * 2.00)
+    assert _estimate_cost(
+        "openai", "gpt-5.4-mini", 1_000_000, 500_000, cached_input_tokens=800_000
+    ) == pytest.approx(expected)
+
+
+def test_estimate_cost_cached_default_preserves_flat_rate_behaviour():
+    """Callers that can't distinguish cache tiers are unchanged."""
+    from theforge.runners.schema_utils import _estimate_cost
+
+    assert _estimate_cost("openai", "gpt-5.4-mini", 1_000_000, 500_000) == pytest.approx(
+        _estimate_cost("openai", "gpt-5.4-mini", 1_000_000, 500_000, cached_input_tokens=0)
+    )
+
+
+def test_estimate_cost_clamps_impossible_cached_count():
+    """More cached than input would otherwise go negative and understate spend."""
+    from theforge.runners.schema_utils import _estimate_cost
+
+    cost = _estimate_cost("openai", "gpt-5.4-mini", 1_000, 0, cached_input_tokens=9_999)
+    assert cost == pytest.approx((1_000 / 1e6) * 0.25 * 0.1)
+
+
 def test_estimate_cost_warns_once_for_unknown_model(caplog):
     from theforge.runners import schema_utils
 

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import stat
+from dataclasses import replace
 from pathlib import Path
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
@@ -11,7 +12,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from theforge.config import ModelProfile
-from theforge.runners.runner_codex import _run_codex
+from theforge.runners.runner_codex import (
+    _agent_text_from_events,
+    _CodexUsage,
+    _error_text_from_events,
+    _price_codex_usage,
+    _run_codex,
+    _usage_from_events,
+)
 
 # Spawn seam patched by the argv-construction tests below.
 _RUN_TARGET = "theforge.runners.runner_codex.process_group.run_in_process_group"
@@ -176,6 +184,141 @@ class TestCodexSandboxFlag:
         assert env_passed["PATH"].split(os.pathsep)[0] == str(venv_bin)
         assert env_passed["VIRTUAL_ENV"] == str(tmp_path / ".venv")
         assert env_passed["OPENAI_API_KEY"] == "secret"
+
+
+class TestCodexJsonInvocationMode:
+    """Codex must be invoked in machine-readable event mode (#2019).
+
+    Without ``--json`` the only usage figure codex prints is a bare human total,
+    which cannot be priced — so every run was recorded cost-unknown and any
+    multi-story sprint on a codex pool deadlocked on the fail-closed budget check.
+    """
+
+    def test_fresh_run_requests_json_events(self, tmp_path: Path) -> None:
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
+            with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
+                _run_codex(prompt="do it", profile=profile, working_dir=tmp_path)
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--json" in cmd
+        # Flag must apply to `exec`, i.e. sit after the subcommand.
+        assert cmd.index("--json") > cmd.index("exec")
+
+    def test_resume_requests_json_events(self, tmp_path: Path) -> None:
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
+            _run_codex(
+                prompt="continue",
+                profile=profile,
+                working_dir=tmp_path,
+                session_id="sess-abc123",
+            )
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--json" in cmd
+        assert cmd.index("--json") > cmd.index("resume")
+
+    def test_output_last_message_file_still_requested(self, tmp_path: Path) -> None:
+        """Agent text still comes from -o; --json only changes what stdout carries."""
+        profile = _make_profile(sandbox_mode="none")
+        mock_proc = _make_subprocess_mock()
+        with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
+            with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
+                _run_codex(prompt="do it", profile=profile, working_dir=tmp_path)
+        assert "-o" in _extract_codex_cmd(mock_run)
+
+
+class TestCodexEventUsageParsing:
+    """Unit coverage for the `turn.completed` usage parser."""
+
+    _EVENT = (
+        '{"type":"thread.started","thread_id":"t1"}\n'
+        '{"type":"turn.completed","usage":{"input_tokens":12892,'
+        '"cached_input_tokens":9088,"cache_write_input_tokens":0,'
+        '"output_tokens":21,"reasoning_output_tokens":14}}\n'
+    )
+
+    def test_parses_full_split(self) -> None:
+        usage = _usage_from_events(self._EVENT)
+        assert usage is not None
+        assert usage.input_tokens == 12892
+        assert usage.cached_input_tokens == 9088
+        assert usage.output_tokens == 21
+        assert usage.reasoning_output_tokens == 14
+
+    def test_sums_multiple_turns(self) -> None:
+        usage = _usage_from_events(self._EVENT + self._EVENT.splitlines()[1] + "\n")
+        assert usage is not None
+        assert usage.input_tokens == 12892 * 2
+        assert usage.output_tokens == 42
+
+    def test_ignores_non_turn_events_and_garbage_lines(self) -> None:
+        stream = 'preamble text\n{"type":"item.completed"}\n{"broken\n'
+        assert _usage_from_events(stream) is None
+
+    def test_tolerates_truncated_final_line(self) -> None:
+        """A killed run's last line is often half-written; earlier turns still count."""
+        usage = _usage_from_events(self._EVENT + '{"type":"turn.compl')
+        assert usage is not None
+        assert usage.input_tokens == 12892
+
+    def test_agent_text_reconstructed_from_events(self) -> None:
+        stream = (
+            '{"type":"item.completed","item":{"type":"agent_message","text":"Done here."}}\n'
+            '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n'
+        )
+        assert _agent_text_from_events(stream) == "Done here."
+
+    def test_agent_text_none_when_no_message_event(self) -> None:
+        assert _agent_text_from_events(self._EVENT) is None
+
+    def test_error_events_surface_for_quota_fallback_classification(self) -> None:
+        """Failures carried only on stdout must still reach AgentResult.output.
+
+        The CLI→API fallback classifier pattern-matches that text, so an error
+        stranded inside the event stream would silently disable quota fallback.
+        """
+        stream = '{"type":"error","message":"429 rate limit exceeded"}\n'
+        assert _error_text_from_events(stream) == "429 rate limit exceeded"
+
+    def test_error_text_reads_nested_message(self) -> None:
+        stream = '{"type":"turn.failed","error":{"message":"usage limit reached"}}\n'
+        assert _error_text_from_events(stream) == "usage limit reached"
+
+
+class TestCodexCachedTokenPricing:
+    """Cached input must be discounted, and reasoning output must not be re-billed."""
+
+    def test_cached_input_is_discounted_not_charged_at_full_rate(self) -> None:
+        profile = _make_profile()
+        usage = _CodexUsage(
+            input_tokens=12892,
+            cached_input_tokens=9088,
+            output_tokens=21,
+            reasoning_output_tokens=14,
+        )
+        cost, model_usage = _price_codex_usage(profile=profile, usage=usage)
+        # o4-mini: (1.10, 4.40)/Mtok. uncached = 12892 - 9088 = 3804.
+        expected = (3804 / 1e6) * 1.10 + (9088 / 1e6) * 1.10 * 0.1 + (21 / 1e6) * 4.40
+        assert cost == pytest.approx(expected)
+        # A flat-rate charge would be strictly larger — that overstatement is the
+        # bug this guards.
+        assert cost < (12892 / 1e6) * 1.10 + (21 / 1e6) * 4.40
+
+    def test_reasoning_tokens_recorded_but_not_double_billed(self) -> None:
+        profile = _make_profile()
+        usage = _CodexUsage(input_tokens=0, output_tokens=1000, reasoning_output_tokens=800)
+        cost, model_usage = _price_codex_usage(profile=profile, usage=usage)
+        assert cost == pytest.approx((1000 / 1e6) * 4.40)
+        assert model_usage[0].thinking_tokens == 800
+
+    def test_cache_write_tokens_surface_in_model_usage(self) -> None:
+        profile = _make_profile()
+        usage = _CodexUsage(input_tokens=100, cache_write_input_tokens=40, output_tokens=10)
+        _, model_usage = _price_codex_usage(profile=profile, usage=usage)
+        assert model_usage[0].cache_creation_tokens == 40
+        assert model_usage[0].cache_read_tokens == 0
 
 
 class TestCodexResumeSandboxReassertion:
@@ -346,6 +489,78 @@ class TestCodexLifecycle:
         )
         assert result.cost_usd == pytest.approx(0.0033)
         assert len(result.model_usage) == 1
+
+    def test_json_event_usage_yields_measured_cost(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A `codex exec --json` turn.completed event is parsed into measured cost."""
+        self._patch_env(monkeypatch, "json_usage")
+        profile = _make_profile(sandbox_mode="none")  # o4-mini: (1.10, 4.40)/Mtok
+        result = _run_codex(prompt="do the thing", profile=profile, working_dir=tmp_path)
+
+        assert result.success is True
+        assert result.cost_usd is not None
+        assert len(result.model_usage) == 1
+        usage = result.model_usage[0]
+        assert usage.input_tokens == 12892
+        assert usage.cache_read_tokens == 9088
+        assert usage.cache_creation_tokens == 256
+        assert usage.output_tokens == 2100
+        assert usage.thinking_tokens == 1400
+        expected = (3804 / 1e6) * 1.10 + (9088 / 1e6) * 1.10 * 0.1 + (2100 / 1e6) * 4.40
+        assert result.cost_usd == pytest.approx(expected)
+
+    def test_json_mode_does_not_leak_events_into_agent_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Empty -o file falls back to the agent message, not the raw JSONL stream."""
+        self._patch_env(monkeypatch, "json_no_output_file")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(prompt="do the thing", profile=profile, working_dir=tmp_path)
+
+        assert result.output == "Task complete."
+        assert "turn.completed" not in result.output
+        assert result.cost_usd is not None
+
+    def test_multi_turn_usage_accumulates(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Two turn.completed events sum, so a multi-turn run is fully accounted."""
+        self._patch_env(monkeypatch, "json_two_turns")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(prompt="do the thing", profile=profile, working_dir=tmp_path)
+
+        assert result.model_usage[0].input_tokens == 12892 * 2
+        assert result.model_usage[0].output_tokens == 2100 * 2
+
+    def test_killed_run_recovers_partial_usage_before_cost_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A run killed on timeout keeps the usage it already emitted (#2019).
+
+        The old path discarded TimeoutExpired output entirely and returned
+        cost_usd=None even when the CLI had already reported a completed turn.
+        """
+        self._patch_env(monkeypatch, "json_partial_hang")
+        profile = replace(_make_profile(sandbox_mode="none"), timeout_seconds=3)
+        result = _run_codex(prompt="do the thing", profile=profile, working_dir=tmp_path)
+
+        assert result.success is False
+        assert result.failure_code == "timeout"
+        assert result.cost_usd is not None
+        assert result.model_usage[0].input_tokens == 12892
+
+    def test_killed_run_without_usage_stays_cost_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No usage emitted before the kill → cost-unknown remains the honest answer."""
+        self._patch_env(monkeypatch, "grandchild_hang")
+        profile = replace(_make_profile(sandbox_mode="none"), timeout_seconds=3)
+        result = _run_codex(prompt="do the thing", profile=profile, working_dir=tmp_path)
+
+        assert result.success is False
+        assert result.cost_usd is None
+        assert result.model_usage == ()
 
     def test_real_total_only_summary_is_cost_unknown_not_fabricated(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/test_sprint_lifecycle.py
+++ b/tests/test_sprint_lifecycle.py
@@ -234,15 +234,9 @@ class TestRunSprint:
         assert "Cost not tracked" not in captured.err
         assert "Budget tracks Claude costs only" not in captured.err
 
-    def test_codex_cli_reviewer_emits_targeted_cost_tracking_warning(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """A CLI Codex reviewer should produce a targeted warning naming that reviewer."""
-        _make_spec_file(tmp_path, "Feature A", "feature-a")
-        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=10.0)
-        config = _make_config(tmp_path)
-        config = replace(
-            config,
+    def _codex_pool_config(self, tmp_path: Path) -> ForgeConfig:
+        return replace(
+            _make_config(tmp_path),
             review_pool=[
                 replace(
                     DEFAULT_REVIEW_PROFILE,
@@ -253,17 +247,79 @@ class TestRunSprint:
                 )
             ],
         )
+
+    def test_codex_cli_reviewer_no_longer_warns_cost_untracked(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Codex is measurable since #2019 (`codex exec --json`), so no untracked warning.
+
+        Replaces the previous assertion that codex emitted "Cost not tracked": the
+        warning was the config-time half of a behaviour that deadlocked multi-story
+        sprints, and it is now wrong rather than merely noisy. Gemini keeps the
+        warning (see the gemini case below) — this is not a blanket removal.
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=10.0)
+        config = self._codex_pool_config(tmp_path)
         result_a = _make_coordinator_result(success=True, cost=1.0)
 
         with patch("theforge.sprint.runner.run_task", return_value=result_a):
             run_sprint(config, manifest_path)
 
         captured = capsys.readouterr()
-        assert (
-            "⚠ Cost not tracked for plan_reviewer (codex CLI, gpt-5.4). "
-            "Audit totals will exclude this agent's usage."
-        ) in captured.err
+        assert "Cost not tracked" not in captured.err
         assert "Budget tracks Claude costs only" not in captured.err
+
+    def test_gemini_cli_reviewer_still_warns_cost_untracked(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Gemini has no measured-usage transport yet, so its warning must survive."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=10.0)
+        config = replace(
+            _make_config(tmp_path),
+            review_pool=[
+                replace(
+                    DEFAULT_REVIEW_PROFILE,
+                    name="gemini_reviewer",
+                    cli="gemini",
+                    provider=None,
+                    model="gemini-2.5-pro",
+                )
+            ],
+        )
+        result_a = _make_coordinator_result(success=True, cost=1.0)
+
+        with patch("theforge.sprint.runner.run_task", return_value=result_a):
+            run_sprint(config, manifest_path)
+
+        assert "Cost not tracked for gemini_reviewer" in capsys.readouterr().err
+
+    def test_multi_story_codex_sprint_dispatches_all_stories_with_measured_total(
+        self, tmp_path: Path
+    ) -> None:
+        """The #2019 regression: a multi-story codex sprint must not skip everything.
+
+        Before the fix every codex pass recorded cost-unknown, so the first budget
+        check refused to dispatch and the whole sprint came back
+        "0 succeeded, 0 failed, N skipped. Total: unknown" despite ample headroom.
+        """
+        for name, slug in (("A", "feature-a"), ("B", "feature-b"), ("C", "feature-c")):
+            _make_spec_file(tmp_path, f"Feature {name}", slug)
+        manifest_path = _make_manifest(
+            tmp_path, ["feature-a.md", "feature-b.md", "feature-c.md"], budget=80.0
+        )
+        config = self._codex_pool_config(tmp_path)
+        results = [_make_coordinator_result(success=True, cost=c) for c in (1.5, 2.0, 2.5)]
+
+        with patch("theforge.sprint.runner.run_task", side_effect=results):
+            sprint_result = run_sprint(config, manifest_path)
+
+        assert sprint_result.specs_total == 3
+        assert sprint_result.specs_succeeded == 3
+        assert sprint_result.specs_skipped == 0
+        assert sprint_result.stopped_reason is None
+        assert sprint_result.total_cost_usd == pytest.approx(6.0)
 
     def test_success_path(self, tmp_path: Path) -> None:
         """Two specs both succeed, costs accumulate, audit written."""


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation satisfies the Codex CLI cost-measurement path, with targeted tests passing locally. | [google-gemini-3.5-flash] Successfully enabled machine-readable token usage and cost tracking for Codex CLI runs, resolving multi-story sprint deadlocks. | [claude-sonnet] Codex CLI now invoked with --json, usage parsed from turn.completed events, cached tokens discounted, killed-run partial usage salvaged; verified the fix flows through the existing cost_usd-is-None -> total_cost_measured -> unmeasured_spend pipeline without needing budget/audit changes.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** unknown (>= $11.24 measured)
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Codex CLI runs are recorded cost-unmeasured, so any multi-story sprint using a Codex-backed model cannot dispatch (GitHub Issue #2019)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2019