### PR TITLE
The shape gate reads headings inside fenced code blocks as document structure, refusing well-formed bugs that quote markdown

### DIFF
--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -15,6 +15,7 @@ from theforge.shape_check.diagnosis_spec import (
     required_diagnosis_tokens,
 )
 from theforge.shape_check.parsing import (
+    FenceTracker,
     extract_ac_section,
     extract_bullets,
     extract_section,
@@ -744,7 +745,7 @@ def check_implementation_design_dump(
         signals += len(pat.findall(ac))
     # Detect fenced blocks tagged python/yaml even without signature
     for line in ac.splitlines():
-        m = re.match(r"^\s*```(\w+)\s*$", line)
+        m = re.match(r"^\s*(?:`{3,}|~{3,})(\w+)\s*$", line)
         if m and m.group(1).lower() in _DESIGN_FENCE_LANGS:
             signals += 1
     if signals >= 3:
@@ -786,20 +787,15 @@ _PLAN_EXCEPTION_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-_FENCE_RE = re.compile(r"^\s*```")
-
 
 def _strip_fenced_blocks(body: str) -> str:
-    out: list[str] = []
-    in_fence = False
-    for line in body.splitlines():
-        if _FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        out.append(line)
-    return "\n".join(out)
+    """Drop fenced code, so prose heuristics never read quoted samples as prose.
+
+    Shares :class:`FenceTracker` with the structural parsers: one definition of
+    what counts as literal content, both fence families included.
+    """
+    tracker = FenceTracker()
+    return "\n".join(line for line in body.splitlines() if tracker.feed(line) == "outside")
 
 
 _EXAMPLE_HEADING_RE = re.compile(

--- a/src/theforge/shape_check/parsing.py
+++ b/src/theforge/shape_check/parsing.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 
 _HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$", re.MULTILINE)
+_FENCE_RE = re.compile(r"^\s{0,3}(`{3,})(.*?)\s*$")
 _BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(?:\[[ xX]\]\s+)?(.+?)\s*$")
 _EXAMPLE_HEADING_RE = re.compile(
     r"^(?:"
@@ -32,13 +33,56 @@ class ContextualFencedBlock:
     in_example_section: bool
 
 
+def fenced_spans(body: str) -> list[tuple[int, int]]:
+    """Return ``(start, end)`` character offsets of each fenced code region.
+
+    A region runs from the start of its opening fence line through the end of
+    its closing fence line. A fence closes on a line with at least as many
+    backticks as the opener and no info string; an unclosed fence runs to the
+    end of the document, as in CommonMark.
+    """
+    spans: list[tuple[int, int]] = []
+    offset = 0
+    open_start: int | None = None
+    open_ticks = 0
+    for line in body.splitlines(keepends=True):
+        m = _FENCE_RE.match(line)
+        if m:
+            ticks = len(m.group(1))
+            if open_start is None:
+                open_start = offset
+                open_ticks = ticks
+            elif ticks >= open_ticks and not m.group(2).strip():
+                spans.append((open_start, offset + len(line)))
+                open_start = None
+        offset += len(line)
+    if open_start is not None:
+        spans.append((open_start, len(body)))
+    return spans
+
+
+def iter_headings(body: str) -> list[re.Match[str]]:
+    """Return every heading match in ``body`` that is not inside a fenced block.
+
+    Headings quoted inside fenced code are content the author is exhibiting,
+    not structure of the document itself, so they are excluded.
+    """
+    spans = fenced_spans(body)
+    return [
+        m
+        for m in _HEADING_RE.finditer(body)
+        if not any(start <= m.start() < end for start, end in spans)
+    ]
+
+
 def find_heading(body: str, pattern: str) -> re.Match[str] | None:
     """Return a re.Match for the first heading whose text matches ``pattern``.
 
-    The match's ``start()`` is the start of the heading line.
+    Headings inside fenced code blocks are ignored. The match's ``start()`` is
+    the start of the heading line.
     """
     regex = re.compile(pattern, re.IGNORECASE)
-    for m in _HEADING_RE.finditer(body):
+    for m in iter_headings(body):
         if regex.search(m.group(2)):
             return m
     return None
@@ -53,19 +97,20 @@ def section_span(body: str, heading_pattern: str) -> tuple[int, int] | None:
 
     ``start`` is the offset just past the end of the heading line; ``end`` is the
     offset of the next heading of same-or-higher level, or ``len(body)``.
-    Returns ``None`` when no heading matches. Producers that need to insert text
-    into an existing section use this rather than re-deriving heading arithmetic.
+    Headings inside fenced code blocks bound nothing — a fenced sample of a
+    document's shape is content, so the section runs past it. Returns ``None``
+    when no heading matches. Producers that need to insert text into an existing
+    section use this rather than re-deriving heading arithmetic.
     """
     m = find_heading(body, heading_pattern)
     if not m:
         return None
     level = len(m.group(1))
     start = m.end()
-    remainder = body[start:]
-    # find next heading of level <= current
-    for nm in _HEADING_RE.finditer(remainder):
-        if len(nm.group(1)) <= level:
-            return start, start + nm.start()
+    # find next unfenced heading of level <= current
+    for nm in iter_headings(body):
+        if nm.start() >= start and len(nm.group(1)) <= level:
+            return start, nm.start()
     return start, len(body)
 
 

--- a/src/theforge/shape_check/parsing.py
+++ b/src/theforge/shape_check/parsing.py
@@ -6,7 +6,10 @@ import re
 from dataclasses import dataclass
 
 _HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$", re.MULTILINE)
-_FENCE_RE = re.compile(r"^\s{0,3}(`{3,})(.*?)\s*$")
+# Indentation is not restricted to CommonMark's 0-3 spaces: fences nested under
+# a bullet are indented to the item's content column, and the bullet-block
+# helpers below have always treated those as fences.
+_FENCE_RE = re.compile(r"^\s*(?P<marker>`{3,}|~{3,})(?P<info>.*?)\s*$")
 _BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(?:\[[ xX]\]\s+)?(.+?)\s*$")
 _EXAMPLE_HEADING_RE = re.compile(
     r"^(?:"
@@ -33,30 +36,74 @@ class ContextualFencedBlock:
     in_example_section: bool
 
 
+class FenceTracker:
+    """Line-by-line fenced-code state for a Markdown document.
+
+    Both fence families are recognised (``` ``` ``` and ``~~~``). A fence closes
+    only on a line using the *same* marker character, at least as long as the
+    opener, with no info string — so a ``~~~`` line inside a backtick block is
+    content, not a delimiter. An unclosed fence runs to the end of the document,
+    as in CommonMark.
+
+    Every fence-aware helper in this module shares this one implementation:
+    the parsers must agree on what counts as literal content, or a body can be
+    admitted by one check and refused by another for the same text.
+    """
+
+    __slots__ = ("_char", "_len")
+
+    def __init__(self) -> None:
+        self._char: str | None = None
+        self._len = 0
+
+    @property
+    def in_fence(self) -> bool:
+        """True when the *previous* fed line left the document inside a fence."""
+        return self._char is not None
+
+    def feed(self, line: str) -> str:
+        """Consume ``line`` and return its role.
+
+        One of ``"open"``, ``"close"`` (the delimiter lines themselves),
+        ``"inside"`` (fenced content) or ``"outside"`` (ordinary document text).
+        """
+        m = _FENCE_RE.match(line)
+        if self._char is None:
+            if m:
+                self._char = m.group("marker")[0]
+                self._len = len(m.group("marker"))
+                return "open"
+            return "outside"
+        if (
+            m
+            and m.group("marker")[0] == self._char
+            and len(m.group("marker")) >= self._len
+            and not m.group("info").strip()
+        ):
+            self._char = None
+            self._len = 0
+            return "close"
+        return "inside"
+
+
 def fenced_spans(body: str) -> list[tuple[int, int]]:
     """Return ``(start, end)`` character offsets of each fenced code region.
 
     A region runs from the start of its opening fence line through the end of
-    its closing fence line. A fence closes on a line with at least as many
-    backticks as the opener and no info string; an unclosed fence runs to the
-    end of the document, as in CommonMark.
+    its closing fence line. See :class:`FenceTracker` for the delimiter rules.
     """
     spans: list[tuple[int, int]] = []
     offset = 0
-    open_start: int | None = None
-    open_ticks = 0
+    open_start = 0
+    tracker = FenceTracker()
     for line in body.splitlines(keepends=True):
-        m = _FENCE_RE.match(line)
-        if m:
-            ticks = len(m.group(1))
-            if open_start is None:
-                open_start = offset
-                open_ticks = ticks
-            elif ticks >= open_ticks and not m.group(2).strip():
-                spans.append((open_start, offset + len(line)))
-                open_start = None
+        role = tracker.feed(line)
+        if role == "open":
+            open_start = offset
+        elif role == "close":
+            spans.append((open_start, offset + len(line)))
         offset += len(line)
-    if open_start is not None:
+    if tracker.in_fence:
         spans.append((open_start, len(body)))
     return spans
 
@@ -163,16 +210,12 @@ def extract_top_level_bullet_blocks(section: str) -> list[str]:
 
     blocks: list[list[str]] = []
     current: list[str] | None = None
-    in_fence = False
+    tracker = FenceTracker()
     for line in lines:
         stripped = line.lstrip(" ")
         indent = len(line) - len(stripped)
-        if stripped.startswith("```"):
-            if current is not None:
-                current.append(line)
-            in_fence = not in_fence
-            continue
-        if in_fence:
+        if tracker.feed(line) != "outside":
+            # fence delimiters and their contents are literal continuation text
             if current is not None:
                 current.append(line)
             continue
@@ -197,21 +240,20 @@ def extract_contextual_bullets(section: str) -> list[ContextualBullet]:
     """Return bullets annotated with whether they appear under an example heading."""
     bullets: list[ContextualBullet] = []
     example_level: int | None = None
-    in_fence = False
+    tracker = FenceTracker()
 
     for line in section.splitlines():
-        stripped = line.strip()
+        role = tracker.feed(line)
+        if role in ("open", "close"):
+            continue
+
         heading_match = _HEADING_RE.match(line)
-        if heading_match and not in_fence:
+        if heading_match and role == "outside":
             level = len(heading_match.group(1))
             if example_level is not None and level <= example_level:
                 example_level = None
             if is_example_heading(heading_match.group(2)):
                 example_level = level
-            continue
-
-        if stripped.startswith("```"):
-            in_fence = not in_fence
             continue
 
         bullet_match = _BULLET_RE.match(line)
@@ -227,21 +269,20 @@ def extract_contextual_bullets(section: str) -> list[ContextualBullet]:
 
 
 def fenced_code_blocks(body: str) -> list[str]:
-    """Return the contents of each triple-backtick fenced code block."""
+    """Return the contents of each fenced code block (backtick or tilde)."""
     blocks: list[str] = []
-    lines = body.splitlines()
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        fence = re.match(r"^\s*```(\w*)\s*$", line)
-        if fence:
-            i += 1
-            buf: list[str] = []
-            while i < len(lines) and not re.match(r"^\s*```\s*$", lines[i]):
-                buf.append(lines[i])
-                i += 1
-            blocks.append("\n".join(buf))
-        i += 1
+    current: list[str] = []
+    tracker = FenceTracker()
+    for line in body.splitlines():
+        role = tracker.feed(line)
+        if role == "open":
+            current = []
+        elif role == "close":
+            blocks.append("\n".join(current))
+        elif role == "inside":
+            current.append(line)
+    if tracker.in_fence:
+        blocks.append("\n".join(current))
     return blocks
 
 
@@ -249,11 +290,12 @@ def extract_contextual_fenced_code_blocks(body: str) -> list[ContextualFencedBlo
     """Return fenced blocks annotated with whether they appear under an example heading."""
     blocks: list[ContextualFencedBlock] = []
     example_level: int | None = None
-    in_fence = False
     current: list[str] = []
+    tracker = FenceTracker()
 
     for line in body.splitlines():
-        if not in_fence:
+        role = tracker.feed(line)
+        if role == "outside":
             heading_match = _HEADING_RE.match(line)
             if heading_match:
                 level = len(heading_match.group(1))
@@ -261,23 +303,18 @@ def extract_contextual_fenced_code_blocks(body: str) -> list[ContextualFencedBlo
                     example_level = None
                 if is_example_heading(heading_match.group(2)):
                     example_level = level
-                continue
-
-        if re.match(r"^\s*```", line):
-            if in_fence:
-                blocks.append(
-                    ContextualFencedBlock(
-                        content="\n".join(current),
-                        in_example_section=example_level is not None,
-                    )
-                )
-                current = []
-                in_fence = False
-            else:
-                in_fence = True
             continue
 
-        if in_fence:
+        if role == "open":
+            current = []
+        elif role == "close":
+            blocks.append(
+                ContextualFencedBlock(
+                    content="\n".join(current),
+                    in_example_section=example_level is not None,
+                )
+            )
+        else:
             current.append(line)
 
     return blocks

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import textwrap
 
+from theforge.intake.shape_classify import DiagnosisState, _detect_diagnosis_state
 from theforge.shape_check import (
     DEFAULT_CLUSTER_THRESHOLD,
     Reason,
@@ -18,6 +19,7 @@ from theforge.shape_check import (
 )
 from theforge.shape_check.classifier import classify
 from theforge.shape_check.heuristics import (
+    check_bug_missing_diagnosis,
     check_criterion_needs_live_evidence,
     check_epic_or_tracking,
     check_implementation_design_dump,
@@ -28,10 +30,14 @@ from theforge.shape_check.heuristics import (
     check_superseded,
     check_too_many_behavioral_clusters,
     check_untriaged_finding,
+    diagnosis_completeness,
 )
 from theforge.shape_check.parsing import (
+    extract_ac_section,
     extract_contextual_bullets,
     extract_contextual_fenced_code_blocks,
+    extract_section,
+    has_heading,
 )
 
 WELL_FORMED_AC = textwrap.dedent(
@@ -527,6 +533,161 @@ class TestExampleParsingContext:
 
         blocks = extract_contextual_fenced_code_blocks(body)
         assert [block.in_example_section for block in blocks] == [True, False]
+
+
+class TestFencedHeadingsAreNotStructure:
+    """Headings inside fenced code are quoted samples, not document structure (#2059)."""
+
+    QUOTED_SAMPLE_BUG_BODY = textwrap.dedent(
+        """\
+        ## Observed behavior
+
+        The command restructures the body. It proposes:
+
+        ```markdown
+        ## Observed behavior
+        <symptom>
+
+        ### Diagnosis
+        Status: confirmed cause documented.
+
+        ## Acceptance Criteria
+        - <criterion>
+        ```
+
+        ## Diagnosis
+
+        - **Observed symptom.** Command exits 1 instead of 0 on success.
+        - **Evidence.** Reproduction in run id `abc123`.
+        - **Ruled out.** Config drift; verified config is loaded correctly.
+        - **Confirmed cause.** Off-by-one in exit-code computation at runner.py:42.
+        - **Affected code path.** runner.exit_code, cli.main return.
+        - **Fix-success criterion.** Command returns 0 on success path.
+        """
+    )
+
+    def test_extract_section_skips_heading_inside_fence(self):
+        section = extract_section(self.QUOTED_SAMPLE_BUG_BODY, r"diagnosis|root cause")
+        assert section is not None
+        assert "Confirmed cause" in section
+        assert "Status: confirmed cause documented." not in section
+
+    def test_extract_ac_section_skips_heading_inside_fence(self):
+        assert extract_ac_section(self.QUOTED_SAMPLE_BUG_BODY) is None
+
+        body = self.QUOTED_SAMPLE_BUG_BODY + textwrap.dedent(
+            """\
+
+            ## Acceptance Criteria
+            - The gate admits a body that quotes markdown.
+            """
+        )
+        ac = extract_ac_section(body)
+        assert ac is not None
+        assert "The gate admits a body that quotes markdown." in ac
+        assert "<criterion>" not in ac
+
+    def test_has_heading_ignores_fenced_only_heading(self):
+        body = textwrap.dedent(
+            """\
+            ## Observed behavior
+
+            ```markdown
+            ### Diagnosis
+            Status: confirmed cause documented.
+            ```
+            """
+        )
+        assert not has_heading(body, r"diagnosis|root cause")
+        assert extract_section(body, r"diagnosis|root cause") is None
+
+    def test_section_span_does_not_end_at_fenced_heading(self):
+        body = textwrap.dedent(
+            """\
+            ## Diagnosis
+
+            Prose before the sample.
+
+            ```markdown
+            ## Notes
+            quoted
+            ```
+
+            Prose after the sample.
+
+            ## Notes
+            real notes
+            """
+        )
+        section = extract_section(body, r"diagnosis")
+        assert section is not None
+        assert "Prose after the sample." in section
+        assert "real notes" not in section
+
+    def test_unclosed_fence_runs_to_end_of_body(self):
+        body = textwrap.dedent(
+            """\
+            ## Observed behavior
+
+            ```markdown
+            ## Diagnosis
+            quoted, and the fence is never closed
+            """
+        )
+        assert not has_heading(body, r"diagnosis")
+
+    def test_gate_admits_bug_quoting_a_diagnosis_sample(self):
+        assert diagnosis_completeness(self.QUOTED_SAMPLE_BUG_BODY) == (True, [])
+        assert (
+            check_bug_missing_diagnosis(
+                "shape gate misparses", self.QUOTED_SAMPLE_BUG_BODY, ["bug"]
+            )
+            is None
+        )
+
+    def test_gate_still_refuses_a_fenced_only_diagnosis(self):
+        body = textwrap.dedent(
+            """\
+            ## Observed behavior
+            It exits 1.
+
+            ## Expected behavior
+            It exits 0.
+
+            ```markdown
+            ## Diagnosis
+            - **Observed symptom.** x
+            - **Evidence.** y
+            - **Ruled out.** z
+            - **Confirmed cause.** off-by-one
+            - **Affected code path.** runner.py
+            - **Fix-success criterion.** exits 0
+            ```
+            """
+        )
+        ok, missing = diagnosis_completeness(body)
+        assert not ok
+        assert missing == ["missing Diagnosis section"]
+        reason = check_bug_missing_diagnosis("it exits 1", body, ["bug"])
+        assert reason is not None
+        assert reason.code == "needs_diagnosis"
+
+    def test_classifier_reads_the_real_diagnosis_not_the_quoted_one(self):
+        body = textwrap.dedent(
+            """\
+            ## Observed behavior
+
+            ```markdown
+            ### Diagnosis
+            Status: confirmed cause documented.
+            ```
+
+            ## Diagnosis
+
+            Not yet investigated.
+            """
+        )
+        assert _detect_diagnosis_state(body) is DiagnosisState.NO_DIAGNOSIS
 
 
 class TestTooManyBehavioralClusters:

--- a/tests/test_shape_check.py
+++ b/tests/test_shape_check.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import textwrap
@@ -37,6 +38,7 @@ from theforge.shape_check.parsing import (
     extract_contextual_bullets,
     extract_contextual_fenced_code_blocks,
     extract_section,
+    fenced_code_blocks,
     has_heading,
 )
 
@@ -535,6 +537,11 @@ class TestExampleParsingContext:
         assert [block.in_example_section for block in blocks] == [True, False]
 
 
+def _with_tilde_fences(body: str) -> str:
+    """Rewrite a body's backtick fence delimiters as tilde delimiters."""
+    return re.sub(r"(?m)^(\s*)```", r"\1~~~", body)
+
+
 class TestFencedHeadingsAreNotStructure:
     """Headings inside fenced code are quoted samples, not document structure (#2059)."""
 
@@ -645,26 +652,28 @@ class TestFencedHeadingsAreNotStructure:
             is None
         )
 
+    FENCED_ONLY_DIAGNOSIS_BODY = textwrap.dedent(
+        """\
+        ## Observed behavior
+        It exits 1.
+
+        ## Expected behavior
+        It exits 0.
+
+        ```markdown
+        ## Diagnosis
+        - **Observed symptom.** x
+        - **Evidence.** y
+        - **Ruled out.** z
+        - **Confirmed cause.** off-by-one
+        - **Affected code path.** runner.py
+        - **Fix-success criterion.** exits 0
+        ```
+        """
+    )
+
     def test_gate_still_refuses_a_fenced_only_diagnosis(self):
-        body = textwrap.dedent(
-            """\
-            ## Observed behavior
-            It exits 1.
-
-            ## Expected behavior
-            It exits 0.
-
-            ```markdown
-            ## Diagnosis
-            - **Observed symptom.** x
-            - **Evidence.** y
-            - **Ruled out.** z
-            - **Confirmed cause.** off-by-one
-            - **Affected code path.** runner.py
-            - **Fix-success criterion.** exits 0
-            ```
-            """
-        )
+        body = self.FENCED_ONLY_DIAGNOSIS_BODY
         ok, missing = diagnosis_completeness(body)
         assert not ok
         assert missing == ["missing Diagnosis section"]
@@ -688,6 +697,95 @@ class TestFencedHeadingsAreNotStructure:
             """
         )
         assert _detect_diagnosis_state(body) is DiagnosisState.NO_DIAGNOSIS
+
+
+class TestTildeFencesAreFences:
+    """``~~~`` marks literal content exactly as ``` ``` ``` does (review iter 1)."""
+
+    def test_gate_admits_bug_quoting_a_tilde_fenced_diagnosis_sample(self):
+        body = _with_tilde_fences(TestFencedHeadingsAreNotStructure.QUOTED_SAMPLE_BUG_BODY)
+        assert "~~~markdown" in body
+        section = extract_section(body, r"diagnosis|root cause")
+        assert section is not None
+        assert "Status: confirmed cause documented." not in section
+        assert diagnosis_completeness(body) == (True, [])
+        assert check_bug_missing_diagnosis("shape gate misparses", body, ["bug"]) is None
+
+    def test_gate_still_refuses_a_tilde_fenced_only_diagnosis(self):
+        body = _with_tilde_fences(TestFencedHeadingsAreNotStructure.FENCED_ONLY_DIAGNOSIS_BODY)
+        assert diagnosis_completeness(body) == (False, ["missing Diagnosis section"])
+        reason = check_bug_missing_diagnosis("it exits 1", body, ["bug"])
+        assert reason is not None
+        assert reason.code == "needs_diagnosis"
+
+    def test_a_fence_is_not_closed_by_the_other_marker_family(self):
+        body = textwrap.dedent(
+            """\
+            ## Observed behavior
+
+            ~~~markdown
+            ```
+            ## Diagnosis
+            still inside the tilde block
+            ```
+            ~~~
+
+            ## Notes
+            Real content.
+            """
+        )
+        assert not has_heading(body, r"diagnosis")
+        assert has_heading(body, r"notes")
+
+    def test_a_shorter_fence_does_not_close_a_longer_one(self):
+        body = textwrap.dedent(
+            """\
+            ## Observed behavior
+
+            ````markdown
+            ```
+            ## Diagnosis
+            quoted sample that itself contains a fence
+            ```
+            ````
+
+            ## Notes
+            Real content.
+            """
+        )
+        assert not has_heading(body, r"diagnosis")
+        assert has_heading(body, r"notes")
+
+    def test_fenced_code_blocks_reads_both_families(self):
+        body = textwrap.dedent(
+            """\
+            ```yaml
+            first: block
+            ```
+
+            ~~~yaml
+            second: block
+            ~~~
+            """
+        )
+        assert fenced_code_blocks(body) == ["first: block", "second: block"]
+
+    def test_contextual_fenced_blocks_reads_tilde_blocks(self):
+        body = textwrap.dedent(
+            """\
+            ## Schema
+            ~~~yaml
+            primary_failure_class: flaky-tests
+            ~~~
+
+            ## Notes
+            ~~~yaml
+            function_signature: str
+            ~~~
+            """
+        )
+        blocks = extract_contextual_fenced_code_blocks(body)
+        assert [block.in_example_section for block in blocks] == [True, False]
 
 
 class TestTooManyBehavioralClusters:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Prior tilde-fence P1 is resolved, and I found no blocking regressions in the reviewed shape-check changes. | [google-gemini-3.5-flash] The shape gate now correctly skips fenced code blocks of both backtick and tilde families when parsing document structure, resolving the prior P1 finding.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $5.60
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

The shape gate reads headings inside fenced code blocks as document structure, refusing well-formed bugs that quote markdown (GitHub Issue #2059)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2059