### PR TITLE
cut-rc.sh requires the operator to know and pass the next RC number by hand

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,12 +54,22 @@ Python that happened to appear on `PATH`.
 ### 1. Cut an RC
 
 ```bash
-scripts/cut-rc.sh X.Y.Z              # first RC: cuts vX.Y.ZrcN with N=0
-scripts/cut-rc.sh X.Y.Z 1            # subsequent RCs: explicit RC_NUM
+scripts/cut-rc.sh X.Y.Z              # cuts the next RC after the highest vX.Y.ZrcN on origin
+scripts/cut-rc.sh X.Y.Z 1            # explicit RC_NUM overrides the computed one
 scripts/cut-rc.sh --dry-run X.Y.Z
 scripts/cut-rc.sh --no-install X.Y.Z # skip the isolated-venv install + launcher repoint
 scripts/cut-rc.sh --resume X.Y.Z N   # finish a cut that aborted after tag-push
 ```
+
+`RC_NUM` is optional. With no `RC_NUM`, the script queries origin for the
+`vX.Y.Zrc*` tags and cuts one past the highest — `rc0` on a release line that
+has none yet — so a repeat cut needs no `git tag --list` lookup first. The
+resolved number and how it was derived are printed in the header
+(`RC number       : 3 (next after highest existing origin tag v0.13.0rc2)`).
+The tag-already-exists guards (local and origin) still run, so a wrong number
+— computed or passed — refuses rather than clobbers. With `--resume` and no
+`RC_NUM`, the script resumes the *highest existing* tag (the one the aborted
+cut targeted), not a fresh next number.
 
 `--resume` is the recovery path when a cut aborts at one of the post-tag steps
 (isolated venv install, managed-launcher repoint, ladder print). Because the
@@ -115,7 +125,8 @@ release's CHANGELOG entry.
 ### 3. Either fix or promote
 
 - **Ladder passes** → `scripts/promote-rc.sh X.Y.Z`
-- **Ladder fails** → fix on `release/vX.Y`, then `scripts/cut-rc.sh X.Y.Z N+1`
+- **Ladder fails** → fix on `release/vX.Y`, then `scripts/cut-rc.sh X.Y.Z` (the
+  next RC number is computed from the tags on origin)
 
 ### 4. Promote the RC to a final release
 

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -98,9 +98,13 @@ Until #1928 lands:
 ## 4. Cutting a release candidate
 
 ```bash
-RC_NUM=n scripts/cut-rc.sh X.Y.Z
+scripts/cut-rc.sh X.Y.Z        # RC number computed from origin's vX.Y.Zrc* tags
+scripts/cut-rc.sh X.Y.Z n      # explicit override
 ```
 
+- With no `RC_NUM` argument, cuts one past the highest `vX.Y.ZrcN` tag on
+  origin (`rc0` if there are none), and prints which number it picked and why.
+  No `git tag --list` lookup needed before a repeat cut.
 - Reads the current version on the release branch, **overwrites** it to
   `X.Y.Zrcn`, runs the gate, commits, tags, pushes, and configures branch
   protection so auto-merge works. A stale version on the branch is therefore

--- a/scripts/cut-rc.sh
+++ b/scripts/cut-rc.sh
@@ -3,7 +3,13 @@
 #
 # Usage: scripts/cut-rc.sh [--dry-run] [--no-install] [--resume] VERSION [RC_NUM]
 #   VERSION   The target final version, e.g. 0.10.0
-#   RC_NUM    The RC number, default 0 (so first RC is 0.10.0rc0)
+#   RC_NUM    The RC number. Optional — when omitted it is computed from the
+#             v<VERSION>rcN tags that exist on origin: one past the highest
+#             (rc0 if the release line has none yet), so a repeat cut needs
+#             no operator lookup. Passing it explicitly overrides the
+#             computed value. With --resume and no RC_NUM, the highest
+#             existing tag is resumed (the one the original cut targeted),
+#             not a fresh next number.
 #   --resume  Re-enter a previous cut past the tag-push step. The post-tag
 #             steps (isolated venv install, launcher repoint, ladder print)
 #             must remain runnable after the operator has fixed whatever
@@ -102,10 +108,59 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 2
 fi
 
-RC_NUM="${RC_NUM:-0}"
-if [[ ! "$RC_NUM" =~ ^[0-9]+$ ]]; then
+if [[ -n "$RC_NUM" && ! "$RC_NUM" =~ ^[0-9]+$ ]]; then
     echo "Error: RC_NUM must be a non-negative integer (got: $RC_NUM)" >&2
     exit 2
+fi
+
+# Print the highest N among the v<VERSION>rcN tags that exist on origin, or
+# nothing if the release line has no RC tags yet. Returns non-zero only when
+# origin itself could not be queried — an empty result is a valid answer, not
+# a failure.
+highest_origin_rc() {
+    local version="$1"
+    local remote_refs=""
+    if ! remote_refs="$(git ls-remote --tags origin "refs/tags/v${version}rc*" 2>/dev/null)"; then
+        return 1
+    fi
+    printf '%s\n' "$remote_refs" \
+        | sed -n "s#.*refs/tags/v${version}rc\([0-9][0-9]*\)\$#\1#p" \
+        | sort -n \
+        | tail -1
+}
+
+# RC_NUM defaulting. An explicit argument always wins; otherwise the number is
+# derived from origin so the operator never has to look up which RCs exist.
+# The tag-collision guards below still run either way, as a backstop against a
+# computed number that is wrong for any reason.
+if [[ -n "$RC_NUM" ]]; then
+    RC_NUM_SOURCE="explicit RC_NUM argument"
+else
+    if ! HIGHEST_RC="$(highest_origin_rc "$VERSION")"; then
+        echo "Error: could not query origin for existing v${VERSION}rc* tags." >&2
+        echo "       Check that the 'origin' remote is reachable, or pass RC_NUM" >&2
+        echo "       explicitly as the second positional argument (e.g. \`$VERSION 3\`)." >&2
+        exit 1
+    fi
+    if [[ "$RESUME" == true ]]; then
+        # Resume must target the RC the original invocation cut — that tag is
+        # already on origin, so it is the highest existing one, NOT the next
+        # free number.
+        if [[ -z "$HIGHEST_RC" ]]; then
+            echo "Error: --resume with no RC_NUM, but no v${VERSION}rc* tag exists on origin." >&2
+            echo "       There is nothing to resume. Run without --resume to cut a" >&2
+            echo "       fresh RC, or pass the RC_NUM you meant explicitly." >&2
+            exit 1
+        fi
+        RC_NUM=$((10#$HIGHEST_RC))
+        RC_NUM_SOURCE="resuming highest existing origin tag v${VERSION}rc${RC_NUM}"
+    elif [[ -z "$HIGHEST_RC" ]]; then
+        RC_NUM=0
+        RC_NUM_SOURCE="no v${VERSION}rc* tags on origin; starting the release line at rc0"
+    else
+        RC_NUM=$((10#$HIGHEST_RC + 1))
+        RC_NUM_SOURCE="next after highest existing origin tag v${VERSION}rc${HIGHEST_RC}"
+    fi
 fi
 
 RC_VERSION="${VERSION}rc${RC_NUM}"
@@ -118,6 +173,7 @@ RELEASE_BRANCH="release/v$(echo "$VERSION" | cut -d. -f1,2)"
 CURRENT_VERSION=""
 
 echo "Cutting RC      : $RC_VERSION"
+echo "RC number       : $RC_NUM ($RC_NUM_SOURCE)"
 echo "RC tag          : $RC_TAG"
 echo "Release branch  : $RELEASE_BRANCH"
 echo "Dry run         : $DRY_RUN"

--- a/tests/test_cut_rc_isolation.py
+++ b/tests/test_cut_rc_isolation.py
@@ -1479,6 +1479,242 @@ def test_cut_fails_loud_when_pinned_rc_build_python_is_missing(tmp_path: Path) -
     assert not (repo / ".forge" / "rc-envs" / "v0.99.0rc0").exists()
 
 
+def _build_rc_num_fixture(tmp_path: Path, origin_tags: list[str]) -> tuple[Path, Path, dict]:
+    """Fixture for the RC_NUM auto-computation tests.
+
+    Builds a fake repo plus a ``git`` shim whose ``ls-remote`` answers from
+    ``origin_tags`` (bare tag names, e.g. ``["v0.99.0rc0"]``) using the same
+    glob semantics real ``git ls-remote <pattern>`` uses, so both the
+    highest-tag query (``refs/tags/v0.99.0rc*``) and the exact-tag collision
+    guard (``refs/tags/v0.99.0rc3``) are exercised against one source of truth.
+
+    Returns (repo, script_copy, env).
+    """
+    repo = tmp_path / "fake_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "pyproject.toml").write_text('version = "0.99.0"\n')
+    (repo / "Makefile").write_text("gate:\n\t@true\n")
+    # The fixture's pinned interpreter and RC envs live in the work tree; keep
+    # them ignored so the script's clean-tree check sees a clean repo.
+    (repo / ".gitignore").write_text(".venv/\n.forge/\n")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
+
+    real_git = subprocess.run(
+        ["bash", "-c", "command -v git"], capture_output=True, text=True
+    ).stdout.strip()
+    assert real_git
+
+    bin_dir = tmp_path / "shim_bin"
+    bin_dir.mkdir()
+    (bin_dir / "gh").write_text("#!/bin/sh\nif [ \"$3\" != '' ]; then echo 0; fi\nexit 0\n")
+    (bin_dir / "gh").chmod(0o755)
+    (bin_dir / "make").write_text("#!/bin/sh\nexit 0\n")
+    (bin_dir / "make").chmod(0o755)
+
+    tag_list = " ".join(origin_tags) if origin_tags else ""
+    git_shim = bin_dir / "git"
+    git_shim.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            case "$1" in
+                ls-remote)
+                    # git ls-remote --tags origin <pattern>
+                    for t in {tag_list}; do
+                        case "refs/tags/$t" in
+                            $4) printf 'deadbeef\\trefs/tags/%s\\n' "$t" ;;
+                        esac
+                    done
+                    exit 0
+                    ;;
+                push|pull) exit 0 ;;
+            esac
+            exec {real_git} "$@"
+            """
+        )
+    )
+    git_shim.chmod(0o755)
+
+    _provision_repo_pinned_python(repo, tmp_path / "pip_calls.log")
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".local" / "bin").mkdir(parents=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(fake_home)
+    env["PATH"] = f"{fake_home}/.local/bin:{bin_dir}:/usr/bin:/bin"
+    env.pop("VIRTUAL_ENV", None)
+
+    script_copy = tmp_path / "cut-rc.sh"
+    script_text = SCRIPT.read_text(encoding="utf-8")
+    script_text = re.sub(
+        r"^export PATH=\"/opt/homebrew/bin:\$PATH\"\s*$",
+        ": # PATH override stripped for hermetic test",
+        script_text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    script_copy.write_text(script_text)
+    script_copy.chmod(0o755)
+    _provision_apply_branch_protection_sibling(script_copy)
+
+    return repo, script_copy, env
+
+
+def _run_cut_rc(repo: Path, script_copy: Path, env: dict, *args: str) -> tuple[int, str]:
+    proc = subprocess.run(
+        ["bash", str(script_copy), "--dry-run", "--no-install", *args],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_auto_rc_num_is_next_after_highest_origin_tag(tmp_path: Path) -> None:
+    """With no RC_NUM, the script must cut one past the highest existing
+    ``v<VERSION>rcN`` tag on origin instead of always attempting rc0.
+    """
+    repo, script_copy, env = _build_rc_num_fixture(
+        tmp_path, ["v0.99.0rc0", "v0.99.0rc1", "v0.99.0rc2"]
+    )
+    rc, combined = _run_cut_rc(repo, script_copy, env, "0.99.0")
+    assert rc == 0, f"cut-rc.sh should compute rc3 and proceed. Output:\n{combined}"
+    assert "Cutting RC      : 0.99.0rc3" in combined, combined
+    # It must also report how the number was derived — the operator should not
+    # have to infer it.
+    assert re.search(r"RC number\s+: 3 \(next after highest existing origin tag", combined), (
+        f"cut-rc.sh must report the computed RC number and its source. Output:\n{combined}"
+    )
+
+
+def test_auto_rc_num_sorts_numerically_not_lexically(tmp_path: Path) -> None:
+    """rc10 is higher than rc9 — a lexical max would compute rc10 again."""
+    repo, script_copy, env = _build_rc_num_fixture(
+        tmp_path, ["v0.99.0rc8", "v0.99.0rc9", "v0.99.0rc10"]
+    )
+    rc, combined = _run_cut_rc(repo, script_copy, env, "0.99.0")
+    assert rc == 0, combined
+    assert "Cutting RC      : 0.99.0rc11" in combined, combined
+
+
+def test_auto_rc_num_starts_at_zero_on_a_fresh_release_line(tmp_path: Path) -> None:
+    """A release line with no RC tags still cuts rc0, unchanged from before."""
+    repo, script_copy, env = _build_rc_num_fixture(tmp_path, ["v0.98.0rc4"])
+    rc, combined = _run_cut_rc(repo, script_copy, env, "0.99.0")
+    assert rc == 0, combined
+    assert "Cutting RC      : 0.99.0rc0" in combined, combined
+    assert "starting the release line at rc0" in combined
+
+
+def test_explicit_rc_num_overrides_computed_number(tmp_path: Path) -> None:
+    """An explicit RC_NUM still wins over whatever origin's tags imply."""
+    repo, script_copy, env = _build_rc_num_fixture(
+        tmp_path, ["v0.99.0rc0", "v0.99.0rc1", "v0.99.0rc2"]
+    )
+    rc, combined = _run_cut_rc(repo, script_copy, env, "0.99.0", "7")
+    assert rc == 0, combined
+    assert "Cutting RC      : 0.99.0rc7" in combined, combined
+    assert "explicit RC_NUM argument" in combined
+
+
+def test_origin_tag_collision_guard_still_refuses_a_colliding_number(tmp_path: Path) -> None:
+    """The existing tag-already-exists guard must remain a backstop: an
+    explicit (or wrongly computed) number that collides with an origin tag
+    still refuses rather than proceeding to bump/commit/tag.
+    """
+    repo, script_copy, env = _build_rc_num_fixture(
+        tmp_path, ["v0.99.0rc0", "v0.99.0rc1", "v0.99.0rc2"]
+    )
+    rc, combined = _run_cut_rc(repo, script_copy, env, "0.99.0", "1")
+    assert rc != 0, f"colliding RC_NUM must be refused. Output:\n{combined}"
+    assert "already exists on origin" in combined
+
+
+def test_local_tag_collision_guard_still_runs(tmp_path: Path) -> None:
+    """The local tag guard also stays in place ahead of the origin check."""
+    repo, script_copy, env = _build_rc_num_fixture(tmp_path, [])
+    subprocess.run(["git", "-C", str(repo), "tag", "v0.99.0rc0"], check=True)
+    rc, combined = _run_cut_rc(repo, script_copy, env, "0.99.0")
+    assert rc != 0, f"locally existing tag must be refused. Output:\n{combined}"
+    assert "already exists locally" in combined
+
+
+def test_resume_without_rc_num_targets_highest_existing_tag(tmp_path: Path) -> None:
+    """--resume must re-enter the RC the aborted cut targeted — the highest
+    tag already on origin — not a freshly computed next number.
+    """
+    repo, script_copy, env = _build_rc_num_fixture(
+        tmp_path, ["v0.99.0rc0", "v0.99.0rc1", "v0.99.0rc2"]
+    )
+    rc, combined = _run_cut_rc(repo, script_copy, env, "--resume", "0.99.0")
+    assert rc == 0, f"--resume should resume rc2. Output:\n{combined}"
+    assert "Cutting RC      : 0.99.0rc2" in combined, combined
+    assert "resuming highest existing origin tag v0.99.0rc2" in combined
+    assert "0.99.0rc3" not in combined
+
+
+def test_resume_with_explicit_rc_num_targets_that_rc(tmp_path: Path) -> None:
+    """An explicit RC_NUM under --resume is still honoured verbatim."""
+    repo, script_copy, env = _build_rc_num_fixture(
+        tmp_path, ["v0.99.0rc0", "v0.99.0rc1", "v0.99.0rc2"]
+    )
+    rc, combined = _run_cut_rc(repo, script_copy, env, "--resume", "0.99.0", "1")
+    assert rc == 0, combined
+    assert "Cutting RC      : 0.99.0rc1" in combined, combined
+
+
+def test_resume_without_rc_num_fails_when_no_rc_tags_exist(tmp_path: Path) -> None:
+    """There is nothing to resume on a release line with no RC tags; the
+    script must say so rather than silently resolve to rc0 and then fail on
+    the resume-requires-tag check with a less specific message.
+    """
+    repo, script_copy, env = _build_rc_num_fixture(tmp_path, [])
+    rc, combined = _run_cut_rc(repo, script_copy, env, "--resume", "0.99.0")
+    assert rc != 0, combined
+    assert "no v0.99.0rc* tag exists on origin" in combined
+
+
+def test_unreachable_origin_fails_loud_instead_of_defaulting_to_rc0(tmp_path: Path) -> None:
+    """If origin cannot be queried, the computed number would be a guess.
+    Refuse and tell the operator to pass RC_NUM instead of silently cutting
+    rc0 on a line that may already have RCs.
+    """
+    repo, script_copy, env = _build_rc_num_fixture(tmp_path, [])
+    git_shim = tmp_path / "shim_bin" / "git"
+    real_git = subprocess.run(
+        ["bash", "-c", "command -v git"], capture_output=True, text=True
+    ).stdout.strip()
+    git_shim.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            case "$1" in
+                ls-remote)
+                    echo "fatal: could not read from remote repository" >&2
+                    exit 128
+                    ;;
+                push|pull) exit 0 ;;
+            esac
+            exec {real_git} "$@"
+            """
+        )
+    )
+    git_shim.chmod(0o755)
+
+    rc, combined = _run_cut_rc(repo, script_copy, env, "0.99.0")
+    assert rc != 0, f"unreachable origin must fail loud. Output:\n{combined}"
+    assert "could not query origin" in combined
+    assert "Cutting RC" not in combined
+
+
 @pytest.mark.skipif(
     not SCRIPT.exists(),
     reason="cut-rc.sh not present",


### PR DESCRIPTION
## Summary

The change satisfies the RC auto-numbering contract, keeps explicit overrides and collision guards, and covers the resume behavior with focused subprocess tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** unknown (>= $3.16 measured)
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

cut-rc.sh requires the operator to know and pass the next RC number by hand (GitHub Issue #1919)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1919