### PR TITLE
Every audit record reports the same hardcoded forge version, so run provenance is unrecoverable

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -6,6 +6,7 @@ import datetime
 import subprocess
 from pathlib import Path
 
+from theforge import __version__ as FORGE_VERSION
 from theforge.config import ForgeConfig
 from theforge.config import provenance as config_provenance
 from theforge.config.sandbox_capabilities import resolve_capabilities
@@ -630,7 +631,7 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
     ]
 
     return {
-        "forge_version": "0.1.0",
+        "forge_version": FORGE_VERSION,
         "schema_version": SCHEMA_VERSION,
         "run_id": state.run_id,
         "task": {

--- a/tests/test_cli_audit_per_run.py
+++ b/tests/test_cli_audit_per_run.py
@@ -63,6 +63,22 @@ class TestPerRunFileWrite:
         assert data["parent_run_id"] is None
         assert "forge_version" in data
 
+    def test_forge_version_reflects_installed_version(self, tmp_path: Path) -> None:
+        """forge_version must reflect the running package, not a hardcoded literal."""
+        import theforge
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = _make_result(tmp_path, run_id="run-version-001")
+
+        _write_audit(result, config, task)
+
+        run_file = tmp_path / ".forge" / "audits" / "runs" / "run-version-001.json"
+        data = json.loads(run_file.read_text())
+
+        assert data["forge_version"] == theforge.__version__
+        assert data["forge_version"] != "0.1.0"
+
     def test_per_run_file_not_written_when_run_id_is_none(self, tmp_path: Path) -> None:
         """When run_id is None, the per-run file should not be written."""
         config = _make_config(tmp_path)


### PR DESCRIPTION
## Summary

The change replaces the hardcoded audit provenance version with the package runtime version and adds a regression test for the observed constant.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $0.94
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Every audit record reports the same hardcoded forge version, so run provenance is unrecoverable (GitHub Issue #2049)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2049