### PR TITLE
Iteration usage reports a cumulative dev count against a per-cycle limit

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -15,6 +15,7 @@ from .agent_failure import NO_JUDGMENT
 from .audit_render import build_agent_entries, build_reviews
 from .audit_substrate import CURRENT_RECORD_SCHEMA_VERSION as SCHEMA_VERSION
 from .audit_substrate import MIGRATION_HELPERS
+from .iteration_usage import dev_usage
 from .landing_record import build_landing_record
 from .state import CoordinatorResult, CoordinatorState
 from .trust_status import derive_trust_status
@@ -429,16 +430,10 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
 
 
 def _build_iteration_usage_summary(state: CoordinatorState, config: ForgeConfig) -> dict:
-    dev_used = len(state.dev_iteration_telemetry)
-    dev_max = (
-        state.adaptive_dev_max
-        if state.adaptive_dev_max
-        else (
-            state.dev_iteration_telemetry[0].max_iterations
-            if state.dev_iteration_telemetry
-            else config.retry.max_dev_iterations
-        )
-    )
+    # Per-cycle used against the per-cycle max: dev_max is a per-cycle budget
+    # limit, so counting every dev iteration the story ever ran reported
+    # used > max for any story spanning more than one review cycle (#1985).
+    dev_used, dev_max = dev_usage(state, default_max=config.retry.max_dev_iterations)
     # Budget view: a review cycle VALIDATE bought for a gate or convention
     # finding was really spent, so exhaustion must not report zero (#1981).
     review_used = state.review_cycles_spent

--- a/src/theforge/coordinator/iteration_usage.py
+++ b/src/theforge/coordinator/iteration_usage.py
@@ -1,0 +1,52 @@
+"""Per-cycle dev iteration usage, shared by coordinator and sprint audit.
+
+Stdlib-only imports, duck-typed on the state object, so both the live
+coordinator state and a rehydrated sprint-level state can be read through the
+same helper and cannot drift apart.
+
+``used`` and ``max`` must be on the same scale. ``max`` (``adaptive_dev_max`` /
+``config.retry.max_dev_iterations``) is a **per-cycle** budget limit, so ``used``
+must be per-cycle too. Counting ``len(state.dev_iteration_telemetry)`` reported
+a cumulative, never-reset, whole-story total against that per-cycle cap, so any
+story spanning more than one review cycle read as a budget overrun that never
+happened (#1985).
+
+The per-cycle figure reported is the *peak* single-cycle usage: each telemetry
+entry's ``iteration`` is ``budget.cycle_count`` at the time the dev call ran
+(1-based, reset at every review-cycle boundary), so the largest one is the
+closest any single cycle came to the cap. The live ``budget.cycle_count`` acts
+as a floor for the in-flight cycle, whose dev call may have consumed budget
+before any telemetry was recorded.
+"""
+
+from __future__ import annotations
+
+
+def peak_dev_cycle_usage(state: object) -> int:
+    """Return the highest dev-iteration count reached in any single review cycle."""
+    peak = 0
+    for item in list(getattr(state, "dev_iteration_telemetry", []) or []):
+        iteration = getattr(item, "iteration", None)
+        if isinstance(iteration, int) and iteration > peak:
+            peak = iteration
+    cycle_count = getattr(getattr(state, "budget", None), "cycle_count", None)
+    if isinstance(cycle_count, int) and cycle_count > peak:
+        peak = cycle_count
+    return peak
+
+
+def dev_usage(state: object, *, default_max: int | None = None) -> tuple[int, int | None]:
+    """Return ``(peak_per_cycle_used, per_cycle_cap)`` for a story's dev budget.
+
+    The cap prefers the adaptive value, falls back to the cap recorded on the
+    first dev telemetry entry, then to ``default_max`` (the configured limit for
+    callers that have a ``ForgeConfig``; ``None`` for those that do not).
+    """
+    used = peak_dev_cycle_usage(state)
+    cap = getattr(state, "adaptive_dev_max", None)
+    if not isinstance(cap, int) or isinstance(cap, bool) or cap <= 0:
+        telemetry = list(getattr(state, "dev_iteration_telemetry", []) or [])
+        cap = getattr(telemetry[0], "max_iterations", None) if telemetry else None
+    if not isinstance(cap, int) or isinstance(cap, bool) or cap <= 0:
+        cap = default_max
+    return used, cap

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import yaml
 
 from ..advisory_conventions import noteworthy_advisory_entries
+from ..coordinator.iteration_usage import dev_usage as _dev_usage
 from ..coordinator.landing_record import build_landing_record
 from ..log_util import _log_line
 from .launch_guard import REASON_RECONCILE_PRIOR_DONE, REASON_STRANDED_WORKTREE
@@ -554,17 +555,8 @@ def _write_sprint_audit(
                     cycle_entry["p2_count"] = sum(1 for f in r.findings if f.severity == "P2")
                 reviews_summary.append(cycle_entry)
 
-            dev_used = len(getattr(res.state, "dev_iteration_telemetry", []))
+            dev_used, dev_max = _dev_usage(res.state)
             review_used, review_max, review_exhausted = _review_usage(res.state)
-            dev_max = (
-                getattr(
-                    getattr(res.state, "dev_iteration_telemetry", [None])[0],
-                    "max_iterations",
-                    None,
-                )
-                if getattr(res.state, "dev_iteration_telemetry", [])
-                else None
-            )
             # Tag the source of an ALREADY_DONE outcome so audit / postmortem
             # consumers can distinguish a preflight short-circuit verdict from
             # the resume-skip-merged classification without parsing strings.
@@ -701,15 +693,8 @@ def _write_sprint_audit(
 
     usage_distribution = []
     for spec_str, res in result.results:
-        dev_used = len(getattr(res.state, "dev_iteration_telemetry", []))
+        dev_used, dev_max = _dev_usage(res.state)
         review_used, review_max, review_exhausted = _review_usage(res.state)
-        dev_max = (
-            getattr(
-                getattr(res.state, "dev_iteration_telemetry", [None])[0], "max_iterations", None
-            )
-            if getattr(res.state, "dev_iteration_telemetry", [])
-            else None
-        )
         usage_distribution.append(
             {
                 "spec": spec_str,
@@ -877,17 +862,8 @@ def _write_sprint_summary(
                 last_verdict = res.state.review_results[-1].verdict
             elif res.success:
                 last_verdict = "APPROVE"
-            dev_used = len(getattr(res.state, "dev_iteration_telemetry", []))
+            dev_used, dev_max = _dev_usage(res.state)
             review_used, review_max, review_exhausted = _review_usage(res.state)
-            dev_max = (
-                getattr(
-                    getattr(res.state, "dev_iteration_telemetry", [None])[0],
-                    "max_iterations",
-                    None,
-                )
-                if getattr(res.state, "dev_iteration_telemetry", [])
-                else None
-            )
             _dev_results_list = list(getattr(res.state, "dev_results", []) or [])
             _dev_model: str | None = None
             if _dev_results_list:
@@ -1046,15 +1022,8 @@ def _write_sprint_summary(
 
     usage_distribution = []
     for spec_str, res in result.results:
-        dev_used = len(getattr(res.state, "dev_iteration_telemetry", []))
+        dev_used, dev_max = _dev_usage(res.state)
         review_used, review_max, review_exhausted = _review_usage(res.state)
-        dev_max = (
-            getattr(
-                getattr(res.state, "dev_iteration_telemetry", [None])[0], "max_iterations", None
-            )
-            if getattr(res.state, "dev_iteration_telemetry", [])
-            else None
-        )
         usage_distribution.append(
             {
                 "spec": spec_str,

--- a/tests/test_iteration_telemetry.py
+++ b/tests/test_iteration_telemetry.py
@@ -13,8 +13,8 @@ from theforge.coordinator.state import (
     Phase,
     ReviewIterationTelemetry,
 )
-from theforge.sprint.audit import _write_sprint_summary
-from theforge.sprint.manifest import SprintManifest, SprintResult
+from theforge.sprint.audit import _write_sprint_audit, _write_sprint_summary
+from theforge.sprint.manifest import ResolvedSprint, SprintManifest, SprintResult
 
 
 def test_story_audit_includes_iteration_loop_metrics(tmp_path):
@@ -198,3 +198,175 @@ def test_sprint_summary_includes_iteration_usage_distribution(tmp_path):
             "review": {"used": 1, "max": 2},
         }
     ]
+
+
+def _multi_cycle_dev_state(
+    *, per_cycle_max: int, calls_per_cycle: list[int], phase: Phase = Phase.DONE
+) -> CoordinatorState:
+    """State for a story whose dev iterations span several review cycles.
+
+    ``dev_iteration`` (and therefore ``budget.cycle_count``) is the last cycle's
+    count, exactly as the coordinator leaves it: the per-cycle counter is reset
+    at every cycle boundary while ``dev_iteration_telemetry`` accumulates for the
+    whole story.
+    """
+    state = CoordinatorState(
+        dev_iteration=calls_per_cycle[-1],
+        review_cycle=len(calls_per_cycle),
+        phase=phase,
+    )
+    state.adaptive_dev_max = per_cycle_max
+    state.dev_iteration_telemetry = [
+        DevIterationTelemetry(
+            iteration=iteration,
+            max_iterations=per_cycle_max,
+            cost_usd=0.1,
+            duration_s=1.0,
+            cycle=cycle,
+        )
+        for cycle, calls in enumerate(calls_per_cycle, start=1)
+        for iteration in range(1, calls + 1)
+    ]
+    return state
+
+
+def test_story_audit_dev_usage_is_per_cycle_not_cumulative(tmp_path):
+    """A multi-cycle story that never hit its per-cycle cap reports used <= max.
+
+    Four dev iterations across two cycles used to be reported against the
+    per-cycle max of 3 as ``{"used": 4, "max": 3}`` — an overrun that never
+    happened (#1985).
+    """
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = _multi_cycle_dev_state(per_cycle_max=3, calls_per_cycle=[2, 2])
+    assert len(state.dev_iteration_telemetry) == 4
+
+    audit = generate_audit_log(
+        config, task, CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok")
+    )
+
+    assert audit["iterations"]["usage_summary"]["dev"] == {
+        "used": 2,
+        "max": 3,
+        "hit_limit": False,
+        "early_finish": True,
+    }
+
+
+def test_story_audit_dev_usage_reports_the_cycle_that_hit_the_cap(tmp_path):
+    """Exhaustion in any single cycle is still reported, not averaged away."""
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = _multi_cycle_dev_state(per_cycle_max=2, calls_per_cycle=[2, 1], phase=Phase.ESCALATE)
+
+    audit = generate_audit_log(
+        config,
+        task,
+        CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="stop"),
+    )
+
+    assert audit["iterations"]["usage_summary"]["dev"] == {
+        "used": 2,
+        "max": 2,
+        "hit_limit": True,
+        "early_finish": False,
+    }
+
+
+def test_story_audit_dev_usage_counts_an_iteration_without_telemetry(tmp_path):
+    """A consumed dev call that recorded no telemetry still counts as used.
+
+    ``record_dev_iteration_telemetry`` returns early when the dev call produced
+    no result, so the live per-cycle counter is the floor for the in-flight
+    cycle.
+    """
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=2, review_cycle=1, phase=Phase.ESCALATE)
+    state.adaptive_dev_max = 2
+
+    audit = generate_audit_log(
+        config,
+        task,
+        CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="stop"),
+    )
+
+    assert audit["iterations"]["usage_summary"]["dev"] == {
+        "used": 2,
+        "max": 2,
+        "hit_limit": True,
+        "early_finish": False,
+    }
+
+
+def _multi_cycle_sprint_result(state: CoordinatorState) -> SprintResult:
+    return SprintResult(
+        name="demo-sprint",
+        budget_usd=5.0,
+        results=[
+            (
+                "issue:123",
+                CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok"),
+            )
+        ],
+        total_cost_usd=0.9,
+        specs_total=1,
+        specs_succeeded=1,
+        specs_failed=0,
+        specs_skipped=0,
+    )
+
+
+def test_sprint_summary_dev_usage_is_per_cycle_not_cumulative(tmp_path):
+    manifest = SprintManifest(name="demo-sprint", budget_usd=5.0, stories=["issue:123"])
+    state = _multi_cycle_dev_state(per_cycle_max=3, calls_per_cycle=[2, 2])
+    ts = _dt.datetime(2024, 1, 1, tzinfo=_dt.timezone.utc)
+    sprint_log_dir = tmp_path / ".forge" / "logs" / "demo-sprint"
+
+    _write_sprint_summary(
+        manifest,
+        _multi_cycle_sprint_result(state),
+        ["issue:123"],
+        ts,
+        ts,
+        0.0,
+        sprint_log_dir,
+        slug_map={"issue:123": "story-123"},
+    )
+
+    summary = yaml.safe_load((sprint_log_dir / "sprint-summary.yaml").read_text())
+    assert summary["stories"][0]["iteration_usage"]["dev"] == {
+        "used": 2,
+        "max": 3,
+        "hit_limit": False,
+        "early_finish": True,
+    }
+    assert summary["iteration_usage_distribution"][0]["dev"] == {"used": 2, "max": 3}
+
+
+def test_sprint_audit_dev_usage_is_per_cycle_not_cumulative(tmp_path):
+    state = _multi_cycle_dev_state(per_cycle_max=3, calls_per_cycle=[2, 2])
+    ts = _dt.datetime(2024, 1, 1, tzinfo=_dt.timezone.utc)
+
+    _write_sprint_audit(
+        manifest=ResolvedSprint(
+            name="demo-sprint", budget_usd=5.0, stories=["issue:123"], max_parallel=1
+        ),
+        result=_multi_cycle_sprint_result(state),
+        canonical_refs=["issue:123"],
+        started_at=ts,
+        finished_at=ts,
+        duration=0.0,
+        project_root=tmp_path,
+        slug_map={"issue:123": "story-123"},
+    )
+
+    audit = yaml.safe_load((tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text())
+    assert audit["specs"][0]["iteration_usage"]["dev"] == {
+        "used": 2,
+        "max": 3,
+        "hit_limit": False,
+        "early_finish": True,
+    }
+    assert audit["iteration_usage_distribution"][0]["dev"] == {"used": 2, "max": 3}


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change keeps dev used/max on a per-cycle scale across coordinator and sprint audit outputs, with targeted regression coverage for the original multi-cycle symptom. | [google-gemini-3.5-flash] The implementation successfully reports dev iteration usage on a per-cycle scale, resolving the scale mismatch where cumulative usage was compared against a per-cycle limit.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $4.59
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Iteration usage reports a cumulative dev count against a per-cycle limit (GitHub Issue #1985)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1985