### PR TITLE
Success message reports a per-cycle dev counter as the story's iteration count

### DIFF
--- a/src/theforge/coordinator/completion.py
+++ b/src/theforge/coordinator/completion.py
@@ -388,7 +388,9 @@ def _create_pr(
         f"- **Verdict:** APPROVE ({p1_count} P1, {p2_count} P2)\n"
         f"- **Reviewers:** {reviewer_names}\n"
         f"- **Cost:** {_fmt_cost_total(state.total_cost_measured, state.total_cost)}\n"
-        f"- **Dev iterations:** {state.dev_iteration}\n"
+        # Story-wide total: state.dev_iteration is the per-cycle counter and
+        # resets on every new review cycle (#1983).
+        f"- **Dev iterations:** {state.budget.total_count}\n"
         f"- **Tests:** N/A\n\n"
         f"## Findings\n\n"
         f"{findings_md}\n\n"

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -188,8 +188,10 @@ def _extract_planner_attempts(state: CoordinatorState, planner_profile) -> list[
 def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: bool) -> RunOutcome:
     """Pure: assemble a :class:`RunOutcome` from coordinator state."""
     complexity = state.preflight_complexity or "medium"
-    # ``dev_trace_count`` is the only monotonic dev-iteration counter (never reset
-    # on cycle boundaries) so it captures total dev attempts across the run.
+    # ``dev_trace_count`` is monotonic (never reset on cycle boundaries) so it
+    # captures total dev attempts across the run. ``budget.total_count`` is the
+    # other such counter — both are incremented together at the single dev call
+    # site (engine.py) and track the same quantity.
     dev_iterations = max(int(state.dev_trace_count or 0), 1)
     # Observed wall-clock of the dev phase (sum of per-call durations). None when
     # nothing was recorded so learning never treats "unknown" as a $0-style zero.

--- a/src/theforge/coordinator/notify.py
+++ b/src/theforge/coordinator/notify.py
@@ -301,7 +301,10 @@ def _escalate_gate_interactive(
     if gate_result:
         _cu._log(f"  Gate:     {gate_result}")
     _cu._log(f"  Cost:     {_cu._fmt_cost_total(state.total_cost_measured, state.total_cost)}")
-    _cu._log(f"  Dev iter: {state.dev_iteration}  Review cycles: {state.review_cycle}")
+    # Both counts are story-wide: the operator is deciding whether this story has
+    # had enough work, so the per-cycle state.dev_iteration would understate it
+    # next to the cumulative review_cycle (#1983).
+    _cu._log(f"  Dev iter: {state.budget.total_count}  Review cycles: {state.review_cycle}")
     _cu._log("")
     _cu._log("  Choose:")
     _cu._log("    [a] Approve  — treat as APPROVE, create PR / merge")

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1687,7 +1687,11 @@ def _run_review_phase(
                     message=(
                         f"Task '{task.name}' completed. "
                         f"Review approved after {state.review_cycle} cycle(s), "
-                        f"{state.dev_iteration} dev iteration(s). "
+                        # budget.total_count, not state.dev_iteration: the latter
+                        # aliases the per-cycle counter, which reset_cycle() zeroes
+                        # whenever a new review cycle opens, so a multi-cycle story
+                        # would report only its final cycle's dev calls (#1983).
+                        f"{state.budget.total_count} dev iteration(s). "
                     ),
                     run_id=run_id,
                 ),

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -676,7 +676,9 @@ def _handle_interactive_review_decision(
             _approve_msg = (
                 f"Task '{task.name}' completed. "
                 f"Human approved after {state.review_cycle} cycle(s), "
-                f"{state.dev_iteration} dev iteration(s). "
+                # budget.total_count, not state.dev_iteration — see the
+                # automatic-approve message below for why (#1983).
+                f"{state.budget.total_count} dev iteration(s). "
             )
         return (
             _ReviewOutcome.DONE,

--- a/tests/test_coord_approve_message_dev_iterations.py
+++ b/tests/test_coord_approve_message_dev_iterations.py
@@ -1,0 +1,151 @@
+"""The approve message reports cross-cycle dev iterations, not per-cycle (#1983).
+
+``state.dev_iteration`` aliases ``budget.cycle_count``, which ``reset_cycle()``
+zeroes whenever a new review cycle opens (engine.py). Reporting it as a story
+total under-counts every multi-cycle story on the success path the operator and
+the sprint summary read. The cumulative value is ``budget.total_count``.
+
+The seam under test is the DEV→REVIEW counter handoff across a cycle boundary,
+so the test drives ``_run_review_phase`` through a real REQUEST_CHANGES →
+RETRY_DEV → APPROVE sequence over a real git worktree, mirroring the engine's
+own budget mutations (``budget.consume()`` per dev call at engine.py:450,
+``budget.reset_cycle()`` on RETRY_DEV at engine.py:715).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.coordinator.review_phase import _ReviewOutcome, _run_review_phase
+from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.review import ReviewFinding, ReviewResult
+
+
+def _init_repo_with_dev_commit(path: Path) -> None:
+    """A repo whose feature branch is ahead of base — the approve path's
+    empty-diff guard refuses to mark DONE otherwise."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+    subprocess.run(["git", "checkout", "-q", "-b", "forge/test-task"], cwd=path, check=True)
+    (path / "src.py").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat: implement"], cwd=path, check=True)
+
+
+def _request_changes_review() -> ReviewResult:
+    return ReviewResult(
+        verdict="REQUEST_CHANGES",
+        summary="needs changes",
+        findings=[
+            ReviewFinding(
+                severity="P1",
+                file="src.py",
+                line=1,
+                observed="Off by one",
+                suggestion="Fix it",
+            )
+        ],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def _approve_review() -> ReviewResult:
+    return ReviewResult(
+        verdict="APPROVE",
+        summary="looks good",
+        findings=[],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def _pool_returning(review: ReviewResult):
+    return lambda *_a, **_kw: ([], [], review, [review], [("review", review)])
+
+
+def test_approve_message_reports_dev_iterations_across_all_cycles(tmp_path: Path) -> None:
+    """2 dev calls in cycle 1 + 1 in cycle 2 → the message must say 3, not 1."""
+    _init_repo_with_dev_commit(tmp_path)
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(log_dir=tmp_path / "logs")
+    state.run_id = "abcd1234"
+    state.budget.max_iterations = config.retry.max_dev_iterations
+
+    # ── Cycle 1: two dev iterations, then REQUEST_CHANGES → back to DEV ──
+    state.budget.consume(review_cycle=state.review_cycle)
+    state.budget.consume(review_cycle=state.review_cycle)
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_pool_returning(_request_changes_review()),
+    ):
+        outcome, result, config = _run_review_phase(
+            state,
+            config,
+            task,
+            "# spec\n",
+            tmp_path,
+            "forge/test-task",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ReviewOutcome.RETRY_DEV
+    assert result is None
+
+    # Cycle boundary: the engine refills the per-cycle pool (engine.py:715).
+    state.budget.reset_cycle()
+    assert state.dev_iteration == 0
+
+    # ── Cycle 2: one more dev iteration, then APPROVE → DONE ──
+    state.budget.consume(review_cycle=state.review_cycle)
+
+    with patch(
+        "theforge.coordinator.review_phase._run_review_pool",
+        side_effect=_pool_returning(_approve_review()),
+    ):
+        outcome, result, config = _run_review_phase(
+            state,
+            config,
+            task,
+            "# spec\n",
+            tmp_path,
+            "forge/test-task",
+            task_start=0.0,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            logger=None,
+        )
+
+    assert outcome is _ReviewOutcome.DONE
+    assert result is not None and result.success is True
+    assert state.phase is Phase.DONE
+
+    # The per-cycle counter is 1 here; the story took 3 dev iterations. The
+    # message — which becomes the run's audit outcome.message — must report 3.
+    assert state.dev_iteration == 1
+    assert state.budget.total_count == 3
+    assert "Review approved after 2 cycle(s), 3 dev iteration(s)." in result.message

--- a/tests/test_coord_approve_message_dev_iterations.py
+++ b/tests/test_coord_approve_message_dev_iterations.py
@@ -80,8 +80,11 @@ def _pool_returning(review: ReviewResult):
     return lambda *_a, **_kw: ([], [], review, [review], [("review", review)])
 
 
-def test_approve_message_reports_dev_iterations_across_all_cycles(tmp_path: Path) -> None:
-    """2 dev calls in cycle 1 + 1 in cycle 2 → the message must say 3, not 1."""
+def _drive_two_cycles_to_approve(tmp_path: Path, *, interactive: bool):
+    """REQUEST_CHANGES (2 dev calls) → RETRY_DEV → APPROVE (1 dev call) → DONE.
+
+    Returns ``(state, result)`` from the approving cycle.
+    """
     _init_repo_with_dev_commit(tmp_path)
 
     config = _make_config(tmp_path)
@@ -106,7 +109,7 @@ def test_approve_message_reports_dev_iterations_across_all_cycles(tmp_path: Path
             tmp_path,
             "forge/test-task",
             task_start=0.0,
-            interactive=False,
+            interactive=interactive,
             auto_merge=False,
             notify=False,
             logger=None,
@@ -134,7 +137,7 @@ def test_approve_message_reports_dev_iterations_across_all_cycles(tmp_path: Path
             tmp_path,
             "forge/test-task",
             task_start=0.0,
-            interactive=False,
+            interactive=interactive,
             auto_merge=False,
             notify=False,
             logger=None,
@@ -142,10 +145,32 @@ def test_approve_message_reports_dev_iterations_across_all_cycles(tmp_path: Path
 
     assert outcome is _ReviewOutcome.DONE
     assert result is not None and result.success is True
-    assert state.phase is Phase.DONE
 
-    # The per-cycle counter is 1 here; the story took 3 dev iterations. The
-    # message — which becomes the run's audit outcome.message — must report 3.
+    # The per-cycle counter is 1 here; the story took 3 dev iterations.
     assert state.dev_iteration == 1
     assert state.budget.total_count == 3
+    return state, result
+
+
+def test_approve_message_reports_dev_iterations_across_all_cycles(tmp_path: Path) -> None:
+    """2 dev calls in cycle 1 + 1 in cycle 2 → the message must say 3, not 1."""
+    state, result = _drive_two_cycles_to_approve(tmp_path, interactive=False)
+
+    assert state.phase is Phase.DONE
+    # This message becomes the run's audit outcome.message.
     assert "Review approved after 2 cycle(s), 3 dev iteration(s)." in result.message
+
+
+def test_interactive_approve_message_reports_dev_iterations_across_all_cycles(
+    tmp_path: Path,
+) -> None:
+    """The human-review approve message has the same contract as the automatic one."""
+    with patch(
+        "theforge.coordinator.review_phase._human_review",
+        return_value=("approve", None),
+    ):
+        state, result = _drive_two_cycles_to_approve(tmp_path, interactive=True)
+
+    assert state.phase is Phase.DONE
+    assert state.human_review_decision == "approve"
+    assert "Human approved after 2 cycle(s), 3 dev iteration(s)." in result.message


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] No P1 findings; the approve messages now use the cumulative dev-iteration counter, and the focused two-cycle regression tests pass. | [google-gemini-3.5-flash] The implementation correctly reports the cumulative dev-iteration count across all cycles in both automatic and interactive approve paths, with comprehensive test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** unknown (>= $4.67 measured)
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Success message reports a per-cycle dev counter as the story's iteration count (GitHub Issue #1983)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1983