### PR TITLE
Sprint timeout/stop leaves failed run live with orphaned gate subprocesses and contradictory state

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -112,6 +112,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     if title_cache is None:
         title_cache = {}
 
+    from theforge.sprint.state_writer import is_terminal_sprint_phase
     from theforge.sprint.status_reader import (
         find_live_state_path,
         find_sprint_summary,
@@ -228,7 +229,14 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
             cost_measured_usd = _measured_sum
 
     # ── Header ───────────────────────────────────────────────────────────
-    if is_live:
+    # A PID file is evidence a process exists, not evidence the sprint is still
+    # advancing: the runner writes the terminal sprint_phase before its own
+    # (possibly slow) wrap-up, and until it exits the header would otherwise
+    # read "[live] phase: failed" alongside nothing but terminal stories
+    # (#2013). The persisted terminal phase is the stronger claim — report it.
+    if is_live and is_terminal_sprint_phase(sprint_phase):
+        state_label = str(sprint_phase)
+    elif is_live:
         state_label = "live"
     elif unexpected_end:
         state_label = "crashed"

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -843,10 +843,13 @@ def _cleanup_stopped_run(
 ) -> None:
     from theforge import detach as _detach
     from theforge import process_group as _process_group
+    from theforge.sprint.audit import finalize_interrupted_story_audit
     from theforge.sprint.lock import cleanup_story_locks
     from theforge.sprint.state_writer import terminalize_state_file
+    from theforge.sprint.status_reader import read_live_sprint_name
 
     lock_slugs = _stopped_run_lock_slugs(run_id, project_root, slug)
+    sprint_name = read_live_sprint_name(run_id, project_root)
     _detach.remove_pid(run_id, project_root)
     _detach.write_run_ended(run_id, project_root, "stopped", force=True)
     # The stopped process died holding whatever phase it was in, so nothing else
@@ -859,6 +862,16 @@ def _cleanup_stopped_run(
             f"[forge] Marked {len(stranded)} in-flight story/stories stopped: "
             f"{', '.join(stranded)}"
         )
+    # Finalize each stopped story's own audit from what the sprint process
+    # flushed while it ran. Only audits still marked in-flight are touched, so a
+    # story that finished on its own keeps the real audit it wrote.
+    if sprint_name:
+        for stranded_slug in stranded:
+            audit_path = finalize_interrupted_story_audit(
+                project_root, sprint_name, stranded_slug, reason="stopped"
+            )
+            if audit_path is not None:
+                print(f"[forge] Finalized in-flight story audit: {audit_path}")
     cleanup_story_locks(lock_slugs, project_root, pid=pid)
     # The stopped sprint's own teardown may not have reached its agent groups
     # (SIGKILL path); reap any now-orphaned groups.

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -638,25 +638,60 @@ def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:
         print("\nPending decisions: (none)")
 
 
-def _find_story_log_path(project_root: Path, slug: str, sprint_name: str | None) -> Path | None:
-    """Locate the most recent per-story run log for ``slug``.
+# Per-story log artifacts in preference order. ``run-*.log`` is the whole-story
+# tee written by standalone runs; a sprint story's directory instead accumulates
+# ``dev-iter-<n>-<model>.log`` per dev iteration, and — when no iteration ran —
+# only the YAML artifacts. Globbing for ``run-*.log`` alone made every slug the
+# ``--story`` enumerator lists structurally untailable inside a sprint (#2013).
+_STORY_LOG_PATTERNS: tuple[str, ...] = (
+    "run-*.log",
+    "dev-iter-*.log",
+    "*.log",
+    "audit.yaml",
+    "preflight.yaml",
+)
 
-    Prefers the nested sprint layout ``.forge/logs/<sprint_name>/<slug>/run-*.log``.
+
+def _newest_story_artifact(story_dir: Path) -> Path | None:
+    """Return the most useful readable artifact in a per-story log directory.
+
+    Preference is by kind first, recency second: an iteration log says more about
+    what the story was doing than the audit YAML does, so a stale ``dev-iter``
+    log still beats a freshly written ``audit.yaml``.
+    """
+    for pattern in _STORY_LOG_PATTERNS:
+        matches = [p for p in story_dir.glob(pattern) if p.is_file()]
+        if matches:
+            return max(matches, key=lambda p: p.stat().st_mtime)
+    return None
+
+
+def _find_story_log_path(project_root: Path, slug: str, sprint_name: str | None) -> Path | None:
+    """Locate the most recent readable per-story log artifact for ``slug``.
+
+    Prefers the nested sprint layout ``.forge/logs/<sprint_name>/<slug>/``.
     Falls back to any log directory named ``<slug>`` so standalone runs and
-    unknown sprint names still resolve. Returns the newest matching file, or
-    ``None`` if the story has no run log yet.
+    unknown sprint names still resolve. Returns ``None`` only when the story has
+    no readable artifact at all.
     """
     logs_dir = project_root / ".forge" / "logs"
     if not logs_dir.exists():
         return None
 
-    candidates: list[Path] = []
     if sprint_name:
         story_dir = logs_dir / sprint_name / slug
         if story_dir.is_dir():
-            candidates = list(story_dir.glob("run-*.log"))
-    if not candidates:
-        candidates = [p for p in logs_dir.rglob("run-*.log") if p.parent.name == slug]
+            found = _newest_story_artifact(story_dir)
+            if found is not None:
+                return found
+
+    candidates: list[Path] = []
+    for story_dir in logs_dir.rglob(slug):
+        if not story_dir.is_dir():
+            continue
+        found = _newest_story_artifact(story_dir)
+        if found is not None:
+            candidates.append(found)
     if not candidates:
         return None
     return max(candidates, key=lambda p: p.stat().st_mtime)
@@ -809,10 +844,21 @@ def _cleanup_stopped_run(
     from theforge import detach as _detach
     from theforge import process_group as _process_group
     from theforge.sprint.lock import cleanup_story_locks
+    from theforge.sprint.state_writer import terminalize_state_file
 
     lock_slugs = _stopped_run_lock_slugs(run_id, project_root, slug)
     _detach.remove_pid(run_id, project_root)
     _detach.write_run_ended(run_id, project_root, "stopped", force=True)
+    # The stopped process died holding whatever phase it was in, so nothing else
+    # will ever write the terminal transition — the surviving .state file would
+    # keep reporting a running sprint with running stories after stop reported
+    # success (#2013). Already-terminal stories keep their recorded outcome.
+    stranded = terminalize_state_file(run_id, project_root)
+    if stranded:
+        print(
+            f"[forge] Marked {len(stranded)} in-flight story/stories stopped: "
+            f"{', '.join(stranded)}"
+        )
     cleanup_story_locks(lock_slugs, project_root, pid=pid)
     # The stopped sprint's own teardown may not have reached its agent groups
     # (SIGKILL path); reap any now-orphaned groups.

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -330,6 +330,46 @@ def _extract_builtin_failed_tests(gate_output_tail: str) -> list[str]:
     return failed
 
 
+# Xcode's test runner prints a "Failing tests:" block listing one test per
+# following indented line, in one of two identifier spellings:
+#   - MyAppTests.LoginTests.testInvalidPassword()
+#   -[LoginTests testInvalidPassword]
+# Neither carries any of the built-in grammar's markers, so an Xcode gate used
+# to report "format not recognized" and retry the whole unfocused test target
+# every cycle (#2013).
+_XCODE_FAILING_HEADER_RE = re.compile(r"^\s*Failing tests:\s*$", re.IGNORECASE)
+_XCODE_DOTTED_TEST_RE = re.compile(r"^-\s+([A-Za-z_][\w.]*\.[A-Za-z_]\w*)\s*(?:\(\))?\s*$")
+_XCODE_BRACKET_TEST_RE = re.compile(r"^-\[([A-Za-z_]\w*)\s+([A-Za-z_]\w*)\]\s*$")
+
+
+def _extract_xcode_failed_tests(gate_output_tail: str) -> list[str]:
+    """Parse failing-test identifiers from an xcodebuild ``Failing tests:`` block."""
+    failed: list[str] = []
+    in_block = False
+    for raw_line in gate_output_tail.splitlines():
+        line = raw_line.strip()
+        if _XCODE_FAILING_HEADER_RE.match(raw_line):
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        if not line:
+            # A blank line inside the block is separator noise, not its end.
+            continue
+        if not line.startswith("-"):
+            in_block = False
+            continue
+        bracket = _XCODE_BRACKET_TEST_RE.match(line)
+        if bracket is not None:
+            candidate = f"{bracket.group(1)}.{bracket.group(2)}"
+        else:
+            dotted = _XCODE_DOTTED_TEST_RE.match(line)
+            candidate = dotted.group(1) if dotted is not None else ""
+        if candidate and candidate not in failed:
+            failed.append(candidate)
+    return failed
+
+
 def _output_matches_builtin_grammar(gate_output_tail: str) -> bool:
     """Return whether gate output carries the built-in test runner's summary grammar.
 
@@ -398,8 +438,15 @@ def extract_failed_tests(
     tests = _extract_builtin_failed_tests(gate_output_tail)
     if tests:
         return FailedTestExtraction(tests=tests, format_recognized=True, source="builtin")
+    xcode_tests = _extract_xcode_failed_tests(gate_output_tail)
+    if xcode_tests:
+        return FailedTestExtraction(tests=xcode_tests, format_recognized=True, source="xcodebuild")
     if _output_matches_builtin_grammar(gate_output_tail):
         return FailedTestExtraction(tests=[], format_recognized=True, source="builtin")
+    # Deliberately no "Xcode ran but named nothing" branch: an Xcode gate that
+    # fails without a ``Failing tests:`` block (a build break, a lint step) gives
+    # no evidence about which tests failed, so claiming a recognized format would
+    # turn that silence into a false "no failing tests".
     return FailedTestExtraction(tests=[], format_recognized=False, source="unrecognized")
 
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -49,6 +49,7 @@ from theforge.task import (
     parse_plan_output,
 )
 
+from . import live_state as _live_state
 from .agent_failure import is_infrastructure_abort
 from .cancellation import StoryCancelled
 from .log_tee import (  # noqa: E402
@@ -146,7 +147,15 @@ def _run_log_context(
     state: CoordinatorState,
     task_start: float,
 ) -> Generator[None, None, None]:
-    """Set up per-run log tee and SIGTERM handler; tear down on exit."""
+    """Set up per-run log tee, live-state registration, and SIGTERM handler.
+
+    The live-state registration is what lets the sprint scheduler write a real
+    audit for a story whose worker never returns (worker timeout): without it
+    the accumulated dev/gate history is unreachable from outside this thread
+    (#2013). It is bound to the same scope as the log tee because they have the
+    same lifetime — everything the run records is in flight between them.
+    """
+    _live_state.register_live_state(task.slug, state)
     _tee = _begin_run_log_tee(config, logger, task.slug, log_dir=state.log_dir)
     _prev_sigterm = None
     if _tee is not None:
@@ -165,6 +174,7 @@ def _run_log_context(
     try:
         yield
     finally:
+        _live_state.release_live_state(task.slug, state)
         _end_run_log_tee(_tee)
         if _prev_sigterm is not None:
             try:

--- a/src/theforge/coordinator/live_state.py
+++ b/src/theforge/coordinator/live_state.py
@@ -1,0 +1,75 @@
+"""In-process registry of the live ``CoordinatorState`` for each running story.
+
+The sprint scheduler and the coordinator engine run in the same process but on
+different threads: the scheduler cannot see the ``CoordinatorState`` the engine
+is mutating, because that object never leaves the worker's stack until the
+engine returns a ``CoordinatorResult``. A story that times out never returns
+one, so the audit the scheduler writes for it was built from a fresh, empty
+state — ``run_id: null``, no ``dev_loop``, no ``gate_decisions`` — even though
+the run log shows several dev iterations and gate retries actually happened
+(#2013).
+
+This module is the seam that makes that history reachable: the engine registers
+its state under the story slug for the lifetime of the run, and the scheduler
+snapshots it when it has to synthesize a terminal result. Registration is
+lifecycle bookkeeping, not a process decision — the engine's control flow is
+unchanged by it.
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+
+from .state import CoordinatorState
+
+_lock = threading.Lock()
+_live_states: dict[str, CoordinatorState] = {}
+
+
+def register_live_state(slug: str, state: CoordinatorState) -> None:
+    """Publish *state* as the live coordinator state for *slug*."""
+    if not slug:
+        return
+    with _lock:
+        _live_states[slug] = state
+
+
+def release_live_state(slug: str, state: CoordinatorState | None = None) -> None:
+    """Drop *slug*'s registration.
+
+    When *state* is given, only that exact object is dropped, so a worker
+    unwinding late cannot delete the registration a re-dispatched run of the
+    same slug has already installed.
+    """
+    if not slug:
+        return
+    with _lock:
+        current = _live_states.get(slug)
+        if current is None:
+            return
+        if state is not None and current is not state:
+            return
+        del _live_states[slug]
+
+
+def snapshot_live_state(slug: str) -> CoordinatorState | None:
+    """Return a detached copy of *slug*'s live state, or None if not registered.
+
+    The owning worker thread is still running when the scheduler calls this (a
+    timed-out worker is unresponsive, not stopped), so the registered object is
+    being mutated concurrently. Copying keeps the audit writer off that shared
+    object; a deep copy that trips over a member mid-mutation falls back to a
+    shallow one rather than losing the telemetry altogether.
+    """
+    with _lock:
+        state = _live_states.get(slug)
+    if state is None:
+        return None
+    try:
+        return copy.deepcopy(state)
+    except Exception:  # noqa: BLE001 — telemetry salvage must never raise
+        try:
+            return copy.copy(state)
+        except Exception:  # noqa: BLE001
+            return state

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -169,7 +169,8 @@ class FailedTestExtraction:
     ``format_recognized`` is True. When it is False the extractor could not
     parse the gate's output at all (an unrecognized toolchain), so the empty
     list is a *silent absence*, not a genuine one. ``source`` records which
-    reader produced the result: ``"pytest"`` (built-in grammar),
+    reader produced the result: ``"builtin"`` (built-in pytest-style grammar),
+    ``"xcodebuild"`` (Xcode's ``Failing tests:`` block),
     ``"custom_pattern"`` (project-configured ``failed_test_pattern``), or
     ``"unrecognized"`` (nothing applied).
     """

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 from theforge.log_level import LogLevel
 from theforge.log_util import _log_line
-from theforge.process_group import KILL_GRACE_SECONDS, is_killable_pgid
+from theforge.process_group import (
+    KILL_GRACE_SECONDS,
+    is_killable_pgid,
+    register_agent_group,
+    unregister_agent_group,
+)
 from theforge.workspace_env import build_workspace_env
 
 # Stable reference captured at import time so test patches that replace the
@@ -235,8 +240,12 @@ def _wait_bounded(proc: subprocess.Popen[str]) -> bool:
     return True
 
 
-def _kill_process_group(proc: subprocess.Popen[str]) -> None:
+def _kill_process_group(proc: subprocess.Popen[str]) -> bool:
     """Best-effort kill for a spawned shell process group, then a bounded wait.
+
+    Returns True only when the ``killpg`` reached the whole group. False means
+    the kill reached at most the direct child, so grandchildren may still be
+    running and the group's reaper sidecar must be kept.
 
     Only ``killpg`` a pgid that denotes a real group (``> 1``); a bogus ``<= 1``
     value would broadcast SIGKILL across the whole session (see
@@ -259,7 +268,7 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
             _log_line("[forge]", f"  ⚠ group kill of pgid={pgid} refused: {exc}")
         else:
             _wait_bounded(proc)
-            return
+            return True
     # Each wait is guarded by whether the signal before it was actually
     # delivered. Waiting on a refused signal is the #1959 mistake in miniature:
     # it buys nothing and costs the grace period every time.
@@ -269,7 +278,7 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
         pass
     else:
         if _wait_bounded(proc):
-            return
+            return False
     # SIGTERM is catchable, so a shell that ignores it survives — and a survivor
     # holds the output pipes open, which is the read this function's caller then
     # blocks on (#1959). Escalate to SIGKILL rather than leave that to chance;
@@ -277,8 +286,9 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
     try:
         proc.kill()
     except OSError:
-        return
+        return False
     _wait_bounded(proc)
+    return False
 
 
 # Longest we will wait to collect a timed-out command's partial output. Small:
@@ -381,9 +391,27 @@ def _run_shell_detailed(
         )
     except Exception as e:
         return False, f"ERROR: {e}", None, False
+    # Record the group with the orphan reaper. ``start_new_session=True`` above
+    # puts this command — a gate invocation, and everything it spawns — in its
+    # own session, which is exactly why a signal to the sprint's own process
+    # group never reaches it. When the sprint is killed (``forge stop``, SIGKILL)
+    # the cleanup below never runs, and without this sidecar there is no record
+    # left for ``reap_orphan_agents`` to kill the tree by: an xcodebuild survived
+    # a stop that reported success (#2013).
+    # ``start_new_session=True`` makes the child the leader of its own session
+    # and group, so its pgid *is* its pid — no ``getpgid`` round trip needed, and
+    # none possible once the child has already exited. The guard keeps a pid that
+    # cannot denote a real group out of the registry (#1793).
+    pgid: int | None = proc.pid if is_killable_pgid(proc.pid) else None
+    if pgid is not None:
+        register_agent_group(pgid, sandbox_dir=str(cwd))
     # False only while a drain thread still owns the streams, in which case that
     # thread closes them and this one must not touch them (see _drain_partial_output).
     owns_streams = True
+    # Normal completion implies the group went with the child; only a teardown
+    # that could not reach the group flips this, and then the sidecar is kept so
+    # a later reaper can still find the survivors.
+    group_gone = True
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
         output = (stdout + stderr).strip()
@@ -392,7 +420,7 @@ def _run_shell_detailed(
         # Kill the whole process group before draining pipes so grandchildren
         # such as pytest-xdist workers cannot keep writing indefinitely after
         # the shell itself has timed out.
-        _kill_process_group(proc)
+        group_gone = bool(_kill_process_group(proc))
         partial_out, drained = _drain_partial_output(te, proc)
         owns_streams = drained
         header = f"TIMEOUT after {timeout}s: {cmd}"
@@ -400,9 +428,15 @@ def _run_shell_detailed(
             return False, f"{header}\n{partial_out}", None, True
         return False, header, None, True
     except BaseException:
-        _kill_process_group(proc)
+        group_gone = bool(_kill_process_group(proc))
         raise
     finally:
+        # Drop the record only once the whole group is known to be gone. A
+        # teardown that reached at most the direct child leaves grandchildren
+        # running, and the sidecar is the only handle a later reaper has on
+        # them — erasing it would strand them permanently (#2013).
+        if pgid is not None and group_gone:
+            unregister_agent_group(pgid)
         if owns_streams:
             for stream_name in ("stdout", "stderr"):
                 stream = getattr(proc, stream_name, None)

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -78,7 +78,7 @@ def persist_accumulated_story_state(
 
 if TYPE_CHECKING:
     from ..config import ForgeConfig
-    from ..coordinator.state import CoordinatorResult
+    from ..coordinator.state import CoordinatorResult, CoordinatorState
     from ..task import TaskStory
 
 
@@ -1274,3 +1274,148 @@ def _write_story_audit(
                 yaml.dump(audit_data, f, default_flow_style=False, sort_keys=False)
         except Exception:
             pass  # best-effort
+
+
+# ── In-flight story audits ────────────────────────────────────────────
+#
+# A story's audit.yaml is normally written once, from the CoordinatorResult its
+# worker returns. A story that never returns one — killed by ``forge stop``,
+# which runs in a *different* process and cannot see the worker's in-memory
+# state — therefore had no audit at all, or a stale one from a prior generation:
+# the dev iterations and gate decisions the run log shows really happened were
+# unrecoverable after the fact (#2013).
+#
+# So the sprint process flushes the story's audit as it goes, marked
+# ``in_flight: true``, and the stop path stamps that same file terminal. The
+# marker is what keeps the two apart: only an in-flight audit may be finalized
+# by an outside process, so a completed story's real audit is never overwritten.
+
+AUDIT_IN_FLIGHT_KEY = "in_flight"
+
+
+def _story_audit_path(project_root: Path, sprint_name: str, slug: str) -> Path:
+    return project_root / ".forge" / "logs" / sprint_name / slug / "audit.yaml"
+
+
+def _dump_audit_atomically(path: Path, audit_data: dict) -> None:
+    """Write an audit mapping so a reader never sees a half-written file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(audit_data, f, default_flow_style=False, sort_keys=False)
+        tmp_path.replace(path)
+    except OSError:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def write_live_story_audit(
+    config: "ForgeConfig",
+    task: "TaskStory",
+    state: "CoordinatorState",
+    *,
+    sprint_id: str | None = None,
+    sprint_name: str | None = None,
+) -> Path | None:
+    """Flush a still-running story's audit to its log dir; return the path written.
+
+    Deliberately narrower than :func:`_write_story_audit`: it writes only the
+    per-story ``audit.yaml``, never the substrate record or the ESCALATE marker.
+    Those describe a finished story, and this one is not finished — the whole
+    point is that it may never be.
+
+    Best-effort: returns ``None`` on any failure rather than disturbing the run
+    it is only observing.
+    """
+    from ..coordinator import audit as coordinator_audit  # noqa: PLC0415
+    from ..coordinator.state import CoordinatorResult  # noqa: PLC0415
+
+    try:
+        in_flight_result = CoordinatorResult(
+            success=False,
+            phase=state.phase,
+            state=state,
+            message=f"story in flight (phase {state.phase.name})",
+        )
+        audit_data = coordinator_audit.generate_audit_log(config, task, in_flight_result)
+        audit_data[AUDIT_IN_FLIGHT_KEY] = True
+        if sprint_id is not None:
+            audit_data["sprint_id"] = sprint_id
+        resolved_sprint_name = sprint_name or state.sprint_name
+        if resolved_sprint_name:
+            audit_data["sprint_name"] = resolved_sprint_name
+        log_dir = state.log_dir
+        if log_dir is None:
+            if not resolved_sprint_name:
+                return None
+            log_dir = _story_audit_path(
+                config.project_root, resolved_sprint_name, task.slug
+            ).parent
+        path = log_dir / "audit.yaml"
+        _dump_audit_atomically(path, audit_data)
+        return path
+    except Exception:  # noqa: BLE001 — an observer must never break the run
+        return None
+
+
+def finalize_interrupted_story_audit(
+    project_root: Path,
+    sprint_name: str,
+    slug: str,
+    *,
+    reason: str = "stopped",
+) -> Path | None:
+    """Stamp an in-flight story audit terminal; return the path, or None if skipped.
+
+    Called by ``forge stop`` after the owning sprint process is gone. Only
+    touches an audit still marked ``in_flight`` — a story that finished on its
+    own already wrote its real audit, and overwriting that with an
+    outside-the-run guess would destroy the record it exists to be.
+
+    The accumulated history (run_id, dev_loop, gate_decisions, phases) is left
+    exactly as the sprint process flushed it; only the outcome and end timing
+    are rewritten, so what the operator reads is what actually happened up to
+    the stop.
+    """
+    path = _story_audit_path(project_root, sprint_name, slug)
+    try:
+        with open(path, encoding="utf-8") as f:
+            audit_data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(audit_data, dict) or not audit_data.get(AUDIT_IN_FLIGHT_KEY):
+        return None
+
+    ended_at = datetime.datetime.now(datetime.timezone.utc)
+    audit_data[AUDIT_IN_FLIGHT_KEY] = False
+    audit_data["interrupted_by"] = reason
+
+    outcome = audit_data.get("outcome")
+    if not isinstance(outcome, dict):
+        outcome = {}
+        audit_data["outcome"] = outcome
+    reached_phase = outcome.get("final_phase") or "UNKNOWN"
+    outcome["success"] = False
+    outcome["error_type"] = "OperatorStopped"
+    outcome["message"] = f"Run {reason} by operator while the story was in {reached_phase}"
+
+    timing = audit_data.get("timing")
+    if isinstance(timing, dict):
+        timing["finished_at"] = ended_at.isoformat()
+        started_raw = timing.get("started_at")
+        if isinstance(started_raw, str) and started_raw:
+            try:
+                started = datetime.datetime.fromisoformat(started_raw)
+                timing["duration_seconds"] = (ended_at - started).total_seconds()
+            except ValueError:
+                pass
+
+    try:
+        _dump_audit_atomically(path, audit_data)
+    except OSError:
+        return None
+    return path

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -60,6 +60,7 @@ from .audit import (
     _write_sprint_summary,
     _write_story_audit,
     persist_accumulated_story_state,
+    write_live_story_audit,
 )
 from .auth_gate import enforce_sprint_auth_readiness
 from .budget import evaluate_budget
@@ -1824,6 +1825,7 @@ def _make_worker_phase_fn(
     outer_fn: "Callable[[dict], None] | None",
     plan_done: "dict[str, str] | None" = None,
     state_writer: "SprintStateWriter | None" = None,
+    audit_flush: "Callable[[str], None] | None" = None,
 ) -> "Callable[[dict], None]":
     """Return a thread-safe state_update_fn wrapper for worker live state.
 
@@ -1836,11 +1838,18 @@ def _make_worker_phase_fn(
     When *state_writer* is provided, live-facing fields are also written to the
     sprint state file so ``forge sprint-status`` reflects both the current phase
     and the latest per-story cost.
+
+    When *audit_flush* is provided it is called once per phase *change* with the
+    new phase, so the story's audit.yaml on disk keeps pace with the run. That
+    file is the only record an outside process (``forge stop``) can finalize —
+    it cannot see this one's memory (#2013). Flushing on phase changes only
+    keeps the cost proportional to real progress rather than to update chatter.
     """
 
     def _update(updates: dict) -> None:
         phase = updates.get("phase", "")
         with phase_lock:
+            phase_changed = bool(phase) and worker_phases.get(slug) != phase
             if phase:
                 worker_phases[slug] = phase
             if state_writer is not None:
@@ -1871,8 +1880,40 @@ def _make_worker_phase_fn(
                     plan_done[slug] = ws
             if outer_fn is not None:
                 outer_fn(updates)
+        # Outside the lock: the flush serializes the whole coordinator state and
+        # writes a file, and no other worker's live-state update should queue
+        # behind that.
+        if phase_changed and audit_flush is not None:
+            audit_flush(phase)
 
     return _update
+
+
+def _make_audit_flush_fn(
+    config: ForgeConfig,
+    task: "TaskStory",
+    sprint_name: str,
+    *,
+    sprint_id: str | None = None,
+) -> "Callable[[str], None]":
+    """Return a callback that rewrites *task*'s audit.yaml from its live state.
+
+    The story's own worker thread runs this, so it reads the engine's live
+    ``CoordinatorState`` straight out of the in-process registry. What it writes
+    is the handoff to processes that have no such access: ``forge stop`` runs
+    elsewhere, after this process is gone, and can only finalize an audit that is
+    already on disk (#2013).
+    """
+
+    def _flush(_phase: str) -> None:
+        from ..coordinator.live_state import snapshot_live_state  # noqa: PLC0415
+
+        state = snapshot_live_state(task.slug)
+        if state is None:
+            return
+        write_live_story_audit(config, task, state, sprint_id=sprint_id, sprint_name=sprint_name)
+
+    return _flush
 
 
 def _terminal_story_model(result: CoordinatorResult) -> str | None:
@@ -3904,6 +3945,9 @@ def run_sprint(
                     state_update_fn,
                     plan_done=plan_done if use_plan_gates else None,
                     state_writer=_state_writer,
+                    audit_flush=_make_audit_flush_fn(
+                        config, task, resolved.name, sprint_id=_sprint_id
+                    ),
                 )
                 stop_evt = threading.Event()
                 stop_events[task.slug] = stop_evt

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -93,8 +93,15 @@ from .manifest import (
 )
 from .query import NormalizedDependencyPlan, normalize_dependency_plan
 from .sources import StorySource
-from .state_writer import SprintStateWriter
+from .state_writer import (
+    SPRINT_PHASE_DONE,
+    SPRINT_PHASE_FAILED,
+    SPRINT_PHASE_STOPPED,
+    SprintStateWriter,
+)
 from .story_state import (
+    GATE_STATUS_INCOMPLETE,
+    GATE_STATUS_TIMEOUT,
     SprintStoryState,
     StoryOutcome,
     coerce_outcome,
@@ -1928,6 +1935,52 @@ def _snapshot_last_known(
         except ValueError:
             snapshot["last_started_at"] = None
     return snapshot
+
+
+def _terminal_state_for(
+    slug: str,
+    *,
+    config: ForgeConfig,
+    sprint_name: str,
+    started_at: datetime.datetime,
+    error: str,
+    error_type: str,
+) -> CoordinatorState:
+    """Build the CoordinatorState for a story the scheduler had to terminate itself.
+
+    A worker that times out or raises never hands back its ``CoordinatorResult``,
+    so the scheduler has to synthesize one. Synthesizing it from scratch threw
+    away everything the engine had already accumulated — the audit for a story
+    with three dev iterations and two gate retries was written with
+    ``run_id: null``, an empty ``dev_loop`` and an empty ``gate_decisions``
+    (#2013). Prefer the engine's own live state for the slug, and fall back to a
+    bare state only when the story never reached the engine.
+
+    The returned state is always stamped ESCALATE with the scheduler's error, so
+    the telemetry is preserved without the audit misreporting how the story ended.
+    """
+    from ..coordinator.live_state import snapshot_live_state  # noqa: PLC0415
+
+    state = snapshot_live_state(slug)
+    if state is None:
+        state = CoordinatorState(
+            started_at=started_at.isoformat(),
+            workspace_path=(config.project_root / config.workspace.path_pattern.format(slug=slug)),
+            log_dir=_make_story_log_dir(config, slug, sprint_name),
+        )
+    else:
+        if not state.started_at:
+            state.started_at = started_at.isoformat()
+        if state.workspace_path is None:
+            state.workspace_path = config.project_root / config.workspace.path_pattern.format(
+                slug=slug
+            )
+        if state.log_dir is None:
+            state.log_dir = _make_story_log_dir(config, slug, sprint_name)
+    state.phase = Phase.ESCALATE
+    state.error = error
+    state.error_type = error_type
+    return state
 
 
 def _failing_required_pr_checks(pr_url: str, project_root: Path, base_branch: str) -> list[str]:
@@ -4063,13 +4116,11 @@ def run_sprint(
                     else:
                         story_started_at = timed_out_at
                     _phase_label = f" during phase {last_phase}" if last_phase else ""
-                    _timeout_state = CoordinatorState(
-                        phase=Phase.ESCALATE,
-                        started_at=story_started_at.isoformat(),
-                        workspace_path=(
-                            config.project_root / config.workspace.path_pattern.format(slug=slug)
-                        ),
-                        log_dir=_make_story_log_dir(config, slug, resolved.name),
+                    _timeout_state = _terminal_state_for(
+                        slug,
+                        config=config,
+                        sprint_name=resolved.name,
+                        started_at=story_started_at,
                         error=(f"Worker timeout (>{story_worker_timeouts[slug]}s){_phase_label}"),
                         error_type="TimeoutError",
                     )
@@ -4107,6 +4158,11 @@ def run_sprint(
                         _timeout_outcome,
                         phase="ESCALATE",
                         last_phase=last_phase,
+                        # The gate this story may have been sitting in never
+                        # reported a decision and never will; leaving the live
+                        # detail at gate_status=running is what made the state
+                        # file claim a running gate on a failed story (#2013).
+                        detail_updates={"gate_status": GATE_STATUS_TIMEOUT},
                     )
                     _persist_current_story_result(
                         slug,
@@ -4139,13 +4195,11 @@ def run_sprint(
                     else:
                         story_started_at = failed_at
                     _phase_label = f" during phase {last_phase}" if last_phase else ""
-                    _exc_state = CoordinatorState(
-                        phase=Phase.ESCALATE,
-                        started_at=story_started_at.isoformat(),
-                        workspace_path=(
-                            config.project_root / config.workspace.path_pattern.format(slug=slug)
-                        ),
-                        log_dir=_make_story_log_dir(config, slug, resolved.name),
+                    _exc_state = _terminal_state_for(
+                        slug,
+                        config=config,
+                        sprint_name=resolved.name,
+                        started_at=story_started_at,
                         error=f"Worker exception{_phase_label}: {exc}",
                         error_type=type(exc).__name__,
                     )
@@ -4182,6 +4236,7 @@ def run_sprint(
                         _exc_outcome,
                         phase="ESCALATE",
                         last_phase=last_phase,
+                        detail_updates={"gate_status": GATE_STATUS_INCOMPLETE},
                     )
                     _persist_current_story_result(
                         slug,
@@ -4441,6 +4496,33 @@ def run_sprint(
     finished_at = datetime.datetime.now(datetime.timezone.utc)
     set_worker_slug("")
     duration = (finished_at - started_at).total_seconds()
+
+    # ── Terminalize live state ────────────────────────────────────────
+    # The work loop is over, so nothing in this sprint can still advance. Write
+    # that fact to the live .state file BEFORE summary/audit finalization: those
+    # steps can take a while (and can raise), and until the terminal transition
+    # lands, `forge status` keeps rendering a running sprint next to stories it
+    # already reports as failed (#2013). The file is removed further down on the
+    # normal path; this is what a crash or a stop in between now finds.
+    if _state_writer is not None:
+        _stranded = _state_writer.terminalize_stories(
+            outcome=StoryOutcome.FAILED,
+            reason=stopped_reason or "sprint ended before this story reached a verdict",
+        )
+        if _stranded:
+            _log(
+                "Terminalized "
+                f"{len(_stranded)} story/stories still non-terminal at sprint end: "
+                + ", ".join(_stranded)
+            )
+        _terminal_counts = _story_state.counts()
+        if stopped_reason is not None:
+            _terminal_sprint_phase = SPRINT_PHASE_STOPPED
+        elif _terminal_counts["failed"]:
+            _terminal_sprint_phase = SPRINT_PHASE_FAILED
+        else:
+            _terminal_sprint_phase = SPRINT_PHASE_DONE
+        _state_writer.set_phase(_terminal_sprint_phase)
 
     # Attribute intake remediation agent spend back to each story's canonical
     # cost_usd so per-story sums (used by sprint-summary.yaml) match the

--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -7,12 +7,31 @@ representation of story state owned by this module.
 
 from __future__ import annotations
 
+import datetime
 import threading
 from pathlib import Path
 
 import yaml
 
-from .story_state import SprintStoryState, StoryOutcome
+from .story_state import (
+    GATE_STATUS_INCOMPLETE,
+    GATE_STATUS_STOPPED,
+    SprintStoryState,
+    StoryOutcome,
+)
+
+# Terminal values for the state file's top-level ``sprint_phase``. Any other
+# value means the sprint is still advancing; these three mean it is not, no
+# matter what the owning process is doing (#2013).
+SPRINT_PHASE_DONE = "done"
+SPRINT_PHASE_FAILED = "failed"
+SPRINT_PHASE_STOPPED = "stopped"
+TERMINAL_SPRINT_PHASES = frozenset({SPRINT_PHASE_DONE, SPRINT_PHASE_FAILED, SPRINT_PHASE_STOPPED})
+
+
+def is_terminal_sprint_phase(phase: object) -> bool:
+    """True when ``phase`` is one of the terminal ``sprint_phase`` values."""
+    return isinstance(phase, str) and phase.strip().lower() in TERMINAL_SPRINT_PHASES
 
 
 class SprintStateWriter:
@@ -136,6 +155,40 @@ class SprintStateWriter:
         with self._lock:
             self._sprint_phase = phase
             self._write_locked()
+
+    def terminalize_stories(
+        self,
+        *,
+        outcome: StoryOutcome | str = StoryOutcome.FAILED,
+        phase: str | None = None,
+        reason: str | None = None,
+        gate_status: str = GATE_STATUS_INCOMPLETE,
+    ) -> list[str]:
+        """Move every still-nonterminal story to a terminal outcome; return their slugs.
+
+        The sprint is over by the time this runs, so a story left at
+        waiting/running/blocked is stranded, not live. Writing it terminal is
+        what keeps the on-disk state from claiming work is in flight after the
+        owning process has finished with it (#2013).
+        """
+        stranded: list[str] = []
+        with self._lock:
+            for entry in self.story_state.stories():
+                if entry.outcome.is_terminal:
+                    continue
+                fields: dict = {
+                    "detail_updates": {"gate_status": gate_status},
+                    "finished_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                }
+                if phase is not None:
+                    fields["phase"] = phase
+                if reason is not None:
+                    fields["reason"] = reason
+                self.story_state.transition(entry.slug, outcome=outcome, **fields)
+                stranded.append(entry.slug)
+            if stranded:
+                self._write_locked()
+        return stranded
 
     def _inherit_existing_metadata(self) -> None:
         """Adopt sprint_phase/base_branch/budget/parallel from an existing file.
@@ -363,6 +416,64 @@ def write_bootstrap_state(
         except OSError:
             pass
     return state_path
+
+
+def terminalize_state_file(
+    run_id: str,
+    project_root: Path,
+    *,
+    sprint_phase: str = SPRINT_PHASE_STOPPED,
+    outcome: StoryOutcome | str = StoryOutcome.FAILED,
+    phase: str | None = "STOPPED",
+    reason: str | None = "stopped",
+    gate_status: str = GATE_STATUS_STOPPED,
+) -> list[str]:
+    """Rewrite a run's live ``.state`` so the sprint and every story read terminal.
+
+    Used by ``forge stop`` once the sprint process is gone: the process died
+    holding whatever phase it was in, so nothing else will ever write the
+    terminal transition, and the file is left claiming a running sprint with
+    running stories (#2013). Already-terminal stories keep their recorded
+    outcome and detail; only stranded ones are moved.
+
+    Returns the slugs that were moved. No-op (empty list) when the state file is
+    absent or unreadable — a stop must never fail over a missing state file.
+    """
+    state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
+    data = _load_existing_state(state_path)
+    if data is None:
+        return []
+
+    story_state = SprintStoryState.from_dict(data.get("stories") or [])
+    stranded: list[str] = []
+    for entry in story_state.stories():
+        if entry.outcome.is_terminal:
+            continue
+        fields: dict = {
+            "detail_updates": {"gate_status": gate_status},
+            "finished_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        if phase is not None:
+            fields["phase"] = phase
+        if reason is not None:
+            fields["reason"] = reason
+        story_state.transition(entry.slug, outcome=outcome, **fields)
+        stranded.append(entry.slug)
+
+    data["sprint_phase"] = sprint_phase
+    data["stories"] = story_state.as_dict()
+
+    tmp_path = state_path.with_name(state_path.name + ".tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        tmp_path.replace(state_path)
+    except OSError:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+    return stranded
 
 
 def update_state_phase(run_id: str, project_root: Path, sprint_phase: str) -> None:

--- a/src/theforge/sprint/story_state.py
+++ b/src/theforge/sprint/story_state.py
@@ -117,6 +117,15 @@ _TERMINAL_OUTCOMES = {
 }
 
 
+# ``detail.gate_status`` values the sprint layer writes. RUNNING is set when a
+# story enters VALIDATE; the rest are terminal readings recorded when the story
+# stops without the gate reporting a decision.
+GATE_STATUS_RUNNING = "running"
+GATE_STATUS_INCOMPLETE = "incomplete"
+GATE_STATUS_TIMEOUT = "timeout"
+GATE_STATUS_STOPPED = "stopped"
+
+
 _CANONICAL_TO_LEGACY_STATUS = {
     StoryOutcome.WAITING: "waiting",
     StoryOutcome.RUNNING: "running",
@@ -250,6 +259,15 @@ class StoryStateEntry:
             if not self.outcome.is_succeeded:
                 for _stale in ("review_verdict", "review_p1", "review_p2"):
                     merged_detail.pop(_stale, None)
+            # A terminal story cannot have a gate that is still running. The
+            # gate_status detail is written while VALIDATE is in flight and is
+            # never revisited when the story dies mid-gate (timeout, worker
+            # exception, operator stop), which is how a `.state` file ends up
+            # claiming `status: failed` and `gate_status: running` at once
+            # (#2013). Enforced here rather than at each transition site so no
+            # future exit path can serialize the contradiction.
+            if merged_detail.get("gate_status") == GATE_STATUS_RUNNING:
+                merged_detail["gate_status"] = GATE_STATUS_INCOMPLETE
         d: dict = {
             "slug": self.slug,
             "path": self.path,
@@ -414,6 +432,13 @@ class SprintStoryState:
                         entry.complexity_score = None
                 elif k == "detail" and isinstance(v, dict):
                     entry.detail = dict(v)
+                elif k == "detail_updates" and isinstance(v, dict):
+                    # Merge, don't replace: a terminal exit path knows one or two
+                    # detail keys (gate_status, say) and must not erase whatever
+                    # the phases before it recorded.
+                    merged = dict(entry.detail)
+                    merged.update(v)
+                    entry.detail = merged
                 elif k == "reason":
                     entry.reason = v  # type: ignore[assignment]
                 elif k == "depends_on" and isinstance(v, list):

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -1487,3 +1487,41 @@ def test_ensure_titles_leaves_transient_failure_uncached(monkeypatch, tmp_path: 
     _ensure_titles([_Entry("Issue #10")], tmp_path, cache)
     # Transient failure leaves the number uncached so a later frame can retry.
     assert cache == {}
+
+
+def test_live_pid_with_terminal_sprint_phase_is_not_reported_as_live(tmp_path: Path) -> None:
+    """A terminal persisted phase outranks a lingering PID file (#2013).
+
+    The runner writes the terminal sprint_phase before its own wrap-up, so the
+    process can still exist while the sprint is over. Reporting "[live] phase:
+    failed" next to nothing but failed stories is the contradiction operators hit.
+    """
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "wrapup-run.pid").write_text("99999\nwrapup-sprint\n")
+
+    state_path = _make_state_file(
+        tmp_path,
+        "wrapup-run",
+        "wrapup-sprint",
+        [
+            {
+                "slug": "issue-50",
+                "path": "Issue #50",
+                "status": "failed",
+                "outcome": "failed",
+                "phase": "ESCALATE",
+                "cost_usd": 0.5,
+                "detail": {"gate_status": "incomplete"},
+            }
+        ],
+    )
+    data = yaml.safe_load(state_path.read_text())
+    data["sprint_phase"] = "failed"
+    state_path.write_text(yaml.dump(data))
+
+    code, output = _run_sprint_status(tmp_path, "wrapup-run")
+
+    assert code == 0
+    assert "[live]" not in output
+    assert "[failed]" in output

--- a/tests/test_coord_dev_phase_extract_failed_tests.py
+++ b/tests/test_coord_dev_phase_extract_failed_tests.py
@@ -123,3 +123,60 @@ def test_struct_empty_output_is_unrecognized():
     result = extract_failed_tests("")
     assert result.tests == []
     assert result.format_recognized is False
+
+
+# ── xcodebuild "Failing tests:" block (#2013) ──────────────────────────
+
+
+def test_struct_xcode_failing_tests_block_dotted_form():
+    """Swift-style identifiers in a Failing tests: block drive a focused retry."""
+    xcode_output = (
+        "Testing failed:\n"
+        "    Failing tests:\n"
+        "        - ForgeUITests.LoginTests.testInvalidPassword()\n"
+        "        - ForgeUITests.LoginTests.testLockout()\n"
+        "    2 tests failed\n"
+        "** TEST FAILED **\n"
+    )
+    result = extract_failed_tests(xcode_output)
+    assert result.tests == [
+        "ForgeUITests.LoginTests.testInvalidPassword",
+        "ForgeUITests.LoginTests.testLockout",
+    ]
+    assert result.format_recognized is True
+    assert result.source == "xcodebuild"
+
+
+def test_struct_xcode_failing_tests_block_bracket_form():
+    """Objective-C -[Class method] entries normalize to Class.method."""
+    xcode_output = "Failing tests:\n    -[LoginTests testInvalidPassword]\n** TEST FAILED **\n"
+    result = extract_failed_tests(xcode_output)
+    assert result.tests == ["LoginTests.testInvalidPassword"]
+    assert result.source == "xcodebuild"
+
+
+def test_struct_xcode_block_stops_at_the_first_non_entry_line():
+    """Trailing summary lines must not be mistaken for test identifiers."""
+    xcode_output = (
+        "Failing tests:\n"
+        "    - AppTests.FooTests.testBar()\n"
+        "    1 test failed\n"
+        "    - not-a-test-line-after-the-block\n"
+    )
+    result = extract_failed_tests(xcode_output)
+    assert result.tests == ["AppTests.FooTests.testBar"]
+
+
+def test_struct_xcode_block_deduplicates_repeated_entries():
+    xcode_output = (
+        "Failing tests:\n    - AppTests.FooTests.testBar()\n    - AppTests.FooTests.testBar()\n"
+    )
+    assert extract_failed_tests(xcode_output).tests == ["AppTests.FooTests.testBar"]
+
+
+def test_struct_custom_pattern_still_wins_over_the_xcode_reader():
+    """A project that declared its own grammar keeps owning extraction."""
+    xcode_output = "Failing tests:\n    - AppTests.FooTests.testBar()\n"
+    result = extract_failed_tests(xcode_output, failed_test_pattern=r"FAILED (?P<test>\S+)")
+    assert result.tests == []
+    assert result.source == "custom_pattern"

--- a/tests/test_sprint_terminal_lifecycle.py
+++ b/tests/test_sprint_terminal_lifecycle.py
@@ -1,0 +1,495 @@
+"""Terminal-state consistency for sprints that time out, fail, or are stopped (#2013).
+
+A sprint that dies mid-VALIDATE used to leave every operator surface disagreeing
+with every other: the ``.state`` file carried a terminal story status next to a
+running sprint phase and a running gate, ``forge stop`` reported success while the
+gate's subprocess tree kept running, the timeout audit lost the dev/gate history
+that had actually happened, and ``forge logs --story <slug>`` could not open a
+single slug it had just listed.
+
+These tests pin each of those seams independently, because they live in different
+modules and fail in different ways.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from theforge.coordinator import util as coord_util
+from theforge.coordinator.live_state import (
+    register_live_state,
+    release_live_state,
+    snapshot_live_state,
+)
+from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.sprint.state_writer import (
+    SPRINT_PHASE_STOPPED,
+    SprintStateWriter,
+    is_terminal_sprint_phase,
+    terminalize_state_file,
+)
+from theforge.sprint.story_state import SprintStoryState, StoryOutcome
+
+
+def _read_state(project_root: Path, run_id: str) -> dict:
+    with open(project_root / ".forge" / "runs" / f"{run_id}.state", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _story(state: dict, slug: str) -> dict:
+    return next(s for s in state["stories"] if s["slug"] == slug)
+
+
+# ── Canonical structure: a terminal story cannot carry a running gate ──
+
+
+def test_terminal_story_never_serializes_a_running_gate() -> None:
+    state = SprintStoryState()
+    state.register("issue-50", "Issue #50", detail={"gate_status": "running"})
+    state.transition("issue-50", outcome=StoryOutcome.FAILED)
+
+    serialized = state.as_dict()[0]
+    assert serialized["status"] == "failed"
+    assert serialized["detail"]["gate_status"] == "incomplete"
+
+
+def test_nonterminal_story_keeps_its_running_gate() -> None:
+    """The guard is about terminal rows only — a live VALIDATE still reads running."""
+    state = SprintStoryState()
+    state.register("issue-50", "Issue #50", detail={"gate_status": "running"})
+    state.transition("issue-50", outcome=StoryOutcome.RUNNING, phase="VALIDATE")
+
+    assert state.as_dict()[0]["detail"]["gate_status"] == "running"
+
+
+def test_detail_updates_merges_instead_of_replacing() -> None:
+    state = SprintStoryState()
+    state.register("issue-50", "Issue #50", detail={"gate_status": "running", "pr": "#7"})
+    state.transition("issue-50", detail_updates={"gate_status": "timeout"})
+
+    entry = state.get("issue-50")
+    assert entry is not None
+    assert entry.detail == {"gate_status": "timeout", "pr": "#7"}
+
+
+# ── State writer: stranded stories are terminalized ────────────────────
+
+
+def test_terminalize_stories_moves_only_stranded_rows(tmp_path: Path) -> None:
+    writer = SprintStateWriter("run1", tmp_path, "sprint-a")
+    writer.init(
+        [
+            {"slug": "issue-50", "path": "Issue #50", "status": "running"},
+            {"slug": "issue-230", "path": "Issue #230", "status": "done"},
+        ]
+    )
+    writer.update("issue-50", phase="VALIDATE", detail={"gate_status": "running"})
+
+    stranded = writer.terminalize_stories(reason="sprint ended")
+
+    assert stranded == ["issue-50"]
+    state = _read_state(tmp_path, "run1")
+    stalled = _story(state, "issue-50")
+    assert stalled["status"] == "failed"
+    assert stalled["outcome"] == "failed"
+    assert stalled["detail"]["gate_status"] == "incomplete"
+    assert stalled["reason"] == "sprint ended"
+    assert stalled["finished_at"]
+    # An already-terminal story is untouched.
+    assert _story(state, "issue-230")["status"] == "done"
+
+
+def test_terminal_sprint_phase_is_written_to_disk(tmp_path: Path) -> None:
+    writer = SprintStateWriter("run1", tmp_path, "sprint-a")
+    writer.init([{"slug": "issue-50", "path": "Issue #50", "status": "failed"}])
+    writer.set_phase("running")
+    assert not is_terminal_sprint_phase(_read_state(tmp_path, "run1")["sprint_phase"])
+
+    writer.set_phase("failed")
+
+    assert is_terminal_sprint_phase(_read_state(tmp_path, "run1")["sprint_phase"])
+
+
+# ── forge stop: the surviving state file is made terminal ──────────────
+
+
+def test_terminalize_state_file_marks_sprint_and_stories_stopped(tmp_path: Path) -> None:
+    writer = SprintStateWriter("run1", tmp_path, "sprint-a")
+    writer.init(
+        [
+            {"slug": "issue-50", "path": "Issue #50", "status": "running"},
+            {"slug": "issue-230", "path": "Issue #230", "status": "done"},
+        ]
+    )
+    writer.update("issue-50", phase="VALIDATE", detail={"gate_status": "running"})
+    writer.set_phase("running")
+
+    stranded = terminalize_state_file("run1", tmp_path)
+
+    assert stranded == ["issue-50"]
+    state = _read_state(tmp_path, "run1")
+    assert state["sprint_phase"] == SPRINT_PHASE_STOPPED
+    stopped = _story(state, "issue-50")
+    assert stopped["status"] == "failed"
+    assert stopped["phase"] == "STOPPED"
+    assert stopped["reason"] == "stopped"
+    assert stopped["detail"]["gate_status"] == "stopped"
+    assert _story(state, "issue-230")["status"] == "done"
+
+
+def test_terminalize_state_file_is_a_noop_without_a_state_file(tmp_path: Path) -> None:
+    assert terminalize_state_file("missing", tmp_path) == []
+
+
+def test_cleanup_stopped_run_terminalizes_before_reaping(tmp_path: Path) -> None:
+    from theforge.cli import status as cli_status
+
+    writer = SprintStateWriter("run1", tmp_path, "sprint-a")
+    writer.init([{"slug": "issue-50", "path": "Issue #50", "status": "running"}])
+    writer.set_phase("running")
+
+    order: list[str] = []
+
+    def _fake_reap(project_root: Path) -> int:
+        order.append("reap")
+        state = _read_state(tmp_path, "run1")
+        # Terminal state must already be on disk when the reaper runs, so an
+        # operator reading .state right after stop never sees a live sprint.
+        assert state["sprint_phase"] == SPRINT_PHASE_STOPPED
+        return 0
+
+    with (
+        patch("theforge.process_group.reap_orphan_agents", side_effect=_fake_reap),
+        patch("theforge.sprint.lock.cleanup_story_locks", side_effect=lambda *a, **k: None),
+    ):
+        cli_status._cleanup_stopped_run("run1", tmp_path, "issue-50", pid=424242)
+
+    assert order == ["reap"]
+    state = _read_state(tmp_path, "run1")
+    assert _story(state, "issue-50")["status"] == "failed"
+    assert _story(state, "issue-50")["detail"]["gate_status"] == "stopped"
+
+
+# ── Gate subprocesses are reachable by the orphan reaper ───────────────
+
+
+def test_gate_subprocess_registers_its_process_group(tmp_path: Path, monkeypatch) -> None:
+    """The gate's own session must leave a sidecar the reaper can kill it by."""
+    monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+    agents_dir = tmp_path / ".forge" / "runs" / "agents"
+    seen: list[dict] = []
+
+    real_register = coord_util.register_agent_group
+
+    def _record(pgid: int, *, sandbox_dir=None) -> None:
+        real_register(pgid, sandbox_dir=sandbox_dir)
+        payload = {"pgid": pgid, "sandbox_dir": sandbox_dir}
+        payload["sidecar_written"] = any(agents_dir.glob("*.json"))
+        seen.append(payload)
+
+    monkeypatch.setattr(coord_util, "register_agent_group", _record)
+
+    ok, _output = coord_util._run_shell("echo hello", tmp_path, timeout=30)
+
+    assert ok is True
+    assert len(seen) == 1
+    assert seen[0]["pgid"] > 1
+    assert seen[0]["sandbox_dir"] == str(tmp_path)
+    assert seen[0]["sidecar_written"] is True
+    # A cleanly finished command leaves no orphan record behind.
+    assert list(agents_dir.glob("*.json")) == []
+
+
+def test_gate_sidecar_is_kept_when_the_group_kill_is_refused(tmp_path: Path, monkeypatch) -> None:
+    """A survivor must stay reachable: the sidecar is the only handle on it."""
+    monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+    # Stand in for a refused group kill (a sandbox that denies killpg): the
+    # direct child may be gone while its grandchildren are not.
+    monkeypatch.setattr(coord_util, "_kill_process_group", lambda proc: False)
+
+    ok, output = coord_util._run_shell(
+        'python3 -c "import time; time.sleep(30)"', tmp_path, timeout=0.2
+    )
+
+    assert ok is False
+    assert output.startswith("TIMEOUT")
+    sidecars = list((tmp_path / ".forge" / "runs" / "agents").glob("*.json"))
+    assert len(sidecars) == 1
+    record = json.loads(sidecars[0].read_text(encoding="utf-8"))
+    assert record["pgid"] > 1
+    assert record["owner_pid"] == os.getpid()
+    assert record["sandbox_dir"] == str(tmp_path)
+    # Leave nothing running behind this assertion.
+    from theforge.process_group import kill_agent_group
+
+    kill_agent_group(record["pgid"])
+
+
+# ── Timeout audits keep the history the run actually produced ──────────
+
+
+def test_snapshot_live_state_detaches_from_the_running_worker() -> None:
+    state = CoordinatorState(run_id="abc123")
+    state.gate_decisions.append("FAIL")
+    register_live_state("issue-50", state)
+    try:
+        snapshot = snapshot_live_state("issue-50")
+    finally:
+        release_live_state("issue-50", state)
+
+    assert snapshot is not None
+    assert snapshot.run_id == "abc123"
+    assert snapshot.gate_decisions == ["FAIL"]
+    assert snapshot is not state
+    assert snapshot_live_state("issue-50") is None
+
+
+def test_release_live_state_ignores_a_superseded_object() -> None:
+    first = CoordinatorState(run_id="first")
+    second = CoordinatorState(run_id="second")
+    register_live_state("issue-50", first)
+    register_live_state("issue-50", second)
+    release_live_state("issue-50", first)
+    try:
+        current = snapshot_live_state("issue-50")
+        assert current is not None
+        assert current.run_id == "second"
+    finally:
+        release_live_state("issue-50")
+
+
+def test_timeout_state_preserves_dev_and_gate_history(tmp_path: Path) -> None:
+    """The audit for a timed-out story keeps the telemetry the engine accumulated."""
+    import datetime
+
+    from theforge.sprint import runner as sprint_runner
+
+    live = CoordinatorState(run_id="deadbeef1234")
+    live.phase = Phase.VALIDATE
+    live.started_at = "2026-07-28T00:00:00+00:00"
+    live.gate_decisions.extend(["FAIL", "FAIL"])
+    live.dev_durations.extend([12.0, 30.0])
+    live.workspace_path = tmp_path / "ws"
+    live.log_dir = tmp_path / "logs"
+
+    register_live_state("issue-50", live)
+    try:
+        with patch.object(sprint_runner, "_make_story_log_dir", return_value=tmp_path / "logs"):
+            state = sprint_runner._terminal_state_for(
+                "issue-50",
+                config=_MinimalConfig(tmp_path),
+                sprint_name="sprint-a",
+                started_at=datetime.datetime(2026, 7, 28, tzinfo=datetime.timezone.utc),
+                error="Worker timeout (>3600s) during phase VALIDATE",
+                error_type="TimeoutError",
+            )
+    finally:
+        release_live_state("issue-50", live)
+
+    assert state.run_id == "deadbeef1234"
+    assert state.gate_decisions == ["FAIL", "FAIL"]
+    assert state.dev_durations == [12.0, 30.0]
+    # ...but the story is reported as the scheduler ended it, not mid-VALIDATE.
+    assert state.phase is Phase.ESCALATE
+    assert state.error_type == "TimeoutError"
+
+
+def test_timeout_state_falls_back_when_the_story_never_reached_the_engine(
+    tmp_path: Path,
+) -> None:
+    import datetime
+
+    from theforge.sprint import runner as sprint_runner
+
+    with patch.object(sprint_runner, "_make_story_log_dir", return_value=tmp_path / "logs"):
+        state = sprint_runner._terminal_state_for(
+            "issue-nonexistent",
+            config=_MinimalConfig(tmp_path),
+            sprint_name="sprint-a",
+            started_at=datetime.datetime(2026, 7, 28, tzinfo=datetime.timezone.utc),
+            error="Worker exception: boom",
+            error_type="RuntimeError",
+        )
+
+    assert state.run_id is None
+    assert state.phase is Phase.ESCALATE
+    assert state.workspace_path == tmp_path / "issue-nonexistent"
+
+
+class _MinimalConfig:
+    """Just the two attributes ``_terminal_state_for`` reads off the config."""
+
+    def __init__(self, project_root: Path) -> None:
+        self.project_root = project_root
+        self.workspace = _MinimalWorkspace()
+
+
+class _MinimalWorkspace:
+    path_pattern = "{slug}"
+
+
+# ── Every listed story slug can actually be tailed ─────────────────────
+
+
+def _make_story_logs(project_root: Path, sprint: str, slug: str, names: list[str]) -> Path:
+    story_dir = project_root / ".forge" / "logs" / sprint / slug
+    story_dir.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (story_dir / name).write_text("content\n", encoding="utf-8")
+    return story_dir
+
+
+def test_story_log_resolves_to_a_dev_iteration_log(tmp_path: Path) -> None:
+    from theforge.cli.status import _find_story_log_path
+
+    _make_story_logs(
+        tmp_path,
+        "issues-50,230",
+        "issue-50",
+        ["dev-iter-1-gpt.log", "dev-iter-2-gpt.log", "audit.yaml", "preflight.yaml"],
+    )
+
+    found = _find_story_log_path(tmp_path, "issue-50", "issues-50,230")
+
+    assert found is not None
+    assert found.name.startswith("dev-iter-")
+
+
+def test_story_log_falls_back_to_audit_yaml(tmp_path: Path) -> None:
+    from theforge.cli.status import _find_story_log_path
+
+    _make_story_logs(tmp_path, "issues-50,230", "issue-230", ["audit.yaml", "preflight.yaml"])
+
+    found = _find_story_log_path(tmp_path, "issue-230", "issues-50,230")
+
+    assert found is not None
+    assert found.name == "audit.yaml"
+
+
+def test_story_log_prefers_run_log_when_present(tmp_path: Path) -> None:
+    from theforge.cli.status import _find_story_log_path
+
+    _make_story_logs(tmp_path, "solo", "issue-9", ["run-abc.log", "dev-iter-1-gpt.log"])
+
+    found = _find_story_log_path(tmp_path, "issue-9", "solo")
+
+    assert found is not None
+    assert found.name == "run-abc.log"
+
+
+def test_story_log_resolves_without_a_known_sprint_name(tmp_path: Path) -> None:
+    from theforge.cli.status import _find_story_log_path
+
+    _make_story_logs(tmp_path, "issues-50,230", "issue-50", ["dev-iter-1-gpt.log"])
+
+    found = _find_story_log_path(tmp_path, "issue-50", None)
+
+    assert found is not None
+    assert found.name == "dev-iter-1-gpt.log"
+
+
+def test_every_listed_slug_opens(tmp_path: Path) -> None:
+    """The enumerator and the tailer must agree — that is the whole contract."""
+    from theforge.cli.status import _find_story_log_path
+
+    sprint = "issues-50,230"
+    _make_story_logs(tmp_path, sprint, "issue-50", ["dev-iter-1-gpt.log", "audit.yaml"])
+    _make_story_logs(tmp_path, sprint, "issue-230", ["audit.yaml"])
+
+    writer = SprintStateWriter("run1", tmp_path, sprint)
+    writer.init(
+        [
+            {"slug": "issue-50", "path": "Issue #50", "status": "failed"},
+            {"slug": "issue-230", "path": "Issue #230", "status": "failed"},
+        ]
+    )
+
+    from theforge.sprint.status_reader import read_live_status
+
+    listed = [e.slug for e in (read_live_status("run1", tmp_path) or []) if e.slug]
+    assert listed == ["issue-50", "issue-230"]
+    for slug in listed:
+        path = _find_story_log_path(tmp_path, slug, sprint)
+        assert path is not None and path.exists(), f"listed slug {slug} is not tailable"
+
+
+# ── End-to-end: a timed-out sprint leaves terminal live state ──────────
+
+
+def test_timed_out_sprint_writes_terminal_state_before_teardown(tmp_path: Path) -> None:
+    """The .state file a crash or a stop would find must already read terminal."""
+    import threading
+
+    from tests.test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+    from theforge.sprint import run_sprint
+
+    config = _make_config(tmp_path)
+    spec = _make_spec_file(tmp_path, "Feature A", "feature-a")
+    manifest = _make_manifest(tmp_path, [spec.name])
+
+    class _NeverDoneFuture:
+        def cancel(self):
+            return True
+
+        def result(self):
+            raise AssertionError("should not be called")
+
+    class _FakeExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            assert isinstance(args[-1], threading.Event)
+            return _NeverDoneFuture()
+
+    # The engine registers its live state for the story it is running; a worker
+    # that times out never returns, so this registry is the only way its
+    # accumulated history can reach the audit the scheduler writes for it.
+    live = CoordinatorState(run_id="livedbeef999")
+    live.gate_decisions.extend(["FAIL", "FAIL"])
+    register_live_state("feature-a", live)
+
+    with (
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.ThreadPoolExecutor", _FakeExecutor),
+        patch("theforge.sprint.runner.wait", return_value=(set(), set())),
+        patch("theforge.sprint.runner.time.monotonic", side_effect=[0.0, 4000.0, 4000.0]),
+        # Keep the live state on disk so the test can read what a run killed
+        # during wrap-up would have left behind.
+        patch.object(SprintStateWriter, "remove", lambda self: None),
+    ):
+        try:
+            run_sprint(config, manifest, run_id="terminalrun01")
+        finally:
+            release_live_state("feature-a", live)
+
+    audit_path = next((tmp_path / ".forge" / "logs").rglob("audit.yaml"))
+    audit = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+    # AC (d): the timeout audit keeps the history the run really produced.
+    assert audit["run_id"] == "livedbeef999"
+    assert audit["iterations"]["gate_decisions"] == ["FAIL", "FAIL"]
+
+    state = tmp_path / ".forge" / "runs" / "terminalrun01.state"
+    data = yaml.safe_load(state.read_text(encoding="utf-8"))
+    assert is_terminal_sprint_phase(data["sprint_phase"])
+    assert data["sprint_phase"] == "failed"
+    story = data["stories"][0]
+    assert story["status"] == "failed"
+    assert story["detail"]["gate_status"] == "timeout"
+    assert story["detail"]["gate_status"] != "running"

--- a/tests/test_sprint_terminal_lifecycle.py
+++ b/tests/test_sprint_terminal_lifecycle.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
+import subprocess
+import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -27,6 +31,7 @@ from theforge.coordinator.live_state import (
     snapshot_live_state,
 )
 from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.process_group import reap_orphan_agents
 from theforge.sprint.state_writer import (
     SPRINT_PHASE_STOPPED,
     SprintStateWriter,
@@ -493,3 +498,237 @@ def test_timed_out_sprint_writes_terminal_state_before_teardown(tmp_path: Path) 
     assert story["status"] == "failed"
     assert story["detail"]["gate_status"] == "timeout"
     assert story["detail"]["gate_status"] != "running"
+
+
+# ── The reaper really kills an orphaned gate tree ──────────────────────
+
+
+def _pid_is_gone(pid: int) -> bool:
+    """True once *pid* is neither alive nor a zombie this process must reap.
+
+    ``os.kill(pid, 0)`` succeeds against a zombie, so a killed direct child
+    reads as alive until its exit status is collected. Reaping it here is what
+    makes the check mean "the process is gone" rather than "it has not been
+    waited on yet".
+    """
+    try:
+        reaped, _status = os.waitpid(pid, os.WNOHANG)
+        if reaped == pid:
+            return True
+    except (ChildProcessError, OSError):
+        pass
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except OSError:
+        return False
+    return False
+
+
+def _wait_until_gone(pids: list[int], timeout: float = 5.0) -> list[int]:
+    """Poll until every pid in *pids* is gone; return whichever survived."""
+    deadline = time.monotonic() + timeout
+    remaining = list(pids)
+    while remaining and time.monotonic() < deadline:
+        remaining = [pid for pid in remaining if not _pid_is_gone(pid)]
+        if remaining:
+            time.sleep(0.05)
+    return remaining
+
+
+def _dead_pid() -> int:
+    """Return a pid that has certainly exited and been reaped."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait(timeout=30)
+    return proc.pid
+
+
+def test_reaper_kills_an_orphaned_gate_tree_after_the_owner_dies(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The production symptom: an xcodebuild tree outliving the sprint that ran it.
+
+    Runs the real registration path (``_run_shell_detailed`` spawning into its own
+    session), neuters only the group kill so the tree genuinely survives teardown
+    — the sandbox-refused-killpg case — then marks the owner sprint dead and lets
+    ``reap_orphan_agents`` do what ``forge stop`` calls it to do. Both the gate
+    shell and its grandchild must actually die (#2013).
+    """
+    monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+    # A refused group kill: teardown reaches nothing, exactly the state that
+    # leaves a live tree behind for the reaper to find.
+    monkeypatch.setattr(coord_util, "_kill_process_group", lambda proc: False)
+
+    cmd = (
+        f'{sys.executable} -u -c "import subprocess, sys, time; '
+        f"child = subprocess.Popen([{sys.executable!r}, '-c', 'import time; time.sleep(120)']); "
+        'print(child.pid, flush=True); time.sleep(120)"'
+    )
+    ok, output, _exit_code, timed_out = coord_util._run_shell_detailed(cmd, tmp_path, timeout=2)
+
+    assert ok is False and timed_out is True
+    grandchild_pid = int(
+        next(line for line in output.splitlines() if line.strip().isdigit()).strip()
+    )
+
+    sidecars = list((tmp_path / ".forge" / "runs" / "agents").glob("*.json"))
+    assert len(sidecars) == 1, "the surviving group must still be registered"
+    record = json.loads(sidecars[0].read_text(encoding="utf-8"))
+    gate_pid = record["pgid"]
+
+    try:
+        assert not _pid_is_gone(grandchild_pid), "grandchild should still be running"
+
+        # The owner sprint is gone — the state `forge stop` leaves behind.
+        record["owner_pid"] = _dead_pid()
+        sidecars[0].write_text(json.dumps(record), encoding="utf-8")
+
+        reaped = reap_orphan_agents(tmp_path)
+
+        assert reaped == 1
+        assert _wait_until_gone([gate_pid, grandchild_pid]) == [], (
+            "reap_orphan_agents left gate descendants alive — the exact #2013 symptom"
+        )
+        assert list((tmp_path / ".forge" / "runs" / "agents").glob("*.json")) == []
+    finally:
+        for pid in (gate_pid, grandchild_pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                os.waitpid(pid, os.WNOHANG)
+            except (ChildProcessError, OSError):
+                pass
+
+
+# ── A stopped story's audit keeps the history it accumulated ───────────
+
+
+def _live_story_state(tmp_path: Path, slug: str, sprint_name: str) -> CoordinatorState:
+    state = CoordinatorState(run_id="stopdbeef777")
+    state.phase = Phase.VALIDATE
+    state.started_at = "2026-07-28T00:00:00+00:00"
+    state.sprint_name = sprint_name
+    state.gate_decisions.extend(["FAIL", "FAIL"])
+    state.workspace_path = tmp_path / slug
+    state.log_dir = tmp_path / ".forge" / "logs" / sprint_name / slug
+    return state
+
+
+def test_live_story_audit_is_flushed_while_the_story_runs(tmp_path: Path) -> None:
+    from tests.test_sprint_resume import _make_config
+    from theforge.sprint.audit import write_live_story_audit
+    from theforge.task import TaskStory
+
+    sprint_name = "issues-50,230"
+    config = _make_config(tmp_path)
+    task = TaskStory(name="Issue #50", slug="issue-50", story_text="do the thing")
+    state = _live_story_state(tmp_path, "issue-50", sprint_name)
+
+    path = write_live_story_audit(config, task, state, sprint_name=sprint_name)
+
+    assert path is not None and path.exists()
+    audit = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert audit["in_flight"] is True
+    assert audit["run_id"] == "stopdbeef777"
+    assert audit["iterations"]["gate_decisions"] == ["FAIL", "FAIL"]
+    # The flush is a live observation, not a verdict: no substrate record and no
+    # ESCALATE marker are written for a story that has not finished.
+    assert not (tmp_path / ".forge" / "audits").exists()
+
+
+def test_phase_change_flushes_the_story_audit_once_per_phase(tmp_path: Path) -> None:
+    """Flush cost tracks real progress, not live-update chatter."""
+    import threading
+
+    from theforge.sprint import runner as sprint_runner
+
+    flushed: list[str] = []
+    update = sprint_runner._make_worker_phase_fn(
+        "issue-50",
+        {},
+        threading.Lock(),
+        None,
+        audit_flush=flushed.append,
+    )
+
+    update({"phase": "DEV"})
+    update({"phase": "DEV", "cost_usd": 0.2})
+    update({"cost_usd": 0.4})
+    update({"phase": "VALIDATE"})
+
+    assert flushed == ["DEV", "VALIDATE"]
+
+
+def test_stop_finalizes_the_in_flight_audit_without_losing_history(tmp_path: Path) -> None:
+    """AC (d) for the operator-stop path, end to end.
+
+    The sprint process flushes the story's audit as it runs; ``forge stop`` — a
+    different process, which cannot see that run's memory — finalizes the file it
+    left behind. The accumulated run_id/gate history must survive that handoff.
+    """
+    from tests.test_sprint_resume import _make_config
+    from theforge.cli import status as cli_status
+    from theforge.sprint.audit import write_live_story_audit
+    from theforge.task import TaskStory
+
+    sprint_name = "issues-50,230"
+    config = _make_config(tmp_path)
+    task = TaskStory(name="Issue #50", slug="issue-50", story_text="do the thing")
+    audit_path = write_live_story_audit(
+        config, task, _live_story_state(tmp_path, "issue-50", sprint_name), sprint_name=sprint_name
+    )
+    assert audit_path is not None
+
+    writer = SprintStateWriter("run1", tmp_path, sprint_name)
+    writer.init([{"slug": "issue-50", "path": "Issue #50", "status": "running"}])
+    writer.update("issue-50", phase="VALIDATE", detail={"gate_status": "running"})
+    writer.set_phase("running")
+
+    with (
+        patch("theforge.process_group.reap_orphan_agents", return_value=0),
+        patch("theforge.sprint.lock.cleanup_story_locks", side_effect=lambda *a, **k: None),
+    ):
+        cli_status._cleanup_stopped_run("run1", tmp_path, "issue-50", pid=424242)
+
+    audit = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+    assert audit["in_flight"] is False
+    assert audit["interrupted_by"] == "stopped"
+    assert audit["outcome"]["success"] is False
+    assert audit["outcome"]["error_type"] == "OperatorStopped"
+    assert "VALIDATE" in audit["outcome"]["message"]
+    assert audit["timing"]["finished_at"]
+    # The point of the whole exercise: the history is still there.
+    assert audit["run_id"] == "stopdbeef777"
+    assert audit["iterations"]["gate_decisions"] == ["FAIL", "FAIL"]
+
+
+def test_stop_does_not_overwrite_a_finished_story_audit(tmp_path: Path) -> None:
+    """A completed story wrote the real audit; stop must not guess over it."""
+    from theforge.cli import status as cli_status
+    from theforge.sprint.audit import finalize_interrupted_story_audit
+
+    sprint_name = "issues-50,230"
+    audit_path = tmp_path / ".forge" / "logs" / sprint_name / "issue-230" / "audit.yaml"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    final_audit = {
+        "run_id": "finished9999",
+        "outcome": {"success": True, "final_phase": "DONE", "message": "approved"},
+    }
+    audit_path.write_text(yaml.dump(final_audit), encoding="utf-8")
+
+    assert finalize_interrupted_story_audit(tmp_path, sprint_name, "issue-230") is None
+    assert yaml.safe_load(audit_path.read_text(encoding="utf-8")) == final_audit
+
+    # ...and the same holds through the stop path itself.
+    writer = SprintStateWriter("run1", tmp_path, sprint_name)
+    writer.init([{"slug": "issue-230", "path": "Issue #230", "status": "done"}])
+    with (
+        patch("theforge.process_group.reap_orphan_agents", return_value=0),
+        patch("theforge.sprint.lock.cleanup_story_locks", side_effect=lambda *a, **k: None),
+    ):
+        cli_status._cleanup_stopped_run("run1", tmp_path, "issue-230", pid=424242)
+
+    assert yaml.safe_load(audit_path.read_text(encoding="utf-8")) == final_audit


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior P1s are resolved, the runtime call paths are wired, and the targeted regression suite passed with 47 tests. | [google-gemini-3.5-flash] The implementation successfully resolves all five gaps in sprint failure/timeout/stop lifecycle handling with robust, thread-safe, and thoroughly tested code. | [claude-sonnet] Both Cycle 1 P1 findings are resolved with real end-to-end tests: the stop path now flushes and finalizes a story's audit.yaml via write_live_story_audit/finalize_interrupted_story_audit, and the reaper's kill of a real orphaned gate subprocess tree (parent + grandchild) after a dead owner is now directly tested. No regressions found in the touched files (cli/status.py, sprint/audit.py, sprint/runner.py); all 6 acceptance criteria have concrete, symptom-matching test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $32.08
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint timeout/stop leaves failed run live with orphaned gate subprocesses and contradictory state (GitHub Issue #2013)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2013