### PR TITLE
`forge diagnose` resolves another repository's issue references against the local repo and injects the results as starting evidence

### DIFF
--- a/src/theforge/coordinator/diagnose_evidence.py
+++ b/src/theforge/coordinator/diagnose_evidence.py
@@ -16,6 +16,15 @@ Design constraints:
 - **Best-effort.** An issue with no recognizable references (or references that
   resolve to nothing on disk) produces an empty block — the flow then behaves
   exactly as it did before this feature existed.
+- **Namespaced.** A reference is only meaningful relative to the namespace it
+  was written in. A bare ``#NNNN`` carries no namespace, so this module refuses
+  to resolve it rather than defaulting to whichever repository the orchestrator
+  happens to be executing in: an issue filed here about an adopter project's
+  ``#246`` must not be handed this repository's PR #246 as "evidence". Only
+  repository-qualified references (``owner/repo#NNNN`` or a github.com issue/PR
+  URL) name a namespace, and those are resolved against the repository they
+  name. Loading nothing is a correct outcome; loading same-numbered content
+  from the wrong repository is not.
 - **Bounded.** Every excerpt is truncated to a fixed line/char cap, each
   reference kind is capped in count, and the whole block is capped in total
   size. The operator can predict the maximum prompt growth from the constants
@@ -59,9 +68,26 @@ _HISTORY_LINE_CHAR_CAP = 800  # per-line truncation of a history match
 # shape alone.
 _HEX_ID_RE = re.compile(r"\b[0-9a-f]{12}\b")
 # Branch names TheForge creates: a conventional-commit-style prefix plus a slug.
-_BRANCH_RE = re.compile(r"\b(?:feat|fix|chore|refactor|docs|test|perf|hotfix)/[A-Za-z0-9._/-]+")
-# PR / issue cross-references.
-_ISSUE_PR_RE = re.compile(r"#(\d{1,7})\b")
+_BRANCH_PREFIXES = ("feat", "fix", "chore", "refactor", "docs", "test", "perf", "hotfix")
+_BRANCH_RE = re.compile(rf"\b(?:{'|'.join(_BRANCH_PREFIXES)})/[A-Za-z0-9._/-]+")
+# PR / issue cross-references. Only *repository-qualified* forms are recognized;
+# a bare "#NNNN" names no repository and is deliberately not matched (see the
+# module docstring's namespace constraint).
+#   owner/repo#NNNN — the lookbehind keeps the owner segment from starting
+#   mid-path; a "feat/…"-style branch head is rejected separately in
+#   _extract_qualified_refs, since "feat/issue-2057#3" is shaped like a
+#   repo-qualified reference but names a branch, not a repository.
+_QUALIFIED_REF_RE = re.compile(
+    r"(?<![A-Za-z0-9._/-])([A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*)#(\d{1,7})\b"
+)
+#   https://github.com/owner/repo/issues/NNNN (or /pull/NNNN)
+_GITHUB_URL_REF_RE = re.compile(
+    r"https?://(?:www\.)?github\.com/([A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*)"
+    r"/(?:issues|pull)/(\d{1,7})\b"
+)
+# Bare, namespace-free references — matched only so the flow can *report* that
+# they were declined. They are never resolved.
+_BARE_REF_RE = re.compile(r"(?<![A-Za-z0-9._/-])#(\d{1,7})\b")
 # An explicit ``.forge/...`` file path with an extension (audit, log, jsonl…).
 _FORGE_PATH_RE = re.compile(r"\.forge/[A-Za-z0-9._:,/-]+\.[A-Za-z0-9]+")
 
@@ -74,10 +100,16 @@ class StartingEvidence:
     or ``""`` when nothing was found. ``reference_labels`` is the list of short
     human labels for each excerpt that was loaded — recorded in the audit so an
     operator can see, deterministically, what the orchestrator handed the agent.
+
+    ``declined_labels`` lists namespace-free references the body cited that were
+    deliberately *not* resolved (bare ``#NNNN``). Recorded for the same reason:
+    an operator reading the audit can see that a reference was seen and skipped
+    on purpose, rather than inferring silence from an empty evidence block.
     """
 
     text: str = ""
     reference_labels: list[str] = field(default_factory=list)
+    declined_labels: list[str] = field(default_factory=list)
 
     @property
     def is_empty(self) -> bool:
@@ -321,43 +353,63 @@ def _load_branch_history(branches: list[str], project_root: Path) -> list[_Item]
 
 
 def _load_pr_issue_refs(
-    numbers: list[str], project_root: Path, *, self_issue_number: int | None
+    refs: list[tuple[str, str]], project_root: Path, *, self_issue_number: int | None
 ) -> list[_Item]:
-    """Load a bounded summary for each cited #NNNN (skipping the issue itself)."""
+    """Load a bounded summary for each repo-qualified reference.
+
+    ``refs`` is a list of ``(owner/repo, number)`` pairs — every reference
+    carries the namespace it was written in, and each lookup is pinned to that
+    namespace with ``gh --repo``. ``project_root`` is still the subprocess cwd
+    (it is where ``gh``'s auth/config resolve from), but it no longer decides
+    *which* repository a number means.
+
+    A reference whose number equals ``self_issue_number`` is skipped: it is
+    either the issue under diagnosis (self-evidence is worthless) or a
+    same-numbered issue elsewhere, and declining to load is the safe direction
+    for both.
+    """
     items: list[_Item] = []
     # Drop the self-issue first (it costs no gh call), then bound gh *attempts*:
     # each remaining reference fires 1-2 gh subprocesses whether or not it
-    # resolves, so a body citing many unresolved #NNNN must not spend one
-    # timeout per reference before the agent starts.
+    # resolves, so a body citing many unresolved refs must not spend one timeout
+    # per reference before the agent starts.
     self_ref = str(self_issue_number) if self_issue_number is not None else None
-    candidates = [num for num in numbers if num != self_ref]
-    for num in candidates[:_MAX_GH_ATTEMPTS_PER_KIND]:
+    candidates = [(repo, num) for repo, num in refs if num != self_ref]
+    for repo, num in candidates[:_MAX_GH_ATTEMPTS_PER_KIND]:
         if len(items) >= _MAX_ITEMS_PER_KIND:
             break
         # A #NNNN can be a PR or an issue. Try PR first (richer landing signal),
         # fall back to the issue view. Both fail open.
         pr_out = _run_gh(
-            ["pr", "view", num, "--json", "number,state,title,mergedAt,mergeCommit"],
+            [
+                "pr",
+                "view",
+                num,
+                "--repo",
+                repo,
+                "--json",
+                "number,state,title,mergedAt,mergeCommit",
+            ],
             project_root,
         )
         if pr_out:
             items.append(
                 _Item(
-                    label=f"PR #{num}",
-                    header=f"PR #{num} (gh pr view {num}):",
+                    label=f"PR {repo}#{num}",
+                    header=f"PR {repo}#{num} (gh pr view {num} --repo {repo}):",
                     body=_truncate(pr_out),
                 )
             )
             continue
         issue_out = _run_gh(
-            ["issue", "view", num, "--json", "number,state,title"],
+            ["issue", "view", num, "--repo", repo, "--json", "number,state,title"],
             project_root,
         )
         if issue_out:
             items.append(
                 _Item(
-                    label=f"issue #{num}",
-                    header=f"Issue #{num} (gh issue view {num}):",
+                    label=f"issue {repo}#{num}",
+                    header=f"Issue {repo}#{num} (gh issue view {num} --repo {repo}):",
                     body=_truncate(issue_out),
                 )
             )
@@ -381,13 +433,19 @@ def build_starting_evidence(
     anything on disk / via ``gh``. The whole block is capped at
     ``_MAX_TOTAL_EVIDENCE_CHARS``; excess items are dropped (and logged) rather
     than silently exploding the prompt.
+
+    Bare ``#NNNN`` references are reported in ``declined_labels`` and never
+    resolved — they name no repository, and the repository this call happens to
+    run in is not a substitute for the one the reference was written about.
     """
     body = issue_body or ""
 
     hex_ids = _ordered_unique(_HEX_ID_RE.findall(body))
     branches = _ordered_unique([m.rstrip(".,;:)]}'\"") for m in _BRANCH_RE.findall(body)])
-    pr_issue_numbers = _ordered_unique(_ISSUE_PR_RE.findall(body))
+    qualified_refs = _extract_qualified_refs(body)
     forge_paths = _ordered_unique([m.rstrip(".,;:)]}'\"") for m in _FORGE_PATH_RE.findall(body)])
+
+    declined = _declined_bare_refs(body, self_issue_number=self_issue_number)
 
     items: list[_Item] = []
     items += _load_run_logs(hex_ids, project_root)
@@ -395,17 +453,60 @@ def build_starting_evidence(
     items += _load_history_entries(hex_ids, project_root)
     items += _load_forge_paths(forge_paths, project_root)
     items += _load_branch_history(branches, project_root)
-    items += _load_pr_issue_refs(
-        pr_issue_numbers, project_root, self_issue_number=self_issue_number
-    )
+    items += _load_pr_issue_refs(qualified_refs, project_root, self_issue_number=self_issue_number)
 
     if not items:
-        return StartingEvidence()
+        return StartingEvidence(declined_labels=declined)
 
-    return _render(items)
+    return _render(items, declined_labels=declined)
 
 
-def _render(items: list[_Item]) -> StartingEvidence:
+def _extract_qualified_refs(body: str) -> list[tuple[str, str]]:
+    """Return ordered, deduped ``(owner/repo, number)`` pairs cited in ``body``.
+
+    Both written forms are accepted — ``owner/repo#NNNN`` and a github.com
+    issue/PR URL — and both carry the namespace the reference was written in.
+    """
+    pairs = _QUALIFIED_REF_RE.findall(body) + _GITHUB_URL_REF_RE.findall(body)
+    seen: set[tuple[str, str]] = set()
+    out: list[tuple[str, str]] = []
+    for repo, num in pairs:
+        # "feat/issue-2057#3" is a branch plus a number, not owner/repo#number.
+        # An ambiguous token resolves to nothing rather than to a guess.
+        if repo.split("/", 1)[0] in _BRANCH_PREFIXES:
+            continue
+        key = (repo, num)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
+def _declined_bare_refs(body: str, *, self_issue_number: int | None) -> list[str]:
+    """Return labels for namespace-free ``#NNNN`` references that were skipped.
+
+    A bare number that is already qualified elsewhere in the body (the ``#NNNN``
+    tail of an ``owner/repo#NNNN``) is not a decline, and neither is a mention of
+    the issue under diagnosis.
+    """
+    qualified = {num for _repo, num in _extract_qualified_refs(body)}
+    self_ref = str(self_issue_number) if self_issue_number is not None else None
+    out: list[str] = []
+    for num in _ordered_unique(_BARE_REF_RE.findall(body)):
+        if num in qualified or num == self_ref:
+            continue
+        out.append(f"#{num}")
+    if out:
+        _log.debug(
+            "starting-evidence: declined %d unqualified reference(s): %s",
+            len(out),
+            ", ".join(out),
+        )
+    return out
+
+
+def _render(items: list[_Item], *, declined_labels: list[str] | None = None) -> StartingEvidence:
     """Assemble loaded items into the bounded STARTING EVIDENCE block."""
     header = "== STARTING EVIDENCE (auto-loaded from issue body references) =="
     rendered: list[str] = []
@@ -427,4 +528,8 @@ def _render(items: list[_Item]) -> StartingEvidence:
         rendered.append(f"[{dropped} further reference excerpt(s) omitted to bound the prompt]")
 
     text = header + "\n\n" + "\n\n".join(rendered)
-    return StartingEvidence(text=text, reference_labels=labels)
+    return StartingEvidence(
+        text=text,
+        reference_labels=labels,
+        declined_labels=list(declined_labels or []),
+    )

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -623,6 +623,7 @@ def write_diagnose_audit(state: DiagnoseState, project_root: Path) -> Path:
         "starting_evidence": {
             "reference_labels": list(state.starting_evidence_labels),
             "chars": state.starting_evidence_chars,
+            "declined_unqualified_refs": list(state.starting_evidence_declined),
         },
         "baseline": {
             "sha": state.baseline_sha,
@@ -1213,6 +1214,10 @@ def _run_diagnose_flow_body(
     # hypothesis-formation rather than rediscovering pointers already in the
     # body. Best-effort — an issue with no recognizable references yields an
     # empty block and the prompt is unchanged from pre-feature behavior.
+    # Namespace-aware: only repo-qualified references (owner/repo#NNNN, github
+    # URLs) are resolved. A bare #NNNN is reported as declined rather than
+    # resolved against this checkout, which on a cross-project issue would hand
+    # the agent a same-numbered local PR/issue as "evidence".
     evidence = build_starting_evidence(
         issue_body=state.issue_body,
         project_root=project_root,
@@ -1220,11 +1225,18 @@ def _run_diagnose_flow_body(
     )
     state.starting_evidence_labels = list(evidence.reference_labels)
     state.starting_evidence_chars = len(evidence.text)
+    state.starting_evidence_declined = list(evidence.declined_labels)
     if evidence.reference_labels:
         emit(
             f"  [diagnose] pre-loaded {len(evidence.reference_labels)} evidence "
             f"excerpt(s) from issue-body references: "
             f"{', '.join(evidence.reference_labels)}"
+        )
+    if evidence.declined_labels:
+        emit(
+            f"  [diagnose] declined {len(evidence.declined_labels)} unqualified "
+            f"issue-body reference(s) (no repository named, not resolved against "
+            f"this checkout): {', '.join(evidence.declined_labels)}"
         )
 
     # ── INVESTIGATE ───────────────────────────────────────────────────

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -230,6 +230,12 @@ class DiagnoseState:
     # nothing recognizable. Recorded so the audit shows exactly what the
     # orchestrator handed the agent (convention: instrument cross-phase data).
     starting_evidence_chars: int = 0
+    starting_evidence_declined: list[str] = field(default_factory=list)
+    # Namespace-free "#NNNN" references the body cited that were deliberately
+    # not resolved (a bare number names no repository, so resolving it against
+    # this checkout would inject same-numbered content from the wrong project).
+    # Recorded so the audit distinguishes "declined on purpose" from "found
+    # nothing".
     # Machine-readable failure identifier returned by the runner (e.g.
     # "timeout"). None when the run did not fail or the runner reported no
     # code. Recorded so the audit trail distinguishes a timeout from a crash.

--- a/tests/test_diagnose_evidence.py
+++ b/tests/test_diagnose_evidence.py
@@ -141,7 +141,7 @@ class TestGhBackedEvidence:
         assert "feat/issue-1135" in ev.text
         assert "1143" in ev.text
 
-    def test_pr_number_loads_view_and_skips_self_issue(self, tmp_path):
+    def test_qualified_ref_loads_view_pinned_to_its_repo(self, tmp_path):
         calls = []
 
         def fake_run_gh(args, project_root):
@@ -152,30 +152,47 @@ class TestGhBackedEvidence:
 
         with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
             ev = build_starting_evidence(
-                issue_body="Related to #1143 but this is issue #1420.",
+                issue_body="Related to fuzzypete/theforge#1143 but this is issue #1420.",
                 project_root=tmp_path,
                 self_issue_number=1420,
             )
         assert "1143" in ev.text
+        # The lookup names the repository the reference was written about.
+        pr_view = next(a for a in calls if a[:2] == ["pr", "view"])
+        assert pr_view[pr_view.index("--repo") + 1] == "fuzzypete/theforge"
         # The self-issue (#1420) must not be queried.
         assert not any(a[:2] == ["pr", "view"] and a[2] == "1420" for a in calls)
+
+    def test_github_url_reference_is_resolved_against_its_repo(self, tmp_path):
+        def fake_run_gh(args, project_root):
+            if args[:2] == ["pr", "view"]:
+                return None
+            return '{"number": 246, "state": "OPEN", "title": "session state lost"}'
+
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
+            ev = build_starting_evidence(
+                issue_body="See https://github.com/fuzzypete/hdp/issues/246 for the symptom.",
+                project_root=tmp_path,
+            )
+        assert "session state lost" in ev.text
+        assert "issue fuzzypete/hdp#246" in ev.reference_labels
 
     def test_gh_failure_fails_open(self, tmp_path):
         with patch("theforge.coordinator.diagnose_evidence._run_gh", return_value=None):
             ev = build_starting_evidence(
-                issue_body="Branch feat/issue-9 and PR #99.",
+                issue_body="Branch feat/issue-9 and PR fuzzypete/theforge#99.",
                 project_root=tmp_path,
             )
         assert ev.is_empty
 
     def test_many_unresolved_refs_are_gh_call_bounded(self, tmp_path):
-        # A body citing far more branches and #NNNN than the attempt cap must
-        # not fire an unbounded number of (up-to-30s) gh subprocesses before the
-        # agent starts. All unresolved → gh returns None every time.
+        # A body citing far more branches and qualified refs than the attempt cap
+        # must not fire an unbounded number of (up-to-30s) gh subprocesses before
+        # the agent starts. All unresolved → gh returns None every time.
         from theforge.coordinator.diagnose_evidence import _MAX_GH_ATTEMPTS_PER_KIND
 
         branches = " ".join(f"feat/issue-{i}" for i in range(40))
-        prs = " ".join(f"#{2000 + i}" for i in range(40))
+        prs = " ".join(f"acme/widgets#{2000 + i}" for i in range(40))
         calls = []
 
         def fake_run_gh(args, project_root):
@@ -189,12 +206,82 @@ class TestGhBackedEvidence:
             )
         assert ev.is_empty
         branch_calls = [a for a in calls if a[:2] == ["pr", "list"]]
-        # A #NNNN attempt is a PR view then (on failure) an issue view: 2 gh calls.
+        # A ref attempt is a PR view then (on failure) an issue view: 2 gh calls.
         pr_calls = [a for a in calls if a[:2] == ["pr", "view"]]
         issue_calls = [a for a in calls if a[:2] == ["issue", "view"]]
         assert len(branch_calls) == _MAX_GH_ATTEMPTS_PER_KIND
         assert len(pr_calls) == _MAX_GH_ATTEMPTS_PER_KIND
         assert len(issue_calls) == _MAX_GH_ATTEMPTS_PER_KIND
+
+
+class TestUnqualifiedReferencesAreNotResolved:
+    """A bare ``#NNNN`` names no repository. Resolving it against whichever
+    checkout diagnose happens to run in injects same-numbered content from the
+    wrong project as asserted evidence — a strictly worse failure than loading
+    nothing. See issue #2057 / run 59bdfe42256b."""
+
+    def test_bare_number_fires_no_gh_lookup(self, tmp_path):
+        calls = []
+
+        def fake_run_gh(args, project_root):
+            calls.append(args)
+            # Simulate the local repo genuinely having these numbers.
+            return '{"number": 246, "state": "MERGED", "title": "Soft conventions"}'
+
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
+            ev = build_starting_evidence(
+                issue_body=(
+                    "Observed in the hdp project: #246 and #248 describe the "
+                    "session-state defects, see also #245 and #231."
+                ),
+                project_root=tmp_path,
+                self_issue_number=2029,
+            )
+        assert ev.is_empty
+        assert calls == []
+        # Local same-numbered content never reaches the prompt.
+        assert "Soft conventions" not in ev.text
+
+    def test_declined_bare_refs_are_reported(self, tmp_path):
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", return_value=None):
+            ev = build_starting_evidence(
+                issue_body="hdp #246 and #248 (this is #2029).",
+                project_root=tmp_path,
+                self_issue_number=2029,
+            )
+        # Reported as declined-on-purpose, not silently absent; the issue under
+        # diagnosis is not itself a declined reference.
+        assert ev.declined_labels == ["#246", "#248"]
+
+    def test_branch_like_path_fragment_is_not_a_repo_qualifier(self, tmp_path):
+        calls = []
+
+        def fake_run_gh(args, project_root):
+            calls.append(args)
+            return None
+
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
+            build_starting_evidence(
+                issue_body="On feat/issue-2057#3 the check fails.",
+                project_root=tmp_path,
+            )
+        # "issue-2057" is a branch segment, not a repository name.
+        assert not any(a[:2] in (["pr", "view"], ["issue", "view"]) for a in calls)
+
+    def test_qualified_and_bare_forms_coexist(self, tmp_path):
+        def fake_run_gh(args, project_root):
+            if args[:2] == ["pr", "view"] and "--repo" in args:
+                return '{"number": 246, "state": "OPEN", "title": "hdp session state"}'
+            return None
+
+        with patch("theforge.coordinator.diagnose_evidence._run_gh", side_effect=fake_run_gh):
+            ev = build_starting_evidence(
+                issue_body="fuzzypete/hdp#246 is the real one; #248 is unqualified.",
+                project_root=tmp_path,
+            )
+        assert "hdp session state" in ev.text
+        assert ev.reference_labels == ["PR fuzzypete/hdp#246"]
+        assert ev.declined_labels == ["#248"]
 
 
 class TestBounding:


### PR DESCRIPTION
## Summary

The change satisfies the namespace-safety requirements for diagnose starting evidence; I found no blocking defects.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $3.07
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

`forge diagnose` resolves another repository's issue references against the local repo and injects the results as starting evidence (GitHub Issue #2057)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2057