### PR TITLE
Close every referenced issue on merge, reverting #2067

### DIFF
--- a/.github/workflows/close-on-merge.yml
+++ b/.github/workflows/close-on-merge.yml
@@ -15,12 +15,21 @@ name: Close story issue on merge
 # closes when the story merges to its base branch, NOT when its content later
 # reaches main.
 #
-# Merging a change and confirming its symptom stopped are different facts.
-# For a `bug`-labeled issue, resolution is defined by the reported symptom no
-# longer occurring — something this workflow cannot observe from a merge
-# event alone. So bug issues referenced by a merged PR are NOT closed; they
-# stay open, get a `verify-symptom` label, and get a comment naming the PR.
-# Only issues without the `bug` label (stories, enhancements) close on merge.
+# Every referenced issue closes on merge, `bug`-labeled or not (#2067 reverted).
+#
+# An earlier revision held bug issues open with a `verify-symptom` label on the
+# grounds that a merge is not an observation of the symptom stopping. That is
+# true and it was still the wrong trade: reviewers already verify symptom
+# resolution before a story merges, so the observation has happened by this
+# point. Holding the issue open past it created a state with an inflow and no
+# outflow — nothing removed the label or closed the issue — and the resulting
+# always-open bugs silently disabled merge detection, which keyed off issue
+# closure (#2111).
+#
+# The policy this restores: close at merge with whatever testing dev could do,
+# and if the symptom is later observed to persist, that is a new regression bug
+# carrying fresh evidence — which is better material than a months-old issue
+# held open waiting for someone to confirm it.
 
 on:
   pull_request:
@@ -58,38 +67,19 @@ jobs:
             exit 0
           fi
 
-          # Ensure the verify-symptom label exists; --force makes this
-          # idempotent whether or not a prior run already created it.
-          gh label create "verify-symptom" --repo "$REPO" \
-            --color "d93f0b" \
-            --description "Fix merged; reported symptom not yet observed to stop" \
-            --force
-
           for n in $nums; do
-            info=$(gh issue view "$n" --repo "$REPO" --json state,labels 2>/dev/null || echo "")
+            info=$(gh issue view "$n" --repo "$REPO" --json state 2>/dev/null || echo "")
             if [ -z "$info" ]; then
               echo "#$n not found or unreadable; skipping."
               continue
             fi
             state=$(printf '%s' "$info" | jq -r .state)
-            is_bug=$(printf '%s' "$info" | jq -r '[.labels[].name] | index("bug") != null')
 
             case "$state" in
               OPEN)
-                if [ "$is_bug" = "true" ]; then
-                  # A bug issue's resolution is defined by an observed symptom
-                  # stopping, not by a merge. Merging the fix is evidence, not
-                  # confirmation, so the issue stays open with that distinction
-                  # on record instead of being closed as resolved.
-                  echo "#$n is a bug issue; leaving open pending symptom verification (fix merged in PR #$PR_NUMBER)."
-                  gh issue edit "$n" --repo "$REPO" --add-label "verify-symptom"
-                  gh issue comment "$n" --repo "$REPO" \
-                    --body "PR #$PR_NUMBER merged a fix for this issue, but the reported symptom has not yet been observed to stop. Leaving this issue open — labeled \`verify-symptom\` — until the symptom is confirmed resolved."
-                else
-                  echo "Closing #$n (referenced by merged PR #$PR_NUMBER)"
-                  gh issue close "$n" --repo "$REPO" \
-                    --comment "Closed by merged PR #$PR_NUMBER."
-                fi
+                echo "Closing #$n (referenced by merged PR #$PR_NUMBER)"
+                gh issue close "$n" --repo "$REPO" \
+                  --comment "Closed by merged PR #$PR_NUMBER."
                 ;;
               CLOSED)
                 echo "#$n already closed; skipping (idempotent with the sprint's synchronous close)."

--- a/tests/test_close_on_merge_workflow.py
+++ b/tests/test_close_on_merge_workflow.py
@@ -1,12 +1,9 @@
 """End-to-end behavior test for the close-story-on-merge workflow.
 
-Closing an issue asserts its reported problem no longer occurs. A merge event
-only establishes that a change shipped, not that a reported symptom stopped.
-This test extracts the workflow's *actual* shell step and runs it under
-``bash`` with the ``gh`` CLI stubbed at the process boundary, verifying that a
-`bug`-labeled issue (whose resolution is defined by an observation) is left
-open with a `verify-symptom` label instead of closed, while a non-bug issue
-still closes on merge as before.
+Every issue a merged PR references closes, whatever its labels. This test
+extracts the workflow's *actual* shell step and runs it under ``bash`` with the
+``gh`` CLI stubbed at the process boundary, verifying that closure does not
+depend on the `bug` label and that an already-closed issue is left alone.
 
 Because the script is read straight out of the YAML, the test stays in
 lockstep with the shipped workflow.
@@ -120,23 +117,20 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_bug_issue_is_left_open_pending_symptom_verification(tmp_path):
-    """AC: a merged PR fixing a bug issue does not close it before the symptom is observed."""
+def test_bug_issue_closes_on_merge(tmp_path):
+    """A `bug`-labeled issue closes on merge like any other (#2067 reverted)."""
     result = _run_step(
         tmp_path,
         "Fixes #2047",
         {"FAKE_STATE": "OPEN", "FAKE_LABELS": "bug"},
     )
-    assert result["close"].strip() == "", "a bug issue must not be closed on merge alone"
-    assert "2047" in result["edit"]
-    assert "verify-symptom" in result["edit"]
-    assert "2047" in result["comment"]
-    assert "2062" in result["comment"]
-    assert "pending symptom verification" in result["stdout"]
+    assert "2047" in result["close"]
+    assert "Closed by merged PR #2062" in result["close"]
+    assert result["edit"].strip() == "", "no label edit: the issue simply closes"
 
 
-def test_non_bug_issue_still_closes_on_merge(tmp_path):
-    """A story/enhancement issue (no `bug` label) keeps closing on merge as before."""
+def test_non_bug_issue_closes_on_merge(tmp_path):
+    """A story/enhancement issue closes on merge; label plays no part in the decision."""
     result = _run_step(
         tmp_path,
         "Closes #100",
@@ -147,7 +141,7 @@ def test_non_bug_issue_still_closes_on_merge(tmp_path):
     assert "Closed by merged PR #2062" in result["close"]
 
 
-def test_already_closed_bug_issue_is_skipped(tmp_path):
+def test_already_closed_issue_is_skipped(tmp_path):
     """An already-closed issue is left alone regardless of label (idempotent)."""
     result = _run_step(
         tmp_path,
@@ -159,11 +153,11 @@ def test_already_closed_bug_issue_is_skipped(tmp_path):
     assert "already closed" in result["stdout"]
 
 
-def test_label_create_is_invoked_idempotently(tmp_path):
-    """The verify-symptom label is (re)created before any bug-issue handling."""
+def test_no_label_is_created(tmp_path):
+    """Closure no longer depends on any label, so none is created (#2067 reverted)."""
     result = _run_step(
         tmp_path,
         "Fixes #2047",
         {"FAKE_STATE": "OPEN", "FAKE_LABELS": "bug"},
     )
-    assert "verify-symptom" in result["label"]
+    assert result["label"].strip() == ""


### PR DESCRIPTION
Reverts the `verify-symptom` hold introduced by #2067.

**Why.** #2067 held `bug` issues open on the grounds that a merge is not an observation of the symptom stopping. Runbook §7 actually places symptom verification with **reviewers, before merge** — so the observation has already happened when this workflow runs. The criterion the change was built from specified only the hold and its legibility, never how the state is exited, so nothing ever removed the label or closed the issue.

**Cost.** Eight issues accumulated in two days with no exit. Because merge detection keys off issue closure, each one returned `no_merge` — which re-triaged three landed stories as stale and overwrote their recorded outcomes (#2111).

**Policy restored.** Close at merge with whatever testing dev could do. A symptom later observed to persist is a new regression bug with fresh evidence.

Gate: 6691 passed, 32 skipped, 0 failed.

Note: this merge will run the *base* branch's copy of the workflow, i.e. the old behavior — the referenced issues are being closed by hand as part of the same cleanup, so no closing keyword is used here.

Refs #2067, #2111

🤖 Generated with [Claude Code](https://claude.com/claude-code)