### PR TITLE
The orphan reaper kills a process group by a recycled id without verifying identity, so forge status can signal an unrelated process

### DIFF
--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -446,6 +446,19 @@ def _resolve_watch_run_ids(active_run_ids: list[str], project_root: Path) -> lis
     return watch_ids
 
 
+def _report_orphan_agents(orphans: list[dict]) -> None:
+    """Print orphaned agent process groups; kill nothing (#2115)."""
+    if not orphans:
+        return
+    print(f"[forge] {len(orphans)} orphaned agent process group record(s):")
+    for record in orphans:
+        print(
+            f"  pgid={record.get('pgid')} owner sprint pid={record.get('owner_pid')} "
+            f"(dead) run={record.get('run_id')} sandbox={record.get('sandbox_dir')}"
+        )
+    print("[forge] These are reaped by `forge stop` or the next sprint launch.")
+
+
 def cmd_status(args: object) -> int:
     """Show active forge runs and pending decisions."""
     from theforge import pending as _pending
@@ -457,11 +470,14 @@ def cmd_status(args: object) -> int:
     config = load_config(config_path)
     project_root = config.project_root
 
-    # Reap agent process groups orphaned by an abruptly-killed sprint. Natural
-    # adjacency to list_active_runs, which already prunes stale PID files.
+    # Report — never signal — agent process groups orphaned by an abruptly-killed
+    # sprint. Reaping here made a read-only inspection command send group SIGKILLs
+    # as a side effect of being run, which is how unrelated processes came to be
+    # killed off recycled pgids (#2115). `forge stop` and sprint startup, both of
+    # which already mutate run state, own the actual reap.
     from theforge import process_group as _process_group
 
-    _process_group.reap_orphan_agents(project_root)
+    _report_orphan_agents(_process_group.list_orphan_agents(project_root))
 
     recent = getattr(args, "recent", False)
     last = getattr(args, "last", False)

--- a/src/theforge/coordinator/util.py
+++ b/src/theforge/coordinator/util.py
@@ -22,6 +22,7 @@ from theforge.process_group import (
     KILL_GRACE_SECONDS,
     is_killable_pgid,
     register_agent_group,
+    retain_group_record,
     unregister_agent_group,
 )
 from theforge.workspace_env import build_workspace_env
@@ -449,8 +450,16 @@ def _run_shell_detailed(
         # teardown that reached at most the direct child leaves grandchildren
         # running, and the sidecar is the only handle a later reaper has on
         # them — erasing it would strand them permanently (#2013).
-        if pgid is not None and group_gone:
-            unregister_agent_group(pgid)
+        if pgid is not None:
+            if group_gone:
+                unregister_agent_group(pgid)
+            else:
+                # Survivors: snapshot who is still in the group while we still
+                # know the group is ours. Once the shell (the group leader) is
+                # gone, that snapshot is the only thing that distinguishes these
+                # descendants from an unrelated group holding a recycled pgid,
+                # and a reaper with no such evidence declines to signal (#2115).
+                retain_group_record(pgid)
         if owns_streams:
             for stream_name in ("stdout", "stderr"):
                 stream = getattr(proc, stream_name, None)

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -12,9 +12,12 @@ Two mechanisms cooperate:
    the direct child.
 2. **Orphan reaper** (`reap_orphan_agents`) — synchronous group-kill cannot run
    when the parent sprint is ``SIGKILL``-ed, so each spawned group records its
-   pgid + owner pid in a sidecar under ``.forge/runs/agents/``. A later ``forge``
-   invocation (status/stop/sprint-startup) sweeps those sidecars and ``killpg``-s
-   any group whose owner sprint is no longer alive.
+   pgid + owner pid in a sidecar under ``.forge/runs/agents/``. A later
+   *mutating* ``forge`` invocation (stop / sprint-startup) sweeps those sidecars
+   and ``killpg``-s any group whose owner sprint is no longer alive **and whose
+   recorded identity still matches the group presently holding that pgid**
+   (`reap_orphan_agents`). ``forge status`` only reports them (`list_orphan_agents`) —
+   a command whose job is to describe state must not signal processes (#2115).
 
 Stdlib-only by design (convention 4) so it can be imported by both the runners
 and the CLI without pulling in heavier dependencies.
@@ -26,6 +29,7 @@ import json
 import os
 import signal
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -282,6 +286,86 @@ def _sidecar_path(agents_dir: Path, owner_pid: int, pgid: int) -> Path:
     return agents_dir / f"{owner_pid}-{pgid}.json"
 
 
+def _running_under_pytest() -> bool:
+    """True when this process is a test run rather than a dispatched agent.
+
+    Sidecars written by the suite are otherwise indistinguishable from ones
+    describing real work, and they land in whatever ``FORGE_PROJECT_ROOT`` the
+    test process inherited — in the dogfood setup, the *real* project (#2115).
+    """
+    return bool(os.environ.get("PYTEST_CURRENT_TEST")) or "pytest" in sys.modules
+
+
+def _start_time_from_proc(pid: int) -> str | None:
+    """Linux: field 22 of ``/proc/<pid>/stat`` — start time in jiffies since boot."""
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    # comm (field 2) is parenthesised and may itself contain spaces, so split
+    # after the final ')' rather than tokenising the whole line.
+    _, _, rest = raw.rpartition(")")
+    fields = rest.split()
+    # rest starts at field 3 (state), so starttime (field 22) is index 19.
+    if len(fields) < 20:
+        return None
+    return f"proc:{fields[19]}"
+
+
+def _start_time_from_sysctl(pid: int) -> str | None:
+    """macOS/BSD: ``kinfo_proc.kp_proc.p_starttime`` via ``sysctl``.
+
+    ``extern_proc`` opens with a union whose other arm is ``p_starttime``, so the
+    ``timeval`` sits at offset 0 of the returned record. Microsecond resolution
+    makes it a far sharper identity than ``ps``'s second-granularity ``lstart``.
+    """
+    import ctypes  # noqa: PLC0415
+
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        # CTL_KERN, KERN_PROC, KERN_PROC_PID, <pid>
+        mib = (ctypes.c_int * 4)(1, 14, 1, pid)
+        buf = ctypes.create_string_buffer(4096)
+        size = ctypes.c_size_t(len(buf))
+        if libc.sysctl(mib, 4, buf, ctypes.byref(size), None, 0) != 0:
+            return None
+        if size.value < ctypes.sizeof(ctypes.c_long) + ctypes.sizeof(ctypes.c_int):
+            return None
+        seconds = ctypes.cast(buf, ctypes.POINTER(ctypes.c_long))[0]
+        micros = ctypes.cast(buf, ctypes.POINTER(ctypes.c_int))[2]
+    except (OSError, ValueError, AttributeError):
+        return None
+    return f"sysctl:{seconds}.{micros:06d}"
+
+
+def _leader_fingerprint(pgid: int) -> str | None:
+    """Start-time fingerprint of the process leading *pgid*, or None.
+
+    The pgid of a group spawned with ``start_new_session=True`` *is* its leader's
+    pid, so the leader's start time is a property a recycled pgid cannot
+    reproduce — the evidence the reaper needs before signalling anything (#2115).
+
+    Read from the kernel directly — ``/proc`` on Linux, ``sysctl`` on macOS — so
+    that taking a fingerprint costs no process spawn: this sits in the path of
+    every agent and gate launch, and ``ps`` is an exec that a sandbox profile can
+    deny outright. ``ps`` remains only as the fallback for a platform with
+    neither interface. Each value carries its source, so a record written from
+    one source is never compared against another (a mismatch there would read as
+    "recycled" and, correctly, kill nothing).
+    """
+    from theforge.detach import _is_pid_alive  # noqa: PLC0415
+    from theforge.pid import _pid_start_time  # noqa: PLC0415
+
+    if not is_killable_pgid(pgid) or not _is_pid_alive(pgid):
+        return None
+    if sys.platform.startswith("linux"):
+        return _start_time_from_proc(pgid)
+    if sys.platform == "darwin":
+        return _start_time_from_sysctl(pgid)
+    started = _pid_start_time(pgid)
+    return None if started is None else f"ps:{started}"
+
+
 def register_agent_group(pgid: int, *, sandbox_dir: str | Path | None = None) -> None:
     """Record a spawned agent group's pgid so a later reaper can kill orphans.
 
@@ -289,6 +373,11 @@ def register_agent_group(pgid: int, *, sandbox_dir: str | Path | None = None) ->
     runs dir, where ``owner_pid`` is the sprint process (``os.getpid()``). Per-pgid
     files avoid write contention from parallel review pools. No-op when the runs
     dir is unresolvable (e.g. ``FORGE_PROJECT_ROOT`` unset in tests).
+
+    Two fields exist purely so a later sweep can decide whether the record is
+    still safe to act on: ``leader_fingerprint`` — the group leader's start time,
+    the evidence that the group holding this pgid at reap time is the group
+    registered here — and ``origin``, which marks records left by a test run.
     """
     agents_dir = _agents_dir_from_env()
     if agents_dir is None:
@@ -299,6 +388,8 @@ def register_agent_group(pgid: int, *, sandbox_dir: str | Path | None = None) ->
         "pgid": pgid,
         "run_id": os.environ.get(_RUN_ID_ENV),
         "sandbox_dir": str(sandbox_dir) if sandbox_dir is not None else None,
+        "leader_fingerprint": _leader_fingerprint(pgid),
+        "origin": "test" if _running_under_pytest() else "agent",
     }
     try:
         agents_dir.mkdir(parents=True, exist_ok=True)
@@ -370,14 +461,117 @@ def kill_agent_group(pgid: int) -> bool:
 # ── Orphan reaper ────────────────────────────────────────────────────
 
 
+def _group_exists(pgid: int) -> bool:
+    """True only when *pgid* is provably a live group we may signal.
+
+    The strict twin of `group_is_alive`, which errs toward "alive" so a record is
+    never dropped while it might still be the only handle on a survivor. Here the
+    question is the opposite one — may we *signal* this group — so an
+    unanswerable probe (EPERM: a group we do not own, which after pgid reuse is
+    exactly the group we must not touch) counts as "no".
+    """
+    if not is_killable_pgid(pgid):
+        return False
+    try:
+        os.killpg(pgid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _identity_verdict(pgid: object, fingerprint: object) -> tuple[bool, str]:
+    """Decide whether *pgid* still denotes the registered group; (may_signal, why).
+
+    Process-group ids are recycled by the OS, so a persisted pgid is a claim
+    about a past moment, not a durable handle. Sending a group ``SIGKILL`` on
+    that claim alone is how a routine sweep came to signal unrelated processes
+    (#2115): the cost of not killing a stale group is one lingering process, and
+    the cost of killing the wrong one is unbounded and lands outside this tool.
+    So a signal requires positive evidence, in one of two forms:
+
+    * **The leader is alive** — then its start time must equal the one recorded
+      at registration. A recycled pgid cannot reproduce that. No recorded
+      fingerprint, or no readable current one, means no evidence: discard.
+    * **The leader has exited but the group is non-empty** — the case the reaper
+      exists for (npm→node→leaf grandchildren outliving a refused teardown,
+      #2013). This is safe without a fingerprint because both Linux and XNU
+      refuse to hand out a pid that is still in use as a process-group id, so a
+      group that has never been empty since registration cannot have been
+      re-created under the same id by anyone else.
+
+    Anything else — an empty group, a group we may not signal — is discarded.
+    """
+    from theforge.detach import _is_pid_alive  # noqa: PLC0415
+
+    if not isinstance(pgid, int) or not is_killable_pgid(pgid):
+        return False, "pgid cannot denote a real process group"
+    if _is_pid_alive(pgid):
+        if not isinstance(fingerprint, str) or not fingerprint:
+            return False, "record carries no leader fingerprint to check the holder against"
+        current = _leader_fingerprint(pgid)
+        if current is None:
+            return False, "the current holder's start time could not be read"
+        if current != fingerprint:
+            return False, (
+                f"pgid is now held by a different process (started {current!r}, "
+                f"record was written for one started {fingerprint!r})"
+            )
+        return True, "the leader's start time still matches the record"
+    if _group_exists(pgid):
+        return True, "the leader exited but the group is non-empty, so the pgid cannot be reused"
+    return False, "no live process group holds this pgid"
+
+
+def _load_sidecar(sidecar: Path) -> dict[str, Any] | None:
+    """Parsed sidecar with a usable owner_pid/pgid pair, or None if unusable."""
+    try:
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not isinstance(data.get("owner_pid"), int) or not isinstance(data.get("pgid"), int):
+        return None
+    return data
+
+
+def list_orphan_agents(project_root: Path) -> list[dict[str, Any]]:
+    """Sidecars whose owner sprint is dead, without touching anything.
+
+    Read-only by contract: no signals, no unlinks. This is what an inspection
+    command such as ``forge status`` may call; killing is reserved for the
+    commands that already mutate run state (#2115).
+    """
+    from theforge.detach import _is_pid_alive  # noqa: PLC0415
+
+    agents_dir = project_root / ".forge" / "runs" / "agents"
+    if not agents_dir.exists():
+        return []
+    orphans: list[dict[str, Any]] = []
+    for sidecar in sorted(agents_dir.glob("*.json")):
+        data = _load_sidecar(sidecar)
+        if data is None:
+            continue
+        if _is_pid_alive(data["owner_pid"]):
+            continue
+        orphans.append(data)
+    return orphans
+
+
 def reap_orphan_agents(project_root: Path) -> int:
     """Kill agent groups whose owner sprint is dead; return the count reaped.
 
-    Sweeps ``.forge/runs/agents/*.json``. For each sidecar whose ``owner_pid`` is
-    no longer alive, ``killpg`` the recorded group, unlink the sidecar, and log the
-    reaped sandbox path loudly. Groups whose owner is still alive are left intact.
-    This is the guaranteed path for the abrupt-``SIGKILL`` case, where the
-    synchronous group kill in `run_in_process_group` never got to run.
+    Sweeps ``.forge/runs/agents/*.json``. A sidecar is acted on only when its
+    ``owner_pid`` is no longer alive *and* the group presently holding the
+    recorded pgid can still be shown to be the registered one (see
+    `_identity_verdict`); otherwise the record is discarded unsignalled, with the
+    reason logged. Groups whose owner is still alive are left intact — the sprint's
+    own teardown owns them. This is the guaranteed path for the
+    abrupt-``SIGKILL`` case, where the synchronous group kill in
+    `run_in_process_group` never got to run.
+
+    Mutating by design, so only mutating commands (``forge stop``, sprint
+    startup) may call it; ``forge status`` uses `list_orphan_agents` instead.
     """
     from theforge.detach import _is_pid_alive  # noqa: PLC0415
 
@@ -387,27 +581,44 @@ def reap_orphan_agents(project_root: Path) -> int:
 
     reaped = 0
     for sidecar in sorted(agents_dir.glob("*.json")):
-        try:
-            data = json.loads(sidecar.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            # Corrupt/unreadable sidecar — drop it so it doesn't linger forever.
+        data = _load_sidecar(sidecar)
+        if data is None:
+            # Corrupt/unusable sidecar — drop it so it doesn't linger forever.
             _unlink(sidecar)
             continue
 
-        owner_pid = data.get("owner_pid")
-        pgid = data.get("pgid")
-        if not isinstance(owner_pid, int) or not isinstance(pgid, int):
-            _unlink(sidecar)
-            continue
+        owner_pid = data["owner_pid"]
+        pgid = data["pgid"]
 
         if _is_pid_alive(owner_pid):
             # Sprint still running — its own teardown owns this group.
             continue
 
         sandbox = data.get("sandbox_dir")
+        # A record the suite left behind describes a test subprocess that exited
+        # long ago, not a dispatched agent. Only a test run may act on one; for an
+        # operator's sweep it is noise pointing at a recyclable pgid (#2115).
+        if data.get("origin") == "test" and not _running_under_pytest():
+            _log(
+                f"  discarding test-origin agent sidecar pgid={pgid} unsignalled "
+                f"(owner pid={owner_pid} is dead, sandbox={sandbox})"
+            )
+            _unlink(sidecar)
+            continue
+
+        may_signal, reason = _identity_verdict(pgid, data.get("leader_fingerprint"))
+        if not may_signal:
+            _log(
+                f"  discarding stale agent sidecar pgid={pgid} unsignalled: {reason} "
+                f"(owner sprint pid={owner_pid} is dead, sandbox={sandbox})"
+            )
+            _unlink(sidecar)
+            continue
+
         _log(
             f"  reaping orphaned agent process group pgid={pgid} "
-            f"(owner sprint pid={owner_pid} is dead, sandbox={sandbox})"
+            f"(owner sprint pid={owner_pid} is dead, sandbox={sandbox}, "
+            f"identity: {reason})"
         )
         kill_agent_group(pgid)
         _unlink(sidecar)

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -19,6 +19,13 @@ Two mechanisms cooperate:
    (`reap_orphan_agents`). ``forge status`` only reports them (`list_orphan_agents`) —
    a command whose job is to describe state must not signal processes (#2115).
 
+Identity is a start time, never an id. Pids and pgids are recycled, so a record
+naming one describes a past moment; acting on it later takes evidence the moment
+still holds. A sidecar therefore carries the leader's start time at registration,
+and — when a teardown leaves survivors — a snapshot of the group's members taken
+while the group was still known to be ours (`retain_group_record`). A sweep that
+can match neither declines to signal and drops the record.
+
 Stdlib-only by design (convention 4) so it can be imported by both the runners
 and the CLI without pulling in heavier dependencies.
 """
@@ -28,6 +35,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import struct
 import subprocess
 import sys
 from pathlib import Path
@@ -168,6 +176,9 @@ def release_group_record(pgid: int, *, group_killed: bool) -> None:
             f"  ⚠ keeping agent sidecar for pgid={pgid}: teardown reached only the "
             "direct child and the group is still alive"
         )
+        # Capture the survivors now, while we still know this group is ours — it
+        # is the only identity a later sweep can check once the leader is gone.
+        retain_group_record(pgid)
         return
     unregister_agent_group(pgid)
 
@@ -296,46 +307,94 @@ def _running_under_pytest() -> bool:
     return bool(os.environ.get("PYTEST_CURRENT_TEST")) or "pytest" in sys.modules
 
 
-def _start_time_from_proc(pid: int) -> str | None:
-    """Linux: field 22 of ``/proc/<pid>/stat`` — start time in jiffies since boot."""
-    try:
-        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return None
+def _parse_proc_stat(raw: str) -> tuple[int, str] | None:
+    """Linux ``/proc/<pid>/stat`` → (process-group id, start-time fingerprint)."""
     # comm (field 2) is parenthesised and may itself contain spaces, so split
     # after the final ')' rather than tokenising the whole line.
     _, _, rest = raw.rpartition(")")
     fields = rest.split()
-    # rest starts at field 3 (state), so starttime (field 22) is index 19.
+    # rest starts at field 3 (state), so pgrp (field 5) is index 2 and starttime
+    # (field 22) is index 19.
     if len(fields) < 20:
         return None
-    return f"proc:{fields[19]}"
+    try:
+        pgrp = int(fields[2])
+    except ValueError:
+        return None
+    return pgrp, f"proc:{fields[19]}"
 
 
-def _start_time_from_sysctl(pid: int) -> str | None:
-    """macOS/BSD: ``kinfo_proc.kp_proc.p_starttime`` via ``sysctl``.
+def _read_proc_stat(pid: int) -> tuple[int, str] | None:
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    return _parse_proc_stat(raw)
 
-    ``extern_proc`` opens with a union whose other arm is ``p_starttime``, so the
-    ``timeval`` sits at offset 0 of the returned record. Microsecond resolution
-    makes it a far sharper identity than ``ps``'s second-granularity ``lstart``.
-    """
+
+# ``sysctl`` MIB pieces and the two offsets this module reads out of the
+# ``struct extern_proc`` that opens every ``kinfo_proc``: its leading union's
+# other arm is ``p_starttime``, so the ``timeval`` sits at offset 0, and
+# ``p_pid`` follows p_vmspace/p_sigacts/p_flag/p_stat at offset 40 on the 64-bit
+# Darwin ABI. Microsecond resolution makes this a far sharper identity than
+# ``ps``'s second-granularity ``lstart``.
+_CTL_KERN = 1
+_KERN_PROC = 14
+_KERN_PROC_PID = 1
+_KERN_PROC_PGRP = 2
+_KINFO_PID_OFFSET = 40
+
+
+def _sysctl_bytes(mib_values: tuple[int, ...]) -> bytes | None:
+    """Raw ``sysctl`` result for *mib_values*, or None if it cannot be read."""
     import ctypes  # noqa: PLC0415
 
     try:
         libc = ctypes.CDLL(None, use_errno=True)
-        # CTL_KERN, KERN_PROC, KERN_PROC_PID, <pid>
-        mib = (ctypes.c_int * 4)(1, 14, 1, pid)
-        buf = ctypes.create_string_buffer(4096)
+        mib = (ctypes.c_int * len(mib_values))(*mib_values)
+        size = ctypes.c_size_t(0)
+        if libc.sysctl(mib, len(mib_values), None, ctypes.byref(size), None, 0) != 0:
+            return None
+        if size.value == 0:
+            return b""
+        # Slack, because the process table can grow between the sizing call and
+        # the read; without it a busy moment returns ENOMEM instead of an answer.
+        buf = ctypes.create_string_buffer(size.value + 8192)
         size = ctypes.c_size_t(len(buf))
-        if libc.sysctl(mib, 4, buf, ctypes.byref(size), None, 0) != 0:
+        if libc.sysctl(mib, len(mib_values), buf, ctypes.byref(size), None, 0) != 0:
             return None
-        if size.value < ctypes.sizeof(ctypes.c_long) + ctypes.sizeof(ctypes.c_int):
-            return None
-        seconds = ctypes.cast(buf, ctypes.POINTER(ctypes.c_long))[0]
-        micros = ctypes.cast(buf, ctypes.POINTER(ctypes.c_int))[2]
+        return buf.raw[: size.value]
     except (OSError, ValueError, AttributeError):
         return None
+
+
+def _kinfo_start_time(raw: bytes, offset: int) -> str | None:
+    try:
+        seconds, micros = struct.unpack_from("qi", raw, offset)
+    except struct.error:
+        return None
     return f"sysctl:{seconds}.{micros:06d}"
+
+
+def _kinfo_pid(raw: bytes, offset: int) -> int | None:
+    try:
+        return int(struct.unpack_from("i", raw, offset + _KINFO_PID_OFFSET)[0])
+    except struct.error:
+        return None
+
+
+def _sysctl_record_size() -> int:
+    """Size of one ``kinfo_proc``, taken from a query that returns exactly one."""
+    raw = _sysctl_bytes((_CTL_KERN, _KERN_PROC, _KERN_PROC_PID, os.getpid()))
+    return 0 if raw is None else len(raw)
+
+
+def _start_time_from_sysctl(pid: int) -> str | None:
+    """macOS/BSD: ``kinfo_proc.kp_proc.p_starttime`` for a single pid."""
+    raw = _sysctl_bytes((_CTL_KERN, _KERN_PROC, _KERN_PROC_PID, pid))
+    if not raw:
+        return None
+    return _kinfo_start_time(raw, 0)
 
 
 def _leader_fingerprint(pgid: int) -> str | None:
@@ -359,11 +418,58 @@ def _leader_fingerprint(pgid: int) -> str | None:
     if not is_killable_pgid(pgid) or not _is_pid_alive(pgid):
         return None
     if sys.platform.startswith("linux"):
-        return _start_time_from_proc(pgid)
+        parsed = _read_proc_stat(pgid)
+        return None if parsed is None else parsed[1]
     if sys.platform == "darwin":
         return _start_time_from_sysctl(pgid)
     started = _pid_start_time(pgid)
     return None if started is None else f"ps:{started}"
+
+
+def group_members(pgid: int) -> dict[int, str]:
+    """``{pid: start-time fingerprint}`` for every live process in *pgid*.
+
+    Membership is the only identity a process group has once its leader is gone:
+    the leader's pid — and with it the pgid — is reusable the moment the group
+    empties, so "some group with this id exists" proves nothing about *which*
+    group it is (#2115). A recorded member that is still alive with the same
+    start time does prove it.
+
+    Empty when the platform offers no way to enumerate a group without spawning
+    ``ps``. That is a deliberate dead end rather than a fallback: it makes the
+    reaper decline to signal leaderless groups on such a platform, which is the
+    safe direction.
+    """
+    if not is_killable_pgid(pgid):
+        return {}
+    if sys.platform.startswith("linux"):
+        members: dict[int, str] = {}
+        try:
+            entries = os.listdir("/proc")
+        except OSError:
+            return {}
+        for entry in entries:
+            if not entry.isdigit():
+                continue
+            parsed = _read_proc_stat(int(entry))
+            if parsed is not None and parsed[0] == pgid:
+                members[int(entry)] = parsed[1]
+        return members
+    if sys.platform == "darwin":
+        record_size = _sysctl_record_size()
+        if record_size <= _KINFO_PID_OFFSET:
+            return {}
+        raw = _sysctl_bytes((_CTL_KERN, _KERN_PROC, _KERN_PROC_PGRP, pgid))
+        if not raw:
+            return {}
+        found: dict[int, str] = {}
+        for offset in range(0, len(raw) - record_size + 1, record_size):
+            pid = _kinfo_pid(raw, offset)
+            fingerprint = _kinfo_start_time(raw, offset)
+            if pid is not None and fingerprint is not None:
+                found[pid] = fingerprint
+        return found
+    return {}
 
 
 def register_agent_group(pgid: int, *, sandbox_dir: str | Path | None = None) -> None:
@@ -396,6 +502,38 @@ def register_agent_group(pgid: int, *, sandbox_dir: str | Path | None = None) ->
         _sidecar_path(agents_dir, owner_pid, pgid).write_text(
             json.dumps(payload), encoding="utf-8"
         )
+    except OSError:
+        pass
+
+
+def retain_group_record(pgid: int) -> None:
+    """Snapshot the group's live membership into its sidecar, for a kept record.
+
+    Called at the one moment a record is deliberately kept: teardown reached at
+    most the direct child, so the leader is dying while its descendants run on.
+    From then on the leader's start time is unverifiable — it will be gone — and
+    the survivors are the only identity the group has left. Recording them is
+    what lets a later sweep tell "the registered group, minus its leader" from
+    "an unrelated group that happens to hold a recycled pgid and whose own
+    leader has also exited" (#2115). Without it the sweep can only decline.
+    """
+    agents_dir = _agents_dir_from_env()
+    if agents_dir is None:
+        return
+    members = group_members(pgid)
+    if not members:
+        return
+    path = _sidecar_path(agents_dir, os.getpid(), pgid)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(data, dict):
+        return
+    # JSON object keys are strings; the reaper converts back on read.
+    data["members"] = {str(pid): fingerprint for pid, fingerprint in members.items()}
+    try:
+        path.write_text(json.dumps(data), encoding="utf-8")
     except OSError:
         pass
 
@@ -461,25 +599,23 @@ def kill_agent_group(pgid: int) -> bool:
 # ── Orphan reaper ────────────────────────────────────────────────────
 
 
-def _group_exists(pgid: int) -> bool:
-    """True only when *pgid* is provably a live group we may signal.
-
-    The strict twin of `group_is_alive`, which errs toward "alive" so a record is
-    never dropped while it might still be the only handle on a survivor. Here the
-    question is the opposite one — may we *signal* this group — so an
-    unanswerable probe (EPERM: a group we do not own, which after pgid reuse is
-    exactly the group we must not touch) counts as "no".
-    """
-    if not is_killable_pgid(pgid):
-        return False
-    try:
-        os.killpg(pgid, 0)
-    except OSError:
-        return False
-    return True
+def _recorded_members(data: dict[str, Any]) -> dict[int, str]:
+    """The ``members`` snapshot from a sidecar, as ``{pid: fingerprint}``."""
+    raw = data.get("members")
+    if not isinstance(raw, dict):
+        return {}
+    members: dict[int, str] = {}
+    for pid, fingerprint in raw.items():
+        try:
+            key = int(pid)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(fingerprint, str) and fingerprint:
+            members[key] = fingerprint
+    return members
 
 
-def _identity_verdict(pgid: object, fingerprint: object) -> tuple[bool, str]:
+def _identity_verdict(pgid: object, data: dict[str, Any]) -> tuple[bool, str]:
     """Decide whether *pgid* still denotes the registered group; (may_signal, why).
 
     Process-group ids are recycled by the OS, so a persisted pgid is a claim
@@ -487,24 +623,29 @@ def _identity_verdict(pgid: object, fingerprint: object) -> tuple[bool, str]:
     that claim alone is how a routine sweep came to signal unrelated processes
     (#2115): the cost of not killing a stale group is one lingering process, and
     the cost of killing the wrong one is unbounded and lands outside this tool.
-    So a signal requires positive evidence, in one of two forms:
+    So a signal requires a live process whose *start time* matches something this
+    record captured while the group was known to be ours — one of:
 
-    * **The leader is alive** — then its start time must equal the one recorded
-      at registration. A recycled pgid cannot reproduce that. No recorded
-      fingerprint, or no readable current one, means no evidence: discard.
-    * **The leader has exited but the group is non-empty** — the case the reaper
-      exists for (npm→node→leaf grandchildren outliving a refused teardown,
-      #2013). This is safe without a fingerprint because both Linux and XNU
-      refuse to hand out a pid that is still in use as a process-group id, so a
-      group that has never been empty since registration cannot have been
-      re-created under the same id by anyone else.
+    * **The leader** — its pid is the pgid, so a recycled id cannot reproduce the
+      start time recorded at registration.
+    * **A recorded member** — captured by `retain_group_record` when a teardown
+      left survivors behind. This is the case the reaper exists for (npm→node→leaf
+      grandchildren outliving a refused teardown, #2013), and it needs a real
+      check of its own: "some group with this id is non-empty" is *not* evidence,
+      because an unrelated group can hold a recycled id and have lost its own
+      leader too.
 
-    Anything else — an empty group, a group we may not signal — is discarded.
+    Everything else — no fingerprint, no recorded members, an unreadable start
+    time, a vanished group — is unverifiable, and unverifiable means no signal.
+    The residual cost is that a group orphaned with no snapshot (the sprint was
+    ``SIGKILL``-ed before any teardown ran, and the leader has since exited)
+    leaks rather than being killed on a guess.
     """
     from theforge.detach import _is_pid_alive  # noqa: PLC0415
 
     if not isinstance(pgid, int) or not is_killable_pgid(pgid):
         return False, "pgid cannot denote a real process group"
+    fingerprint = data.get("leader_fingerprint")
     if _is_pid_alive(pgid):
         if not isinstance(fingerprint, str) or not fingerprint:
             return False, "record carries no leader fingerprint to check the holder against"
@@ -517,9 +658,22 @@ def _identity_verdict(pgid: object, fingerprint: object) -> tuple[bool, str]:
                 f"record was written for one started {fingerprint!r})"
             )
         return True, "the leader's start time still matches the record"
-    if _group_exists(pgid):
-        return True, "the leader exited but the group is non-empty, so the pgid cannot be reused"
-    return False, "no live process group holds this pgid"
+
+    recorded = _recorded_members(data)
+    if not recorded:
+        return False, (
+            "the leader is gone and the record names no surviving member to identify the group by"
+        )
+    live = group_members(pgid)
+    if not live:
+        return False, "no live process group holds this pgid"
+    matched = [pid for pid, fingerprint in recorded.items() if live.get(pid) == fingerprint]
+    if not matched:
+        return False, (
+            "the group holding this pgid contains none of the recorded members — "
+            "the id has been reused"
+        )
+    return True, f"the leader is gone but recorded member(s) {matched} are still in the group"
 
 
 def _load_sidecar(sidecar: Path) -> dict[str, Any] | None:
@@ -606,7 +760,7 @@ def reap_orphan_agents(project_root: Path) -> int:
             _unlink(sidecar)
             continue
 
-        may_signal, reason = _identity_verdict(pgid, data.get("leader_fingerprint"))
+        may_signal, reason = _identity_verdict(pgid, data)
         if not may_signal:
             _log(
                 f"  discarding stale agent sidecar pgid={pgid} unsignalled: {reason} "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,10 +149,19 @@ def _scrub_agent_credentials_for_gate():
 # assume run in the non-detached default (e.g. cmd_run's daemonize branch).
 # Tests that exercise the detached branch set these explicitly via
 # monkeypatch.setenv, which overrides this session-scoped scrub for their scope.
+#
+# FORGE_PROJECT_ROOT belongs on this list for a sharper reason (#2115): it is
+# what ``process_group.register_agent_group`` resolves the pgid-sidecar
+# directory from, so when the suite runs inside a detached forge child (the
+# dogfood gate), every test that spawns a real subprocess writes agent sidecars
+# into the *real* project's ``.forge/runs/agents/`` — records naming pgids of
+# pytest subprocesses that a later ``forge`` sweep would then act on. Scrubbing
+# it makes registration a no-op unless a test opts in with monkeypatch.setenv.
 _DETACHED_RUNTIME_ENV_VARS: tuple[str, ...] = (
     "FORGE_DETACHED",
     "FORGE_DETACHED_RUN_ID",
     "FORGE_DETACHED_SLUG",
+    "FORGE_PROJECT_ROOT",
 )
 
 

--- a/tests/test_cli_status_integration.py
+++ b/tests/test_cli_status_integration.py
@@ -569,3 +569,54 @@ def test_watch_loop_drops_finished_sprint_on_next_frame(tmp_path: Path, capsys: 
     assert rc == 0
     assert "run=run-a" in out
     assert out.count("run=run-b") == 2
+
+
+# ── forge status reports orphaned agent groups, it does not kill them (#2115) ──
+
+
+def test_status_reports_orphan_agent_groups_without_signalling_them(
+    tmp_path: Path, capsys: object
+) -> None:
+    """A read-only inspection command must not send group SIGKILLs as a side effect.
+
+    Reaping from ``forge status`` meant a routine operator command signalled
+    process groups off recorded pgids the OS had since recycled. Status now
+    reports the records; the reap belongs to the commands that already mutate run
+    state (``forge stop``, sprint launch).
+    """
+    import subprocess
+    import sys
+
+    from theforge import process_group
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    pgid = os.getpgid(proc.pid)
+    agents_dir = tmp_path / ".forge" / "runs" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    sidecar = agents_dir / f"999999-{pgid}.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "owner_pid": 999_999,  # never-assigned high pid: certainly dead
+                "pgid": pgid,
+                "run_id": "run-old",
+                "sandbox_dir": str(tmp_path),
+                "leader_fingerprint": process_group._leader_fingerprint(pgid),
+                "origin": "agent",
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        rc, out = _run_cmd_status(tmp_path, capsys)
+        assert rc == 0
+        assert proc.poll() is None, "forge status killed a process group"
+        assert sidecar.exists(), "forge status consumed the record it only reported"
+        assert f"pgid={pgid}" in out
+        assert "orphaned agent process group record(s)" in out
+    finally:
+        process_group.kill_agent_group(pgid)
+        proc.wait(timeout=5)

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -65,11 +65,14 @@ class _SidecarWriter:
         *,
         fingerprint: str | None = _UNSET,
         origin: str | None = None,
+        members: dict[int, str] | None = None,
     ) -> Path:
         """Write a sidecar; by default with the *real* fingerprint of ``pgid``.
 
         ``fingerprint`` may be overridden to simulate the recycled-pgid case
-        (a record whose recorded leader is not the one now holding the id).
+        (a record whose recorded leader is not the one now holding the id), and
+        ``members`` stands in for the survivor snapshot `retain_group_record`
+        takes when a teardown leaves descendants behind.
         """
         agents_dir = project_root / ".forge" / "runs" / "agents"
         agents_dir.mkdir(parents=True, exist_ok=True)
@@ -85,6 +88,8 @@ class _SidecarWriter:
         }
         if origin is not None:
             record["origin"] = origin
+        if members is not None:
+            record["members"] = {str(pid): fp for pid, fp in members.items()}
         path.write_text(json.dumps(record), encoding="utf-8")
         return path
 
@@ -208,34 +213,144 @@ class TestReapVerifiesGroupIdentity(_SidecarWriter):
         assert process_group.reap_orphan_agents(tmp_path) == 0
         assert not sidecar.exists()
 
-    def test_surviving_descendants_are_still_reaped_after_the_leader_exits(
-        self, tmp_path: Path
-    ) -> None:
-        """The #2013 case must survive the new check.
+    def _leaderless_group(self, tmp_path: Path) -> tuple[int, int]:
+        """Spawn a group, let its leader exit with a grandchild still in it.
 
-        A group whose leader has exited but which still has members cannot have
-        had its pgid reused — the kernel will not hand out a pid that is still in
-        use as a process-group id — so those members are provably the registered
-        group's, and killing them is exactly what the reaper is for.
+        Returns ``(pgid, grandchild pid)``. This is both the shape the reaper
+        exists for (#2013) and the shape a recycled pgid can take, which is why
+        the two cases below must be told apart by evidence, not by the fact that
+        the group is non-empty.
         """
         pidfile = tmp_path / "gc.pid"
         script = (
-            "import subprocess,sys,pathlib,time;"
+            "import subprocess,sys,pathlib;"
             "gc=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
             f"pathlib.Path(r'{pidfile}').write_text(str(gc.pid))"
         )
         leader = subprocess.Popen([sys.executable, "-c", script], start_new_session=True)
         pgid = os.getpgid(leader.pid)
-        sidecar = self._write_sidecar(tmp_path, owner_pid=999_999, pgid=pgid)
         leader.wait(timeout=10)
         assert _wait_until(pidfile.exists, timeout=5.0)
-        gc_pid = int(pidfile.read_text().strip())
+        return pgid, int(pidfile.read_text().strip())
+
+    def test_surviving_descendants_are_still_reaped_after_the_leader_exits(
+        self, tmp_path: Path
+    ) -> None:
+        """The #2013 case must survive the new check.
+
+        The record names a member that is still alive with the start time it had
+        when the group was known to be ours, which identifies the group without
+        the leader.
+        """
+        pgid, gc_pid = self._leaderless_group(tmp_path)
+        sidecar = self._write_sidecar(
+            tmp_path, owner_pid=999_999, pgid=pgid, members=process_group.group_members(pgid)
+        )
         try:
             assert process_group.reap_orphan_agents(tmp_path) == 1
             assert _wait_until(lambda: not _pid_alive(gc_pid)), (
                 "a grandchild left by an exited leader was not reaped"
             )
             assert not sidecar.exists()
+        finally:
+            try:
+                os.kill(gc_pid, signal.SIGKILL)
+            except OSError:
+                pass
+
+    def test_recycled_pgid_whose_own_leader_exited_is_not_signalled(self, tmp_path: Path) -> None:
+        """The other half of the recycled case: an unrelated *leaderless* group.
+
+        A stale record naming a pgid that now belongs to someone else's group —
+        one that has itself lost its leader and kept its descendants — must not
+        be killed. "The group is non-empty" says nothing about whose group it is.
+        """
+        pgid, gc_pid = self._leaderless_group(tmp_path)
+        # Recorded members from the registered group: pids that are not in this
+        # group at all, which is what a record predating the id's reuse holds.
+        sidecar = self._write_sidecar(
+            tmp_path,
+            owner_pid=999_999,
+            pgid=pgid,
+            fingerprint=process_group._leader_fingerprint(os.getpid()),
+            members={999_998: "proc:1", 999_999: "sysctl:1.000000"},
+        )
+        try:
+            assert process_group.reap_orphan_agents(tmp_path) == 0
+            assert _pid_alive(gc_pid), (
+                "a leaderless group holding a recycled pgid was killed on a stale record"
+            )
+            assert not sidecar.exists(), "the unverifiable record must still be discarded"
+        finally:
+            try:
+                os.kill(gc_pid, signal.SIGKILL)
+            except OSError:
+                pass
+
+    def test_leaderless_group_without_recorded_members_is_not_signalled(
+        self, tmp_path: Path
+    ) -> None:
+        """No snapshot, no evidence: the group is left alone and the record dropped.
+
+        This is the deliberate residual cost of the fix — a group orphaned before
+        any teardown could snapshot it leaks rather than being killed on a guess.
+        """
+        pgid, gc_pid = self._leaderless_group(tmp_path)
+        sidecar = self._write_sidecar(tmp_path, owner_pid=999_999, pgid=pgid)
+        try:
+            assert process_group.reap_orphan_agents(tmp_path) == 0
+            assert _pid_alive(gc_pid), "a group was killed with no identity evidence at all"
+            assert not sidecar.exists()
+        finally:
+            try:
+                os.kill(gc_pid, signal.SIGKILL)
+            except OSError:
+                pass
+
+    def test_teardown_that_leaves_survivors_records_them_and_the_reaper_uses_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End to end over the real seam: partial teardown → snapshot → reap.
+
+        The group kill is refused and only the direct child dies — the sandbox
+        case `release_group_record` keeps the sidecar for. The survivors it
+        records are what lets the later sweep prove the leaderless group it finds
+        is this one.
+        """
+        monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+        monkeypatch.setattr(process_group, "_killpg_for", lambda _pid: False)
+        monkeypatch.setattr(
+            process_group, "_kill_pid", lambda pid: os.kill(pid, signal.SIGKILL) is None
+        )
+
+        pidfile = tmp_path / "gc.pid"
+        script = (
+            "import subprocess,sys,pathlib,time;"
+            "gc=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+            f"pathlib.Path(r'{pidfile}').write_text(str(gc.pid));"
+            "time.sleep(30)"
+        )
+        with pytest.raises(subprocess.TimeoutExpired):
+            process_group.run_in_process_group(
+                [sys.executable, "-c", script], timeout=1.5, capture_output=True, text=True
+            )
+        assert _wait_until(pidfile.exists, timeout=3.0)
+        gc_pid = int(pidfile.read_text().strip())
+        sidecars = list((tmp_path / ".forge" / "runs" / "agents").glob("*.json"))
+        assert len(sidecars) == 1, "the surviving group must still be registered"
+        record = json.loads(sidecars[0].read_text(encoding="utf-8"))
+        assert str(gc_pid) in record.get("members", {}), (
+            "the survivor was not snapshotted, so no later sweep could identify the group"
+        )
+
+        # The owner sprint is gone — the state `forge stop` leaves behind.
+        record["owner_pid"] = 999_999
+        sidecars[0].write_text(json.dumps(record), encoding="utf-8")
+        try:
+            assert process_group.reap_orphan_agents(tmp_path) == 1
+            assert _wait_until(lambda: not _pid_alive(gc_pid)), (
+                "the recorded survivor was not reaped"
+            )
         finally:
             try:
                 os.kill(gc_pid, signal.SIGKILL)
@@ -261,6 +376,36 @@ class TestReapVerifiesGroupIdentity(_SidecarWriter):
         finally:
             process_group.kill_agent_group(pgid)
             proc.wait(timeout=5)
+
+
+class TestGroupMembers:
+    """Membership enumeration is the identity a leaderless group still has."""
+
+    def test_lists_every_live_process_in_the_group(self, tmp_path: Path) -> None:
+        pidfile = tmp_path / "gc.pid"
+        script = (
+            "import subprocess,sys,pathlib,time;"
+            "gc=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+            f"pathlib.Path(r'{pidfile}').write_text(str(gc.pid));"
+            "time.sleep(30)"
+        )
+        leader = subprocess.Popen([sys.executable, "-c", script], start_new_session=True)
+        pgid = os.getpgid(leader.pid)
+        try:
+            assert _wait_until(pidfile.exists, timeout=5.0)
+            gc_pid = int(pidfile.read_text().strip())
+            members = process_group.group_members(pgid)
+            assert set(members) >= {leader.pid, gc_pid}, members
+            # The leader's entry must agree with the fingerprint recorded at
+            # registration, or a record could never match its own group.
+            assert members[leader.pid] == process_group._leader_fingerprint(pgid)
+        finally:
+            process_group.kill_agent_group(pgid)
+            leader.wait(timeout=5)
+
+    def test_unsafe_pgid_enumerates_nothing(self) -> None:
+        for bogus in (0, 1, -1, None, "4321"):
+            assert process_group.group_members(bogus) == {}  # type: ignore[arg-type]
 
 
 class TestListOrphanAgents:
@@ -357,6 +502,8 @@ class TestRegistry:
 
         monkeypatch.setattr(subprocess, "Popen", _no_spawn)
         assert process_group._leader_fingerprint(os.getpid())
+        # Same for membership, which teardown takes on the way out of a run.
+        assert process_group.group_members(os.getpgid(os.getpid()))
 
     def test_register_marks_records_written_by_a_test_run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -27,6 +27,9 @@ from theforge.runners.runner_codex import _run_codex
 
 _FAKE_BIN = Path(__file__).parent / "fake_bin"
 
+# Sentinel for "compute the real fingerprint" vs. an explicit (possibly None) one.
+_UNSET = object()
+
 
 def _pid_alive(pid: int) -> bool:
     try:
@@ -52,26 +55,41 @@ def _wait_until(predicate, timeout: float = 5.0) -> bool:
 # ---------------------------------------------------------------------------
 
 
-class TestReapOrphanAgents:
+class _SidecarWriter:
     def _write_sidecar(
-        self, project_root: Path, owner_pid: int, pgid: int, sandbox: str | None = None
+        self,
+        project_root: Path,
+        owner_pid: int,
+        pgid: int,
+        sandbox: str | None = None,
+        *,
+        fingerprint: str | None = _UNSET,
+        origin: str | None = None,
     ) -> Path:
+        """Write a sidecar; by default with the *real* fingerprint of ``pgid``.
+
+        ``fingerprint`` may be overridden to simulate the recycled-pgid case
+        (a record whose recorded leader is not the one now holding the id).
+        """
         agents_dir = project_root / ".forge" / "runs" / "agents"
         agents_dir.mkdir(parents=True, exist_ok=True)
         path = agents_dir / f"{owner_pid}-{pgid}.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "owner_pid": owner_pid,
-                    "pgid": pgid,
-                    "run_id": "run-test",
-                    "sandbox_dir": sandbox,
-                }
+        record: dict[str, object] = {
+            "owner_pid": owner_pid,
+            "pgid": pgid,
+            "run_id": "run-test",
+            "sandbox_dir": sandbox,
+            "leader_fingerprint": (
+                process_group._leader_fingerprint(pgid) if fingerprint is _UNSET else fingerprint
             ),
-            encoding="utf-8",
-        )
+        }
+        if origin is not None:
+            record["origin"] = origin
+        path.write_text(json.dumps(record), encoding="utf-8")
         return path
 
+
+class TestReapOrphanAgents(_SidecarWriter):
     def test_dead_owner_group_is_killed_and_sidecar_unlinked(self, tmp_path: Path) -> None:
         """A sidecar whose owner sprint is dead → its group is killpg-ed and the file removed."""
         proc = subprocess.Popen(
@@ -124,6 +142,162 @@ class TestReapOrphanAgents:
 
 
 # ---------------------------------------------------------------------------
+# Identity verification before signalling (issue #2115)
+# ---------------------------------------------------------------------------
+
+
+class TestReapVerifiesGroupIdentity(_SidecarWriter):
+    """A recorded pgid is a claim about the past, not a durable handle.
+
+    The OS recycles process-group ids, and sidecars persist until some later
+    sweep consumes them, so the group holding a recorded id at reap time may be
+    an unrelated process. Every one of these asserts that a record which cannot
+    be *shown* to still describe its group produces no signal at all.
+    """
+
+    def test_recycled_pgid_is_not_signalled(self, tmp_path: Path) -> None:
+        """The bug: a live group whose leader is not the recorded one is spared."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        # Same pgid, but the recorded fingerprint is a real one belonging to a
+        # different process — the shape a recycled pgid actually produces, not a
+        # value the format check alone could reject.
+        sidecar = self._write_sidecar(
+            tmp_path,
+            owner_pid=999_999,
+            pgid=pgid,
+            fingerprint=process_group._leader_fingerprint(os.getpid()),
+        )
+        try:
+            assert process_group.reap_orphan_agents(tmp_path) == 0
+            assert proc.poll() is None, (
+                "an unrelated process group holding a recycled pgid was killed"
+            )
+            assert not sidecar.exists(), "the unverifiable record must be discarded"
+        finally:
+            process_group.kill_agent_group(pgid)
+            proc.wait(timeout=5)
+
+    def test_record_without_a_fingerprint_is_not_signalled(self, tmp_path: Path) -> None:
+        """No evidence is not weak evidence — a legacy record kills nothing."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        sidecar = self._write_sidecar(tmp_path, owner_pid=999_999, pgid=pgid, fingerprint=None)
+        try:
+            assert process_group.reap_orphan_agents(tmp_path) == 0
+            assert proc.poll() is None, "a group was killed on an unverifiable record"
+            assert not sidecar.exists()
+        finally:
+            process_group.kill_agent_group(pgid)
+            proc.wait(timeout=5)
+
+    def test_record_for_a_vanished_group_is_dropped(self, tmp_path: Path) -> None:
+        """Nothing holds the pgid any more: no signal, and the record goes away."""
+        proc = subprocess.Popen([sys.executable, "-c", "pass"], start_new_session=True)
+        pgid = proc.pid
+        proc.wait(timeout=5)
+        sidecar = self._write_sidecar(
+            tmp_path, owner_pid=999_999, pgid=pgid, fingerprint="Thu Jan  1 00:00:00 1970"
+        )
+        assert process_group.reap_orphan_agents(tmp_path) == 0
+        assert not sidecar.exists()
+
+    def test_surviving_descendants_are_still_reaped_after_the_leader_exits(
+        self, tmp_path: Path
+    ) -> None:
+        """The #2013 case must survive the new check.
+
+        A group whose leader has exited but which still has members cannot have
+        had its pgid reused — the kernel will not hand out a pid that is still in
+        use as a process-group id — so those members are provably the registered
+        group's, and killing them is exactly what the reaper is for.
+        """
+        pidfile = tmp_path / "gc.pid"
+        script = (
+            "import subprocess,sys,pathlib,time;"
+            "gc=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+            f"pathlib.Path(r'{pidfile}').write_text(str(gc.pid))"
+        )
+        leader = subprocess.Popen([sys.executable, "-c", script], start_new_session=True)
+        pgid = os.getpgid(leader.pid)
+        sidecar = self._write_sidecar(tmp_path, owner_pid=999_999, pgid=pgid)
+        leader.wait(timeout=10)
+        assert _wait_until(pidfile.exists, timeout=5.0)
+        gc_pid = int(pidfile.read_text().strip())
+        try:
+            assert process_group.reap_orphan_agents(tmp_path) == 1
+            assert _wait_until(lambda: not _pid_alive(gc_pid)), (
+                "a grandchild left by an exited leader was not reaped"
+            )
+            assert not sidecar.exists()
+        finally:
+            try:
+                os.kill(gc_pid, signal.SIGKILL)
+            except OSError:
+                pass
+
+    def test_test_origin_record_is_discarded_unsignalled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An operator's sweep never acts on a record the suite left behind."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        sidecar = self._write_sidecar(tmp_path, owner_pid=999_999, pgid=pgid, origin="test")
+        # The sweeping process is a real forge invocation, not a test run.
+        monkeypatch.setattr(process_group, "_running_under_pytest", lambda: False)
+        try:
+            assert process_group.reap_orphan_agents(tmp_path) == 0
+            assert proc.poll() is None, "a test-origin record was acted on as real work"
+            assert not sidecar.exists()
+        finally:
+            process_group.kill_agent_group(pgid)
+            proc.wait(timeout=5)
+
+
+class TestListOrphanAgents:
+    """``forge status`` must be able to see orphans without touching them."""
+
+    def test_lists_dead_owner_records_without_signalling_or_unlinking(
+        self, tmp_path: Path
+    ) -> None:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        agents_dir = tmp_path / ".forge" / "runs" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        sidecar = agents_dir / f"999999-{pgid}.json"
+        sidecar.write_text(
+            json.dumps({"owner_pid": 999_999, "pgid": pgid, "sandbox_dir": str(tmp_path)}),
+            encoding="utf-8",
+        )
+        live = agents_dir / f"{os.getpid()}-4242.json"
+        live.write_text(json.dumps({"owner_pid": os.getpid(), "pgid": 4242}), encoding="utf-8")
+        try:
+            orphans = process_group.list_orphan_agents(tmp_path)
+            assert [record["pgid"] for record in orphans] == [pgid]
+            assert proc.poll() is None, "a read-only listing killed a process group"
+            assert sidecar.exists(), "a read-only listing must not consume records"
+            assert live.exists()
+        finally:
+            process_group.kill_agent_group(pgid)
+            proc.wait(timeout=5)
+
+    def test_missing_agents_dir_lists_nothing(self, tmp_path: Path) -> None:
+        assert process_group.list_orphan_agents(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
 # Registry sidecars (register / unregister)
 # ---------------------------------------------------------------------------
 
@@ -145,6 +319,54 @@ class TestRegistry:
 
         process_group.unregister_agent_group(pgid)
         assert not sidecar.exists()
+
+    def test_register_records_the_group_leader_fingerprint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The identity evidence the reaper needs is captured at registration (#2115)."""
+        monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        try:
+            process_group.register_agent_group(pgid, sandbox_dir=tmp_path)
+            sidecar = tmp_path / ".forge" / "runs" / "agents" / f"{os.getpid()}-{pgid}.json"
+            data = json.loads(sidecar.read_text(encoding="utf-8"))
+            assert data["leader_fingerprint"] == process_group._leader_fingerprint(pgid)
+            assert data["leader_fingerprint"], "no start time captured for a live leader"
+        finally:
+            process_group.kill_agent_group(pgid)
+            proc.wait(timeout=5)
+
+    @pytest.mark.skipif(
+        not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+        reason="kernel start-time interface is Linux/macOS only",
+    )
+    def test_fingerprinting_spawns_no_process(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Registration must not exec anything to fingerprint a group (#2115).
+
+        It runs for every agent and gate launch, and ``ps`` is both a spawn in a
+        hot path and an exec a sandbox profile can deny — which would silently
+        leave every record unverifiable.
+        """
+
+        def _no_spawn(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("fingerprinting spawned a process")
+
+        monkeypatch.setattr(subprocess, "Popen", _no_spawn)
+        assert process_group._leader_fingerprint(os.getpid())
+
+    def test_register_marks_records_written_by_a_test_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A suite-written record must be distinguishable from real work (#2115)."""
+        monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+        process_group.register_agent_group(4242, sandbox_dir=tmp_path)
+        sidecar = tmp_path / ".forge" / "runs" / "agents" / f"{os.getpid()}-4242.json"
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert data["origin"] == "test"
 
     def test_register_is_noop_without_project_root(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_sprint_terminal_lifecycle.py
+++ b/tests/test_sprint_terminal_lifecycle.py
@@ -603,6 +603,57 @@ def test_reaper_kills_an_orphaned_gate_tree_after_the_owner_dies(
                 pass
 
 
+def test_gate_teardown_records_survivors_so_a_leaderless_tree_can_be_reaped(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The gate seam must leave identity evidence, not just a pgid (#2115).
+
+    Once the gate shell (the group leader) is gone, its pgid is reusable, so
+    "a group with this id exists" no longer identifies the survivors. The
+    teardown that keeps the sidecar therefore snapshots the group's members
+    while it still knows the group is its own, and the reaper kills only on a
+    member that is still alive with the start time it was recorded with.
+    """
+    monkeypatch.setenv("FORGE_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setattr(coord_util, "_kill_process_group", lambda proc: False)
+
+    cmd = (
+        f'{sys.executable} -u -c "import subprocess, sys, time; '
+        f"child = subprocess.Popen([{sys.executable!r}, '-c', 'import time; time.sleep(120)']); "
+        'print(child.pid, flush=True); time.sleep(120)"'
+    )
+    _ok, output, _exit_code, _timed_out = coord_util._run_shell_detailed(cmd, tmp_path, timeout=2)
+    grandchild_pid = int(
+        next(line for line in output.splitlines() if line.strip().isdigit()).strip()
+    )
+
+    sidecars = list((tmp_path / ".forge" / "runs" / "agents").glob("*.json"))
+    assert len(sidecars) == 1
+    record = json.loads(sidecars[0].read_text(encoding="utf-8"))
+    gate_pid = record["pgid"]
+    assert str(grandchild_pid) in record.get("members", {}), (
+        "teardown kept the record but not the membership that identifies the group"
+    )
+
+    try:
+        # The leader dies, leaving a group that only its recorded members can
+        # distinguish from an unrelated one holding the same recycled id.
+        os.kill(gate_pid, signal.SIGKILL)
+        assert _wait_until_gone([gate_pid]) == []
+        record["owner_pid"] = _dead_pid()
+        sidecars[0].write_text(json.dumps(record), encoding="utf-8")
+
+        assert reap_orphan_agents(tmp_path) == 1
+        assert _wait_until_gone([grandchild_pid]) == [], (
+            "the recorded survivor of a leaderless gate group was not reaped"
+        )
+    finally:
+        try:
+            os.kill(grandchild_pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+
 # ── A stopped story's audit keeps the history it accumulated ───────────
 
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The cycle-1 leaderless recycled-pgid P1 is resolved, status is read-only for orphan records, and the focused process-group/status/gate tests pass. | [google-gemini-3.5-flash] The implementation successfully resolves the recycled pgid signalling issue by verifying group identity using start-time fingerprints and membership snapshots, and makes forge status read-only.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $15.33
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

The orphan reaper kills a process group by a recycled id without verifying identity, so forge status can signal an unrelated process (GitHub Issue #2115)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2115