### PR TITLE
A completed `forge diagnose` investigation is discarded entirely on a YAML syntax slip — no retry, and the output is not recoverable

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -502,6 +502,26 @@ forge diagnose --issue <issue> --interactive
 [Mid-sprint workflow](authoring.md#mid-sprint-workflow) for the full
 `capture → shape → diagnose → groom → ready` sequence.
 
+**Recovering a run that failed at PARSE.** A completed investigation is the
+expensive part of a diagnose run, so a syntax error in the YAML it emits does not
+discard it:
+
+- The agent's **complete** output is written to
+  `.forge/audits/diagnose-issue-<N>-<run-id>.raw.txt` before the first parse
+  attempt, on both the success and the failure path. The audit YAML's
+  `agent.raw_output_tail` is a bounded preview; `agent.raw_output_path`,
+  `agent.raw_output_paths`, `agent.raw_output_chars`, and
+  `agent.raw_output_sha256` point at the full copy on disk.
+- Unparseable output triggers up to `retry.max_diagnose_parse_retries`
+  (default 2) **reformat-only** retries: the agent gets its own output back plus
+  the parser error and is asked to re-serialize the same diagnosis — it does not
+  re-investigate. Each attempt writes its own
+  `…-<run-id>.raw.retry<N>.txt` sidecar and one `agent.parse_retries[]` audit
+  entry with the parse error, cost, duration, and outcome.
+- If the retries are exhausted the run still fails, but the diagnosis is
+  readable from the sidecar and can be applied by hand with `gh issue edit`
+  rather than paying for a second investigation.
+
 ---
 
 ## `forge groom`

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -512,6 +512,13 @@ discard it:
   `agent.raw_output_tail` is a bounded preview; `agent.raw_output_path`,
   `agent.raw_output_paths`, `agent.raw_output_chars`, and
   `agent.raw_output_sha256` point at the full copy on disk.
+- Persistence is guaranteed rather than best-effort. If the audit sidecar cannot
+  be written, the output goes to `.forge/logs/diagnose-<N>/run-<run-id>.raw.txt`;
+  if that also fails, the audit record carries the complete output inline as
+  `agent.raw_output`, and `agent.raw_output_error` names every location that
+  refused it. Read `agent.raw_output_path` first — an empty value means the
+  content is inline. There is no path on which a run consumes a paid-for
+  investigation and leaves only the truncated tail.
 - Unparseable output triggers up to `retry.max_diagnose_parse_retries`
   (default 2) **reformat-only** retries: the agent gets its own output back plus
   the parser error and is asked to re-serialize the same diagnosis — it does not

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -333,6 +333,10 @@ retry:
                              # (gate failure, hard convention violation) also
                              # spends one, once the dev attempts above are gone.
   max_review_parse_retries: 2  # reviewer output parse/schema error retries
+  max_diagnose_parse_retries: 2 # `forge diagnose` reformat-only retries when the
+                             # investigative agent finishes but emits unparseable
+                             # YAML. The retry re-serializes the completed
+                             # investigation; it does NOT re-investigate. 0 disables.
   max_plan_regen_attempts: 3 # plan review reject → regeneration cycles
 
 # ── Classic manual profiles (advanced alternative) ─────────

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -943,6 +943,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         max_plan_transport_retries=int(retry_data.get("max_plan_transport_retries", 2)),
         max_review_cycles=int(retry_data.get("max_review_cycles", 2)),
         max_review_parse_retries=int(retry_data.get("max_review_parse_retries", 2)),
+        max_diagnose_parse_retries=int(retry_data.get("max_diagnose_parse_retries", 2)),
         max_plan_review_transport_retries=int(
             retry_data.get("max_plan_review_transport_retries", 2)
         ),

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -435,6 +435,10 @@ class RetryPolicy:
     )
     max_review_cycles: int = 2  # full dev->review loops
     max_review_parse_retries: int = 2  # reviewer retries on parse/schema error per cycle
+    max_diagnose_parse_retries: int = (
+        2  # reformat-only retries when the diagnose agent completes its
+        # investigation but emits unparseable YAML; 0 disables
+    )
     max_plan_review_transport_retries: int = (
         2  # per-reviewer retries on transient plan-review transport/provider failure
     )

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -473,33 +473,57 @@ def diagnose_raw_output_path(
     return _audit_dir(project_root) / f"{stem}{suffix}"
 
 
+def diagnose_fallback_output_path(
+    project_root: Path, state: DiagnoseState, *, attempt: int = 0
+) -> Path:
+    """Return the second durable location for a run's complete agent output.
+
+    Used when the audit sidecar cannot be written. Lives in the run's own log
+    directory — already created and written to by this flow, and the place
+    ``forge logs`` points an operator at — so a failure isolated to
+    ``.forge/audits`` does not cost the recoverability guarantee.
+    """
+    slug = state.run_slug or f"diagnose-{state.issue_number}"
+    suffix = ".raw.txt" if attempt <= 0 else f".raw.retry{attempt}.txt"
+    return project_root / ".forge" / "logs" / slug / f"run-{state.run_id}{suffix}"
+
+
 def _write_output_sidecar(
     state: DiagnoseState, project_root: Path, text: str, attempt: int
 ) -> tuple[Path | None, str]:
-    """Write one agent emission to its numbered sidecar. Returns ``(path, error)``.
+    """Write one agent emission durably. Returns ``(path, error)``.
 
-    Records the path on ``state.raw_output_paths`` so every emission this run paid
-    for is enumerable from the audit, whether or not it parsed.
+    Tries the canonical audit sidecar, then the run-log fallback. ``error`` is
+    empty exactly when the text reached disk, and names every location that
+    refused it otherwise — a caller must not report a file that is not there.
+
+    Records the written path on ``state.raw_output_paths`` so every emission this
+    run paid for is enumerable from the audit, whether or not it parsed.
     """
     if not text:
         return None, ""
-    path = diagnose_raw_output_path(
-        project_root, state.issue_number, state.run_id, attempt=attempt
+    candidates = (
+        diagnose_raw_output_path(project_root, state.issue_number, state.run_id, attempt=attempt),
+        diagnose_fallback_output_path(project_root, state, attempt=attempt),
     )
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text, encoding="utf-8")
-    except OSError as exc:
-        return None, f"failed to persist agent output to {path}: {exc}"
-    if str(path) not in state.raw_output_paths:
-        state.raw_output_paths.append(str(path))
-    return path, ""
+    errors: list[str] = []
+    for path in candidates:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{path}: {exc}")
+            continue
+        if str(path) not in state.raw_output_paths:
+            state.raw_output_paths.append(str(path))
+        return path, ""
+    return None, "failed to persist agent output (" + "; ".join(errors) + ")"
 
 
 def persist_agent_output(
     state: DiagnoseState, project_root: Path, *, attempt: int = 0, emit=None
 ) -> Path | None:
-    """Write the agent's full output to its sidecar; record provenance on ``state``.
+    """Persist the agent's full output durably; record provenance on ``state``.
 
     The audit's ``raw_output_tail`` is bounded at 2000 characters — enough to
     glance at, not enough to recover from. A run that spent budget and produced
@@ -507,26 +531,46 @@ def persist_agent_output(
     distinguish an agent defect from a parser defect, and a substantively complete
     diagnosis dies with the process (#2055).
 
-    ``state.raw_output_*`` always describes whatever ``state.agent_output``
-    currently holds, so the recorded digest matches the recorded path.
+    Persistence is guaranteed rather than best-effort, by escalating through three
+    locations until one accepts the content:
 
-    Best-effort — an unwritable sidecar never fails the run, but the error is
-    recorded on ``state`` so the audit does not claim a file that is not there.
-    Returns the path written, or None.
+    1. the audit sidecar (``.forge/audits/diagnose-issue-N-<run>.raw.txt``),
+    2. the run-log fallback (``.forge/logs/<slug>/run-<run>.raw.txt``),
+    3. inline in the audit record itself, as ``agent.raw_output``.
+
+    Tier 3 cannot silently lose the output: it is written by the same
+    ``write_diagnose_audit`` call the operator reads the failure from, and if even
+    that write fails the exception propagates out of the flow rather than being
+    swallowed. So an operator either has the complete output or has a loud error —
+    never a run that quietly consumed a paid-for investigation.
+
+    ``state.raw_output_chars``/``_sha256`` describe whatever ``state.agent_output``
+    currently holds regardless of which tier stored it, so the recorded digest
+    always matches the recorded content.
+
+    Returns the file path written, or None when the content is carried inline.
     """
     if not state.agent_output:
         return None
+    state.raw_output_chars = len(state.agent_output)
+    state.raw_output_sha256 = hashlib.sha256(state.agent_output.encode("utf-8")).hexdigest()
     path, error = _write_output_sidecar(state, project_root, state.agent_output, attempt)
     if path is None:
+        # Every file location refused the write. Carry the complete output in the
+        # audit record instead of degrading to the bounded tail — an audit that
+        # omits what the agent actually said is the failure mode #2055 is about.
         state.raw_output_path = ""
         state.raw_output_error = error
-        if emit is not None and error:
-            emit(f"  [diagnose] WARNING: {error}")
+        state.raw_output_inline = state.agent_output
+        if emit is not None:
+            emit(
+                f"  [diagnose] WARNING: {error} — carrying the full output inline "
+                "in the run audit (agent.raw_output) instead"
+            )
         return None
     state.raw_output_error = ""
     state.raw_output_path = str(path)
-    state.raw_output_chars = len(state.agent_output)
-    state.raw_output_sha256 = hashlib.sha256(state.agent_output.encode("utf-8")).hexdigest()
+    state.raw_output_inline = ""
     if emit is not None:
         emit(f"  [diagnose] full agent output persisted ({state.raw_output_chars} chars): {path}")
     return path
@@ -566,6 +610,9 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
             "raw_output_chars": state.raw_output_chars,
             "raw_output_sha256": state.raw_output_sha256,
             "raw_output_error": state.raw_output_error,
+            # Tier-3 carrier: non-empty only when no file location accepted the
+            # write, so the complete output is still recoverable from this record.
+            "raw_output": state.raw_output_inline,
             "parse_retries": [dict(entry) for entry in state.parse_retries],
         },
         "landing": {
@@ -929,6 +976,11 @@ def _retry_diagnose_parse(
             retry_output, issue_number=issue_number, partial=partial
         )
         if candidate.artifact is not None:
+            # When the prior emission survives only inline (no file location took
+            # it), carry it in this attempt's record before it is replaced — the
+            # invariant is that a retry never destroys an earlier emission.
+            if state.raw_output_inline:
+                record["previous_output"] = state.raw_output_inline
             state.agent_output = retry_output
             record["success"] = True
             path = persist_agent_output(state, project_root, attempt=attempt, emit=emit)
@@ -948,7 +1000,11 @@ def _retry_diagnose_parse(
         )
         record["output_path"] = str(failed_path) if failed_path is not None else ""
         if failed_error:
+            # Same escalation as the investigation's own output: if no file
+            # location took it, the attempt record carries it in full rather than
+            # leaving only the bounded tail.
             record["output_path_error"] = failed_error
+            record["output"] = retry_output
         state.parse_retries.append(record)
         parsed = candidate
     return parsed
@@ -1270,7 +1326,12 @@ def _run_diagnose_flow_body(
     artifact = parsed.artifact
     if artifact is None:
         attempts = len(state.parse_retries)
-        where = state.raw_output_path or "<not persisted>"
+        if state.raw_output_path:
+            where = state.raw_output_path
+        elif state.raw_output_inline:
+            where = "inline in this run's audit record, field agent.raw_output"
+        else:
+            where = "<no output to persist>"
         state.error = (
             f"PARSE failed: investigative agent did not emit a parseable YAML block "
             f"({parsed.error}) and {attempts} reformat retry attempt(s) did not "

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -48,7 +48,12 @@ from theforge.diagnose_types import (
     render_artifact_markdown,
     upsert_diagnosis_section,
 )
-from theforge.task.diagnose_prompts import build_diagnose_prompt, parse_diagnose_output
+from theforge.task.diagnose_prompts import (
+    DiagnoseParseOutcome,
+    build_diagnose_prompt,
+    build_diagnose_reformat_prompt,
+    parse_diagnose_output_result,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -451,6 +456,82 @@ def _audit_dir(project_root: Path) -> Path:
     return project_root / ".forge" / "audits"
 
 
+def diagnose_raw_output_path(
+    project_root: Path, issue_number: int, run_id: str, *, attempt: int = 0
+) -> Path:
+    """Return the deterministic sidecar path for a run's complete agent output.
+
+    Sits beside the run's audit YAML under ``.forge/audits`` and shares its
+    ``diagnose-issue-{N}-{run_id}`` stem, so an operator holding an audit file can
+    find the raw output without a search. ``attempt`` 0 is the investigation's own
+    output; a reformat parse retry writes to its own numbered sidecar rather than
+    overwriting attempt 0, because the original emission is the evidence that
+    distinguishes an agent serialization defect from a parser defect.
+    """
+    stem = f"diagnose-issue-{issue_number}-{run_id}"
+    suffix = ".raw.txt" if attempt <= 0 else f".raw.retry{attempt}.txt"
+    return _audit_dir(project_root) / f"{stem}{suffix}"
+
+
+def _write_output_sidecar(
+    state: DiagnoseState, project_root: Path, text: str, attempt: int
+) -> tuple[Path | None, str]:
+    """Write one agent emission to its numbered sidecar. Returns ``(path, error)``.
+
+    Records the path on ``state.raw_output_paths`` so every emission this run paid
+    for is enumerable from the audit, whether or not it parsed.
+    """
+    if not text:
+        return None, ""
+    path = diagnose_raw_output_path(
+        project_root, state.issue_number, state.run_id, attempt=attempt
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    except OSError as exc:
+        return None, f"failed to persist agent output to {path}: {exc}"
+    if str(path) not in state.raw_output_paths:
+        state.raw_output_paths.append(str(path))
+    return path, ""
+
+
+def persist_agent_output(
+    state: DiagnoseState, project_root: Path, *, attempt: int = 0, emit=None
+) -> Path | None:
+    """Write the agent's full output to its sidecar; record provenance on ``state``.
+
+    The audit's ``raw_output_tail`` is bounded at 2000 characters — enough to
+    glance at, not enough to recover from. A run that spent budget and produced
+    content must persist that content in full: without it a failure record cannot
+    distinguish an agent defect from a parser defect, and a substantively complete
+    diagnosis dies with the process (#2055).
+
+    ``state.raw_output_*`` always describes whatever ``state.agent_output``
+    currently holds, so the recorded digest matches the recorded path.
+
+    Best-effort — an unwritable sidecar never fails the run, but the error is
+    recorded on ``state`` so the audit does not claim a file that is not there.
+    Returns the path written, or None.
+    """
+    if not state.agent_output:
+        return None
+    path, error = _write_output_sidecar(state, project_root, state.agent_output, attempt)
+    if path is None:
+        state.raw_output_path = ""
+        state.raw_output_error = error
+        if emit is not None and error:
+            emit(f"  [diagnose] WARNING: {error}")
+        return None
+    state.raw_output_error = ""
+    state.raw_output_path = str(path)
+    state.raw_output_chars = len(state.agent_output)
+    state.raw_output_sha256 = hashlib.sha256(state.agent_output.encode("utf-8")).hexdigest()
+    if emit is not None:
+        emit(f"  [diagnose] full agent output persisted ({state.raw_output_chars} chars): {path}")
+    return path
+
+
 def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
     """Write the audit YAML for a diagnose run.
 
@@ -478,6 +559,14 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
             "duration_s": round(state.agent_duration_s, 3),
             "failure_code": state.agent_failure_code,
             "raw_output_tail": state.agent_output[-2000:] if state.agent_output else "",
+            # Full-output recoverability (#2055): the tail above is for a quick
+            # glance; these fields point at the complete output on disk.
+            "raw_output_path": state.raw_output_path,
+            "raw_output_paths": list(state.raw_output_paths),
+            "raw_output_chars": state.raw_output_chars,
+            "raw_output_sha256": state.raw_output_sha256,
+            "raw_output_error": state.raw_output_error,
+            "parse_retries": [dict(entry) for entry in state.parse_retries],
         },
         "landing": {
             "destination": state.landing_destination,
@@ -712,6 +801,157 @@ def _land_artifact(
     )
     out_path.write_text(full, encoding="utf-8")
     return str(out_path)
+
+
+# ── Parse retry ───────────────────────────────────────────────────────
+# A completed investigation is the expensive part of a diagnose run; a YAML
+# syntax slip in its serialization is the cheap part. Before #2055 the cheap
+# failure destroyed the expensive result: one unterminated quoted scalar in an
+# optional field discarded a confirmed cause, its hypotheses and its evidence,
+# with no retry and only a 2000-character tail retained. This is the review
+# path's per-reviewer parse retry (review_pool._build_review_retry_prompt) applied
+# to the one flow that has no pool to fall back on.
+
+
+def _accumulate_retry_cost(state: DiagnoseState, cost: float | None) -> None:
+    """Fold one retry's cost into the run total without faking a measurement.
+
+    An unmeasured retry (``None``) makes the run's *total* unknown: leaving the
+    pre-retry number in place would record the retry's real spend as free. Once
+    unknown, the total stays unknown — a later measured retry cannot recover the
+    missing one.
+    """
+    if cost is None:
+        state.agent_cost_usd = None
+        return
+    if state.agent_cost_usd is None:
+        return
+    state.agent_cost_usd += cost
+
+
+def _retry_diagnose_parse(
+    *,
+    state: DiagnoseState,
+    initial: DiagnoseParseOutcome,
+    issue_number: int,
+    partial: bool,
+    config: ForgeConfig,
+    project_root: Path,
+    profile: ModelProfile,
+    emit: "callable",
+) -> DiagnoseParseOutcome:
+    """Ask the agent to re-serialize its completed investigation, bounded by config.
+
+    Runs at most ``config.retry.max_diagnose_parse_retries`` reformat-only
+    invocations against the same profile and runner path as the investigation.
+    The investigation itself is NOT re-run: each attempt hands the agent back its
+    own verbatim output plus the parser's error and asks for serialization repair.
+
+    Parsing stays strict on every attempt, and ``state.agent_output`` is replaced
+    only by a retry output that actually parses — a failed repair must not
+    overwrite the original investigation an operator may still want to salvage.
+    Every attempt is appended to ``state.parse_retries`` so the audit shows what
+    was retried, what it cost, and whether it worked.
+
+    Returns the first parsing outcome, or the last failure when the budget is
+    exhausted (``max_diagnose_parse_retries: 0`` returns ``initial`` untouched).
+
+    Two cases return ``initial`` without spending anything, because there is no
+    completed investigation to re-serialize: an agent that emitted nothing at all
+    (the timeout/kill shape — the content floor downstream reports that as
+    "produced no diagnosis"), and a run that has already breached its budget
+    envelope, where more spend is exactly what the envelope forbids.
+    """
+    if not state.agent_output.strip():
+        emit(
+            "  [diagnose] agent emitted no output — no serialization to repair, "
+            "skipping reformat retry"
+        )
+        return initial
+    if (
+        state.agent_cost_usd is not None
+        and state.agent_cost_usd > config.diagnose.budget_usd * 1.05
+    ):
+        emit(
+            f"  [diagnose] budget ${config.diagnose.budget_usd} already exceeded — "
+            "skipping reformat retry"
+        )
+        return initial
+    max_retries = max(0, int(config.retry.max_diagnose_parse_retries))
+    parsed = initial
+    for attempt in range(1, max_retries + 1):
+        emit(
+            f"  ↻ [diagnose] agent output failed YAML parse — reformat retry "
+            f"{attempt}/{max_retries}: {parsed.error[:160]}"
+        )
+        record: dict = {
+            "attempt": attempt,
+            "parse_error": parsed.error,
+            "cost_usd": None,
+            "duration_s": 0.0,
+            "success": False,
+        }
+        prompt = build_diagnose_reformat_prompt(
+            original_output=state.agent_output, parse_error=parsed.error
+        )
+        t0 = time.monotonic()
+        try:
+            retry_result = _run_agent_with_heartbeat(
+                prompt=prompt,
+                profile=profile,
+                working_dir=project_root,
+                secrets=config.secrets,
+                on_heartbeat=emit,
+            )
+        except Exception as exc:
+            duration = time.monotonic() - t0
+            state.agent_duration_s += duration
+            record["duration_s"] = round(duration, 3)
+            record["error"] = f"reformat retry crashed: {exc}"
+            state.parse_retries.append(record)
+            emit(f"  [diagnose] reformat retry {attempt} crashed: {exc}")
+            break
+
+        duration = time.monotonic() - t0
+        state.agent_duration_s += duration
+        record["duration_s"] = round(duration, 3)
+        raw_cost = getattr(retry_result, "cost_usd", None)
+        cost = float(raw_cost) if raw_cost is not None else None
+        record["cost_usd"] = round(cost, 6) if cost is not None else None
+        _accumulate_retry_cost(state, cost)
+        retry_output = getattr(retry_result, "output", "") or ""
+        record["output_chars"] = len(retry_output)
+        record["output_tail"] = retry_output[-2000:]
+        if not getattr(retry_result, "success", False):
+            record["failure_code"] = getattr(retry_result, "failure_code", None)
+
+        candidate = parse_diagnose_output_result(
+            retry_output, issue_number=issue_number, partial=partial
+        )
+        if candidate.artifact is not None:
+            state.agent_output = retry_output
+            record["success"] = True
+            path = persist_agent_output(state, project_root, attempt=attempt, emit=emit)
+            record["output_path"] = str(path) if path is not None else ""
+            state.parse_retries.append(record)
+            emit(
+                f"  [diagnose] reformat retry {attempt} produced parseable YAML — "
+                "investigation recovered"
+            )
+            return candidate
+        # A repair that still does not parse cost real money and is itself
+        # evidence (did the agent re-investigate? did it drop the field?), so it
+        # gets its own sidecar rather than surviving only as a 2000-char tail.
+        record["parse_error_after"] = candidate.error
+        failed_path, failed_error = _write_output_sidecar(
+            state, project_root, retry_output, attempt
+        )
+        record["output_path"] = str(failed_path) if failed_path is not None else ""
+        if failed_error:
+            record["output_path_error"] = failed_error
+        state.parse_retries.append(record)
+        parsed = candidate
+    return parsed
 
 
 # ── Public entry point ────────────────────────────────────────────────
@@ -985,22 +1225,56 @@ def _run_diagnose_flow_body(
     # Budget guard — if the agent cost exceeded the configured budget, mark
     # the result as partial regardless of whether the agent reported success.
     # A cost-unknown run (None) cannot be shown to exceed the budget, so it is
-    # not treated as a budget breach here.
-    budget_exceeded = (
-        state.agent_cost_usd is not None
-        and state.agent_cost_usd > config.diagnose.budget_usd * 1.05
-    )
+    # not treated as a budget breach here. Re-evaluated after any parse retry,
+    # whose spend counts against the same envelope.
+    def _budget_exceeded() -> bool:
+        return (
+            state.agent_cost_usd is not None
+            and state.agent_cost_usd > config.diagnose.budget_usd * 1.05
+        )
+
+    budget_exceeded = _budget_exceeded()
     if budget_exceeded:
         partial = True
 
     # ── PARSE ─────────────────────────────────────────────────────────
     emit_phase(DiagnosePhase.PARSE)
-    artifact = parse_diagnose_output(
+    # Persist the agent's complete output BEFORE the first parse attempt, so both
+    # the success and the failure path leave the investigation recoverable from
+    # disk. A run that spent budget and produced content must not have that
+    # content exist only in this process's memory (#2055).
+    persist_agent_output(state, project_root, emit=emit)
+
+    parsed = parse_diagnose_output_result(
         state.agent_output, issue_number=issue_number, partial=partial
     )
+    if parsed.artifact is None:
+        # The investigation is done; only its serialization is broken. Ask for the
+        # same diagnosis, correctly encoded, before declaring the paid-for work
+        # lost. Parsing of each retry stays strict.
+        parsed = _retry_diagnose_parse(
+            state=state,
+            initial=parsed,
+            issue_number=issue_number,
+            partial=partial,
+            config=config,
+            project_root=project_root,
+            profile=profile,
+            emit=emit,
+        )
+        # Retry invocations spend against the same budget envelope.
+        budget_exceeded = _budget_exceeded()
+        if budget_exceeded:
+            partial = True
+
+    artifact = parsed.artifact
     if artifact is None:
+        attempts = len(state.parse_retries)
+        where = state.raw_output_path or "<not persisted>"
         state.error = (
-            f"PARSE failed: investigative agent did not emit a parseable YAML block. "
+            f"PARSE failed: investigative agent did not emit a parseable YAML block "
+            f"({parsed.error}) and {attempts} reformat retry attempt(s) did not "
+            f"produce one. Full agent output: {where}. "
             f"Raw tail: {state.agent_output[-200:]!r}"
         )
         emit_phase(DiagnosePhase.FAILED)

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -245,6 +245,10 @@ class DiagnoseState:
     raw_output_chars: int = 0
     raw_output_sha256: str = ""
     raw_output_error: str = ""
+    # Last-resort carrier for the complete output when no file location accepted
+    # the write: the audit record embeds it verbatim as ``agent.raw_output`` rather
+    # than degrading to the bounded tail. Empty whenever a file holds the content.
+    raw_output_inline: str = ""
     # Every sidecar persisted by this run, in write order: the investigation's own
     # output first, then one per reformat parse retry. A retry never overwrites an
     # earlier emission — the original is the evidence separating an agent

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -237,6 +237,23 @@ class DiagnoseState:
     # Followable-log slug for this run (``diagnose-<issue>``). Set at run
     # registration so status/logs can resolve the per-run log file.
     run_slug: str = ""
+    # Sidecar holding the agent's COMPLETE output, written before the first parse
+    # attempt. The audit's ``raw_output_tail`` is a bounded display convenience;
+    # this is the recoverable copy of a paid-for investigation. Empty when there
+    # was no output to persist, or when the write failed (see raw_output_error).
+    raw_output_path: str = ""
+    raw_output_chars: int = 0
+    raw_output_sha256: str = ""
+    raw_output_error: str = ""
+    # Every sidecar persisted by this run, in write order: the investigation's own
+    # output first, then one per reformat parse retry. A retry never overwrites an
+    # earlier emission — the original is the evidence separating an agent
+    # serialization defect from a parser defect.
+    raw_output_paths: list[str] = field(default_factory=list)
+    # One entry per reformat-only parse-retry invocation: attempt number, the
+    # parse error that triggered it, cost, duration, and whether it produced
+    # parseable YAML. Empty when the first parse succeeded.
+    parse_retries: list[dict] = field(default_factory=list)
 
     def transition(self, new_phase: DiagnosePhase, when: str) -> None:
         self.phase = new_phase

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -7,6 +7,8 @@ plan describes how to *act on* a known cause; diagnose describes how to
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import yaml
 
 from theforge.diagnose_types import (
@@ -69,6 +71,14 @@ Mode: {mode}
 
 == OUTPUT FORMAT ==
 
+{output_format}
+"""
+
+# The requested serialization contract, factored out of the investigation prompt
+# so the parse-retry prompt (:func:`build_diagnose_reformat_prompt`) restates the
+# *same* contract verbatim. A retry that quoted a drifted copy of the schema
+# would be asking for a different document than the one the parser accepts.
+_DIAGNOSE_OUTPUT_FORMAT = """\
 Emit a single fenced YAML block.  Required keys:
 
 ```yaml
@@ -120,6 +130,41 @@ related_findings:
   - summary: "<one-line description of a separate adjacent defect>"
     related: "<owning/related issue ref, e.g. '#1649', or empty>"
 ```
+"""
+
+_DIAGNOSE_REFORMAT_PROMPT_TEMPLATE = """\
+Your previous diagnosis output could not be parsed as YAML:
+
+{parse_error}
+
+Your INVESTIGATION is finished and its CONTENT is correct — the confirmed cause,
+the hypotheses, the evidence, and the fix-success criterion are what you meant to
+say.  ONLY the ENCODING (YAML serialization) is broken.  Re-emit the SAME
+diagnosis with the syntax error fixed.
+
+Preserve your previous output verbatim:
+  - Keep the SAME confirmed_cause, word for word.  Do NOT re-scope it.
+  - Keep EVERY hypothesis, with the same statement, status, and evidence.
+  - Keep EVERY inspected_files entry, premise_anchors entry, and
+    related_findings entry.
+  - Keep the same notes.
+
+Dropping or altering a value to make the parse error go away is a WRONG
+response.  If a scalar failed to parse, fix its QUOTING/ESCAPING — the usual
+culprit is an unterminated quoted string or a colon inside an unquoted value.
+Prefer a block scalar (``key: |``) or single quotes for any multi-line or
+punctuation-heavy value.  Do NOT delete the value, do NOT empty an optional
+field such as ``related_findings`` to sidestep the error, and do NOT weaken a
+confirmed cause into an inconclusive one.
+
+Do NOT investigate anything further.  Do NOT read files, run commands, or revise
+your conclusions.  This turn is a serialization repair and nothing else.
+
+{output_format}
+
+Your previous output (fix its YAML syntax, keep its content):
+
+{original_output}
 """
 
 
@@ -234,6 +279,29 @@ def build_diagnose_prompt(
         mode=mode,
         starting_evidence=evidence_block,
         environment=build_environment_briefing(),
+        output_format=_DIAGNOSE_OUTPUT_FORMAT,
+    )
+
+
+def build_diagnose_reformat_prompt(*, original_output: str, parse_error: str) -> str:
+    """Return a reformat-only retry prompt for unparseable diagnose output.
+
+    A completed investigation is the expensive part of a diagnose run; a YAML
+    syntax slip in its serialization is the cheap part.  This prompt asks the
+    agent for *serialization repair only*: it hands back the agent's verbatim
+    prior emission plus the parser's error and restates the same output contract,
+    so the reachable response is "the same diagnosis, correctly encoded".
+
+    It deliberately does NOT ask for renewed investigation (which would spend the
+    budget again for a result already produced) and does NOT relax the schema
+    (dropping the field that failed to encode is named as a wrong answer).  The
+    parser stays strict on the retry output — a retry earns its way in by
+    producing conforming YAML, never by having the contract widened for it.
+    """
+    return _DIAGNOSE_REFORMAT_PROMPT_TEMPLATE.format(
+        parse_error=parse_error or "(no parser detail available)",
+        output_format=_DIAGNOSE_OUTPUT_FORMAT,
+        original_output=original_output or "(previous output was empty)",
     )
 
 
@@ -256,6 +324,21 @@ def _extract_yaml_block(output: str) -> str:
     return output
 
 
+@dataclass(frozen=True)
+class DiagnoseParseOutcome:
+    """Result of one strict parse attempt over diagnose agent output.
+
+    ``artifact`` is None exactly when the output did not yield a YAML mapping;
+    ``error`` then carries the concrete reason (the ``yaml.YAMLError`` message, or
+    the non-mapping root shape).  Callers need that distinction to tell a
+    recoverable serialization defect — worth one reformat retry — from an agent
+    that emitted no diagnosis at all.
+    """
+
+    artifact: DiagnosisArtifact | None
+    error: str = ""
+
+
 def parse_diagnose_output(
     output: str,
     *,
@@ -267,14 +350,41 @@ def parse_diagnose_output(
     Returns None when the YAML cannot be parsed at all.  When the YAML is
     parseable but missing fields, returns an artifact with empty strings for
     missing values; the caller decides what to do with an incomplete artifact.
+
+    Thin wrapper over :func:`parse_diagnose_output_result` for callers that only
+    need the artifact-or-None answer.
+    """
+    return parse_diagnose_output_result(
+        output, issue_number=issue_number, partial=partial
+    ).artifact
+
+
+def parse_diagnose_output_result(
+    output: str,
+    *,
+    issue_number: int,
+    partial: bool = False,
+) -> DiagnoseParseOutcome:
+    """Strictly parse agent output, reporting *why* a parse failed.
+
+    Parsing is unchanged and remains the artifact integrity boundary: a document
+    that is not a YAML mapping is still rejected.  The only addition over
+    :func:`parse_diagnose_output` is that the rejection reason is returned instead
+    of discarded, so the diagnose flow can put it in the audit trail and in a
+    bounded reformat-retry prompt.
     """
     yaml_text = _extract_yaml_block(output)
     try:
         parsed = yaml.safe_load(yaml_text)
-    except yaml.YAMLError:
-        return None
+    except yaml.YAMLError as exc:
+        detail = " ".join(str(exc).split())
+        return DiagnoseParseOutcome(None, f"YAML syntax error: {detail}")
     if not isinstance(parsed, dict):
-        return None
+        return DiagnoseParseOutcome(
+            None,
+            "YAML block did not parse to a mapping of diagnosis keys "
+            f"(root was {type(parsed).__name__}).",
+        )
 
     raw_hypotheses = parsed.get("hypotheses") or []
     hypotheses: list[Hypothesis] = []
@@ -351,7 +461,7 @@ def parse_diagnose_output(
             seen_related.add(key)
             related.append(RelatedFinding(summary=summary, related=ref))
 
-    return DiagnosisArtifact(
+    artifact = DiagnosisArtifact(
         issue_number=issue_number,
         observed_symptom=str(parsed.get("observed_symptom", "")).strip(),
         reproduction_or_evidence=str(parsed.get("reproduction_or_evidence", "")).strip(),
@@ -365,3 +475,4 @@ def parse_diagnose_output(
         premise_anchors=tuple(anchors),
         related_findings=tuple(related),
     )
+    return DiagnoseParseOutcome(artifact)

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -258,6 +258,16 @@ class TestLoadConfig:
         config = load_config(config_path)
         assert config.retry.max_plan_review_parse_retries == 0
 
+    def test_diagnose_parse_retries_default(self, tmp_path):
+        config_path = _write_config({"retry": {}}, tmp_path)
+        config = load_config(config_path)
+        assert config.retry.max_diagnose_parse_retries == 2
+
+    def test_diagnose_parse_retries_override(self, tmp_path):
+        config_path = _write_config({"retry": {"max_diagnose_parse_retries": 0}}, tmp_path)
+        config = load_config(config_path)
+        assert config.retry.max_diagnose_parse_retries == 0
+
     def test_auto_model_escalation_defaults_false(self, tmp_path):
         config_path = _write_config({"retry": {}}, tmp_path)
         config = load_config(config_path)

--- a/tests/test_diagnose_parse_retry.py
+++ b/tests/test_diagnose_parse_retry.py
@@ -1,0 +1,502 @@
+"""Diagnose parse-retry and full-output recoverability seams (issue #2055).
+
+A completed `forge diagnose` investigation is the expensive part of the run; a
+YAML syntax slip in its serialization is the cheap part. These tests pin both
+halves of the fix:
+
+- a single recoverable syntax defect in the emitted document lands a diagnosis
+  via a bounded, reformat-only retry instead of failing terminally, and
+- for any run that reaches PARSE, the agent's COMPLETE output is retrievable
+  from disk afterward — including when the retries are exhausted.
+
+The seam under test is the PARSE transition of ``_run_diagnose_flow_body``: it
+spans prompt construction (``task.diagnose_prompts``), strict parsing, the
+retry-limit config, and the audit payload, so the coverage is flow-level rather
+than unit-level.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from coord_test_helpers import _make_config
+
+from theforge.config.types import RetryPolicy
+from theforge.diagnose_types import DiagnosePhase
+from theforge.task.diagnose_prompts import (
+    build_diagnose_reformat_prompt,
+    parse_diagnose_output,
+    parse_diagnose_output_result,
+)
+
+# Long enough that the audit's 2000-char ``raw_output_tail`` cannot possibly
+# cover the confirmed cause — the exact condition that made #2029 unrecoverable.
+_LONG_NOTES = ("The investigation walked the whole PARSE transition and the audit writer. ") * 40
+
+
+def _payload(*, with_related: bool = True) -> dict:
+    payload: dict = {
+        "observed_symptom": "Sprint flow drops the third story silently",
+        "reproduction_or_evidence": "Run forge sprint --issues 1,2,3 — story 3 never starts",
+        "hypotheses": [
+            {
+                "statement": "DAG scheduler skips dependents when a blocker fails",
+                "status": "ruled_out",
+                "evidence": "Logs show no failed blockers in this run",
+            },
+            {
+                "statement": "Worker pool size off-by-one",
+                "status": "confirmed",
+                "evidence": "scheduler.py:142 reserves N-1 slots when N requested",
+            },
+        ],
+        "confirmed_cause": "Worker pool reserves N-1 slots in scheduler.py:142",
+        "affected_code_path": "src/theforge/sprint/scheduler.py:142",
+        "fix_success_criterion": "Running with --parallel 3 completes all 3 stories",
+        "notes": _LONG_NOTES,
+        "inspected_files": ["src/theforge/sprint/scheduler.py"],
+        "premise_anchors": [
+            {"file": "src/theforge/sprint/scheduler.py", "pattern": "reserve_slots"}
+        ],
+    }
+    if with_related:
+        payload["related_findings"] = [{"summary": "an adjacent defect", "related": "#1649"}]
+    return payload
+
+
+def _valid_output() -> str:
+    return f"```yaml\n{yaml.safe_dump(_payload(), sort_keys=False)}```"
+
+
+def _output_with_unterminated_quote() -> str:
+    """The #2029 byte shape: one unterminated double-quoted scalar, nothing else wrong.
+
+    Every required key is present and well-formed; the single defect is an opening
+    double quote in ``related_findings[0].summary`` that runs several lines without
+    a closing quote before the next key. ``related_findings`` is the OPTIONAL
+    field — the confirmed cause, hypotheses and evidence are all intact.
+    """
+    body = yaml.safe_dump(_payload(with_related=False), sort_keys=False)
+    defect = (
+        "related_findings:\n"
+        "  - summary: \"agent_failure.py's substrate-failure classifier "
+        "(_NO_OUTPUT_MARKERS,\n"
+        "      _SUBSTRATE_MARKERS) duplicates the capability-profile reasoning\n"
+        "      without any awareness of it — worth checking whether one shared\n"
+        "      surface should own substrate-explains-the-symptom reasoning.\n"
+        '    related: ""\n'
+    )
+    return f"```yaml\n{body}{defect}```"
+
+
+def _fake_agent_result(output: str, *, success: bool = True, cost: float | None = 0.05):
+    from theforge.agent_types import AgentResult
+
+    return AgentResult(
+        success=success,
+        output=output,
+        session_id=None,
+        cost_usd=cost,
+        exit_code=0 if success else 1,
+        raw={},
+    )
+
+
+def _config(tmp_path: Path, *, parse_retries: int = 2):
+    config = _make_config(tmp_path)
+    return dataclasses.replace(
+        config,
+        retry=RetryPolicy(
+            max_dev_iterations=2,
+            max_review_cycles=2,
+            max_diagnose_parse_retries=parse_retries,
+        ),
+    )
+
+
+def _issue(number: int = 2029) -> dict:
+    return {
+        "number": number,
+        "title": "diagnose discards a completed investigation on a YAML slip",
+        "body": "Run 59bdfe42256b investigated for 141s and then failed at PARSE.",
+        "state": "OPEN",
+    }
+
+
+def _audit_for(tmp_path: Path, issue_number: int, run_id: str) -> dict:
+    path = tmp_path / ".forge" / "audits" / f"diagnose-issue-{issue_number}-{run_id}.yaml"
+    assert path.exists(), f"missing audit at {path}"
+    return yaml.safe_load(path.read_text())
+
+
+# ── Parser: failures now report why ───────────────────────────────────
+
+
+class TestStrictParseReportsReason:
+    def test_yaml_syntax_error_is_named(self):
+        outcome = parse_diagnose_output_result(
+            _output_with_unterminated_quote(), issue_number=2029
+        )
+        assert outcome.artifact is None
+        assert "YAML syntax error" in outcome.error
+        # The parser's own detail survives, so the retry prompt and the audit can
+        # both quote what actually broke.
+        assert "quoted scalar" in outcome.error
+
+    def test_non_mapping_root_is_rejected_and_named(self):
+        outcome = parse_diagnose_output_result("```yaml\n- just\n- a\n- list\n```", issue_number=1)
+        assert outcome.artifact is None
+        assert "mapping" in outcome.error
+        assert "list" in outcome.error
+
+    def test_well_formed_output_reports_no_error(self):
+        outcome = parse_diagnose_output_result(_valid_output(), issue_number=7)
+        assert outcome.artifact is not None
+        assert outcome.artifact.is_complete()
+        assert outcome.error == ""
+
+    def test_none_returning_wrapper_behavior_is_unchanged(self):
+        # Existing callers keep the artifact-or-None contract.
+        assert parse_diagnose_output("not yaml at all: just: : :", issue_number=1) is None
+        assert parse_diagnose_output(_valid_output(), issue_number=1) is not None
+
+
+# ── Reformat prompt: repair only, never re-investigation ──────────────
+
+
+class TestReformatPrompt:
+    def test_carries_prior_output_and_parse_error(self):
+        original = _output_with_unterminated_quote()
+        error = parse_diagnose_output_result(original, issue_number=2029).error
+        prompt = build_diagnose_reformat_prompt(original_output=original, parse_error=error)
+        assert original in prompt
+        assert error in prompt
+
+    def test_forbids_renewed_investigation_and_schema_relaxation(self):
+        prompt = build_diagnose_reformat_prompt(original_output="x", parse_error="boom")
+        assert "Do NOT investigate anything further." in prompt
+        # Dropping the optional field that failed to encode is named as wrong,
+        # so "reformat" cannot be read as "emit something easier to encode".
+        assert "related_findings" in prompt
+        assert "WRONG" in prompt
+        # The same output contract is restated, not a relaxed variant.
+        for key in ("confirmed_cause", "premise_anchors", "inspected_files"):
+            assert key in prompt
+
+
+# ── Flow seam: recovery ───────────────────────────────────────────────
+
+
+class TestParseRetryRecovery:
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_single_syntax_defect_lands_diagnosis_after_reformat_retry(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        """The fix-success criterion: one recoverable defect → a landed diagnosis."""
+        mock_fetch.return_value = _issue()
+        mock_agent.side_effect = [
+            _fake_agent_result(_output_with_unterminated_quote(), cost=0.725),
+            _fake_agent_result(_valid_output(), cost=0.04),
+        ]
+        mock_post.return_value = "https://example/comment-1"
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert result.success, result.message
+        assert result.state.phase == DiagnosePhase.DONE
+        assert result.state.artifact is not None
+        assert result.state.artifact.confirmed_cause.startswith("Worker pool reserves N-1")
+        assert mock_agent.call_count == 2
+        # The retry re-serialized; it did not re-investigate.
+        retry_prompt = mock_agent.call_args_list[1].kwargs["prompt"]
+        assert "Do NOT investigate anything further." in retry_prompt
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_retry_attempt_is_audit_visible_with_cost_and_duration(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        mock_fetch.return_value = _issue()
+        mock_agent.side_effect = [
+            _fake_agent_result(_output_with_unterminated_quote(), cost=0.725),
+            _fake_agent_result(_valid_output(), cost=0.04),
+        ]
+        mock_post.return_value = "https://example/comment-1"
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        retries = audit["agent"]["parse_retries"]
+        assert len(retries) == 1
+        entry = retries[0]
+        assert entry["attempt"] == 1
+        assert entry["success"] is True
+        assert "YAML syntax error" in entry["parse_error"]
+        assert entry["cost_usd"] == 0.04
+        assert entry["duration_s"] >= 0.0
+        # The retry's spend is folded into the run total, not silently dropped.
+        assert audit["agent"]["cost_usd"] == 0.765
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_failed_repair_does_not_replace_the_original_investigation(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        """A repair that still does not parse must not overwrite the salvageable output."""
+        mock_fetch.return_value = _issue()
+        original = _output_with_unterminated_quote()
+        mock_agent.side_effect = [
+            _fake_agent_result(original, cost=0.725),
+            _fake_agent_result("I could not reformat that. Sorry!", cost=0.01),
+            _fake_agent_result(_valid_output(), cost=0.03),
+        ]
+        mock_post.return_value = "https://example/comment-1"
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert result.success, result.message
+        assert mock_agent.call_count == 3
+        # The second retry prompt still anchors on the ORIGINAL emission, not on
+        # the failed repair — otherwise the investigation content would be lost.
+        second_retry_prompt = mock_agent.call_args_list[2].kwargs["prompt"]
+        assert original in second_retry_prompt
+        assert "I could not reformat that" not in second_retry_prompt
+        # And the original emission is still on disk verbatim.
+        audits = tmp_path / ".forge" / "audits"
+        initial = audits / f"diagnose-issue-2029-{result.state.run_id}.raw.txt"
+        assert initial.read_text() == original
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_zero_retry_budget_disables_the_retry_path(self, mock_agent, mock_fetch, tmp_path):
+        mock_fetch.return_value = _issue()
+        mock_agent.return_value = _fake_agent_result(_output_with_unterminated_quote())
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=0),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.FAILED
+        assert mock_agent.call_count == 1
+        assert result.state.parse_retries == []
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_empty_output_is_not_retried(self, mock_agent, mock_fetch, tmp_path):
+        """A killed/timed-out agent emitted nothing — there is no serialization to repair."""
+        mock_fetch.return_value = _issue()
+        mock_agent.return_value = _fake_agent_result("", success=False, cost=0.4)
+        mock_agent.return_value = dataclasses.replace(
+            mock_agent.return_value, failure_code="timeout"
+        )
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=2),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        assert not result.success
+        assert mock_agent.call_count == 1, "spent budget re-serializing an empty investigation"
+        assert result.state.parse_retries == []
+        # No output means no sidecar to claim.
+        assert result.state.raw_output_path == ""
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_already_over_budget_run_is_not_retried(self, mock_agent, mock_fetch, tmp_path):
+        """More spend is exactly what a breached envelope forbids."""
+        mock_fetch.return_value = _issue()
+        config = _config(tmp_path, parse_retries=2)
+        over = config.diagnose.budget_usd * 5
+        mock_agent.return_value = _fake_agent_result(_output_with_unterminated_quote(), cost=over)
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        assert not result.success
+        assert mock_agent.call_count == 1
+        assert result.state.parse_retries == []
+        # The investigation is still recoverable from disk without a retry.
+        assert Path(result.state.raw_output_path).exists()
+
+
+# ── Flow seam: recoverability when retries are exhausted ──────────────
+
+
+class TestExhaustedRetriesStayRecoverable:
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_exhausted_retries_fail_with_full_output_on_disk(
+        self, mock_agent, mock_fetch, tmp_path
+    ):
+        mock_fetch.return_value = _issue()
+        original = _output_with_unterminated_quote()
+        mock_agent.side_effect = [
+            _fake_agent_result(original, cost=0.725),
+            _fake_agent_result('still broken: "unterminated', cost=0.02),
+            _fake_agent_result("- not a mapping either", cost=0.02),
+        ]
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=2),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.FAILED
+        assert mock_agent.call_count == 3
+        # The terminal message points the operator at the recoverable output
+        # rather than at a truncated tail alone.
+        assert "reformat retry attempt(s)" in result.message
+        assert result.state.raw_output_path in result.message
+
+        raw = Path(result.state.raw_output_path)
+        assert raw.exists()
+        assert raw.read_text() == original
+        # Full output — not the last 2000 characters. The confirmed cause the
+        # tail could not reach is retrievable.
+        assert len(original) > 2000
+        assert "Worker pool reserves N-1 slots" in raw.read_text()
+
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        agent = audit["agent"]
+        assert agent["raw_output_path"] == str(raw)
+        assert agent["raw_output_chars"] == len(original)
+        assert agent["raw_output_sha256"]
+        assert agent["raw_output_error"] == ""
+        # Both retry attempts, with their own parse errors, are audit-visible.
+        retries = agent["parse_retries"]
+        assert [e["attempt"] for e in retries] == [1, 2]
+        assert all(e["success"] is False for e in retries)
+        assert any("mapping" in e["parse_error_after"] for e in retries)
+        # Every emission this run paid for is enumerable and on disk.
+        assert len(agent["raw_output_paths"]) == 3
+        for recorded in agent["raw_output_paths"]:
+            assert Path(recorded).exists()
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_successful_run_also_persists_full_output(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        """Recoverability is a property of reaching PARSE, not of failing there."""
+        mock_fetch.return_value = _issue()
+        output = _valid_output()
+        mock_agent.return_value = _fake_agent_result(output)
+        mock_post.return_value = "https://example/comment-1"
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert result.success, result.message
+        raw = Path(result.state.raw_output_path)
+        assert raw.read_text() == output
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        assert audit["agent"]["raw_output_chars"] == len(output)
+        assert audit["agent"]["parse_retries"] == []
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_unmeasured_retry_cost_marks_the_run_total_unknown(
+        self, mock_agent, mock_fetch, tmp_path
+    ):
+        """A retry whose spend was not measured must not be recorded as free."""
+        mock_fetch.return_value = _issue()
+        mock_agent.side_effect = [
+            _fake_agent_result(_output_with_unterminated_quote(), cost=0.725),
+            _fake_agent_result("nope", success=False, cost=None),
+        ]
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=1),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        assert not result.success
+        assert result.state.agent_cost_usd is None
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        assert audit["agent"]["cost_usd"] is None
+        assert audit["agent"]["parse_retries"][0]["cost_usd"] is None
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_crashing_retry_is_recorded_and_stops_the_loop(self, mock_agent, mock_fetch, tmp_path):
+        mock_fetch.return_value = _issue()
+        mock_agent.side_effect = [
+            _fake_agent_result(_output_with_unterminated_quote(), cost=0.725),
+            RuntimeError("transport exploded"),
+        ]
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=2),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+        assert not result.success
+        assert result.state.phase == DiagnosePhase.FAILED
+        # Crash breaks the loop rather than burning the remaining budget.
+        assert mock_agent.call_count == 2
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        retries = audit["agent"]["parse_retries"]
+        assert len(retries) == 1
+        assert "transport exploded" in retries[0]["error"]
+        # The investigation is still recoverable despite the crash.
+        assert Path(result.state.raw_output_path).exists()

--- a/tests/test_diagnose_parse_retry.py
+++ b/tests/test_diagnose_parse_retry.py
@@ -446,6 +446,183 @@ class TestExhaustedRetriesStayRecoverable:
         audit = _audit_for(tmp_path, 2029, result.state.run_id)
         assert audit["agent"]["raw_output_chars"] == len(output)
         assert audit["agent"]["parse_retries"] == []
+        # Nothing needed the inline carrier.
+        assert audit["agent"]["raw_output"] == ""
+
+
+# ── Persistence is guaranteed, not best-effort ────────────────────────
+#
+# An unwritable sidecar must not silently downgrade the recoverability
+# guarantee to the bounded 2000-char tail. Persistence escalates through the
+# audit sidecar, then the run-log fallback, then the audit record itself.
+
+
+def _unwritable(tmp_path: Path, name: str):
+    """Return a path factory whose parent is a regular file, so mkdir/write fail."""
+    blocker = tmp_path / name
+    blocker.write_text("not a directory", encoding="utf-8")
+
+    def _factory(*_args, **kwargs):
+        attempt = kwargs.get("attempt", 0)
+        return blocker / f"attempt-{attempt}.raw.txt"
+
+    return _factory
+
+
+class TestPersistenceIsGuaranteed:
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_unwritable_sidecar_falls_back_to_the_run_log_location(
+        self, mock_agent, mock_fetch, tmp_path, monkeypatch
+    ):
+        import theforge.coordinator.diagnose_flow as flow
+
+        monkeypatch.setattr(
+            flow, "diagnose_raw_output_path", _unwritable(tmp_path, "blocked-audits")
+        )
+        mock_fetch.return_value = _issue()
+        original = _output_with_unterminated_quote()
+        mock_agent.return_value = _fake_agent_result(original, cost=0.7)
+
+        result = flow.run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=0),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert not result.success
+        # Tier 2 accepted the write, so the guarantee holds without the sidecar.
+        fallback = Path(result.state.raw_output_path)
+        assert fallback.exists()
+        assert fallback.read_text() == original
+        assert ".forge/logs/" in str(fallback).replace("\\", "/")
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        assert audit["agent"]["raw_output_path"] == str(fallback)
+        assert audit["agent"]["raw_output_chars"] == len(original)
+        assert audit["agent"]["raw_output_error"] == ""
+        # The operator is pointed at the real location, not at a missing file.
+        assert str(fallback) in result.message
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_no_writable_location_carries_full_output_inline_in_the_audit(
+        self, mock_agent, mock_fetch, tmp_path, monkeypatch
+    ):
+        """The P1 case: every file location refuses, and the output is STILL recoverable."""
+        import theforge.coordinator.diagnose_flow as flow
+
+        monkeypatch.setattr(
+            flow, "diagnose_raw_output_path", _unwritable(tmp_path, "blocked-audits")
+        )
+        monkeypatch.setattr(
+            flow, "diagnose_fallback_output_path", _unwritable(tmp_path, "blocked-logs")
+        )
+        mock_fetch.return_value = _issue()
+        original = _output_with_unterminated_quote()
+        mock_agent.return_value = _fake_agent_result(original, cost=0.7)
+
+        result = flow.run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=0),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert not result.success
+        assert result.state.raw_output_path == ""
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        agent = audit["agent"]
+        # The COMPLETE output — not the bounded tail — survives in the audit the
+        # operator reads the failure from.
+        assert agent["raw_output"] == original
+        assert len(original) > 2000
+        assert "Worker pool reserves N-1 slots" in agent["raw_output"]
+        assert agent["raw_output_chars"] == len(original)
+        assert agent["raw_output_sha256"]
+        # Both refused locations are named, so the audit never claims a file that
+        # is not there.
+        assert "blocked-audits" in agent["raw_output_error"]
+        assert "blocked-logs" in agent["raw_output_error"]
+        assert agent["raw_output_paths"] == []
+        # And the terminal message routes the operator to the surviving copy.
+        assert "agent.raw_output" in result.message
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_retry_still_recovers_the_diagnosis_when_no_location_is_writable(
+        self, mock_agent, mock_fetch, mock_post, tmp_path, monkeypatch
+    ):
+        """A persistence failure must not block the retry path from landing a diagnosis."""
+        import theforge.coordinator.diagnose_flow as flow
+
+        monkeypatch.setattr(
+            flow, "diagnose_raw_output_path", _unwritable(tmp_path, "blocked-audits")
+        )
+        monkeypatch.setattr(
+            flow, "diagnose_fallback_output_path", _unwritable(tmp_path, "blocked-logs")
+        )
+        mock_fetch.return_value = _issue()
+        mock_agent.side_effect = [
+            _fake_agent_result(_output_with_unterminated_quote(), cost=0.7),
+            _fake_agent_result(_valid_output(), cost=0.04),
+        ]
+        mock_post.return_value = "https://example/comment-1"
+
+        result = flow.run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert result.success, result.message
+        assert result.state.phase == DiagnosePhase.DONE
+        audit = _audit_for(tmp_path, 2029, result.state.run_id)
+        # The repaired output is the run's output, carried inline since no file
+        # location would take it.
+        assert audit["agent"]["raw_output"] == _valid_output()
+        entry = audit["agent"]["parse_retries"][0]
+        assert entry["success"] is True
+        # The original emission is not destroyed by the repair that replaced it.
+        assert entry["previous_output"] == _output_with_unterminated_quote()
+
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_failed_repair_output_is_carried_in_its_attempt_record(
+        self, mock_agent, mock_fetch, tmp_path, monkeypatch
+    ):
+        import theforge.coordinator.diagnose_flow as flow
+
+        monkeypatch.setattr(
+            flow, "diagnose_raw_output_path", _unwritable(tmp_path, "blocked-audits")
+        )
+        monkeypatch.setattr(
+            flow, "diagnose_fallback_output_path", _unwritable(tmp_path, "blocked-logs")
+        )
+        mock_fetch.return_value = _issue()
+        broken_repair = 'still broken: "unterminated' + ("x" * 3000)
+        mock_agent.side_effect = [
+            _fake_agent_result(_output_with_unterminated_quote(), cost=0.7),
+            _fake_agent_result(broken_repair, cost=0.02),
+        ]
+
+        result = flow.run_diagnose_flow(
+            issue_number=2029,
+            config=_config(tmp_path, parse_retries=1),
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert not result.success
+        entry = _audit_for(tmp_path, 2029, result.state.run_id)["agent"]["parse_retries"][0]
+        # A retry that cost money and produced an unparseable repair is itself
+        # evidence; it survives in full, not as a 2000-char tail.
+        assert entry["output"] == broken_repair
+        assert len(broken_repair) > 2000
+        assert entry["output_path"] == ""
+        assert "blocked-logs" in entry["output_path_error"]
 
     @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
     @patch("theforge.coordinator.diagnose_flow.run_agent")


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior P1 is resolved; diagnose now retries parse slips and preserves full outputs through sidecar, fallback, or inline audit storage. | [google-gemini-3.5-flash] The implementation successfully resolves the unrecoverable YAML syntax slip issue by introducing a bounded reformat-only retry loop and a guaranteed multi-tier persistence mechanism.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $15.65
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

A completed `forge diagnose` investigation is discarded entirely on a YAML syntax slip — no retry, and the output is not recoverable (GitHub Issue #2055)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2055