### PR TITLE
Audit records no commit or gate result for a review cycle, so a verdict cannot be told from a stale one

### DIFF
--- a/src/theforge/cli/audit.py
+++ b/src/theforge/cli/audit.py
@@ -185,6 +185,22 @@ def cmd_audit(args: object) -> int:
             summary = r.get("summary", "")
             print(f"    Cycle {cycle}: {verdict} ({p1} P1, {p2} P2) — {summary}")
 
+            # What the verdict was a verdict about. A cycle rendered without
+            # its commit and that commit's gate state reads as current even
+            # when later commits already superseded it (#2052).
+            commit = r.get("commit")
+            verification = r.get("verification")
+            vstate = verification.get("state") if isinstance(verification, dict) else None
+            gate_decision = (
+                verification.get("gate_decision") if isinstance(verification, dict) else None
+            )
+            if commit or vstate:
+                commit_str = commit[:12] if isinstance(commit, str) and commit else "unknown"
+                verification_str = vstate or "unknown"
+                if gate_decision:
+                    verification_str = f"{verification_str} (gate {gate_decision})"
+                print(f"      Reviewed commit: {commit_str} — verification: {verification_str}")
+
             findings = r.get("findings", [])
             if findings:
                 for finding in findings:

--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from theforge.config import ForgeConfig
 
-from .state import CoordinatorState
+from .state import CoordinatorState, ReviewedCommitVerification
 
 
 def _model_usage_entries(r: object) -> list[dict]:
@@ -79,6 +79,16 @@ def build_reviews(state: CoordinatorState) -> list[dict]:
     for i, meta in enumerate(state.review_cycle_metadata):
         entry: dict = {
             "cycle": i + 1,
+            # Provenance of what this cycle judged (#2052). Without it a stored
+            # verdict is indistinguishable from one later commits superseded.
+            # Metadata from older runs carries neither, and renders as an
+            # explicit "unknown" verification state rather than as current.
+            "commit": meta.reviewed_commit,
+            "verification": (
+                meta.verification.to_audit_dict()
+                if meta.verification is not None
+                else ReviewedCommitVerification().to_audit_dict()
+            ),
             "pool_models": meta.pool_models,
             "successful": meta.successful,
             "failed": meta.failed,

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -77,6 +77,7 @@ from .state import (
     Phase,
     RetryReason,
     ReviewCycleMetadata,
+    ReviewedCommitVerification,
     ReviewIterationTelemetry,
 )
 from .util import (
@@ -166,6 +167,34 @@ def _build_reviewer_verdicts(state: CoordinatorState) -> dict[str, str]:
             if failed_name not in verdicts:
                 verdicts[failed_name] = "FAIL"
     return verdicts
+
+
+def _record_reviewed_commit_provenance(
+    state: CoordinatorState, meta: ReviewCycleMetadata, workspace_path: Path
+) -> None:
+    """Stamp the commit this cycle judges, and its verification state (#2052).
+
+    Called at cycle open, before reviewers read the tree, so the recorded SHA is
+    the one they are given. The verification state is derived mechanically from
+    the gate provenance already on state — never from verdict or summary text,
+    which would let a reviewer's prose stand in for a gate result.
+    """
+    ok, out = _run_shell("git rev-parse HEAD", workspace_path)
+    sha = out.strip() if ok else ""
+    meta.reviewed_commit = sha or None
+    story_validation_verdict = (
+        state.story_validation_result.verdict
+        if state.story_validation_result is not None
+        else None
+    )
+    meta.verification = ReviewedCommitVerification.derive(
+        reviewed_commit=meta.reviewed_commit,
+        gate_commit=state.last_gate_commit,
+        gate_decision=state.last_gate_decision,
+        gate_runs=state.gate_runs,
+        validate_blocks=len(state.validate_blocks),
+        story_validation_verdict=story_validation_verdict,
+    )
 
 
 def _run_escalate_gate(
@@ -1028,6 +1057,7 @@ def _run_review_phase(
         synthesized=False,
         parse_retries=0,
     )
+    _record_reviewed_commit_provenance(state, meta, workspace_path)
     state.review_cycle_metadata.append(meta)
     # Snapshot the result COUNT, not a coerced dollar subtotal: this cycle's
     # cost is the sum over the results this cycle appends, and that sum stays
@@ -1923,6 +1953,7 @@ def _run_review_only_phase(
         failed=[],
         synthesized=False,
     )
+    _record_reviewed_commit_provenance(state, meta, workspace_path)
     state.review_cycle_metadata.append(meta)
 
     _pool_start = time.monotonic()

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -155,6 +155,11 @@ def save_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
         # covers the story's whole history rather than restarting at the most
         # recent --resume (#1984).
         "gate_runs": state.gate_runs,
+        # Which commit the gate last judged, and what it decided. Without these
+        # a resumed run reports every review cycle as ungated even though a gate
+        # ran before the resume (#2052).
+        "last_gate_commit": state.last_gate_commit,
+        "last_gate_decision": state.last_gate_decision,
         "hygiene_escalation_dev_commit_sha": state.hygiene_escalation_dev_commit_sha,
         "hygiene_escalation_prior_approve_count": state.hygiene_escalation_prior_approve_count,
         "hygiene_escalation_total_count": state.hygiene_escalation_total_count,
@@ -202,6 +207,10 @@ def load_trajectory_state(workspace_path: Path, state: CoordinatorState) -> None
         state.surviving_families = data["surviving_families"]
     if isinstance(data.get("gate_runs"), int) and not isinstance(data.get("gate_runs"), bool):
         state.gate_runs = max(0, int(data["gate_runs"]))
+    if isinstance(data.get("last_gate_commit"), str) and data["last_gate_commit"]:
+        state.last_gate_commit = data["last_gate_commit"]
+    if isinstance(data.get("last_gate_decision"), str) and data["last_gate_decision"]:
+        state.last_gate_decision = data["last_gate_decision"]
     if data.get("escalate_kind") in ("hygiene", "content", "decompose"):
         state.escalate_kind = data["escalate_kind"]
     if isinstance(data.get("hygiene_escalation_dev_commit_sha"), str):

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -355,6 +355,94 @@ class ReviewIterationTelemetry:
     restated_findings: int
 
 
+#: Verification states a reviewed commit can be in. Derived mechanically from
+#: the recorded gate provenance — never inferred from verdict or summary text.
+REVIEWED_COMMIT_VERIFICATION_STATES = (
+    "gate_passed",
+    "gate_failed",
+    "gate_skipped",
+    "gate_stale",
+    "ungated",
+    "unknown",
+)
+
+
+@dataclass(frozen=True)
+class ReviewedCommitVerification:
+    """Verification state of the commit a single review cycle judged (#2052).
+
+    A review verdict stored without the verification state of the code it
+    judged is indistinguishable from a stale verdict that later commits already
+    superseded. This records, per cycle, what the gate had actually said about
+    the exact commit under review at the moment the cycle opened.
+
+    ``state`` is one of :data:`REVIEWED_COMMIT_VERIFICATION_STATES`:
+
+    - ``gate_passed`` / ``gate_failed`` — the gate ran on *this* commit
+    - ``gate_skipped``  — a story ``gate:`` override suppressed the gate
+    - ``gate_stale``    — the gate ran, but on a different (earlier) commit
+    - ``ungated``       — no gate has run for this story yet
+    - ``unknown``       — the reviewed commit could not be resolved
+    """
+
+    state: str = "unknown"
+    # Decision recorded by the most recent gate execution: PASS / FAIL /
+    # ERROR / SKIPPED, or None when no gate has run.
+    gate_decision: str | None = None
+    # Commit the most recent gate execution ran against, or None.
+    gate_commit: str | None = None
+    # Total gate executions for this story so far (survives --resume).
+    gate_runs: int = 0
+    # Count of coordinator-raised blocking findings recorded at cycle open.
+    validate_blocks: int = 0
+    # Verdict of the story (spec) validator, when one ran.
+    story_validation_verdict: str | None = None
+
+    @classmethod
+    def derive(
+        cls,
+        *,
+        reviewed_commit: str | None,
+        gate_commit: str | None,
+        gate_decision: str | None,
+        gate_runs: int = 0,
+        validate_blocks: int = 0,
+        story_validation_verdict: str | None = None,
+    ) -> ReviewedCommitVerification:
+        """Classify a reviewed commit against the recorded gate provenance."""
+        if not reviewed_commit:
+            state = "unknown"
+        elif not gate_commit:
+            state = "ungated"
+        elif gate_commit != reviewed_commit:
+            state = "gate_stale"
+        elif gate_decision == "SKIPPED":
+            state = "gate_skipped"
+        elif gate_decision == "PASS":
+            state = "gate_passed"
+        else:
+            state = "gate_failed"
+        return cls(
+            state=state,
+            gate_decision=gate_decision,
+            gate_commit=gate_commit,
+            gate_runs=gate_runs,
+            validate_blocks=validate_blocks,
+            story_validation_verdict=story_validation_verdict,
+        )
+
+    def to_audit_dict(self) -> dict[str, Any]:
+        """Render as the ``verification`` block of a rendered review cycle."""
+        return {
+            "state": self.state,
+            "gate_decision": self.gate_decision,
+            "gate_commit": self.gate_commit,
+            "gate_runs": self.gate_runs,
+            "validate_blocks": self.validate_blocks,
+            "story_validation_verdict": self.story_validation_verdict,
+        }
+
+
 @dataclass
 class ReviewCycleMetadata:
     """Per-cycle metadata for audit logging."""
@@ -381,6 +469,13 @@ class ReviewCycleMetadata:
     degraded_quorum: bool = False
     # Human-readable audit note describing a degraded-quorum decision, or None.
     degraded_quorum_warning: str | None = None
+    # ── Reviewed-commit provenance (#2052) ────────────────────────────
+    # The repository HEAD this cycle's reviewers judged, and the verification
+    # state of that exact commit. Both stay None for metadata deserialized from
+    # older runs, which render as an explicit "unknown" verification state
+    # rather than silently reading as current.
+    reviewed_commit: str | None = None
+    verification: ReviewedCommitVerification | None = None
 
 
 @dataclass(frozen=True)
@@ -473,6 +568,13 @@ class CoordinatorState:
     # synthetic "PASS" on the skip path (so non-runs are counted) (#1984).
     # Persisted to the resume sidecar so escalation counts survive --resume.
     gate_runs: int = 0
+    # Commit the most recent gate ran against, and the decision it returned
+    # ("PASS"/"FAIL"/"ERROR", or "SKIPPED" for a story gate override). Recorded
+    # as a pair so a review cycle can state whether the code it judged was the
+    # code the gate judged (#2052). Persisted to the resume sidecar: without it
+    # a resumed run reports every cycle as ungated even though a gate ran.
+    last_gate_commit: str | None = None
+    last_gate_decision: str | None = None
     last_review_findings: str | None = None
     cycle_history: list[CycleHistory] = field(default_factory=list)
     cycle_history_total: int = 0  # monotonically increasing count of all appended entries

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -211,7 +211,25 @@ def _gate_attempts(state: CoordinatorState) -> int:
     return state.gate_runs
 
 
-def _record_gate_run(state: CoordinatorState, workspace_path: Path) -> None:
+def _record_gate_commit(state: CoordinatorState, workspace_path: Path, decision: str) -> None:
+    """Record which commit the gate just judged, and what it decided (#2052).
+
+    Stored as a pair so a review cycle can say whether the commit its reviewers
+    read is the commit the gate ran on — a verdict against an earlier tree is
+    not evidence about the current one. Recorded for the skip path too, with
+    decision ``SKIPPED``, so an override reads as a suppressed gate rather than
+    as a passing one. A HEAD read that fails leaves the commit unset, which
+    renders as ``ungated``: unknown provenance, never assumed-current.
+    """
+    state.last_gate_decision = decision
+    ok, out = _cu._run_shell("git rev-parse HEAD", workspace_path)
+    sha = out.strip() if ok else ""
+    state.last_gate_commit = sha or None
+
+
+def _record_gate_run(
+    state: CoordinatorState, workspace_path: Path, decision: str | None = None
+) -> None:
     """Count one gate execution and persist the count for ``--resume``.
 
     Called immediately after the gate command returns, before any routing, so
@@ -222,6 +240,8 @@ def _record_gate_run(state: CoordinatorState, workspace_path: Path) -> None:
     the run: the count degrades, the story does not.
     """
     state.gate_runs += 1
+    if decision is not None:
+        _record_gate_commit(state, workspace_path, decision)
     try:
         save_trajectory_state(workspace_path, state)
     except Exception as exc:  # noqa: BLE001
@@ -651,6 +671,9 @@ def _run_validate_phase(
         gate_decision: str | None = "PASS"
         gate_err: str | None = None
         gate_result_for_telemetry = gate_decision
+        # No gate ran, so this is not a gate run — but the commit still has a
+        # verification state, and "suppressed by override" is that state.
+        _record_gate_commit(state, workspace_path, "SKIPPED")
     else:
         if gate_override is not None:
             _log_phase(state.phase, "running gate... (override)")
@@ -669,7 +692,7 @@ def _run_validate_phase(
         # The gate command ran. Count it here — before decision/error routing —
         # so timeouts and errors, which return without ever appending to
         # gate_decisions, are still counted as the executions they were (#1984).
-        _record_gate_run(state, workspace_path)
+        _record_gate_run(state, workspace_path, decision=gate_decision or "ERROR")
         gate_result_for_telemetry = gate_decision or "ERROR"
     _gate_elapsed = time.monotonic() - _gate_start
     state.validate_durations.append(_gate_elapsed)

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -211,6 +211,14 @@ def _gate_attempts(state: CoordinatorState) -> int:
     return state.gate_runs
 
 
+def _persist_trajectory(state: CoordinatorState, workspace_path: Path, what: str) -> None:
+    """Write the resume sidecar. A write failure degrades data, never the run."""
+    try:
+        save_trajectory_state(workspace_path, state)
+    except Exception as exc:  # noqa: BLE001
+        _log_verbose(f"Could not persist {what}: {exc}")
+
+
 def _record_gate_commit(state: CoordinatorState, workspace_path: Path, decision: str) -> None:
     """Record which commit the gate just judged, and what it decided (#2052).
 
@@ -220,11 +228,18 @@ def _record_gate_commit(state: CoordinatorState, workspace_path: Path, decision:
     decision ``SKIPPED``, so an override reads as a suppressed gate rather than
     as a passing one. A HEAD read that fails leaves the commit unset, which
     renders as ``ungated``: unknown provenance, never assumed-current.
+
+    Persisted here rather than only on the gate-run path. The skip path records
+    a decision without a gate run, so hanging persistence off ``_record_gate_run``
+    lost the pair whenever a story stopped after VALIDATE and resumed into
+    REVIEW — the resumed cycle then rendered a deliberately suppressed gate as
+    ``ungated``, which is exactly the wrong verification state to report.
     """
     state.last_gate_decision = decision
     ok, out = _cu._run_shell("git rev-parse HEAD", workspace_path)
     sha = out.strip() if ok else ""
     state.last_gate_commit = sha or None
+    _persist_trajectory(state, workspace_path, "gate-commit provenance")
 
 
 def _record_gate_run(
@@ -241,11 +256,10 @@ def _record_gate_run(
     """
     state.gate_runs += 1
     if decision is not None:
+        # Writes the whole sidecar, incremented gate_runs included.
         _record_gate_commit(state, workspace_path, decision)
-    try:
-        save_trajectory_state(workspace_path, state)
-    except Exception as exc:  # noqa: BLE001
-        _log_verbose(f"Could not persist gate-run count: {exc}")
+    else:
+        _persist_trajectory(state, workspace_path, "gate-run count")
 
 
 def _new_review_cycle_available(state: CoordinatorState, config: ForgeConfig) -> bool:

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -334,12 +334,25 @@ def _load_story_summary_entry_from_audit(
 
     reviews = audit_data.get("reviews")
     verdict = None
+    # Provenance of the verdict reported below: the commit that verdict judged
+    # and that commit's verification state. Carried alongside the verdict so a
+    # summary cannot present a superseded verdict as a current one (#2052).
+    verdict_commit: str | None = None
+    verdict_verification_state: str | None = None
     if isinstance(reviews, list) and reviews:
         last_review = reviews[-1]
         if isinstance(last_review, dict):
             raw_verdict = last_review.get("verdict")
             if isinstance(raw_verdict, str) and raw_verdict:
                 verdict = raw_verdict
+            raw_commit = last_review.get("commit")
+            if isinstance(raw_commit, str) and raw_commit:
+                verdict_commit = raw_commit
+            verification = last_review.get("verification")
+            raw_state = verification.get("state") if isinstance(verification, dict) else None
+            verdict_verification_state = (
+                raw_state if isinstance(raw_state, str) and raw_state else "unknown"
+            )
     if verdict is None and outcome_block.get("success") is True:
         verdict = "APPROVE"
 
@@ -374,6 +387,8 @@ def _load_story_summary_entry_from_audit(
         "outcome": final_phase,
         "outcome_source": outcome_source,
         "verdict": verdict,
+        "verdict_commit": verdict_commit,
+        "verdict_verification_state": verdict_verification_state,
         "cost_usd": _optional_cost(cost_block.get("total_usd"))
         if isinstance(cost_block, dict)
         else 0.0,
@@ -542,6 +557,16 @@ def _write_sprint_audit(
             for i, meta in enumerate(res.state.review_cycle_metadata):
                 cycle_entry: dict = {
                     "cycle": i + 1,
+                    # Reviewed-commit provenance (#2052). A cycle summary that
+                    # carries the verdict but drops the commit and its gate
+                    # state reintroduces the ambiguity at the sprint level.
+                    "commit": meta.reviewed_commit,
+                    "verification_state": (
+                        meta.verification.state if meta.verification is not None else "unknown"
+                    ),
+                    "gate_decision": (
+                        meta.verification.gate_decision if meta.verification is not None else None
+                    ),
                     "pool": meta.pool_models,
                     "successful": meta.successful,
                     "failed": meta.failed,

--- a/tests/test_review_commit_provenance.py
+++ b/tests/test_review_commit_provenance.py
@@ -177,6 +177,54 @@ class TestGateProvenanceCapture:
         assert restored.last_gate_decision == "PASS"
         assert restored.gate_runs == 3
 
+    def test_gate_run_persists_provenance_without_a_second_write(self, tmp_path: Path) -> None:
+        """The gate-run path must reach the sidecar with the pair, not just the count."""
+        from theforge.coordinator.run_setup import load_trajectory_state
+        from theforge.coordinator.validate_phase import _record_gate_run
+
+        repo = _init_repo(tmp_path)
+        state = CoordinatorState()
+        _record_gate_run(state, repo, decision="PASS")
+
+        restored = CoordinatorState()
+        load_trajectory_state(repo, restored)
+        assert restored.gate_runs == 1
+        assert restored.last_gate_commit == _git(repo, "rev-parse", "HEAD")
+        assert restored.last_gate_decision == "PASS"
+
+    def test_skipped_gate_survives_resume_into_review(self, tmp_path: Path) -> None:
+        """A `gate: none` override must not resume as `ungated`.
+
+        The skip path records a decision without a gate run, so provenance that
+        only persisted alongside the run count vanished when a story stopped
+        after VALIDATE and resumed into REVIEW — the resumed cycle then reported
+        a deliberately suppressed gate as an ungated one.
+        """
+        from theforge.coordinator.run_setup import load_trajectory_state
+        from theforge.coordinator.validate_phase import _record_gate_commit
+
+        repo = _init_repo(tmp_path)
+        head = _git(repo, "rev-parse", "HEAD")
+
+        # VALIDATE with a story gate override, then the run stops.
+        validate_state = CoordinatorState()
+        _record_gate_commit(validate_state, repo, "SKIPPED")
+        assert validate_state.gate_runs == 0  # a skip is not a gate run
+
+        # --resume picks the story back up and opens a review cycle.
+        resumed = CoordinatorState()
+        load_trajectory_state(repo, resumed)
+        assert resumed.last_gate_commit == head
+        assert resumed.last_gate_decision == "SKIPPED"
+
+        meta = _meta()
+        _record_reviewed_commit_provenance(resumed, meta, repo)
+        assert meta.verification is not None
+        assert meta.verification.state == "gate_skipped"
+
+        resumed.review_cycle_metadata.append(meta)
+        assert build_reviews(resumed)[0]["verification"]["state"] == "gate_skipped"
+
 
 class TestAuditRendering:
     """Every rendered review cycle names its commit and verification state."""

--- a/tests/test_review_commit_provenance.py
+++ b/tests/test_review_commit_provenance.py
@@ -1,0 +1,333 @@
+"""Reviewed-commit provenance in audit records (#2052).
+
+A review verdict recorded without the commit it judged, and without that
+commit's verification state, is indistinguishable from a stale verdict that
+later commits already superseded. These tests pin the provenance at each seam
+it has to survive: capture at cycle open, rendering into the run audit record,
+and forwarding through the operator-facing sprint summary projections.
+"""
+
+from __future__ import annotations
+
+import datetime
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from theforge.coordinator.audit_render import build_reviews
+from theforge.coordinator.review_phase import _record_reviewed_commit_provenance
+from theforge.coordinator.state import (
+    CoordinatorState,
+    ReviewCycleMetadata,
+    ReviewedCommitVerification,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "T")
+    (repo / "a.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-qm", "first")
+    return repo
+
+
+def _meta() -> ReviewCycleMetadata:
+    return ReviewCycleMetadata(pool_models=["r1"], successful=["r1"], failed=[], synthesized=False)
+
+
+class TestVerificationDerivation:
+    """The verification state is derived from the gate record, never verdict text."""
+
+    def test_gate_on_the_reviewed_commit_is_gate_passed(self) -> None:
+        v = ReviewedCommitVerification.derive(
+            reviewed_commit="abc", gate_commit="abc", gate_decision="PASS", gate_runs=1
+        )
+        assert v.state == "gate_passed"
+        assert v.gate_commit == "abc"
+        assert v.gate_runs == 1
+
+    def test_failing_gate_on_the_reviewed_commit_is_gate_failed(self) -> None:
+        v = ReviewedCommitVerification.derive(
+            reviewed_commit="abc", gate_commit="abc", gate_decision="FAIL"
+        )
+        assert v.state == "gate_failed"
+
+    def test_gate_error_on_the_reviewed_commit_is_not_a_pass(self) -> None:
+        v = ReviewedCommitVerification.derive(
+            reviewed_commit="abc", gate_commit="abc", gate_decision="ERROR"
+        )
+        assert v.state == "gate_failed"
+
+    def test_gate_on_an_earlier_commit_is_stale(self) -> None:
+        """The central case: the verdict is about code the gate never saw."""
+        v = ReviewedCommitVerification.derive(
+            reviewed_commit="def", gate_commit="abc", gate_decision="PASS"
+        )
+        assert v.state == "gate_stale"
+
+    def test_story_override_reads_as_skipped_not_passed(self) -> None:
+        v = ReviewedCommitVerification.derive(
+            reviewed_commit="abc", gate_commit="abc", gate_decision="SKIPPED"
+        )
+        assert v.state == "gate_skipped"
+
+    def test_no_gate_yet_is_ungated(self) -> None:
+        v = ReviewedCommitVerification.derive(
+            reviewed_commit="abc", gate_commit=None, gate_decision=None
+        )
+        assert v.state == "ungated"
+
+    def test_unresolvable_commit_is_unknown(self) -> None:
+        v = ReviewedCommitVerification.derive(
+            reviewed_commit=None, gate_commit="abc", gate_decision="PASS"
+        )
+        assert v.state == "unknown"
+
+
+class TestCaptureAtCycleOpen:
+    """Cycle open must stamp the HEAD reviewers are about to read."""
+
+    def test_records_head_and_gate_state_for_the_same_commit(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        head = _git(repo, "rev-parse", "HEAD")
+
+        state = CoordinatorState()
+        state.last_gate_commit = head
+        state.last_gate_decision = "PASS"
+        state.gate_runs = 2
+        state.validate_blocks = [{"kind": "gate_fail"}]
+
+        meta = _meta()
+        _record_reviewed_commit_provenance(state, meta, repo)
+
+        assert meta.reviewed_commit == head
+        assert meta.verification is not None
+        assert meta.verification.state == "gate_passed"
+        assert meta.verification.gate_runs == 2
+        assert meta.verification.validate_blocks == 1
+
+    def test_commit_after_the_gate_ran_records_as_stale(self, tmp_path: Path) -> None:
+        """A dev commit landed after VALIDATE must not read as gated."""
+        repo = _init_repo(tmp_path)
+        gated = _git(repo, "rev-parse", "HEAD")
+        state = CoordinatorState()
+        state.last_gate_commit = gated
+        state.last_gate_decision = "PASS"
+        state.gate_runs = 1
+
+        (repo / "a.txt").write_text("two\n", encoding="utf-8")
+        _git(repo, "commit", "-aqm", "second")
+        new_head = _git(repo, "rev-parse", "HEAD")
+
+        meta = _meta()
+        _record_reviewed_commit_provenance(state, meta, repo)
+
+        assert meta.reviewed_commit == new_head
+        assert meta.verification is not None
+        assert meta.verification.state == "gate_stale"
+        assert meta.verification.gate_commit == gated
+
+    def test_no_gate_run_records_ungated(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        meta = _meta()
+        _record_reviewed_commit_provenance(CoordinatorState(), meta, repo)
+        assert meta.reviewed_commit
+        assert meta.verification is not None
+        assert meta.verification.state == "ungated"
+
+
+class TestGateProvenanceCapture:
+    """VALIDATE must record which commit the gate actually judged."""
+
+    def test_gate_run_records_commit_and_decision(self, tmp_path: Path) -> None:
+        from theforge.coordinator.validate_phase import _record_gate_commit
+
+        repo = _init_repo(tmp_path)
+        state = CoordinatorState()
+        _record_gate_commit(state, repo, "FAIL")
+        assert state.last_gate_commit == _git(repo, "rev-parse", "HEAD")
+        assert state.last_gate_decision == "FAIL"
+
+    def test_provenance_survives_resume(self, tmp_path: Path) -> None:
+        """Without persistence a resumed run reports every cycle as ungated."""
+        from theforge.coordinator.run_setup import load_trajectory_state, save_trajectory_state
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState()
+        state.last_gate_commit = "e" * 40
+        state.last_gate_decision = "PASS"
+        state.gate_runs = 3
+        save_trajectory_state(workspace, state)
+
+        restored = CoordinatorState()
+        load_trajectory_state(workspace, restored)
+        assert restored.last_gate_commit == "e" * 40
+        assert restored.last_gate_decision == "PASS"
+        assert restored.gate_runs == 3
+
+
+class TestAuditRendering:
+    """Every rendered review cycle names its commit and verification state."""
+
+    def test_rendered_cycle_carries_commit_and_verification(self) -> None:
+        state = CoordinatorState()
+        meta = _meta()
+        meta.reviewed_commit = "a" * 40
+        meta.verification = ReviewedCommitVerification.derive(
+            reviewed_commit="a" * 40,
+            gate_commit="a" * 40,
+            gate_decision="PASS",
+            gate_runs=1,
+        )
+        state.review_cycle_metadata.append(meta)
+
+        entry = build_reviews(state)[0]
+        assert entry["commit"] == "a" * 40
+        assert entry["verification"]["state"] == "gate_passed"
+        assert entry["verification"]["gate_decision"] == "PASS"
+        assert entry["verification"]["gate_commit"] == "a" * 40
+
+    def test_legacy_metadata_renders_explicit_unknown_not_current(self) -> None:
+        """Records from before this change must not read as verified."""
+        state = CoordinatorState()
+        state.review_cycle_metadata.append(_meta())
+
+        entry = build_reviews(state)[0]
+        assert entry["commit"] is None
+        assert entry["verification"]["state"] == "unknown"
+
+    def test_existing_review_keys_are_preserved(self) -> None:
+        state = CoordinatorState()
+        state.review_cycle_metadata.append(_meta())
+        entry = build_reviews(state)[0]
+        for key in ("cycle", "pool_models", "successful", "failed", "quorum_met"):
+            assert key in entry
+
+
+class TestSprintSummaryProjections:
+    """Sprint-level summaries must not drop the provenance the record carries."""
+
+    def test_story_summary_forwards_verdict_provenance(self, tmp_path: Path) -> None:
+        from theforge.sprint.audit import _load_story_summary_entry_from_audit
+
+        sprint_dir = tmp_path / "sprint"
+        story_dir = sprint_dir / "issue-2052"
+        story_dir.mkdir(parents=True)
+        (story_dir / "audit.yaml").write_text(
+            yaml.dump(
+                {
+                    "outcome": {"final_phase": "DONE", "success": True},
+                    "reviews": [
+                        {
+                            "cycle": 1,
+                            "verdict": "APPROVE",
+                            "commit": "b" * 40,
+                            "verification": {"state": "gate_stale", "gate_decision": "PASS"},
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        entry = _load_story_summary_entry_from_audit(sprint_dir, "issue:2052", "issue-2052")
+        assert entry is not None
+        assert entry["verdict"] == "APPROVE"
+        assert entry["verdict_commit"] == "b" * 40
+        assert entry["verdict_verification_state"] == "gate_stale"
+
+    def test_story_summary_marks_legacy_reviews_unknown(self, tmp_path: Path) -> None:
+        from theforge.sprint.audit import _load_story_summary_entry_from_audit
+
+        sprint_dir = tmp_path / "sprint"
+        story_dir = sprint_dir / "issue-2052"
+        story_dir.mkdir(parents=True)
+        (story_dir / "audit.yaml").write_text(
+            yaml.dump(
+                {
+                    "outcome": {"final_phase": "DONE", "success": True},
+                    "reviews": [{"cycle": 1, "verdict": "APPROVE"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        entry = _load_story_summary_entry_from_audit(sprint_dir, "issue:2052", "issue-2052")
+        assert entry is not None
+        assert entry["verdict_commit"] is None
+        assert entry["verdict_verification_state"] == "unknown"
+
+    def test_sprint_audit_reviews_summary_keeps_provenance(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from theforge.sprint.audit import _write_sprint_audit
+        from theforge.sprint.manifest import ResolvedSprint, SprintResult
+
+        meta = _meta()
+        meta.reviewed_commit = "c" * 40
+        meta.verification = ReviewedCommitVerification.derive(
+            reviewed_commit="c" * 40, gate_commit="d" * 40, gate_decision="PASS"
+        )
+
+        story_state = MagicMock()
+        story_state.preflight_cached = False
+        story_state.preflight_verdict = "PROCEED"
+        story_state.preflight_reason = None
+        story_state.preflight_cached_original_verdict = None
+        story_state.preflight_cached_from_run_id = None
+        story_state.total_cost = 0.05
+        story_state.error = None
+        story_state.error_type = None
+        story_state.review_results = []
+        story_state.review_cycle_metadata = [meta]
+        story_state.dev_iteration_telemetry = []
+        story_state.review_iteration_telemetry = []
+
+        phase = MagicMock()
+        phase.name = "DONE"
+        result = MagicMock()
+        result.state = story_state
+        result.phase = phase
+        result.merge = None
+
+        started = datetime.datetime(2026, 7, 31, 9, 0, tzinfo=datetime.timezone.utc)
+        _write_sprint_audit(
+            manifest=ResolvedSprint(name="s", budget_usd=10.0, stories=[]),
+            result=SprintResult(
+                name="s",
+                specs_total=1,
+                specs_succeeded=1,
+                specs_failed=0,
+                specs_skipped=0,
+                total_cost_usd=0.05,
+                budget_usd=10.0,
+                results=[("issue:2052", result)],
+                stopped_reason=None,
+            ),
+            canonical_refs=["issue:2052"],
+            started_at=started,
+            finished_at=started + datetime.timedelta(seconds=300),
+            duration=300.0,
+            project_root=tmp_path,
+            slug_map={"issue:2052": "issue-2052"},
+        )
+
+        data = yaml.safe_load(
+            (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+        )
+        cycle = data["specs"][0]["reviews"][0]
+        assert cycle["commit"] == "c" * 40
+        assert cycle["verification_state"] == "gate_stale"
+        assert cycle["gate_decision"] == "PASS"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior skipped-gate resume P1 is resolved, and the committed provenance changes satisfy the review-cycle audit requirements. | [google-gemini-3.5-flash] The implementation successfully records and persists the reviewed commit and its verification state, resolving the resume-boundary bug.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $10.97
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Audit records no commit or gate result for a review cycle, so a verdict cannot be told from a stale one (GitHub Issue #2052)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2052