### PR TITLE
A failure cause code is assigned from text describing the target repository's source rather than forge's own run

### DIFF
--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -119,6 +119,14 @@ class RcaRule:
     # field-derived (implemented in ``_signal_rule_hits``) rather than
     # pattern-based.
     patterns: tuple[str, ...] = ()
+    # When True, the rule's patterns are scanned only against sources forge
+    # emitted about its own execution — structured summary/audit fields and run
+    # or iteration logs — never against agent-authored prose (``authored`` kind:
+    # markdown and preflight artifacts, which carry analysis *of the target
+    # repository*). Set it on any rule whose patterns are ordinary English a
+    # dev/reviewer agent could plausibly write about the project under
+    # development; see ``_text_source_kind_for_path``.
+    forge_emitted_only: bool = False
 
 
 # ── Classifier rule set (single discoverable location) ────────────────────────
@@ -133,7 +141,18 @@ RULES: tuple[RcaRule, ...] = (
         rule_id="provider_usage_limit",
         failure_class="provider_quota",
         role="primary",
-        description="Provider reported a usage/quota/rate limit in captured output.",
+        description=(
+            "Provider reported a usage/quota/rate limit — from the run's own CLI "
+            "transport telemetry, or from a limit phrase in forge-emitted output."
+        ),
+        # "rate limit" / "overloaded" / "resource exhausted" are ordinary English an
+        # agent can write while analysing the project under development, so this rule
+        # carries the same exposure #2031 fixed for the fallback rule. Two guards,
+        # short of deleting patterns that still catch real provider errors nothing
+        # else records: agent-authored prose is out of scope for the scan
+        # (``forge_emitted_only``), and forge's own per-iteration quota observation
+        # fires the rule without any text at all (``_provider_quota_evidence``).
+        forge_emitted_only=True,
         patterns=(
             "usage limit",
             "current quota",
@@ -736,6 +755,10 @@ def _text_rule_hits(sources: list[_TextSource]) -> list[tuple[str, str, str, str
         if not rule.patterns:
             continue
         for src in sources:
+            if rule.forge_emitted_only and src.kind == "authored":
+                # Agent-authored prose describes the work being attempted, not the
+                # run attempting it — it can never assign this rule's cause code.
+                continue
             lowered = src.text.lower()
             matched = [p for p in rule.patterns if _pattern_matches(p, lowered)]
             if not matched:
@@ -806,6 +829,50 @@ def _configuration_change_evidence(
     return None
 
 
+def _dev_loop_entries(audit: dict) -> list[dict]:
+    """The per-dev-iteration telemetry records the coordinator audit persisted."""
+    iterations = audit.get("iterations") if isinstance(audit, dict) else None
+    dev_loop = iterations.get("dev_loop") if isinstance(iterations, dict) else None
+    if not isinstance(dev_loop, list):
+        return []
+    return [entry for entry in dev_loop if isinstance(entry, dict)]
+
+
+def _provider_quota_evidence(audit: dict, audit_source: str) -> tuple[str, str, str] | None:
+    """Return a ``provider_usage_limit`` hit from the run's own quota observation.
+
+    ``cli_quota_error_observed`` is forge's classification of *its own* CLI
+    invocation — set from the transport's exit code or its captured stderr/stdout
+    by ``runners.cli._classify_cli_fallback_decision`` — and the coordinator audit
+    records it per dev iteration. That makes it a statement about the run, unlike
+    the rule's English patterns.
+
+    Restricted to the *terminal* dev iteration with no fallback fired: an earlier
+    quota blip that a fallback absorbed, or that a later iteration recovered from,
+    is not what the story died of, and provider_quota is the highest-priority
+    primary class — promoting a survived blip to root cause would send the
+    operator to wait for a quota reset that was never the blocker.
+    """
+    entries = _dev_loop_entries(audit)
+    if not entries:
+        return None
+    last = entries[-1]
+    if not last.get("cli_quota_error_observed") or last.get("transport_fallback_fired"):
+        return None
+    iteration = last.get("iteration")
+    where = f"dev iteration {iteration}" if iteration is not None else "the terminal dev iteration"
+    reason = _nonempty(last.get("transport_fallback_reason"))
+    detail = f" ({reason})" if reason else ""
+    return (
+        "provider_usage_limit",
+        audit_source,
+        _truncate(
+            f"the run's own transport telemetry recorded a provider quota/rate-limit "
+            f"error on {where}{detail}, with no fallback transport applied"
+        ),
+    )
+
+
 def _fallback_not_applied_evidence(audit: dict, audit_source: str) -> tuple[str, str, str] | None:
     """Return a ``provider_fallback_not_applied`` hit from the run's own telemetry.
 
@@ -821,13 +888,7 @@ def _fallback_not_applied_evidence(audit: dict, audit_source: str) -> tuple[str,
     (Reason set + fired true is a fallback that *did* apply — including one that
     applied and then failed — so it is deliberately not a hit.)
     """
-    iterations = audit.get("iterations") if isinstance(audit, dict) else None
-    dev_loop = iterations.get("dev_loop") if isinstance(iterations, dict) else None
-    if not isinstance(dev_loop, list):
-        return None
-    for entry in dev_loop:
-        if not isinstance(entry, dict):
-            continue
+    for entry in _dev_loop_entries(audit):
         reason = _nonempty(entry.get("transport_fallback_reason"))
         if not reason or entry.get("transport_fallback_fired"):
             continue
@@ -878,8 +939,11 @@ def _signal_rule_hits(
     if config_change is not None:
         hits.append(config_change)
 
-    # Provider fallback that never applied (#2031) — read from the run's own
-    # transport telemetry rather than scanned for in prose.
+    # Provider quota / fallback classification from the run's own transport
+    # telemetry rather than scanned for in prose (#2031).
+    quota_hit = _provider_quota_evidence(audit, audit_source)
+    if quota_hit is not None:
+        hits.append(quota_hit)
     fallback_hit = _fallback_not_applied_evidence(audit, audit_source)
     if fallback_hit is not None:
         hits.append(fallback_hit)

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -41,7 +41,7 @@ SCHEMA_VERSION = 1
 # (schema_version stays 1) rather than a silent rewrite of historical judgement:
 # an operator can tell whether two RCA files for one sprint were produced by the
 # same rule set by comparing this field.
-RULESET_VERSION = 4
+RULESET_VERSION = 5
 RCA_FILENAME = "sprint-rca.yaml"
 
 # Outcomes that mean the story landed / succeeded. These stay accounted for in
@@ -275,8 +275,19 @@ RULES: tuple[RcaRule, ...] = (
         rule_id="provider_fallback_not_applied",
         failure_class="fallback_not_applied",
         role="contributing",
-        description="A configured provider fallback did not apply on the failure.",
-        patterns=("fallback not applied", "no fallback", "fallback unavailable"),
+        description=(
+            "A configured provider fallback did not apply on the failure — "
+            "field-derived from the run's own transport telemetry "
+            "(transport_fallback_reason set with transport_fallback_fired false)."
+        ),
+        # Deliberately NOT pattern-based (#2031). The prior patterns were ordinary
+        # English ("no fallback", "fallback unavailable") matched as unanchored
+        # substrings against every text source, which includes agent-authored prose
+        # *about the project under development*. That fired the rule on a preflight
+        # analysis of a target repo's own error handling and sent the operator to
+        # wire a forge subsystem that had never been involved. A runtime cause code
+        # may only be assigned from something forge emits about its own execution,
+        # so detection moved to ``_fallback_not_applied_evidence``.
     ),
     RcaRule(
         rule_id="dev_iteration_limit_hit",
@@ -547,7 +558,9 @@ def _classify_story(
     evidence: list[dict] = []
     structured_primary_classes: list[str] = []
     text_primary_classes: list[str] = []
-    contributing_classes: list[str] = []
+    # (failure_class, source_kind) so an unclassifiable story can drop the
+    # contributing factors that rest on nothing but a text scan.
+    contributing_hits: list[tuple[str, str]] = []
     for rule_id, source, excerpt, matched_pattern, source_kind in hits:
         if rule_id in seen_rules:
             continue
@@ -572,7 +585,7 @@ def _classify_story(
             else:
                 text_primary_classes.append(rule.failure_class)
         elif rule.role == "contributing":
-            contributing_classes.append(rule.failure_class)
+            contributing_hits.append((rule.failure_class, source_kind))
 
     # Always append the baseline outcome evidence last.
     evidence.append(
@@ -589,7 +602,20 @@ def _classify_story(
 
     # Contributing factors: unique, in rule-declaration order, minus whichever
     # class was elevated to primary.
-    contributing = _dedupe_ordered(contributing_classes)
+    #
+    # When the engine could not classify the failure at all, its own uncertainty
+    # propagates (#2031): a text-scan-derived amplifier is a match on vocabulary,
+    # and asserting one confidently — plus the remediation the operator is then
+    # told to go perform — on a run forge has just declared unexplained costs more
+    # trust than declining to guess. Field-derived (structured) factors are the
+    # run's own recorded facts, not an inference, so they still stand.
+    contributing = _dedupe_ordered(
+        [
+            failure_class
+            for failure_class, source_kind in contributing_hits
+            if primary != UNKNOWN_CLASS or source_kind == "structured"
+        ]
+    )
 
     partial_value = _detect_partial_value(story, audit)
     actions = _recommend_actions(primary, contributing, story)
@@ -780,6 +806,46 @@ def _configuration_change_evidence(
     return None
 
 
+def _fallback_not_applied_evidence(audit: dict, audit_source: str) -> tuple[str, str, str] | None:
+    """Return a ``provider_fallback_not_applied`` hit from the run's own telemetry.
+
+    The authoritative statement that a provider fallback did not apply is made by
+    forge itself, per dev iteration, in ``iterations.dev_loop``:
+    ``transport_fallback_reason`` is set only when the CLI transport failed with a
+    fallback-eligible error (quota/capacity/model-not-found), and
+    ``transport_fallback_fired`` records whether a fallback transport actually ran.
+    Reason set + fired false is exactly "forge classified the failure as one a
+    fallback should have covered, and no fallback was applied" — the fallback
+    machinery reporting on itself, never vocabulary borrowed from agent prose.
+
+    (Reason set + fired true is a fallback that *did* apply — including one that
+    applied and then failed — so it is deliberately not a hit.)
+    """
+    iterations = audit.get("iterations") if isinstance(audit, dict) else None
+    dev_loop = iterations.get("dev_loop") if isinstance(iterations, dict) else None
+    if not isinstance(dev_loop, list):
+        return None
+    for entry in dev_loop:
+        if not isinstance(entry, dict):
+            continue
+        reason = _nonempty(entry.get("transport_fallback_reason"))
+        if not reason or entry.get("transport_fallback_fired"):
+            continue
+        iteration = entry.get("iteration")
+        where = f"dev iteration {iteration}" if iteration is not None else "a dev iteration"
+        transport = _nonempty(entry.get("transport_used")) or "cli"
+        return (
+            "provider_fallback_not_applied",
+            audit_source,
+            _truncate(
+                f"{where} failed with a fallback-eligible transport error ({reason}) but no "
+                f"provider fallback was applied (transport_fallback_fired=false, "
+                f"transport_used={transport})"
+            ),
+        )
+    return None
+
+
 def _signal_rule_hits(
     story: dict,
     audit: dict,
@@ -811,6 +877,12 @@ def _signal_rule_hits(
     )
     if config_change is not None:
         hits.append(config_change)
+
+    # Provider fallback that never applied (#2031) — read from the run's own
+    # transport telemetry rather than scanned for in prose.
+    fallback_hit = _fallback_not_applied_evidence(audit, audit_source)
+    if fallback_hit is not None:
+        hits.append(fallback_hit)
 
     if outcome == "MERGE_FAILED":
         hits.append(("merge_failed", summary_source, _outcome_excerpt()))

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -438,6 +438,230 @@ def test_unknown_needs_rca_residual(tmp_path: Path) -> None:
     assert any("diagnose" in a for a in entry["recommended_next_actions"])
 
 
+# ── Engine: cause codes come from forge's own run, not target-repo prose (#2031) ──
+
+
+def test_agent_prose_about_project_fallbacks_is_not_a_runtime_cause(tmp_path: Path) -> None:
+    """Agent prose analysing the *target repository* must not assign a cause code.
+
+    A preflight/dev agent describing the project under development ("no fallback
+    path", "the fallback is unavailable") is describing the work being attempted,
+    not the run attempting it. Matching that vocabulary into
+    ``provider_fallback_not_applied`` told the operator to go wire a forge
+    subsystem that was never involved.
+    """
+    d = _sprint_dir(tmp_path, name="prose-fallback")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-248", "outcome": "FAILED", "error": "story did not complete"}]),
+    )
+    (d / "issue-248").mkdir(parents=True, exist_ok=True)
+    (d / "issue-248" / "preflight-raw.log").write_text(
+        "The rest-timer scheduling function invalidates the session unconditionally, "
+        "with no fallback or guard path preserving the existing alarm.\n",
+        encoding="utf-8",
+    )
+    (d / "issue-248" / "dev-iteration-1.log").write_text(
+        "Dev notes: the fallback is unavailable in the target module, so a fallback "
+        "not applied branch has to be added.\n",
+        encoding="utf-8",
+    )
+
+    entry = _build(d)["stories"]["issue-248"]
+    assert entry["primary_failure_class"] == UNKNOWN_CLASS
+    assert "fallback_not_applied" not in entry["contributing_factors"]
+    assert "provider_fallback_not_applied" not in {ev["rule_id"] for ev in entry["evidence"]}
+    assert not any("wire the provider fallback" in a for a in entry["recommended_next_actions"])
+    assert any("diagnose" in a for a in entry["recommended_next_actions"])
+
+
+def test_genuine_unapplied_provider_fallback_still_recorded(tmp_path: Path) -> None:
+    """A fallback forge really declined to apply is still classified.
+
+    Detection is field-derived from the run's own transport telemetry: a
+    fallback-eligible transport failure (``transport_fallback_reason``) where no
+    fallback ran (``transport_fallback_fired: false``).
+    """
+    d = _sprint_dir(tmp_path, name="real-fallback")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-300",
+                    "outcome": "ESCALATE",
+                    "error": "escalated",
+                    "verdict": "REQUEST_CHANGES",
+                }
+            ]
+        ),
+    )
+    _write(
+        d / "issue-300" / "audit.yaml",
+        {
+            "iterations": {
+                "dev_loop": [
+                    {
+                        "iteration": 1,
+                        "transport_fallback_fired": False,
+                        "transport_fallback_reason": None,
+                        "transport_used": "cli",
+                    },
+                    {
+                        "iteration": 2,
+                        "transport_fallback_fired": False,
+                        "transport_fallback_reason": "cli_quota_exhausted",
+                        "transport_used": "cli",
+                    },
+                ]
+            }
+        },
+    )
+
+    entry = _build(d)["stories"]["issue-300"]
+    assert entry["primary_failure_class"] == "review_rejected"
+    assert "fallback_not_applied" in entry["contributing_factors"]
+    hit = next(ev for ev in entry["evidence"] if ev["rule_id"] == "provider_fallback_not_applied")
+    assert hit["source"].endswith("audit.yaml")
+    assert "cli_quota_exhausted" in hit["excerpt"]
+    assert any("wire the provider fallback" in a for a in entry["recommended_next_actions"])
+
+
+def test_applied_provider_fallback_is_not_recorded_as_unapplied(tmp_path: Path) -> None:
+    """A fallback that fired (even into a later failure) is not "not applied"."""
+    d = _sprint_dir(tmp_path, name="fired-fallback")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-301", "outcome": "FAILED", "error": "boom"}]),
+    )
+    _write(
+        d / "issue-301" / "audit.yaml",
+        {
+            "iterations": {
+                "dev_loop": [
+                    {
+                        "iteration": 1,
+                        "transport_fallback_fired": True,
+                        "transport_fallback_reason": "cli_quota_exhausted",
+                        "transport_used": "api",
+                    }
+                ]
+            }
+        },
+    )
+
+    entry = _build(d)["stories"]["issue-301"]
+    assert "fallback_not_applied" not in entry["contributing_factors"]
+    assert not any("wire the provider fallback" in a for a in entry["recommended_next_actions"])
+
+
+def test_unclassified_story_drops_text_derived_contributing_factors(tmp_path: Path) -> None:
+    """An unexplained failure does not also assert a confident text-scan amplifier.
+
+    ``unknown_needs_rca`` means forge could not classify the run; a contributing
+    factor resting only on a text scan — and the remediation derived from it —
+    must not be emitted alongside that admission.
+    """
+    d = _sprint_dir(tmp_path, name="unknown-contributing")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-302", "outcome": "FAILED", "error": "unexplained"}]),
+    )
+    (d / "issue-302").mkdir(parents=True, exist_ok=True)
+    (d / "run-6c83b3061455.log").write_text(
+        "Pending decision timed out after 10m 0s — auto-escalating for #302\n",
+        encoding="utf-8",
+    )
+
+    entry = _build(d)["stories"]["issue-302"]
+    assert entry["primary_failure_class"] == UNKNOWN_CLASS
+    assert entry["contributing_factors"] == []
+    # The evidence trail still records what fired, so the trace is not lost.
+    assert "pending_decision_auto_rejected" in {ev["rule_id"] for ev in entry["evidence"]}
+    assert not any("operator decision gate" in a for a in entry["recommended_next_actions"])
+
+
+def test_structured_contributing_factor_survives_unknown_primary(tmp_path: Path) -> None:
+    """Field-derived amplifiers are the run's own facts, not an inference."""
+    d = _sprint_dir(tmp_path, name="unknown-structured-contributing")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-303", "outcome": "FAILED", "error": "unexplained"}]),
+    )
+    _write(
+        d / "issue-303" / "audit.yaml",
+        {
+            "iterations": {
+                "dev_loop": [
+                    {
+                        "iteration": 1,
+                        "transport_fallback_fired": False,
+                        "transport_fallback_reason": "cli_quota_exhausted",
+                    }
+                ]
+            }
+        },
+    )
+
+    entry = _build(d)["stories"]["issue-303"]
+    assert entry["primary_failure_class"] == UNKNOWN_CLASS
+    assert "fallback_not_applied" in entry["contributing_factors"]
+    assert any("wire the provider fallback" in a for a in entry["recommended_next_actions"])
+
+
+def test_fallback_seam_coordinator_audit_to_rca(tmp_path: Path) -> None:
+    """Seam: real dev telemetry → generate_audit_log → RCA fallback classification.
+
+    Verifies the cause code is anchored to the field the coordinator actually
+    writes, not to a field name this test invented.
+    """
+    from coord_test_helpers import _make_config, _make_task
+
+    from theforge.coordinator.audit import generate_audit_log
+    from theforge.coordinator.state import (
+        CoordinatorResult,
+        CoordinatorState,
+        DevIterationTelemetry,
+        Phase,
+    )
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=1, review_cycle=0)
+    state.phase = Phase.ESCALATE
+    state.error = "dev agent failed"
+    state.dev_iteration_telemetry = [
+        DevIterationTelemetry(
+            iteration=1,
+            max_iterations=3,
+            cost_usd=1.0,
+            duration_s=5.0,
+            cycle=0,
+            gate_result="FAIL",
+            transport_fallback_fired=False,
+            transport_fallback_reason="cli_quota_exhausted",
+            transport_used="cli",
+        )
+    ]
+
+    audit = generate_audit_log(
+        config,
+        task,
+        CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message=state.error),
+    )
+
+    d = _sprint_dir(tmp_path, name="seam-fallback")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-304", "outcome": "MERGE_FAILED", "error": "conflict"}]),
+    )
+    _write(d / "issue-304" / "audit.yaml", audit)
+
+    entry = _build(d)["stories"]["issue-304"]
+    assert entry["primary_failure_class"] == "merge_failed"
+    assert "fallback_not_applied" in entry["contributing_factors"]
+
+
 # ── Engine: determinism / regenerability ──────────────────────────────────────
 
 
@@ -467,7 +691,7 @@ def test_ruleset_version_stamped(tmp_path: Path) -> None:
     payload = _build(d)
     assert payload["schema_version"] == rca_mod.SCHEMA_VERSION
     assert payload["ruleset_version"] == rca_mod.RULESET_VERSION
-    assert payload["ruleset_version"] == 4
+    assert payload["ruleset_version"] == 5
 
 
 def test_improved_ruleset_regenerates_versioned(tmp_path: Path, monkeypatch) -> None:
@@ -488,9 +712,9 @@ def test_improved_ruleset_regenerates_versioned(tmp_path: Path, monkeypatch) -> 
     write_sprint_rca(d)
     before = read_sprint_rca(d)
     assert before["stories"]["issue-5"]["primary_failure_class"] == UNKNOWN_CLASS
-    assert before["ruleset_version"] == 4
+    assert before["ruleset_version"] == 5
 
-    # Improved rule set (v5): a new rule now recognises the previously-unknown
+    # Improved rule set (v6): a new rule now recognises the previously-unknown
     # signature. Inputs on disk are unchanged.
     improved_rule = rca_mod.RcaRule(
         rule_id="flooble_detected",
@@ -504,12 +728,12 @@ def test_improved_ruleset_regenerates_versioned(tmp_path: Path, monkeypatch) -> 
     monkeypatch.setattr(
         rca_mod, "_PRIMARY_PRIORITY", ("flooble_fault", *rca_mod._PRIMARY_PRIORITY)
     )
-    monkeypatch.setattr(rca_mod, "RULESET_VERSION", 5)
+    monkeypatch.setattr(rca_mod, "RULESET_VERSION", 6)
 
     write_sprint_rca(d, overwrite=True)
     after = read_sprint_rca(d)
     assert after["stories"]["issue-5"]["primary_failure_class"] == "flooble_fault"
-    assert after["ruleset_version"] == 5
+    assert after["ruleset_version"] == 6
     # Same inputs, different rule set → distinguishable analyses.
     assert before["ruleset_version"] != after["ruleset_version"]
 

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -662,6 +662,111 @@ def test_fallback_seam_coordinator_audit_to_rca(tmp_path: Path) -> None:
     assert "fallback_not_applied" in entry["contributing_factors"]
 
 
+def test_agent_prose_about_project_rate_limits_is_not_provider_quota(tmp_path: Path) -> None:
+    """The same anchoring applies to the quota rule's ordinary-English patterns.
+
+    "rate limit" / "overloaded" are phrases an agent writes while analysing the
+    project under development; they are scanned for only in output forge emitted
+    about its own run, never in agent-authored preflight/markdown analysis.
+    """
+    d = _sprint_dir(tmp_path, name="prose-rate-limit")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-310", "outcome": "FAILED", "error": "story did not complete"}]),
+    )
+    (d / "issue-310").mkdir(parents=True, exist_ok=True)
+    (d / "issue-310" / "preflight-raw.log").write_text(
+        "The upload endpoint has no rate limit, so a burst of clients leaves the "
+        "worker pool overloaded and the quota limit unenforced.\n",
+        encoding="utf-8",
+    )
+    (d / "issue-310" / "dev-notes.md").write_text(
+        "Plan: add a rate limit guard so the service is not overloaded.\n",
+        encoding="utf-8",
+    )
+
+    entry = _build(d)["stories"]["issue-310"]
+    assert entry["primary_failure_class"] == UNKNOWN_CLASS
+    assert "provider_usage_limit" not in {ev["rule_id"] for ev in entry["evidence"]}
+
+
+def test_provider_quota_from_run_telemetry_without_any_matching_text(tmp_path: Path) -> None:
+    """Forge's own per-iteration quota observation classifies with no text at all."""
+    d = _sprint_dir(tmp_path, name="telemetry-quota")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-311", "outcome": "FAILED", "error": "dev agent failed"}]),
+    )
+    _write(
+        d / "issue-311" / "audit.yaml",
+        {
+            "iterations": {
+                "dev_loop": [
+                    {
+                        "iteration": 1,
+                        "cli_quota_error_observed": True,
+                        "transport_fallback_fired": False,
+                        "transport_fallback_reason": "CLI exited 7",
+                    }
+                ]
+            }
+        },
+    )
+
+    entry = _build(d)["stories"]["issue-311"]
+    assert entry["primary_failure_class"] == "provider_quota"
+    hit = next(ev for ev in entry["evidence"] if ev["rule_id"] == "provider_usage_limit")
+    assert hit["source"].endswith("audit.yaml")
+    assert any("quota" in a for a in entry["recommended_next_actions"])
+
+
+def test_survived_quota_blip_is_not_promoted_to_root_cause(tmp_path: Path) -> None:
+    """A quota error an earlier iteration or a fallback recovered from is not the cause."""
+    d = _sprint_dir(tmp_path, name="quota-blip")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {"slug": "issue-312", "outcome": "FAILED", "error": "gate never passed"},
+                {"slug": "issue-313", "outcome": "FAILED", "error": "gate never passed"},
+            ]
+        ),
+    )
+    # Recovered by a later iteration.
+    _write(
+        d / "issue-312" / "audit.yaml",
+        {
+            "iterations": {
+                "dev_loop": [
+                    {"iteration": 1, "cli_quota_error_observed": True},
+                    {"iteration": 2, "cli_quota_error_observed": False},
+                ]
+            }
+        },
+    )
+    # Absorbed by a fallback transport that did fire.
+    _write(
+        d / "issue-313" / "audit.yaml",
+        {
+            "iterations": {
+                "dev_loop": [
+                    {
+                        "iteration": 1,
+                        "cli_quota_error_observed": True,
+                        "transport_fallback_fired": True,
+                        "transport_used": "api",
+                    }
+                ]
+            }
+        },
+    )
+
+    stories = _build(d)["stories"]
+    for slug in ("issue-312", "issue-313"):
+        assert stories[slug]["primary_failure_class"] == UNKNOWN_CLASS
+        assert "provider_usage_limit" not in {ev["rule_id"] for ev in stories[slug]["evidence"]}
+
+
 # ── Engine: determinism / regenerability ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] No prior P1s were pending, and the current diff resolves the observed fallback false positive without introducing a blocking regression. | [google-gemini-3.5-flash] The implementation successfully derives failure cause codes from forge's own transport telemetry and prevents false positives from target-repo prose.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $7.53
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

A failure cause code is assigned from text describing the target repository's source rather than forge's own run (GitHub Issue #2031)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2031