### PR TITLE
Merge detection is gated on the issue being closed, so a landed story is re-triaged as stale and its recorded outcome overwritten

### DIFF
--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -643,6 +643,37 @@ def _count_unpublished_commits(branch_name: str, project_root: Path) -> int | No
         return None
 
 
+def _is_registered_worktree_path(path: Path, project_root: Path) -> bool | None:
+    """Return True when git registers ``path`` as a linked worktree.
+
+    Returns ``None`` when ``git worktree list`` cannot be read, so callers can
+    fail open rather than delete a directory on an unreadable answer. An empty
+    listing counts as unreadable: a real repository always reports at least its
+    own main worktree, so a listing with no entries is a failed probe, not a
+    statement that ``path`` is unregistered.
+    """
+    ok, output = _cu._run_shell("git worktree list --porcelain", project_root)
+    if not ok:
+        return None
+    try:
+        target = path.resolve()
+    except OSError:
+        target = path
+    saw_entry = False
+    for line in output.splitlines():
+        if not line.startswith("worktree "):
+            continue
+        saw_entry = True
+        candidate = Path(line[len("worktree ") :])
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if resolved == target:
+            return True
+    return False if saw_entry else None
+
+
 def _find_worktree_for_branch(branch: str, project_root: Path) -> Path | None:
     """Return the registered worktree path for branch, or None if not found."""
     ok, output = _cu._run_shell("git worktree list --porcelain", project_root)
@@ -1062,6 +1093,28 @@ def _create_workspace(
 
     if workspace_path.exists():
         _cu._log(f"⚠ WORKSPACE  existing worktree found: {workspace_path}")
+        # A directory under the managed worktrees root that git does not register
+        # as a worktree is residue, not a checkout. Reusing it runs the setup
+        # command against a directory with no project in it, and the failure
+        # surfaces as a confusing "not a Python project" error (#2111). Note that
+        # git commands run inside such a directory resolve against the *parent*
+        # repository, so the staleness probe below cannot tell the difference.
+        registered = _is_registered_worktree_path(workspace_path, config.project_root)
+        if registered is False:
+            _cu._log(
+                "⚠ WORKSPACE  path is not a registered git worktree — "
+                f"treating as stale residue: {workspace_path}"
+            )
+            _remove_leftover_worktree_dir(workspace_path)
+            if workspace_path.exists():
+                return (
+                    None,
+                    None,
+                    "Workspace path exists but git does not register it as a worktree "
+                    f"and it holds non-Forge contents: {workspace_path}",
+                )
+
+    if workspace_path.exists():
         is_stale, info_line = _is_stale_worktree(
             workspace_path, config.workspace.base_branch, config
         )

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -204,13 +204,48 @@ def _branch_merge_evidence(
     project_root: Path,
     slug: str | None = None,
 ) -> MergeEvidence:
-    """Return structured merge evidence for ``branch`` against ``base_branch``."""
+    """Return structured merge evidence for ``branch`` against ``base_branch``.
+
+    Evidence is consulted strongest-first, and issue state is deliberately not a
+    precondition for any of it (#2111). Whether a referencing GitHub issue is
+    closed is a policy another system owns and is free to redefine — symptom bugs
+    are now held open pending verification after their fix lands — so gating merge
+    detection on it silently disabled detection for a whole class of story and
+    re-ran work already in the base branch. Issue closure survives only as a
+    corroborating signal for *external* dependencies in
+    :func:`resolve_satisfied_dependencies`.
+
+    Order of precedence:
+
+    1. The forge audit trail — the evidence this run recorded when it landed the
+       branch. Owned evidence is consulted before any external signal.
+    2. Git topology — a regular merge, provable locally.
+    3. GitHub's own record of a merged PR for the branch.
+    4. A base commit whose message references the issue. This is the loosest
+       signal (any commit mentioning ``(#N)`` matches), so it runs last, only
+       once every stronger source has declined.
+    """
     no_merge = MergeEvidence(merged=False)
     issue_number = _issue_number_from_slug(slug) if slug is not None else None
     if issue_number is None:
         issue_number = _issue_number_from_ref(branch)
-    issue_is_closed = issue_number is None or _is_issue_closed(issue_number, project_root)
 
+    # 1. Owned evidence: the APPROVE + landed record this run wrote itself.
+    if slug is not None:
+        try:
+            if _has_prior_review_approve(project_root, slug, base_branch, branch):
+                return _with_pr_metadata(
+                    MergeEvidence(merged=True, source="audit"),
+                    branch,
+                    project_root,
+                    issue_number,
+                )
+        except Exception:
+            # A transient audit-read failure must not discard the remaining
+            # evidence sources below — fall through rather than claim no_merge.
+            pass
+
+    # 2. Git topology.
     try:
         merge_result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", branch, base_branch],
@@ -243,52 +278,34 @@ def _branch_merge_evidence(
                 if unique_count > 0:
                     # Regular merge: base has moved past branch and branch had
                     # unique work of its own.
-                    if issue_is_closed:
-                        return _with_pr_metadata(
-                            MergeEvidence(merged=True, source="topology"),
-                            branch,
-                            project_root,
-                            issue_number,
-                        )
-                    return no_merge
+                    return _with_pr_metadata(
+                        MergeEvidence(merged=True, source="topology"),
+                        branch,
+                        project_root,
+                        issue_number,
+                    )
     except (subprocess.TimeoutExpired, OSError, ValueError):
         pass
 
-    if not issue_is_closed:
-        return no_merge
-
-    if issue_number is not None and _has_base_commit_referencing_issue(
-        project_root,
-        base_branch,
-        issue_number,
-    ):
-        return _with_pr_metadata(
-            MergeEvidence(merged=True, source="issue_commit"),
-            branch,
-            project_root,
-            issue_number,
-        )
-
-    # Fast-forward merges at the same tip and squash merges both need the audit
-    # trail fallback. In real squash merges, --is-ancestor returns non-zero, so
-    # this check must live outside the topology-success branch above.
-    if slug is not None:
-        try:
-            if _has_prior_review_approve(project_root, slug, base_branch, branch):
-                return _with_pr_metadata(
-                    MergeEvidence(merged=True, source="audit"),
-                    branch,
-                    project_root,
-                    issue_number,
-                )
-        except Exception:
-            return no_merge
-
+    # 3. GitHub's record of the merge. Fast-forward merges at the same tip and
+    # squash merges are both invisible to topology, so they need this and the
+    # issue-commit fallback below.
     merged_pr = (
         _lookup_merged_pr_for_branch(branch, project_root) if issue_number is not None else None
     )
     if merged_pr is not None:
         return merged_pr
+
+    # 4. Loosest signal last: a base commit message referencing the issue. The
+    #    merged-PR lookup above already declined, so there is no PR metadata to
+    #    attach here.
+    if issue_number is not None and _has_base_commit_referencing_issue(
+        project_root,
+        base_branch,
+        issue_number,
+    ):
+        return MergeEvidence(merged=True, source="issue_commit")
+
     return no_merge
 
 
@@ -300,7 +317,7 @@ def _is_branch_merged(
 ) -> bool:
     """Return True if branch has been merged into base_branch.
 
-    Three detection paths handle the merge strategies theforge uses:
+    Detection must cover the merge strategies theforge uses:
 
     1. Regular merge commit (git merge --no-edit fallback):
        --is-ancestor passes AND branch..base_branch count > 0 (base advanced
@@ -315,9 +332,12 @@ def _is_branch_merged(
        The feature branch tip remains an ancestor of base because it was based
        on base, but the squash commit on base is a new commit with no parent
        relationship to the branch. Git topology alone therefore cannot prove
-       the merge. Issue-backed branches first look for a base commit that
-       references the issue, then fall back to the forge APPROVE audit trail
-       when slug is provided.
+       the merge, so the forge APPROVE audit trail (when slug is provided), a
+       merged PR for the branch, and finally a base commit referencing the
+       issue stand in for it.
+
+    See :func:`_branch_merge_evidence` for the order these are consulted in and
+    why GitHub issue state is not part of it.
 
     A branch that was merely created at base HEAD (count == 0, no audit entry)
     correctly returns False.
@@ -596,7 +616,10 @@ def _triage_spec(
         commits_ahead = None
         commits_behind = None
 
-    # 2. Check if already merged to base branch.
+    # 2. Check if already merged to base branch. This must stay ahead of the
+    # stale/empty classification below: a same-tip branch is ambiguous, and
+    # resolving it toward "no work was done" discards a landed story, while
+    # resolving it toward "already merged" at worst repeats a skip (#2111).
     # Pass slug so _is_branch_merged can use the audit trail as a tiebreaker
     # for fast-forward merges where branch and base land on the same commit.
     merge_evidence = _branch_merge_evidence(branch, base_branch, project_root, slug=slug)
@@ -614,10 +637,12 @@ def _triage_spec(
             slug=slug,
         )
 
-    # 3. A branch at the base tip (0 ahead, 0 behind) is stale/empty, not merged.
-    # This can happen when a prior run created the branch/worktree but never
-    # produced story commits. Treat it as full so WORKSPACE recreates it, even
-    # if the old worktree directory has already been removed.
+    # 3. A branch at the base tip (0 ahead, 0 behind) with no merge evidence of
+    # any kind is stale/empty, not merged. This can happen when a prior run
+    # created the branch/worktree but never produced story commits. Treat it as
+    # full so WORKSPACE recreates it, even if the old worktree directory has
+    # already been removed. Step 2 above has already claimed every same-tip
+    # branch backed by audit, PR, or issue-commit evidence.
     if commits_ahead == [] and commits_behind == 0:
         stale_reason = (
             f"branch is at {base_branch} HEAD with 0 commits ahead"

--- a/tests/test_coord_workspace.py
+++ b/tests/test_coord_workspace.py
@@ -1038,6 +1038,8 @@ class TestDeindexRunsOnAllReturnPaths:
         wt_path.mkdir(parents=True, exist_ok=True)
 
         def shell_side_effect(cmd, cwd, **kwargs):
+            if "worktree list --porcelain" in cmd:
+                return (True, f"worktree {wt_path}\nbranch refs/heads/forge/test-task\n")
             if "rev-parse --abbrev-ref HEAD" in cmd:
                 return (True, "forge/test-task")
             if "git log" in cmd and ".." in cmd:
@@ -1090,3 +1092,135 @@ class TestDeindexRunsOnAllReturnPaths:
 
         assert err is None
         mock_deindex.assert_called_once_with(workspace_path, purge=True)
+
+
+# ── Unregistered leftover workspace paths (#2111) ─────────────────────
+
+
+class TestUnregisteredWorkspacePath:
+    """A path git does not register as a worktree is residue, not a checkout.
+
+    Git commands run inside a leftover directory under the managed worktrees
+    root resolve against the *parent* repository, so the staleness probe cannot
+    tell residue from a real worktree. Setup then runs against a directory with
+    no project in it and fails with a confusing error (#2111).
+    """
+
+    def _config_with_setup(self, tmp_path):
+        config = _make_config(tmp_path)
+        return dataclasses.replace(
+            config,
+            workspace=dataclasses.replace(config.workspace, setup_command="pip install -e ."),
+        )
+
+    @patch("theforge.coordinator.workspace._propagate_claude_memory")
+    @patch("theforge.coordinator.workspace._deindex_forge_artifacts")
+    @patch("theforge.coordinator.workspace._run_setup_split")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_forge_only_residue_is_removed_and_recreated(
+        self, mock_log, mock_shell, mock_setup, mock_deindex, mock_memory, tmp_path
+    ):
+        """Forge-owned residue is deleted and the workspace recreated from scratch."""
+        config = self._config_with_setup(tmp_path)
+        task = _make_task(tmp_path)
+
+        wt_path = tmp_path / task.slug
+        (wt_path / ".forge").mkdir(parents=True)
+        (wt_path / ".forge" / "runs.jsonl").write_text("{}\n", encoding="utf-8")
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "worktree list --porcelain" in cmd:
+                # git registers only the project root — the leftover path is
+                # not a worktree.
+                return (True, f"worktree {tmp_path}\nbranch refs/heads/main\n")
+            if cmd.startswith("mkdir -p"):
+                wt_path.mkdir(parents=True, exist_ok=True)
+                return (True, "")
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+        mock_setup.return_value = (True, "")
+
+        workspace_path, branch, err = _create_workspace(config, task, no_pull=True)
+
+        assert err is None
+        assert workspace_path == wt_path
+        assert branch == "forge/test-task"
+        # The residue was cleared before the workspace was recreated.
+        assert not (wt_path / ".forge" / "runs.jsonl").exists()
+        # Setup ran exactly once, on the freshly created workspace.
+        assert mock_setup.call_count == 1
+
+    @patch("theforge.coordinator.workspace._run_setup_split")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_unregistered_path_with_foreign_contents_fails_closed(
+        self, mock_log, mock_shell, mock_setup, tmp_path
+    ):
+        """Residue holding non-Forge contents is preserved and the run fails closed."""
+        config = self._config_with_setup(tmp_path)
+        task = _make_task(tmp_path)
+
+        wt_path = tmp_path / task.slug
+        (wt_path / ".venv").mkdir(parents=True)
+        (wt_path / ".venv" / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "worktree list --porcelain" in cmd:
+                return (True, f"worktree {tmp_path}\nbranch refs/heads/main\n")
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            if "git status --porcelain" in cmd:
+                return (True, "?? .venv/\n")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+
+        workspace_path, branch, err = _create_workspace(config, task, no_pull=True)
+
+        assert workspace_path is None
+        assert branch is None
+        assert err is not None
+        assert "not register it as a worktree" in err
+        # Critically: setup never ran inside the residue directory.
+        mock_setup.assert_not_called()
+        assert (wt_path / ".venv" / "pyvenv.cfg").exists()
+
+    @patch("theforge.coordinator.workspace._propagate_claude_memory")
+    @patch("theforge.coordinator.workspace._deindex_forge_artifacts")
+    @patch("theforge.coordinator.workspace._run_setup_split")
+    @patch("theforge.coordinator.workspace._cu._run_shell")
+    @patch("theforge.coordinator.workspace._cu._log")
+    def test_unreadable_worktree_list_fails_open_to_reuse(
+        self, mock_log, mock_shell, mock_setup, mock_deindex, mock_memory, tmp_path
+    ):
+        """An unreadable `git worktree list` must not delete an existing directory."""
+        config = self._config_with_setup(tmp_path)
+        task = _make_task(tmp_path)
+
+        wt_path = tmp_path / task.slug
+        wt_path.mkdir(parents=True)
+        (wt_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            if "worktree list --porcelain" in cmd:
+                return (False, "fatal: not a git repository")
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return (True, "forge/test-task")
+            if "git log" in cmd and ".." in cmd:
+                return (True, "abc1234 a commit\n")
+            if "rev-list" in cmd:
+                return (True, "0\n")
+            return (True, "")
+
+        mock_shell.side_effect = shell_side_effect
+        mock_setup.return_value = (True, "")
+
+        workspace_path, _, err = _create_workspace(config, task, no_pull=True)
+
+        assert err is None
+        assert workspace_path == wt_path
+        assert (wt_path / "pyproject.toml").exists()

--- a/tests/test_coord_workspace_stale.py
+++ b/tests/test_coord_workspace_stale.py
@@ -443,6 +443,10 @@ class TestStaleWorktree:
         workspace.mkdir()
 
         def shell_side_effect(cmd, cwd, **kwargs):
+            if "worktree list --porcelain" in cmd:
+                # git registers the path, so it is a real worktree and not
+                # leftover residue.
+                return (True, f"worktree {workspace}\nbranch refs/heads/feat/test-task\n")
             if "rev-parse --abbrev-ref HEAD" in cmd:
                 return (True, "feat/test-task")
             if "git status --porcelain" in cmd:

--- a/tests/test_sprint_gate_visibility.py
+++ b/tests/test_sprint_gate_visibility.py
@@ -83,6 +83,11 @@ def _triage_git_mock(commit_line: bytes = b"abc1234 some commit\n"):
         m = MagicMock()
         if "--is-ancestor" in cmd:
             m.returncode = 1  # not merged
+        elif any(isinstance(c, str) and c.startswith("--grep=") for c in cmd):
+            # No base commit references the issue — the branch is unmerged, so
+            # the issue-commit merge-evidence search must come back empty.
+            m.returncode = 0
+            m.stdout = b""
         elif "log" in cmd:
             m.returncode = 0
             m.stdout = commit_line

--- a/tests/test_sprint_reexec_reconcile.py
+++ b/tests/test_sprint_reexec_reconcile.py
@@ -29,6 +29,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.coordinator import audit_substrate
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint import run_sprint
 from theforge.sprint.audit import persist_accumulated_story_state
@@ -797,3 +798,103 @@ def test_cmd_sprint_detached_child_reexec_passes_reexec_true(
     # ...but cmd_sprint captured the signal first, so reexec reached run_sprint.
     mock_run_sprint.assert_called_once()
     assert mock_run_sprint.call_args.kwargs["reexec"] is True
+
+
+def test_reexec_landed_story_with_open_issue_is_not_redispatched(
+    tmp_path: Path,
+) -> None:
+    """#2111: a landed story whose GitHub issue is deliberately held open must
+    still triage as skip_merged and keep its recorded DONE outcome.
+
+    This exercises the real ``_triage_spec`` (not a stubbed StoryTriage) so the
+    whole chain is covered: merge evidence is drawn from the run's own audit
+    trail rather than issue state, the story is pre-marked complete in the DAG,
+    and the scheduler never re-enters it through WORKSPACE where a workspace
+    failure could overwrite its outcome.
+    """
+    _make_spec_file(tmp_path, "Issue 2054", "issue-2054")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["issue-2054.md", "feature-b.md"])
+    config = _make_config(tmp_path)
+
+    sprint_id = _set_sprint_id(tmp_path)
+    _write_prior_sprint_audit(tmp_path, sprint_id, 0.33)
+    persist_accumulated_story_state(
+        sprint_id,
+        "Test Sprint",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "issue-2054.md",
+                "slug": "issue-2054",
+                "path": "issue-2054.md",
+                "outcome": "DONE",
+                "cost_usd": 0.33,
+                "story_run_id": "run-prev",
+                "depends_on": [],
+            }
+        ],
+    )
+
+    # The run's own landed APPROVE record — the evidence it wrote when it merged.
+    audit_substrate.seed_records(
+        tmp_path,
+        [
+            {
+                "run_id": "run-prev",
+                "task": {"slug": "issue-2054"},
+                "landing_status": "landed",
+                "reviews": [{"verdict": "APPROVE"}],
+            }
+        ],
+    )
+
+    def _mock_git(cmd, **kwargs):
+        m = MagicMock()
+        # Patching subprocess.run via the dag module replaces the attribute on
+        # the shared stdlib module, so the runner's own probes land here too.
+        # tmp_path is not a git checkout: keep it that way so no base-branch
+        # pull is attempted.
+        if cmd[:2] == ["git", "rev-parse"]:
+            m.returncode = 128
+            m.stdout = ""
+            m.stderr = "fatal: not a git repository"
+        # Branch is at base HEAD: 0 commits ahead, 0 behind — the ambiguous
+        # same-tip state a squash merge plus rebase leaves behind.
+        elif "log" in cmd:
+            m.returncode = 0
+            m.stdout = b""
+        elif "rev-list" in cmd and "--count" in cmd:
+            m.returncode = 0
+            m.stdout = b"0"
+        elif "--is-ancestor" in cmd:
+            m.returncode = 0
+            m.stdout = b""
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_git),
+        # The symptom bug is held open pending verification after its fix landed.
+        patch("theforge.sprint.dag._is_issue_closed", return_value=False),
+        patch(
+            "theforge.sprint.runner.run_batch_preflight", return_value={}
+        ) as mock_batch_preflight,
+        patch("theforge.sprint.runner.run_task", return_value=fresh_result) as mock_run_task,
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        result = run_sprint(config, manifest_path, reexec=True)
+
+    preflight_slugs = [t.slug for t in mock_batch_preflight.call_args.args[0]]
+    assert preflight_slugs == ["feature-b"]
+
+    dispatched_slugs = [c.args[1].slug for c in mock_run_task.call_args_list]
+    assert dispatched_slugs == ["feature-b"]
+
+    assert result.specs_succeeded == 2
+    assert result.specs_failed == 0
+    assert result.total_cost_usd == pytest.approx(1.33)

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -544,8 +544,13 @@ class TestReadPriorSprintCost:
         assert triage.action == "skip_merged"
         assert "merged" in triage.reason
 
-    def test_triage_open_issue_with_landed_audit_stays_full(self, tmp_path: Path) -> None:
-        """An open issue is contradictory evidence and must not be skipped as merged."""
+    def test_triage_open_issue_with_landed_audit_skips_merged(self, tmp_path: Path) -> None:
+        """A landed audit record wins over an open issue (#2111).
+
+        Symptom bugs are held open pending verification after their fix merges,
+        so an open issue is no longer contradictory evidence — the run's own
+        landed APPROVE record is what establishes the merge.
+        """
 
         _make_spec_file(tmp_path, "Issue 1071", "issue-1071")
         config = _make_config(tmp_path)
@@ -582,8 +587,79 @@ class TestReadPriorSprintCost:
         ):
             triage = _triage_spec("issue-1071.md", config, tmp_path)
 
-        assert triage.action == "full"
-        assert triage.reason == "branch is at main HEAD with 0 commits ahead"
+        assert triage.action == "skip_merged"
+        assert "audit trail" in triage.reason
+
+    def test_triage_open_issue_with_base_commit_reference_skips_merged(
+        self, tmp_path: Path
+    ) -> None:
+        """A base commit referencing the open issue is enough to skip (#2111)."""
+
+        _make_spec_file(tmp_path, "Issue 1072", "issue-1072")
+        config = _make_config(tmp_path)
+
+        def _mock_run(cmd, **kwargs):
+            m = MagicMock()
+            if cmd[:2] == ["git", "log"] and "--grep=(#1072)" in cmd:
+                m.returncode = 0
+                m.stdout = b"abc123\n"
+            elif "log" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            elif "rev-list" in cmd and "--count" in cmd:
+                m.returncode = 0
+                m.stdout = b"0"
+            elif "--is-ancestor" in cmd:
+                m.returncode = 1
+                m.stdout = b""
+            else:
+                m.returncode = 0
+                m.stdout = b""
+            return m
+
+        with (
+            patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run),
+            patch("theforge.sprint.dag._is_issue_closed", return_value=False),
+            patch("theforge.sprint.dag.has_review_approve", return_value=False),
+        ):
+            triage = _triage_spec("issue-1072.md", config, tmp_path)
+
+        assert triage.action == "skip_merged"
+        assert triage.reason == "already merged to main"
+
+    def test_triage_open_issue_with_topology_merge_skips_merged(self, tmp_path: Path) -> None:
+        """A topologically merged branch skips even while its issue is open (#2111)."""
+
+        _make_spec_file(tmp_path, "Issue 1073", "issue-1073")
+        config = _make_config(tmp_path)
+
+        def _mock_run(cmd, **kwargs):
+            m = MagicMock()
+            if "--is-ancestor" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            elif "rev-list" in cmd and "--count" in cmd:
+                # Both directions non-zero: base advanced past a branch that had
+                # unique work of its own.
+                m.returncode = 0
+                m.stdout = b"2"
+            elif "log" in cmd:
+                m.returncode = 0
+                m.stdout = b""
+            else:
+                m.returncode = 0
+                m.stdout = b""
+            return m
+
+        with (
+            patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run),
+            patch("theforge.sprint.dag._is_issue_closed", return_value=False),
+            patch("theforge.sprint.dag.has_review_approve", return_value=False),
+        ):
+            triage = _triage_spec("issue-1073.md", config, tmp_path)
+
+        assert triage.action == "skip_merged"
+        assert triage.reason == "already merged to main"
 
     def test_triage_worktree_with_prior_approve(self, tmp_path: Path) -> None:
         """Worktree has commits ahead and prior APPROVE in audit trail → skip."""

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -27,6 +27,7 @@ from theforge.config.types import IntakeConfig
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint.dag import (
     StoryDAG,
+    _branch_merge_evidence,
     _is_branch_merged,
     build_dag,
     resolve_satisfied_dependencies,
@@ -756,8 +757,12 @@ def test_is_branch_merged_issue_branch_without_base_commit_or_audit(tmp_path: Pa
     assert result is False
 
 
-def test_is_branch_merged_issue_branch_open_issue_blocks_merge_evidence(tmp_path: Path) -> None:
-    """Open GitHub issues stay eligible even when audit or git hints look merged."""
+def test_is_branch_merged_open_issue_does_not_block_merge_evidence(tmp_path: Path) -> None:
+    """An open GitHub issue no longer suppresses merge evidence (#2111).
+
+    Symptom bugs are deliberately held open pending verification after their fix
+    lands, so issue state is not a precondition for detecting the merge.
+    """
 
     def _mock_external_squash(cmd: list[str], **kwargs: object) -> MagicMock:
         m = MagicMock()
@@ -775,9 +780,81 @@ def test_is_branch_merged_issue_branch_open_issue_blocks_merge_evidence(tmp_path
     with (
         patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_squash),
         patch("theforge.sprint.dag._is_issue_closed", return_value=False),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
     ):
         result = _is_branch_merged("feat/issue-265", "main", tmp_path, slug="issue-265")
-    assert result is False
+    assert result is True
+
+
+def test_branch_merge_evidence_never_consults_issue_state(tmp_path: Path) -> None:
+    """Issue state is not a gate on branch merge detection at all (#2111)."""
+
+    def _mock_no_evidence(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        m.returncode = 1
+        m.stdout = b""
+        return m
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_no_evidence),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+        patch("theforge.sprint.dag._is_issue_closed") as is_issue_closed,
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+
+    assert evidence.merged is False
+    is_issue_closed.assert_not_called()
+
+
+def test_branch_merge_evidence_prefers_owned_audit_over_issue_commit(tmp_path: Path) -> None:
+    """Owned audit evidence is consulted before the loose issue-commit grep."""
+
+    grepped: list[list[str]] = []
+
+    def _mock_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if cmd[:2] == ["git", "log"] and any(c.startswith("--grep=") for c in cmd):
+            grepped.append(cmd)
+        m.returncode = 1
+        m.stdout = b""
+        return m
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run),
+        patch("theforge.sprint.dag.has_review_approve", return_value=True),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+
+    assert evidence.merged is True
+    assert evidence.source == "audit"
+    assert grepped == []
+
+
+def test_branch_merge_evidence_audit_error_falls_through_to_pr_lookup(tmp_path: Path) -> None:
+    """A transient audit-read failure must not discard the merged-PR fallback."""
+
+    def _mock_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if cmd[:3] == ["gh", "pr", "list"]:
+            m.returncode = 0
+            m.stdout = (
+                '[{"number":1111,"url":"https://github.com/o/r/pull/1111",'
+                '"mergedAt":"2026-05-01T12:34:56Z"}]'
+            )
+        else:
+            m.returncode = 1
+            m.stdout = b""
+        return m
+
+    with (
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run),
+        patch("theforge.sprint.dag.has_review_approve", side_effect=OSError("audit unreadable")),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+
+    assert evidence.merged is True
+    assert evidence.source == "github_pr"
+    assert evidence.pr_number == 1111
 
 
 def test_run_sprint_summary_records_run_log(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] Merge detection now uses owned merge evidence before stale classification, and the targeted regressions pass. | [google-gemini-3.5-flash] Approved: Merge detection is successfully decoupled from issue closure state, and workspace reuse is safely guarded against unregistered worktrees.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $19.45
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Merge detection is gated on the issue being closed, so a landed story is re-triaged as stale and its recorded outcome overwritten (GitHub Issue #2111)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2111