### PR TITLE
`forge shape` proposes labels the issue already carries and can never report an issue as ready

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -463,7 +463,8 @@ should become before grooming or diagnosing it.
 **The command never auto-invokes a producer.** `--next` prints a hint
 (`forge diagnose --issue 123`, `forge groom 123`, etc.); it does not run it.
 `--next` output is human-readable in v0.11; no stable machine-readable
-contract is promised yet.
+contract is promised yet. Its exit code carries the same readiness signal as
+the default path — 0 only when the recommendation is terminal.
 
 **ADR candidates** receive a proposed slug and title — the ADR file is not
 written. **Epic** classifications may propose child stories in prose; no
@@ -488,8 +489,10 @@ Next: none — #2050 already satisfies the shape gate (verdict: runnable); no fu
 ```
 
 Any other state exits 1 and names the stage that still owes work (`forge
-diagnose`, `forge groom`, splitting an epic, closing a duplicate). `--apply` on
-a gate-passing issue makes no `gh` call at all.
+diagnose`, `forge groom`, splitting an epic, closing a duplicate). This holds
+for `--next` too. `--apply` is the exception: it reports whether the mutation
+succeeded, not whether the issue is ready, and on a gate-passing issue it makes
+no `gh` call at all.
 
 Every invocation writes a row into the audit substrate's `shape_events`
 table (issue number, input source, classification, confidence, ambiguity

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -474,12 +474,27 @@ gate reports missing — an absent `## Observed` / `## Expected` section, or the
 specific `## Diagnosis` components the gate names — inserting missing diagnosis
 components into the existing `## Diagnosis` section. Existing headings are never
 re-levelled, rewritten, or demoted into quoted prose. A bug body that already
-passes the shape gate produces no diff, and `forge shape <issue>` exits 0 when
-neither the body nor the labels need changing.
+passes the shape gate produces no diff.
+
+**The proposal is a diff against observed state, and the exit code is the
+readiness signal.** Labels the issue already carries are never proposed, and
+`forge shape <issue>` exits 0 exactly when the issue already satisfies the
+shape gate — nothing left to add, remove, or restructure, and the gate's
+verdict on the current body is `runnable`. In that case the recommendation is
+terminal:
+
+```
+Next: none — #2050 already satisfies the shape gate (verdict: runnable); no further action is needed.
+```
+
+Any other state exits 1 and names the stage that still owes work (`forge
+diagnose`, `forge groom`, splitting an epic, closing a duplicate). `--apply` on
+a gate-passing issue makes no `gh` call at all.
 
 Every invocation writes a row into the audit substrate's `shape_events`
 table (issue number, input source, classification, confidence, ambiguity
-question count, whether `--apply` mutated the issue).
+question count, whether `--apply` mutated the issue, and the shape-gate
+verdict observed).
 
 `forge shape` is the first step of the mid-sprint capture flow — see
 [Mid-sprint workflow](authoring.md#mid-sprint-workflow) for the full

--- a/src/theforge/cli/shape.py
+++ b/src/theforge/cli/shape.py
@@ -24,6 +24,8 @@ from theforge.intake.shape_classify import (
     classify,
 )
 from theforge.intake.shape_render import (
+    ShapeReadiness,
+    evaluate_readiness,
     next_command,
     render_proposal,
     restructure_body,
@@ -103,9 +105,15 @@ def _apply_to_github(
     issue_number: int,
     proposal: ShapeProposal,
     new_body: str,
+    current_body: str,
     cwd: Path,
 ) -> bool:
-    """Apply label edits + body restructure via gh. Returns True on success."""
+    """Apply label edits + body restructure via gh. Returns True on success.
+
+    Each edit is applied only where it is an actual delta — a body write that
+    replaces the body with its own content is a mutation the operator did not
+    ask for and cannot see in the proposal (#2054).
+    """
     # Add labels (one --add-label per label keeps gh happy across versions).
     for label in proposal.proposed_labels:
         proc = _gh(
@@ -127,6 +135,8 @@ def _apply_to_github(
             )
             print(err, file=sys.stderr)
             return False
+    if new_body == current_body:
+        return True
     # Body restructure goes via --body-file so we don't have to escape.
     import tempfile
 
@@ -185,6 +195,9 @@ def cmd_shape(args: argparse.Namespace) -> int:
         confidence=Confidence.LOW,
     )
     apply_mutated = False
+    # None until the issue is loaded and the gate can actually be run — an
+    # early failure records "no verdict observed" rather than a fabricated one.
+    readiness: ShapeReadiness | None = None
 
     try:
         title: str
@@ -214,10 +227,14 @@ def cmd_shape(args: argparse.Namespace) -> int:
             return 1
 
         proposal = classify(title, body, labels)
+        # Readiness is computed against the state actually observed, so the
+        # command can report a terminal "nothing to do" rather than always
+        # naming a further pipeline stage (#2054).
+        readiness = evaluate_readiness(proposal, title=title, body=body, labels=labels)
 
         # --next: print only the operator-facing next command and exit 0.
         if args.next:
-            print(next_command(proposal, issue_number))
+            print(next_command(proposal, issue_number, ready=readiness.ready))
             return 0
 
         source_label = (
@@ -234,7 +251,7 @@ def cmd_shape(args: argparse.Namespace) -> int:
             show_diff=True,
         )
         print(rendered, end="")
-        print(next_command(proposal, issue_number))
+        print(next_command(proposal, issue_number, ready=readiness.ready))
 
         if args.apply:
             if proposal.classification is Classification.UNRESOLVED:
@@ -250,22 +267,32 @@ def cmd_shape(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 return 1
+            if readiness.ready:
+                # Nothing to apply: mutating here would rewrite the issue with
+                # the content it already has (#2054).
+                print(f"No changes to apply; #{issue_number} already satisfies the shape gate.")
+                return 0
             new_body = restructure_body(proposal, body)
-            ok = _apply_to_github(issue_number, proposal, new_body, project_root)
+            has_delta = bool(
+                proposal.proposed_labels or proposal.removed_labels or new_body != body
+            )
+            ok = _apply_to_github(issue_number, proposal, new_body, body, project_root)
             if not ok:
                 return 1
+            if not has_delta:
+                # The issue does not satisfy the gate, but nothing this command
+                # proposes would move it — say so rather than claim an edit that
+                # never happened (#2054).
+                print(f"Nothing to apply to #{issue_number}; no proposed edits differ from it.")
+                return 0
             print(f"Applied proposal to #{issue_number}.")
             apply_mutated = True
             return 0
 
-        # Without --apply: non-zero when changes would be needed.
-        needs_change = (
-            proposal.classification is Classification.UNRESOLVED
-            or bool(proposal.proposed_labels)
-            or bool(proposal.removed_labels)
-            or restructure_body(proposal, body) != body
-        )
-        return 1 if needs_change else 0
+        # Without --apply: exit zero exactly when the issue is already ready —
+        # the exit code is the readiness signal, so a gate-passing issue is
+        # distinguishable from one that still needs work (#2054).
+        return 0 if readiness.ready else 1
     finally:
         _safe_emit(
             project_root,
@@ -273,6 +300,7 @@ def cmd_shape(args: argparse.Namespace) -> int:
             input_source=input_source,
             proposal=proposal,
             apply_mutated=apply_mutated,
+            readiness=readiness,
         )
 
 
@@ -283,6 +311,7 @@ def _safe_emit(
     input_source: str,
     proposal: ShapeProposal,
     apply_mutated: bool,
+    readiness: ShapeReadiness | None = None,
 ) -> None:
     try:
         emit_shape_event(
@@ -296,6 +325,7 @@ def _safe_emit(
             diagnosis_state=(
                 proposal.diagnosis_state.value if proposal.diagnosis_state is not None else None
             ),
+            gate_verdict=(readiness.verdict.value if readiness is not None else None),
         )
     except Exception as exc:  # noqa: BLE001 — audit emission is fire-and-forget
         print(f"[forge shape] audit emission failed: {exc}", file=sys.stderr)

--- a/src/theforge/cli/shape.py
+++ b/src/theforge/cli/shape.py
@@ -3,8 +3,14 @@
 Refusal-capable: when the classifier's confidence is low, the command
 keeps the item as ``todo:draft`` and emits structured ambiguity questions
 rather than forcing a classification. Without ``--apply`` it prints a
-diff and exits non-zero; with ``--apply`` it edits the issue via ``gh``.
+diff; with ``--apply`` it edits the issue via ``gh``.
 The command never auto-invokes a producer (`forge diagnose`, `forge groom`).
+
+Outside ``--apply``, the exit code is the readiness signal: 0 when the issue
+already satisfies the shape gate and this command asks nothing further of the
+operator, 1 otherwise. That holds for ``--next`` too — a recommendation that
+still names a pipeline stage is not a success (#2054). Under ``--apply`` the
+exit code reports whether the mutation succeeded, not readiness.
 """
 
 from __future__ import annotations
@@ -232,10 +238,12 @@ def cmd_shape(args: argparse.Namespace) -> int:
         # naming a further pipeline stage (#2054).
         readiness = evaluate_readiness(proposal, title=title, body=body, labels=labels)
 
-        # --next: print only the operator-facing next command and exit 0.
+        # --next: print only the operator-facing next command. The exit code is
+        # the same readiness signal every other path reports — a recommendation
+        # that still names a stage is not success (#2054).
         if args.next:
             print(next_command(proposal, issue_number, ready=readiness.ready))
-            return 0
+            return 0 if readiness.ready else 1
 
         source_label = (
             f"#{issue_number} {title!r}".strip()
@@ -360,7 +368,10 @@ def register_parser(subparsers: object) -> None:
         "--next",
         action="store_true",
         default=False,
-        help="Print only the recommended next operator command and exit (never auto-invokes it)",
+        help=(
+            "Print only the recommended next operator command and exit "
+            "(never auto-invokes it; exits 0 only when nothing is left to do)"
+        ),
     )
     p.set_defaults(func=cmd_shape)
 

--- a/src/theforge/coordinator/shape_audit.py
+++ b/src/theforge/coordinator/shape_audit.py
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS shape_events (
     confidence TEXT NOT NULL,
     ambiguity_question_count INTEGER NOT NULL DEFAULT 0,
     apply_mutated INTEGER NOT NULL DEFAULT 0,
-    diagnosis_state TEXT
+    diagnosis_state TEXT,
+    gate_verdict TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_shape_events_emitted_at
     ON shape_events(emitted_at);
@@ -41,6 +42,13 @@ VALID_INPUT_SOURCES: frozenset[str] = frozenset({"issue", "file", "stdin", "none
 
 def _ensure_shape_events(conn: sqlite3.Connection) -> None:
     conn.executescript(_SHAPE_EVENTS_SCHEMA)
+    # Idempotent column add for substrates created under an older schema.
+    # SQLite < 3.35 lacks ADD COLUMN IF NOT EXISTS, so swallow the duplicate
+    # error from re-runs (same pattern as audit_substrate._apply_schema).
+    try:
+        conn.execute("ALTER TABLE shape_events ADD COLUMN gate_verdict TEXT")
+    except sqlite3.OperationalError:
+        pass
 
 
 def _open_or_create(project_root: Path) -> sqlite3.Connection:
@@ -62,8 +70,14 @@ def emit_shape_event(
     ambiguity_question_count: int,
     apply_mutated: bool,
     diagnosis_state: str | None = None,
+    gate_verdict: str | None = None,
 ) -> int:
     """Insert a single shape event row. Returns the new ``id``.
+
+    ``gate_verdict`` is the shape-gate verdict observed on the issue's state at
+    invocation time (``None`` when the invocation failed before the issue could
+    be read). It is what makes a "no action needed" report reconstructable from
+    the audit trail rather than only from the operator's terminal (#2054).
 
     Emission is best-effort wrt schema migrations on older substrates: the
     ``shape_events`` table is created idempotently before insert. Callers
@@ -77,8 +91,9 @@ def emit_shape_event(
         cur = conn.execute(
             "INSERT INTO shape_events("
             "emitted_at, issue_number, input_source, classification, "
-            "confidence, ambiguity_question_count, apply_mutated, diagnosis_state"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "confidence, ambiguity_question_count, apply_mutated, diagnosis_state, "
+            "gate_verdict"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 _now_iso(),
                 issue_number,
@@ -88,6 +103,7 @@ def emit_shape_event(
                 int(ambiguity_question_count),
                 1 if apply_mutated else 0,
                 diagnosis_state,
+                gate_verdict,
             ),
         )
         conn.commit()

--- a/src/theforge/intake/shape_render.py
+++ b/src/theforge/intake/shape_render.py
@@ -8,6 +8,8 @@ the gate enforces, so it reads that contract rather than restating it (#2053).
 from __future__ import annotations
 
 import difflib
+from collections.abc import Iterable
+from dataclasses import dataclass
 
 from theforge.intake.shape_classify import (
     Classification,
@@ -15,6 +17,7 @@ from theforge.intake.shape_classify import (
     DiagnosisState,
     ShapeProposal,
 )
+from theforge.shape_check.check import check as shape_gate_check
 from theforge.shape_check.diagnosis_spec import (
     DIAGNOSIS_HEADING,
     REQUIRED_DIAGNOSIS_COMPONENTS,
@@ -24,6 +27,7 @@ from theforge.shape_check.heuristics import (
     diagnosis_completeness,
 )
 from theforge.shape_check.parsing import has_heading, section_span
+from theforge.shape_check.types import ShapeVerdict
 
 # Heading patterns for the two narrative sections a bug body carries alongside
 # its Diagnosis. Matched heading-level-agnostically through the same parser the
@@ -198,8 +202,64 @@ def render_proposal(
     return "\n".join(lines) + "\n"
 
 
-def next_command(proposal: ShapeProposal, issue_number: int | None) -> str:
-    """Return the operator-facing recommended next command."""
+@dataclass(frozen=True)
+class ShapeReadiness:
+    """Whether the issue, as it stands, already satisfies the shape gate.
+
+    ``ready`` is the single readiness signal ``forge shape`` reports: it is true
+    only when the gate's verdict on the *current* title/body/labels is
+    ``RUNNABLE`` **and** the proposal asks nothing further of the operator. A
+    proposal that restates state the issue already has is not a change, so it
+    must not keep the command from reporting a terminal state (#2054).
+    """
+
+    verdict: ShapeVerdict
+    ready: bool
+
+
+def evaluate_readiness(
+    proposal: ShapeProposal,
+    *,
+    title: str,
+    body: str,
+    labels: Iterable[str],
+) -> ShapeReadiness:
+    """Return the shape-gate verdict for the current issue state + readiness.
+
+    The verdict comes from the same ``shape_check.check`` entry point the sprint
+    gate and ``forge groom`` derive their own verdicts from, so a "ready" report
+    here means exactly what "runnable" means everywhere else — there is no
+    second, shape-private definition of readiness to drift from it.
+    """
+    verdict = shape_gate_check(title or "", body or "", list(labels)).verdict
+    ready = (
+        proposal.classification is not Classification.UNRESOLVED
+        and not proposal.proposed_labels
+        and not proposal.removed_labels
+        and restructure_body(proposal, body or "") == (body or "")
+        and verdict is ShapeVerdict.RUNNABLE
+    )
+    return ShapeReadiness(verdict=verdict, ready=ready)
+
+
+def next_command(
+    proposal: ShapeProposal,
+    issue_number: int | None,
+    *,
+    ready: bool = False,
+) -> str:
+    """Return the operator-facing recommended next command.
+
+    When ``ready``, the recommendation is terminal: the pipeline has nothing
+    left to do for this issue, and saying so is what makes the non-terminal
+    recommendations meaningful (#2054).
+    """
+    if ready:
+        subject = f"#{issue_number}" if issue_number is not None else "the draft"
+        return (
+            f"Next: none — {subject} already satisfies the shape gate "
+            "(verdict: runnable); no further action is needed."
+        )
     if proposal.classification is Classification.UNRESOLVED:
         return "Next: resolve ambiguity questions, then re-run `forge shape`."
     target = f" {issue_number}" if issue_number is not None else ""
@@ -226,4 +286,11 @@ def next_command(proposal: ShapeProposal, issue_number: int | None) -> str:
 
 # Confidence is only used through ShapeProposal, but re-export so consumers
 # don't have to import the classify module separately when assembling text.
-__all__ = ["Confidence", "next_command", "render_proposal", "restructure_body"]
+__all__ = [
+    "Confidence",
+    "ShapeReadiness",
+    "evaluate_readiness",
+    "next_command",
+    "render_proposal",
+    "restructure_body",
+]

--- a/tests/test_cli_shape.py
+++ b/tests/test_cli_shape.py
@@ -101,7 +101,10 @@ def test_shape_next_prints_only_command(tmp_path, capsys):
     args = _make_args(tmp_path, from_brief=str(brief), next=True)
     rc = cmd_shape(args)
     out = capsys.readouterr().out
-    assert rc == 0
+    # --next prints the recommendation and nothing else; its exit code is the
+    # same readiness signal the default path reports, and this draft still
+    # needs diagnosis (#2054).
+    assert rc == 1
     assert out.strip().startswith("Next:")
     # Audit still emitted.
     db = substrate_path(tmp_path)

--- a/tests/test_shape_terminal_state.py
+++ b/tests/test_shape_terminal_state.py
@@ -163,6 +163,25 @@ def test_shape_next_flag_reports_terminal_state(mock_run, tmp_path, capsys):
 
 
 @patch("theforge.cli.shape.subprocess.run")
+def test_shape_next_flag_exits_nonzero_when_work_remains(mock_run, tmp_path, capsys):
+    """--next reports the same readiness signal as every other path."""
+    mock_run.return_value = _gh_view("thing is broken", SYMPTOM_ONLY_BODY, ["bug"])
+    rc = cmd_shape(_make_args(tmp_path, issue=77, next=True))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert out.strip() == "Next: forge diagnose 77"
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_shape_next_flag_exits_nonzero_for_unresolved_draft(mock_run, tmp_path, capsys):
+    mock_run.return_value = _gh_view("???", "", [])
+    rc = cmd_shape(_make_args(tmp_path, issue=78, next=True))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "ambiguity" in out.lower()
+
+
+@patch("theforge.cli.shape.subprocess.run")
 def test_shape_exits_nonzero_and_names_a_stage_when_work_remains(mock_run, tmp_path, capsys):
     mock_run.return_value = _gh_view("thing is broken", SYMPTOM_ONLY_BODY, ["bug"])
     rc = cmd_shape(_make_args(tmp_path, issue=77))

--- a/tests/test_shape_terminal_state.py
+++ b/tests/test_shape_terminal_state.py
@@ -1,0 +1,289 @@
+"""`forge shape` must be able to report that an issue is ready (#2054).
+
+A recommendation that always names a further pipeline stage gives the operator
+no way to tell progress from a loop, and an exit code that is non-zero whenever
+a proposal exists cannot distinguish a gate-passing issue from a malformed one.
+These tests pin the terminal state: gate-passing input produces a "no further
+action" recommendation, exit 0, and no downstream command name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.cli.shape import cmd_shape
+from theforge.coordinator.audit_substrate import substrate_path
+from theforge.coordinator.shape_audit import emit_shape_event
+from theforge.intake.shape_classify import Classification, classify
+from theforge.intake.shape_render import evaluate_readiness, next_command
+from theforge.shape_check.types import ShapeVerdict
+
+GATE_PASSING_TITLE = "forge shape proposes labels the issue already carries"
+GATE_PASSING_BODY = (
+    "## Observed behavior\n\n"
+    "`forge shape` proposes work the issue has already had done to it.\n\n"
+    "## Expected behavior\n\n"
+    "A command that proposes changes proposes only the difference.\n\n"
+    "## Diagnosis\n\n"
+    "- **Observed symptom:** the recommendation always names a further stage.\n"
+    "- **Evidence:** issue #2050 printed `Next: forge groom 2050` while passing.\n"
+    "- **Confirmed cause:** proposals are built without reading current state.\n"
+    "- **Affected code path:** `intake.shape_render.next_command`.\n"
+    "- **Fix-success criterion:** a gate-passing issue reports no action needed.\n"
+)
+
+SYMPTOM_ONLY_BODY = "## Observed behavior\n\nthe thing broke on every release run.\n"
+
+
+def _make_args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project:\n  root: .\n", encoding="utf-8")
+    data: dict[str, object] = {
+        "config": str(forge_yaml),
+        "issue": None,
+        "from_brief": None,
+        "from_stdin": False,
+        "apply": False,
+        "next": False,
+    }
+    data.update(overrides)
+    return argparse.Namespace(**data)
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+def _gh_view(title: str, body: str, labels: list[str]) -> MagicMock:
+    return _proc(
+        stdout=json.dumps(
+            {
+                "title": title,
+                "body": body,
+                "labels": [{"name": name} for name in labels],
+            }
+        )
+    )
+
+
+# --- readiness evaluation (pure) --------------------------------------------
+
+
+def test_readiness_true_for_gate_passing_bug():
+    proposal = classify(GATE_PASSING_TITLE, GATE_PASSING_BODY, ["bug"])
+    readiness = evaluate_readiness(
+        proposal, title=GATE_PASSING_TITLE, body=GATE_PASSING_BODY, labels=["bug"]
+    )
+    assert readiness.verdict is ShapeVerdict.RUNNABLE
+    assert readiness.ready is True
+
+
+def test_readiness_false_for_symptom_only_bug():
+    proposal = classify("thing is broken", SYMPTOM_ONLY_BODY, ["bug"])
+    readiness = evaluate_readiness(
+        proposal, title="thing is broken", body=SYMPTOM_ONLY_BODY, labels=["bug"]
+    )
+    assert readiness.verdict is ShapeVerdict.NEEDS_DIAGNOSIS
+    assert readiness.ready is False
+
+
+def test_readiness_false_while_a_label_edit_is_still_pending():
+    """The gate may pass while the proposal still asks for a label edit."""
+    labels = ["bug", "todo:draft"]
+    proposal = classify(GATE_PASSING_TITLE, GATE_PASSING_BODY, labels)
+    readiness = evaluate_readiness(
+        proposal, title=GATE_PASSING_TITLE, body=GATE_PASSING_BODY, labels=labels
+    )
+    assert proposal.removed_labels == ("todo:draft",)
+    assert readiness.verdict is ShapeVerdict.RUNNABLE
+    assert readiness.ready is False
+
+
+def test_readiness_false_for_unresolved_draft():
+    proposal = classify("???", "", [])
+    assert proposal.classification is Classification.UNRESOLVED
+    readiness = evaluate_readiness(proposal, title="???", body="", labels=[])
+    assert readiness.ready is False
+
+
+# --- next_command terminal state --------------------------------------------
+
+
+def test_next_command_terminal_when_ready():
+    proposal = classify(GATE_PASSING_TITLE, GATE_PASSING_BODY, ["bug"])
+    text = next_command(proposal, 2050, ready=True)
+    assert "no further action is needed" in text
+    assert "#2050" in text
+    assert "forge groom" not in text
+    assert "forge diagnose" not in text
+
+
+def test_next_command_terminal_without_issue_number():
+    proposal = classify(GATE_PASSING_TITLE, GATE_PASSING_BODY, ["bug"])
+    text = next_command(proposal, None, ready=True)
+    assert "no further action is needed" in text
+    assert "forge groom" not in text
+
+
+def test_next_command_still_names_a_stage_when_not_ready():
+    proposal = classify("thing is broken", SYMPTOM_ONLY_BODY, ["bug"])
+    assert next_command(proposal, 42, ready=False) == "Next: forge diagnose 42"
+
+
+# --- CLI wiring -------------------------------------------------------------
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_shape_reports_no_action_needed_and_exits_zero(mock_run, tmp_path, capsys):
+    mock_run.return_value = _gh_view(GATE_PASSING_TITLE, GATE_PASSING_BODY, ["bug"])
+    rc = cmd_shape(_make_args(tmp_path, issue=2050))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no further action is needed" in out
+    assert "Add labels:" not in out
+    assert "forge groom" not in out
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_shape_next_flag_reports_terminal_state(mock_run, tmp_path, capsys):
+    mock_run.return_value = _gh_view(GATE_PASSING_TITLE, GATE_PASSING_BODY, ["bug"])
+    rc = cmd_shape(_make_args(tmp_path, issue=2050, next=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no further action is needed" in out
+    assert "forge groom" not in out
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_shape_exits_nonzero_and_names_a_stage_when_work_remains(mock_run, tmp_path, capsys):
+    mock_run.return_value = _gh_view("thing is broken", SYMPTOM_ONLY_BODY, ["bug"])
+    rc = cmd_shape(_make_args(tmp_path, issue=77))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Next: forge diagnose 77" in out
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_apply_on_gate_passing_issue_makes_no_edit(mock_run, tmp_path, capsys):
+    mock_run.return_value = _gh_view(GATE_PASSING_TITLE, GATE_PASSING_BODY, ["bug"])
+    rc = cmd_shape(_make_args(tmp_path, issue=2050, apply=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "No changes to apply" in out
+    # Only the gh issue view — no gh issue edit of any kind.
+    assert mock_run.call_count == 1
+    assert mock_run.call_args.args[0][:3] == ["gh", "issue", "view"]
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_apply_skips_body_edit_when_only_labels_change(mock_run, tmp_path, capsys):
+    """A body write that replaces the body with its own content is not a change."""
+    labels = ["bug", "todo:draft"]
+    mock_run.side_effect = [
+        _gh_view(GATE_PASSING_TITLE, GATE_PASSING_BODY, labels),
+        _proc(stdout="ok"),
+    ]
+    rc = cmd_shape(_make_args(tmp_path, issue=2050, apply=True))
+    assert rc == 0
+    argvs = [call.args[0] for call in mock_run.call_args_list]
+    assert argvs[1][-2:] == ["--remove-label", "todo:draft"]
+    assert not any("--body-file" in argv for argv in argvs)
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_gate_failing_issue_with_no_proposal_still_exits_nonzero(mock_run, tmp_path, capsys):
+    """No proposed edits is not the same as ready — the gate decides."""
+    mock_run.return_value = _gh_view(
+        "Epic: intake automation", "roll-up of intake work.", ["epic"]
+    )
+    rc = cmd_shape(_make_args(tmp_path, issue=900))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Add labels:" not in out
+    assert "split into child stories" in out
+    assert _gate_verdicts(tmp_path) == ["needs_operator_action"]
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_apply_reports_honestly_when_no_edit_differs(mock_run, tmp_path, capsys):
+    mock_run.return_value = _gh_view(
+        "Epic: intake automation", "roll-up of intake work.", ["epic"]
+    )
+    rc = cmd_shape(_make_args(tmp_path, issue=900, apply=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Nothing to apply" in out
+    assert "Applied proposal" not in out
+    assert mock_run.call_count == 1
+    # An invocation that mutated nothing must not be audited as a mutation.
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        assert conn.execute("SELECT apply_mutated FROM shape_events").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+# --- audit provenance -------------------------------------------------------
+
+
+def _gate_verdicts(tmp_path: Path) -> list[str | None]:
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    try:
+        return [row[0] for row in conn.execute("SELECT gate_verdict FROM shape_events")]
+    finally:
+        conn.close()
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_audit_records_observed_gate_verdict(mock_run, tmp_path, capsys):
+    mock_run.return_value = _gh_view(GATE_PASSING_TITLE, GATE_PASSING_BODY, ["bug"])
+    cmd_shape(_make_args(tmp_path, issue=2050))
+    capsys.readouterr()
+    assert _gate_verdicts(tmp_path) == ["runnable"]
+
+
+@patch("theforge.cli.shape.subprocess.run")
+def test_audit_records_no_verdict_when_issue_never_loaded(mock_run, tmp_path, capsys):
+    mock_run.return_value = _proc(returncode=1, stderr="no such issue")
+    assert cmd_shape(_make_args(tmp_path, issue=999999)) == 1
+    capsys.readouterr()
+    assert _gate_verdicts(tmp_path) == [None]
+
+
+def test_emit_shape_event_migrates_legacy_substrate(tmp_path):
+    """A substrate created before gate_verdict existed still accepts events."""
+    db = substrate_path(tmp_path)
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "CREATE TABLE shape_events ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, emitted_at TEXT NOT NULL, "
+            "issue_number INTEGER, input_source TEXT NOT NULL, "
+            "classification TEXT NOT NULL, confidence TEXT NOT NULL, "
+            "ambiguity_question_count INTEGER NOT NULL DEFAULT 0, "
+            "apply_mutated INTEGER NOT NULL DEFAULT 0, diagnosis_state TEXT)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    emit_shape_event(
+        tmp_path,
+        issue_number=2050,
+        input_source="issue",
+        classification="bug",
+        confidence="high",
+        ambiguity_question_count=0,
+        apply_mutated=False,
+        gate_verdict="runnable",
+    )
+    assert _gate_verdicts(tmp_path) == ["runnable"]


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change satisfies the reported shape readiness and redundant-label symptoms, with focused tests passing. | [google-gemini-3.5-flash] The implementation successfully resolves the issue by evaluating readiness against the observed state and reporting a terminal ready state instead of always naming a stage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $1.34
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

`forge shape` proposes labels the issue already carries and can never report an issue as ready (GitHub Issue #2054)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2054