### PR TITLE
A `forge diagnose` artifact with no confirmed cause is derived as fix-ready, bypassing the three-state bug invariant

### DIFF
--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -280,8 +280,10 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
     """Render a DiagnosisArtifact as a Markdown ``## Diagnosis`` section.
 
     Output format intentionally matches the headings expected by the shape gate
-    (DIAGNOSIS_HEADING_PATTERN / required Diagnosis labels in shape_check)
-    so a landed artifact makes the issue fix-ready.
+    (DIAGNOSIS_HEADING_PATTERN / required Diagnosis labels in shape_check) so a
+    landed artifact is *readable* by the gate. Readable is not the same as
+    fix-ready: the confirmed-cause value decides that, and an artifact that
+    confirmed no cause lands investigation-ready (#2060).
 
     Raises ``ValueError`` when the artifact carries no substantive content.
     Rendering an all-empty artifact would emit a Diagnosis section whose only
@@ -341,7 +343,14 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
             "",
             "### Confirmed cause",
             "",
-            artifact.confirmed_cause.strip() or "_(empty)_",
+            # An empty cause is the designed honest-refusal outcome (the
+            # diagnose prompt asks for `confirmed_cause: ""` when nothing was
+            # confirmed), so it is written as an explicit non-assertion rather
+            # than a slot placeholder: the readiness derivation reads this
+            # value, and a record that no cause was found must never read as a
+            # record that one was (#2060).
+            artifact.confirmed_cause.strip()
+            or "unknown — the investigation did not confirm a cause",
             "",
             "### Affected code path",
             "",

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -248,7 +248,15 @@ _NON_ASSERTION_CAUSE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*unconfirmed\b", re.IGNORECASE),
     re.compile(r"^\s*unidentified\b", re.IGNORECASE),
     re.compile(r"^\s*investigation\s+(?:ongoing|in\s+progress)\b", re.IGNORECASE),
+    re.compile(r"^\s*investigating\b", re.IGNORECASE),
     re.compile(r"^\s*\?+\s*$"),
+    # Placeholder values a producer emits for an unfilled field. These are the
+    # shape `render_artifact_markdown` used to emit for an empty
+    # ``confirmed_cause`` (#2060) — a slot marker is never a cause claim.
+    re.compile(
+        r"^\s*_*\(?\s*(?:empty|none(?:\s+recorded)?|not\s+recorded|n/?a)\s*\)?_*\s*$",
+        re.IGNORECASE,
+    ),
 )
 
 # Status labels operators can apply to a bug to communicate fix-readiness intent.
@@ -257,6 +265,23 @@ RECOGNIZED_STATUS_LABELS: frozenset[str] = frozenset(
     {"status:triage", "status:investigating", "status:diagnosed"}
 )
 FIX_READY_STATUS_LABELS: frozenset[str] = frozenset({"status:diagnosed"})
+
+
+def _value_below_label(lines: list[str]) -> str:
+    """Return the value carried on the lines below a bare field label.
+
+    Used for the heading and label-only forms, where the value lives on a
+    following line rather than after a colon. The first non-blank line is the
+    value — unless it opens a sibling field (a new heading or a bullet), in
+    which case the field has no value at all.
+    """
+    for line in lines:
+        if not line.strip():
+            continue
+        if re.match(r"^\s*(?:#|[-*+]\s)", line):
+            return ""
+        return line.strip()
+    return ""
 
 
 def _extract_confirmed_cause_value(section: str) -> str | None:
@@ -269,13 +294,28 @@ def _extract_confirmed_cause_value(section: str) -> str | None:
         - Confirmed cause: not yet identified
         - Confirmed cause — pending investigation
 
-    Returns the trimmed text after the label up to the end of that logical
-    line, or ``None`` when no labelled occurrence exists. The match is
-    case-insensitive on the label only.
+    First-party producers — notably ``forge diagnose`` via
+    :func:`theforge.diagnose_types.render_artifact_markdown` — write the same
+    field as a heading with the value on a following line::
+
+        ### Confirmed cause
+
+        unknown
+
+    Both shapes must yield the same value: a value readable in one form and
+    invisible in the other let a diagnose-landed artifact with no confirmed
+    cause derive as implementation-ready (#2060).
+
+    Returns the trimmed value, ``""`` when the label carries no value, or
+    ``None`` when no labelled occurrence exists. The match is case-insensitive
+    on the label only.
     """
-    for line in section.splitlines():
-        # Strip leading whitespace, bullet markers, and opening bold markers.
-        cleaned = re.sub(r"^\s*(?:[-*+]\s+)?", "", line)
+    lines = section.splitlines()
+    for idx, line in enumerate(lines):
+        # Strip leading whitespace, heading markers, bullet markers, and
+        # opening bold markers.
+        cleaned = re.sub(r"^\s*#+\s*", "", line)
+        cleaned = re.sub(r"^\s*(?:[-*+]\s+)?", "", cleaned)
         cleaned = re.sub(r"^\*+\s*", "", cleaned)
         m = re.match(r"confirmed\s+cause\b", cleaned, re.IGNORECASE)
         if m is None:
@@ -285,7 +325,9 @@ def _extract_confirmed_cause_value(section: str) -> str | None:
         # whitespace separating the label from its value.
         rest = re.sub(r"^[\s*:.\-—]+", "", rest)
         value = re.sub(r"\*+\s*$", "", rest).strip()
-        return value
+        if value:
+            return value
+        return _value_below_label(lines[idx + 1 :])
     return None
 
 
@@ -304,9 +346,13 @@ def cause_assertion_state(body: str) -> str:
       specific cause claim (i.e. not non-assertion vocabulary).
     - ``"non_asserted"``: the field exists but its value is non-assertion
       vocabulary (``unknown``, ``not yet identified``, ``pending
-      investigation``, ``TBD``, etc.). Bug is investigation-ready.
+      investigation``, ``TBD``, etc.), a slot placeholder, or empty. Bug is
+      investigation-ready.
     - ``"missing"``: no confirmed-cause line present (or no Diagnosis
       section at all).
+
+    A field written but left empty is a non-assertion, not an assertion: the
+    record states no cause was found, and must never read as one (#2060).
     """
     section = extract_section(body, DIAGNOSIS_HEADING_PATTERN)
     if section is None:
@@ -314,7 +360,7 @@ def cause_assertion_state(body: str) -> str:
     value = _extract_confirmed_cause_value(section)
     if value is None:
         return "missing"
-    if _is_non_assertion_cause(value):
+    if not value or _is_non_assertion_cause(value):
         return "non_asserted"
     return "asserted"
 
@@ -382,6 +428,20 @@ def derive_fix_ready(
                         "identified'). Dev cycle's first job is cause discovery."
                     ],
                 )
+            if state == "missing":
+                # Completeness only saw the label token somewhere in the
+                # section; no field value could be read. An unreadable cause is
+                # not an asserted cause — refusing to promote it keeps the
+                # three-state invariant closed against producer drift (#2060).
+                return (
+                    True,
+                    True,
+                    [
+                        "bug is investigation-ready: the Diagnosis section's "
+                        "confirmed-cause field carries no readable value. Dev cycle's "
+                        "first job is cause discovery."
+                    ],
+                )
             return True, False, []
         if missing == ["missing Diagnosis section"]:
             return (
@@ -439,7 +499,8 @@ def check_missing_type(title: str, body: str, labels: Iterable[str]) -> Reason |
 
 # Phrases that explicitly mark a bug's confirmed cause as still open.
 # Narrow on purpose: an unrelated body line containing "tbd" elsewhere
-# must not flip a complete diagnosis into "cause unknown".
+# must not flip a complete diagnosis into "cause unknown". The separator class
+# admits newlines, so the heading form (label, blank line, value) matches too.
 _UNRESOLVED_CAUSE_RE = re.compile(
     r"confirmed\s+cause[^\w\n]*[:.\-\*\s]*"
     r"(?:not\s+yet\s+identified|unknown|tbd|investigating|n/?a)\b",
@@ -453,11 +514,18 @@ def _diagnosis_cause_unknown(body: str) -> bool:
     This is the admissible "investigation-ready" state: the bug is not
     malformed (it has been investigated), but it is not implementation-runnable
     because no cause has been confirmed.
+
+    A confirmed-cause field written but left without a value counts as open:
+    the vocabulary above cannot see an absence, and a producer that emits the
+    label with nothing under it is reporting no cause, not a cause (#2060).
     """
     section = extract_section(body, DIAGNOSIS_HEADING_PATTERN)
     if section is None:
         return False
-    return bool(_UNRESOLVED_CAUSE_RE.search(section))
+    if _UNRESOLVED_CAUSE_RE.search(section):
+        return True
+    value = _extract_confirmed_cause_value(section)
+    return value is not None and not value
 
 
 def check_bug_missing_diagnosis(title: str, body: str, labels: Iterable[str]) -> Reason | None:

--- a/tests/test_diagnose_artifact_readiness.py
+++ b/tests/test_diagnose_artifact_readiness.py
@@ -1,0 +1,157 @@
+"""Seam tests: a `forge diagnose` artifact read by the shape gate (#2060).
+
+`forge diagnose` renders its artifact with :func:`render_artifact_markdown` and
+lands the result as the issue body; the shape gate then derives fix-readiness
+from that body. The two sides wrote and read the confirmed-cause field in
+different shapes — heading form out, bullet form in — so every diagnose-landed
+artifact derived as implementation-ready regardless of whether a cause had been
+confirmed, including the honest-refusal case the diagnose prompt asks for.
+
+These tests pin the seam itself: the verdict a rendered artifact receives, and
+the requirement that it not depend on which of the two admissible shapes the
+field was written in.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from theforge.diagnose_types import DiagnosisArtifact, Hypothesis, render_artifact_markdown
+from theforge.intake.groom_flow import BugDiagnosisState, classify_bug_diagnosis
+from theforge.shape_check.diagnosis_spec import REQUIRED_DIAGNOSIS_COMPONENTS
+from theforge.shape_check.heuristics import (
+    cause_assertion_state,
+    check_bug_missing_diagnosis,
+    derive_fix_ready,
+    diagnosis_completeness,
+)
+
+
+def _artifact(confirmed_cause: str) -> DiagnosisArtifact:
+    return DiagnosisArtifact(
+        issue_number=2060,
+        observed_symptom="A diagnose artifact with no confirmed cause derives as fix-ready.",
+        reproduction_or_evidence="Rendered at baseline `f2caf7d` and passed to derive_fix_ready.",
+        hypotheses=(
+            Hypothesis(
+                statement="the extractor never reads the heading form",
+                status="confirmed",
+                evidence="`_extract_confirmed_cause_value` stripped bullet markers only",
+            ),
+        ),
+        confirmed_cause=confirmed_cause,
+        affected_code_path="src/theforge/shape_check/heuristics.py",
+        fix_success_criterion="an empty-cause artifact derives as investigation-ready.",
+    )
+
+
+def _bullet_body(cause_value: str) -> str:
+    """The same fields an operator would write, in bullet form."""
+    return textwrap.dedent(
+        f"""\
+        ## Diagnosis
+
+        - **Observed symptom:** a diagnose artifact derives as fix-ready.
+        - **Evidence:** rendered at baseline `f2caf7d`.
+        - **Confirmed cause:** {cause_value}
+        - **Affected code path:** src/theforge/shape_check/heuristics.py
+        - **Fix-success criterion:** derives as investigation-ready.
+        """
+    )
+
+
+REAL_CAUSE = "the renderer writes the field in heading form while the extractor reads bullet form."
+NON_ASSERTIONS = ["unknown", "not yet identified", "pending investigation", "TBD"]
+
+
+class TestRenderedArtifactReadiness:
+    def test_rendered_real_cause_is_implementation_ready(self) -> None:
+        body = render_artifact_markdown(_artifact(REAL_CAUSE))
+        assert cause_assertion_state(body) == "asserted"
+        assert derive_fix_ready("bug", body) == (True, False, [])
+
+    @pytest.mark.parametrize("cause_value", NON_ASSERTIONS)
+    def test_rendered_non_assertion_is_investigation_ready(self, cause_value: str) -> None:
+        body = render_artifact_markdown(_artifact(cause_value))
+        assert cause_assertion_state(body) == "non_asserted"
+        fix_ready, investigation_ready, warnings = derive_fix_ready("bug", body)
+        assert (fix_ready, investigation_ready) == (True, True)
+        assert warnings and "investigation-ready" in warnings[0]
+
+    def test_rendered_empty_cause_is_investigation_ready(self) -> None:
+        # The designed honest-refusal path: the diagnose prompt asks the agent
+        # for `confirmed_cause: ""` when nothing was confirmed. That outcome
+        # must not carry the implementation-ready verdict.
+        body = render_artifact_markdown(_artifact(""))
+        assert cause_assertion_state(body) == "non_asserted"
+        fix_ready, investigation_ready, warnings = derive_fix_ready("bug", body)
+        assert (fix_ready, investigation_ready) == (True, True)
+        assert warnings and "investigation-ready" in warnings[0]
+
+    def test_rendered_empty_cause_stays_complete(self) -> None:
+        # Investigation-ready is an admissible shape, not a malformed body: the
+        # section is still complete, so the bug is not refused outright.
+        body = render_artifact_markdown(_artifact(""))
+        assert diagnosis_completeness(body) == (True, [])
+
+    def test_rendered_empty_cause_states_the_non_assertion_in_prose(self) -> None:
+        # A human reading the landed body must see "no cause was confirmed",
+        # not an unexplained slot placeholder.
+        body = render_artifact_markdown(_artifact(""))
+        assert "_(empty)_" not in body.split("### Confirmed cause")[1].split("###")[0]
+        assert "did not confirm a cause" in body
+
+    def test_rendered_empty_cause_gets_the_cause_unknown_reason(self) -> None:
+        body = render_artifact_markdown(_artifact(""))
+        reason = check_bug_missing_diagnosis("Bug: foo", body, ["bug"])
+        assert reason is not None
+        assert reason.code == "diagnosis_cause_unknown"
+
+    def test_rendered_empty_cause_grooms_as_cause_unknown(self) -> None:
+        # ADR-0001 / groom_flow: a bug whose diagnosis is complete but whose
+        # cause is not asserted MUST NOT transition to `ready`.
+        body = render_artifact_markdown(_artifact(""))
+        assert classify_bug_diagnosis(body, ["bug"]) is BugDiagnosisState.CAUSE_UNKNOWN
+
+    def test_rendered_real_cause_grooms_as_confirmed(self) -> None:
+        body = render_artifact_markdown(_artifact(REAL_CAUSE))
+        assert classify_bug_diagnosis(body, ["bug"]) is BugDiagnosisState.CONFIRMED_CAUSE
+
+
+class TestHeadingAndBulletFormAgree:
+    @pytest.mark.parametrize("cause_value", [REAL_CAUSE, *NON_ASSERTIONS])
+    def test_same_verdict_either_form(self, cause_value: str) -> None:
+        rendered = render_artifact_markdown(_artifact(cause_value))
+        operator = _bullet_body(cause_value)
+        assert cause_assertion_state(rendered) == cause_assertion_state(operator)
+        assert derive_fix_ready("bug", rendered) == derive_fix_ready("bug", operator)
+
+    def test_label_only_bullet_does_not_absorb_the_next_field(self) -> None:
+        # A bullet whose value is empty must not read the following field's
+        # bullet as its value.
+        body = _bullet_body("")
+        assert cause_assertion_state(body) == "non_asserted"
+
+
+class TestRendererLabelsMatchSpec:
+    """The renderer restates the field labels the gate validates — pin them.
+
+    `diagnosis_spec` is the single source of truth for the component labels
+    (#1629). The renderer writes its own heading strings, so a spec-side label
+    change with no renderer change is exactly the drift that produced #2060.
+    """
+
+    def test_every_required_component_label_is_rendered_as_a_heading(self) -> None:
+        body = render_artifact_markdown(_artifact(REAL_CAUSE))
+        for component in REQUIRED_DIAGNOSIS_COMPONENTS:
+            token = component.token
+            headings = [
+                line.lstrip("#").strip().lower()
+                for line in body.splitlines()
+                if line.startswith("#")
+            ]
+            assert any(token in heading for heading in headings), (
+                f"renderer emits no heading carrying the required label {component.label!r}"
+            )


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change makes diagnose-rendered confirmed-cause headings readable by the shape gate and covers the original empty-cause safety failure. | [google-gemini-3.5-flash] The fix correctly aligns the shape gate's value extractor with the diagnose renderer's heading format, preserving the three-state bug invariant.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.09
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

A `forge diagnose` artifact with no confirmed cause is derived as fix-ready, bypassing the three-state bug invariant (GitHub Issue #2060)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2060