### PR TITLE
A dirty project root is only detected at landing, after the story's full spend

### DIFF
--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -82,11 +82,24 @@ Whether a story lands locally is decided per story, not per config value. A
 **dependency parent carried by this sprint** is merged locally to unblock its
 child — in parallel mode the scheduler forces that merge after the parent
 returns — even under `on_approve: none` or `pr`, so those parents carry the
-precondition too. A `depends_on` edge pointing at an **external** issue (already
-merged, or simply not in this sprint) imposes nothing: no story here merges it,
-so a PR-landing sprint with only external edges runs against a dirty root
-untouched. Workflows where nothing merges into the local checkout are genuinely
-unaffected.
+precondition too.
+
+Because of that, the sprint checks twice, and the log line names which pass
+refused:
+
+- `[sprint-entry]` — the configuration-level answer (`on_approve: merge` or
+  `--auto-merge`). Knowable immediately, so this one costs seconds.
+- `[dependency-resolved]` — the dependency-derived answer, asserted once the
+  satisfied and resume-triage sets say which parents will actually be
+  dispatched. Still ahead of intake remediation, batch preflight, and every
+  story dispatch, so nothing has been spent.
+
+A `depends_on` edge imposes nothing when it points at an **external** issue (not
+carried by this sprint) or at a parent already **satisfied** — merged into the
+base branch, or triaged `skip_merged` on resume. Those parents never run and
+never merge, so a PR-landing sprint whose only edges are of that kind runs
+against a dirty root untouched. Workflows where nothing merges into the local
+checkout are genuinely unaffected.
 
 ## 2. Branch & forward-port model
 

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -75,8 +75,14 @@ and then fail with `MERGE_FAILED`, leaving reviewed work stranded on its feature
 branch after the full spend. Remedy: commit, stash, or revert the change in the
 project root, then re-run. Each story re-evaluates the condition at its own
 entry, so dirtying the root mid-sprint stops the *next* story rather than
-costing it. Workflows that never merge into the local checkout (`pr`,
-`merge-pr`, `none`) are unaffected.
+costing it — that story escalates in WORKSPACE with the message above instead
+of running.
+
+Whether a story lands locally is decided per story, not per config value. A
+**dependency parent in a parallel sprint** is forced into a local merge by the
+scheduler after it returns, even under `on_approve: none` or `pr`, so it carries
+the precondition too. Workflows where nothing merges into the local checkout are
+genuinely unaffected.
 
 ## 2. Branch & forward-port model
 

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -58,6 +58,26 @@ story and per phase. Stories the breaker cancels are recorded **SKIPPED** and
 attributed to the credential, not FAILED — the sprint killed them, no model
 judged them, and they contribute nothing to adaptive memory.
 
+### Landing precondition — clean project root (issue #2048)
+
+Under a landing workflow (`workspace.on_approve: merge`, or `--auto-merge`), a
+sprint refuses at entry when the project root has uncommitted changes, naming
+the offending paths:
+
+```
+LANDING PRECONDITION: uncommitted changes in project root /path/to/repo:  M forge.yaml.
+```
+
+The condition is the same one `_merge_branch` enforces at landing — untracked
+files included — moved to the point where it costs nothing. Before this check,
+a modified `forge.yaml` in the root let a story run dev and review to approval
+and then fail with `MERGE_FAILED`, leaving reviewed work stranded on its feature
+branch after the full spend. Remedy: commit, stash, or revert the change in the
+project root, then re-run. Each story re-evaluates the condition at its own
+entry, so dirtying the root mid-sprint stops the *next* story rather than
+costing it. Workflows that never merge into the local checkout (`pr`,
+`merge-pr`, `none`) are unaffected.
+
 ## 2. Branch & forward-port model
 
 - Fixes land on the **base branch**. `forward-port.yml` then auto-carries every

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -79,10 +79,14 @@ costing it — that story escalates in WORKSPACE with the message above instead
 of running.
 
 Whether a story lands locally is decided per story, not per config value. A
-**dependency parent in a parallel sprint** is forced into a local merge by the
-scheduler after it returns, even under `on_approve: none` or `pr`, so it carries
-the precondition too. Workflows where nothing merges into the local checkout are
-genuinely unaffected.
+**dependency parent carried by this sprint** is merged locally to unblock its
+child — in parallel mode the scheduler forces that merge after the parent
+returns — even under `on_approve: none` or `pr`, so those parents carry the
+precondition too. A `depends_on` edge pointing at an **external** issue (already
+merged, or simply not in this sprint) imposes nothing: no story here merges it,
+so a PR-landing sprint with only external edges runs against a dirty root
+untouched. Workflows where nothing merges into the local checkout are genuinely
+unaffected.
 
 ## 2. Branch & forward-port model
 

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -80,9 +80,18 @@ of running.
 
 Whether a story lands locally is decided per story, not per config value. A
 **dependency parent carried by this sprint** is merged locally to unblock its
-child — in parallel mode the scheduler forces that merge after the parent
-returns — even under `on_approve: none` or `pr`, so those parents carry the
-precondition too.
+child, so those parents carry the precondition even under `on_approve: none` or
+`pr` — in sequential mode the parent is eager-merged, and in parallel mode the
+scheduler forces the merge after it returns. Two exceptions follow from how that
+resolution actually works, and both mean *no* refusal:
+
+- **`on_approve: merge-pr` in parallel mode.** The parent already has its own
+  landing, so the scheduler never rewrites it to a local merge; it lands through
+  its PR. Sequential mode still eager-merges it, so there the precondition
+  applies.
+- **`--auto-merge` in parallel mode.** The flag is dropped when
+  `max_parallel > 1`, so it cannot cause a local merge and the configured
+  landing path stands.
 
 Because of that, the sprint checks twice, and the log line names which pass
 refused:

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -748,6 +748,7 @@ def run_task(
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
+    lands_in_project_root: bool | None = None,
 ) -> CoordinatorResult:
     """Execute the full coordinator state machine for a single task.
 
@@ -770,6 +771,12 @@ def run_task(
             auto_merge and config, which is right for a standalone run but not
             inside a sprint, where an earlier story may have merged locally
             while this one did not.
+        lands_in_project_root: Override for the landing precondition — whether
+            *this* story's approval merges into the project-root checkout.
+            Distinct from base_lands_locally, which is a run-wide question about
+            the base branch. The sprint scheduler supplies it because in
+            parallel mode it forces a local merge on dependency parents after
+            the story returns, which auto_merge and on_approve do not reveal.
     """
     _ensure_runners()
     state = _fresh_run_state()
@@ -889,7 +896,9 @@ def run_task(
         # for: a dirty project root blocks this story's landing, and in a
         # sprint this is the first point at which a root dirtied by the
         # operator mid-run can be observed while the spend is still avoidable.
-        _landing_block = landing_precondition_error(config, auto_merge=auto_merge)
+        _landing_block = landing_precondition_error(
+            config, auto_merge=auto_merge, lands_in_project_root=lands_in_project_root
+        )
         if _landing_block is not None:
             state.phase = Phase.ESCALATE
             state.error = _landing_block
@@ -1296,6 +1305,7 @@ def _run_resume_coordinator(
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
+    lands_in_project_root: bool | None = None,
 ) -> CoordinatorResult:
     """Shared body for run_from_review and run_from_dev.
 
@@ -1330,7 +1340,9 @@ def _run_resume_coordinator(
     # Same landing precondition run_task enforces, at the resume entry point:
     # a resumed story re-runs dev and/or review, so a dirty project root has to
     # refuse here rather than after that spend (#2048).
-    _landing_block = landing_precondition_error(config, auto_merge=auto_merge)
+    _landing_block = landing_precondition_error(
+        config, auto_merge=auto_merge, lands_in_project_root=lands_in_project_root
+    )
     if _landing_block is not None:
         state.phase = Phase.ESCALATE
         state.error = _landing_block
@@ -1525,6 +1537,7 @@ def run_from_review(
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
+    lands_in_project_root: bool | None = None,
 ) -> CoordinatorResult:
     """Start at REVIEW on an existing worktree, then iterate DEV→VALIDATE→REVIEW as needed.
 
@@ -1542,6 +1555,10 @@ def run_from_review(
         auto_merge: When True, merge the feature branch after APPROVE.
         defer_landing: When True, skip the landing step and leave
             landing_status="pending_integration" for the caller (sprint scheduler).
+        lands_in_project_root: Caller's answer to whether this story's approval
+            merges into the project-root checkout, used by the landing
+            precondition. The sprint scheduler supplies it; None derives it from
+            auto_merge and config.
     """
     return _run_resume_coordinator(
         config,
@@ -1560,6 +1577,7 @@ def run_from_review(
         defer_landing=defer_landing,
         stop_event=stop_event,
         base_lands_locally=base_lands_locally,
+        lands_in_project_root=lands_in_project_root,
     )
 
 
@@ -1579,6 +1597,7 @@ def run_from_dev(
     defer_landing: bool = False,
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
+    lands_in_project_root: bool | None = None,
 ) -> CoordinatorResult:
     """Start at DEV on an existing worktree, skipping WORKSPACE and PREFLIGHT.
 
@@ -1593,6 +1612,10 @@ def run_from_dev(
         auto_merge: When True, merge the feature branch after APPROVE.
         defer_landing: When True, skip the landing step and leave
             landing_status="pending_integration" for the caller (sprint scheduler).
+        lands_in_project_root: Caller's answer to whether this story's approval
+            merges into the project-root checkout, used by the landing
+            precondition. The sprint scheduler supplies it; None derives it from
+            auto_merge and config.
     """
     return _run_resume_coordinator(
         config,
@@ -1611,6 +1634,7 @@ def run_from_dev(
         defer_landing=defer_landing,
         stop_event=stop_event,
         base_lands_locally=base_lands_locally,
+        lands_in_project_root=lands_in_project_root,
     )
 
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -85,7 +85,12 @@ from .util import (
     _round_cost,
     live_complexity_fields,
 )
-from .workspace import _base_branch_lands_locally, _create_workspace, pull_base_branch
+from .workspace import (
+    _base_branch_lands_locally,
+    _create_workspace,
+    landing_precondition_error,
+    pull_base_branch,
+)
 from .workspace_scrub import _scrub_forge_history
 
 # ── Lazy runner symbols ───────────────────────────────────────────────
@@ -880,6 +885,28 @@ def run_task(
         _log_phase(state.phase, task.slug)
         logger._safe_emit("phase_start", phase="WORKSPACE", iteration=0)
 
+        # Refuse before the workspace exists, not after review has been paid
+        # for: a dirty project root blocks this story's landing, and in a
+        # sprint this is the first point at which a root dirtied by the
+        # operator mid-run can be observed while the spend is still avoidable.
+        _landing_block = landing_precondition_error(config, auto_merge=auto_merge)
+        if _landing_block is not None:
+            state.phase = Phase.ESCALATE
+            state.error = _landing_block
+            _log(f"✗ ESCALATE   {_landing_block}")
+            logger._safe_emit("phase_end", phase="WORKSPACE", outcome="escalate")
+            logger._safe_emit("escalate", reason=_landing_block, phase="WORKSPACE")
+            logger._safe_emit(
+                "run_end", outcome="escalate", total_cost_usd=0.0, total_duration_s=0.0
+            )
+            _escalate_notify(task, state, notify, config)
+            return CoordinatorResult(
+                success=False,
+                phase=state.phase,
+                state=state,
+                message=_landing_block,
+            )
+
         workspace_path, branch_name, err = _create_workspace(
             config,
             task,
@@ -1299,6 +1326,25 @@ def _run_resume_coordinator(
     if isinstance(setup, CoordinatorResult):
         return setup
     state, logger, branch_name, story_content, _task_start = setup
+
+    # Same landing precondition run_task enforces, at the resume entry point:
+    # a resumed story re-runs dev and/or review, so a dirty project root has to
+    # refuse here rather than after that spend (#2048).
+    _landing_block = landing_precondition_error(config, auto_merge=auto_merge)
+    if _landing_block is not None:
+        state.phase = Phase.ESCALATE
+        state.error = _landing_block
+        _log(f"✗ ESCALATE   {_landing_block}")
+        logger._safe_emit("escalate", reason=_landing_block, phase="INIT")
+        logger._safe_emit("run_end", outcome="escalate", total_cost_usd=0.0, total_duration_s=0.0)
+        _escalate_notify(task, state, notify, config)
+        return CoordinatorResult(
+            success=False,
+            phase=state.phase,
+            state=state,
+            message=_landing_block,
+        )
+
     state.log_dir = _make_story_log_dir(config, task.slug, sprint_name=sprint_name)
     state.sprint_name = sprint_name
 

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -28,6 +28,9 @@ run_agent = None
 _MAX_AUTO_RESOLVE_FILES = 5
 _CONFLICT_RESOLUTION_TIMEOUT = 120
 
+# Cap on the porcelain excerpt quoted back to the operator in a dirty-root refusal.
+_DIRTY_ROOT_SUMMARY_LIMIT = 200
+
 # Matches setup_command templates that still contain the {forge_python} placeholder.
 # Captures the install command (group 1).  Matched BEFORE substitution so we never
 # have to parse shlex.quote() output — any valid interpreter path is accepted.
@@ -326,6 +329,56 @@ def _resolve_merge_conflicts(
     return True
 
 
+def project_root_dirty_status(project_root: Path) -> str:
+    """Porcelain status of the project-root checkout; ``""`` when clean.
+
+    A failing ``git status`` yields ``""``: a root we cannot inspect is not
+    evidence of dirt, and the landing check has always failed open there.
+
+    Single source of truth for the landing precondition so the entry-time
+    refusal and ``_merge_branch``'s refusal can never drift apart.
+    """
+    ok, out = _cu._run_shell("git status --porcelain", project_root)
+    if not ok:
+        return ""
+    return out.strip()
+
+
+def landing_precondition_error(config: ForgeConfig, *, auto_merge: bool = False) -> str | None:
+    """Refusal message when the project root cannot accept a landing, else ``None``.
+
+    A dirty project root makes ``_merge_branch`` refuse *after* dev and review
+    have been paid for (#2048). The condition is knowable before any agent is
+    dispatched, so callers evaluate it at run entry — and re-evaluate it at each
+    story's entry, which is the first point a root dirtied mid-sprint can be
+    observed while the next story's spend is still avoidable.
+
+    ``auto_merge`` mirrors ``completion._finalize_approve``'s effective-mode
+    resolution: the CLI flag forces ``"merge"`` regardless of configuration.
+    Under ``on_approve`` values that never touch the project-root checkout
+    (``pr``, ``merge-pr``, ``none``) its cleanliness is not forge's business and
+    this returns ``None``.
+
+    The dirty condition mirrors ``_merge_branch`` exactly — untracked files
+    included — so anything refused here is something that would have been
+    refused at landing anyway.
+    """
+    if not (auto_merge or config.workspace.on_approve == "merge"):
+        return None
+    if not (config.project_root / ".git").exists():
+        return None
+    dirty = project_root_dirty_status(config.project_root)
+    if not dirty:
+        return None
+    files = ", ".join(line.strip() for line in dirty.splitlines())[:_DIRTY_ROOT_SUMMARY_LIMIT]
+    return (
+        "LANDING PRECONDITION: uncommitted changes in project root "
+        f"{config.project_root}: {files}. An approved story cannot merge into a "
+        "dirty checkout — commit, stash, or revert these before running, so the "
+        "refusal does not arrive after dev and review have already been paid for."
+    )
+
+
 def _merge_branch(
     project_root: Path,
     base_branch: str,
@@ -354,9 +407,9 @@ def _merge_branch(
         _cu._log(f"Auto-merge skipped: {info['error']}")
         return info
 
-    ok, dirty = _cu._run_shell("git status --porcelain", project_root)
-    if ok and dirty.strip():
-        info["error"] = f"Uncommitted changes in project root: {dirty.strip()[:200]}"
+    dirty = project_root_dirty_status(project_root)
+    if dirty:
+        info["error"] = f"Uncommitted changes in project root: {dirty[:_DIRTY_ROOT_SUMMARY_LIMIT]}"
         _cu._log(f"Auto-merge skipped: {info['error']}")
         return info
 

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -344,7 +344,36 @@ def project_root_dirty_status(project_root: Path) -> str:
     return out.strip()
 
 
-def landing_precondition_error(config: ForgeConfig, *, auto_merge: bool = False) -> str | None:
+def story_lands_in_project_root(
+    config: ForgeConfig,
+    *,
+    auto_merge: bool = False,
+    lands_in_project_root: bool | None = None,
+) -> bool:
+    """Whether this story's approval merges into the project-root checkout.
+
+    The default derivation mirrors ``completion._finalize_approve``: the
+    ``--auto-merge`` flag forces ``"merge"`` regardless of configuration, and no
+    other ``on_approve`` value (``pr``, ``merge-pr``, ``none``) ever touches that
+    checkout.
+
+    ``lands_in_project_root`` is the caller's own answer and wins when supplied.
+    The sprint scheduler has one: in parallel mode it rewrites a dependency
+    parent's landing to a local merge after the story returns
+    (``runner._attempt_integration``'s ``pending_integration`` conversion), so
+    the story's own ``auto_merge`` and ``on_approve`` understate the obligation.
+    """
+    if lands_in_project_root is not None:
+        return lands_in_project_root
+    return auto_merge or config.workspace.on_approve == "merge"
+
+
+def landing_precondition_error(
+    config: ForgeConfig,
+    *,
+    auto_merge: bool = False,
+    lands_in_project_root: bool | None = None,
+) -> str | None:
     """Refusal message when the project root cannot accept a landing, else ``None``.
 
     A dirty project root makes ``_merge_branch`` refuse *after* dev and review
@@ -353,17 +382,18 @@ def landing_precondition_error(config: ForgeConfig, *, auto_merge: bool = False)
     story's entry, which is the first point a root dirtied mid-sprint can be
     observed while the next story's spend is still avoidable.
 
-    ``auto_merge`` mirrors ``completion._finalize_approve``'s effective-mode
-    resolution: the CLI flag forces ``"merge"`` regardless of configuration.
-    Under ``on_approve`` values that never touch the project-root checkout
-    (``pr``, ``merge-pr``, ``none``) its cleanliness is not forge's business and
-    this returns ``None``.
+    Whether the story lands locally at all comes from
+    ``story_lands_in_project_root``; under workflows that never touch the
+    project-root checkout its cleanliness is not forge's business and this
+    returns ``None``.
 
     The dirty condition mirrors ``_merge_branch`` exactly — untracked files
     included — so anything refused here is something that would have been
     refused at landing anyway.
     """
-    if not (auto_merge or config.workspace.on_approve == "merge"):
+    if not story_lands_in_project_root(
+        config, auto_merge=auto_merge, lands_in_project_root=lands_in_project_root
+    ):
         return None
     if not (config.project_root / ".git").exists():
         return None

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2527,6 +2527,15 @@ def run_sprint(
     }
     dependent_slugs = {dep for task, _src, _ref in task_entries for dep in task.depends_on}
 
+    # Dependency parents this sprint can actually dispatch and integrate itself.
+    # ``dependent_slugs`` is the raw edge target set, which also names external
+    # references — an issue already merged on main, or one this sprint does not
+    # carry. Those parents never run here and never merge into the project-root
+    # checkout, so a landing obligation derived from the raw set would refuse a
+    # PR-landing sprint whose only edge points outside the manifest (#2048
+    # review iteration 2).
+    in_manifest_dependency_parents = dependent_slugs & set(slug_to_context)
+
     # Stories of this sprint whose agent survived the re-exec. They stay in the
     # DAG and are dispatched like any other story, but through the deferred path
     # (``_run_inherited_story``): wait for the inherited agent, then resume from
@@ -2542,10 +2551,12 @@ def run_sprint(
     # its own effective_auto_merge. Parallel mode never eager-merges (see the
     # effective_am computation below, which forces False when max_parallel > 1);
     # sequential mode merges for --auto-merge and, independently of it, for any
-    # story other stories depend on.
+    # story other stories depend on — which is the in-manifest parent set, the
+    # same one ``effective_am`` tests per story. The raw edge-target set would
+    # also count purely external references, which no story here ever merges.
     _sprint_lands_locally = coordinator_workspace._base_branch_lands_locally(
         config,
-        auto_merge=(max_parallel <= 1 and (auto_merge or bool(dependent_slugs))),
+        auto_merge=(max_parallel <= 1 and (auto_merge or bool(in_manifest_dependency_parents))),
     )
 
     total = len(task_entries)
@@ -2687,10 +2698,17 @@ def run_sprint(
     # suppresses itself in parallel mode: parallel stories skip the *eager*
     # merge but still land through the integration step, so on_approve == "merge"
     # merges locally regardless of max_parallel. Dependency parents merge locally
-    # in sequential mode even without --auto-merge, hence dependent_slugs.
+    # even without --auto-merge, hence in_manifest_dependency_parents — the
+    # in-manifest set, because an edge pointing at an external issue produces no
+    # local merge and must not refuse a sprint that never lands here.
     if _project_root_is_git_checkout(config.project_root):
         _landing_block = coordinator_workspace.landing_precondition_error(
-            config, auto_merge=(auto_merge or bool(dependent_slugs))
+            config,
+            lands_in_project_root=(
+                auto_merge
+                or config.workspace.on_approve == "merge"
+                or bool(in_manifest_dependency_parents)
+            ),
         )
         if _landing_block is not None:
             _log(f"✗ SPRINT ABORT  {_landing_block}")
@@ -4061,7 +4079,7 @@ def run_sprint(
                 _story_lands_in_root = (
                     effective_am
                     or config.workspace.on_approve == "merge"
-                    or task.slug in dependent_slugs
+                    or task.slug in in_manifest_dependency_parents
                 )
 
                 spec_str = slug_to_spec[task.slug]

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2668,6 +2668,22 @@ def run_sprint(
     except Exception:
         pass
 
+    # Landing precondition, evaluated before a single agent is dispatched: a
+    # dirty project root makes every local merge refuse, and discovering that at
+    # landing means the story's full dev+review spend is already sunk (#2048).
+    # The predicate deliberately differs from _sprint_lands_locally, which
+    # suppresses itself in parallel mode: parallel stories skip the *eager*
+    # merge but still land through the integration step, so on_approve == "merge"
+    # merges locally regardless of max_parallel. Dependency parents merge locally
+    # in sequential mode even without --auto-merge, hence dependent_slugs.
+    if _project_root_is_git_checkout(config.project_root):
+        _landing_block = coordinator_workspace.landing_precondition_error(
+            config, auto_merge=(auto_merge or bool(dependent_slugs))
+        )
+        if _landing_block is not None:
+            _log(f"✗ SPRINT ABORT  {_landing_block}")
+            raise RuntimeError(_landing_block)
+
     if not no_pull and _project_root_is_git_checkout(config.project_root):
         coordinator_workspace.pull_base_branch(config, lands_locally=_sprint_lands_locally)
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2563,6 +2563,31 @@ def run_sprint(
     # review iteration 2).
     in_manifest_dependency_parents = dependent_slugs & set(slug_to_context)
 
+    # Which landing paths in this sprint actually merge into the project-root
+    # checkout? Both flags mirror the effective-mode resolution the workers
+    # reach (``effective_am`` below → ``completion._finalize_approve``), because
+    # a landing precondition asserted for a merge that never happens refuses
+    # work forge could have done.
+    #
+    #   * ``on_approve: merge`` merges locally in either mode.
+    #   * ``--auto-merge`` forces ``"merge"`` only where the flag survives to
+    #     the worker. ``effective_am`` is hard-False in parallel mode, so the
+    #     flag is dropped there and nothing merges locally on its account.
+    #   * A dependency parent merges locally in sequential mode — ``effective_am``
+    #     forces ``"merge"`` for it whatever ``on_approve`` says — and in
+    #     parallel mode through the scheduler's ``pending_integration``
+    #     conversion. That conversion fires only for a story that produced no
+    #     landing of its own (``landing_status is None``), i.e. ``on_approve``
+    #     ``"pr"`` or ``"none"``. Under ``"merge-pr"`` the parent lands through
+    #     its own PR and never touches the project-root checkout — the same
+    #     carve-out the ``auto_enabled_dependency_merges`` warning makes below.
+    config_lands_in_project_root = config.workspace.on_approve == "merge" or (
+        auto_merge and max_parallel <= 1
+    )
+    dependency_parents_land_in_project_root = (
+        max_parallel <= 1 or config.workspace.on_approve != "merge-pr"
+    )
+
     # Stories of this sprint whose agent survived the re-exec. They stay in the
     # DAG and are dispatched like any other story, but through the deferred path
     # (``_run_inherited_story``): wait for the inherited agent, then resume from
@@ -2721,11 +2746,11 @@ def run_sprint(
     # Landing precondition, first pass: a dirty project root makes every local
     # merge refuse, and discovering that at landing means the story's full
     # dev+review spend is already sunk (#2048). Only the configuration-level
-    # signals are used here, because they are the only ones knowable this early
-    # and they are never wrong. The predicate deliberately differs from
-    # _sprint_lands_locally, which suppresses itself in parallel mode: parallel
-    # stories skip the *eager* merge but still land through the integration
-    # step, so on_approve == "merge" merges locally regardless of max_parallel.
+    # answer is used here, because it is the only one knowable this early. It
+    # deliberately differs from _sprint_lands_locally, which suppresses itself
+    # in parallel mode: parallel stories skip the *eager* merge but still land
+    # through the integration step, so on_approve == "merge" merges locally
+    # regardless of max_parallel.
     #
     # The dependency-derived obligation is NOT evaluated here. Whether an
     # in-manifest parent actually merges depends on the satisfied and
@@ -2735,7 +2760,7 @@ def run_sprint(
     # still ahead of every agent spend.
     _refuse_dirty_root_before_spend(
         config,
-        lands_in_project_root=(auto_merge or config.workspace.on_approve == "merge"),
+        lands_in_project_root=config_lands_in_project_root,
         stage="sprint-entry",
     )
 
@@ -3067,19 +3092,26 @@ def run_sprint(
 
     # Landing precondition, dependency-resolved pass. A dependency parent this
     # sprint carries is merged into the project-root checkout to unblock its
-    # child, whatever on_approve says — but only if it is actually dispatched.
-    # A parent already satisfied (closed dependency, branch merged into base) or
-    # triaged skip_merged on resume never runs and never merges, so it owes
-    # nothing and must not refuse a sprint that otherwise never lands here
-    # (#2048 review iteration 3). Both sets are known now and nothing has been
-    # spent yet: intake remediation, batch preflight, and story dispatch are all
-    # still ahead.
+    # child — but only when two things hold, and both are false often enough
+    # that asserting either one alone refuses work forge could have done:
+    #
+    #   1. The parent is actually dispatched. One already satisfied (closed
+    #      dependency, branch merged into base) or triaged skip_merged on resume
+    #      never runs and never merges (#2048 review iteration 3). Both sets are
+    #      known now, and nothing has been spent: intake remediation, batch
+    #      preflight, and story dispatch are all still ahead.
+    #   2. The sprint's landing path for parents is a local merge at all — see
+    #      dependency_parents_land_in_project_root. A parallel merge-pr sprint
+    #      lands its parent through that parent's own PR and never touches the
+    #      project-root checkout (#2048 review iteration 4).
     _dispatchable_dependency_parents = (
         in_manifest_dependency_parents - satisfied_slugs - skip_slugs
     )
     _refuse_dirty_root_before_spend(
         config,
-        lands_in_project_root=bool(_dispatchable_dependency_parents),
+        lands_in_project_root=(
+            bool(_dispatchable_dependency_parents) and dependency_parents_land_in_project_root
+        ),
         stage="dependency-resolved",
     )
 
@@ -4119,10 +4151,15 @@ def run_sprint(
                 # conversion below), so with on_approve "none" or "pr" the
                 # worker would otherwise see no landing obligation, run dev and
                 # review, and only then meet the dirty-root refusal (#2048).
+                # It also overstates it, hence the dependency_parents_ guard: a
+                # parallel merge-pr parent lands through its PR, not here.
                 _story_lands_in_root = (
                     effective_am
-                    or config.workspace.on_approve == "merge"
-                    or task.slug in in_manifest_dependency_parents
+                    or config_lands_in_project_root
+                    or (
+                        task.slug in in_manifest_dependency_parents
+                        and dependency_parents_land_in_project_root
+                    )
                 )
 
                 spec_str = slug_to_spec[task.slug]

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -968,6 +968,33 @@ def _project_root_is_git_checkout(project_root: Path) -> bool:
     return git_dir_check.returncode == 0
 
 
+def _refuse_dirty_root_before_spend(
+    config: ForgeConfig, *, lands_in_project_root: bool, stage: str
+) -> None:
+    """Abort the sprint when the project root cannot accept the landing it owes.
+
+    Called at two points, each as soon as the obligation it tests becomes
+    knowable: ``sprint-entry`` for the configuration-level signals, and
+    ``dependency-resolved`` once the satisfied and resume-triage sets say which
+    in-manifest dependency parents will actually be dispatched and merged. Both
+    run ahead of every agent spend, so the operator learns of a dirty root
+    instead of paying dev and review and meeting the refusal at landing (#2048).
+
+    ``stage`` is logged with the refusal so the audit trail records which pass
+    fired — the two answer different questions and a misfire is diagnosed by
+    knowing which one spoke.
+    """
+    if not lands_in_project_root:
+        return
+    if not _project_root_is_git_checkout(config.project_root):
+        return
+    block = coordinator_workspace.landing_precondition_error(config, lands_in_project_root=True)
+    if block is None:
+        return
+    _log(f"✗ SPRINT ABORT  [{stage}] {block}")
+    raise RuntimeError(block)
+
+
 #: ``GateLabel.purpose`` for the pre-sprint merge-base gate.
 BASELINE_GATE_PURPOSE = "baseline gate"
 
@@ -2691,28 +2718,26 @@ def run_sprint(
     except Exception:
         pass
 
-    # Landing precondition, evaluated before a single agent is dispatched: a
-    # dirty project root makes every local merge refuse, and discovering that at
-    # landing means the story's full dev+review spend is already sunk (#2048).
-    # The predicate deliberately differs from _sprint_lands_locally, which
-    # suppresses itself in parallel mode: parallel stories skip the *eager*
-    # merge but still land through the integration step, so on_approve == "merge"
-    # merges locally regardless of max_parallel. Dependency parents merge locally
-    # even without --auto-merge, hence in_manifest_dependency_parents — the
-    # in-manifest set, because an edge pointing at an external issue produces no
-    # local merge and must not refuse a sprint that never lands here.
-    if _project_root_is_git_checkout(config.project_root):
-        _landing_block = coordinator_workspace.landing_precondition_error(
-            config,
-            lands_in_project_root=(
-                auto_merge
-                or config.workspace.on_approve == "merge"
-                or bool(in_manifest_dependency_parents)
-            ),
-        )
-        if _landing_block is not None:
-            _log(f"✗ SPRINT ABORT  {_landing_block}")
-            raise RuntimeError(_landing_block)
+    # Landing precondition, first pass: a dirty project root makes every local
+    # merge refuse, and discovering that at landing means the story's full
+    # dev+review spend is already sunk (#2048). Only the configuration-level
+    # signals are used here, because they are the only ones knowable this early
+    # and they are never wrong. The predicate deliberately differs from
+    # _sprint_lands_locally, which suppresses itself in parallel mode: parallel
+    # stories skip the *eager* merge but still land through the integration
+    # step, so on_approve == "merge" merges locally regardless of max_parallel.
+    #
+    # The dependency-derived obligation is NOT evaluated here. Whether an
+    # in-manifest parent actually merges depends on the satisfied and
+    # resume-triage sets, which are only resolved further down — asserting it
+    # now would refuse sprints whose parent is already merged and will never be
+    # dispatched. That term is checked at the "dependency-resolved" pass below,
+    # still ahead of every agent spend.
+    _refuse_dirty_root_before_spend(
+        config,
+        lands_in_project_root=(auto_merge or config.workspace.on_approve == "merge"),
+        stage="sprint-entry",
+    )
 
     if not no_pull and _project_root_is_git_checkout(config.project_root):
         coordinator_workspace.pull_base_branch(config, lands_locally=_sprint_lands_locally)
@@ -3039,6 +3064,24 @@ def run_sprint(
         pre_satisfied=pre_satisfied,
     )
     normalized = normalize_dependency_plan(all_tasks, satisfied=satisfied_slugs)
+
+    # Landing precondition, dependency-resolved pass. A dependency parent this
+    # sprint carries is merged into the project-root checkout to unblock its
+    # child, whatever on_approve says — but only if it is actually dispatched.
+    # A parent already satisfied (closed dependency, branch merged into base) or
+    # triaged skip_merged on resume never runs and never merges, so it owes
+    # nothing and must not refuse a sprint that otherwise never lands here
+    # (#2048 review iteration 3). Both sets are known now and nothing has been
+    # spent yet: intake remediation, batch preflight, and story dispatch are all
+    # still ahead.
+    _dispatchable_dependency_parents = (
+        in_manifest_dependency_parents - satisfied_slugs - skip_slugs
+    )
+    _refuse_dirty_root_before_spend(
+        config,
+        lands_in_project_root=bool(_dispatchable_dependency_parents),
+        stage="dependency-resolved",
+    )
 
     # Surface the current sprint phase to forge status --watch so operators
     # see meaningful progress signals during the multi-minute pre-init window.

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1566,6 +1566,7 @@ def _run_fresh(
     *,
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
+    lands_in_project_root: bool | None = None,
 ) -> CoordinatorResult:
     """Run a fresh story, optionally splitting at PLAN_REVIEW for overlap gating."""
     if plan_gate is None:
@@ -1600,6 +1601,7 @@ def _run_fresh(
                 defer_landing=True,
                 stop_event=stop_event,
                 base_lands_locally=base_lands_locally,
+                lands_in_project_root=lands_in_project_root,
             )
         return run_task(
             config,
@@ -1614,6 +1616,7 @@ def _run_fresh(
             defer_landing=True,
             stop_event=stop_event,
             base_lands_locally=base_lands_locally,
+            lands_in_project_root=lands_in_project_root,
         )
 
     # Phase 1: run through PLAN only
@@ -1631,6 +1634,7 @@ def _run_fresh(
         defer_landing=True,
         stop_event=stop_event,
         base_lands_locally=base_lands_locally,
+        lands_in_project_root=lands_in_project_root,
     )
 
     if not plan_result.success:
@@ -1668,6 +1672,7 @@ def _run_fresh(
         defer_landing=True,
         stop_event=stop_event,
         base_lands_locally=base_lands_locally,
+        lands_in_project_root=lands_in_project_root,
     )
 
 
@@ -1687,6 +1692,7 @@ def _run_single_story(
     preflight_states: dict[str, CoordinatorState] | None = None,
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
+    lands_in_project_root: bool | None = None,
 ) -> "tuple[TaskStory, CoordinatorResult, float, datetime.datetime, datetime.datetime]":
     """Execute a single story and return (task, result, elapsed, started_at, finished_at).
 
@@ -1723,6 +1729,7 @@ def _run_single_story(
                     defer_landing=True,
                     stop_event=stop_event,
                     base_lands_locally=base_lands_locally,
+                    lands_in_project_root=lands_in_project_root,
                 )
             elif triage.action == "dev" and triage.worktree_path is not None:
                 result = run_from_dev(
@@ -1739,6 +1746,7 @@ def _run_single_story(
                     defer_landing=True,
                     stop_event=stop_event,
                     base_lands_locally=base_lands_locally,
+                    lands_in_project_root=lands_in_project_root,
                 )
             else:
                 result = _run_fresh(
@@ -1755,6 +1763,7 @@ def _run_single_story(
                     preflight_states,
                     stop_event=stop_event,
                     base_lands_locally=base_lands_locally,
+                    lands_in_project_root=lands_in_project_root,
                 )
         else:
             result = _run_fresh(
@@ -1771,6 +1780,7 @@ def _run_single_story(
                 preflight_states,
                 stop_event=stop_event,
                 base_lands_locally=base_lands_locally,
+                lands_in_project_root=lands_in_project_root,
             )
     except Exception as exc:
         _log(f"ERROR {task.slug}: worker thread raised {type(exc).__name__}: {exc}")
@@ -1811,6 +1821,7 @@ def _run_inherited_story(
     preflight_states: dict[str, CoordinatorState] | None = None,
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
+    lands_in_project_root: bool | None = None,
     *,
     canonical_ref: str,
     quiesce_timeout: float,
@@ -1890,6 +1901,7 @@ def _run_inherited_story(
         preflight_states,
         stop_event,
         base_lands_locally=base_lands_locally,
+        lands_in_project_root=lands_in_project_root,
     )
 
 
@@ -4039,6 +4051,19 @@ def run_sprint(
                     False if max_parallel > 1 else (auto_merge or task.slug in dependent_slugs)
                 )
 
+                # Will *this* story's approval merge into the project-root
+                # checkout? effective_am alone understates it: a parallel
+                # dependency parent is forced into a local merge by the
+                # scheduler after it returns (see the pending_integration
+                # conversion below), so with on_approve "none" or "pr" the
+                # worker would otherwise see no landing obligation, run dev and
+                # review, and only then meet the dirty-root refusal (#2048).
+                _story_lands_in_root = (
+                    effective_am
+                    or config.workspace.on_approve == "merge"
+                    or task.slug in dependent_slugs
+                )
+
                 spec_str = slug_to_spec[task.slug]
                 triage = triages.get(spec_str) if resume else None
                 # A story whose agent survived the re-exec is dispatched through
@@ -4084,7 +4109,10 @@ def run_sprint(
                 )
                 stop_evt = threading.Event()
                 stop_events[task.slug] = stop_evt
-                _dispatch_kwargs: dict = {"base_lands_locally": _sprint_lands_locally}
+                _dispatch_kwargs: dict = {
+                    "base_lands_locally": _sprint_lands_locally,
+                    "lands_in_project_root": _story_lands_in_root,
+                }
                 if _inherited:
                     _dispatch_fn = _run_inherited_story
                     _dispatch_kwargs["canonical_ref"] = spec_str

--- a/tests/test_coord_landing_precondition.py
+++ b/tests/test_coord_landing_precondition.py
@@ -471,14 +471,39 @@ def test_in_manifest_dependency_parent_still_imposes_a_landing_obligation(
     """A parent carried by this sprint is merged locally to unblock its child.
 
     on_approve is "pr" and --auto-merge is off, so only the dependency edge
-    reveals the landing — the sprint must still refuse a dirty root.
+    reveals the landing — the sprint must still refuse a dirty root, and must
+    do so before batch preflight, the first agent spend.
     """
     config, manifest = _dependency_sprint(
         tmp_path, on_approve="pr", dep="parent", in_manifest_parent=True
     )
 
     with ExitStack() as stack:
-        for cm in _entry_patches(set()):
-            stack.enter_context(cm)
+        mocks = [stack.enter_context(cm) for cm in _entry_patches(set())]
+        mock_preflight = mocks[-1]
         with pytest.raises(RuntimeError, match="forge.yaml"):
+            run_sprint(config, manifest)
+
+    mock_preflight.assert_not_called()
+
+
+def test_satisfied_in_manifest_parent_imposes_no_landing_obligation(tmp_path: Path) -> None:
+    """A parent already merged is never dispatched, so it owes no landing.
+
+    Same shape as the test above — an in-manifest dependency parent under
+    on_approve "pr" — except dependency resolution reports it satisfied. Nothing
+    in this sprint can merge into the project-root checkout, so the dirty root
+    must not refuse it (#2048 review iteration 3). Sprint entry cannot know
+    this, which is why the dependency-derived term is asserted only after the
+    satisfied and resume-triage sets are resolved.
+    """
+    config, manifest = _dependency_sprint(
+        tmp_path, on_approve="pr", dep="parent", in_manifest_parent=True
+    )
+
+    with ExitStack() as stack:
+        for cm in _entry_patches({"parent"}):
+            stack.enter_context(cm)
+        # Reaching batch preflight proves neither pass refused.
+        with pytest.raises(RuntimeError, match="stop after baseline"):
             run_sprint(config, manifest)

--- a/tests/test_coord_landing_precondition.py
+++ b/tests/test_coord_landing_precondition.py
@@ -35,6 +35,7 @@ from theforge.coordinator.workspace import (
     _merge_branch,
     landing_precondition_error,
     project_root_dirty_status,
+    story_lands_in_project_root,
 )
 from theforge.sprint.runner import run_sprint
 
@@ -111,6 +112,29 @@ class TestLandingPreconditionError:
         assert project_root_dirty_status(tmp_path) == ""
         assert landing_precondition_error(_merge_config(tmp_path)) is None
 
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_caller_supplied_obligation_overrides_the_derivation(self, mock_shell, tmp_path):
+        """The scheduler's answer wins over auto_merge + on_approve.
+
+        A parallel dependency parent has auto_merge=False and on_approve="none"
+        yet is forced into a local merge after it returns, so the derivation
+        alone would let it spend before the refusal.
+        """
+        mock_shell.side_effect = _shell(DIRTY)
+        config = _merge_config(tmp_path, on_approve="none")
+
+        assert story_lands_in_project_root(config) is False
+        assert story_lands_in_project_root(config, lands_in_project_root=True) is True
+        assert landing_precondition_error(config) is None
+        assert landing_precondition_error(config, lands_in_project_root=True) is not None
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_caller_can_waive_a_derived_obligation(self, mock_shell, tmp_path):
+        """An explicit False also wins — the override is not an OR."""
+        mock_shell.side_effect = _shell(DIRTY)
+        config = _merge_config(tmp_path, on_approve="merge")
+        assert landing_precondition_error(config, lands_in_project_root=False) is None
+
 
 # ── Parity with the landing-time refusal ──────────────────────────────
 
@@ -149,6 +173,27 @@ class TestRunTaskEntry:
         task = _make_task(tmp_path)
 
         result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase is Phase.ESCALATE
+        assert "forge.yaml" in result.message
+        mock_create.assert_not_called()
+
+    @patch("theforge.coordinator.engine._create_workspace")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_scheduler_obligation_escalates_under_on_approve_none(
+        self, mock_shell, mock_create, tmp_path
+    ):
+        """A parallel dependency parent refuses before spend.
+
+        auto_merge is False and on_approve is "none", so only the scheduler's
+        obligation reveals that this story will be forced into a local merge.
+        """
+        mock_shell.side_effect = _shell(DIRTY)
+        config = _merge_config(tmp_path, on_approve="none")
+        task = _make_task(tmp_path)
+
+        result = run_task(config, task, auto_merge=False, lands_in_project_root=True)
 
         assert result.success is False
         assert result.phase is Phase.ESCALATE
@@ -272,3 +317,80 @@ def test_run_sprint_clean_root_proceeds(tmp_path: Path) -> None:
             run_sprint(config, resolved)
 
     mock_pull.assert_called_once()
+
+
+# ── Scheduler seam: the per-story landing obligation reaches the worker ──
+
+
+class _StopDispatch(RuntimeError):
+    """Raised from the fake executor to end the sprint at first submit."""
+
+
+def _capturing_executor(captured: dict):
+    class _FakeExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            # _run_single_story positionals: config, task, triage, run_id,
+            # sprint_name, interactive, notify, resume, effective_auto_merge, ...
+            captured[args[1].slug] = {
+                "lands_in_project_root": kwargs.get("lands_in_project_root"),
+                "effective_auto_merge": args[8],
+            }
+            raise _StopDispatch(args[1].slug)
+
+    return _FakeExecutor
+
+
+def test_parallel_dependency_parent_dispatched_with_landing_obligation(tmp_path: Path) -> None:
+    """A parallel dependency parent must reach its worker knowing it lands locally.
+
+    on_approve is "none" and --auto-merge is off, so ``effective_am`` is False
+    and the story's own flags reveal no landing. The scheduler nevertheless
+    rewrites its result to a local merge once it returns, so without the
+    threaded obligation the dirty-root refusal would land after dev and review
+    (#2048 review iteration 1).
+    """
+    from tests.test_sprint_resume import _make_config as _make_sprint_config
+    from tests.test_sprint_resume import _make_spec_file
+
+    config = _make_sprint_config(tmp_path)
+    assert config.workspace.on_approve == "none"
+
+    parent = _make_spec_file(tmp_path, "Parent", "parent")
+    child = _make_spec_file(tmp_path, "Child", "child", depends_on=["parent"])
+    manifest = tmp_path / "sprint.yaml"
+    manifest.write_text(
+        "name: Test Sprint\nbudget_usd: 10.0\nmax_parallel: 2\nspecs:\n"
+        f"  - {parent.name}\n  - {child.name}\n",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, bool | None] = {}
+
+    with (
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.ThreadPoolExecutor", _capturing_executor(captured)),
+    ):
+        with pytest.raises(_StopDispatch):
+            run_sprint(config, manifest)
+
+    parent_kwargs = captured.get("parent")
+    assert parent_kwargs is not None, "dependency parent was never dispatched"
+    # Proves the parallel path: the story's own auto-merge flag says no landing.
+    assert parent_kwargs["effective_auto_merge"] is False
+    assert parent_kwargs["lands_in_project_root"] is True, (
+        "dependency parent dispatched without its scheduler-forced landing obligation"
+    )

--- a/tests/test_coord_landing_precondition.py
+++ b/tests/test_coord_landing_precondition.py
@@ -401,7 +401,12 @@ def test_parallel_dependency_parent_dispatched_with_landing_obligation(tmp_path:
 
 
 def _dependency_sprint(
-    tmp_path: Path, *, on_approve: str, dep: str, in_manifest_parent: bool
+    tmp_path: Path,
+    *,
+    on_approve: str,
+    dep: str,
+    in_manifest_parent: bool,
+    max_parallel: int = 1,
 ) -> tuple[ForgeConfig, Path]:
     """A dirty-rooted sprint whose only dependency edge is `dep`."""
     from tests.test_sprint_resume import _make_config as _make_sprint_config
@@ -418,7 +423,8 @@ def _dependency_sprint(
 
     manifest = tmp_path / "sprint.yaml"
     manifest.write_text(
-        "name: Test Sprint\nbudget_usd: 10.0\nspecs:\n" + "".join(f"  - {s}\n" for s in specs),
+        f"name: Test Sprint\nbudget_usd: 10.0\nmax_parallel: {max_parallel}\nspecs:\n"
+        + "".join(f"  - {s}\n" for s in specs),
         encoding="utf-8",
     )
     return config, manifest
@@ -507,3 +513,153 @@ def test_satisfied_in_manifest_parent_imposes_no_landing_obligation(tmp_path: Pa
         # Reaching batch preflight proves neither pass refused.
         with pytest.raises(RuntimeError, match="stop after baseline"):
             run_sprint(config, manifest)
+
+
+def test_parallel_merge_pr_dependency_parent_imposes_no_landing_obligation(
+    tmp_path: Path,
+) -> None:
+    """A parallel merge-pr parent lands through its own PR, not the local checkout.
+
+    ``_finalize_approve`` gives a merge-pr story landing_status
+    "pending_integration" with action "merge-pr", so the scheduler's
+    pending_integration conversion — which only fires for a story that produced
+    no landing of its own — never rewrites it to a local merge. Nothing here
+    touches the project root, so a dirty one must not refuse the sprint
+    (#2048 review iteration 4).
+    """
+    config, manifest = _dependency_sprint(
+        tmp_path, on_approve="merge-pr", dep="parent", in_manifest_parent=True, max_parallel=2
+    )
+
+    with ExitStack() as stack:
+        for cm in _entry_patches(set()):
+            stack.enter_context(cm)
+        # Reaching batch preflight proves neither pass refused.
+        with pytest.raises(RuntimeError, match="stop after baseline"):
+            run_sprint(config, manifest)
+
+
+def test_sequential_merge_pr_dependency_parent_still_imposes_a_landing_obligation(
+    tmp_path: Path,
+) -> None:
+    """Sequential mode eager-merges the parent, so merge-pr is not a blanket waiver.
+
+    ``effective_am`` is True for a dependency parent in sequential mode, which
+    forces effective on_approve to "merge" — a real local merge whatever the
+    configured landing path says.
+    """
+    config, manifest = _dependency_sprint(
+        tmp_path, on_approve="merge-pr", dep="parent", in_manifest_parent=True, max_parallel=1
+    )
+
+    with ExitStack() as stack:
+        mocks = [stack.enter_context(cm) for cm in _entry_patches(set())]
+        with pytest.raises(RuntimeError, match="forge.yaml"):
+            run_sprint(config, manifest)
+
+    mocks[-1].assert_not_called()
+
+
+def test_parallel_pr_dependency_parent_still_imposes_a_landing_obligation(
+    tmp_path: Path,
+) -> None:
+    """The merge-pr carve-out must not swallow the parallel "pr" case.
+
+    A "pr" story leaves landing_status None, so the scheduler's conversion does
+    rewrite the parent to a local merge — the very path review iteration 1 found.
+    """
+    config, manifest = _dependency_sprint(
+        tmp_path, on_approve="pr", dep="parent", in_manifest_parent=True, max_parallel=2
+    )
+
+    with ExitStack() as stack:
+        mocks = [stack.enter_context(cm) for cm in _entry_patches(set())]
+        with pytest.raises(RuntimeError, match="forge.yaml"):
+            run_sprint(config, manifest)
+
+    mocks[-1].assert_not_called()
+
+
+def test_parallel_merge_pr_parent_dispatched_without_landing_obligation(tmp_path: Path) -> None:
+    """The worker-side obligation carries the same merge-pr carve-out.
+
+    Mirror of test_parallel_dependency_parent_dispatched_with_landing_obligation:
+    same parallel dependency parent, but under merge-pr it does not land in the
+    project root, so the worker must not be told it does — otherwise a dirty
+    root would escalate a story that could have run.
+    """
+    from tests.test_sprint_resume import _make_config as _make_sprint_config
+    from tests.test_sprint_resume import _make_spec_file
+
+    config = _make_sprint_config(tmp_path)
+    config = replace(config, workspace=replace(config.workspace, on_approve="merge-pr"))
+
+    parent = _make_spec_file(tmp_path, "Parent", "parent")
+    child = _make_spec_file(tmp_path, "Child", "child", depends_on=["parent"])
+    manifest = tmp_path / "sprint.yaml"
+    manifest.write_text(
+        "name: Test Sprint\nbudget_usd: 10.0\nmax_parallel: 2\nspecs:\n"
+        f"  - {parent.name}\n  - {child.name}\n",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, dict] = {}
+
+    with (
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.ThreadPoolExecutor", _capturing_executor(captured)),
+    ):
+        with pytest.raises(_StopDispatch):
+            run_sprint(config, manifest)
+
+    parent_kwargs = captured.get("parent")
+    assert parent_kwargs is not None, "dependency parent was never dispatched"
+    assert parent_kwargs["effective_auto_merge"] is False
+    assert parent_kwargs["lands_in_project_root"] is False, (
+        "merge-pr parent told it lands in the project root, which it does not"
+    )
+
+
+def test_auto_merge_refuses_in_sequential_mode(tmp_path: Path) -> None:
+    """--auto-merge reaches the worker in sequential mode and forces a local merge."""
+    config, manifest = _dependency_sprint(
+        tmp_path,
+        on_approve="pr",
+        dep="external-issue",
+        in_manifest_parent=False,
+        max_parallel=1,
+    )
+
+    with ExitStack() as stack:
+        mocks = [stack.enter_context(cm) for cm in _entry_patches({"external-issue"})]
+        with pytest.raises(RuntimeError, match="forge.yaml"):
+            run_sprint(config, manifest, auto_merge=True)
+
+    mocks[-1].assert_not_called()
+
+
+def test_auto_merge_in_parallel_mode_imposes_no_landing_obligation(tmp_path: Path) -> None:
+    """--auto-merge is dropped in parallel mode, so it cannot make a story land.
+
+    ``effective_am`` is hard-False when max_parallel > 1, so the flag never
+    reaches ``_finalize_approve`` and the configured "pr" landing stands. The
+    dirty root must not refuse a sprint whose merges will not happen.
+    """
+    config, manifest = _dependency_sprint(
+        tmp_path,
+        on_approve="pr",
+        dep="external-issue",
+        in_manifest_parent=False,
+        max_parallel=2,
+    )
+
+    with ExitStack() as stack:
+        for cm in _entry_patches({"external-issue"}):
+            stack.enter_context(cm)
+        with pytest.raises(RuntimeError, match="stop after baseline"):
+            run_sprint(config, manifest, auto_merge=True)

--- a/tests/test_coord_landing_precondition.py
+++ b/tests/test_coord_landing_precondition.py
@@ -18,6 +18,7 @@ condition being evaluated at the points where the spend can still be avoided:
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -394,3 +395,90 @@ def test_parallel_dependency_parent_dispatched_with_landing_obligation(tmp_path:
     assert parent_kwargs["lands_in_project_root"] is True, (
         "dependency parent dispatched without its scheduler-forced landing obligation"
     )
+
+
+# ── Sprint entry: the obligation follows in-manifest dependency parents ──
+
+
+def _dependency_sprint(
+    tmp_path: Path, *, on_approve: str, dep: str, in_manifest_parent: bool
+) -> tuple[ForgeConfig, Path]:
+    """A dirty-rooted sprint whose only dependency edge is `dep`."""
+    from tests.test_sprint_resume import _make_config as _make_sprint_config
+    from tests.test_sprint_resume import _make_spec_file
+
+    config = _make_sprint_config(tmp_path)
+    config = replace(config, workspace=replace(config.workspace, on_approve=on_approve))
+    (tmp_path / ".git").mkdir(exist_ok=True)
+
+    specs = []
+    if in_manifest_parent:
+        specs.append(_make_spec_file(tmp_path, "Parent", dep).name)
+    specs.append(_make_spec_file(tmp_path, "Child", "child", depends_on=[dep]).name)
+
+    manifest = tmp_path / "sprint.yaml"
+    manifest.write_text(
+        "name: Test Sprint\nbudget_usd: 10.0\nspecs:\n" + "".join(f"  - {s}\n" for s in specs),
+        encoding="utf-8",
+    )
+    return config, manifest
+
+
+def _entry_patches(satisfied: set[str]):
+    return (
+        patch("theforge.sprint.runner._scrub_root_forge_artifacts"),
+        patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+        patch("theforge.sprint.runner._project_root_is_git_checkout", return_value=True),
+        patch("theforge.coordinator.workspace._cu._run_shell", side_effect=_shell(DIRTY)),
+        patch("theforge.coordinator.workspace.pull_base_branch", return_value=True),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "duration_seconds": 0.0, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.resolve_satisfied_dependencies", return_value=satisfied),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight",
+            side_effect=RuntimeError("stop after baseline"),
+        ),
+    )
+
+
+def test_external_satisfied_dependency_does_not_impose_a_landing_obligation(
+    tmp_path: Path,
+) -> None:
+    """A PR-landing sprint whose only edge points outside the manifest must run.
+
+    The dependency target is an already-satisfied external issue: no story here
+    merges into the project-root checkout, so its dirtiness is not forge's
+    business and refusing would block a workflow that cannot hit the landing
+    failure (#2048 review iteration 2).
+    """
+    config, manifest = _dependency_sprint(
+        tmp_path, on_approve="pr", dep="external-issue", in_manifest_parent=False
+    )
+
+    with ExitStack() as stack:
+        for cm in _entry_patches({"external-issue"}):
+            stack.enter_context(cm)
+        # Reaching the baseline gate proves the entry check did not refuse.
+        with pytest.raises(RuntimeError, match="stop after baseline"):
+            run_sprint(config, manifest)
+
+
+def test_in_manifest_dependency_parent_still_imposes_a_landing_obligation(
+    tmp_path: Path,
+) -> None:
+    """A parent carried by this sprint is merged locally to unblock its child.
+
+    on_approve is "pr" and --auto-merge is off, so only the dependency edge
+    reveals the landing — the sprint must still refuse a dirty root.
+    """
+    config, manifest = _dependency_sprint(
+        tmp_path, on_approve="pr", dep="parent", in_manifest_parent=True
+    )
+
+    with ExitStack() as stack:
+        for cm in _entry_patches(set()):
+            stack.enter_context(cm)
+        with pytest.raises(RuntimeError, match="forge.yaml"):
+            run_sprint(config, manifest)

--- a/tests/test_coord_landing_precondition.py
+++ b/tests/test_coord_landing_precondition.py
@@ -1,0 +1,274 @@
+"""Tests for the entry-time landing precondition (dirty project root).
+
+A dirty project root makes ``_merge_branch`` refuse, but that refusal used to
+arrive only after dev and review had been paid for (#2048). These tests pin the
+condition being evaluated at the points where the spend can still be avoided:
+
+- ``landing_precondition_error``: the predicate itself — only for runs that
+  merge into the project-root checkout, naming the offending files
+- ``run_task``: refuses in WORKSPACE, before the workspace is created and
+  therefore before any dev or review agent is dispatched
+- ``_run_resume_coordinator``: same refusal at the resume entry point, which is
+  the first point a mid-sprint dirtying can be observed by the next story
+- ``run_sprint``: refuses at sprint entry, before the base-branch pull and
+  before the baseline gate
+- ``_merge_branch``: still refuses on the same condition (parity — the entry
+  check must not be able to drift away from the landing check)
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from coord_test_helpers import _make_config, _make_task
+from test_sprint_runner import _make_empty_resolved, _make_runner_config
+
+from theforge.config import ForgeConfig
+from theforge.coordinator.engine import _run_resume_coordinator, run_task
+from theforge.coordinator.logging import StructuredLogger
+from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.coordinator.workspace import (
+    _merge_branch,
+    landing_precondition_error,
+    project_root_dirty_status,
+)
+from theforge.sprint.runner import run_sprint
+
+DIRTY = " M forge.yaml"
+
+
+def _merge_config(tmp_path: Path, *, on_approve: str = "merge") -> ForgeConfig:
+    """Config whose approvals land in the project-root checkout."""
+    config = _make_config(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
+    return replace(config, workspace=replace(config.workspace, on_approve=on_approve))
+
+
+def _shell(status_out: str):
+    """_run_shell stub answering `git status --porcelain` with status_out."""
+
+    def _side_effect(cmd, cwd, **kwargs):
+        if "status --porcelain" in cmd:
+            return (True, status_out)
+        return (True, "")
+
+    return _side_effect
+
+
+# ── The predicate ─────────────────────────────────────────────────────
+
+
+class TestLandingPreconditionError:
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_dirty_root_under_merge_names_the_file(self, mock_shell, tmp_path):
+        mock_shell.side_effect = _shell(DIRTY)
+        err = landing_precondition_error(_merge_config(tmp_path))
+        assert err is not None
+        assert "forge.yaml" in err
+        assert str(tmp_path) in err
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_clean_root_passes(self, mock_shell, tmp_path):
+        mock_shell.side_effect = _shell("")
+        assert landing_precondition_error(_merge_config(tmp_path)) is None
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_untracked_file_refused_like_merge_does(self, mock_shell, tmp_path):
+        """Parity with _merge_branch, which blocks on untracked files too."""
+        mock_shell.side_effect = _shell("?? scratch.txt")
+        err = landing_precondition_error(_merge_config(tmp_path))
+        assert err is not None
+        assert "scratch.txt" in err
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_pr_workflow_ignores_dirty_root(self, mock_shell, tmp_path):
+        """on_approve: pr never touches the project-root checkout."""
+        mock_shell.side_effect = _shell(DIRTY)
+        assert landing_precondition_error(_merge_config(tmp_path, on_approve="pr")) is None
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_auto_merge_flag_forces_the_check(self, mock_shell, tmp_path):
+        """--auto-merge forces "merge" regardless of configuration."""
+        mock_shell.side_effect = _shell(DIRTY)
+        config = _merge_config(tmp_path, on_approve="pr")
+        assert landing_precondition_error(config, auto_merge=True) is not None
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_non_git_project_root_passes(self, mock_shell, tmp_path):
+        mock_shell.side_effect = _shell(DIRTY)
+        config = _make_config(tmp_path)
+        config = replace(config, workspace=replace(config.workspace, on_approve="merge"))
+        assert landing_precondition_error(config) is None
+
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_unreadable_status_fails_open(self, mock_shell, tmp_path):
+        """A root we cannot inspect is not evidence of dirt."""
+        mock_shell.return_value = (False, "fatal: not a git repository")
+        assert project_root_dirty_status(tmp_path) == ""
+        assert landing_precondition_error(_merge_config(tmp_path)) is None
+
+
+# ── Parity with the landing-time refusal ──────────────────────────────
+
+
+class TestMergeBranchParity:
+    @patch("theforge.coordinator.workspace._cu._log")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_merge_branch_still_refuses_a_dirty_root(self, mock_shell, _mock_log, tmp_path):
+        def _side_effect(cmd, cwd, **kwargs):
+            if "branch --list" in cmd:
+                return (True, "  main\n")
+            if "status --porcelain" in cmd:
+                return (True, DIRTY)
+            return (True, "")
+
+        mock_shell.side_effect = _side_effect
+
+        info = _merge_branch(tmp_path, "main", "forge/x", "x", tmp_path / "wt")
+
+        assert info["merged"] is False
+        assert "Uncommitted changes in project root" in info["error"]
+        assert "forge.yaml" in info["error"]
+
+
+# ── run_task: refuse before the workspace exists ──────────────────────
+
+
+class TestRunTaskEntry:
+    @patch("theforge.coordinator.engine._create_workspace")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_dirty_root_escalates_before_workspace_creation(
+        self, mock_shell, mock_create, tmp_path
+    ):
+        mock_shell.side_effect = _shell(DIRTY)
+        config = _merge_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.phase is Phase.ESCALATE
+        assert "forge.yaml" in result.message
+        mock_create.assert_not_called()
+
+    @patch("theforge.coordinator.engine._create_workspace")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_clean_root_proceeds_to_workspace(self, mock_shell, mock_create, tmp_path):
+        mock_shell.side_effect = _shell("")
+        mock_create.return_value = (None, None, "stop here")
+        config = _merge_config(tmp_path)
+        task = _make_task(tmp_path)
+
+        result = run_task(config, task)
+
+        mock_create.assert_called_once()
+        assert "stop here" in result.message
+
+
+# ── Resume entry: same refusal before re-running dev/review ───────────
+
+
+class TestResumeEntry:
+    @patch("theforge.coordinator.engine._setup_resume_entry")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    def test_dirty_root_escalates_at_resume_entry(self, mock_shell, mock_setup, tmp_path):
+        mock_shell.side_effect = _shell(DIRTY)
+        config = _merge_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir(exist_ok=True)
+
+        state = CoordinatorState(phase=Phase.REVIEW)
+        logger = StructuredLogger(
+            run_id="r1",
+            project="test",
+            task=task.slug,
+            log_file=None,
+            enabled=False,
+            project_root=tmp_path,
+        )
+        mock_setup.return_value = (state, logger, "forge/test-task", "story", 0.0)
+
+        result = _run_resume_coordinator(
+            config,
+            task,
+            workspace,
+            initial_phase=Phase.REVIEW,
+            skip_dev_first_iter=True,
+            interactive=False,
+            auto_merge=False,
+            notify=False,
+            run_id="r1",
+            sprint_name=None,
+            state_update_fn=None,
+            no_pull=True,
+        )
+
+        assert result.success is False
+        assert result.phase is Phase.ESCALATE
+        assert "forge.yaml" in result.message
+
+
+# ── Sprint entry: refuse before pull and before the baseline gate ─────
+
+
+def _sprint_config(tmp_path: Path) -> ForgeConfig:
+    config = _make_runner_config(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
+    return replace(config, workspace=replace(config.workspace, on_approve="merge"))
+
+
+def test_run_sprint_dirty_root_aborts_before_pull_and_baseline(tmp_path: Path) -> None:
+    config = _sprint_config(tmp_path)
+    resolved = _make_empty_resolved()
+
+    with (
+        patch("theforge.sprint.runner._scrub_root_forge_artifacts"),
+        patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+        patch("theforge.sprint.runner._get_or_create_sprint_id", return_value=None),
+        patch("theforge.sprint.runner._project_root_is_git_checkout", return_value=True),
+        patch("theforge.coordinator.workspace._cu._run_shell", side_effect=_shell(DIRTY)),
+        patch("theforge.coordinator.workspace.pull_base_branch") as mock_pull,
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_baseline,
+    ):
+        with pytest.raises(RuntimeError, match="forge.yaml"):
+            run_sprint(config, resolved)
+
+    mock_pull.assert_not_called()
+    mock_baseline.assert_not_called()
+
+
+def test_run_sprint_clean_root_proceeds(tmp_path: Path) -> None:
+    """The entry check must not block a sprint whose project root is clean."""
+    config = _sprint_config(tmp_path)
+    resolved = _make_empty_resolved()
+
+    with (
+        patch("theforge.sprint.runner._scrub_root_forge_artifacts"),
+        patch("theforge.sprint.runner.sweep_orphan_worktrees"),
+        patch("theforge.sprint.runner._get_or_create_sprint_id", return_value=None),
+        patch("theforge.sprint.runner._project_root_is_git_checkout", return_value=True),
+        patch("theforge.coordinator.workspace._cu._run_shell", side_effect=_shell("")),
+        patch("theforge.coordinator.workspace.pull_base_branch") as mock_pull,
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.resolve_satisfied_dependencies", return_value=set()),
+        patch(
+            "theforge.sprint.runner.normalize_dependency_plan",
+            return_value=SimpleNamespace(tasks=[], blocked={}),
+        ),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight",
+            side_effect=RuntimeError("stop after baseline"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="stop after baseline"):
+            run_sprint(config, resolved)
+
+    mock_pull.assert_called_once()


### PR DESCRIPTION
## Summary

The prior parallel merge-pr false refusal is resolved, and the dirty-root precondition is now covered at sprint entry, dependency resolution, and per-story entry.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $6.94
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A dirty project root is only detected at landing, after the story's full spend (GitHub Issue #2048)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2048