### PR TITLE
`forge shape --apply` rewrites a gate-passing bug body into one the shape gate refuses

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -469,6 +469,14 @@ contract is promised yet.
 written. **Epic** classifications may propose child stories in prose; no
 child issues are created.
 
+**The body restructure is strictly additive.** It only appends what the shape
+gate reports missing — an absent `## Observed` / `## Expected` section, or the
+specific `## Diagnosis` components the gate names — inserting missing diagnosis
+components into the existing `## Diagnosis` section. Existing headings are never
+re-levelled, rewritten, or demoted into quoted prose. A bug body that already
+passes the shape gate produces no diff, and `forge shape <issue>` exits 0 when
+neither the body nor the labels need changing.
+
 Every invocation writes a row into the audit substrate's `shape_events`
 table (issue number, input source, classification, confidence, ambiguity
 question count, whether `--apply` mutated the issue).

--- a/src/theforge/intake/shape_classify.py
+++ b/src/theforge/intake/shape_classify.py
@@ -286,6 +286,12 @@ def classify(title: str, body: str, labels: list[str]) -> ShapeProposal:
     else:
         proposed_labels = ()
 
+    # Only propose label edits that are actual deltas: a proposal that restates
+    # a label the issue already carries reads as a change the operator must
+    # apply, and makes `forge shape` exit non-zero on an issue that already
+    # satisfies the shape it is being checked against (#2053).
+    proposed_labels = tuple(label for label in proposed_labels if label.lower() not in label_set)
+
     return ShapeProposal(
         classification=primary,
         confidence=confidence,

--- a/src/theforge/intake/shape_render.py
+++ b/src/theforge/intake/shape_render.py
@@ -1,6 +1,8 @@
 """Render shape proposals as operator-facing text + body restructure.
 
-Pure text-shaping helpers, stdlib only. No I/O.
+Pure text-shaping helpers, no I/O. Stdlib plus the ``shape_check`` parsers and
+the declarative diagnosis spec — the restructure must aim at exactly the shape
+the gate enforces, so it reads that contract rather than restating it (#2053).
 """
 
 from __future__ import annotations
@@ -13,16 +15,38 @@ from theforge.intake.shape_classify import (
     DiagnosisState,
     ShapeProposal,
 )
+from theforge.shape_check.diagnosis_spec import (
+    DIAGNOSIS_HEADING,
+    REQUIRED_DIAGNOSIS_COMPONENTS,
+)
+from theforge.shape_check.heuristics import (
+    DIAGNOSIS_HEADING_PATTERN,
+    diagnosis_completeness,
+)
+from theforge.shape_check.parsing import has_heading, section_span
+
+# Heading patterns for the two narrative sections a bug body carries alongside
+# its Diagnosis. Matched heading-level-agnostically through the same parser the
+# gate uses, so a conformant ``## Observed behavior`` is recognised as present
+# (#2053: a private substring probe for a hard-coded heading level is exactly
+# the producer/validator drift ``diagnosis_spec`` exists to eliminate).
+_OBSERVED_HEADING_PATTERN = r"\bobserved\b|what happened"
+_EXPECTED_HEADING_PATTERN = r"\bexpected\b"
+
+# The gate's own acceptance-criteria heading vocabulary (parsing.extract_ac_section).
+_AC_HEADING_PATTERN = r"acceptance criteria|done criteria|checklist"
 
 
 def restructure_body(proposal: ShapeProposal, current_body: str) -> str:
     """Return the proposed restructured body for the issue, or ``current_body``
     unchanged when no restructure is proposed.
 
-    The restructure is intentionally minimal — it adds the scaffolding the
-    downstream producers (diagnose/groom) expect to see, and never deletes
-    existing operator text. The original body is appended under a quoted
-    ``Original`` block so nothing is silently lost.
+    The restructure is strictly additive: it appends the scaffolding the shape
+    gate and the downstream producers (diagnose/groom) require and nothing else.
+    Existing operator structure is never rewritten, re-levelled, or demoted into
+    quoted prose — a remediation offered toward a gate must be a no-op on input
+    that gate already accepts, and additive on input that is partially
+    conformant (#2053).
     """
     current_body = current_body or ""
     if proposal.classification is Classification.BUG:
@@ -34,46 +58,86 @@ def restructure_body(proposal: ShapeProposal, current_body: str) -> str:
     return current_body
 
 
-def _has_section(body: str, marker: str) -> bool:
-    return marker.lower() in body.lower()
-
-
 def _restructure_bug(proposal: ShapeProposal, current_body: str) -> str:
-    parts: list[str] = []
-    if not _has_section(current_body, "## Observed"):
-        parts.append("## Observed\n\n<fill from current body>\n")
-    if not _has_section(current_body, "## Expected"):
-        parts.append("## Expected\n\n<state the category-level rule that should hold here>\n")
-    if not _has_section(current_body, "### Diagnosis"):
-        state = proposal.diagnosis_state or DiagnosisState.NO_DIAGNOSIS
-        if state is DiagnosisState.NO_DIAGNOSIS:
-            line = "Status: no diagnosis yet. Next step: run `forge diagnose`."
-        elif state is DiagnosisState.DIAGNOSIS_CAUSE_UNKNOWN:
-            line = (
-                "Status: investigation in progress; cause unknown. Next step: continue diagnosis."
-            )
+    body = current_body
+    appended: list[str] = []
+    if not has_heading(body, _OBSERVED_HEADING_PATTERN):
+        appended.append("## Observed\n\n<fill from current body>\n")
+    if not has_heading(body, _EXPECTED_HEADING_PATTERN):
+        appended.append("## Expected\n\n<state the category-level rule that should hold here>\n")
+
+    # The gate is the authority on what a complete Diagnosis section is, so ask
+    # it directly instead of probing for a heading string of our own choosing.
+    complete, missing = diagnosis_completeness(body)
+    if not complete:
+        if has_heading(body, DIAGNOSIS_HEADING_PATTERN):
+            # Section exists but is incomplete: add only the missing components,
+            # in place, leaving every original heading at its original level.
+            body = _fill_diagnosis_gaps(body, missing)
         else:
-            line = "Status: confirmed cause documented."
-        parts.append(f"### Diagnosis\n\n{line}\n")
-    if not parts:
-        return current_body
-    rendered = "\n".join(parts).rstrip() + "\n"
-    if current_body.strip():
-        rendered += "\n## Original\n\n" + _quote_block(current_body) + "\n"
-    return rendered
+            appended.append(_diagnosis_section(proposal))
+
+    if not appended:
+        return body
+    return _append_sections(body, appended)
+
+
+def _diagnosis_status_line(proposal: ShapeProposal) -> str:
+    state = proposal.diagnosis_state or DiagnosisState.NO_DIAGNOSIS
+    if state is DiagnosisState.NO_DIAGNOSIS:
+        return "Status: no diagnosis yet. Next step: run `forge diagnose`."
+    if state is DiagnosisState.DIAGNOSIS_CAUSE_UNKNOWN:
+        return "Status: investigation in progress; cause unknown. Next step: continue diagnosis."
+    return "Status: confirmed cause documented."
+
+
+def _diagnosis_bullets(missing_tokens: list[str]) -> list[str]:
+    """Placeholder bullets for the components the gate reports missing.
+
+    Labels come from :mod:`theforge.shape_check.diagnosis_spec` so the scaffold
+    names exactly the components the validator scans for.
+    """
+    tokens = {token.lower() for token in missing_tokens}
+    return [
+        f"- **{component.label}:** <fill in>"
+        for component in REQUIRED_DIAGNOSIS_COMPONENTS
+        if component.token in tokens
+    ]
+
+
+def _diagnosis_section(proposal: ShapeProposal) -> str:
+    """A whole ``## Diagnosis`` scaffold, at the heading level the gate requires."""
+    lines = [DIAGNOSIS_HEADING, "", _diagnosis_status_line(proposal), ""]
+    lines.extend(_diagnosis_bullets([c.token for c in REQUIRED_DIAGNOSIS_COMPONENTS]))
+    return "\n".join(lines) + "\n"
+
+
+def _fill_diagnosis_gaps(body: str, missing_tokens: list[str]) -> str:
+    """Append the missing component bullets to the end of the Diagnosis section."""
+    span = section_span(body, DIAGNOSIS_HEADING_PATTERN)
+    bullets = _diagnosis_bullets(missing_tokens)
+    if span is None or not bullets:
+        return body
+    head = body[: span[1]].rstrip("\n")
+    tail = body[span[1] :].lstrip("\n")
+    block = "\n".join(bullets)
+    if tail:
+        return f"{head}\n{block}\n\n{tail}"
+    return f"{head}\n{block}\n"
+
+
+def _append_sections(body: str, parts: list[str]) -> str:
+    block = "\n".join(parts).rstrip("\n") + "\n"
+    if not body.strip():
+        return block
+    return body.rstrip("\n") + "\n\n" + block
 
 
 def _restructure_enhancement(current_body: str) -> str:
-    if _has_section(current_body, "## Acceptance criteria") or _has_section(
-        current_body, "## Acceptance Criteria"
-    ):
+    if has_heading(current_body, _AC_HEADING_PATTERN):
         return current_body
     suffix = "\n\n## Acceptance criteria\n\n- <state an observable, testable outcome>\n"
     return (current_body.rstrip() + suffix) if current_body.strip() else suffix.lstrip("\n")
-
-
-def _quote_block(text: str) -> str:
-    return "\n".join(f"> {line}" if line else ">" for line in text.splitlines())
 
 
 def render_proposal(

--- a/src/theforge/shape_check/parsing.py
+++ b/src/theforge/shape_check/parsing.py
@@ -48,8 +48,14 @@ def has_heading(body: str, pattern: str) -> bool:
     return find_heading(body, pattern) is not None
 
 
-def extract_section(body: str, heading_pattern: str) -> str | None:
-    """Return text from a matching heading up to the next heading of same-or-higher level."""
+def section_span(body: str, heading_pattern: str) -> tuple[int, int] | None:
+    """Return ``(start, end)`` offsets of a matching heading's section content.
+
+    ``start`` is the offset just past the end of the heading line; ``end`` is the
+    offset of the next heading of same-or-higher level, or ``len(body)``.
+    Returns ``None`` when no heading matches. Producers that need to insert text
+    into an existing section use this rather than re-deriving heading arithmetic.
+    """
     m = find_heading(body, heading_pattern)
     if not m:
         return None
@@ -57,14 +63,18 @@ def extract_section(body: str, heading_pattern: str) -> str | None:
     start = m.end()
     remainder = body[start:]
     # find next heading of level <= current
-    next_heading = None
     for nm in _HEADING_RE.finditer(remainder):
         if len(nm.group(1)) <= level:
-            next_heading = nm
-            break
-    if next_heading:
-        return remainder[: next_heading.start()]
-    return remainder
+            return start, start + nm.start()
+    return start, len(body)
+
+
+def extract_section(body: str, heading_pattern: str) -> str | None:
+    """Return text from a matching heading up to the next heading of same-or-higher level."""
+    span = section_span(body, heading_pattern)
+    if span is None:
+        return None
+    return body[span[0] : span[1]]
 
 
 def extract_ac_section(body: str) -> str | None:

--- a/tests/test_cli_shape.py
+++ b/tests/test_cli_shape.py
@@ -162,6 +162,38 @@ def test_shape_issue_calls_gh_and_applies(mock_run, tmp_path, capsys):
     assert row == ("issue", "bug", 1, "no-diagnosis")
 
 
+@patch("theforge.cli.shape.subprocess.run")
+def test_shape_exits_zero_on_gate_passing_bug(mock_run, tmp_path, capsys):
+    """A bug issue the shape gate already accepts needs no shaping (#2053)."""
+    body = (
+        "## Observed behavior\n\n"
+        "`forge shape --apply` rewrote a passing body into a failing one.\n\n"
+        "## Expected behavior\n\n"
+        "A remediation is a no-op on input that already passes.\n\n"
+        "## Diagnosis\n\n"
+        "- **Observed symptom:** the applied body no longer passes the gate.\n"
+        "- **Evidence:** issue #2050 at baseline `f2caf7d`.\n"
+        "- **Confirmed cause:** the renderer probed for an H3 heading.\n"
+        "- **Affected code path:** `intake.shape_render._restructure_bug`.\n"
+        "- **Fix-success criterion:** the body is returned unchanged.\n"
+    )
+    mock_run.return_value = _proc(
+        stdout=json.dumps(
+            {
+                "title": "forge shape --apply rewrites a passing bug body",
+                "body": body,
+                "labels": [{"name": "bug"}],
+            }
+        )
+    )
+    args = _make_args(tmp_path, issue=2053)
+    rc = cmd_shape(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Proposed body restructure:" not in out
+    assert "Add labels:" not in out
+
+
 def test_shape_no_input_errors(tmp_path, capsys):
     args = _make_args(tmp_path)
     rc = cmd_shape(args)

--- a/tests/test_intake/test_shape_render.py
+++ b/tests/test_intake/test_shape_render.py
@@ -14,6 +14,7 @@ from theforge.intake.shape_render import (
     render_proposal,
     restructure_body,
 )
+from theforge.shape_check.heuristics import diagnosis_completeness
 
 
 def _bug_proposal(state: DiagnosisState = DiagnosisState.NO_DIAGNOSIS) -> ShapeProposal:
@@ -27,12 +28,76 @@ def _bug_proposal(state: DiagnosisState = DiagnosisState.NO_DIAGNOSIS) -> ShapeP
     )
 
 
+def _complete_bug_body() -> str:
+    """A bug body the shape gate already accepts (diagnosis_completeness True)."""
+    return (
+        "## Observed behavior\n\n"
+        "`forge shape --apply` rewrites a passing body into a failing one.\n\n"
+        "## Expected behavior\n\n"
+        "A remediation must be a no-op on input that already passes.\n\n"
+        "## Diagnosis\n\n"
+        "- **Observed symptom:** the applied body no longer passes the gate.\n"
+        "- **Evidence:** issue #2050 at baseline `f2caf7d`.\n"
+        "- **Confirmed cause:** the renderer probed for an H3 heading.\n"
+        "- **Affected code path:** `intake.shape_render._restructure_bug`.\n"
+        "- **Fix-success criterion:** the body is returned unchanged.\n\n"
+        "## Notes\n\n"
+        "Found while auditing intake.\n"
+    )
+
+
 def test_restructure_bug_adds_observed_expected_diagnosis():
     new = restructure_body(_bug_proposal(), "original body")
     assert "## Observed" in new
     assert "## Expected" in new
-    assert "### Diagnosis" in new
-    assert "original body" in new  # original preserved in quote block
+    assert "## Diagnosis" in new
+    assert "### Diagnosis" not in new  # gate requires H2, not H3
+    assert "## Original" not in new  # original is never demoted into a quote block
+    assert new.startswith("original body")  # original preserved verbatim, in place
+
+
+def test_restructure_bug_is_noop_on_gate_passing_body():
+    body = _complete_bug_body()
+    assert diagnosis_completeness(body) == (True, [])
+    assert restructure_body(_bug_proposal(DiagnosisState.DIAGNOSIS_CONFIRMED_CAUSE), body) == body
+
+
+def test_restructure_bug_adds_only_missing_component_in_place():
+    body = _complete_bug_body().replace("- **Evidence:** issue #2050 at baseline `f2caf7d`.\n", "")
+    assert diagnosis_completeness(body) == (False, ["evidence"])
+
+    new = restructure_body(_bug_proposal(DiagnosisState.DIAGNOSIS_CONFIRMED_CAUSE), body)
+
+    # Every original heading survives at its original level.
+    for heading in (
+        "## Observed behavior",
+        "## Expected behavior",
+        "## Diagnosis",
+        "## Notes",
+    ):
+        assert heading in new
+    # The only delta is the added component bullet.
+    added = [line for line in new.splitlines() if line not in body.splitlines()]
+    assert added == ["- **Evidence:** <fill in>"]
+    # ...and the addition lands inside the Diagnosis section, so the gate sees it.
+    assert diagnosis_completeness(new) == (True, [])
+
+
+def test_restructure_bug_appends_diagnosis_when_section_absent():
+    body = "## Observed behavior\n\nthing broke\n\n## Expected behavior\n\nit should not\n"
+    new = restructure_body(_bug_proposal(), body)
+    assert new.startswith(body.rstrip("\n"))
+    assert "## Diagnosis" in new
+    assert diagnosis_completeness(new) == (True, [])
+
+
+def test_restructure_bug_keeps_h3_observed_heading():
+    """A heading at a non-H2 level still counts as present — no duplicate stub."""
+    body = "### Observed\n\nx\n\n### Expected\n\ny\n"
+    new = restructure_body(_bug_proposal(), body)
+    assert new.startswith(body.rstrip("\n"))
+    assert "<fill from current body>" not in new
+    assert "<state the category-level rule" not in new
 
 
 def test_restructure_bug_with_confirmed_cause_says_so():


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the additive/no-op shape contract, with targeted renderer and CLI tests passing. | [google-gemini-3.5-flash] Approved: The implementation successfully makes forge shape's bug restructure additive and gate-aligned, resolving the issue where a gate-passing body was rewritten into a failing one.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $4.77
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

`forge shape --apply` rewrites a gate-passing bug body into one the shape gate refuses (GitHub Issue #2053)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2053