### PR TITLE
A fixed 30s shutdown grace bounds every dev verification command, so a declared multi-minute timeout is unreachable

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -594,11 +594,13 @@ What makes this bounded:
 - **The budget is fail-closed and per-iteration.** Every request counts, accepted
   or refused, so a loop of malformed requests cannot buy unbounded execution.
   It does not reset when a transient transport failure re-attempts the agent.
-- **No command outlives the iteration that asked for it.** If the agent returns
-  while a declared command is still running, it gets a short grace period to
-  finish and is then killed — an unconfined build still writing to the worktree
-  would otherwise race the coordinator's own authoritative gate. The kill is
-  recorded as `cancelled: true`, which reads differently from a real failure.
+- **No command outlives its declared `timeout`.** If the agent returns while a
+  declared command is still running, the command keeps the rest of its own
+  `timeout` to finish and is killed past that — an unconfined build still
+  writing to the worktree would otherwise race the coordinator's own
+  authoritative gate. `timeout` is the budget the command actually gets, at the
+  agent's turn or after it. The kill is recorded as `cancelled: true`, which
+  reads differently from a real failure.
 - **Malformed declarations fail at config load** — an empty name, a
   path-traversing name, a missing command, an unknown field, or a non-positive
   limit is a config error, not a runtime surprise on something already running

--- a/src/theforge/coordinator/dev_verification.py
+++ b/src/theforge/coordinator/dev_verification.py
@@ -55,13 +55,18 @@ _POLL_INTERVAL_S = 0.25
 # this many polls before treating the file as genuinely malformed. Agents are
 # told to write atomically (tmp + rename); this is the belt to that suspenders.
 _MALFORMED_RETRY_POLLS = 12
-# Shutdown budget. When the agent returns, a declared command may still be
-# running. It gets this long to finish on its own — a build seconds from done
-# yields a real record worth keeping — and is then killed outright. It must not
-# survive the iteration: an unconfined build racing the coordinator's own
-# authoritative gate in the same worktree is exactly what the gate result would
-# then be measuring.
+# Fallback shutdown budget, used only when shutdown cannot derive a budget from
+# the in-flight command itself (nothing running, or a command declared with no
+# meaningful timeout). It is a floor, never a cap: a command's declared
+# ``timeout`` is a promise about how long that work is permitted to take, and a
+# fixed constant that truncates it makes every configured value describe
+# something that cannot happen (#2078).
 _SHUTDOWN_GRACE_SECONDS = 30.0
+# Slack added to a command's own remaining budget when waiting it out at
+# shutdown, so ``_run_shell_detailed``'s timeout handling — kill the process
+# group, drain output, return ``timed_out=True`` — gets to land and produce the
+# honest record rather than being pre-empted a moment before it fires.
+_TIMEOUT_SETTLE_SECONDS = 5.0
 # After the kill, how long to wait for the serving thread to finish recording
 # the terminated command's outcome.
 _CANCEL_JOIN_SECONDS = 15.0
@@ -118,6 +123,27 @@ class VerificationRequestRecord:
         }
 
 
+@dataclass(frozen=True)
+class _ActiveCommand:
+    """The declared command currently executing, as shutdown needs to see it.
+
+    ``started`` is a ``time.monotonic`` stamp taken just before the subprocess
+    is launched, so shutdown can compute how much of the command's declared
+    budget is left rather than applying a budget of its own.
+    """
+
+    request_id: str
+    declared: DevVerificationCommand
+    proc: object | None
+    started: float
+
+    def remaining_budget(self, now: float) -> float:
+        """Return seconds left of this command's declared timeout, floored at 0."""
+        if self.declared.timeout is None or self.declared.timeout <= 0:
+            return 0.0
+        return max(0.0, float(self.declared.timeout) - (now - self.started))
+
+
 @dataclass
 class DevVerificationBroker:
     """Serve declared verification requests for one dev iteration.
@@ -140,13 +166,12 @@ class DevVerificationBroker:
     _malformed_polls: dict[str, int] = field(default_factory=dict, init=False)
     _stop_event: threading.Event = field(default_factory=threading.Event, init=False)
     _thread: threading.Thread | None = field(default=None, init=False)
-    # The command currently executing, if any, guarded by ``_active_lock``:
-    # ``(request_id, command, Popen | None)``. ``stop`` reads this from the
-    # coordinator thread to kill a command that outlived the iteration, and
-    # ``_execute`` reads ``_cancelled`` afterwards to record the kill honestly.
-    _active: tuple[str, DevVerificationCommand, object | None] | None = field(
-        default=None, init=False
-    )
+    # The command currently executing, if any, guarded by ``_active_lock``.
+    # ``stop`` reads this from the coordinator thread both to size its wait
+    # against the command's own declared budget and to kill a command that
+    # outlived that budget; ``_execute`` reads ``_cancelled_ids`` afterwards to
+    # record the kill honestly.
+    _active: _ActiveCommand | None = field(default=None, init=False)
     _active_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
     _cancelled_ids: set[str] = field(default_factory=set, init=False)
 
@@ -189,37 +214,58 @@ class DevVerificationBroker:
         self._thread.start()
 
     def stop(self, timeout: float | None = None) -> None:
-        """Stop serving, and guarantee no declared command outlives the iteration.
+        """Stop serving, and guarantee no declared command outlives its own budget.
 
-        ``timeout`` defaults to ``_SHUTDOWN_GRACE_SECONDS``, resolved at call
-        time rather than bound as a default argument so the budget stays a single
-        module-level knob.
+        The agent can exit while a command it asked for is still running.
+        Dropping that command silently is not an option: the request would leave
+        no audit record at all, which is precisely the invisibility this
+        capability exists to remove. Neither is letting it run unbounded — an
+        unconfined build still writing to the worktree would race the
+        coordinator's own authoritative gate, which then measures a tree the
+        build was still mutating.
 
-        The agent can exit while a command it asked for is still running. Waiting
-        that command out is not an option — a declared command's budget is
-        minutes, and an unconfined build still writing to the worktree would race
-        the coordinator's own authoritative gate, which then measures a tree the
-        build was still mutating. Dropping it silently is worse: the request
-        would leave no audit record at all, which is precisely the invisibility
-        this capability exists to remove.
+        So shutdown is bounded and terminal, but the bound is the command's
+        *own* declared ``timeout``, not a constant of this module's choosing.
+        A command declared at 1800s that has run 40s gets the remaining ~1760s
+        to finish; only past that is its process group killed and the real
+        outcome of the kill recorded by the serving thread. A fixed grace here
+        would make every declared timeout unreachable and every configured value
+        describe something that cannot occur (#2078).
 
-        So shutdown is bounded and terminal. The in-flight command gets
-        ``timeout`` seconds to finish naturally; past that its process group is
-        killed and the serving thread records the real outcome of the kill. If
-        even that does not land, a synthetic cancelled record is written here so
-        the request is never absent from the trail.
+        ``timeout``, when passed, overrides that derivation outright — callers
+        that know the budget they want (tests, mostly) still get it.
         """
         self._stop_event.set()
         thread, self._thread = self._thread, None
         if thread is None:
             return
-        thread.join(timeout=_SHUTDOWN_GRACE_SECONDS if timeout is None else timeout)
+        thread.join(timeout=self._shutdown_budget() if timeout is None else timeout)
         if not thread.is_alive():
             return
         cancelled = self._cancel_active()
         thread.join(timeout=_CANCEL_JOIN_SECONDS)
         if cancelled is not None:
             self._backfill_cancelled_record(cancelled)
+
+    def _shutdown_budget(self) -> float:
+        """Return how long shutdown waits for the in-flight command, in seconds.
+
+        ``_SHUTDOWN_GRACE_SECONDS`` is a floor, not a cap: it covers the case
+        where there is nothing running (or a command with no meaningful declared
+        budget) and a request could still be mid-flight, while a command that
+        declared a longer budget keeps all of it.
+        """
+        with self._active_lock:
+            active = self._active
+        if active is None:
+            return _SHUTDOWN_GRACE_SECONDS
+        remaining = active.remaining_budget(time.monotonic())
+        if remaining <= 0:
+            # Its own timeout is already due; ``_run_shell_detailed`` is about to
+            # fire it, so allow that to land rather than pre-empting the honest
+            # ``timed_out=True`` record with a cancellation.
+            return _SHUTDOWN_GRACE_SECONDS
+        return max(_SHUTDOWN_GRACE_SECONDS, remaining + _TIMEOUT_SETTLE_SECONDS)
 
     def _cancel_active(self) -> tuple[str, DevVerificationCommand] | None:
         """Kill the in-flight declared command's process group, if any.
@@ -233,11 +279,12 @@ class DevVerificationBroker:
             active = self._active
             if active is None:
                 return None
-            request_id, declared, proc = active
+            request_id, declared, proc = active.request_id, active.declared, active.proc
             self._cancelled_ids.add(request_id)
         _cu._log(
             f"  ⚠ DEV   verification {declared.name!r} (request {request_id}) was still "
-            "running when the dev iteration ended — terminating it"
+            f"running when its declared budget of {declared.timeout}s ran out after the "
+            "dev iteration ended — terminating it"
         )
         if proc is not None:
             try:
@@ -410,10 +457,13 @@ class DevVerificationBroker:
             # its group. Registered *before* the run rather than after, because
             # the whole point is to reach a command that has not finished.
             with self._active_lock:
-                self._active = (request_id, declared, proc)
+                self._active = _ActiveCommand(request_id, declared, proc, started)
 
+        # Published before the run too, so a ``stop`` racing the launch sizes its
+        # wait against this command's declared budget rather than seeing nothing
+        # in flight and falling back to the fixed grace.
         with self._active_lock:
-            self._active = (request_id, declared, None)
+            self._active = _ActiveCommand(request_id, declared, None, started)
         try:
             ok, output, exit_code, timed_out = _cu._run_shell_detailed(
                 declared.command,

--- a/tests/test_coord_dev_verification_seam.py
+++ b/tests/test_coord_dev_verification_seam.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -38,13 +39,13 @@ VERIFY_WATCH = DevVerificationCommand(
 VERIFY_OUTPUT = "** TEST SUCCEEDED **"
 
 
-def _config_with_verification(tmp_path: Path, *, max_requests: int = 10):
+def _config_with_verification(tmp_path: Path, *, max_requests: int = 10, commands=None):
     base = _make_config(tmp_path)
     return dataclasses.replace(
         base,
         validation=dataclasses.replace(
             base.validation,
-            dev_verification_commands=(VERIFY_WATCH,),
+            dev_verification_commands=(VERIFY_WATCH,) if commands is None else commands,
             dev_verification_max_requests=max_requests,
         ),
     )
@@ -295,12 +296,73 @@ class TestDevLoopConsumesCoordinatorVerification:
         assert "/.forge/verify/iter-2/requests" in prompt
         assert "/.forge/verify/iter-2/responses" in prompt
 
-    def test_a_command_still_running_at_handoff_is_killed_and_audited(self, tmp_path):
-        """No declared command outlives the iteration, and none vanishes from audit."""
+    def test_a_command_still_running_at_handoff_keeps_its_declared_timeout(self, tmp_path):
+        """The seam's no-argument ``stop()`` must not truncate a declared budget (#2078).
+
+        ``dev_phase`` calls ``_verification_broker.stop()`` with no arguments in
+        its ``finally``. That call used to wait a fixed 30s and then kill,
+        regardless of the command's declared ``timeout`` — so a project
+        declaring 1800s could never obtain more than 30s of it. Here the fixed
+        grace is patched to a hair, the declared budget is 900s, and the command
+        finishes well past the grace: it must run to completion and be recorded
+        as a real result rather than as a cancellation.
+        """
         from theforge.coordinator.dev_phase import _run_dev_phase
         from theforge.coordinator.state import CoordinatorState
 
         config = _config_with_verification(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        state = CoordinatorState()
+        state.dev_iteration = 1
+
+        started = threading.Event()
+        gate = _gate_side_effect(workspace, "PASS")
+
+        def shell(cmd, cwd, **kwargs):
+            if cmd != VERIFY_WATCH.command:
+                return gate(cmd, cwd, **kwargs)
+            kwargs["on_process_start"](object())
+            started.set()
+            # Far past the (patched) fixed grace, far inside the declared 900s.
+            time.sleep(0.6)
+            return (True, VERIFY_OUTPUT, 0, False)
+
+        def run_agent(*, prompt, **kwargs):
+            """An agent that requests a build, then exits without waiting for it."""
+            request_dir = Path(_extract_dir(prompt, "requests"))
+            tmp = request_dir / "r1.json.tmp"
+            tmp.write_text(json.dumps({"command": "verify-watch"}), encoding="utf-8")
+            tmp.rename(request_dir / "r1.json")
+            assert started.wait(10), "the command never started"
+            return _make_agent_result()
+
+        with (
+            patch_gate_shell(side_effect=shell),
+            patch("theforge.coordinator.util._kill_process_group") as mock_kill,
+            patch("theforge.coordinator.dev_phase.run_agent", side_effect=run_agent),
+            patch("theforge.coordinator.dev_phase.log_agent_result"),
+            patch("theforge.coordinator.dev_verification._SHUTDOWN_GRACE_SECONDS", 0.05),
+        ):
+            _run_dev_phase(
+                state, config, task, "# t\n", workspace, "feat/x", notify=False, logger=None
+            )
+
+        assert mock_kill.call_count == 0, "the declared timeout was truncated at the seam"
+        (record,) = state.dev_verification_requests
+        assert record["command_name"] == "verify-watch"
+        assert record["cancelled"] is False
+        assert record["exit_code"] == 0
+        assert state.pending_dev_verification_requests == state.dev_verification_requests
+
+    def test_a_command_outliving_its_declared_timeout_is_killed_and_audited(self, tmp_path):
+        """The budget is generous but terminal: no command outlives its own timeout."""
+        from theforge.coordinator.dev_phase import _run_dev_phase
+        from theforge.coordinator.state import CoordinatorState
+
+        brief = dataclasses.replace(VERIFY_WATCH, timeout=1)
+        config = _config_with_verification(tmp_path, commands=(brief,))
         task = _make_task(tmp_path)
         workspace = tmp_path / "test-task"
         workspace.mkdir()
@@ -339,13 +401,14 @@ class TestDevLoopConsumesCoordinatorVerification:
             patch("theforge.coordinator.util._kill_process_group", side_effect=fake_kill),
             patch("theforge.coordinator.dev_phase.run_agent", side_effect=run_agent),
             patch("theforge.coordinator.dev_phase.log_agent_result"),
-            patch("theforge.coordinator.dev_verification._SHUTDOWN_GRACE_SECONDS", 0.2),
+            patch("theforge.coordinator.dev_verification._SHUTDOWN_GRACE_SECONDS", 0.05),
+            patch("theforge.coordinator.dev_verification._TIMEOUT_SETTLE_SECONDS", 0.1),
         ):
             _run_dev_phase(
                 state, config, task, "# t\n", workspace, "feat/x", notify=False, logger=None
             )
 
-        assert killed, "the in-flight command must not outlive the dev iteration"
+        assert killed, "a command past its declared timeout must not outlive the iteration"
         # The record reaches the DEV snapshot despite the agent already being gone.
         (record,) = state.dev_verification_requests
         assert record["command_name"] == "verify-watch"

--- a/tests/test_dev_verification_broker.py
+++ b/tests/test_dev_verification_broker.py
@@ -369,6 +369,164 @@ class TestShutdownWithCommandInFlight:
         assert record["refusal_reason"] == "cancelled_at_iteration_end"
 
 
+class TestShutdownBudgetIsTheDeclaredTimeout:
+    """A declared ``timeout`` is the budget the command actually gets (#2078).
+
+    The shutdown wait used to be a fixed 30s constant unrelated to the declared
+    value, so a command configured at 1800s could never obtain more than 30s
+    once the agent's turn ended — every configured value described something
+    that could not happen.
+    """
+
+    def test_stop_lets_a_command_run_past_the_fixed_grace_toward_its_own_timeout(self, tmp_path):
+        slow = DevVerificationCommand(
+            name="check-ios", command="xcodebuild build", timeout=30, output_tail_chars=100
+        )
+        broker = _broker(tmp_path, commands=(slow,))
+        started = threading.Event()
+
+        def slow_command(cmd, cwd, **kwargs):
+            kwargs["on_process_start"](object())
+            started.set()
+            # Comfortably longer than the (patched) fixed grace, comfortably
+            # shorter than the command's own declared budget.
+            time.sleep(0.6)
+            return (True, "** BUILD SUCCEEDED **", 0, False)
+
+        with (
+            patch_gate_shell(side_effect=slow_command),
+            patch("theforge.coordinator.util._kill_process_group") as mock_kill,
+            patch("theforge.coordinator.dev_verification._SHUTDOWN_GRACE_SECONDS", 0.05),
+        ):
+            broker.start()
+            _request(broker, "r1", {"command": "check-ios"})
+            assert started.wait(10), "command never started"
+            # The agent has returned; stop() is called exactly as dev_phase does.
+            broker.stop()
+
+        assert mock_kill.call_count == 0, "the declared timeout was truncated by the grace"
+        (record,) = broker.records()
+        assert record["cancelled"] is False
+        assert record["exit_code"] == 0
+        assert _response(broker, "r1")["success"] is True
+
+    def test_stop_still_kills_a_command_that_outruns_its_declared_timeout(self, tmp_path):
+        """The budget is the declared timeout — generous, but still terminal."""
+        brief = DevVerificationCommand(
+            name="check-ios", command="xcodebuild build", timeout=1, output_tail_chars=100
+        )
+        broker = _broker(tmp_path, commands=(brief,))
+        started = threading.Event()
+        release = threading.Event()
+        killed: list[object] = []
+
+        def wedged_command(cmd, cwd, **kwargs):
+            kwargs["on_process_start"](object())
+            started.set()
+            assert release.wait(10), "command was never terminated"
+            return (False, "partial build output", -9, False)
+
+        def fake_kill(proc):
+            killed.append(proc)
+            release.set()
+            return True
+
+        with (
+            patch_gate_shell(side_effect=wedged_command),
+            patch("theforge.coordinator.util._kill_process_group", side_effect=fake_kill),
+            patch("theforge.coordinator.dev_verification._SHUTDOWN_GRACE_SECONDS", 0.05),
+            patch("theforge.coordinator.dev_verification._TIMEOUT_SETTLE_SECONDS", 0.1),
+        ):
+            broker.start()
+            _request(broker, "r1", {"command": "check-ios"})
+            assert started.wait(10), "command never started"
+            broker.stop()
+
+        assert killed, "a command past its declared budget must not survive shutdown"
+        (record,) = broker.records()
+        assert record["cancelled"] is True
+        assert record["refusal_reason"] == "cancelled_at_iteration_end"
+
+    def test_stop_falls_back_to_the_fixed_grace_with_no_command_in_flight(self, tmp_path):
+        broker = _broker(tmp_path)
+
+        with patch("theforge.coordinator.dev_verification._SHUTDOWN_GRACE_SECONDS", 5.0):
+            broker.start()
+            elapsed_start = time.monotonic()
+            broker.stop()
+            elapsed = time.monotonic() - elapsed_start
+
+        # Nothing was running, so the idle thread exits at once rather than
+        # burning the fallback grace.
+        assert elapsed < 4.0
+        assert broker.records() == []
+
+    def test_an_explicit_stop_timeout_overrides_the_derived_budget(self, tmp_path):
+        """Callers that pass a budget get it, declared timeout notwithstanding."""
+        broker = _broker(tmp_path)  # VERIFY_WATCH declares 900s
+        started = threading.Event()
+        release = threading.Event()
+        killed: list[object] = []
+
+        def wedged_command(cmd, cwd, **kwargs):
+            kwargs["on_process_start"](object())
+            started.set()
+            assert release.wait(10), "command was never terminated"
+            return (False, "", -9, False)
+
+        def fake_kill(proc):
+            killed.append(proc)
+            release.set()
+            return True
+
+        with (
+            patch_gate_shell(side_effect=wedged_command),
+            patch("theforge.coordinator.util._kill_process_group", side_effect=fake_kill),
+        ):
+            broker.start()
+            _request(broker, "r1", {"command": "verify-watch"})
+            assert started.wait(10), "command never started"
+            broker.stop(timeout=0.2)
+
+        assert killed, "an explicit stop timeout must bound the wait"
+
+    def test_the_derived_budget_shrinks_as_the_command_burns_its_own_timeout(self, tmp_path):
+        """The wait is the *remaining* budget, not the declared value restarted."""
+        import theforge.coordinator.dev_verification as dv
+
+        declared = DevVerificationCommand(
+            name="check-ios", command="xcodebuild build", timeout=100, output_tail_chars=100
+        )
+        broker = _broker(tmp_path, commands=(declared,))
+        now = time.monotonic()
+        broker._active = dv._ActiveCommand("r1", declared, None, now - 60.0)
+
+        with (
+            patch.object(dv, "_SHUTDOWN_GRACE_SECONDS", 30.0),
+            patch.object(dv, "_TIMEOUT_SETTLE_SECONDS", 5.0),
+        ):
+            budget = broker._shutdown_budget()
+
+        assert 40.0 <= budget <= 46.0, budget
+
+    def test_the_fixed_grace_is_a_floor_for_a_command_already_past_its_budget(self, tmp_path):
+        import theforge.coordinator.dev_verification as dv
+
+        declared = DevVerificationCommand(
+            name="check-ios", command="xcodebuild build", timeout=10, output_tail_chars=100
+        )
+        broker = _broker(tmp_path, commands=(declared,))
+        broker._active = dv._ActiveCommand("r1", declared, None, time.monotonic() - 500.0)
+
+        with (
+            patch.object(dv, "_SHUTDOWN_GRACE_SECONDS", 30.0),
+            patch.object(dv, "_TIMEOUT_SETTLE_SECONDS", 5.0),
+        ):
+            # Its own timeout handling is due to fire; shutdown gives that room
+            # to land rather than pre-empting the honest timed_out record.
+            assert broker._shutdown_budget() == 30.0
+
+
 class TestAuditRecords:
     def test_records_carry_the_outcome_without_duplicating_output(self, tmp_path):
         broker = _broker(tmp_path, max_requests=2)


### PR DESCRIPTION
## Summary

[claude-sonnet] Shutdown budget now derives from the in-flight command's declared timeout (with a fixed floor when nothing is running), correctly fixing the truncation bug; logic verified against _run_shell_detailed's own communicate(timeout=...) semantics and thoroughly tested. | [google-gemini-3.5-flash] The dev verification broker now correctly derives its shutdown budget from the active command's declared timeout, ensuring configured budgets are fully honored. | [openai-gpt-5.4] The broker now derives shutdown wait time from the active command's remaining declared timeout on the live dev-phase path, and the added broker and seam tests cover both the original truncation symptom and the terminal timeout behavior. | [claude-opus] Shutdown wait is now derived from the in-flight command's remaining declared timeout with the fixed 30s grace kept only as a floor; behaviour verified by new broker and seam tests (49 passed locally). | [openai-gpt-5.5] The shutdown path now grants in-flight dev verification commands their remaining declared timeout, with focused broker and dev-phase seam coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $2.74
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

A fixed 30s shutdown grace bounds every dev verification command, so a declared multi-minute timeout is unreachable (GitHub Issue #2078)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2078