### PR TITLE
Recovering from an unparseable reviewer response costs a full cold re-review instead of a repair

### DIFF
--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -363,7 +363,7 @@ _PLAN_REVIEW_CORRECTIVE_YAML_STRUCTURE = (
     "criteria_coverage:\n"
     '  - criterion: "<acceptance criterion text from the spec>"\n'
     "    covered: true | false\n"
-    '    plan_section: "<which part of the plan addresses this, or \'missing\'>"\n'
+    "    plan_section: \"<which part of the plan addresses this, or 'missing'>\"\n"
     "findings:\n"
     "  - severity: P0 | P1 | P1-impl | P2\n"
     '    description: "<what is wrong with the plan>"\n'
@@ -381,9 +381,7 @@ def _build_plan_review_retry_prompt(error_desc: str, original_output: str) -> st
     from scratch (#2065).
     """
     return (
-        "Your previous plan review output failed schema/parse validation:\n"
-        + error_desc
-        + "\n\n"
+        "Your previous plan review output failed schema/parse validation:\n" + error_desc + "\n\n"
         "The CONTENT of your previous review is correct — your verdict and your "
         "findings are what you meant to say. ONLY the ENCODING (YAML formatting) "
         "is broken. Re-emit the SAME review with the formatting error fixed.\n\n"

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -353,9 +353,57 @@ def _plan_review_parse_errors(result: "AgentResult") -> list[str]:
     return [str(e) for e in parsed.parse_errors]
 
 
+# Corrective YAML structure appended to every plan-review parse-retry prompt.
+# Mirrors review_pool._CORRECTIVE_YAML_STRUCTURE for the plan-review schema
+# (verdict/summary/criteria_coverage/findings) so the reviewer sees the exact
+# shape parse_plan_review_output requires.
+_PLAN_REVIEW_CORRECTIVE_YAML_STRUCTURE = (
+    "verdict: APPROVE | REJECT\n"
+    'summary: "<one-line summary of your review>"\n'
+    "criteria_coverage:\n"
+    '  - criterion: "<acceptance criterion text from the spec>"\n'
+    "    covered: true | false\n"
+    '    plan_section: "<which part of the plan addresses this, or \'missing\'>"\n'
+    "findings:\n"
+    "  - severity: P0 | P1 | P1-impl | P2\n"
+    '    description: "<what is wrong with the plan>"\n'
+    '    suggestion: "<how to fix it>"\n'
+)
+
+
+def _build_plan_review_retry_prompt(error_desc: str, original_output: str) -> str:
+    """Build a corrective retry prompt that anchors the reviewer's prior content.
+
+    Mirrors review_pool._build_review_retry_prompt: the prior output's CONTENT
+    (verdict + findings) is correct, only its YAML ENCODING failed parsing.
+    Handing the reviewer its own rejected output plus the specific parse
+    objections lets it repair the emission instead of re-deriving the review
+    from scratch (#2065).
+    """
+    return (
+        "Your previous plan review output failed schema/parse validation:\n"
+        + error_desc
+        + "\n\n"
+        "The CONTENT of your previous review is correct — your verdict and your "
+        "findings are what you meant to say. ONLY the ENCODING (YAML formatting) "
+        "is broken. Re-emit the SAME review with the formatting error fixed.\n\n"
+        "Preserve your previous output verbatim:\n"
+        "  - Keep the SAME verdict. Do NOT switch APPROVE <-> REJECT.\n"
+        "  - Keep EVERY finding. Do NOT drop, merge, or downgrade a finding.\n\n"
+        "Dropping or altering a field to make a validation error go away is a "
+        "WRONG response. If a value failed to parse, fix the QUOTING/ESCAPING of "
+        "that value — do NOT delete the value, and do NOT change the verdict to "
+        "sidestep a cross-validation rule.\n\n"
+        "Do NOT re-review the plan.\n\n"
+        "Required YAML structure:\n"
+        + _PLAN_REVIEW_CORRECTIVE_YAML_STRUCTURE
+        + "\n\nYour previous output (fix its formatting, keep its content):\n"
+        + original_output
+    )
+
+
 def _retry_parse_failed_plan_reviews(
     *,
-    prompt: str,
     profiles: list[ModelProfile],
     results: list["AgentResult"],
     state: CoordinatorState,
@@ -369,9 +417,17 @@ def _retry_parse_failed_plan_reviews(
     non-mapping YAML root is a transient *agent* failure, not a story failure. The
     transport-retry path (_retry_transient_plan_review_failures) never reaches these
     because it gates on result.success == False. Mirror it for the success-but-
-    unparseable case: re-invoke that specific reviewer in a fresh session (a stale
-    session anchors on its own bad output) up to max_plan_review_parse_retries times
-    before the minimum-reviewers gate is evaluated.
+    unparseable case: re-invoke that specific reviewer up to
+    max_plan_review_parse_retries times before the minimum-reviewers gate is
+    evaluated.
+
+    Unlike a fresh cold re-review, the retry prompt hands the reviewer its own
+    rejected output together with the specific parse objections and asks for a
+    corrected emission (#2065) — the reviewer has already done the expensive
+    work, so recovery repairs the encoding rather than re-deriving the review
+    from scratch. Session continuity is kept for CLI-mode reviewers (the explicit
+    anchor in the prompt makes relying on session memory alone unnecessary, but
+    reusing the session when available is strictly more informative).
 
     Each pre-retry result is appended to state.plan_review_results so cost and the
     per-reviewer audit reconstruction stay consistent with the transport path.
@@ -393,17 +449,19 @@ def _retry_parse_failed_plan_reviews(
         while retry_count < max_retries and errors:
             state.plan_review_results.append(current)
             retry_count += 1
+            error_desc = "; ".join(errors)
             _log(
                 f"  ↻ PLAN_REVIEW   {profile.name} unparseable output "
-                f"(parse retry {retry_count}/{max_retries}): {'; '.join(errors)[:120]}"
+                f"(parse retry {retry_count}/{max_retries}): {error_desc[:120]}"
             )
+            retry_prompt = _build_plan_review_retry_prompt(error_desc, current.output or "")
             retried = run_agent(
-                prompt=prompt,
+                prompt=retry_prompt,
                 profile=profile,
                 working_dir=workspace_path,
                 quiet=True,
                 secrets=config.secrets,
-                session_id=None,  # fresh session — prior anchors on its own bad output
+                session_id=current.session_id if profile.mode == "cli" else None,
             )
             if retried.session_id:
                 state.plan_review_session_ids[profile.name] = retried.session_id
@@ -1060,7 +1118,6 @@ def _run_plan_agent_review(
         )
         state.plan_review_transport_retries.extend(_transport_retry_events)
         pr_results, _parse_retry_events = _retry_parse_failed_plan_reviews(
-            prompt=pr_prompt,
             profiles=par_profiles,
             results=pr_results,
             state=state,

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -400,8 +400,37 @@ def _build_plan_review_retry_prompt(error_desc: str, original_output: str) -> st
     )
 
 
+# Parse-error prefixes that mean the prior output never carried structured
+# plan-review content to anchor a corrective prompt on — the YAML extraction
+# itself failed, or the root wasn't even a mapping. Distinct from errors that
+# fire once a mapping WAS parsed (bad verdict value, malformed finding, etc.),
+# which are repairable.
+_NON_REPAIRABLE_PARSE_ERROR_PREFIXES = (
+    "YAML parse error",
+    "Plan review output root is not a YAML mapping",
+)
+
+
+def _plan_review_output_is_repairable(output: str | None, errors: list[str]) -> bool:
+    """Return True when a parse-failed plan review has content worth repairing.
+
+    A blank/whitespace-only response, or one whose YAML never parsed to a
+    mapping in the first place, has nothing for a corrective prompt to anchor
+    on — recovery for those must fall back to a full cold re-review of the
+    original task rather than repairing unusable text (#2065).
+    """
+    if not output or not output.strip():
+        return False
+    return not any(
+        error.startswith(prefix)
+        for error in errors
+        for prefix in _NON_REPAIRABLE_PARSE_ERROR_PREFIXES
+    )
+
+
 def _retry_parse_failed_plan_reviews(
     *,
+    prompt: str,
     profiles: list[ModelProfile],
     results: list["AgentResult"],
     state: CoordinatorState,
@@ -419,13 +448,18 @@ def _retry_parse_failed_plan_reviews(
     max_plan_review_parse_retries times before the minimum-reviewers gate is
     evaluated.
 
-    Unlike a fresh cold re-review, the retry prompt hands the reviewer its own
-    rejected output together with the specific parse objections and asks for a
-    corrected emission (#2065) — the reviewer has already done the expensive
+    When the prior output has usable content, the retry prompt hands the reviewer
+    its own rejected output together with the specific parse objections and asks
+    for a corrected emission (#2065) — the reviewer has already done the expensive
     work, so recovery repairs the encoding rather than re-deriving the review
     from scratch. Session continuity is kept for CLI-mode reviewers (the explicit
     anchor in the prompt makes relying on session memory alone unnecessary, but
     reusing the session when available is strictly more informative).
+
+    When the prior output is blank or never parsed to a YAML mapping at all
+    (`_plan_review_output_is_repairable` returns False), there is nothing to
+    repair — the retry falls back to the original task prompt on a fresh
+    session, the same cold re-review the transport-retry path performs.
 
     Each pre-retry result is appended to state.plan_review_results so cost and the
     per-reviewer audit reconstruction stay consistent with the transport path.
@@ -448,18 +482,28 @@ def _retry_parse_failed_plan_reviews(
             state.plan_review_results.append(current)
             retry_count += 1
             error_desc = "; ".join(errors)
-            _log(
-                f"  ↻ PLAN_REVIEW   {profile.name} unparseable output "
-                f"(parse retry {retry_count}/{max_retries}): {error_desc[:120]}"
-            )
-            retry_prompt = _build_plan_review_retry_prompt(error_desc, current.output or "")
+            repairable = _plan_review_output_is_repairable(current.output, errors)
+            if repairable:
+                _log(
+                    f"  ↻ PLAN_REVIEW   {profile.name} unparseable output "
+                    f"(parse retry {retry_count}/{max_retries}): {error_desc[:120]}"
+                )
+                retry_prompt = _build_plan_review_retry_prompt(error_desc, current.output or "")
+                retry_session_id = current.session_id if profile.mode == "cli" else None
+            else:
+                _log(
+                    f"  ↻ PLAN_REVIEW   {profile.name} non-repairable output — cold retry "
+                    f"(parse retry {retry_count}/{max_retries}): {error_desc[:120]}"
+                )
+                retry_prompt = prompt
+                retry_session_id = None  # fresh session — nothing usable to anchor on
             retried = run_agent(
                 prompt=retry_prompt,
                 profile=profile,
                 working_dir=workspace_path,
                 quiet=True,
                 secrets=config.secrets,
-                session_id=current.session_id if profile.mode == "cli" else None,
+                session_id=retry_session_id,
             )
             if retried.session_id:
                 state.plan_review_session_ids[profile.name] = retried.session_id
@@ -474,6 +518,7 @@ def _retry_parse_failed_plan_reviews(
                     "reviewer": profile.name,
                     "retry": retry_count,
                     "errors": list(errors),
+                    "repair": repairable,
                 }
             )
             current = retried
@@ -1116,6 +1161,7 @@ def _run_plan_agent_review(
         )
         state.plan_review_transport_retries.extend(_transport_retry_events)
         pr_results, _parse_retry_events = _retry_parse_failed_plan_reviews(
+            prompt=pr_prompt,
             profiles=par_profiles,
             results=pr_results,
             state=state,

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -35,6 +35,7 @@ from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.engine import _fresh_run_state, run_task
 from theforge.coordinator.plan_flow import (
     _build_plan_review_retry_prompt,
+    _plan_review_output_is_repairable,
     _record_plan_model_escalation,
     _retry_parse_failed_plan_reviews,
 )
@@ -2089,7 +2090,22 @@ class TestPlanReviewerFailureAudit:
 # Prose emitted by a reviewer that stalled instead of producing contract output
 # (mirrors issue-75: "Waiting on the verification agent's results before I
 # finalize the review.").  Parses to a non-mapping YAML root → parse error.
+# This is the "otherwise non-repairable" case (#2065): there is no structured
+# content to anchor a corrective prompt on, so recovery must cold-retry.
 PLAN_REVIEW_PROSE = "Waiting on the verification agent's results before I finalize the review."
+
+# A YAML mapping root with a valid verdict but a malformed finding (wrong key
+# name — "issue" instead of "description") — mirrors the issue-2050 defect the
+# story is built on: the CONTENT is correct, only the field encoding is wrong.
+# This IS repairable: the corrective prompt has something to anchor on.
+PLAN_REVIEW_BAD_FINDING_KEY = """\
+```yaml
+verdict: APPROVE
+findings:
+  - severity: P2
+    issue: "wrong key name used instead of description"
+```
+"""
 
 
 class TestPlanReviewParseRetry:
@@ -2116,7 +2132,8 @@ class TestPlanReviewParseRetry:
         mock_code_pool,
         tmp_path,
     ):
-        """Single reviewer emits prose → retried once → parses → story proceeds to DONE."""
+        """Single reviewer emits a malformed-but-repairable finding → retried
+        once with a corrective prompt → parses → story proceeds to DONE."""
         config = dataclasses.replace(
             _make_plan_agent_review_config(tmp_path),
             retry=RetryPolicy(
@@ -2146,12 +2163,13 @@ class TestPlanReviewParseRetry:
             ),
             _make_agent_result(success=True, output="Implemented."),
         ]
-        # Initial pool completion succeeds at transport level but is unparseable prose.
+        # Initial pool completion succeeds at transport level with a dict-rooted
+        # output that has usable content (a valid verdict) but a malformed finding.
         mock_plan_pool.side_effect = [
             [
                 _make_agent_result(
                     success=True,
-                    output=PLAN_REVIEW_PROSE,
+                    output=PLAN_REVIEW_BAD_FINDING_KEY,
                     cost_usd=0.08,
                     profile_name="plan-review",
                 )
@@ -2174,7 +2192,8 @@ class TestPlanReviewParseRetry:
         assert retry["reviewer"] == "plan-review"
         assert retry["retry"] == 1
         assert retry["errors"]
-        # Both the prose completion and the successful retry are cost-tracked.
+        assert retry["repair"] is True
+        # Both the rejected completion and the successful retry are cost-tracked.
         assert len(result.state.plan_review_results) == 2
         assert result.state.total_plan_review_cost == pytest.approx(0.14)
         # CLI-mode reviewer: parse retry reuses the prior session (the corrective
@@ -2188,7 +2207,7 @@ class TestPlanReviewParseRetry:
         # a repair, not a cold re-review (#2065).
         retry_prompt = retry_call.kwargs["prompt"]
         assert "previous plan review output failed" in retry_prompt
-        assert PLAN_REVIEW_PROSE in retry_prompt
+        assert PLAN_REVIEW_BAD_FINDING_KEY in retry_prompt
 
         audit = generate_audit_log(config, task, result)
         assert audit["plan_review"]["parse_retries"] == result.state.plan_review_parse_retries
@@ -2211,7 +2230,8 @@ class TestPlanReviewParseRetry:
         mock_code_pool,
         tmp_path,
     ):
-        """Prose on every attempt → parse retries exhausted → min-reviewers gate escalates."""
+        """Malformed-but-repairable finding on every attempt → parse retries
+        exhausted → min-reviewers gate escalates."""
         config = dataclasses.replace(
             _make_plan_agent_review_config(tmp_path),
             retry=RetryPolicy(
@@ -2230,21 +2250,27 @@ class TestPlanReviewParseRetry:
         mock_preflight.return_value = _make_agent_result(
             success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
         )
-        # run_agent sequence: PLAN → two parse retries, both still unparseable prose.
+        # run_agent sequence: PLAN → two parse retries, both still malformed.
         mock_agent.side_effect = [
             _make_agent_result(success=True, output="# Plan\n\nA plan.", cost_usd=0.10),
             _make_agent_result(
-                success=True, output=PLAN_REVIEW_PROSE, cost_usd=0.06, profile_name="plan-review"
+                success=True,
+                output=PLAN_REVIEW_BAD_FINDING_KEY,
+                cost_usd=0.06,
+                profile_name="plan-review",
             ),
             _make_agent_result(
-                success=True, output=PLAN_REVIEW_PROSE, cost_usd=0.06, profile_name="plan-review"
+                success=True,
+                output=PLAN_REVIEW_BAD_FINDING_KEY,
+                cost_usd=0.06,
+                profile_name="plan-review",
             ),
         ]
         mock_plan_pool.side_effect = [
             [
                 _make_agent_result(
                     success=True,
-                    output=PLAN_REVIEW_PROSE,
+                    output=PLAN_REVIEW_BAD_FINDING_KEY,
                     cost_usd=0.08,
                     profile_name="plan-review",
                 )
@@ -2263,10 +2289,11 @@ class TestPlanReviewParseRetry:
         # Two retries attempted before escalating, each with a corrective prompt
         # (CLI-mode reviewer, so the prior session is reused on top of that).
         assert len(result.state.plan_review_parse_retries) == 2
+        assert all(e["repair"] is True for e in result.state.plan_review_parse_retries)
         for _retry_call in mock_plan_agent.call_args_list[1:]:
             assert _retry_call.kwargs["session_id"] == "sess-1"
             assert "previous plan review output failed" in _retry_call.kwargs["prompt"]
-        # Prose completion + two prose retries are all cost-tracked.
+        # Rejected completion + two rejected retries are all cost-tracked.
         assert len(result.state.plan_review_results) == 3
         assert result.state.total_plan_review_cost == pytest.approx(0.20)
         assert len(result.state.plan_review_failures) == 1
@@ -2289,6 +2316,88 @@ class TestPlanReviewParseRetry:
             }
         ]
 
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_non_repairable_prose_falls_back_to_cold_retry(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_plan_pool,
+        mock_human_review,
+        mock_code_pool,
+        tmp_path,
+    ):
+        """Prose (no YAML mapping at all) has nothing to repair → the retry falls
+        back to the original review-task prompt on a fresh session instead of a
+        corrective prompt anchored on unusable text (#2065)."""
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                max_plan_regen_attempts=0,
+                max_plan_review_parse_retries=2,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        # run_agent sequence: PLAN → plan-review cold retry (now valid) → DEV
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="# Plan\n\nA plan.", cost_usd=0.10),
+            _make_agent_result(
+                success=True,
+                output=PLAN_AGENT_APPROVE,
+                cost_usd=0.06,
+                profile_name="plan-review",
+            ),
+            _make_agent_result(success=True, output="Implemented."),
+        ]
+        mock_plan_pool.side_effect = [
+            [
+                _make_agent_result(
+                    success=True,
+                    output=PLAN_REVIEW_PROSE,
+                    cost_usd=0.08,
+                    profile_name="plan-review",
+                    session_id="sess-1",
+                )
+            ]
+        ]
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert len(result.state.plan_review_parse_retries) == 1
+        retry = result.state.plan_review_parse_retries[0]
+        assert retry["repair"] is False
+        # The retry is the last plan_flow.run_agent call (PLAN is the first).
+        retry_call = mock_plan_agent.call_args_list[-1]
+        # Fresh session — nothing usable in the prose to anchor a session on.
+        assert retry_call.kwargs["session_id"] is None
+        # The original review-task prompt is re-issued verbatim, NOT a corrective
+        # prompt anchored on the unusable prose.
+        retry_prompt = retry_call.kwargs["prompt"]
+        assert "previous plan review output failed" not in retry_prompt
+        assert PLAN_REVIEW_PROSE not in retry_prompt
+
 
 # ── TestPlanReviewRetryPromptRepair ────────────────────────────────────
 # The retry must hand the reviewer its own rejected output plus the specific
@@ -2307,10 +2416,129 @@ class TestPlanReviewRetryPromptRepair:
         assert "Do NOT re-review the plan" in prompt
         assert "Keep the SAME verdict" in prompt
 
+    def test_repairable_detection(self):
+        # A YAML mapping root is repairable even when a nested field is malformed.
+        assert _plan_review_output_is_repairable(
+            PLAN_REVIEW_BAD_FINDING_KEY,
+            ["findings[0].description must be non-empty"],
+        )
+        # Prose that never parsed to a mapping is not repairable.
+        assert not _plan_review_output_is_repairable(
+            "Waiting on the verification agent's results.",
+            ["Plan review output root is not a YAML mapping"],
+        )
+        # A YAML syntax error also leaves nothing structured to anchor on.
+        assert not _plan_review_output_is_repairable(
+            "verdict: APPROVE\n  bad: [unterminated",
+            ["YAML parse error: while parsing a flow sequence"],
+        )
+        # Blank/whitespace-only output is not repairable regardless of errors.
+        assert not _plan_review_output_is_repairable("   \n  ", [])
+        assert not _plan_review_output_is_repairable(None, [])
+
     @patch("theforge.coordinator.plan_flow.run_agent")
     def test_retry_call_uses_corrective_prompt_not_original(self, mock_run_agent, tmp_path):
-        """The retried run_agent call must receive the corrective prompt (rejected
-        output + parse errors), never the original review-task prompt."""
+        """A repairable prior output (a YAML mapping with a malformed finding)
+        must receive the corrective prompt (rejected output + parse errors),
+        never the original review-task prompt."""
+        original_prompt = "Review this plan against the spec and submit a verdict."
+        profile = ModelProfile(
+            name="plan-review",
+            cli="claude",
+            model="sonnet",
+            budget_usd=0.50,
+            timeout_seconds=300,
+            allowed_tools=(),
+        )
+        malformed_result = _make_agent_result(
+            success=True,
+            output=PLAN_REVIEW_BAD_FINDING_KEY,
+            session_id="sess-cli",
+            cost_usd=0.06,
+            profile_name="plan-review",
+        )
+        mock_run_agent.return_value = _make_agent_result(
+            success=True,
+            output=PLAN_AGENT_APPROVE,
+            session_id="sess-cli",
+            cost_usd=0.02,
+            profile_name="plan-review",
+        )
+        state = CoordinatorState()
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(max_plan_review_parse_retries=2),
+        )
+
+        _retry_parse_failed_plan_reviews(
+            prompt=original_prompt,
+            profiles=[profile],
+            results=[malformed_result],
+            state=state,
+            config=config,
+            workspace_path=tmp_path,
+            attempt=0,
+        )
+
+        assert mock_run_agent.call_count == 1
+        call = mock_run_agent.call_args
+        assert call.kwargs["prompt"] != original_prompt
+        assert "previous plan review output failed" in call.kwargs["prompt"]
+        assert malformed_result.output in call.kwargs["prompt"]
+        # CLI-mode reviewer: session continuity kept on top of the explicit anchor.
+        assert call.kwargs["session_id"] == "sess-cli"
+
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    def test_api_mode_reviewer_retry_uses_fresh_session(self, mock_run_agent, tmp_path):
+        """API-mode reviewers have no session to continue — the corrective prompt
+        is the only anchor, and session_id must stay None."""
+        profile = ModelProfile(
+            name="plan-review",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            budget_usd=0.50,
+            timeout_seconds=300,
+            allowed_tools=(),
+        )
+        malformed_result = _make_agent_result(
+            success=True,
+            output=PLAN_REVIEW_BAD_FINDING_KEY,
+            session_id="sess-api",
+            cost_usd=0.06,
+            profile_name="plan-review",
+        )
+        mock_run_agent.return_value = _make_agent_result(
+            success=True,
+            output=PLAN_AGENT_APPROVE,
+            session_id=None,
+            cost_usd=0.02,
+            profile_name="plan-review",
+        )
+        state = CoordinatorState()
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(max_plan_review_parse_retries=2),
+        )
+
+        _retry_parse_failed_plan_reviews(
+            prompt="Review this plan against the spec and submit a verdict.",
+            profiles=[profile],
+            results=[malformed_result],
+            state=state,
+            config=config,
+            workspace_path=tmp_path,
+            attempt=0,
+        )
+
+        assert mock_run_agent.call_args.kwargs["session_id"] is None
+
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    def test_prose_output_falls_back_to_original_prompt_and_fresh_session(
+        self, mock_run_agent, tmp_path
+    ):
+        """Prose that never parsed to a YAML mapping has nothing to repair — the
+        retry must fall back to the ORIGINAL task prompt on a fresh session,
+        never a corrective prompt anchored on the unusable text (#2065)."""
         original_prompt = "Review this plan against the spec and submit a verdict."
         profile = ModelProfile(
             name="plan-review",
@@ -2330,7 +2558,7 @@ class TestPlanReviewRetryPromptRepair:
         mock_run_agent.return_value = _make_agent_result(
             success=True,
             output=PLAN_AGENT_APPROVE,
-            session_id="sess-cli",
+            session_id="sess-new",
             cost_usd=0.02,
             profile_name="plan-review",
         )
@@ -2340,7 +2568,8 @@ class TestPlanReviewRetryPromptRepair:
             retry=RetryPolicy(max_plan_review_parse_retries=2),
         )
 
-        _retry_parse_failed_plan_reviews(
+        _, retry_events = _retry_parse_failed_plan_reviews(
+            prompt=original_prompt,
             profiles=[profile],
             results=[prose_result],
             state=state,
@@ -2351,35 +2580,36 @@ class TestPlanReviewRetryPromptRepair:
 
         assert mock_run_agent.call_count == 1
         call = mock_run_agent.call_args
-        assert call.kwargs["prompt"] != original_prompt
-        assert "previous plan review output failed" in call.kwargs["prompt"]
-        assert prose_result.output in call.kwargs["prompt"]
-        # CLI-mode reviewer: session continuity kept on top of the explicit anchor.
-        assert call.kwargs["session_id"] == "sess-cli"
+        assert call.kwargs["prompt"] == original_prompt
+        assert call.kwargs["session_id"] is None
+        assert retry_events[0]["repair"] is False
 
     @patch("theforge.coordinator.plan_flow.run_agent")
-    def test_api_mode_reviewer_retry_uses_fresh_session(self, mock_run_agent, tmp_path):
-        """API-mode reviewers have no session to continue — the corrective prompt
-        is the only anchor, and session_id must stay None."""
+    def test_blank_output_falls_back_to_original_prompt_and_fresh_session(
+        self, mock_run_agent, tmp_path
+    ):
+        """An empty/whitespace-only response is the clearest non-repairable case
+        — there is no text at all to anchor a corrective prompt on."""
+        original_prompt = "Review this plan against the spec and submit a verdict."
         profile = ModelProfile(
             name="plan-review",
-            provider="anthropic",
-            model="claude-sonnet-4-6",
+            cli="claude",
+            model="sonnet",
             budget_usd=0.50,
             timeout_seconds=300,
             allowed_tools=(),
         )
-        prose_result = _make_agent_result(
+        blank_result = _make_agent_result(
             success=True,
-            output="Waiting on the verification agent's results.",
-            session_id="sess-api",
+            output="   \n  ",
+            session_id="sess-cli",
             cost_usd=0.06,
             profile_name="plan-review",
         )
         mock_run_agent.return_value = _make_agent_result(
             success=True,
             output=PLAN_AGENT_APPROVE,
-            session_id=None,
+            session_id="sess-new",
             cost_usd=0.02,
             profile_name="plan-review",
         )
@@ -2389,13 +2619,18 @@ class TestPlanReviewRetryPromptRepair:
             retry=RetryPolicy(max_plan_review_parse_retries=2),
         )
 
-        _retry_parse_failed_plan_reviews(
+        _, retry_events = _retry_parse_failed_plan_reviews(
+            prompt=original_prompt,
             profiles=[profile],
-            results=[prose_result],
+            results=[blank_result],
             state=state,
             config=config,
             workspace_path=tmp_path,
             attempt=0,
         )
 
-        assert mock_run_agent.call_args.kwargs["session_id"] is None
+        assert mock_run_agent.call_count == 1
+        call = mock_run_agent.call_args
+        assert call.kwargs["prompt"] == original_prompt
+        assert call.kwargs["session_id"] is None
+        assert retry_events[0]["repair"] is False

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -33,7 +33,11 @@ from theforge.config import (
 )
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.engine import _fresh_run_state, run_task
-from theforge.coordinator.plan_flow import _record_plan_model_escalation
+from theforge.coordinator.plan_flow import (
+    _build_plan_review_retry_prompt,
+    _record_plan_model_escalation,
+    _retry_parse_failed_plan_reviews,
+)
 from theforge.coordinator.state import CoordinatorState, Phase
 
 # ── Local helpers ─────────────────────────────────────────────────────
@@ -2173,9 +2177,18 @@ class TestPlanReviewParseRetry:
         # Both the prose completion and the successful retry are cost-tracked.
         assert len(result.state.plan_review_results) == 2
         assert result.state.total_plan_review_cost == pytest.approx(0.14)
-        # Fresh session on retry (session_id=None passed to run_agent). The retry
-        # is the last plan_flow.run_agent call (PLAN is the first).
-        assert mock_plan_agent.call_args_list[-1].kwargs["session_id"] is None
+        # CLI-mode reviewer: parse retry reuses the prior session (the corrective
+        # prompt anchors the reviewer's own rejected output; session continuity is
+        # kept on top of that, not discarded). The retry is the last
+        # plan_flow.run_agent call (PLAN is the first).
+        retry_call = mock_plan_agent.call_args_list[-1]
+        assert retry_call.kwargs["session_id"] == "sess-1"
+        # The retry prompt hands the reviewer its own rejected output and the
+        # specific parse objections instead of re-issuing the original prompt —
+        # a repair, not a cold re-review (#2065).
+        retry_prompt = retry_call.kwargs["prompt"]
+        assert "previous plan review output failed" in retry_prompt
+        assert PLAN_REVIEW_PROSE in retry_prompt
 
         audit = generate_audit_log(config, task, result)
         assert audit["plan_review"]["parse_retries"] == result.state.plan_review_parse_retries
@@ -2247,8 +2260,12 @@ class TestPlanReviewParseRetry:
         assert result.phase == Phase.ESCALATE
         assert result.state.plan_review_decision == "reject"
         assert "minimum required is 1" in (result.message or "")
-        # Two fresh-session retries attempted before escalating.
+        # Two retries attempted before escalating, each with a corrective prompt
+        # (CLI-mode reviewer, so the prior session is reused on top of that).
         assert len(result.state.plan_review_parse_retries) == 2
+        for _retry_call in mock_plan_agent.call_args_list[1:]:
+            assert _retry_call.kwargs["session_id"] == "sess-1"
+            assert "previous plan review output failed" in _retry_call.kwargs["prompt"]
         # Prose completion + two prose retries are all cost-tracked.
         assert len(result.state.plan_review_results) == 3
         assert result.state.total_plan_review_cost == pytest.approx(0.20)
@@ -2271,3 +2288,114 @@ class TestPlanReviewParseRetry:
                 "cost_usd": pytest.approx(0.06),
             }
         ]
+
+
+# ── TestPlanReviewRetryPromptRepair ────────────────────────────────────
+# The retry must hand the reviewer its own rejected output plus the specific
+# parse objections and ask for a correction — a bounded repair, not a cold
+# re-review that re-issues the original task from scratch (#2065).
+
+
+class TestPlanReviewRetryPromptRepair:
+    def test_retry_prompt_anchors_prior_output_and_errors(self):
+        prompt = _build_plan_review_retry_prompt(
+            "verdict must be APPROVE or REJECT, got: 'MAYBE'",
+            "```yaml\nverdict: MAYBE\nfindings: []\n```",
+        )
+        assert "verdict must be APPROVE or REJECT, got: 'MAYBE'" in prompt
+        assert "verdict: MAYBE" in prompt
+        assert "Do NOT re-review the plan" in prompt
+        assert "Keep the SAME verdict" in prompt
+
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    def test_retry_call_uses_corrective_prompt_not_original(self, mock_run_agent, tmp_path):
+        """The retried run_agent call must receive the corrective prompt (rejected
+        output + parse errors), never the original review-task prompt."""
+        original_prompt = "Review this plan against the spec and submit a verdict."
+        profile = ModelProfile(
+            name="plan-review",
+            cli="claude",
+            model="sonnet",
+            budget_usd=0.50,
+            timeout_seconds=300,
+            allowed_tools=(),
+        )
+        prose_result = _make_agent_result(
+            success=True,
+            output="Waiting on the verification agent's results.",
+            session_id="sess-cli",
+            cost_usd=0.06,
+            profile_name="plan-review",
+        )
+        mock_run_agent.return_value = _make_agent_result(
+            success=True,
+            output=PLAN_AGENT_APPROVE,
+            session_id="sess-cli",
+            cost_usd=0.02,
+            profile_name="plan-review",
+        )
+        state = CoordinatorState()
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(max_plan_review_parse_retries=2),
+        )
+
+        _retry_parse_failed_plan_reviews(
+            profiles=[profile],
+            results=[prose_result],
+            state=state,
+            config=config,
+            workspace_path=tmp_path,
+            attempt=0,
+        )
+
+        assert mock_run_agent.call_count == 1
+        call = mock_run_agent.call_args
+        assert call.kwargs["prompt"] != original_prompt
+        assert "previous plan review output failed" in call.kwargs["prompt"]
+        assert prose_result.output in call.kwargs["prompt"]
+        # CLI-mode reviewer: session continuity kept on top of the explicit anchor.
+        assert call.kwargs["session_id"] == "sess-cli"
+
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    def test_api_mode_reviewer_retry_uses_fresh_session(self, mock_run_agent, tmp_path):
+        """API-mode reviewers have no session to continue — the corrective prompt
+        is the only anchor, and session_id must stay None."""
+        profile = ModelProfile(
+            name="plan-review",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            budget_usd=0.50,
+            timeout_seconds=300,
+            allowed_tools=(),
+        )
+        prose_result = _make_agent_result(
+            success=True,
+            output="Waiting on the verification agent's results.",
+            session_id="sess-api",
+            cost_usd=0.06,
+            profile_name="plan-review",
+        )
+        mock_run_agent.return_value = _make_agent_result(
+            success=True,
+            output=PLAN_AGENT_APPROVE,
+            session_id=None,
+            cost_usd=0.02,
+            profile_name="plan-review",
+        )
+        state = CoordinatorState()
+        config = dataclasses.replace(
+            _make_plan_agent_review_config(tmp_path),
+            retry=RetryPolicy(max_plan_review_parse_retries=2),
+        )
+
+        _retry_parse_failed_plan_reviews(
+            profiles=[profile],
+            results=[prose_result],
+            state=state,
+            config=config,
+            workspace_path=tmp_path,
+            attempt=0,
+        )
+
+        assert mock_run_agent.call_args.kwargs["session_id"] is None


### PR DESCRIPTION
## Summary

Plan-review parse retries now repair structured malformed output and cold-retry non-repairable output; targeted plan-review retry tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $7.55
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Recovering from an unparseable reviewer response costs a full cold re-review instead of a repair (GitHub Issue #2065)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2065