### PR TITLE
Sprint starting phase hides long pre-story/reuse gates behind identical gate log lines

### DIFF
--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -137,6 +137,8 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     cost_measured_usd: float | None = None
     duration_seconds: float | None = None
     sprint_phase: str | None = None
+    sprint_phase_detail: str | None = None
+    sprint_phase_started_at: str | None = None
     base_branch: str | None = None
     budget_usd: float | None = None
     max_parallel: int | None = None
@@ -148,6 +150,8 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
             sprint_name = _read_sprint_name_from_state(state_path)
             meta = _read_sprint_meta_from_state(state_path)
             sprint_phase = meta.get("sprint_phase")
+            sprint_phase_detail = meta.get("sprint_phase_detail")
+            sprint_phase_started_at = meta.get("sprint_phase_started_at")
             base_branch = meta.get("base_branch")
             budget_usd = meta.get("budget_usd")
             max_parallel = meta.get("max_parallel")
@@ -249,7 +253,9 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
 
     header_parts: list[str] = [f"Sprint: {sprint_name}  run: {run_id}  [{state_label}]"]
     if sprint_phase:
-        header_parts.append(f"phase: {sprint_phase}")
+        header_parts.append(
+            _format_sprint_phase(sprint_phase, sprint_phase_detail, sprint_phase_started_at)
+        )
     if total_cost_usd is not None:
         header_parts.append(f"cost: ${total_cost_usd:.2f}")
     elif not cost_complete:
@@ -366,6 +372,10 @@ def _read_sprint_meta_from_state(state_path: object) -> dict:
     out: dict = {}
     if isinstance(data.get("sprint_phase"), str):
         out["sprint_phase"] = data["sprint_phase"]
+    if isinstance(data.get("sprint_phase_detail"), str):
+        out["sprint_phase_detail"] = data["sprint_phase_detail"]
+    if isinstance(data.get("sprint_phase_started_at"), str):
+        out["sprint_phase_started_at"] = data["sprint_phase_started_at"]
     if isinstance(data.get("base_branch"), str):
         out["base_branch"] = data["base_branch"]
     if isinstance(data.get("budget_usd"), (int, float)):
@@ -474,6 +484,30 @@ def _print_story_line(
             f"{detail_lines[index] if index < len(detail_lines) else ''}"
         )
         print(f"{prefix}{line}")
+
+
+def _format_sprint_phase(
+    sprint_phase: str,
+    detail: str | None,
+    started_at: str | None,
+) -> str:
+    """Render the header's phase cell, naming what a long phase is working on.
+
+    A phase name alone cannot distinguish a gate that has been running for
+    fifteen minutes from a sprint that is wedged, so a phase that publishes a
+    target and a start time gets both reported inline (#2014).
+    """
+    from theforge.sprint.status_reader import elapsed_seconds_since
+
+    parts = [part for part in (detail,) if part]
+    elapsed = elapsed_seconds_since(started_at)
+    if elapsed is not None:
+        # Sub-minute phases matter here in a way they do not for story rows: the
+        # first seconds of a gate are exactly when an operator is watching.
+        parts.append(f"{int(elapsed)}s" if elapsed < 60 else _format_story_elapsed(elapsed))
+    if not parts:
+        return f"phase: {sprint_phase}"
+    return f"phase: {sprint_phase} ({', '.join(parts)})"
 
 
 def _format_story_elapsed(elapsed_s: float | None) -> str:

--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -7,7 +7,7 @@ import shlex
 from pathlib import Path
 
 from theforge.config import ForgeConfig
-from theforge.coordinator.state import GateDebugTelemetry
+from theforge.coordinator.state import GateDebugTelemetry, GateLabel
 from theforge.task import TaskStory
 from theforge.traces import write_trace
 
@@ -74,6 +74,7 @@ def run_gate_full(
     iter_num: int | None = None,
     *,
     output_digest: list[str] | None = None,
+    label: GateLabel | None = None,
 ) -> tuple[str | None, str | None, str, str, int | None]:
     """Run the gate command and determine pass/fail from exit code.
 
@@ -92,6 +93,12 @@ def run_gate_full(
     returning a record — would churn all of them to carry one scalar that only
     one caller reads. A caller-supplied list keeps it explicit and per-call, so
     parallel story workers cannot share it.
+
+    ``label``, when given, names the gate's purpose and target in the "Running
+    gate" log line so semantically different gates that resolve to the same
+    command (baseline vs. per-story reuse vs. validation) are distinguishable
+    in the sprint log (#2014). It is display-only: it never reaches the shell
+    command, the timeout, or the decision.
     """
     has_override = (
         task is not None and task.gate_override and not _is_gate_skip(task.gate_override)
@@ -106,7 +113,8 @@ def run_gate_full(
         gate_cmd = gate_cmd.replace("{test_target}", test_target)
         gate_cmd = gate_cmd.replace("{slug}", slug)
 
-    _cu._log_verbose(f"Running gate: {gate_cmd}")
+    gate_identity = label.describe() if label is not None else "gate"
+    _cu._log_verbose(f"Running {gate_identity}: {gate_cmd}")
     gate_timeout = config.validation.gate_timeout or 600
     ok, output, exit_code, timed_out = _cu._run_shell_detailed(
         gate_cmd,
@@ -221,10 +229,14 @@ def _run_gate_debug_command(
 
 
 def _run_gate(
-    config: ForgeConfig, workspace_path: Path, task: TaskStory | None = None
+    config: ForgeConfig,
+    workspace_path: Path,
+    task: TaskStory | None = None,
+    *,
+    label: GateLabel | None = None,
 ) -> tuple[str | None, str | None, str]:
     """Run the gate command. Returns (decision, error, output_tail)."""
     decision, error, output_tail, _resolved_cmd, _exit_code = run_gate_full(
-        config, workspace_path, task
+        config, workspace_path, task, label=label
     )
     return decision, error, output_tail

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -230,6 +230,47 @@ class DevIterationTelemetry:
 
 
 @dataclass(frozen=True)
+class GateLabel:
+    """Operator-facing identity of one gate invocation.
+
+    The resolved gate command is identical for the sprint baseline gate, each
+    story's reuse gate during resume triage, and each story's validation gate,
+    so the command string alone cannot tell an operator which of them a log
+    line belongs to (#2014). Callers attach the purpose and target they already
+    hold at the call site; nothing here affects gate execution or its result.
+
+    ``target`` is the branch under gate, or a marker naming a non-branch target
+    such as ``"merge base"`` for the baseline gate.
+    """
+
+    purpose: str
+    slug: str | None = None
+    target: str | None = None
+    commit: str | None = None
+    worktree_path: str | None = None
+
+    def describe(self) -> str:
+        """Render as a log phrase: ``reuse gate for issue-50 on feat/issue-50 abc1234``."""
+        parts = [self.purpose]
+        if self.slug:
+            parts.append(f"for {self.slug}")
+        location = self.target or self.worktree_path
+        if location:
+            parts.append(f"on {location}")
+        if self.commit:
+            parts.append(short_sha(self.commit))
+        return " ".join(parts)
+
+
+def short_sha(commit: str, length: int = 8) -> str:
+    """Abbreviate a full hex SHA; any other ref (branch name, tag) is returned as-is."""
+    text = commit.strip()
+    if len(text) > length and all(c in "0123456789abcdefABCDEF" for c in text):
+        return text[:length]
+    return text
+
+
+@dataclass(frozen=True)
 class GateDebugTelemetry:
     """Diagnostic command telemetry captured when the validation gate times out.
 

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -5,15 +5,26 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import ForgeConfig
 from ..coordinator.audit import has_review_approve
 from ..coordinator.gate import _run_gate
+from ..coordinator.state import GateLabel
 from ..log_util import _log_line
 from ..task import TaskStory
 from .manifest import _build_task_from_story
+
+#: Story phase written to live sprint state while a story's reuse gate runs.
+#: Resume triage runs one gate per story before any story is dispatched; without
+#: a phase of its own that window reads as ``waiting`` for its whole (possibly
+#: many-minute) duration (#2014).
+REUSE_GATE_PHASE = "REUSE_GATE"
+
+#: ``GateLabel.purpose`` for the per-story resume-triage gate.
+REUSE_GATE_PURPOSE = "reuse gate"
 
 
 def _log(msg: str) -> None:
@@ -506,12 +517,27 @@ def resolve_satisfied_dependencies(
     return satisfied_slugs
 
 
+def _branch_tip_sha(commits_ahead: list[str] | None) -> str | None:
+    """Return the branch tip's abbreviated SHA from ``git log --oneline`` lines.
+
+    ``commits_ahead`` is newest-first, so its first entry starts with the tip's
+    abbreviated SHA. Reading it here costs nothing; asking git again for a value
+    already in hand would add a subprocess per story to the triage loop.
+    """
+    if not commits_ahead:
+        return None
+    head = commits_ahead[0].split(maxsplit=1)
+    return head[0] if head else None
+
+
 def _triage_spec(
     story_path: str,
     config: ForgeConfig,
     project_root: Path,
     *,
     task: TaskStory | None = None,
+    on_gate_start: Callable[[GateLabel], None] | None = None,
+    on_gate_end: Callable[[GateLabel], None] | None = None,
 ) -> StoryTriage:
     """Determine the optimal re-entry point for a story.
 
@@ -523,6 +549,12 @@ def _triage_spec(
       gate fails?               → dev
 
     When *task* is provided, skip building from disk (used for issue-backed stories).
+
+    ``on_gate_start`` / ``on_gate_end`` bracket the reuse gate — the only step
+    here that can run for minutes. They fire with the gate's ``GateLabel`` so the
+    caller can publish live progress for exactly that window, rather than for
+    the cheap git probes that surround it (#2014). Every other path returns
+    without calling either.
     """
     if task is None:
         full_path = (project_root / story_path).resolve()
@@ -652,7 +684,22 @@ def _triage_spec(
         )
 
     # 6. Gate pre-check to decide REVIEW vs DEV entry
-    gate_decision, gate_err, _gate_output = _run_gate(config, worktree_path, task=task)
+    gate_label = GateLabel(
+        purpose=REUSE_GATE_PURPOSE,
+        slug=slug,
+        target=branch,
+        commit=_branch_tip_sha(commits_ahead),
+        worktree_path=str(worktree_path),
+    )
+    if on_gate_start is not None:
+        on_gate_start(gate_label)
+    try:
+        gate_decision, gate_err, _gate_output = _run_gate(
+            config, worktree_path, task=task, label=gate_label
+        )
+    finally:
+        if on_gate_end is not None:
+            on_gate_end(gate_label)
 
     if gate_err is None and gate_decision == "PASS":
         return StoryTriage(

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -36,7 +36,7 @@ from ..coordinator.log_tee import _make_story_log_dir, set_worker_slug
 from ..coordinator.logging import StructuredLogger
 from ..coordinator.notify import _notify
 from ..coordinator.ntfy_client import _ntfy_publish
-from ..coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from ..coordinator.state import CoordinatorResult, CoordinatorState, GateLabel, Phase
 from ..coordinator.util import (
     _fmt_cost_total,
     _fmt_duration,
@@ -72,6 +72,7 @@ from .collision import (
     run_batch_preflight,
 )
 from .dag import (
+    REUSE_GATE_PHASE,
     StoryDAG,
     StoryTriage,
     _triage_spec,
@@ -99,6 +100,8 @@ from .state_writer import (
     SPRINT_PHASE_FAILED,
     SPRINT_PHASE_STOPPED,
     SprintStateWriter,
+    update_state_phase,
+    update_state_story,
 )
 from .story_state import (
     GATE_STATUS_INCOMPLETE,
@@ -965,6 +968,71 @@ def _project_root_is_git_checkout(project_root: Path) -> bool:
     return git_dir_check.returncode == 0
 
 
+#: ``GateLabel.purpose`` for the pre-sprint merge-base gate.
+BASELINE_GATE_PURPOSE = "baseline gate"
+
+#: Top-level ``sprint_phase`` values for the pre-story window. Both gates below
+#: can run for many minutes; without their own phases the whole window reports
+#: as ``starting`` with every story ``waiting`` (#2014).
+SPRINT_PHASE_STARTING = "starting"
+SPRINT_PHASE_BASELINE_GATE = "baseline-gate"
+SPRINT_PHASE_TRIAGE = "triage"
+
+
+def _publish_reuse_gate_start(run_id: str | None, project_root: Path, label: GateLabel) -> None:
+    """Show a story as actively gated while resume triage validates its worktree.
+
+    Triage runs before ``SprintStateWriter`` exists, so this writes the bootstrap
+    state file directly. The story is not dispatched yet, but it is not waiting
+    either: a real gate subprocess is running against its worktree, and that —
+    with the branch, commit, and start time — is what the operator needs to see
+    instead of ``waiting`` for the gate's whole duration (#2014).
+
+    No-op without a ``run_id`` (headless invocations have no live state file).
+    """
+    if not run_id or not label.slug:
+        return
+    update_state_story(
+        run_id,
+        project_root,
+        label.slug,
+        status="running",
+        phase=REUSE_GATE_PHASE,
+        started_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        detail_updates={
+            "gate_purpose": label.purpose,
+            "gate_branch": label.target,
+            "gate_commit": label.commit,
+            "gate_worktree": label.worktree_path,
+        },
+    )
+
+
+def _publish_reuse_gate_end(run_id: str | None, project_root: Path, label: GateLabel) -> None:
+    """Return the story to waiting once its reuse gate is done.
+
+    The triage verdict is applied by the normal dispatch path later; leaving the
+    story at ``running`` here would keep claiming in-flight work — with a
+    growing elapsed time — for the rest of the startup window.
+    """
+    if not run_id or not label.slug:
+        return
+    update_state_story(
+        run_id,
+        project_root,
+        label.slug,
+        status="waiting",
+        phase=None,
+        started_at=None,
+        detail_updates={
+            "gate_purpose": None,
+            "gate_branch": None,
+            "gate_commit": None,
+            "gate_worktree": None,
+        },
+    )
+
+
 def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[str, object]:
     """Run the configured gate on the sprint merge base before any agent work starts."""
 
@@ -1114,7 +1182,14 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
                 }
 
         decision, error, output_tail, resolved_gate_cmd, gate_exit_code = run_gate_full(
-            config, baseline_worktree
+            config,
+            baseline_worktree,
+            label=GateLabel(
+                purpose=BASELINE_GATE_PURPOSE,
+                target="merge base",
+                commit=merge_base_ref,
+                worktree_path=str(baseline_worktree),
+            ),
         )
         duration = time.monotonic() - started_monotonic
         finished_at = datetime.datetime.now(datetime.timezone.utc)
@@ -2596,6 +2671,23 @@ def run_sprint(
     if not no_pull and _project_root_is_git_checkout(config.project_root):
         coordinator_workspace.pull_base_branch(config, lands_locally=_sprint_lands_locally)
 
+    def _publish_sprint_phase(
+        phase: str,
+        *,
+        detail: str | None = None,
+        started_at: str | None = None,
+    ) -> None:
+        """Record the sprint-level phase in the live state file, when there is one.
+
+        Headless invocations pass no ``run_id`` and have no state file; those
+        callers simply produce no live phase.
+        """
+        if not run_id:
+            return
+        update_state_phase(
+            run_id, config.project_root, phase, detail=detail, started_at=started_at
+        )
+
     baseline_started_at = datetime.datetime.now(datetime.timezone.utc)
     _continuation_reason = _continuation_evidence(
         reexec=reexec,
@@ -2610,7 +2702,20 @@ def run_sprint(
             live_stories=sorted(_live_story_slugs),
         )
     else:
-        baseline_gate = _run_baseline_gate(config, resolved)
+        # The baseline gate is the sprint's first potentially many-minute step.
+        # Publishing it as its own phase (with the moment it began) is what lets
+        # `forge status` distinguish a slow gate from a stuck sprint; the phase
+        # is cleared the moment the gate returns so the elapsed time on screen
+        # is never that of finished work (#2014).
+        _publish_sprint_phase(
+            SPRINT_PHASE_BASELINE_GATE,
+            detail=f"merge base of {config.workspace.base_branch}",
+            started_at=baseline_started_at.isoformat(),
+        )
+        try:
+            baseline_gate = _run_baseline_gate(config, resolved)
+        finally:
+            _publish_sprint_phase(SPRINT_PHASE_STARTING)
     resolved.baseline_gate = baseline_gate
     _log(str(baseline_gate.get("message", "Baseline gate check completed")))
     if not bool(baseline_gate.get("passed", False)):
@@ -2837,6 +2942,7 @@ def run_sprint(
         if recovered_prior_started_at is not None and recovered_prior_started_at < started_at:
             started_at = recovered_prior_started_at
         _log("Triaging specs...")
+        _publish_sprint_phase(SPRINT_PHASE_TRIAGE)
         for slug, (task, _src, canonical_ref) in slug_to_context.items():
             if slug in _inflight_slugs:
                 # Triage reads the worktree to decide the re-entry point, and
@@ -2845,7 +2951,18 @@ def run_sprint(
                 # dispatch, after the inherited agent has stopped.
                 _log(f"  {slug:<20} DEFERRED (agent still running; triage after it finishes)")
                 continue
-            triage = _triage_spec(canonical_ref, config, config.project_root, task=task)
+            triage = _triage_spec(
+                canonical_ref,
+                config,
+                config.project_root,
+                task=task,
+                on_gate_start=lambda label: _publish_reuse_gate_start(
+                    run_id, config.project_root, label
+                ),
+                on_gate_end=lambda label: _publish_reuse_gate_end(
+                    run_id, config.project_root, label
+                ),
+            )
             triages[canonical_ref] = triage
             _log(
                 f"  {triage.slug:<20} {triage.action.upper().replace('_', ' ')} ({triage.reason})"

--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -405,16 +405,7 @@ def write_bootstrap_state(
         "max_parallel": max_parallel,
         "stories": stories,
     }
-    tmp_path = state_path.with_name(state_path.name + ".tmp")
-    try:
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
-        tmp_path.replace(state_path)
-    except OSError:
-        try:
-            tmp_path.unlink()
-        except OSError:
-            pass
+    _write_state_data(state_path, data)
     return state_path
 
 
@@ -462,7 +453,12 @@ def terminalize_state_file(
 
     data["sprint_phase"] = sprint_phase
     data["stories"] = story_state.as_dict()
+    _write_state_data(state_path, data)
+    return stranded
 
+
+def _write_state_data(state_path: Path, data: dict) -> None:
+    """Atomically replace a state file's contents. Best-effort; never raises."""
     tmp_path = state_path.with_name(state_path.name + ".tmp")
     try:
         with open(tmp_path, "w", encoding="utf-8") as f:
@@ -473,36 +469,85 @@ def terminalize_state_file(
             tmp_path.unlink()
         except OSError:
             pass
-    return stranded
 
 
-def update_state_phase(run_id: str, project_root: Path, sprint_phase: str) -> None:
+def update_state_phase(
+    run_id: str,
+    project_root: Path,
+    sprint_phase: str,
+    *,
+    detail: str | None = None,
+    started_at: str | None = None,
+) -> None:
     """Update the ``sprint_phase`` field of an existing state file in place.
 
     No-op when the state file is absent (e.g. headless invocations without a
     bootstrap write). Called from the runner at phase boundaries that fire
     before SprintStateWriter is constructed.
+
+    ``detail`` and ``started_at`` describe a phase the sprint is *inside* right
+    now — the target of a long pre-story gate and when it began — so the status
+    header can report elapsed time instead of an unchanging phase name (#2014).
+    They are always rewritten, including to ``None``: leaving a finished gate's
+    detail behind would report stale work as active.
     """
     state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
     if not state_path.exists():
         return
-    try:
-        with open(state_path, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-    except (OSError, yaml.YAMLError):
+    data = _load_existing_state(state_path)
+    if data is None:
         return
-    if not isinstance(data, dict):
-        return
-    if data.get("sprint_phase") == sprint_phase:
+    if (
+        data.get("sprint_phase") == sprint_phase
+        and data.get("sprint_phase_detail") == detail
+        and data.get("sprint_phase_started_at") == started_at
+    ):
         return
     data["sprint_phase"] = sprint_phase
-    tmp_path = state_path.with_name(state_path.name + ".tmp")
-    try:
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
-        tmp_path.replace(state_path)
-    except OSError:
-        try:
-            tmp_path.unlink()
-        except OSError:
-            pass
+    data["sprint_phase_detail"] = detail
+    data["sprint_phase_started_at"] = started_at
+    _write_state_data(state_path, data)
+
+
+def update_state_story(run_id: str, project_root: Path, slug: str, **fields: object) -> None:
+    """Update one story row of an existing state file in place.
+
+    The pre-story triage loop runs before ``SprintStateWriter`` exists, so the
+    only live record of its progress is the bootstrap state file written at
+    daemonize time. Without this, a story being gated for reuse reads
+    ``waiting`` / no phase for the entire gate (#2014).
+
+    ``detail_updates`` merges into the row's ``detail`` dict; every other field
+    is assigned. Values of ``None`` are written as ``None`` so a completed phase
+    can be cleared. No-op when the file, or a row for ``slug``, is absent — a
+    progress write must never fail the sprint.
+    """
+    state_path = project_root / ".forge" / "runs" / f"{run_id}.state"
+    if not state_path.exists():
+        return
+    data = _load_existing_state(state_path)
+    if data is None:
+        return
+    stories = data.get("stories")
+    if not isinstance(stories, list):
+        return
+    detail_updates = fields.pop("detail_updates", None)
+    for story in stories:
+        if not isinstance(story, dict) or story.get("slug") != slug:
+            continue
+        if "status" in fields:
+            # The live file carries both the legacy status and the canonical
+            # outcome; a reader picking either one must see the same thing.
+            fields.setdefault("outcome", fields["status"])
+        story.update(fields)
+        if isinstance(detail_updates, dict):
+            existing_detail = story.get("detail")
+            merged = dict(existing_detail) if isinstance(existing_detail, dict) else {}
+            for key, value in detail_updates.items():
+                if value is None:
+                    merged.pop(key, None)
+                else:
+                    merged[key] = value
+            story["detail"] = merged
+        _write_state_data(state_path, data)
+        return

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -255,6 +255,15 @@ def _elapsed_seconds_from_bounds(started_at: object, finished_at: object) -> flo
     return elapsed if elapsed >= 0 else None
 
 
+def elapsed_seconds_since(started_at: object) -> float | None:
+    """Seconds elapsed from a persisted UTC timestamp to now; None if unparsable."""
+    started_at_dt = _parse_status_timestamp(started_at)
+    if started_at_dt is None:
+        return None
+    elapsed = (datetime.datetime.now(datetime.timezone.utc) - started_at_dt).total_seconds()
+    return elapsed if elapsed >= 0 else None
+
+
 def _elapsed_seconds_from_live_story(story: dict) -> float | None:
     """Compute elapsed time for a live state entry when timestamps are available."""
     started_at_dt = _parse_status_timestamp(story.get("started_at"))
@@ -267,8 +276,7 @@ def _elapsed_seconds_from_live_story(story: dict) -> float | None:
         return elapsed if elapsed >= 0 else None
 
     if story.get("status") == "running":
-        elapsed = (datetime.datetime.now(datetime.timezone.utc) - started_at_dt).total_seconds()
-        return elapsed if elapsed >= 0 else None
+        return elapsed_seconds_since(story.get("started_at"))
 
     return None
 
@@ -622,6 +630,22 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
             detail_data.get("review_p2"),
         )
         return stage, detail or "reviewing plan", complexity
+
+    if phase_val == "REUSE_GATE":
+        # Resume triage gating an existing worktree. Naming the branch and
+        # commit under gate is the whole point of the phase: it tells the
+        # operator which stranded worktree the long-running gate belongs to.
+        target = _nonempty_str(detail_data.get("gate_branch")) or _nonempty_str(
+            detail_data.get("gate_worktree")
+        )
+        commit = _nonempty_str(detail_data.get("gate_commit"))
+        if target and commit:
+            gate_detail = f"validating {target} @ {commit}"
+        elif target:
+            gate_detail = f"validating {target}"
+        else:
+            gate_detail = "validating existing worktree"
+        return _nonempty_str(detail_data.get("gate_purpose")) or "", gate_detail, complexity
 
     if phase_val == "WORKSPACE":
         return (

--- a/tests/test_sprint_gate_visibility.py
+++ b/tests/test_sprint_gate_visibility.py
@@ -1,0 +1,400 @@
+"""Pre-story gate visibility: labeled gate logs and live per-story gate phase (#2014).
+
+A sprint can spend many minutes in the baseline gate and in the per-story reuse
+gates that resume triage runs, while every gate logs the same resolved command
+and `forge status` reports `starting` with all stories `waiting`. These tests
+pin both halves of the fix: the gate log line names its purpose and target, and
+the live state file shows a concrete phase for the story being gated.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from theforge.cli.sprint_status import _format_sprint_phase, _read_sprint_meta_from_state
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator import util as coordinator_util
+from theforge.coordinator.gate import run_gate_full
+from theforge.coordinator.state import GateLabel
+from theforge.sprint.dag import REUSE_GATE_PHASE, _triage_spec
+from theforge.sprint.manifest import ResolvedSprint
+from theforge.sprint.runner import (
+    SPRINT_PHASE_BASELINE_GATE,
+    _publish_reuse_gate_end,
+    _publish_reuse_gate_start,
+    _run_baseline_gate,
+)
+from theforge.sprint.sources import FileSource
+from theforge.sprint.state_writer import (
+    update_state_phase,
+    update_state_story,
+    write_bootstrap_state,
+)
+from theforge.sprint.status_reader import read_live_status
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_config(tmp_path: Path, gate_command: str = "echo gate") -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+            base_branch="main",
+        ),
+        validation=replace(DEFAULT_VALIDATION, gate_command=gate_command),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_spec_file(tmp_path: Path, slug: str) -> Path:
+    spec = tmp_path / f"{slug}.md"
+    spec.write_text(
+        f"---\nname: Story {slug}\nslug: {slug}\n---\n# Story {slug}\nDo the thing.",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _triage_git_mock(commit_line: bytes = b"abc1234 some commit\n"):
+    """git stub for a story whose branch has commits ahead of an unmerged base."""
+
+    def _mock_run(cmd, **kwargs):
+        m = MagicMock()
+        if "--is-ancestor" in cmd:
+            m.returncode = 1  # not merged
+        elif "log" in cmd:
+            m.returncode = 0
+            m.stdout = commit_line
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    return _mock_run
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> tuple[ForgeConfig, ResolvedSprint, str]:
+    config = _make_config(tmp_path)
+    story_file = tmp_path / "story.md"
+    story_file.write_text(
+        "---\nname: My Story\nslug: my-story\n---\n# Content\n", encoding="utf-8"
+    )
+    source = FileSource()
+    task = source.fetch("story.md", tmp_path)
+    resolved = ResolvedSprint(
+        name="Test Sprint",
+        budget_usd=10.0,
+        stories=[(task, source, "story.md")],
+        max_parallel=1,
+    )
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "base")
+    base_commit = _git(tmp_path, "rev-parse", "HEAD")
+    return config, resolved, base_commit
+
+
+# ── Gate labeling ────────────────────────────────────────────────────
+
+
+class TestGateLabel:
+    def test_baseline_label_names_merge_base_and_short_sha(self) -> None:
+        label = GateLabel(
+            purpose="baseline gate",
+            target="merge base",
+            commit="10fdbd8ae9d06ab628dc15da924fa691c0bcaefd",
+        )
+        assert label.describe() == "baseline gate on merge base 10fdbd8a"
+
+    def test_reuse_label_names_story_branch_and_commit(self) -> None:
+        label = GateLabel(
+            purpose="reuse gate",
+            slug="issue-50",
+            target="feat/issue-50",
+            commit="abc1234",
+            worktree_path="/repo/.forge/worktrees/issue-50",
+        )
+        assert label.describe() == "reuse gate for issue-50 on feat/issue-50 abc1234"
+
+    def test_label_falls_back_to_worktree_when_no_branch(self) -> None:
+        label = GateLabel(purpose="reuse gate", slug="issue-50", worktree_path="/repo/wt/issue-50")
+        assert label.describe() == "reuse gate for issue-50 on /repo/wt/issue-50"
+
+
+class TestRunGateFullLogging:
+    def _capture_gate_log(self, tmp_path: Path, label: GateLabel | None) -> list[str]:
+        lines: list[str] = []
+        config = _make_config(tmp_path)
+        with patch.object(coordinator_util, "_log_verbose", side_effect=lines.append):
+            with patch.object(
+                coordinator_util,
+                "_run_shell_detailed",
+                return_value=(True, "ok", 0, False),
+            ):
+                run_gate_full(config, tmp_path, label=label)
+        return lines
+
+    def test_labeled_gate_log_names_purpose_and_target(self, tmp_path: Path) -> None:
+        lines = self._capture_gate_log(
+            tmp_path,
+            GateLabel(
+                purpose="reuse gate",
+                slug="issue-50",
+                target="feat/issue-50",
+                commit="abc1234",
+            ),
+        )
+        assert lines == ["Running reuse gate for issue-50 on feat/issue-50 abc1234: echo gate"]
+
+    def test_unlabeled_gate_log_is_unchanged(self, tmp_path: Path) -> None:
+        assert self._capture_gate_log(tmp_path, None) == ["Running gate: echo gate"]
+
+    def test_label_does_not_reach_the_shell_command(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        with patch.object(
+            coordinator_util, "_run_shell_detailed", return_value=(True, "ok", 0, False)
+        ) as shell:
+            _decision, _err, _tail, resolved_cmd, _code = run_gate_full(
+                config,
+                tmp_path,
+                label=GateLabel(purpose="reuse gate", slug="issue-50"),
+            )
+        assert resolved_cmd == "echo gate"
+        assert shell.call_args.args[0] == "echo gate"
+
+
+def test_baseline_gate_log_line_names_the_merge_base(tmp_path: Path) -> None:
+    """Seam: the real baseline gate call site labels its gate with the merge base."""
+    config, resolved, base_commit = _init_repo(tmp_path)
+    lines: list[str] = []
+
+    with patch.object(coordinator_util, "_log_verbose", side_effect=lines.append):
+        baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is True
+    gate_lines = [line for line in lines if line.startswith("Running ")]
+    assert gate_lines == [f"Running baseline gate on merge base {base_commit[:8]}: echo gate"]
+
+
+def test_triage_labels_the_reuse_gate_with_story_branch_and_commit(tmp_path: Path) -> None:
+    """Seam: resume triage's gate call carries the story's identity."""
+    _make_spec_file(tmp_path, "issue-50")
+    config = _make_config(tmp_path)
+    (tmp_path / "issue-50").mkdir()
+
+    with patch("theforge.sprint.dag.subprocess.run", side_effect=_triage_git_mock()):
+        with patch(
+            "theforge.sprint.dag._run_gate", return_value=("PASS", None, "")
+        ) as run_gate_mock:
+            triage = _triage_spec("issue-50.md", config, tmp_path)
+
+    assert triage.action == "review"
+    label = run_gate_mock.call_args.kwargs["label"]
+    assert label.describe() == "reuse gate for issue-50 on feat/issue-50 abc1234"
+    assert label.worktree_path == str(tmp_path / "issue-50")
+
+
+def test_triage_brackets_only_the_gate_with_progress_callbacks(tmp_path: Path) -> None:
+    """A story that never reaches the gate publishes no gate progress."""
+    _make_spec_file(tmp_path, "issue-50")
+    config = _make_config(tmp_path)
+    events: list[str] = []
+
+    # No worktree on disk → triage returns "full" before any gate runs.
+    with patch("theforge.sprint.dag.subprocess.run", side_effect=_triage_git_mock()):
+        triage = _triage_spec(
+            "issue-50.md",
+            config,
+            tmp_path,
+            on_gate_start=lambda label: events.append("start"),
+            on_gate_end=lambda label: events.append("end"),
+        )
+
+    assert triage.action == "full"
+    assert events == []
+
+
+def test_gate_end_callback_fires_even_when_the_gate_raises(tmp_path: Path) -> None:
+    _make_spec_file(tmp_path, "issue-50")
+    config = _make_config(tmp_path)
+    (tmp_path / "issue-50").mkdir()
+    events: list[str] = []
+
+    with patch("theforge.sprint.dag.subprocess.run", side_effect=_triage_git_mock()):
+        with patch("theforge.sprint.dag._run_gate", side_effect=RuntimeError("boom")):
+            try:
+                _triage_spec(
+                    "issue-50.md",
+                    config,
+                    tmp_path,
+                    on_gate_start=lambda label: events.append("start"),
+                    on_gate_end=lambda label: events.append("end"),
+                )
+            except RuntimeError:
+                pass
+
+    assert events == ["start", "end"]
+
+
+# ── Live status visibility ───────────────────────────────────────────
+
+
+def _bootstrap(tmp_path: Path, run_id: str = "run-2014") -> str:
+    write_bootstrap_state(
+        run_id,
+        tmp_path,
+        sprint_name="Test Sprint",
+        sprint_phase="starting",
+        issues=[{"number": 50}],
+    )
+    return run_id
+
+
+class TestReuseGateStateVisibility:
+    def test_story_is_running_in_reuse_gate_phase_while_the_gate_runs(
+        self, tmp_path: Path
+    ) -> None:
+        """Seam: with the real triage callbacks wired, status shows the gated story.
+
+        The stubbed gate reads live status from inside the gate window — exactly
+        where the operator's `forge status` lands during a multi-minute gate.
+        """
+        run_id = _bootstrap(tmp_path)
+        _make_spec_file(tmp_path, "issue-50")
+        config = _make_config(tmp_path)
+        (tmp_path / "issue-50").mkdir()
+        observed: list = []
+
+        def _gate_reads_status(*args, **kwargs):
+            observed.extend(read_live_status(run_id, tmp_path) or [])
+            return ("PASS", None, "")
+
+        with patch("theforge.sprint.dag.subprocess.run", side_effect=_triage_git_mock()):
+            with patch("theforge.sprint.dag._run_gate", side_effect=_gate_reads_status):
+                _triage_spec(
+                    "issue-50.md",
+                    config,
+                    tmp_path,
+                    on_gate_start=lambda label: _publish_reuse_gate_start(run_id, tmp_path, label),
+                    on_gate_end=lambda label: _publish_reuse_gate_end(run_id, tmp_path, label),
+                )
+
+        during = [entry for entry in observed if entry.slug == "issue-50"]
+        assert len(during) == 1
+        entry = during[0]
+        assert entry.status == "running"
+        assert entry.phase == REUSE_GATE_PHASE
+        assert entry.stage == "reuse gate"
+        assert entry.detail == "validating feat/issue-50 @ abc1234"
+        assert entry.elapsed_seconds is not None
+
+    def test_story_returns_to_waiting_once_the_gate_finishes(self, tmp_path: Path) -> None:
+        run_id = _bootstrap(tmp_path)
+        _make_spec_file(tmp_path, "issue-50")
+        config = _make_config(tmp_path)
+        (tmp_path / "issue-50").mkdir()
+
+        with patch("theforge.sprint.dag.subprocess.run", side_effect=_triage_git_mock()):
+            with patch("theforge.sprint.dag._run_gate", return_value=("PASS", None, "")):
+                _triage_spec(
+                    "issue-50.md",
+                    config,
+                    tmp_path,
+                    on_gate_start=lambda label: _publish_reuse_gate_start(run_id, tmp_path, label),
+                    on_gate_end=lambda label: _publish_reuse_gate_end(run_id, tmp_path, label),
+                )
+
+        entries = read_live_status(run_id, tmp_path) or []
+        entry = next(e for e in entries if e.slug == "issue-50")
+        assert entry.status == "waiting"
+        assert entry.phase is None
+        assert entry.elapsed_seconds is None
+
+        state = yaml.safe_load((tmp_path / ".forge" / "runs" / f"{run_id}.state").read_text())
+        story = next(s for s in state["stories"] if s["slug"] == "issue-50")
+        assert story["detail"] == {}
+        assert story["outcome"] == "waiting"
+
+    def test_publish_is_a_noop_without_a_run_id(self, tmp_path: Path) -> None:
+        label = GateLabel(purpose="reuse gate", slug="issue-50", target="feat/issue-50")
+        _publish_reuse_gate_start(None, tmp_path, label)
+        _publish_reuse_gate_end(None, tmp_path, label)
+        assert not (tmp_path / ".forge" / "runs").exists()
+
+    def test_update_state_story_ignores_unknown_slugs(self, tmp_path: Path) -> None:
+        run_id = _bootstrap(tmp_path)
+        update_state_story(run_id, tmp_path, "issue-999", status="running")
+        entries = read_live_status(run_id, tmp_path) or []
+        assert [e.slug for e in entries] == ["issue-50"]
+        assert entries[0].status == "waiting"
+
+
+class TestBaselineGatePhaseVisibility:
+    def test_phase_carries_target_and_start_time(self, tmp_path: Path) -> None:
+        run_id = _bootstrap(tmp_path)
+        update_state_phase(
+            run_id,
+            tmp_path,
+            SPRINT_PHASE_BASELINE_GATE,
+            detail="merge base of main",
+            started_at="2026-07-28T21:56:41.137562+00:00",
+        )
+
+        meta = _read_sprint_meta_from_state(tmp_path / ".forge" / "runs" / f"{run_id}.state")
+        assert meta["sprint_phase"] == "baseline-gate"
+        assert meta["sprint_phase_detail"] == "merge base of main"
+        assert meta["sprint_phase_started_at"] == "2026-07-28T21:56:41.137562+00:00"
+
+    def test_finishing_the_gate_clears_the_transient_phase_context(self, tmp_path: Path) -> None:
+        run_id = _bootstrap(tmp_path)
+        update_state_phase(
+            run_id,
+            tmp_path,
+            SPRINT_PHASE_BASELINE_GATE,
+            detail="merge base of main",
+            started_at="2026-07-28T21:56:41.137562+00:00",
+        )
+        update_state_phase(run_id, tmp_path, "starting")
+
+        meta = _read_sprint_meta_from_state(tmp_path / ".forge" / "runs" / f"{run_id}.state")
+        assert meta["sprint_phase"] == "starting"
+        assert "sprint_phase_detail" not in meta
+        assert "sprint_phase_started_at" not in meta
+
+    def test_header_reports_target_and_elapsed(self) -> None:
+        import datetime
+
+        started = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=13)
+        rendered = _format_sprint_phase("baseline-gate", "merge base of main", started.isoformat())
+        assert rendered == "phase: baseline-gate (merge base of main, 13m)"
+
+    def test_header_without_phase_context_is_unchanged(self) -> None:
+        assert _format_sprint_phase("starting", None, None) == "phase: starting"

--- a/tests/test_sprint_intake_remediation_cost.py
+++ b/tests/test_sprint_intake_remediation_cost.py
@@ -324,7 +324,7 @@ class TestResumeReloadsIntakeCost:
             slug="feature-b",
         )
 
-        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+        def _mock_triage(canonical_ref, cfg, project_root, task=None, **_progress):
             slug = task.slug if task else Path(canonical_ref).stem
             return skip_triage if slug == "feature-a" else full_triage
 

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -779,7 +779,7 @@ class TestParallelDependencyGating:
         # story-b: clean review re-entry once actually dispatched.
         result_b = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
 
-        def _fake_triage(story_path, cfg, project_root, *, task=None):  # noqa: ANN001
+        def _fake_triage(story_path, cfg, project_root, *, task=None, **_progress):  # noqa: ANN001
             slug = task.slug
             return StoryTriage(
                 story_path=story_path,

--- a/tests/test_sprint_reexec_continuation.py
+++ b/tests/test_sprint_reexec_continuation.py
@@ -102,7 +102,7 @@ def _make_coordinator_result(cost: float = 1.0) -> CoordinatorResult:
     )
 
 
-def _triage_full(spec_path, config, project_root, *, task=None):
+def _triage_full(spec_path, config, project_root, *, task=None, **_progress):
     return StoryTriage(
         story_path=spec_path,
         action="full",

--- a/tests/test_sprint_reexec_reconcile.py
+++ b/tests/test_sprint_reexec_reconcile.py
@@ -157,7 +157,7 @@ def test_reexec_excludes_merged_story_from_preflight_and_dag_dispatch(
         slug="feature-b",
     )
 
-    def triage_side_effect(spec_path, config, project_root, *, task=None):
+    def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
         return merged_triage if "feature-a" in spec_path else full_triage
 
     fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
@@ -225,7 +225,7 @@ def test_reexec_reconcile_prior_done_drop_ends_succeeded_and_preserves_cost(
         ],
     )
 
-    def triage_side_effect(spec_path, config, project_root, *, task=None):
+    def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
         return StoryTriage(
             story_path=spec_path,
             action="full",
@@ -303,7 +303,7 @@ def test_reexec_reconcile_prior_done_satisfies_dependent_story(
         ],
     )
 
-    def triage_side_effect(spec_path, config, project_root, *, task=None):
+    def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
         return StoryTriage(
             story_path=spec_path,
             action="full",
@@ -352,7 +352,7 @@ def test_reexec_stranded_drop_does_not_rerun_and_keeps_distinct_reason(
     config = _make_config(tmp_path)
     _set_sprint_id(tmp_path)
 
-    def triage_side_effect(spec_path, config, project_root, *, task=None):
+    def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
         return StoryTriage(
             story_path=spec_path,
             action="full",

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -759,7 +759,7 @@ class TestResumeSprintIntegration:
             worktree_path=None,
         )
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             if "feature-a" in spec_path:
                 return merged_triage
             return full_triage
@@ -986,7 +986,7 @@ class TestResumeSprintIntegration:
             slug="feature-b",
         )
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             return merged_triage if "feature-a" in spec_path else full_triage
 
         coord_result = _make_coordinator_result(success=True, cost=1.25, landing_status="landed")
@@ -1076,7 +1076,7 @@ class TestResumeSprintIntegration:
             slug="feature-b",
         )
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             return merged_triage if "feature-a" in spec_path else full_triage
 
         # Generation 2: re-exec of the same sprint picks up where gen 1 left off.
@@ -1309,7 +1309,7 @@ class TestResumeSprintIntegration:
             slug="feature-b",
         )
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             return merged_triage if "feature-a" in spec_path else full_triage
 
         with patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect):
@@ -1445,7 +1445,7 @@ class TestSprintDependencies:
         )
         result_b = _make_coordinator_result(success=True, cost=1.0, merged=True)
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             if "spec-a" in spec_path:
                 return merged_triage
             return full_triage
@@ -1483,7 +1483,7 @@ class TestSprintDependencies:
         )
         result_b = _make_coordinator_result(success=True, cost=1.0, merged=True)
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             if "spec-a" in spec_path:
                 return approved_triage
             return full_triage

--- a/tests/test_sprint_resume_cached_preflight.py
+++ b/tests/test_sprint_resume_cached_preflight.py
@@ -68,7 +68,7 @@ class TestSprintResumeCachedPreflight:
         )
         dev_cached.run_id = "run-dev"
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             if "feature-a" in spec_path:
                 return review_triage
             return dev_triage
@@ -152,7 +152,7 @@ class TestSprintResumeCachedPreflight:
         dev_result.state.preflight_cached_original_verdict = "ALREADY_DONE"
         dev_result.state.preflight_cached_from_run_id = "run-dev"
 
-        def triage_side_effect(spec_path, config, project_root, *, task=None):
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
             if "feature-a" in spec_path:
                 return review_triage
             return dev_triage

--- a/tests/test_sprint_run_id_rollover.py
+++ b/tests/test_sprint_run_id_rollover.py
@@ -342,7 +342,7 @@ class TestRunIdRolloverReporting:
             slug="feature-b",
         )
 
-        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+        def _mock_triage(canonical_ref, cfg, project_root, task=None, **_progress):
             slug = task.slug if task else Path(canonical_ref).stem
             return skip_triage if slug == "feature-a" else full_triage
 
@@ -423,7 +423,7 @@ class TestRunIdRolloverReporting:
             slug="feature-b",
         )
 
-        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+        def _mock_triage(canonical_ref, cfg, project_root, task=None, **_progress):
             slug = task.slug if task else Path(canonical_ref).stem
             return skip_triage if slug == "feature-a" else full_triage
 
@@ -539,7 +539,7 @@ class TestRunIdRolloverReporting:
             slug="feature-b",
         )
 
-        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+        def _mock_triage(canonical_ref, cfg, project_root, task=None, **_progress):
             slug = task.slug if task else Path(canonical_ref).stem
             return skip_triage if slug == "feature-a" else full_triage
 
@@ -906,7 +906,7 @@ class TestRedirectChainResolution:
             slug="feature-b",
         )
 
-        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+        def _mock_triage(canonical_ref, cfg, project_root, task=None, **_progress):
             return full_triage
 
         captured: dict[str, object] = {}
@@ -985,7 +985,7 @@ class TestRedirectChainResolution:
             slug="feature-b",
         )
 
-        def _mock_triage(canonical_ref, cfg, project_root, task=None):
+        def _mock_triage(canonical_ref, cfg, project_root, task=None, **_progress):
             slug = task.slug if task else Path(canonical_ref).stem
             return skip_triage if slug == "feature-a" else full_triage
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation satisfies the gate log labeling and live status visibility requirements; focused status and resume tests pass. | [google-gemini-3.5-flash] The implementation successfully introduces gate labeling and pre-story progress publishing, resolving the observability gap during long pre-story/reuse gates.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $11.83
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint starting phase hides long pre-story/reuse gates behind identical gate log lines (GitHub Issue #2014)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2014