### PR TITLE
The ready queue presents issues the shape gate refuses, so the queue-for-next-sprint surface and sprint entry disagree

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -131,7 +131,10 @@ sprint's selected work.
 
 There is no `forge queue` command — the `ready` label is the queue-for-next-sprint
 convention, and it carries no ordering or priority semantics. Use
-`forge status --ready [--milestone …]` to see the eligible set. Live injection of
+`forge status --ready [--milestone …]` to see the eligible set; it checks each
+entry against the sprint shape gate and marks `BLOCKED:<verdict>` any issue the
+gate would refuse, so the listing cannot disagree with sprint entry about
+admissibility. Live injection of
 new work into an in-flight sprint is deliberately out of scope; it belongs to the
 v0.12+ autonomy roadmap. See ADR-0001 and `docs/guides/authoring.md`
 (Mid-sprint workflow).

--- a/docs/guides/authoring.md
+++ b/docs/guides/authoring.md
@@ -507,11 +507,21 @@ issue is what normal sprint selection considers. To see the current eligible set
 use `forge status --ready` (scope it with `--milestone`):
 
 ```
-$ forge status --ready --milestone v0.10.0
-Ready for next sprint in v0.10.0 (2 issues):
-  #1487  bug   ready  status --watch blank during preflight
-  #1512  bug   ready  cut-rc.sh shim wrapper regression
+$ forge status --ready --milestone v0.13.0
+Ready for next sprint in v0.13.0 (2 issues, 1 blocked by shape gate):
+  #1487  bug  ready                    status --watch blank during preflight
+  #1512  bug  BLOCKED:needs_diagnosis  cut-rc.sh shim wrapper regression
+
+1 issue carries the `ready` label but would be refused at sprint entry:
+  #1512  needs_diagnosis: Bug has no Diagnosis section — not fix-ready. …
+Run `forge shape <n>` for the full verdict, then `forge groom <n>` / `forge diagnose <n>` before sprint selection.
 ```
+
+The `ready` label is applied by hand, so the listing does not take it at face
+value: every entry is run through the same shape gate that guards sprint entry,
+and one the gate would refuse is marked `BLOCKED:<verdict>` rather than
+presented as eligible. Groom or diagnose those before selecting a sprint —
+otherwise the sprint discovers the problem after budget is committed.
 
 ### Live sprint injection is out of scope
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -330,11 +330,22 @@ a new command: there is **no `forge queue`**, and this listing adds no ordering
 or priority semantics. It is simply the current eligible set, recomputed from
 GitHub on each invocation.
 
+`ready` is a human-applied label and nothing enforces that it is applied only
+after `capture → shape → diagnose → groom`. So each entry is also run through
+the same shape gate that guards sprint entry: an issue the gate would refuse is
+marked `BLOCKED:<verdict>` instead of `ready`, and its refusal is spelled out
+below the listing. Selecting only the `ready`-marked entries cannot produce a
+story the sprint refuses.
+
 ```
-$ forge status --ready --milestone v0.10.0
-Ready for next sprint in v0.10.0 (2 issues):
-  #1487  bug   ready  status --watch blank during preflight
-  #1512  bug   ready  cut-rc.sh shim wrapper regression
+$ forge status --ready --milestone v0.13.0
+Ready for next sprint in v0.13.0 (2 issues, 1 blocked by shape gate):
+  #1487  bug  ready                    status --watch blank during preflight
+  #1512  bug  BLOCKED:needs_diagnosis  cut-rc.sh shim wrapper regression
+
+1 issue carries the `ready` label but would be refused at sprint entry:
+  #1512  needs_diagnosis: Bug has no Diagnosis section — not fix-ready. …
+Run `forge shape <n>` for the full verdict, then `forge groom <n>` / `forge diagnose <n>` before sprint selection.
 ```
 
 ---

--- a/src/theforge/admissibility.py
+++ b/src/theforge/admissibility.py
@@ -1,0 +1,270 @@
+"""Sprint-entry admissibility: the single verdict both the gate and the queue use.
+
+``forge status --ready`` and ``sprint.shape_gate`` answer the same question —
+"may this issue enter a sprint?" — and previously answered it from different
+data: the queue from the ``ready`` label alone, the gate from a live
+``shape_check`` run. That let a surface advertising work as sprint-ready
+present issues the gate refused (#2027).
+
+This module holds the classification both call, so a disagreement is a code
+change rather than a drift. It is pure: callers supply the issue's title, body
+and labels; nothing here fetches from GitHub or reads coordinator state.
+
+Stdlib + ``shape_check`` imports only (``shape_check`` is itself stdlib-only),
+so the low-dependency ``ready_queue`` surface can import it freely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .shape_check import Shape, ShapeResult, ShapeVerdict, check
+from .shape_check.parsing import extract_ac_section, extract_bullets
+from .shape_check.types import VERDICT_DESCRIPTIONS, Severity
+
+NEEDS_GROOMING_LABEL = "needs-grooming"
+
+# operator-action: deliberate non-dispatch type. The label declares an issue
+# whose deliverable is human action no dev agent can perform. The gate refuses
+# to dispatch these issues to dev cycles — distinct from "wrong shape" skips.
+OPERATOR_ACTION_LABEL = "operator-action"
+OPERATOR_ACTION_CODE = "operator_action"
+OPERATOR_ACTION_LABEL_CONFLICT_CODE = "operator_action_label_conflict"
+OPERATOR_ACTION_MISSING_AC_CODE = "operator_action_missing_ac"
+# operator-action is mutually exclusive with the runnable type labels.
+OPERATOR_ACTION_CONFLICT_LABELS = frozenset({"bug", "enhancement", "epic", "task"})
+
+NEEDS_GROOMING_LABEL_CODE = "needs_grooming_label"
+
+_VALID_CLASSIFIER_MODES = frozenset({"heuristic", "off", "llm"})
+
+
+@dataclass(frozen=True)
+class Admissibility:
+    """Whether an issue may enter a sprint, and why not when it may not.
+
+    ``source`` mirrors the shape gate's provenance vocabulary: ``"label"`` when
+    a label alone decided the outcome (``needs-grooming``, ``operator-action``),
+    ``"local_check"`` when the live ``shape_check`` run did.
+    """
+
+    admissible: bool
+    source: str
+    verdict: str
+    verdict_description: str
+    reason_codes: tuple[str, ...]
+    detail: str
+    # True when the issue carries the ``operator-action`` label at all, however
+    # it classified. ``--force`` must not override that label, so callers need
+    # to see it even when the outcome was a conflict or missing-AC skip.
+    operator_action_label: bool = False
+    # True only for a clean operator-action issue: deliberate non-dispatch
+    # rather than a wrong-shape refusal.
+    deliberate_non_dispatch: bool = False
+    # The underlying shape_check result, or None when a label short-circuited
+    # ahead of the check (operator-action).
+    result: ShapeResult | None = None
+
+
+def resolve_classifier(classifier_mode: str, llm_caller=None) -> str:
+    """Return the classifier mode to actually use at sprint time.
+
+    Honors the configured ``shape_check.classifier`` value when supported.
+    Falls back to ``heuristic`` when:
+
+    - The mode is unknown (defensive — misconfiguration shouldn't block sprints).
+    - The mode is ``llm`` but no ``llm_caller`` is available to refine fuzzy
+      reasons. (The ``classifier.classify`` function already silently falls
+      back in this case; resolving explicitly keeps the sprint gate honest
+      about what it actually ran.)
+    """
+    if classifier_mode not in _VALID_CLASSIFIER_MODES:
+        return "heuristic"
+    if classifier_mode == "llm" and llm_caller is None:
+        return "heuristic"
+    return classifier_mode
+
+
+def has_acceptance_criteria(body: str) -> bool:
+    """Return True if the body has a non-empty ``## Acceptance criteria`` section."""
+    section = extract_ac_section(body)
+    if not section:
+        return False
+    return bool(extract_bullets(section))
+
+
+def blocking_codes(result: ShapeResult) -> list[str]:
+    return [r.code for r in result.reasons if r.severity is Severity.BLOCKING]
+
+
+def skip_detail(
+    result: ShapeResult,
+    fallback: str,
+    *,
+    include_advisory_when_no_blocking: bool = False,
+) -> str:
+    blocking_details = [
+        reason.detail.strip()
+        for reason in result.reasons
+        if reason.severity is Severity.BLOCKING and reason.detail.strip()
+    ]
+    if blocking_details:
+        return "; ".join(blocking_details)
+
+    if include_advisory_when_no_blocking:
+        reason_details = [
+            reason.detail.strip() for reason in result.reasons if reason.detail.strip()
+        ]
+        if reason_details:
+            return "; ".join(reason_details)
+
+    return fallback
+
+
+def _classify_operator_action(body: str, labels: list[str]) -> Admissibility:
+    """Return the admissibility of an issue carrying the ``operator-action`` label."""
+    label_set = {str(lbl).strip().lower() for lbl in labels}
+    conflicts = sorted(label_set & OPERATOR_ACTION_CONFLICT_LABELS)
+    if conflicts:
+        return Admissibility(
+            admissible=False,
+            source="label",
+            verdict=ShapeVerdict.NEEDS_OPERATOR_ACTION.value,
+            verdict_description="",
+            reason_codes=(OPERATOR_ACTION_LABEL_CONFLICT_CODE,),
+            detail=(
+                f"'{OPERATOR_ACTION_LABEL}' conflicts with type label(s) "
+                f"{conflicts!r}; pick exactly one issue type."
+            ),
+            operator_action_label=True,
+        )
+    if not has_acceptance_criteria(body):
+        return Admissibility(
+            admissible=False,
+            source="label",
+            verdict=ShapeVerdict.NEEDS_OPERATOR_ACTION.value,
+            verdict_description="",
+            reason_codes=(OPERATOR_ACTION_MISSING_AC_CODE,),
+            detail=(
+                f"'{OPERATOR_ACTION_LABEL}' issues require an "
+                "'## Acceptance criteria' section describing the operator deliverable."
+            ),
+            operator_action_label=True,
+        )
+    return Admissibility(
+        admissible=False,
+        source="label",
+        verdict=ShapeVerdict.NEEDS_OPERATOR_ACTION.value,
+        verdict_description="",
+        reason_codes=(OPERATOR_ACTION_CODE,),
+        detail="not sprintable; operator deliverable",
+        operator_action_label=True,
+        deliberate_non_dispatch=True,
+    )
+
+
+def classify_admissibility(
+    title: str,
+    body: str,
+    labels: list[str],
+    *,
+    classifier_mode: str = "heuristic",
+    llm_caller=None,
+    trust_local_over_grooming_label: bool = False,
+) -> Admissibility:
+    """Return whether an issue may enter a sprint, with the verdict explaining why not.
+
+    Ordering mirrors the sprint gate exactly:
+
+    1. ``operator-action`` short-circuits ahead of the shape check. Such an
+       issue is not malformed; running the standard check would flag it for
+       ``missing_type`` and conflate two distinct operator signals.
+    2. A live ``shape_check`` run supplies the verdict for everything else.
+    3. A ``needs-grooming`` label refuses with ``source='label'`` while
+       surfacing the live blocking findings that explain the current state.
+    4. ``diagnosis_cause_unknown`` is admissible as a *shape* but not
+       implementation-runnable per ADR-0001, so it is refused on the verdict.
+    5. Any non-``RUNNABLE`` shape is refused with ``source='local_check'``.
+
+    ``trust_local_over_grooming_label`` suppresses step 3: the caller has
+    authoritatively edited the body (intake remediation) and the async
+    relabeler may not have caught up.
+    """
+    label_set_lc = {str(lbl).strip().lower() for lbl in labels}
+    if OPERATOR_ACTION_LABEL in label_set_lc:
+        return _classify_operator_action(body, labels)
+
+    local = check(
+        title,
+        body,
+        labels,
+        classifier_mode=resolve_classifier(classifier_mode, llm_caller=llm_caller),
+        llm_caller=llm_caller,
+    )
+
+    if NEEDS_GROOMING_LABEL in labels and not trust_local_over_grooming_label:
+        codes = blocking_codes(local) or [NEEDS_GROOMING_LABEL_CODE]
+        verdict = (
+            local.verdict
+            if local.verdict is not ShapeVerdict.RUNNABLE
+            else ShapeVerdict.NEEDS_OPERATOR_ACTION
+        )
+        return Admissibility(
+            admissible=False,
+            source="label",
+            verdict=verdict.value,
+            verdict_description=VERDICT_DESCRIPTIONS[verdict],
+            reason_codes=tuple(codes),
+            detail=skip_detail(
+                local,
+                fallback=f"issue carries '{NEEDS_GROOMING_LABEL}' label",
+            ),
+            result=local,
+        )
+
+    if local.verdict is ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN:
+        codes = [r.code for r in local.reasons] or [ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN.value]
+        return Admissibility(
+            admissible=False,
+            source="local_check",
+            verdict=ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN.value,
+            verdict_description=VERDICT_DESCRIPTIONS[ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN],
+            reason_codes=tuple(codes),
+            detail=skip_detail(
+                local,
+                fallback="bug investigation-ready; confirmed cause not yet identified",
+                include_advisory_when_no_blocking=True,
+            ),
+            result=local,
+        )
+
+    if local.shape is not Shape.RUNNABLE:
+        codes = blocking_codes(local) or [r.code for r in local.reasons]
+        verdict = (
+            local.verdict
+            if local.verdict is not ShapeVerdict.RUNNABLE
+            else ShapeVerdict.NEEDS_OPERATOR_ACTION
+        )
+        return Admissibility(
+            admissible=False,
+            source="local_check",
+            verdict=verdict.value,
+            verdict_description=VERDICT_DESCRIPTIONS[verdict],
+            reason_codes=tuple(codes),
+            detail=skip_detail(
+                local,
+                fallback=f"local shape check: {local.suggested_action.value}",
+                include_advisory_when_no_blocking=True,
+            ),
+            result=local,
+        )
+
+    return Admissibility(
+        admissible=True,
+        source="local_check",
+        verdict=ShapeVerdict.RUNNABLE.value,
+        verdict_description=VERDICT_DESCRIPTIONS[ShapeVerdict.RUNNABLE],
+        reason_codes=(),
+        detail="",
+        result=local,
+    )

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -1125,7 +1125,9 @@ def register_parsers(subparsers: object) -> None:
         default=False,
         help=(
             "List open issues carrying the `ready` label — the set eligible for "
-            "the next sprint. Combine with --milestone to scope to one milestone."
+            "the next sprint. Each entry is checked against the sprint shape "
+            "gate; entries the gate would refuse are marked BLOCKED with their "
+            "verdict. Combine with --milestone to scope to one milestone."
         ),
     )
     status_parser.add_argument(

--- a/src/theforge/ready_queue.py
+++ b/src/theforge/ready_queue.py
@@ -9,6 +9,16 @@ next sprint — optionally scoped to a milestone.
 No queue *ordering* or *priority* semantics are added: the list is simply the
 current set of open, ``ready``-labeled issues, recomputed from GitHub on each
 call so it always reflects live label/milestone state.
+
+The ``ready`` label is a human-applied marker and nothing enforces that it is
+applied only after ``capture → shape → diagnose → groom``. A queue whose
+entries the sprint gate would refuse is worse than no queue: it moves the
+discovery of inadmissibility from planning time to sprint time, after budget
+is committed. So each entry is also run through the shared
+``admissibility.classify_admissibility`` — the same decision
+``sprint.shape_gate`` enforces at sprint entry — and entries the gate would
+refuse are rendered with their blocking verdict rather than as ``ready``
+(#2027).
 """
 
 from __future__ import annotations
@@ -19,13 +29,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from .admissibility import classify_admissibility
+
 READY_LABEL = "ready"
 
 _GH_TIMEOUT_SECONDS = 30
 
 # Dev-runnable and operator work-object type labels, in the order we prefer to
-# report them when an issue carries more than one. This is display-only — it
-# does not gate eligibility (the ``ready`` label alone does that).
+# report them when an issue carries more than one. This is display-only — the
+# ``ready`` label decides membership in this listing, and
+# ``classify_admissibility`` decides whether a member is actually admissible.
 _TYPE_LABELS = (
     "bug",
     "enhancement",
@@ -38,11 +51,19 @@ _TYPE_LABELS = (
 
 @dataclass(frozen=True)
 class ReadyEntry:
-    """An open, ``ready``-labeled issue eligible for the next sprint."""
+    """An open, ``ready``-labeled issue and the sprint gate's verdict on it.
+
+    ``admissible`` is the shape gate's answer, not the label's: an entry with
+    ``admissible=False`` carries the ``ready`` label but would be refused at
+    sprint entry, and ``verdict``/``detail`` say why.
+    """
 
     issue_number: int
     title: str
     type_label: str
+    admissible: bool = True
+    verdict: str = ""
+    detail: str = ""
 
 
 def _issue_type_label(labels: list[str]) -> str:
@@ -59,7 +80,11 @@ def _issue_type_label(labels: list[str]) -> str:
 
 
 def _gh_list_ready_issues(project_root: Path, milestone: str | None) -> list[dict]:
-    """Return open ``ready``-labeled issues (number/title/labels) via the gh CLI.
+    """Return open ``ready``-labeled issues (number/title/labels/body) via the gh CLI.
+
+    The body is fetched in the same listing call — without it the shape gate's
+    admissibility decision cannot be evaluated from the data the queue holds,
+    which is exactly how the listing and sprint entry came to disagree (#2027).
 
     When ``milestone`` is given, the listing is scoped to that GitHub milestone.
     Best-effort: returns an empty list on any gh failure so the status surface
@@ -76,7 +101,7 @@ def _gh_list_ready_issues(project_root: Path, milestone: str | None) -> list[dic
         "--limit",
         "200",
         "--json",
-        "number,title,labels",
+        "number,title,labels,body",
     ]
     if milestone:
         cmd.extend(["--milestone", milestone])
@@ -125,7 +150,12 @@ def build_ready_queue(
     milestone: str | None = None,
     fetch_issues: Callable[[], list[dict]] | None = None,
 ) -> list[ReadyEntry]:
-    """Return the ``ready``-labeled, sprint-eligible issue set.
+    """Return the ``ready``-labeled issue set with each entry's gate verdict.
+
+    Every entry is classified with ``classify_admissibility`` — the same
+    decision ``sprint.shape_gate`` applies at sprint entry — so an entry the
+    gate would refuse carries ``admissible=False`` and its blocking verdict
+    rather than being presented as sprint-ready.
 
     ``milestone`` optionally scopes the listing to one GitHub milestone.
     ``fetch_issues`` is an injection seam for testing; it defaults to the
@@ -137,36 +167,94 @@ def build_ready_queue(
     issues = fetch_issues()
     entries: list[ReadyEntry] = []
     for issue in issues:
+        labels = _label_names(issue)
+        title = str(issue.get("title", "") or "")
+        # No llm_caller here: a status listing must not spend agent budget, and
+        # the gate's own _resolve_classifier falls back to the heuristic
+        # classifier without a caller, so both sides evaluate identically.
+        verdict = classify_admissibility(title, str(issue.get("body", "") or ""), labels)
         entries.append(
             ReadyEntry(
                 issue_number=int(issue["number"]),
-                title=str(issue.get("title", "") or ""),
-                type_label=_issue_type_label(_label_names(issue)),
+                title=title,
+                type_label=_issue_type_label(labels),
+                admissible=verdict.admissible,
+                verdict=verdict.verdict,
+                detail=verdict.detail,
             )
         )
     entries.sort(key=lambda entry: entry.issue_number)
     return entries
 
 
+_DETAIL_WIDTH = 160
+
+
+def _entry_marker(entry: ReadyEntry) -> str:
+    """Return the status-column token for an entry: ``ready`` or the refusal."""
+    if entry.admissible:
+        return "ready"
+    return f"BLOCKED:{entry.verdict}" if entry.verdict else "BLOCKED"
+
+
+def _short_detail(detail: str) -> str:
+    """Return a one-line, bounded form of a gate refusal detail.
+
+    Shape-check details embed full remediation instructions and can run to
+    several hundred characters; unabridged they bury the listing they annotate.
+    ``forge shape <n>`` prints the full text.
+    """
+    collapsed = " ".join(detail.split())
+    if len(collapsed) <= _DETAIL_WIDTH:
+        return collapsed
+    return collapsed[: _DETAIL_WIDTH - 1].rstrip() + "…"
+
+
 def format_ready_queue(entries: list[ReadyEntry], *, milestone: str | None = None) -> str:
     """Render the ready-label queue as human- and tooling-parseable text.
 
-    Column order is stable (issue ref, type, ``ready`` marker, title) so adjacent
-    tooling can consume it without breaking on cosmetic changes::
+    Column order is stable (issue ref, type, status marker, title) so adjacent
+    tooling can consume it without breaking on cosmetic changes. The status
+    column carries the sprint gate's verdict, so a ``ready``-labeled issue the
+    gate would refuse is never presented as admissible::
 
-        Ready for next sprint (2 issues):
-          #1487  bug          ready  status --watch blank during preflight
-          #1512  bug          ready  cut-rc.sh shim wrapper regression
+        Ready for next sprint (2 issues, 1 blocked by shape gate):
+          #1487  bug  ready                    status --watch blank during preflight
+          #1512  bug  BLOCKED:needs_diagnosis  cut-rc.sh shim wrapper regression
+
+        1 issue carries the `ready` label but would be refused at sprint entry:
+          #1512  needs_diagnosis: Bug has no Diagnosis section — not fix-ready. …
+        Run `forge shape <n>` for the full verdict, then `forge groom <n>` / …
     """
     scope = f" in {milestone}" if milestone else ""
     if not entries:
         return f"Ready for next sprint{scope}: none."
 
+    blocked = [entry for entry in entries if not entry.admissible]
     noun = "issue" if len(entries) == 1 else "issues"
-    lines = [f"Ready for next sprint{scope} ({len(entries)} {noun}):"]
+    counts = f"{len(entries)} {noun}"
+    if blocked:
+        counts += f", {len(blocked)} blocked by shape gate"
+
+    lines = [f"Ready for next sprint{scope} ({counts}):"]
     type_width = max((len(entry.type_label) for entry in entries), default=0)
+    marker_width = max((len(_entry_marker(entry)) for entry in entries), default=0)
     for entry in entries:
         lines.append(
-            f"  #{entry.issue_number}  {entry.type_label.ljust(type_width)}  ready  {entry.title}"
+            f"  #{entry.issue_number}  {entry.type_label.ljust(type_width)}  "
+            f"{_entry_marker(entry).ljust(marker_width)}  {entry.title}"
         )
+
+    if blocked:
+        subject = "1 issue carries" if len(blocked) == 1 else f"{len(blocked)} issues carry"
+        lines.append("")
+        lines.append(f"{subject} the `{READY_LABEL}` label but would be refused at sprint entry:")
+        for entry in blocked:
+            detail = f": {_short_detail(entry.detail)}" if entry.detail else ""
+            lines.append(f"  #{entry.issue_number}  {entry.verdict or 'blocked'}{detail}")
+        lines.append(
+            "Run `forge shape <n>` for the full verdict, then `forge groom <n>` / "
+            "`forge diagnose <n>` before sprint selection."
+        )
+
     return "\n".join(lines)

--- a/src/theforge/sprint/shape_gate.py
+++ b/src/theforge/sprint/shape_gate.py
@@ -10,6 +10,10 @@ unreachable ``gh`` calls: an issue whose labels/body cannot be fetched is
 left runnable (the pre-existing sources.py fetch will surface any real
 error). We do not want the shape gate itself to be a new source of silent
 drops.
+
+The admissibility decision itself lives in ``theforge.admissibility`` so that
+operator-facing surfaces which advertise sprint-eligible work (``forge status
+--ready``) render the same verdict this gate enforces (#2027).
 """
 
 from __future__ import annotations
@@ -22,27 +26,48 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
-from ..shape_check import Shape, ShapeResult, ShapeVerdict, check
-from ..shape_check.parsing import extract_ac_section, extract_bullets
-from ..shape_check.types import VERDICT_DESCRIPTIONS, Severity
+from ..admissibility import (
+    NEEDS_GROOMING_LABEL,
+    OPERATOR_ACTION_CODE,
+    OPERATOR_ACTION_CONFLICT_LABELS,
+    OPERATOR_ACTION_LABEL,
+    OPERATOR_ACTION_LABEL_CONFLICT_CODE,
+    OPERATOR_ACTION_MISSING_AC_CODE,
+    classify_admissibility,
+    has_acceptance_criteria,
+    resolve_classifier,
+)
+from ..shape_check import ShapeVerdict
 from .reopen_context import analyze_reopen_contract, format_reopen_stale_detail
 
 _log = logging.getLogger(__name__)
 
 VerdictEmitter = Callable[[dict], None]
 
-NEEDS_GROOMING_LABEL = "needs-grooming"
 REOPENED_STALE_CONTRACT_CODE = "reopened_stale_contract"
 
-# operator-action: deliberate non-dispatch type. The label declares an issue
-# whose deliverable is human action no dev agent can perform. The gate refuses
-# to dispatch these issues to dev cycles — distinct from "wrong shape" skips.
-OPERATOR_ACTION_LABEL = "operator-action"
-OPERATOR_ACTION_CODE = "operator_action"
-OPERATOR_ACTION_LABEL_CONFLICT_CODE = "operator_action_label_conflict"
-OPERATOR_ACTION_MISSING_AC_CODE = "operator_action_missing_ac"
-# operator-action is mutually exclusive with the runnable type labels.
-OPERATOR_ACTION_CONFLICT_LABELS = frozenset({"bug", "enhancement", "epic", "task"})
+# Aliases for helpers that moved to ``admissibility``: the gate stays the
+# import site callers already know.
+_has_acceptance_criteria = has_acceptance_criteria
+_resolve_classifier = resolve_classifier
+
+__all__ = [
+    "NEEDS_GROOMING_LABEL",
+    "OPERATOR_ACTION_CODE",
+    "OPERATOR_ACTION_CONFLICT_LABELS",
+    "OPERATOR_ACTION_LABEL",
+    "OPERATOR_ACTION_LABEL_CONFLICT_CODE",
+    "OPERATOR_ACTION_MISSING_AC_CODE",
+    "REOPENED_STALE_CONTRACT_CODE",
+    "ShapeGateResult",
+    "SkippedIssue",
+    "VerdictEmitter",
+    "apply_shape_gate",
+    "format_advisory_warning",
+    "format_operator_action_notice",
+    "format_skipped_warning",
+    "skipped_issue_state_fields",
+]
 
 # Bot comments from #806b embed machine-readable reason codes on a single
 # line so local re-runs can match the Action's verdict exactly. Accept either
@@ -88,58 +113,6 @@ class ShapeGateResult:
     # operator work". Issues with ``operator-action`` plus a label conflict
     # or no AC section land in ``skipped`` instead.
     operator_action: list[SkippedIssue] = field(default_factory=list)
-
-
-def _has_acceptance_criteria(body: str) -> bool:
-    """Return True if the body has a non-empty ``## Acceptance criteria`` section."""
-    section = extract_ac_section(body)
-    if not section:
-        return False
-    return bool(extract_bullets(section))
-
-
-def _classify_operator_action(
-    number: int,
-    title: str,
-    body: str,
-    labels: list[str],
-) -> SkippedIssue:
-    """Return the SkippedIssue describing how an ``operator-action`` issue is handled.
-
-    Caller decides whether to surface this in the deliberate-non-dispatch list
-    or in the wrong-shape skipped list based on the returned ``reason_codes``.
-    """
-    label_set = {str(lbl).strip().lower() for lbl in labels}
-    conflicts = sorted(label_set & OPERATOR_ACTION_CONFLICT_LABELS)
-    if conflicts:
-        return SkippedIssue(
-            issue_number=number,
-            reason_codes=(OPERATOR_ACTION_LABEL_CONFLICT_CODE,),
-            source="label",
-            title=title,
-            detail=(
-                f"'{OPERATOR_ACTION_LABEL}' conflicts with type label(s) "
-                f"{conflicts!r}; pick exactly one issue type."
-            ),
-        )
-    if not _has_acceptance_criteria(body):
-        return SkippedIssue(
-            issue_number=number,
-            reason_codes=(OPERATOR_ACTION_MISSING_AC_CODE,),
-            source="label",
-            title=title,
-            detail=(
-                f"'{OPERATOR_ACTION_LABEL}' issues require an "
-                "'## Acceptance criteria' section describing the operator deliverable."
-            ),
-        )
-    return SkippedIssue(
-        issue_number=number,
-        reason_codes=(OPERATOR_ACTION_CODE,),
-        source="label",
-        title=title,
-        detail="not sprintable; operator deliverable",
-    )
 
 
 def skipped_issue_state_fields(skipped: object) -> tuple[str, dict]:
@@ -324,56 +297,6 @@ def _fetch_bot_reason_codes(number: int, project_root: Path | None) -> list[str]
     return []
 
 
-def _blocking_codes(result: ShapeResult) -> list[str]:
-    return [r.code for r in result.reasons if r.severity is Severity.BLOCKING]
-
-
-def _skip_detail(
-    result: ShapeResult,
-    fallback: str,
-    *,
-    include_advisory_when_no_blocking: bool = False,
-) -> str:
-    blocking_details = [
-        reason.detail.strip()
-        for reason in result.reasons
-        if reason.severity is Severity.BLOCKING and reason.detail.strip()
-    ]
-    if blocking_details:
-        return "; ".join(blocking_details)
-
-    if include_advisory_when_no_blocking:
-        reason_details = [
-            reason.detail.strip() for reason in result.reasons if reason.detail.strip()
-        ]
-        if reason_details:
-            return "; ".join(reason_details)
-
-    return fallback
-
-
-_VALID_CLASSIFIER_MODES = frozenset({"heuristic", "off", "llm"})
-
-
-def _resolve_classifier(classifier_mode: str, llm_caller=None) -> str:
-    """Return the classifier mode to actually use at sprint time.
-
-    Honors the configured ``shape_check.classifier`` value when supported.
-    Falls back to ``heuristic`` when:
-
-    - The mode is unknown (defensive — misconfiguration shouldn't block sprints).
-    - The mode is ``llm`` but no ``llm_caller`` is available to refine fuzzy
-      reasons. (The ``classifier.classify`` function already silently falls
-      back in this case; resolving explicitly keeps the sprint gate honest
-      about what it actually ran.)
-    """
-    if classifier_mode not in _VALID_CLASSIFIER_MODES:
-        return "heuristic"
-    if classifier_mode == "llm" and llm_caller is None:
-        return "heuristic"
-    return classifier_mode
-
-
 def _noop_emit_verdict(_event: dict) -> None:
     return None
 
@@ -414,7 +337,6 @@ def apply_shape_gate(
     just-remediated issue on the post-re-exec gate pass.
     """
     remediated = frozenset(intake_remediated_numbers or ())
-    effective_mode = _resolve_classifier(classifier_mode, llm_caller=llm_caller)
     runnable: list[dict] = []
     skipped: list[SkippedIssue] = []
     advisories: list[SkippedIssue] = []
@@ -453,58 +375,60 @@ def apply_shape_gate(
         title = detail["title"] or title_short
         body = detail["body"]
 
-        # operator-action: short-circuit ahead of the regular shape check.
-        # An operator-action issue is not malformed; it is correctly identified
-        # as work no dev agent can perform. Running the standard shape check on
-        # it would flag it for missing_type (since operator-action is mutually
+        # The admissibility decision (operator-action short-circuit, the live
+        # shape_check run, the needs-grooming label, and the verdict/shape
+        # branches) is shared with the ready-queue surface so both agree on
+        # what may enter a sprint.
+        adm = classify_admissibility(
+            title,
+            body,
+            labels,
+            classifier_mode=classifier_mode,
+            llm_caller=llm_caller,
+            trust_local_over_grooming_label=number in remediated,
+        )
+
+        # operator-action: refused ahead of the regular shape check. An
+        # operator-action issue is not malformed; it is correctly identified as
+        # work no dev agent can perform. Running the standard shape check on it
+        # would flag it for missing_type (since operator-action is mutually
         # exclusive with bug/enhancement/epic/task), conflating two distinct
         # operator signals. Refuse here with a label-source skip and stop.
-        label_set_lc = {str(lbl).strip().lower() for lbl in labels}
-        if OPERATOR_ACTION_LABEL in label_set_lc:
+        if adm.operator_action_label:
             operator_action_label_numbers.add(number)
-            entry = _classify_operator_action(number, title_short, body, labels)
-            if OPERATOR_ACTION_CODE in entry.reason_codes:
+            entry = SkippedIssue(
+                issue_number=number,
+                reason_codes=adm.reason_codes,
+                source=adm.source,
+                title=title_short,
+                detail=adm.detail,
+            )
+            if adm.deliberate_non_dispatch:
                 operator_action.append(entry)
             else:
                 skipped.append(entry)
             continue
 
         reopen_state = analyze_reopen_contract(detail, detail.get("timeline") or [])
-        local = check(
-            title,
-            body,
-            labels,
-            classifier_mode=effective_mode,
-            llm_caller=llm_caller,
-        )
 
-        if NEEDS_GROOMING_LABEL in labels and number not in remediated:
-            codes = _blocking_codes(local) or ["needs_grooming_label"]
-            verdict = (
-                local.verdict
-                if local.verdict is not ShapeVerdict.RUNNABLE
-                else ShapeVerdict.NEEDS_OPERATOR_ACTION
-            )
+        if not adm.admissible and adm.source == "label":
             skipped.append(
                 SkippedIssue(
                     issue_number=number,
-                    reason_codes=tuple(codes),
+                    reason_codes=adm.reason_codes,
                     source="label",
                     title=title_short,
-                    detail=_skip_detail(
-                        local,
-                        fallback=f"issue carries '{NEEDS_GROOMING_LABEL}' label",
-                    ),
-                    verdict=verdict.value,
-                    verdict_description=VERDICT_DESCRIPTIONS[verdict],
+                    detail=adm.detail,
+                    verdict=adm.verdict,
+                    verdict_description=adm.verdict_description,
                 )
             )
             _safe_emit(
                 {
                     "issue_id": str(number),
-                    "verdict": verdict.value,
+                    "verdict": adm.verdict,
                     "source": "label",
-                    "reason_codes": list(codes),
+                    "reason_codes": list(adm.reason_codes),
                 }
             )
             continue
@@ -531,65 +455,28 @@ def apply_shape_gate(
                 )
             )
 
-        # diagnosis_cause_unknown is admissible (Shape.RUNNABLE) but not
-        # implementation-runnable per ADR-0001 — surface it via skipped so
-        # only the runnable verdict proceeds to dev. The verdict is the
-        # routing signal here; map_shape's binary view is intentionally not.
-        if local.verdict is ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN:
-            codes = [r.code for r in local.reasons] or ["diagnosis_cause_unknown"]
+        # Refusals from the live check: a non-RUNNABLE shape, or the
+        # diagnosis_cause_unknown verdict, which is admissible as a *shape*
+        # (Shape.RUNNABLE) but not implementation-runnable per ADR-0001. The
+        # verdict is the routing signal; map_shape's binary view is not.
+        if not adm.admissible:
             skipped.append(
                 SkippedIssue(
                     issue_number=number,
-                    reason_codes=tuple(codes),
+                    reason_codes=adm.reason_codes,
                     source="local_check",
                     title=title_short,
-                    detail=_skip_detail(
-                        local,
-                        fallback="bug investigation-ready; confirmed cause not yet identified",
-                        include_advisory_when_no_blocking=True,
-                    ),
-                    verdict=ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN.value,
-                    verdict_description=VERDICT_DESCRIPTIONS[ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN],
+                    detail=adm.detail,
+                    verdict=adm.verdict,
+                    verdict_description=adm.verdict_description,
                 )
             )
             _safe_emit(
                 {
                     "issue_id": str(number),
-                    "verdict": ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN.value,
+                    "verdict": adm.verdict,
                     "source": "local_check",
-                    "reason_codes": list(codes),
-                }
-            )
-            continue
-
-        if local.shape is not Shape.RUNNABLE:
-            codes = _blocking_codes(local) or [r.code for r in local.reasons]
-            verdict = (
-                local.verdict
-                if local.verdict is not ShapeVerdict.RUNNABLE
-                else ShapeVerdict.NEEDS_OPERATOR_ACTION
-            )
-            skipped.append(
-                SkippedIssue(
-                    issue_number=number,
-                    reason_codes=tuple(codes),
-                    source="local_check",
-                    title=title_short,
-                    detail=_skip_detail(
-                        local,
-                        fallback=f"local shape check: {local.suggested_action.value}",
-                        include_advisory_when_no_blocking=True,
-                    ),
-                    verdict=verdict.value,
-                    verdict_description=VERDICT_DESCRIPTIONS[verdict],
-                )
-            )
-            _safe_emit(
-                {
-                    "issue_id": str(number),
-                    "verdict": verdict.value,
-                    "source": "local_check",
-                    "reason_codes": list(codes),
+                    "reason_codes": list(adm.reason_codes),
                 }
             )
             continue

--- a/tests/test_admissibility.py
+++ b/tests/test_admissibility.py
@@ -1,0 +1,313 @@
+"""Tests for the shared sprint-entry admissibility decision (#2027).
+
+``classify_admissibility`` is the single answer to "may this issue enter a
+sprint?", called by both ``sprint.shape_gate`` (which enforces it) and
+``ready_queue`` (which renders it). These tests pin the decision itself; the
+gate's and the queue's use of it are covered by their own modules' tests.
+"""
+
+from __future__ import annotations
+
+from theforge.admissibility import (
+    NEEDS_GROOMING_LABEL,
+    OPERATOR_ACTION_CODE,
+    OPERATOR_ACTION_LABEL,
+    OPERATOR_ACTION_LABEL_CONFLICT_CODE,
+    OPERATOR_ACTION_MISSING_AC_CODE,
+    blocking_codes,
+    classify_admissibility,
+    has_acceptance_criteria,
+    resolve_classifier,
+    skip_detail,
+)
+from theforge.shape_check import Reason, Severity, Shape, ShapeResult, ShapeVerdict
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+_RUNNABLE_BODY = """## What
+
+Add a CLI flag.
+
+## Why
+
+Users need a way to bypass the gate.
+
+## Example
+
+    $ forge sprint --force
+    [forge] 2 issue(s) flagged by shape gate
+
+## Acceptance Criteria
+
+- `forge sprint --force` runs every issue regardless of shape check
+- warnings still list every skipped issue's reason codes
+"""
+
+# A bug filing with no `## Diagnosis` section — symptom-only, the shape the
+# gate refuses with a BLOCKING `needs_diagnosis` reason.
+_UNDIAGNOSED_BUG_BODY = """## Observed behavior
+
+`forge status --ready` lists issues the gate refuses.
+
+## Expected behavior
+
+The listing agrees with the gate.
+"""
+
+# A bug that has done the diagnosis work but has not landed a cause:
+# investigation-ready, admissible as a *shape*, not implementation-runnable.
+_CAUSE_UNKNOWN_BUG_BODY = """## Observed behavior
+
+`forge status --ready` lists issues the gate refuses.
+
+## Expected behavior
+
+The listing agrees with the gate.
+
+## Diagnosis
+
+- **Observed symptom:** the ready listing and the gate disagree.
+- **Evidence:** run id `1ff6b0bb7992` — five ready issues, five refusals.
+- **Confirmed cause:** unknown
+- **Affected code path:** `ready_queue.build_ready_queue`.
+- **Fix-success criterion:** the listing and sprint entry cannot disagree.
+"""
+
+_OPERATOR_ACTION_BODY = """## What
+
+Rotate the production API token.
+
+## Acceptance criteria
+
+- the token is rotated and the new value is stored in `.forge/.env`
+"""
+
+
+# ── resolve_classifier ──────────────────────────────────────────────────────
+
+
+def test_resolve_classifier_passes_through_supported_modes() -> None:
+    assert resolve_classifier("heuristic") == "heuristic"
+    assert resolve_classifier("off") == "off"
+
+
+def test_resolve_classifier_falls_back_when_llm_has_no_caller() -> None:
+    assert resolve_classifier("llm") == "heuristic"
+    assert resolve_classifier("llm", llm_caller=None) == "heuristic"
+
+
+def test_resolve_classifier_passes_through_llm_when_caller_available() -> None:
+    assert resolve_classifier("llm", llm_caller=lambda _b, _r: None) == "llm"
+
+
+def test_resolve_classifier_falls_back_on_unknown_mode() -> None:
+    # Misconfiguration must not block sprints.
+    assert resolve_classifier("bogus-mode") == "heuristic"
+
+
+# ── has_acceptance_criteria ─────────────────────────────────────────────────
+
+
+def test_has_acceptance_criteria_true_for_populated_section() -> None:
+    assert has_acceptance_criteria(_RUNNABLE_BODY) is True
+
+
+def test_has_acceptance_criteria_false_when_section_absent() -> None:
+    assert has_acceptance_criteria("## What\n\nSomething.\n") is False
+
+
+def test_has_acceptance_criteria_false_when_section_has_no_bullets() -> None:
+    assert has_acceptance_criteria("## Acceptance criteria\n\nTBD\n") is False
+
+
+# ── blocking_codes / skip_detail ────────────────────────────────────────────
+
+
+def _result(*reasons: Reason, shape: Shape = Shape.NEEDS_GROOMING) -> ShapeResult:
+    return ShapeResult(shape=shape, reasons=reasons)
+
+
+def test_blocking_codes_keeps_only_blocking_reasons() -> None:
+    result = _result(
+        Reason(code="needs_diagnosis", severity=Severity.BLOCKING, detail="no diagnosis"),
+        Reason(code="advice", severity=Severity.ADVISORY, detail="consider splitting"),
+    )
+    assert blocking_codes(result) == ["needs_diagnosis"]
+
+
+def test_skip_detail_prefers_blocking_details() -> None:
+    result = _result(
+        Reason(code="a", severity=Severity.BLOCKING, detail="blocking one"),
+        Reason(code="b", severity=Severity.BLOCKING, detail="blocking two"),
+        Reason(code="c", severity=Severity.ADVISORY, detail="advisory"),
+    )
+    assert skip_detail(result, "fallback") == "blocking one; blocking two"
+
+
+def test_skip_detail_falls_back_when_no_blocking_details() -> None:
+    result = _result(Reason(code="c", severity=Severity.ADVISORY, detail="advisory"))
+    assert skip_detail(result, "fallback") == "fallback"
+
+
+def test_skip_detail_uses_advisories_when_opted_in() -> None:
+    result = _result(Reason(code="c", severity=Severity.ADVISORY, detail="advisory"))
+    detail = skip_detail(result, "fallback", include_advisory_when_no_blocking=True)
+    assert detail == "advisory"
+
+
+# ── classify_admissibility: admissible ──────────────────────────────────────
+
+
+def test_well_shaped_enhancement_is_admissible() -> None:
+    verdict = classify_admissibility("Add a flag", _RUNNABLE_BODY, ["enhancement"])
+
+    assert verdict.admissible is True
+    assert verdict.verdict == ShapeVerdict.RUNNABLE.value
+    assert verdict.reason_codes == ()
+    assert verdict.source == "local_check"
+    assert verdict.result is not None
+
+
+def test_admissible_entry_carries_no_operator_action_flags() -> None:
+    verdict = classify_admissibility("Add a flag", _RUNNABLE_BODY, ["enhancement"])
+    assert verdict.operator_action_label is False
+    assert verdict.deliberate_non_dispatch is False
+
+
+# ── classify_admissibility: local-check refusals ────────────────────────────
+
+
+def test_undiagnosed_bug_is_refused_with_needs_diagnosis() -> None:
+    verdict = classify_admissibility("Counter is wrong", _UNDIAGNOSED_BUG_BODY, ["bug"])
+
+    assert verdict.admissible is False
+    assert verdict.verdict == ShapeVerdict.NEEDS_DIAGNOSIS.value
+    assert verdict.source == "local_check"
+    assert verdict.reason_codes
+    assert verdict.detail
+    assert verdict.verdict_description
+
+
+def test_untyped_issue_is_refused_with_needs_type() -> None:
+    verdict = classify_admissibility("Add a flag", _RUNNABLE_BODY, [])
+
+    assert verdict.admissible is False
+    assert verdict.verdict == ShapeVerdict.NEEDS_TYPE.value
+
+
+def test_investigation_ready_bug_is_refused_as_cause_unknown() -> None:
+    # Admissible as a *shape* but not implementation-runnable per ADR-0001:
+    # the verdict is the routing signal, not map_shape's binary view.
+    verdict = classify_admissibility("Counter is wrong", _CAUSE_UNKNOWN_BUG_BODY, ["bug"])
+
+    assert verdict.result is not None and verdict.result.shape is Shape.RUNNABLE
+    assert verdict.admissible is False
+    assert verdict.verdict == ShapeVerdict.DIAGNOSIS_CAUSE_UNKNOWN.value
+    assert verdict.source == "local_check"
+
+
+# ── classify_admissibility: needs-grooming label ────────────────────────────
+
+
+def test_needs_grooming_label_refuses_an_otherwise_runnable_issue() -> None:
+    verdict = classify_admissibility(
+        "Add a flag", _RUNNABLE_BODY, ["enhancement", NEEDS_GROOMING_LABEL]
+    )
+
+    assert verdict.admissible is False
+    assert verdict.source == "label"
+    # Nothing blocking in the live check, so the label's own code stands in.
+    assert verdict.reason_codes == ("needs_grooming_label",)
+    assert NEEDS_GROOMING_LABEL in verdict.detail
+
+
+def test_needs_grooming_label_surfaces_live_blocking_findings() -> None:
+    verdict = classify_admissibility(
+        "Counter is wrong", _UNDIAGNOSED_BUG_BODY, ["bug", NEEDS_GROOMING_LABEL]
+    )
+
+    assert verdict.admissible is False
+    assert verdict.source == "label"
+    assert verdict.verdict == ShapeVerdict.NEEDS_DIAGNOSIS.value
+    assert "needs_diagnosis" in verdict.reason_codes
+
+
+def test_trust_local_over_grooming_label_readmits_a_remediated_issue() -> None:
+    # Intake remediation just rewrote the body; the async relabeler may not
+    # have caught up, so the live check is trusted instead of the label.
+    verdict = classify_admissibility(
+        "Add a flag",
+        _RUNNABLE_BODY,
+        ["enhancement", NEEDS_GROOMING_LABEL],
+        trust_local_over_grooming_label=True,
+    )
+
+    assert verdict.admissible is True
+    assert verdict.verdict == ShapeVerdict.RUNNABLE.value
+
+
+def test_trust_local_override_does_not_readmit_a_still_malformed_issue() -> None:
+    verdict = classify_admissibility(
+        "Counter is wrong",
+        _UNDIAGNOSED_BUG_BODY,
+        ["bug", NEEDS_GROOMING_LABEL],
+        trust_local_over_grooming_label=True,
+    )
+
+    assert verdict.admissible is False
+    assert verdict.source == "local_check"
+    assert verdict.verdict == ShapeVerdict.NEEDS_DIAGNOSIS.value
+
+
+# ── classify_admissibility: operator-action ─────────────────────────────────
+
+
+def test_clean_operator_action_is_deliberate_non_dispatch() -> None:
+    verdict = classify_admissibility(
+        "Rotate the token", _OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL]
+    )
+
+    assert verdict.admissible is False
+    assert verdict.operator_action_label is True
+    assert verdict.deliberate_non_dispatch is True
+    assert verdict.reason_codes == (OPERATOR_ACTION_CODE,)
+    assert verdict.source == "label"
+
+
+def test_operator_action_short_circuits_ahead_of_the_shape_check() -> None:
+    # Running the standard check would flag missing_type (operator-action is
+    # mutually exclusive with the runnable type labels), conflating two
+    # distinct operator signals.
+    verdict = classify_admissibility(
+        "Rotate the token", _OPERATOR_ACTION_BODY, [OPERATOR_ACTION_LABEL]
+    )
+    assert verdict.result is None
+
+
+def test_operator_action_with_type_label_is_a_conflict_not_a_non_dispatch() -> None:
+    for conflicting in ("bug", "enhancement", "epic", "task"):
+        verdict = classify_admissibility(
+            "Rotate the token",
+            _OPERATOR_ACTION_BODY,
+            [OPERATOR_ACTION_LABEL, conflicting],
+        )
+        assert verdict.reason_codes == (OPERATOR_ACTION_LABEL_CONFLICT_CODE,), conflicting
+        assert verdict.deliberate_non_dispatch is False, conflicting
+        assert verdict.operator_action_label is True, conflicting
+
+
+def test_operator_action_without_acceptance_criteria_is_refused_as_missing_ac() -> None:
+    verdict = classify_admissibility(
+        "Rotate the token", "## What\n\nRotate it.\n", [OPERATOR_ACTION_LABEL]
+    )
+
+    assert verdict.reason_codes == (OPERATOR_ACTION_MISSING_AC_CODE,)
+    assert verdict.deliberate_non_dispatch is False
+    assert verdict.operator_action_label is True
+
+
+def test_operator_action_label_matching_ignores_case_and_whitespace() -> None:
+    verdict = classify_admissibility(
+        "Rotate the token", _OPERATOR_ACTION_BODY, [f"  {OPERATOR_ACTION_LABEL.upper()} "]
+    )
+    assert verdict.operator_action_label is True

--- a/tests/test_ready_queue.py
+++ b/tests/test_ready_queue.py
@@ -4,6 +4,9 @@ Covers type-label projection, stable rendering, milestone scoping passed through
 to the gh listing, and the ``forge status --ready [--milestone]`` CLI surface.
 The queue carries no ordering/priority semantics — it is simply the set of open,
 ``ready``-labeled issues, so tests assert eligibility surfacing, not ranking.
+
+Also covers the shape-gate agreement property (#2027): an issue the sprint gate
+would refuse must not be presented as sprint-ready by this listing.
 """
 
 from __future__ import annotations
@@ -27,12 +30,45 @@ from theforge.ready_queue import (
     format_ready_queue,
 )
 
+# An enhancement body the shape gate admits: type label, acceptance criteria,
+# and a concrete example.
+_RUNNABLE_BODY = """## What
 
-def _issue(number: int, title: str, labels: list[str]) -> dict:
+Add a CLI flag.
+
+## Why
+
+Users need a way to bypass the gate.
+
+## Example
+
+    $ forge sprint --force
+    [forge] 2 issue(s) flagged by shape gate
+
+## Acceptance Criteria
+
+- `forge sprint --force` runs every issue regardless of shape check
+- warnings still list every skipped issue's reason codes
+"""
+
+# A bug filing with no `## Diagnosis` section — the exact shape the gate refuses
+# with a BLOCKING `needs_diagnosis` reason (#1983-#1987 in the story).
+_UNDIAGNOSED_BUG_BODY = """## Observed behavior
+
+`forge status --ready` lists issues the gate refuses.
+
+## Expected behavior
+
+The listing agrees with the gate.
+"""
+
+
+def _issue(number: int, title: str, labels: list[str], body: str = _RUNNABLE_BODY) -> dict:
     return {
         "number": number,
         "title": title,
         "labels": [{"name": name} for name in labels],
+        "body": body,
     }
 
 
@@ -40,9 +76,11 @@ def _issue(number: int, title: str, labels: list[str]) -> dict:
 
 
 def test_build_projects_type_label_from_issue_labels(tmp_path: Path) -> None:
-    issues = [_issue(1512, "cut-rc.sh shim regression", ["ready", "bug"])]
+    issues = [_issue(1512, "cut-rc.sh shim regression", ["ready", "enhancement"])]
     entries = build_ready_queue(tmp_path, fetch_issues=lambda: issues)
-    assert entries == [ReadyEntry(1512, "cut-rc.sh shim regression", "bug")]
+    assert [(e.issue_number, e.title, e.type_label) for e in entries] == [
+        (1512, "cut-rc.sh shim regression", "enhancement")
+    ]
 
 
 def test_build_falls_back_to_dash_when_no_type_label(tmp_path: Path) -> None:
@@ -71,6 +109,77 @@ def test_build_prefers_first_known_type_when_multiple(tmp_path: Path) -> None:
     assert entries[0].type_label == "bug"
 
 
+# ── shape-gate agreement (#2027) ───────────────────────────────────────────
+
+
+def test_build_marks_admissible_issue_ready(tmp_path: Path) -> None:
+    issues = [_issue(1512, "add a flag", ["ready", "enhancement"])]
+    entry = build_ready_queue(tmp_path, fetch_issues=lambda: issues)[0]
+    assert entry.admissible is True
+    assert entry.verdict == "runnable"
+
+
+def test_build_marks_undiagnosed_bug_not_admissible(tmp_path: Path) -> None:
+    issues = [_issue(1983, "counter is wrong", ["ready", "bug"], _UNDIAGNOSED_BUG_BODY)]
+    entry = build_ready_queue(tmp_path, fetch_issues=lambda: issues)[0]
+    assert entry.admissible is False
+    assert entry.verdict == "needs_diagnosis"
+    assert entry.detail
+
+
+def test_build_marks_needs_grooming_labeled_issue_not_admissible(tmp_path: Path) -> None:
+    issues = [_issue(1900, "well shaped but flagged", ["ready", "enhancement", "needs-grooming"])]
+    entry = build_ready_queue(tmp_path, fetch_issues=lambda: issues)[0]
+    assert entry.admissible is False
+
+
+def test_build_marks_operator_action_issue_not_admissible(tmp_path: Path) -> None:
+    # The gate deliberately never dispatches operator-action issues, so the
+    # ready listing must not advertise them as sprint-eligible either.
+    issues = [_issue(1901, "rotate the token", ["ready", "operator-action"])]
+    entry = build_ready_queue(tmp_path, fetch_issues=lambda: issues)[0]
+    assert entry.admissible is False
+
+
+def test_build_agrees_with_shape_gate_on_the_same_issues(tmp_path: Path) -> None:
+    """Seam test: the queue's verdict matches what apply_shape_gate decides.
+
+    This is the property the bug violated — two surfaces answering "may this
+    issue enter a sprint?" from different data.
+    """
+    from theforge.sprint.shape_gate import apply_shape_gate
+
+    issues = [
+        _issue(1983, "counter is wrong", ["ready", "bug"], _UNDIAGNOSED_BUG_BODY),
+        _issue(1512, "add a flag", ["ready", "enhancement"]),
+        _issue(1901, "rotate the token", ["ready", "operator-action"]),
+    ]
+    by_number = {issue["number"]: issue for issue in issues}
+
+    def _fetch_detail(number: int, _project_root):  # noqa: ANN001
+        issue = by_number[number]
+        return {
+            "title": issue["title"],
+            "body": issue["body"],
+            "labels": [lbl["name"] for lbl in issue["labels"]],
+        }
+
+    gate = apply_shape_gate(
+        [{"number": i["number"], "title": i["title"]} for i in issues],
+        tmp_path,
+        fetch_detail=_fetch_detail,
+    )
+    gate_runnable = {int(item["number"]) for item in gate.runnable}
+
+    queue_admissible = {
+        entry.issue_number
+        for entry in build_ready_queue(tmp_path, fetch_issues=lambda: issues)
+        if entry.admissible
+    }
+
+    assert queue_admissible == gate_runnable == {1512}
+
+
 # ── gh listing wiring: milestone scoping ───────────────────────────────────
 
 
@@ -93,6 +202,9 @@ def test_gh_listing_passes_milestone_flag(tmp_path: Path) -> None:
     assert "--label" in captured_cmd and "ready" in captured_cmd
     assert "--milestone" in captured_cmd
     assert "v0.10.0" in captured_cmd
+    # The body is required to evaluate the shape gate's verdict (#2027).
+    json_fields = captured_cmd[captured_cmd.index("--json") + 1].split(",")
+    assert "body" in json_fields
 
 
 def test_gh_listing_omits_milestone_when_none(tmp_path: Path) -> None:
@@ -155,6 +267,57 @@ def test_format_lists_ready_entries_with_stable_columns() -> None:
 def test_format_single_issue_uses_singular_noun() -> None:
     rendered = format_ready_queue([ReadyEntry(1512, "one", "bug")])
     assert "(1 issue):" in rendered
+
+
+def test_format_shows_blocking_verdict_instead_of_ready_marker() -> None:
+    entries = [
+        ReadyEntry(1487, "admissible", "enhancement"),
+        ReadyEntry(
+            1983,
+            "counter is wrong",
+            "bug",
+            admissible=False,
+            verdict="needs_diagnosis",
+            detail="Bug has no Diagnosis section",
+        ),
+    ]
+    rendered = format_ready_queue(entries, milestone="v0.13.0")
+
+    assert "1 blocked by shape gate" in rendered
+    assert "BLOCKED:needs_diagnosis" in rendered
+    # The blocked row must not be presented with the ready marker.
+    blocked_row = next(line for line in rendered.splitlines() if "#1983" in line)
+    assert "  ready  " not in blocked_row
+    assert "would be refused at sprint entry" in rendered
+    assert "Bug has no Diagnosis section" in rendered
+    assert "forge groom" in rendered
+
+
+def test_format_bounds_long_refusal_detail_to_one_line() -> None:
+    # Shape-check details embed full remediation text; unabridged they bury the
+    # listing. The row stays one line and points at the full verdict.
+    entries = [
+        ReadyEntry(
+            1983,
+            "counter is wrong",
+            "bug",
+            admissible=False,
+            verdict="needs_diagnosis",
+            detail="Bug has no Diagnosis section.\n" + ("remediation prose " * 40),
+        )
+    ]
+    rendered = format_ready_queue(entries)
+    detail_row = next(line for line in rendered.splitlines() if "needs_diagnosis:" in line)
+
+    assert len(detail_row) < 200
+    assert detail_row.endswith("…")
+    assert "forge shape <n>" in rendered
+
+
+def test_format_omits_blocked_section_when_all_admissible() -> None:
+    rendered = format_ready_queue([ReadyEntry(1487, "fine", "enhancement")])
+    assert "blocked by shape gate" not in rendered
+    assert "would be refused at sprint entry" not in rendered
 
 
 # ── CLI: forge status --ready ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The ready queue now uses the shared sprint admissibility classifier, renders refused ready-labeled issues as blocked, and has focused tests for the original disagreement. | [google-gemini-3.5-flash] The implementation successfully unifies the admissibility decision between the ready queue and the shape gate, resolving the disagreement.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $12.40
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

The ready queue presents issues the shape gate refuses, so the queue-for-next-sprint surface and sprint entry disagree (GitHub Issue #2027)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2027