### PR TITLE
Adaptive assignment docs and backlog alignment

### DIFF
--- a/docs/guides/adaptive-assignment.md
+++ b/docs/guides/adaptive-assignment.md
@@ -1,0 +1,131 @@
+# Adaptive Assignment
+
+Adaptive assignment is TheForge's current routing system for choosing eligible
+models and reviewers from recorded evidence. The canonical design boundary is:
+
+- **ADR-0006** defines what historical signals may influence routing, how they
+  are admitted, and what every routing decision must record.
+- **ADR-0002** defines what telemetry is authoritative enough for ADR-0006 to
+  consume.
+
+This guide is the operator-facing summary of that system. It does not replace
+either ADR; it connects the pieces into one current model.
+
+## The system in one sentence
+
+Static config decides **eligibility**. Adaptive assignment decides
+**preference within the eligible pool** from admissible audit telemetry, with
+recovery paths, taint exclusion, bounded exploration, and a recorded
+`routing_decision` that explains the result.
+
+## Trust boundary: authoritative telemetry vs. derived views
+
+Per ADR-0002, adaptive assignment reads only from the audit substrate:
+
+- **Authoritative:** native-provenance per-run records and coordinator-written
+  native substrate rows.
+- **Derived/queryable, not authoritative:** `.forge/audits/index.sqlite`,
+  `history.jsonl`, `assignment_history.yaml`, `forge_audit.yaml`, and any other
+  rebuildable cache or export.
+- **Advisory only:** LLM summaries, postmortems, freeform comments, and other
+  prose. They may motivate future structured tags, but they do not route.
+
+The router trusts the structured audit substrate, not convenience views and not
+unstructured narrative.
+
+## Eligibility first, preference second
+
+Adaptive assignment never invents a candidate outside operator policy.
+
+- CLI flags and explicit `forge.yaml` settings define the eligible pool.
+- The adaptive layer reranks candidates inside that pool.
+- Deprioritization is sort-after, not filter-out: a weakly ranked eligible
+  candidate still runs when no better-standing candidate is available.
+
+This is the core ADR-0006 distinction: history affects preference, not
+eligibility.
+
+## Which signals may move routing
+
+ADR-0006 requires every routing-weighted signal to be:
+
+1. Mechanically recorded by coordinator code.
+2. Complete over attempts, including failures.
+3. Above its configured sample floor.
+4. Recency-weighted rather than lifetime-cumulative.
+5. Read from schema-stable substrate fields.
+6. Admitted per role, not assumed to transfer across roles.
+
+That yields four practical buckets:
+
+- **Directly routing-safe:** current-run facts and trusted structured audit
+  fields.
+- **Routing-safe after aggregation:** rates and trends such as success rate,
+  reviewer completion, reviewer value, role reliability, or escalation history,
+  once the admissibility gates above pass.
+- **Advisory only:** summaries, narrative RCA, freeform comments, or any signal
+  whose quality interpretation is not yet validated.
+- **Forbidden:** unknown future schema, raw logs, ad-hoc runtime state outside
+  the substrate, and any signal with untraceable provenance.
+
+The important boundary is that **LLM prose never routes directly**. If a prose
+pattern matters, ADR-0006 clause 6 requires it to be promoted into a structured,
+audited substrate tag first; only the admitted tag may later carry routing
+weight.
+
+## Taint, recovery, symmetry, and exploration
+
+Adaptive assignment is allowed to learn only from trustworthy history:
+
+- **Tainted-run exclusion:** runs that fail their own trust checks are kept in
+  the audit record but excluded from routing aggregates. They persist; they do
+  not teach.
+- **Recovery / symmetry:** every adaptive ratchet needs a return path. Recency
+  decay is the universal passive recovery path, and discrete promotions or
+  demotions need explicit inverses.
+- **Exploration:** challenger sampling is the one bounded off-policy exception.
+  It is recorded explicitly in `routing_decision`, gated by its own sample
+  floors, and can be disabled for deterministic dogfood baselines.
+
+## Explainability surface: `routing_decision` first
+
+Every adaptive decision writes a top-level `routing_decision` block into the
+per-run audit record. That block is the canonical explanation contract:
+
+- selected model(s) and final rationale,
+- eligible and excluded candidates with canonical exclusion reasons,
+- consulted signals with raw value, weighted value, sample-floor result, and
+  taint-aware counts,
+- adaptive mechanisms with tri-state outcomes,
+- exploration mode and per-role score-policy details.
+
+`forge explain` and the assignment summary surface from #270 are **read-only
+views over that recorded block**. They are not separate audit sources and they
+do not recompute routing from live profiles. When operator and audit views
+disagree, the per-run native audit record wins.
+
+## Major v0.13 adaptive mechanisms
+
+The v0.13 adaptive system spans these major mechanisms and issue owners:
+
+| Issue | Mechanism | Role in the system |
+|---|---|---|
+| #1388 | Reviewer completion tracking | Completeness-safe reviewer reliability signal |
+| #1392 | Recency weighting | Shared stale-evidence recovery path |
+| #1489 | Role-wide routing | Per-role admissibility beyond dev |
+| #1443 | Reviewer value reranking | Structured comparative reviewer signal |
+| #155 | Domain-aware routing | Preference within eligible pool from domain evidence |
+| #158 | Dev pre-promotion from capability profiles | Bounded history-driven preference shift |
+| #325 | Exploration / challenger sampling | Recorded bounded exploration |
+| #1851 | Trust-status marker | Structured taint evidence on runs |
+| #1852 | Tainted-run exclusion | Exclude failed-trust runs from aggregates |
+
+Related follow-ons also exist, notably #1389 for the symmetry invariant and
+#270 / #1391 for the recorded explanation surface.
+
+## Historical note
+
+[`docs/vision/self-adapting-router.md`](../vision/self-adapting-router.md)
+captures the pre-ADR design discussion that led here. Treat it as historical
+vision, not as the current routing contract. For current behavior, use this
+guide plus ADR-0006 and ADR-0002.

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -221,6 +221,48 @@ In v0.8, this is the quickest way to inspect the role table derived from `models
 
 ---
 
+## `forge explain`
+
+Render the operator-facing assignment summary for one recorded run.
+
+```bash
+forge explain --story <issue-or-slug>
+forge explain --run <run-id>
+forge explain --file .forge/audits/runs/<run-id>.json
+```
+
+**Use this when:** You need to answer why a model or reviewer was selected,
+avoided, deprioritized, or escalated.
+**Avoid this when:** You need live process state; use `forge status` for liveness
+and the raw per-run audit JSON for full forensics.
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--story <id>` | Explain the latest recorded run for a GitHub issue number (`270`, `#270`) or slug (`issue-270`) |
+| `--run <run-id>` | Explain one exact run ID from the audit substrate |
+| `--file <path>` | Render directly from a per-run audit JSON file |
+| `--config <path>` | Path to `forge.yaml` when resolving substrate-backed lookups |
+
+`forge explain` is a **read-only view over the recorded `routing_decision`
+block**. It does not invoke agents, rebuild profiles, or recompute routing from
+live state. The per-run audit record is the contract; this command is one
+presentation of it.
+
+The output includes:
+
+- Selected model(s) per role and the recorded rationale
+- Candidate pools with canonical exclusion reasons
+- Consulted signals, including raw vs. recency-weighted values and sample-floor status
+- Adaptive mechanism outcomes, distinguishing not checked / checked and did not fire / fired
+- Exploration mode and score-policy details
+
+If a run predates the `routing_decision` contract, the command says so
+explicitly instead of fabricating an explanation.
+
+---
+
 ## `forge eval-preflight`
 
 Evaluate candidate preflight models against a golden story set.

--- a/docs/guides/model-reference.md
+++ b/docs/guides/model-reference.md
@@ -4,8 +4,11 @@ Per-provider model recommendations for TheForge, organized by phase and
 complexity tier. These reflect vendor positioning and observed behavior as of
 April 2026.
 
-TheForge's adaptive assignment maps complexity (small/medium/large) to tiers
-(cheap/mid/strong). The tables below show which concrete model fits each cell.
+TheForge's adaptive assignment maps complexity to routing tiers
+(`cheap`/`mid`/`strong`) through the current routing policy described in
+[`adaptive-assignment.md`](adaptive-assignment.md) and
+[`routing-policy.md`](routing-policy.md). The tables below show which concrete
+model fits each tier cell.
 
 ---
 

--- a/docs/guides/routing-policy.md
+++ b/docs/guides/routing-policy.md
@@ -8,6 +8,11 @@ keeps cost variance predictable. This guide is the operator-facing answer to the
 fair question "I see `complexity_score=4` in the audit — what would `8` do
 differently?" (issue #1019).
 
+For the full adaptive-assignment system — eligibility vs. preference, signal
+admissibility, taint exclusion, recency recovery, exploration, and
+`routing_decision` explainability — see
+[Adaptive Assignment](adaptive-assignment.md).
+
 The thresholds below are **not** duplicated prose: they are read directly from
 the single source of truth, `src/theforge/routing.py`
 (`ROUTING_POLICY` / the `*_BUCKETS` tables). If the code and this table ever

--- a/docs/plans/forge-storage-layout.md
+++ b/docs/plans/forge-storage-layout.md
@@ -596,4 +596,4 @@ Knowledge-capture Layer 1 has a hard implementation dependency on Story 1
 and nothing else from this chain. Stories 2–6 are independent
 improvements that land on the rollout and performance timelines described
 in "Story Sequence" above, and they also unblock other downstream work
-(the self-adapting router flywheel queries the same index, for example).
+(adaptive assignment's routing flywheel queries the same index, for example).

--- a/docs/plans/knowledge-capture.md
+++ b/docs/plans/knowledge-capture.md
@@ -26,8 +26,8 @@ feeds that knowledge back into future runs.
 
 Three things are converging:
 
-**The adaptive router needs historical signal.** The self-adapting router
-vision (`docs/vision/self-adapting-router.md`) describes a flywheel:
+**Adaptive assignment needs historical signal.** The current adaptive
+assignment model (`docs/guides/adaptive-assignment.md`) describes a flywheel:
 "Run stories → Collect telemetry → Update performance table → Better routing."
 That flywheel runs on process metrics alone today — model, phase, outcome,
 cost, duration. But the router's real power comes from correlating outcomes
@@ -360,7 +360,7 @@ practice.
 
 #### 3e. Feeding the adaptive router
 
-The self-adapting router (`docs/vision/self-adapting-router.md`) consumes
+Adaptive assignment (`docs/guides/adaptive-assignment.md`) consumes
 **deterministic metrics and structured inputs from the audit record**, not
 freeform summary claims. Layer 1 enriches the router's data model from:
 

--- a/docs/v0.13-dogfood-readiness.md
+++ b/docs/v0.13-dogfood-readiness.md
@@ -16,6 +16,7 @@ path.
 Design source of truth: `docs/adr/0006-adaptive-router-trust-boundary.md`
 (ADR-0006, Adaptive Router Trust Boundary). Clause references below point into
 that ADR.
+Operator-facing system overview: `docs/guides/adaptive-assignment.md`.
 
 ---
 
@@ -68,8 +69,9 @@ make the switch unsafe:
 The dogfood-safety queue items already landed before this checklist (canonical
 `routing_decision` contract #1391, assignment summary view #270, trust-status
 marker #1851, tainted-run filtering #1852, recency weighting #1392, reviewer
-completion telemetry #1388, domain signal #155, exploration sampling #325) are
-the substrate this checklist verifies; they are not re-litigated here.
+completion telemetry #1388, role-wide reliability routing #1489, domain signal
+#155, exploration sampling #325) are the substrate this checklist verifies;
+they are not re-litigated here.
 
 ---
 

--- a/docs/vision/self-adapting-router.md
+++ b/docs/vision/self-adapting-router.md
@@ -2,6 +2,14 @@
 
 Captured 2026-03-23 from design discussion on adaptive routing evolution.
 
+> **Historical design note.** This document predates ADR-0002 and ADR-0006.
+> It is retained as background on the direction that led to adaptive
+> assignment, not as the current routing contract. The current system is
+> documented in [Adaptive Assignment](../guides/adaptive-assignment.md) and the
+> ADRs it cites. In particular, references below to a direct
+> `query_escalation_memory()`-style router are superseded by the current
+> admissibility, taint, recency, and `routing_decision` rules.
+
 ## The Problem With Config
 
 Today's forge.yaml is ~100 lines of model configuration: reviewer profiles,


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The docs-only change aligns the adaptive assignment narrative with ADR-0006/ADR-0002 and introduces no merge-blocking issues. | [claude-opus] Docs-only change; new adaptive-assignment guide and forge explain docs verified accurate against ADR-0002/0006 and src/theforge/cli/explain.py.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $3.23
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Adaptive assignment docs and backlog alignment (GitHub Issue #272)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #272