### PR TITLE
A sprint drops its own running stories as foreign worktree collisions, reports them free, and advises deleting the only copy of the work

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -13,6 +13,7 @@ from theforge.runners import LogLevel
 from theforge.runners import set_log_level as runner_set_log_level
 from theforge.sprint import run_sprint
 from theforge.sprint.launch_guard import acquire_launch_story_locks
+from theforge.sprint.live_stories import LivenessResolution
 from theforge.sprint.lock import release_story_locks
 from theforge.sprint.preflight import reacquire_story_locks_in_daemon
 from theforge.sprint.runner import parse_manifest_slugs
@@ -27,6 +28,11 @@ _BACKSTOP: dict[str, str | None] = {"outcome": "completed", "cause": None}
 # either completing run_sprint or catching an exception (SIGINT, SystemExit,
 # BaseException escaping the runner).
 _UNKNOWN_END_CAUSE = "sprint process ended before recording a completion"
+
+# A launch that is not a re-exec has no inherited work by construction: nothing
+# is live and nothing is unresolved. Distinct from a failed lookup, which yields
+# an *unresolved* result (see ``_resolve_story_liveness``).
+_NO_LIVENESS = LivenessResolution()
 
 
 def _exc_cause(exc: BaseException) -> str:
@@ -285,8 +291,9 @@ def _cmd_sprint(args: object) -> int:
         except Exception:
             prior_outcomes = None
     # Stories this same process (the pid survives ``os.execv``) still has agents
-    # running for. They are this run's own live work, not foreign state.
-    in_flight_slugs = _resolve_live_story_slugs(config, slugs) if reexec else set()
+    # running for — plus the ones whose liveness could not be established, which
+    # are this run's own possible live work, not foreign state either.
+    liveness = _resolve_story_liveness(config, slugs) if reexec else _NO_LIVENESS
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
         slugs=slugs,
         config=config,
@@ -294,7 +301,8 @@ def _cmd_sprint(args: object) -> int:
         allow_drop=reexec,
         force=force,
         prior_outcomes=prior_outcomes,
-        live_slugs=in_flight_slugs,
+        live_slugs=set(liveness.live_slugs),
+        unresolved_slugs=set(liveness.unresolved_slugs),
     )
     if launch_error is not None:
         return launch_error
@@ -369,7 +377,8 @@ def _cmd_sprint(args: object) -> int:
             run_id=run_id,
             dropped_slugs=dropped_slugs,
             force=force,
-            live_story_slugs=in_flight_slugs,
+            live_story_slugs=set(liveness.live_slugs),
+            unresolved_live_slugs=set(liveness.unresolved_slugs),
         )
     except KeyboardInterrupt:
         # Ctrl-C is a deliberate termination, not a crash — record it as such
@@ -407,6 +416,7 @@ def _acquire_launch_locks(
     force: bool = False,
     prior_outcomes: dict[str, str] | None = None,
     live_slugs: set[str] | None = None,
+    unresolved_slugs: set[str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     return acquire_launch_story_locks(
         slugs=slugs,
@@ -416,26 +426,33 @@ def _acquire_launch_locks(
         force=force,
         prior_outcomes=prior_outcomes,
         live_slugs=live_slugs,
+        unresolved_slugs=unresolved_slugs,
     )
 
 
-def _resolve_live_story_slugs(config: object, slugs: list[str]) -> set[str]:
+def _resolve_story_liveness(config: object, slugs: list[str]) -> LivenessResolution:
     """Stories of this same process still executing across a re-exec boundary.
 
     Thin CLI seam over :mod:`theforge.sprint.live_stories` — the ownership
-    decision itself lives in the sprint package. Best-effort: a resolution
-    failure degrades to today's behaviour rather than failing the launch.
+    decision and the fail-closed semantics both live in the sprint package. A
+    resolution failure yields an *unresolved* result, never an empty one: "we
+    could not ask" must stay distinguishable from "nothing is running", or the
+    launch guard reconciles this run's own live work as a foreign collision
+    (#2079).
     """
-    try:
-        from theforge.sprint.live_stories import resolve_live_story_slugs  # noqa: PLC0415
+    from theforge.sprint.live_stories import (  # noqa: PLC0415
+        resolve_liveness,
+        unresolved_liveness,
+    )
 
-        return resolve_live_story_slugs(
+    try:
+        return resolve_liveness(
             slugs,
             project_root=config.project_root,
             path_pattern=config.workspace.path_pattern,
         )
-    except Exception:
-        return set()
+    except Exception as exc:  # noqa: BLE001 - fail closed, never fail the launch
+        return unresolved_liveness(slugs, reason=f"liveness lookup unavailable: {exc}")
 
 
 def _resolve_prior_outcomes(config: object, sprint_name: str) -> dict[str, str]:
@@ -1155,8 +1172,9 @@ def _run_query_mode(
     # flattening them into fresh collisions. Best-effort — a miss degrades to
     # today's behavior.
     prior_outcomes = _resolve_prior_outcomes(config, resolved.name) if reexec else None
-    # Stories this same process still has live agents for (see manifest mode).
-    in_flight_slugs = _resolve_live_story_slugs(config, slugs) if reexec else set()
+    # Stories this same process still has live (or unresolved) agents for — see
+    # manifest mode above for why unresolved is deferred rather than dropped.
+    liveness = _resolve_story_liveness(config, slugs) if reexec else _NO_LIVENESS
     locked_fds, launch_error, dropped_slugs = _acquire_launch_locks(
         slugs=slugs,
         config=config,
@@ -1164,7 +1182,8 @@ def _run_query_mode(
         allow_drop=reexec,
         force=force,
         prior_outcomes=prior_outcomes,
-        live_slugs=in_flight_slugs,
+        live_slugs=set(liveness.live_slugs),
+        unresolved_slugs=set(liveness.unresolved_slugs),
     )
     if launch_error is not None:
         return launch_error
@@ -1247,7 +1266,8 @@ def _run_query_mode(
             skipped_issues=skipped_issues,
             entry_intake_outcomes=entry_intake_outcomes,
             force=force,
-            live_story_slugs=in_flight_slugs,
+            live_story_slugs=set(liveness.live_slugs),
+            unresolved_live_slugs=set(liveness.unresolved_slugs),
         )
     except KeyboardInterrupt:
         # Ctrl-C is a deliberate termination, not a crash — record it as such

--- a/src/theforge/sprint/dropped_work.py
+++ b/src/theforge/sprint/dropped_work.py
@@ -47,8 +47,15 @@ class WorktreeWork:
 
     @property
     def determined(self) -> bool:
-        """True when the commit count was actually established."""
-        return self.commits_ahead is not None
+        """True only when *both* forms of work were actually established.
+
+        Committed and uncommitted work are two independent ways a worktree can
+        hold the only copy of something. Ruling out one says nothing about the
+        other, so a zero commit count paired with an unreadable ``git status`` is
+        not a worktree known to be empty — treating it as one is the same
+        unknown-means-nothing inference this whole change exists to remove.
+        """
+        return self.commits_ahead is not None and self.dirty is not None
 
     @property
     def has_work(self) -> bool:
@@ -59,11 +66,13 @@ class WorktreeWork:
     def may_have_work(self) -> bool:
         """True when work is confirmed present, or could not be ruled out.
 
-        The predicate every destructive decision must consult: an existing
-        worktree whose state could not be read is not a worktree known to be
-        empty.
+        The predicate every destructive decision must consult: a worktree whose
+        state could not be read is not a worktree known to be empty. Absence is
+        reported only through ``determined`` — a worktree that does not exist
+        sets both counters explicitly rather than leaving them unknown — so no
+        unreadable case can reach this as a False.
         """
-        return self.has_work or (self.exists and not self.determined)
+        return self.has_work or not self.determined
 
     def as_state_fields(self) -> dict[str, object]:
         """Fields recorded on the story's audit/state entry."""
@@ -138,7 +147,9 @@ def inspect_worktree_work(
     try:
         exists = worktree.is_dir()
     except OSError:
-        exists = False
+        # Whether there is a worktree at all is itself unknown — leave every
+        # counter unset so the caller treats it as possibly holding work.
+        return WorktreeWork(slug=slug, path=str(worktree), branch=branch, exists=True)
     if not exists:
         # No worktree: nothing was left behind, and that is a determined answer.
         return WorktreeWork(
@@ -174,8 +185,12 @@ def describe_worktree_work(work: WorktreeWork) -> str | None:
         head = f"{work.commits_ahead} unmerged commit(s) on {where}"
     elif work.determined:
         head = f"uncommitted changes on {where}"
-    else:
+    elif work.commits_ahead is None:
         head = f"unread worktree state on {where} (git could not be queried)"
+    else:
+        # Commits ruled out, uncommitted changes not: still possibly the only
+        # copy of something.
+        head = f"unread uncommitted state on {where} (no commits ahead; git status failed)"
     if work.dirty and work.commits_ahead:
         head += " plus uncommitted changes"
     if work.path:

--- a/src/theforge/sprint/dropped_work.py
+++ b/src/theforge/sprint/dropped_work.py
@@ -1,0 +1,183 @@
+"""What a story that was never scheduled left behind in its worktree.
+
+A story dropped at launch is normally a story that never ran: nothing was spent,
+nothing was produced, and its worktree is disposable. That assumption is load
+bearing in two places — the audit records the drop at ``cost_usd: 0.0``, and RCA
+recommends clearing the worktree — and when it is wrong, both cause harm: a run
+that did work is reported as free, and the operator is advised to delete the only
+copy of it (#2079).
+
+This module answers the question those two places should have asked first: does
+the dropped story's worktree hold work? It reports commits ahead of the base
+branch and uncommitted changes, and it fails *closed* — a git lookup that cannot
+be completed yields ``None``, meaning "unknown", never ``0``. Callers must treat
+unknown as "there may be work here", because the cost of the opposite mistake is
+destroyed work.
+
+Stdlib-only, per convention 4.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "WorktreeWork",
+    "describe_worktree_work",
+    "inspect_worktree_work",
+]
+
+_GIT_TIMEOUT = 10
+
+
+@dataclass(frozen=True)
+class WorktreeWork:
+    """Evidence of work held in a story worktree that this sprint did not run."""
+
+    slug: str
+    path: str | None = None
+    branch: str | None = None
+    exists: bool = False
+    #: Commits on the story branch not reachable from base. ``None`` = unknown.
+    commits_ahead: int | None = None
+    #: Uncommitted changes present. ``None`` = unknown.
+    dirty: bool | None = None
+
+    @property
+    def determined(self) -> bool:
+        """True when the commit count was actually established."""
+        return self.commits_ahead is not None
+
+    @property
+    def has_work(self) -> bool:
+        """True only when work is *positively confirmed* present."""
+        return bool(self.commits_ahead) or self.dirty is True
+
+    @property
+    def may_have_work(self) -> bool:
+        """True when work is confirmed present, or could not be ruled out.
+
+        The predicate every destructive decision must consult: an existing
+        worktree whose state could not be read is not a worktree known to be
+        empty.
+        """
+        return self.has_work or (self.exists and not self.determined)
+
+    def as_state_fields(self) -> dict[str, object]:
+        """Fields recorded on the story's audit/state entry."""
+        return {
+            "worktree": self.path,
+            "branch": self.branch,
+            "unmerged_commits": self.commits_ahead,
+            "unmerged_work_determined": self.determined,
+            "worktree_dirty": self.dirty,
+        }
+
+
+def _git_out(args: list[str], cwd: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except Exception:  # noqa: BLE001 - any git failure is "unknown", not "none"
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _commits_ahead(worktree: Path, base_branch: str) -> int | None:
+    for ref in (f"origin/{base_branch}", base_branch):
+        out = _git_out(["rev-list", "--count", f"{ref}..HEAD"], worktree)
+        if out is None:
+            continue
+        try:
+            return int(out.strip() or "0")
+        except ValueError:
+            continue
+    return None
+
+
+def _is_dirty(worktree: Path) -> bool | None:
+    out = _git_out(["status", "--porcelain"], worktree)
+    if out is None:
+        return None
+    return bool(out.strip())
+
+
+def inspect_worktree_work(
+    slug: str,
+    *,
+    project_root: Path,
+    path_pattern: str,
+    base_branch: str,
+    branch_pattern: str | None = None,
+) -> WorktreeWork:
+    """Inspect *slug*'s worktree for work this sprint is about to write off.
+
+    Never raises: a malformed pattern, a missing directory, or a git failure all
+    resolve to a ``WorktreeWork`` whose unknowns stay unknown.
+    """
+    branch: str | None = None
+    if branch_pattern:
+        try:
+            branch = branch_pattern.format(slug=slug)
+        except (IndexError, KeyError):
+            branch = None
+    try:
+        worktree = (Path(project_root) / path_pattern.format(slug=slug)).resolve()
+    except (IndexError, KeyError, OSError, ValueError):
+        return WorktreeWork(slug=slug, branch=branch)
+
+    try:
+        exists = worktree.is_dir()
+    except OSError:
+        exists = False
+    if not exists:
+        # No worktree: nothing was left behind, and that is a determined answer.
+        return WorktreeWork(
+            slug=slug,
+            path=str(worktree),
+            branch=branch,
+            exists=False,
+            commits_ahead=0,
+            dirty=False,
+        )
+
+    return WorktreeWork(
+        slug=slug,
+        path=str(worktree),
+        branch=branch,
+        exists=True,
+        commits_ahead=_commits_ahead(worktree, base_branch),
+        dirty=_is_dirty(worktree),
+    )
+
+
+def describe_worktree_work(work: WorktreeWork) -> str | None:
+    """An operator-facing description of the work at risk, or None if there is none.
+
+    Deliberately concrete — how much work, on which branch, in which directory —
+    so the audit record for a dropped story names what it dropped instead of
+    echoing whatever text happened to be nearby.
+    """
+    if not work.may_have_work:
+        return None
+    where = f"branch {work.branch}" if work.branch else "its branch"
+    if work.commits_ahead:
+        head = f"{work.commits_ahead} unmerged commit(s) on {where}"
+    elif work.determined:
+        head = f"uncommitted changes on {where}"
+    else:
+        head = f"unread worktree state on {where} (git could not be queried)"
+    if work.dirty and work.commits_ahead:
+        head += " plus uncommitted changes"
+    if work.path:
+        head += f", preserved at {work.path}"
+    return head

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -37,6 +37,13 @@ REASON_STRANDED_WORKTREE = "stranded-prior-generation-worktree"
 # collision. The runner surfaces this string on the story's live status while it
 # waits for the inherited agent to finish, then resumes the story.
 REASON_IN_FLIGHT = "in-flight-current-sprint"
+# Not a drop reason either: the deferral marker for a story whose liveness could
+# not be established (an unreadable/absent agent sidecar) but whose worktree is
+# present. Failing to resolve liveness is not evidence that nothing is running,
+# so such a story is treated exactly like a confirmed in-flight one — deferred
+# and resumed by this sprint — instead of falling through to the branch whose
+# remediation is to delete the worktree (#2079).
+REASON_IN_FLIGHT_UNRESOLVED = "in-flight-liveness-unresolved"
 
 # Prior-generation outcome strings (upper-cased) that mean the story succeeded
 # and its worktree should be reconciled/preserved rather than treated as a fresh
@@ -53,6 +60,7 @@ def acquire_launch_story_locks(
     force: bool = False,
     prior_outcomes: dict[str, str] | None = None,
     live_slugs: set[str] | None = None,
+    unresolved_slugs: set[str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     """Acquire launch-time story locks after checking for active worktrees.
 
@@ -82,6 +90,13 @@ def acquire_launch_story_locks(
     inherited agent exits and then resumes it. Dropping them instead would strand
     the story, since no other process can adopt an agent group this pid owns.
 
+    ``unresolved_slugs`` names the stories whose liveness could *not* be
+    established (see :class:`theforge.sprint.live_stories.LivenessResolution`).
+    They are handled identically to ``live_slugs``: an unresolved lookup is not
+    evidence that no agent is running, and classifying such a story as a foreign
+    ``REASON_ACTIVE_WORKTREE`` collision is what produced #2079 — a sprint
+    dropping its own committed work and advising the operator to delete it.
+
     Invariants the callers rely on:
 
     - Every slug in the returned ``dropped_slugs`` is *not* counted in
@@ -99,13 +114,29 @@ def acquire_launch_story_locks(
     # the story stays scheduled and keeps its launch lock, because this process
     # is the only one that can still finish it (the runner waits for the
     # inherited agent, then resumes the story through triage).
-    in_flight_slugs = [s for s in slugs if s in (live_slugs or set())]
+    #
+    # A story whose liveness could not be resolved is held to the same rule: the
+    # lookup failing is not evidence that its agent is gone, so it is deferred
+    # rather than reconciled against a worktree that may be under active write.
+    confirmed_live = [s for s in slugs if s in (live_slugs or set())]
+    unresolved_live = [
+        s for s in slugs if s in (unresolved_slugs or set()) and s not in confirmed_live
+    ]
+    in_flight_slugs = confirmed_live + unresolved_live
     dropped: dict[str, str] = {}
-    if in_flight_slugs:
+    if confirmed_live:
         print(
-            f"[forge] IN-FLIGHT {', '.join(in_flight_slugs)}: agent process group "
+            f"[forge] IN-FLIGHT {', '.join(confirmed_live)}: agent process group "
             "from this sprint survived the re-exec; preserving the live worktree and "
             "deferring the story until its agent finishes.",
+            file=sys.stderr,
+            flush=True,
+        )
+    if unresolved_live:
+        print(
+            f"[forge] IN-FLIGHT {', '.join(unresolved_live)}: liveness of this "
+            "sprint's own agent could not be resolved; preserving the worktree and "
+            "deferring the story rather than treating it as a foreign collision.",
             file=sys.stderr,
             flush=True,
         )

--- a/src/theforge/sprint/live_stories.py
+++ b/src/theforge/sprint/live_stories.py
@@ -37,10 +37,13 @@ from theforge.process_group import group_is_alive, kill_agent_group
 
 __all__ = [
     "InheritedAgentGroup",
+    "LivenessResolution",
     "await_inherited_agents",
     "reclaim_inherited_agents",
     "resolve_inherited_agents",
+    "resolve_liveness",
     "resolve_live_story_slugs",
+    "unresolved_liveness",
 ]
 
 
@@ -53,14 +56,67 @@ class InheritedAgentGroup:
     sidecar: Path
 
 
-def _agent_sidecars(project_root: Path) -> list[Path]:
+@dataclass(frozen=True)
+class LivenessResolution:
+    """What a liveness lookup established — including what it could not.
+
+    ``live_slugs`` are *confirmed* live: a sidecar owned by this pid names the
+    slug's worktree and its group answered "alive". ``unresolved_slugs`` are the
+    slugs the lookup could not answer for, because a sidecar was unreadable or
+    malformed, the agents directory could not be listed, or the liveness probe
+    itself failed. The distinction is the whole point of this type: an empty
+    ``live_slugs`` alone cannot tell a caller whether nothing is running or
+    whether nothing could be *asked*, and treating the second as the first is how
+    a sprint's own running story became a foreign worktree collision (#2079).
+
+    Unresolved is scoped to slugs whose worktree exists on disk: a slug with no
+    worktree has nothing that could be live, so a scan failure says nothing about
+    it and it stays fully schedulable.
+    """
+
+    live_slugs: frozenset[str] = frozenset()
+    unresolved_slugs: frozenset[str] = frozenset()
+    failures: tuple[str, ...] = ()
+
+    @property
+    def resolved(self) -> bool:
+        """True when every candidate slug's liveness was actually established."""
+        return not self.unresolved_slugs
+
+    @property
+    def deferred_slugs(self) -> frozenset[str]:
+        """Slugs that must not be reconciled as foreign state by this launch.
+
+        Confirmed-live and unresolved alike: both may have an agent of this
+        generation writing to their worktree right now.
+        """
+        return frozenset(self.live_slugs | self.unresolved_slugs)
+
+
+def unresolved_liveness(slugs: Iterable[str], *, reason: str) -> LivenessResolution:
+    """A resolution that established nothing — every slug stays unresolved.
+
+    The fail-closed answer for a caller whose lookup could not run at all (a bad
+    config, an import failure). Coarser than :func:`resolve_liveness`, which can
+    scope the taint to slugs that actually have a worktree, because a failure
+    this early means even that much is unknown.
+    """
+    return LivenessResolution(
+        live_slugs=frozenset(),
+        unresolved_slugs=frozenset(s for s in slugs if s),
+        failures=(reason,),
+    )
+
+
+def _agent_sidecars(project_root: Path) -> tuple[list[Path], str | None]:
+    """Sidecar paths, plus a failure description when they could not be listed."""
     agents_dir = Path(project_root) / ".forge" / "runs" / "agents"
     if not agents_dir.exists():
-        return []
+        return [], None
     try:
-        return sorted(agents_dir.glob("*.json"))
-    except OSError:
-        return []
+        return sorted(agents_dir.glob("*.json")), None
+    except OSError as exc:
+        return [], f"agents directory {agents_dir} could not be listed: {exc}"
 
 
 def _slug_for_sandbox(sandbox: Path, worktree_to_slug: dict[Path, str]) -> str | None:
@@ -84,6 +140,66 @@ def _worktree_index(slugs: Iterable[str], root: Path, path_pattern: str) -> dict
     return index
 
 
+def _scan_inherited_agents(
+    worktree_to_slug: dict[Path, str],
+    root: Path,
+    *,
+    owner_pid: int | None,
+    only_live: bool,
+    is_group_alive: Callable[[int], bool],
+) -> tuple[list[InheritedAgentGroup], list[tuple[str | None, str]]]:
+    """Scan the sidecar directory, returning groups and unresolved-liveness facts.
+
+    Each failure is ``(slug_or_None, description)``. ``None`` means the failure
+    could not be attributed to one slug — an unreadable sidecar names no worktree,
+    so it may belong to any of them and taints them all.
+    """
+    failures: list[tuple[str | None, str]] = []
+    sidecars, listing_failure = _agent_sidecars(root)
+    if listing_failure is not None:
+        failures.append((None, listing_failure))
+
+    my_pid = os.getpid() if owner_pid is None else int(owner_pid)
+    found: list[InheritedAgentGroup] = []
+    for sidecar in sidecars:
+        try:
+            data = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            failures.append((None, f"sidecar {sidecar.name} is unreadable: {exc}"))
+            continue
+        if not isinstance(data, dict):
+            failures.append((None, f"sidecar {sidecar.name} is not a record"))
+            continue
+        if data.get("owner_pid") != my_pid:
+            # Another process's group: not this sprint generation's work.
+            continue
+        pgid = data.get("pgid")
+        sandbox_raw = data.get("sandbox_dir")
+        if not isinstance(pgid, int) or not sandbox_raw:
+            failures.append((None, f"sidecar {sidecar.name} names no pgid/sandbox"))
+            continue
+        try:
+            sandbox = Path(str(sandbox_raw)).resolve()
+        except OSError as exc:
+            failures.append((None, f"sidecar {sidecar.name} sandbox is unresolvable: {exc}"))
+            continue
+        slug = _slug_for_sandbox(sandbox, worktree_to_slug)
+        if slug is None:
+            # Ours, but for a story outside this launch's slug set — knowable,
+            # and irrelevant here.
+            continue
+        if only_live:
+            try:
+                alive = is_group_alive(pgid)
+            except Exception as exc:  # noqa: BLE001 - a failed probe is unresolved, not "dead"
+                failures.append((slug, f"liveness probe for pgid {pgid} failed: {exc}"))
+                continue
+            if not alive:
+                continue
+        found.append(InheritedAgentGroup(slug=slug, pgid=pgid, sidecar=sidecar))
+    return found, failures
+
+
 def resolve_inherited_agents(
     slugs: Iterable[str],
     *,
@@ -101,42 +217,81 @@ def resolve_inherited_agents(
     worktree. With ``only_live`` (the default) dead groups are filtered out;
     pass ``False`` to reach their sidecar records for cleanup.
 
-    Best-effort by construction: an unreadable or malformed sidecar is ignored
-    rather than raised on. The cost of a miss is today's behaviour (the story is
-    treated as foreign), so this must never fail a launch.
+    Returns only what it could positively establish. Callers that must not read
+    "found nothing" as "nothing is running" use :func:`resolve_liveness`, which
+    reports the same scan's failures instead of discarding them.
     """
     root = Path(project_root)
     worktree_to_slug = _worktree_index(slugs, root, path_pattern)
     if not worktree_to_slug:
         return []
+    groups, _failures = _scan_inherited_agents(
+        worktree_to_slug,
+        root,
+        owner_pid=owner_pid,
+        only_live=only_live,
+        is_group_alive=is_group_alive,
+    )
+    return groups
 
-    my_pid = os.getpid() if owner_pid is None else int(owner_pid)
-    found: list[InheritedAgentGroup] = []
-    for sidecar in _agent_sidecars(root):
+
+def _existing_worktree_slugs(worktree_to_slug: dict[Path, str]) -> set[str]:
+    present: set[str] = set()
+    for path, slug in worktree_to_slug.items():
         try:
-            data = json.loads(sidecar.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
-        if not isinstance(data, dict):
-            continue
-        if data.get("owner_pid") != my_pid:
-            # Another process's group: not this sprint generation's work.
-            continue
-        pgid = data.get("pgid")
-        sandbox_raw = data.get("sandbox_dir")
-        if not isinstance(pgid, int) or not sandbox_raw:
-            continue
-        try:
-            sandbox = Path(str(sandbox_raw)).resolve()
+            if path.exists():
+                present.add(slug)
         except OSError:
-            continue
-        slug = _slug_for_sandbox(sandbox, worktree_to_slug)
-        if slug is None:
-            continue
-        if only_live and not is_group_alive(pgid):
-            continue
-        found.append(InheritedAgentGroup(slug=slug, pgid=pgid, sidecar=sidecar))
-    return found
+            # Cannot even tell whether the worktree is there — assume it may be.
+            present.add(slug)
+    return present
+
+
+def resolve_liveness(
+    slugs: Iterable[str],
+    *,
+    project_root: Path,
+    path_pattern: str,
+    owner_pid: int | None = None,
+    is_group_alive: Callable[[int], bool] = group_is_alive,
+) -> LivenessResolution:
+    """Establish, per slug, whether this process still has an agent running for it.
+
+    Fail-closed: any part of the lookup that could not be completed leaves the
+    affected slugs *unresolved* rather than silently absent from ``live_slugs``.
+    A launch guard must be able to tell "this story is definitely not running"
+    from "nobody could say", because only the first justifies reconciling the
+    story's worktree as foreign state.
+    """
+    wanted = [s for s in slugs if s]
+    try:
+        root = Path(project_root)
+        worktree_to_slug = _worktree_index(wanted, root, path_pattern)
+        groups, failures = _scan_inherited_agents(
+            worktree_to_slug,
+            root,
+            owner_pid=owner_pid,
+            only_live=True,
+            is_group_alive=is_group_alive,
+        )
+    except Exception as exc:  # noqa: BLE001 - a broken scan resolves nothing
+        return unresolved_liveness(wanted, reason=f"liveness scan failed: {exc}")
+
+    live = {group.slug for group in groups}
+    if not failures:
+        return LivenessResolution(live_slugs=frozenset(live))
+
+    if any(slug is None for slug, _msg in failures):
+        # An unattributable failure could concern any worktree that exists.
+        tainted = _existing_worktree_slugs(worktree_to_slug)
+    else:
+        tainted = {slug for slug, _msg in failures if slug}
+    unresolved = (tainted & set(wanted)) - live
+    return LivenessResolution(
+        live_slugs=frozenset(live),
+        unresolved_slugs=frozenset(unresolved),
+        failures=tuple(msg for _slug, msg in failures),
+    )
 
 
 def resolve_live_story_slugs(
@@ -147,17 +302,20 @@ def resolve_live_story_slugs(
     owner_pid: int | None = None,
     is_group_alive: Callable[[int], bool] = group_is_alive,
 ) -> set[str]:
-    """The subset of *slugs* whose inherited agent group is still running."""
-    return {
-        group.slug
-        for group in resolve_inherited_agents(
+    """The subset of *slugs* whose inherited agent group is confirmed running.
+
+    Drops the unresolved set; use :func:`resolve_liveness` where "unknown" and
+    "not running" must not be conflated.
+    """
+    return set(
+        resolve_liveness(
             slugs,
             project_root=project_root,
             path_pattern=path_pattern,
             owner_pid=owner_pid,
             is_group_alive=is_group_alive,
-        )
-    }
+        ).live_slugs
+    )
 
 
 def _discard_records(groups: Iterable[InheritedAgentGroup]) -> None:

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -998,6 +998,41 @@ def _merge_failed_action(story: dict, ref: str) -> str:
     return f"inspect {ref}'s PR for the merge failure cause recorded above, then re-run the merge"
 
 
+def _launch_collision_action(story: dict, ref: str) -> str:
+    """Next step for a launch-guard drop, gated on what the worktree holds.
+
+    "Clear the worktree" is destructive advice, and a drop is not evidence that
+    the worktree is disposable: in #2079 the colliding worktrees held this
+    sprint's own unmerged commits, and following the advice would have destroyed
+    them. So the clearing advice is emitted only when the absence of unmerged
+    work was positively established — an unknown answer gets the preserving
+    advice, exactly as a known-nonzero one does.
+    """
+    commits = story.get("unmerged_commits")
+    determined = story.get("unmerged_work_determined")
+    dirty = story.get("worktree_dirty")
+    branch = _nonempty(story.get("branch"))
+    worktree = _nonempty(story.get("worktree"))
+    where = f" (branch {branch})" if branch else ""
+
+    has_commits = isinstance(commits, int) and not isinstance(commits, bool) and commits > 0
+    if has_commits or dirty is True:
+        held = f"{commits} unmerged commit(s)" if has_commits else "uncommitted changes"
+        location = f" at {worktree}" if worktree else ""
+        return (
+            f"preserve the worktree{location} blocking {ref}{where}: it holds {held} — "
+            "recover that branch (push it, or land/rebase it) BEFORE clearing anything, "
+            "and do not re-sprint the story until the work is safe"
+        )
+    if determined is True:
+        return f"clear the active worktree/lock blocking {ref}, then re-sprint it"
+    return (
+        f"inspect the worktree/lock blocking {ref}{where} before clearing it — whether it "
+        "holds unmerged work was never established, so treat it as if it does "
+        "(git log/status in the worktree, then recover or clear deliberately)"
+    )
+
+
 def _recommend_actions(primary: str, contributing: list[str], story: dict) -> list[str]:
     """Map primary class + contributing factors to actionable next steps."""
     ref = _story_ref(story)
@@ -1037,7 +1072,7 @@ def _recommend_actions(primary: str, contributing: list[str], story: dict) -> li
             "gate (or re-sprint) before trusting any earlier review verdict"
         ),
         "operator_action": f"perform the operator action described in {ref} (no dev agent can)",
-        "launch_collision": (f"clear the active worktree/lock blocking {ref}, then re-sprint it"),
+        "launch_collision": _launch_collision_action(story, ref),
         "sprint_state_stranded": (
             f"re-resume/reconcile the sprint so {ref}'s prior-generation state is "
             "recovered — do NOT clear the worktree and re-sprint fresh, which would "

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -80,9 +80,11 @@ from .dag import (
     resolve_satisfied_dependencies,
 )
 from .display import _print_worker_status, _story_header
+from .dropped_work import WorktreeWork, describe_worktree_work, inspect_worktree_work
 from .gate_timeout_resolver import resolve_effective_gate_timeout
 from .launch_guard import (
     REASON_IN_FLIGHT,
+    REASON_IN_FLIGHT_UNRESOLVED,
     REASON_RECONCILE_PRIOR_DONE,
     REASON_STRANDED_WORKTREE,
 )
@@ -1290,6 +1292,7 @@ def _continuation_evidence(
     *,
     reexec: bool,
     live_story_slugs: set[str],
+    unresolved_slugs: "set[str] | None" = None,
 ) -> str | None:
     """Describe why this launch is a continuation of in-flight work, or None.
 
@@ -1304,13 +1307,28 @@ def _continuation_evidence(
     Deliberately narrow: prior *recorded* outcomes are not used as evidence,
     because a sprint id is stable across separate invocations of the same sprint
     and would make an unrelated later run skip its baseline gate.
+
+    Liveness that could not be *resolved* counts as evidence too, and is named as
+    such: the gate's precondition is "no dev work has started", and an unreadable
+    sidecar cannot establish that. Asserting the precondition anyway is the same
+    empty-set-means-idle inference that produced #2079.
     """
-    if not reexec or not live_story_slugs:
+    if not reexec:
         return None
-    return (
-        "agent process groups still running for "
-        f"{', '.join(sorted(live_story_slugs))} after the re-exec"
-    )
+    parts: list[str] = []
+    if live_story_slugs:
+        parts.append(
+            "agent process groups still running for "
+            f"{', '.join(sorted(live_story_slugs))} after the re-exec"
+        )
+    if unresolved_slugs:
+        parts.append(
+            "liveness unresolved (worktree present, agent record unreadable) for "
+            f"{', '.join(sorted(unresolved_slugs))} after the re-exec"
+        )
+    if not parts:
+        return None
+    return "; ".join(parts)
 
 
 def _skipped_baseline_gate(config: ForgeConfig, evidence: str) -> dict[str, object]:
@@ -2468,6 +2486,7 @@ def run_sprint(
     entry_intake_outcomes: "dict[int, IntakeOutcome] | None" = None,
     force: bool = False,
     live_story_slugs: "set[str] | None" = None,
+    unresolved_live_slugs: "set[str] | None" = None,
 ) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -2505,6 +2524,11 @@ def run_sprint(
             this process is the only one that can still finish them. Their
             existence is also the evidence that startup-only checks (the baseline
             gate) no longer hold their precondition.
+        unresolved_live_slugs: Stories whose liveness could not be established
+            after a re-exec (unreadable/absent agent sidecars). Treated exactly
+            like ``live_story_slugs`` everywhere protection or deferral matters —
+            an unresolved lookup is not evidence that no agent is running — but
+            reported honestly as unresolved rather than as observed live work.
 
     Returns:
         SprintResult with per-story outcomes and aggregate stats.
@@ -2530,7 +2554,14 @@ def run_sprint(
     # would otherwise treat their state as foreign — the orphan worktree sweep,
     # the baseline gate's "nothing has started yet" precondition, the gate-timeout
     # load model — is told about them explicitly.
-    _live_story_slugs: set[str] = {s for s in (live_story_slugs or set()) if s}
+    _confirmed_live_slugs: set[str] = {s for s in (live_story_slugs or set()) if s}
+    _unresolved_live_slugs: set[str] = {
+        s for s in (unresolved_live_slugs or set()) if s and s not in _confirmed_live_slugs
+    }
+    # One set for every consumer that must not treat the worktree as foreign.
+    # Unresolved liveness joins confirmed-live here deliberately: the failure to
+    # resolve is not evidence the agent is gone (#2079).
+    _live_story_slugs: set[str] = _confirmed_live_slugs | _unresolved_live_slugs
 
     # Establish that the agents are reachable BEFORE committing wall clock or
     # budget to them (#1952). This runs ahead of the baseline gate, the base
@@ -2787,7 +2818,8 @@ def run_sprint(
     baseline_started_at = datetime.datetime.now(datetime.timezone.utc)
     _continuation_reason = _continuation_evidence(
         reexec=reexec,
-        live_story_slugs=_live_story_slugs,
+        live_story_slugs=_confirmed_live_slugs,
+        unresolved_slugs=_unresolved_live_slugs,
     )
     if _continuation_reason is not None:
         baseline_gate = _skipped_baseline_gate(config, _continuation_reason)
@@ -3218,7 +3250,7 @@ def run_sprint(
         *,
         error: str | None = None,
         error_type: str | None = None,
-        cost_usd: float = 0.0,
+        cost_usd: float | None = 0.0,
         extras: dict | None = None,
     ) -> None:
         task_ctx = slug_to_context.get(slug)
@@ -3566,9 +3598,51 @@ def run_sprint(
     # ``preserved-escalated`` is a disjoint case: the worktree is intentionally
     # kept for human review, and counts as skipped (not failed) in aggregates.
     _dropped_slugs: dict[str, str] = dict(dropped_slugs or {})
+    _dropped_work: dict[str, WorktreeWork] = {}
+    # slug -> description of the work the drop abandoned. Membership is the
+    # single test for "this drop was not free and not evidence-free".
+    _dropped_with_work: dict[str, str] = {}
+
+    def _inspect_dropped_work(slug: str) -> WorktreeWork:
+        work = inspect_worktree_work(
+            slug,
+            project_root=config.project_root,
+            path_pattern=config.workspace.path_pattern,
+            base_branch=config.workspace.base_branch,
+            branch_pattern=getattr(config.workspace, "branch_pattern", None),
+        )
+        _dropped_work[slug] = work
+        return work
+
+    def _reclaim_dropped_agents(slug: str) -> None:
+        """Settle any inherited agent group belonging to a story we will not run.
+
+        This sprint owns the group — the sidecar names this pid — so nothing else
+        can adopt it. Leaving it running hands a live process to the next
+        invocation's orphan reaper, hours later and with no context (#2079).
+        """
+        from .live_stories import reclaim_inherited_agents  # noqa: PLC0415
+
+        try:
+            killed = reclaim_inherited_agents(
+                slug,
+                project_root=config.project_root,
+                path_pattern=config.workspace.path_pattern,
+            )
+        except Exception as exc:  # noqa: BLE001 - cleanup must not fail the sprint
+            _log(f"WARN {slug}: could not reclaim inherited agent group(s): {exc}")
+            return
+        if killed:
+            _log(
+                f"RECLAIMED {slug}: terminated inherited agent process group(s) "
+                f"{', '.join(str(p) for p in killed)} belonging to a story this "
+                "sprint did not schedule"
+            )
+
     for slug, reason in _dropped_slugs.items():
         if slug not in slug_to_context:
             continue
+        _reclaim_dropped_agents(slug)
         if reason == "preserved-escalated":
             _log(f"PRESERVED {slug} (escalated worktree held for review)")
             dag.mark_skipped(slug)
@@ -3609,10 +3683,45 @@ def run_sprint(
                 extras={"drop_reason": reason},
             )
         else:
-            _log(f"DROPPED {slug} (reason: {reason})")
+            # A dropped story is normally a story that never ran — but if its
+            # worktree holds commits, it did run, and recording that as a $0.00
+            # no-evidence drop erases exactly the run an operator needs evidence
+            # for. Cost cannot be recovered here (the spend was the previous
+            # process image's), so it is recorded as unmeasured, not as zero.
+            work = _inspect_dropped_work(slug)
+            work_detail = describe_worktree_work(work)
+            if work_detail:
+                _dropped_with_work[slug] = work_detail
+            _detail_msg = f"{reason}: {work_detail}" if work_detail else reason
+            _log(f"DROPPED {slug} (reason: {_detail_msg})")
             dag.mark_skipped(slug)
-            _set_outcome(slug, StoryOutcome.DROPPED, reason=reason)
-            _record_current_story_entry(slug, "DROPPED", error=reason, error_type="dropped")
+            _extras: dict[str, object] = {"drop_reason": reason, **work.as_state_fields()}
+            if work_detail:
+                unmeasured_spend.append(f"dropped-with-work:{slug}")
+                _set_outcome(
+                    slug,
+                    StoryOutcome.DROPPED,
+                    reason=_detail_msg,
+                    cost_usd=None,
+                    detail={"final_outcome": "DROPPED", **_extras},
+                )
+                _record_current_story_entry(
+                    slug,
+                    "DROPPED",
+                    error=_detail_msg,
+                    error_type="dropped",
+                    cost_usd=None,
+                    extras=_extras,
+                )
+            else:
+                _set_outcome(slug, StoryOutcome.DROPPED, reason=reason)
+                _record_current_story_entry(
+                    slug,
+                    "DROPPED",
+                    error=reason,
+                    error_type="dropped",
+                    extras=_extras,
+                )
 
     # Persist resume-time already-completed stories before any possible re-exec
     # handoff so later generations can recover the full logical sprint history.
@@ -3732,6 +3841,19 @@ def run_sprint(
                 _status = "failed"
                 _blocked_by = [f"dropped: {_drop_reason}"]
                 _detail = {"final_outcome": "ESCALATE"}
+                # A drop that abandoned real work says so here, with the work
+                # named — an operator reading this row must not have to infer
+                # from a zero cost that nothing was produced.
+                _work = _dropped_work.get(_slug)
+                _work_detail = _dropped_with_work.get(_slug)
+                if _work is not None and _work_detail:
+                    _blocked_by = [f"dropped: {_drop_reason}: {_work_detail}"]
+                    _detail = {
+                        "final_outcome": "DROPPED",
+                        "drop_reason": _drop_reason,
+                        "drop_detail": _work_detail,
+                        **_work.as_state_fields(),
+                    }
             elif _triage and _triage.action == "skip_merged":
                 _status = "done"
                 _detail = {
@@ -3742,12 +3864,18 @@ def run_sprint(
                 _status = "skipped"
                 _detail = {"final_outcome": "SKIPPED"}
             elif _slug in _inflight_slugs:
-                # Still running from before the re-exec: this run will wait for
-                # that agent and then resume the story, so it is waiting work —
-                # not a drop, and not something an operator should read as idle.
+                # Still running from before the re-exec — or not resolvable as
+                # finished, which this run treats the same way. Either way it
+                # waits for the agent and then resumes the story: not a drop, and
+                # not something an operator should read as idle.
+                _in_flight_reason = (
+                    REASON_IN_FLIGHT_UNRESOLVED
+                    if _slug in _unresolved_live_slugs
+                    else REASON_IN_FLIGHT
+                )
                 _status = "waiting"
-                _blocked_by = [f"in flight: {REASON_IN_FLIGHT}"]
-                _detail = {"in_flight": True, "in_flight_reason": REASON_IN_FLIGHT}
+                _blocked_by = [f"in flight: {_in_flight_reason}"]
+                _detail = {"in_flight": True, "in_flight_reason": _in_flight_reason}
             elif _blocked_by:
                 _status = "blocked"
                 _detail = {}
@@ -3760,7 +3888,9 @@ def run_sprint(
                     "path": _display_key,
                     "status": _status,
                     "phase": "PREFLIGHT" if _status == "waiting" else None,
-                    "cost_usd": 0.0,
+                    # A dropped story that abandoned work has a real, unrecovered
+                    # cost: record it unmeasured rather than fabricating $0.00.
+                    "cost_usd": None if _slug in _dropped_with_work else 0.0,
                     "bundle_candidate": _slug in _bundle_candidate_slugs,
                     "blocked_by": _blocked_by,
                     "complexity": None,

--- a/tests/test_sprint_launch_liveness.py
+++ b/tests/test_sprint_launch_liveness.py
@@ -1,0 +1,693 @@
+"""Seam tests for issue #2079: a sprint must not drop its own running stories.
+
+The incident: a mid-run re-exec could not resolve which of its own agent groups
+were still alive, read the empty result as "nothing is running", and classified
+two of its own executing stories as foreign ``active-worktree-collision`` drops.
+Downstream, each symptom followed from that one misclassification — the stories
+were recorded at ``cost_usd: 0.0`` with no evidence, the operator was advised to
+delete the worktrees holding the only copy of five unmerged commits, and the
+inherited agent group survived the sprint to be reaped hours later.
+
+These tests pin each link in that chain at its own seam: liveness resolution
+(unresolved ≠ not-live), launch-guard classification, the audit record for a drop
+that abandoned work, RCA remediation gating, and inherited-group cleanup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.sprint import run_sprint
+from theforge.sprint.dag import StoryTriage
+from theforge.sprint.dropped_work import describe_worktree_work, inspect_worktree_work
+from theforge.sprint.launch_guard import (
+    REASON_ACTIVE_WORKTREE,
+    REASON_IN_FLIGHT_UNRESOLVED,
+    acquire_launch_story_locks,
+)
+from theforge.sprint.live_stories import resolve_liveness, unresolved_liveness
+
+_DEAD_PGID = 999999
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_spec_file(tmp_path: Path, name: str, slug: str) -> Path:
+    spec = tmp_path / f"{slug}.md"
+    spec.write_text(
+        f"---\nname: {name}\nslug: {slug}\n---\n# {name}\nDo the thing.",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _make_manifest(tmp_path: Path, specs: list[str], budget: float = 10.0) -> Path:
+    manifest_path = tmp_path / "sprint.yaml"
+    manifest_path.write_text(
+        yaml.dump({"name": "Test Sprint", "budget_usd": budget, "specs": specs}),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _make_coordinator_result(cost: float = 1.0) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    mock_preflight = MagicMock()
+    mock_preflight.cost_usd = cost
+    state.preflight_result = mock_preflight
+    return CoordinatorResult(
+        success=True,
+        phase=Phase.DONE,
+        state=state,
+        message="Done.",
+        landing_status="landed",
+    )
+
+
+def _triage_full(spec_path, config, project_root, *, task=None, **_progress):
+    return StoryTriage(
+        story_path=spec_path,
+        action="full",
+        reason="x",
+        worktree_path=None,
+        slug=Path(spec_path).stem,
+    )
+
+
+def _write_agent_sidecar(
+    project_root: Path,
+    *,
+    owner_pid: int,
+    pgid: int,
+    sandbox_dir: Path | None,
+) -> Path:
+    agents_dir = project_root / ".forge" / "runs" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    path = agents_dir / f"{owner_pid}-{pgid}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "owner_pid": owner_pid,
+                "pgid": pgid,
+                "run_id": "run-prev",
+                "sandbox_dir": str(sandbox_dir) if sandbox_dir else None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _worktree_with_commit(root: Path, slug: str, *, base_branch: str = "main") -> Path:
+    """A story worktree whose branch carries one commit ahead of the base."""
+    worktree = root / slug
+    worktree.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-q", f"--initial-branch={base_branch}"], worktree)
+    _git(["config", "user.email", "test@example.com"], worktree)
+    _git(["config", "user.name", "Test"], worktree)
+    (worktree / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(["add", "-A"], worktree)
+    _git(["commit", "-qm", "base"], worktree)
+    _git(["checkout", "-qb", f"forge/{slug}"], worktree)
+    (worktree / "work.py").write_text("# the only copy of the work\n", encoding="utf-8")
+    _git(["add", "-A"], worktree)
+    _git(["commit", "-qm", "fix(scope): the work this story was dispatched to write"], worktree)
+    return worktree
+
+
+# ── liveness resolution: unresolved is not "not live" ────────────────
+
+
+def test_unreadable_sidecar_leaves_liveness_unresolved(tmp_path: Path) -> None:
+    """A sidecar that cannot be parsed names no slug — so it taints them all.
+
+    This is the exact input the incident could not recover: the empty
+    ``live_slugs`` that followed is indistinguishable from "nothing is running"
+    unless the failure itself is reported.
+    """
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-2048").mkdir(parents=True)
+    (worktrees / "issue-2060").mkdir(parents=True)
+    agents_dir = tmp_path / ".forge" / "runs" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "broken.json").write_text("{not json", encoding="utf-8")
+
+    resolution = resolve_liveness(
+        ["issue-2048", "issue-2060"],
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+    )
+
+    assert resolution.live_slugs == frozenset()
+    assert resolution.unresolved_slugs == {"issue-2048", "issue-2060"}
+    assert resolution.resolved is False
+    assert resolution.failures
+
+
+def test_unresolved_scope_excludes_slugs_with_no_worktree(tmp_path: Path) -> None:
+    """A slug with no worktree has nothing that could be live.
+
+    Fail-closed must not mean fail-broad: a story with no worktree keeps its full
+    intake/preflight path even when the sidecar scan is broken.
+    """
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-2048").mkdir(parents=True)
+    agents_dir = tmp_path / ".forge" / "runs" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "broken.json").write_text("[]", encoding="utf-8")
+
+    resolution = resolve_liveness(
+        ["issue-2048", "issue-2060"],
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+    )
+
+    assert resolution.unresolved_slugs == {"issue-2048"}
+
+
+def test_clean_scan_resolves_confirmed_live_and_nothing_else(tmp_path: Path) -> None:
+    """A readable scan still answers precisely: live is live, absent is absent."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-2048").mkdir(parents=True)
+    (worktrees / "issue-2060").mkdir(parents=True)
+    _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=os.getpgrp(),
+        sandbox_dir=worktrees / "issue-2048",
+    )
+
+    resolution = resolve_liveness(
+        ["issue-2048", "issue-2060"],
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+    )
+
+    assert resolution.live_slugs == {"issue-2048"}
+    assert resolution.unresolved_slugs == frozenset()
+    assert resolution.resolved is True
+
+
+def test_failed_liveness_probe_is_unresolved_not_dead(tmp_path: Path) -> None:
+    """A probe that raises says nothing about the group — least of all that it exited."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-2048").mkdir(parents=True)
+    _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=4242,
+        sandbox_dir=worktrees / "issue-2048",
+    )
+
+    def _boom(_pgid: int) -> bool:
+        raise OSError("cannot signal")
+
+    resolution = resolve_liveness(
+        ["issue-2048"],
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        is_group_alive=_boom,
+    )
+
+    assert resolution.unresolved_slugs == {"issue-2048"}
+    assert resolution.live_slugs == frozenset()
+
+
+def test_unresolved_liveness_factory_taints_every_slug() -> None:
+    """A lookup that could not run at all resolves nothing, for anyone."""
+    resolution = unresolved_liveness(["a", "b"], reason="config unavailable")
+
+    assert resolution.deferred_slugs == {"a", "b"}
+    assert resolution.live_slugs == frozenset()
+
+
+def test_cli_liveness_seam_fails_closed(tmp_path: Path) -> None:
+    """The CLI seam degrades to *unresolved*, never to an empty live set."""
+    from theforge.cli.sprint import _resolve_story_liveness
+
+    broken_config = MagicMock()
+    broken_config.project_root = tmp_path
+    type(broken_config).workspace = property(
+        lambda _self: (_ for _ in ()).throw(RuntimeError("no workspace"))
+    )
+
+    resolution = _resolve_story_liveness(broken_config, ["issue-2048"])
+
+    assert resolution.unresolved_slugs == {"issue-2048"}
+    assert resolution.live_slugs == frozenset()
+
+
+# ── launch-guard classification ──────────────────────────────────────
+
+
+def test_unresolved_liveness_is_never_an_active_worktree_collision(tmp_path: Path) -> None:
+    """The incident's classification, at its seam.
+
+    An unresolved story's worktree is active and has no prior-generation record —
+    the combination that fell through to ``REASON_ACTIVE_WORKTREE``. It must come
+    back scheduled and lock-holding, never dropped.
+    """
+    config = _make_config(tmp_path)
+
+    with (
+        patch(
+            "theforge.sprint.launch_guard.check_active_worktrees",
+            return_value=["issue-2048"],
+        ) as mock_active,
+        patch("theforge.sprint.launch_guard.check_escalated_worktrees", return_value=[]),
+    ):
+        locked_fds, exit_code, dropped = acquire_launch_story_locks(
+            slugs=["issue-2048", "issue-2060"],
+            config=config,
+            resume=False,
+            allow_drop=True,
+            live_slugs=set(),
+            unresolved_slugs={"issue-2048"},
+        )
+
+    try:
+        assert exit_code is None
+        assert "issue-2048" not in dropped
+        assert REASON_ACTIVE_WORKTREE not in dropped.values()
+        # Never even offered to the collision classifier.
+        assert "issue-2048" not in mock_active.call_args.args[0]
+        assert len(locked_fds) == 2
+    finally:
+        from theforge.sprint.lock import release_story_locks
+
+        release_story_locks(locked_fds)
+
+
+def test_unresolved_liveness_survives_a_prior_generation_record(tmp_path: Path) -> None:
+    """Deferral outranks reconciliation: a possibly-live story is not prior state.
+
+    The prior-generation classifications (#1838) only make sense for a story that
+    is *not* running now; an unresolved one may be, and re-consuming its outcome
+    while an agent writes to the worktree is the same mistake in another branch.
+    """
+    config = _make_config(tmp_path)
+
+    with (
+        patch(
+            "theforge.sprint.launch_guard.check_active_worktrees",
+            return_value=["issue-2048"],
+        ) as mock_active,
+        patch("theforge.sprint.launch_guard.check_escalated_worktrees", return_value=[]),
+    ):
+        locked_fds, exit_code, dropped = acquire_launch_story_locks(
+            slugs=["issue-2048"],
+            config=config,
+            resume=False,
+            allow_drop=True,
+            prior_outcomes={"issue-2048": "FAILED"},
+            unresolved_slugs={"issue-2048"},
+        )
+    assert "issue-2048" not in mock_active.call_args.args[0]
+
+    try:
+        assert exit_code is None
+        assert dropped == {}
+        assert len(locked_fds) == 1
+    finally:
+        from theforge.sprint.lock import release_story_locks
+
+        release_story_locks(locked_fds)
+
+
+def test_unresolved_liveness_is_announced_distinctly(tmp_path: Path, capsys) -> None:
+    """The operator is told the story was deferred *because nothing could be resolved*."""
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.launch_guard.check_active_worktrees", return_value=[]),
+        patch("theforge.sprint.launch_guard.check_escalated_worktrees", return_value=[]),
+    ):
+        locked_fds, _exit_code, _dropped = acquire_launch_story_locks(
+            slugs=["issue-2048"],
+            config=config,
+            resume=False,
+            allow_drop=True,
+            unresolved_slugs={"issue-2048"},
+        )
+    from theforge.sprint.lock import release_story_locks
+
+    release_story_locks(locked_fds)
+
+    err = capsys.readouterr().err
+    assert "IN-FLIGHT issue-2048" in err
+    assert "could not be resolved" in err
+
+
+# ── work left behind by a drop ───────────────────────────────────────
+
+
+def test_worktree_work_reports_commits_ahead_of_base(tmp_path: Path) -> None:
+    worktree = _worktree_with_commit(tmp_path, "issue-2048")
+
+    work = inspect_worktree_work(
+        "issue-2048",
+        project_root=tmp_path,
+        path_pattern="{slug}",
+        base_branch="main",
+        branch_pattern="forge/{slug}",
+    )
+
+    assert work.path == str(worktree.resolve())
+    assert work.commits_ahead == 1
+    assert work.has_work is True
+    assert "1 unmerged commit(s)" in (describe_worktree_work(work) or "")
+
+
+def test_unreadable_worktree_state_is_treated_as_holding_work(tmp_path: Path) -> None:
+    """Fail closed: a directory git cannot answer for is not a directory known empty."""
+    (tmp_path / "issue-2048").mkdir()  # present, but not a git repo
+
+    work = inspect_worktree_work(
+        "issue-2048",
+        project_root=tmp_path,
+        path_pattern="{slug}",
+        base_branch="main",
+    )
+
+    assert work.determined is False
+    assert work.may_have_work is True
+    assert describe_worktree_work(work)
+
+
+def test_absent_worktree_is_determined_empty(tmp_path: Path) -> None:
+    """A story that never got a worktree is a genuinely free drop."""
+    work = inspect_worktree_work(
+        "issue-2048",
+        project_root=tmp_path,
+        path_pattern="{slug}",
+        base_branch="main",
+    )
+
+    assert work.determined is True
+    assert work.may_have_work is False
+    assert describe_worktree_work(work) is None
+
+
+# ── audit record for a drop that abandoned work ──────────────────────
+
+
+def test_dropped_story_with_commits_is_unmeasured_and_evidenced(tmp_path: Path) -> None:
+    """A drop that abandoned committed work is never recorded as free and silent.
+
+    The run that produced commits is precisely the run an operator needs evidence
+    for; ``cost_usd: 0.0`` plus no detail is the record that hid it.
+    """
+    _make_spec_file(tmp_path, "Issue 2048", "issue-2048")
+    _make_spec_file(tmp_path, "Issue 2060", "issue-2060")
+    manifest_path = _make_manifest(tmp_path, ["issue-2048.md", "issue-2060.md"])
+    config = _make_config(tmp_path)
+    _worktree_with_commit(tmp_path, "issue-2048")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        result = run_sprint(
+            config,
+            manifest_path,
+            run_id="run-2079",
+            dropped_slugs={"issue-2048": REASON_ACTIVE_WORKTREE},
+        )
+
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
+    )
+    story = {s["slug"]: s for s in summary["stories"]}["issue-2048"]
+
+    assert story["outcome"] == "DROPPED"
+    # Not free: the spend happened, it just cannot be recovered here.
+    assert story["cost_usd"] is None
+    assert story["unmerged_commits"] == 1
+    assert story["unmerged_work_determined"] is True
+    assert story["branch"] == "forge/issue-2048"
+    # The recorded detail names the abandoned work, not an unrelated fragment.
+    assert "unmerged commit" in story["error"]
+    assert REASON_ACTIVE_WORKTREE in story["error"]
+    # The sprint total is a lower bound, and says so.
+    assert result.cost_complete is False
+    assert "dropped-with-work:issue-2048" in result.unmeasured_spend_sources
+
+    # The same evidence reaches the audit trail, which is where an operator
+    # reconstructing the run actually looks.
+    audit = yaml.safe_load((tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text())
+    spec = {s["path"]: s for s in audit["specs"]}["issue-2048.md"]
+    assert spec["outcome"] == "DROPPED"
+    assert spec["cost_usd"] is None
+    assert spec["unmerged_commits"] == 1
+    assert "unmerged commit" in spec["error"]
+    assert audit["sprint"]["total_cost_usd"] is None
+
+
+def test_dropped_story_without_a_worktree_stays_a_free_drop(tmp_path: Path) -> None:
+    """No worktree, no work: the ordinary drop record is unchanged."""
+    _make_spec_file(tmp_path, "Issue 2048", "issue-2048")
+    _make_spec_file(tmp_path, "Issue 2060", "issue-2060")
+    manifest_path = _make_manifest(tmp_path, ["issue-2048.md", "issue-2060.md"])
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        result = run_sprint(
+            config,
+            manifest_path,
+            run_id="run-2079",
+            dropped_slugs={"issue-2048": REASON_ACTIVE_WORKTREE},
+        )
+
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
+    )
+    story = {s["slug"]: s for s in summary["stories"]}["issue-2048"]
+
+    assert story["outcome"] == "DROPPED"
+    assert story["cost_usd"] == 0.0
+    assert story["error"] == REASON_ACTIVE_WORKTREE
+    assert result.cost_complete is True
+
+
+def test_dropped_story_inherited_group_is_settled_by_this_sprint(tmp_path: Path) -> None:
+    """No agent record belonging to the sprint outlives it.
+
+    The observed orphan (``pgid=22830``, reaped four hours later by an unrelated
+    ``forge status``) existed because a dropped story's inherited group was never
+    handed to the wait/reclaim path. A drop settles it now.
+    """
+    _make_spec_file(tmp_path, "Issue 2048", "issue-2048")
+    _make_spec_file(tmp_path, "Issue 2060", "issue-2060")
+    manifest_path = _make_manifest(tmp_path, ["issue-2048.md", "issue-2060.md"])
+    config = _make_config(tmp_path)
+    (tmp_path / "issue-2048").mkdir()
+    sidecar = _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=_DEAD_PGID,
+        sandbox_dir=tmp_path / "issue-2048",
+    )
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        run_sprint(
+            config,
+            manifest_path,
+            run_id="run-2079",
+            dropped_slugs={"issue-2048": REASON_ACTIVE_WORKTREE},
+        )
+
+    assert not sidecar.exists()
+
+
+# ── the whole chain: an unresolved re-exec ───────────────────────────
+
+
+def test_reexec_with_unresolved_liveness_defers_and_resumes(tmp_path: Path) -> None:
+    """End to end on the incident's inputs, with liveness unresolvable.
+
+    The story is not dropped, not reported free, and reaches a terminal outcome in
+    this run — and the baseline gate, whose precondition ("no dev work started")
+    cannot be established, is skipped with that stated as its evidence.
+    """
+    _make_spec_file(tmp_path, "Issue 2048", "issue-2048")
+    _make_spec_file(tmp_path, "Issue 2060", "issue-2060")
+    manifest_path = _make_manifest(tmp_path, ["issue-2048.md", "issue-2060.md"])
+    config = _make_config(tmp_path)
+    (tmp_path / "issue-2048").mkdir()
+
+    with (
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch(
+            "theforge.sprint.runner.run_task", return_value=_make_coordinator_result()
+        ) as mock_run_task,
+    ):
+        result = run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            unresolved_live_slugs={"issue-2048"},
+        )
+
+    mock_gate.assert_not_called()
+    dispatched = sorted(c.args[1].slug for c in mock_run_task.call_args_list)
+    assert dispatched == ["issue-2048", "issue-2060"]
+    assert result.specs_succeeded == 2
+
+    audit = yaml.safe_load((tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text())
+    baseline = audit["baseline_check"]
+    assert baseline["status"] == "skipped"
+    assert "issue-2048" in baseline["skip_evidence"]
+    assert "unresolved" in baseline["skip_evidence"]
+
+
+def test_reexec_state_names_unresolved_deferral_distinctly(tmp_path: Path) -> None:
+    """The live status row distinguishes 'waiting on a known agent' from 'unknown'."""
+    _make_spec_file(tmp_path, "Issue 2048", "issue-2048")
+    manifest_path = _make_manifest(tmp_path, ["issue-2048.md"])
+    config = _make_config(tmp_path)
+    (tmp_path / "issue-2048").mkdir()
+
+    seen: list[dict] = []
+    real_init = None
+
+    from theforge.sprint.state_writer import SprintStateWriter
+
+    real_init = SprintStateWriter.init
+
+    def _capture_init(self, stories):
+        seen.extend(stories)
+        return real_init(self, stories)
+
+    with (
+        patch("theforge.sprint.runner._run_baseline_gate"),
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+        patch.object(SprintStateWriter, "init", _capture_init),
+    ):
+        run_sprint(
+            config,
+            manifest_path,
+            run_id="run-2079",
+            reexec=True,
+            unresolved_live_slugs={"issue-2048"},
+        )
+
+    row = {s["slug"]: s for s in seen}["issue-2048"]
+    assert row["status"] == "waiting"
+    assert row["detail"]["in_flight_reason"] == REASON_IN_FLIGHT_UNRESOLVED
+
+
+# ── RCA remediation gating ───────────────────────────────────────────
+
+
+def test_launch_collision_remediation_preserves_unmerged_work() -> None:
+    """Advice that deletes a worktree is not emitted over unmerged commits."""
+    from theforge.sprint.rca import _recommend_actions
+
+    actions = _recommend_actions(
+        "launch_collision",
+        [],
+        {
+            "slug": "issue-2048",
+            "unmerged_commits": 4,
+            "unmerged_work_determined": True,
+            "branch": "forge/issue-2048",
+            "worktree": "/repo/.forge/worktrees/issue-2048",
+        },
+    )
+
+    assert "clear the active worktree" not in actions[0]
+    assert "preserve the worktree" in actions[0]
+    assert "4 unmerged commit(s)" in actions[0]
+
+
+def test_launch_collision_remediation_is_conservative_when_undetermined() -> None:
+    """No evidence either way is not evidence of an empty worktree."""
+    from theforge.sprint.rca import _recommend_actions
+
+    actions = _recommend_actions("launch_collision", [], {"slug": "issue-2048"})
+
+    assert "clear the active worktree" not in actions[0]
+    assert "inspect the worktree" in actions[0]
+
+
+def test_launch_collision_remediation_clears_only_a_confirmed_empty_worktree() -> None:
+    """With absence of work established, the direct remediation stands."""
+    from theforge.sprint.rca import _recommend_actions
+
+    actions = _recommend_actions(
+        "launch_collision",
+        [],
+        {
+            "slug": "issue-2048",
+            "unmerged_commits": 0,
+            "unmerged_work_determined": True,
+            "worktree_dirty": False,
+        },
+    )
+
+    assert "clear the active worktree/lock" in actions[0]

--- a/tests/test_sprint_launch_liveness.py
+++ b/tests/test_sprint_launch_liveness.py
@@ -420,6 +420,47 @@ def test_unreadable_worktree_state_is_treated_as_holding_work(tmp_path: Path) ->
     assert describe_worktree_work(work)
 
 
+def test_unknown_dirty_state_is_not_a_determined_empty_worktree(tmp_path: Path) -> None:
+    """Ruling out commits does not rule out uncommitted work.
+
+    Commit counting can succeed while ``git status`` fails (a lock file, a
+    permission error). Reporting that as a determined-empty worktree would put a
+    dirty worktree back on the free-drop-and-clear path this change closes.
+    """
+    _worktree_with_commit(tmp_path, "issue-2048")
+
+    with patch(
+        "theforge.sprint.dropped_work._is_dirty",
+        return_value=None,
+    ):
+        work = inspect_worktree_work(
+            "issue-2048",
+            project_root=tmp_path,
+            path_pattern="{slug}",
+            base_branch="forge/issue-2048",  # HEAD == base: zero commits ahead
+            branch_pattern="forge/{slug}",
+        )
+
+    assert work.commits_ahead == 0
+    assert work.dirty is None
+    assert work.determined is False
+    assert work.may_have_work is True
+    assert "git status failed" in (describe_worktree_work(work) or "")
+
+
+def test_unresolvable_worktree_path_is_not_a_determined_empty_worktree(tmp_path: Path) -> None:
+    """A worktree whose location cannot even be computed is unknown, not absent."""
+    work = inspect_worktree_work(
+        "issue-2048",
+        project_root=tmp_path,
+        path_pattern="{missing_key}",
+        base_branch="main",
+    )
+
+    assert work.determined is False
+    assert work.may_have_work is True
+
+
 def test_absent_worktree_is_determined_empty(tmp_path: Path) -> None:
     """A story that never got a worktree is a genuinely free drop."""
     work = inspect_worktree_work(
@@ -670,6 +711,25 @@ def test_launch_collision_remediation_is_conservative_when_undetermined() -> Non
     from theforge.sprint.rca import _recommend_actions
 
     actions = _recommend_actions("launch_collision", [], {"slug": "issue-2048"})
+
+    assert "clear the active worktree" not in actions[0]
+    assert "inspect the worktree" in actions[0]
+
+
+def test_launch_collision_remediation_withholds_clearing_on_unknown_dirty_state() -> None:
+    """Zero commits plus an unread dirty state is not a clearable worktree."""
+    from theforge.sprint.rca import _recommend_actions
+
+    actions = _recommend_actions(
+        "launch_collision",
+        [],
+        {
+            "slug": "issue-2048",
+            "unmerged_commits": 0,
+            "unmerged_work_determined": False,
+            "worktree_dirty": None,
+        },
+    )
 
     assert "clear the active worktree" not in actions[0]
     assert "inspect the worktree" in actions[0]


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Cycle 1 dirty-state P1 is fixed, the focused liveness suite passes, and I found no blocking regressions in the reviewed commits. | [google-gemini-3.5-flash] The implementation successfully resolves the liveness lookup failure, prevents self-collisions, preserves unmerged work, and cleans up orphaned agent groups. | [claude-sonnet] Cycle 1's single P1 (unknown-dirty-state read as a determined-empty worktree) is fixed: WorktreeWork.determined now requires both commits_ahead and dirty to be established, closing the path where a failed git status still produced cost_usd 0.0 and clear-the-worktree advice. Swept two further instances of the same unknown-means-nothing pattern (unresolvable path_pattern, is_dir() OSError). No regressions found in the touched files; full related test suite (117 tests: 23 new + 94 in launch_guard/live_stories/rca/runner/dropped_work) passes, and no repo-root scratch files were introduced.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $22.26
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

A sprint drops its own running stories as foreign worktree collisions, reports them free, and advises deleting the only copy of the work (GitHub Issue #2079)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2079