### PR TITLE
Forward-port pushes as the Actions token, not the App — clear checkout's persisted credential (#2047)

### DIFF
--- a/.github/workflows/forward-port.yml
+++ b/.github/workflows/forward-port.yml
@@ -74,12 +74,17 @@ jobs:
           RELEASE_REF: ${{ github.ref_name }}
         run: |
           set -o pipefail
-          # Author the merge commit as the forward-port App, not the Actions
-          # bot. This commit becomes the port PR's head, and the head's identity
-          # is the "actor of the pull request event" that main's workflow-approval
-          # policy checks. Runs attributed to github-actions[bot] land
-          # action_required and stall the armed auto-merge; runs attributed to
-          # forward-port[bot] have never required approval.
+          # Author the merge commit as the forward-port App rather than the
+          # Actions bot, so the port's history reads as the App's work.
+          #
+          # NOTE: this is cosmetic, not load-bearing. An earlier revision claimed
+          # the merge commit's identity is "the actor of the pull request event"
+          # that the workflow-approval policy checks. That is false and was
+          # measured so (#2047): held and unheld runs had head commits with
+          # identical forward-port[bot] author *and* committer. Run attribution
+          # follows the identity that **pushed** the branch — see the push step
+          # below, which must clear checkout's persisted Actions-token header for
+          # that to be the App.
           git config user.name "forward-port[bot]"
           git config user.email "304654100+forward-port[bot]@users.noreply.github.com"
           git fetch origin "$RELEASE_REF"
@@ -195,6 +200,21 @@ jobs:
         run: |
           branch="forward-port/${RELEASE_REF//\//-}"
           # Push the bot branch as the App identity.
+          #
+          # actions/checkout persists an Actions-token credential as
+          # http.https://github.com/.extraheader (persist-credentials defaults
+          # to true). git sends that Authorization header on every push to
+          # github.com and it takes precedence over the inline URL credential
+          # below, so without clearing it this push authenticates as
+          # github-actions[bot] regardless of the URL. The resulting
+          # `synchronize` run is then attributed to github-actions[bot] and held
+          # at action_required, stalling the armed auto-merge (#2047).
+          #
+          # Cleared here rather than via persist-credentials: false on the
+          # checkout, so the merge step above keeps authenticated access for its
+          # `git fetch origin "$RELEASE_REF"`. Nothing after this push needs git
+          # credentials — gh uses GH_TOKEN.
+          git config --unset-all 'http.https://github.com/.extraheader' || true
           git push --force \
             "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" \
             "HEAD:refs/heads/$branch"


### PR DESCRIPTION
Fixes #2047.

## What was wrong

Every force-push to every forward-port branch was performed by
`github-actions[bot]` — 21 events on #2001, one on #2018, one on #2046, and
none by `forward-port[bot]` — despite the push at `forward-port.yml:198`
supplying an inline App-token URL.

`actions/checkout` persists an Actions-token credential as
`http.https://github.com/.extraheader` (`persist-credentials` defaults to
`true`). git sends that `Authorization` header on every push to `github.com`,
and it takes precedence over the inline URL credential — so the push
authenticates as the Actions token no matter what URL it is given.

The resulting `synchronize` run is attributed to `github-actions[bot]` and held
at `action_required`, stalling the armed auto-merge. `gh pr create` uses
`GH_TOKEN` correctly, so the `opened` run is App-attributed and proceeds. That
split is why only ports which force-push an *existing* PR stall, and why the
failure reads as intermittent rather than deterministic.

## What this changes

Clears the persisted header immediately before the push. Deliberately scoped to
the push step rather than setting `persist-credentials: false` on the checkout,
so the merge step keeps authenticated access for its
`git fetch origin "$RELEASE_REF"`. Nothing after the push needs git credentials
— `gh` uses `GH_TOKEN`.

Also corrects the merge step's comment, which asserted that the merge commit's
identity is "the actor of the pull request event". That premise — which #1646's
fix was built on — is false, and was measured so: held and unheld runs had head
commits with identical `forward-port[bot]` author *and* committer.

```
8c605adde62b  success          author=forward-port[bot]  committer=forward-port[bot]
e7d9fade8a4c  success          author=forward-port[bot]  committer=forward-port[bot]
a534d92202d6  action_required  author=forward-port[bot]  committer=forward-port[bot]
a27981d08073  action_required  author=forward-port[bot]  committer=forward-port[bot]
```

## Also ruled out

- **A fork-contributor policy.** All four forward-port PRs report
  `isCrossRepository: false` — same-repo branch PRs, not fork PRs. The
  repository's `first_time_contributors` setting is correct for a public repo
  and is not the defect.
- **Merge-commit identity**, per the table above.

## Verification

The fix cannot be proven before merge: this workflow only runs on `push` to
`release/**`, so its behaviour is observable only once it is on the release
branch. After merge, the next push to `release/v0.13` should produce a
`head_ref_force_pushed` event with `actor=forward-port[bot]` and a CI run that
is not held.

Targets `release/v0.13` rather than `main` because `guard-release-mechanics`
rejects release-mechanics path edits aimed at main; this reaches main via the
forward-port it repairs. The first port carrying it may still need one manual
approval, since the broken behaviour is what ports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)