### PR TITLE
Reviewer re-inclusion — restore a deprioritized reviewer after clean attempts (inverse of #1388)

### DIFF
--- a/docs/routing-symmetry-followups.md
+++ b/docs/routing-symmetry-followups.md
@@ -13,27 +13,50 @@ them to exist (and be either landed or catalogued here) before further promotion
 mechanisms land.
 
 > **Tracked issues.** Acceptance criterion 3 of #1389 asks for these to be filed
-> as tracked issues, each linking back to #1389. Both open asymmetries below have
-> been filed as GitHub issues (numbers noted per entry); this catalogue and the
+> as tracked issues, each linking back to #1389. Every asymmetry catalogued here
+> was filed as a GitHub issue (numbers noted per entry); this catalogue and the
 > tracker agree. Keep them in sync: when an entry's inverse lands, close its issue
 > and move the entry to "Resolved / not open".
 
 ## Open asymmetries
 
-### Reviewer re-inclusion path (inverse of #1388 completion-rate deprioritization) — #1880
-
-- **Deprioritization path:** `assignment.py:_reviewer_completion_check` (#1388) —
-  a reviewer with a poor attempt-completion history is reranked down.
-- **Gap:** there is no landed mechanism that re-includes a deprioritized reviewer
-  once its subsequent attempts complete cleanly. #1388 (reviewer attempt-completion
-  profiles) has landed, so this inverse is now actionable.
-- **Proposed inverse:** re-include a deprioritized reviewer after K consecutive
-  clean attempts, with audit attribution and tests for both directions.
-- **Registry marker:** `open_followup="reviewer-reinclusion"` on the reviewer pair
-  in `ROUTING_SYMMETRY_REGISTRY`.
-- **Tracked issue:** #1880 (back-links #1389; companion to #1388).
+None currently open. Every registered promotion/deprioritization path in
+`ROUTING_SYMMETRY_REGISTRY` has a landed, tested inverse; no pair carries an
+`open_followup` marker. A new promotion mechanism that lands without its inverse
+must add its entry back to this section (the enforcement test in
+`tests/test_routing_symmetry_invariant.py` requires one or the other).
 
 ## Resolved / not open
+
+### Reviewer re-inclusion path (inverse of #1388 completion-rate deprioritization) — RESOLVED (#1880)
+
+The reviewer completion-rate deprioritization
+(`assignment.py:_rerank_reviewers_by_completion`, surfaced by
+`_reviewer_completion_check`, #1388) is no longer a one-way ratchet. Its paired
+return path is an explicit **K-consecutive-clean-attempts** recovery rule
+(`MECHANISM_REVIEWER_COMPLETION_REINCLUSION = "reviewer_completion_reinclusion"`):
+a reviewer whose recency-weighted completion rate sits below
+`assignment.reviewer_completion_threshold` is restored to normal ranking as soon
+as the newest **K** outcomes in its `_completion_recent` ring are all clean.
+`K` is `assignment.reviewer_completion_min_runs` — the same sample floor the
+deprioritization is gated on — so recovery reuses the existing config surface and
+demands exactly as much fresh evidence as the deprioritization did.
+
+This matters because the two rules are not redundant: the recency weighting decays
+with a ~50-run half-life, so a reviewer with a long stale failure history can
+complete five straight attempts cleanly and *still* score under threshold. Passive
+decay alone would leave it deprioritized for dozens of runs; the explicit streak
+rule re-includes it immediately on demonstrated recovery.
+
+**Audit attribution.** Every `routing_decision[<reviewer role>].completion_check`
+carries a nested `reinclusion_check` block whenever reviewer completion profiles
+were consulted — `mechanism`, `fired`, `clean_attempts_required`, `reincluded`,
+`checked`, `checked_detail` (per-reviewer clean streak and below-threshold state)
+and a `reason` distinguishing fired from checked-but-didn't-fire (ADR-0006
+clause 7). **Registry:** the reviewer pair in `ROUTING_SYMMETRY_REGISTRY` now
+names this as its `demotion` (audit label `reinclusion_check`) instead of
+`open_followup="reviewer-reinclusion"`. **Tests:** both directions in
+`tests/test_assignment_reviewer_completion.py`.
 
 ### Escalation-history decay for dev-tier promotion — RESOLVED (#158)
 

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -93,6 +93,7 @@ MECHANISM_DEV_PROMOTION = "_check_promotion"
 MECHANISM_DEV_RECENCY_RECOVERY = "dev_recency_recovery"
 MECHANISM_POST_PLAN_DEMOTION = "post_plan_checkpoint"
 MECHANISM_REVIEWER_COMPLETION_DEPRIORITIZE = "reviewer_completion_rate"
+MECHANISM_REVIEWER_COMPLETION_REINCLUSION = "reviewer_completion_reinclusion"
 MECHANISM_PERSISTENT_P1_DEV_ESCALATION = "persistent_p1_dev_escalation"
 MECHANISM_PLAN_MODEL_ESCALATION = "plan_model_escalation"
 MECHANISM_RUN_SCOPED_RESET = "fresh_run_state_reset"
@@ -172,21 +173,29 @@ ROUTING_SYMMETRY_REGISTRY: tuple[RoutingSymmetryPair, ...] = (
         demotion_test_token="recency_recovery",
     ),
     # Reviewer completion-rate deprioritization (#1388): a reviewer with a poor
-    # attempt-completion history is reranked down. The inverse — re-inclusion once
-    # subsequent attempts complete cleanly — is NOT yet landed; catalogued as an
-    # open follow-up (see docs/routing-symmetry-followups.md).
+    # attempt-completion history is reranked down. Its PAIRED return path is the
+    # K-consecutive-clean-attempts re-inclusion rule (#1880): once the newest K
+    # attempt outcomes are all clean (K = the completion sample floor), the
+    # reviewer is restored to normal ranking even while stale failures still drag
+    # the recency-weighted rate under threshold. Recorded — fired or merely
+    # checked — in the nested completion_check.reinclusion_check block (clause 7).
     RoutingSymmetryPair(
         promotion=RoutingMechanism(
             name=MECHANISM_REVIEWER_COMPLETION_DEPRIORITIZE,
             symbol="theforge.assignment._reviewer_completion_check",
             audit_label="completion_check",
         ),
-        demotion=None,
+        demotion=RoutingMechanism(
+            name=MECHANISM_REVIEWER_COMPLETION_REINCLUSION,
+            symbol="theforge.assignment._rerank_reviewers_by_completion",
+            audit_label="reinclusion_check",
+        ),
         promotion_tests=("tests/test_assignment_reviewer_completion.py",),
+        demotion_tests=("tests/test_assignment_reviewer_completion.py",),
         # Exercised via assign_models/_select_reviewers, not by calling the
         # audit-block builder directly, so grep for the mechanism token.
         promotion_test_token="completion",
-        open_followup="reviewer-reinclusion",
+        demotion_test_token="reinclusion_check",
     ),
     # In-run persistent-P1 dev escalation (#296): a repeated P1 across
     # consecutive review cycles upgrades the dev model for the current run only.
@@ -802,6 +811,17 @@ def _rerank_reviewers_by_completion(
     is not deprioritized and ordering falls through to the incoming tier/budget/
     cross-provider order. The sort is stable on the original index, so ties (and
     every non-deprioritized reviewer) keep the existing ordering exactly.
+
+    **Re-inclusion (#1880).** The deprioritization is not a one-way ratchet. Its
+    registered inverse is an explicit *K-consecutive-clean-attempts* recovery
+    rule: a below-threshold reviewer whose newest ``K`` attempt outcomes are all
+    clean is restored to normal ranking even while its stale failures still drag
+    the recency-weighted rate under ``threshold``. ``K`` is ``min_runs`` — the
+    same sample floor the deprioritization is gated on — so recovery needs no new
+    config surface and requires exactly as much fresh evidence as the
+    deprioritization required to fire. The recovery check is recorded in ``audit``
+    for *every* consulted reviewer (fired or merely checked), per the
+    routing-symmetry audit-attribution requirement (ADR-0006 clause 7).
     """
     if not model_profiles or not candidates:
         return candidates
@@ -809,6 +829,9 @@ def _rerank_reviewers_by_completion(
 
     rows: list[tuple[int, int, AgentDef]] = []
     deprioritized: list[str] = []
+    reincluded: list[str] = []
+    recovery_checked: dict[str, dict[str, object]] = {}
+    required_clean = max(int(min_runs), 1)
     for idx, agent in enumerate(candidates):
         signal = get_review_signal(
             model_profiles,
@@ -822,22 +845,40 @@ def _rerank_reviewers_by_completion(
         if signals_out is not None:
             signals_out[agent.name] = signal
         rate = signal["rate"]
-        is_low = signal["floor"] == "pass" and rate is not None and rate < threshold
+        recovery = signal.get("recovery") or {}
+        recovered = bool(recovery.get("recovered"))
+        below_threshold = signal["floor"] == "pass" and rate is not None and rate < threshold
+        # Re-inclusion (#1880): K consecutive clean attempts restore a
+        # below-threshold reviewer to normal ranking. Recorded for every
+        # consulted reviewer so the checked-but-didn't-fire path stays visible.
+        recovery_checked[agent.name] = {
+            "clean_streak": recovery.get("clean_streak", 0),
+            "clean_attempts_required": recovery.get("clean_attempts_required", required_clean),
+            "recovered": recovered,
+            "below_threshold": below_threshold,
+        }
+        is_low = below_threshold and not recovered
         if is_low:
             deprioritized.append(agent.name)
+        elif below_threshold:
+            reincluded.append(agent.name)
         rows.append((1 if is_low else 0, idx, agent))
 
     reranked = [row[2] for row in sorted(rows, key=lambda r: (r[0], r[1]))]
     if audit is not None:
         original_order = [a.name for a in candidates]
         final_order = [a.name for a in reranked]
-        audit["mechanism"] = "reviewer_completion_rate"
+        audit["mechanism"] = MECHANISM_REVIEWER_COMPLETION_DEPRIORITIZE
         audit["threshold"] = threshold
         audit["min_runs"] = min_runs
         audit["applied"] = original_order != final_order
         audit["deprioritized"] = deprioritized
         audit["original_order"] = original_order
         audit["final_order"] = final_order
+        audit["reinclusion_mechanism"] = MECHANISM_REVIEWER_COMPLETION_REINCLUSION
+        audit["reinclusion_clean_attempts_required"] = required_clean
+        audit["reincluded"] = reincluded
+        audit["reinclusion_checked"] = recovery_checked
     return reranked
 
 
@@ -1732,6 +1773,12 @@ def _reviewer_completion_check(
     sample-floor status, threshold result) for the reviewers it weighed so the
     decision stays reconstructable. Returns an empty dict when no reviewer profile
     was consulted (e.g. static routing / no profiles), which the caller omits.
+
+    The nested ``reinclusion_check`` block is the registered inverse's audit
+    attribution (#1880): whenever reviewer completion profiles were consulted it
+    records the K-consecutive-clean-attempts recovery rule, whether it fired, the
+    reviewers it restored, and the reviewers it merely checked — so the return
+    path is never a silent gap (ADR-0006 clause 7).
     """
     if not signals and not audit:
         return {}
@@ -1745,20 +1792,58 @@ def _reviewer_completion_check(
             "weighted": sig.get("weighted"),
             "rate": sig.get("rate"),
             "floor": sig.get("floor"),
+            "recovery": sig.get("recovery"),
             "selected": name in selected_names,
         }
     block: dict[str, object] = {
-        "mechanism": "reviewer_completion_rate",
+        "mechanism": MECHANISM_REVIEWER_COMPLETION_DEPRIORITIZE,
         "fired": fired,
         "threshold": audit.get("threshold") if audit else None,
         "min_runs": audit.get("min_runs") if audit else None,
         "deprioritized": (audit.get("deprioritized") if audit else None) or [],
         "signals": per_candidate,
+        "reinclusion_check": _reviewer_reinclusion_check(signals, audit),
     }
     if fired and audit:
         block["original_order"] = audit.get("original_order")
         block["final_order"] = audit.get("final_order")
     return block
+
+
+def _reviewer_reinclusion_check(
+    signals: dict[str, dict] | None,
+    audit: dict[str, object] | None,
+) -> dict[str, object]:
+    """Build the reviewer re-inclusion audit sub-block (#1880, ADR-0006 c7).
+
+    The registered inverse of the completion-rate deprioritization. Present on
+    every ``completion_check`` (i.e. whenever reviewer completion profiles were
+    consulted), so an operator can always answer "did a deprioritized reviewer
+    recover this run, and if not, how close was it?" without grepping logs.
+    """
+    checked_meta = (audit or {}).get("reinclusion_checked") or {}
+    if not isinstance(checked_meta, dict):
+        checked_meta = {}
+    reincluded = list((audit or {}).get("reincluded") or [])
+    required = (audit or {}).get("reinclusion_clean_attempts_required")
+    if required is None:
+        required = (audit or {}).get("min_runs")
+    checked = sorted(checked_meta) if checked_meta else sorted(signals or {})
+    if reincluded:
+        reason = f"clean_attempt_streak_met: {', '.join(sorted(reincluded))}"
+    elif not checked:
+        reason = "no_reviewer_completion_signal_consulted"
+    else:
+        reason = "no_below_threshold_reviewer_met_clean_attempt_streak"
+    return {
+        "mechanism": MECHANISM_REVIEWER_COMPLETION_REINCLUSION,
+        "fired": bool(reincluded),
+        "clean_attempts_required": required,
+        "reincluded": sorted(reincluded),
+        "checked": checked,
+        "checked_detail": checked_meta,
+        "reason": reason,
+    }
 
 
 def _reviewer_value_check(

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -1355,6 +1355,23 @@ def get_dev_success_rate(
     )["rate"]
 
 
+def _trailing_clean_streak(recent: list[int]) -> int:
+    """Length of the newest all-clean run in an ordered ``0/1`` outcome ring.
+
+    ``recent`` is oldest-first / newest-last (the shape every ``_completion_recent``
+    ring is folded in). Counts backwards from the newest outcome and stops at the
+    first failure, so the result is the number of *consecutive* clean attempts a
+    model has most recently strung together — the evidence the reviewer
+    re-inclusion recovery rule is defined over (#1880).
+    """
+    streak = 0
+    for outcome in reversed(recent):
+        if int(outcome) != 1:
+            break
+        streak += 1
+    return streak
+
+
 def get_review_signal(
     profiles: dict,
     model: str,
@@ -1385,6 +1402,13 @@ def get_review_signal(
     - ``floor``: ``"pass"`` when ``attempted >= min_runs`` (and ``> 0``), else
       ``"fail"``.
     - ``weighting``: the recency parameters actually applied.
+    - ``recovery``: the re-inclusion evidence (#1880) — ``clean_streak`` (how many
+      of the newest ring outcomes are consecutively clean),
+      ``clean_attempts_required`` (``K``, pinned to ``min_runs`` so the recovery
+      rule reuses the existing sample floor rather than adding a config surface),
+      and ``recovered`` (``True`` once the newest ``K`` attempts are all clean).
+      This is reported unconditionally; the *threshold* comparison that decides
+      whether recovery is relevant lives in the router, which owns the threshold.
     """
     mode, half_life, window = _recency_params(recency)
     matching = _matching_profile_entries(
@@ -1418,6 +1442,8 @@ def get_review_signal(
         min_samples=min_runs,
     )
     floor_ok = attempted >= min_runs and attempted > 0
+    clean_streak = _trailing_clean_streak(recent)
+    required_clean = max(int(min_runs), 1)
     return {
         "raw": raw,
         "weighted": weighted,
@@ -1427,6 +1453,11 @@ def get_review_signal(
         "floor": "pass" if floor_ok else "fail",
         "weighting": {"mode": mode, "half_life_runs": half_life, "window": window},
         "rate": weighted if floor_ok else None,
+        "recovery": {
+            "clean_streak": clean_streak,
+            "clean_attempts_required": required_clean,
+            "recovered": clean_streak >= required_clean,
+        },
     }
 
 

--- a/tests/test_assignment_reviewer_completion.py
+++ b/tests/test_assignment_reviewer_completion.py
@@ -4,6 +4,11 @@ Mirrors the dev-side _rerank_by_profiles behavior for reviewers: below min_runs
 the completion signal is ignored (cold start preserves existing order); at/above
 min_runs a below-threshold reviewer is sorted *after* higher-completion
 candidates — a sort-after, never a filter-out.
+
+Both directions are covered here (#1880): the deprioritization above and its
+registered inverse, the K-consecutive-clean-attempts re-inclusion rule that
+restores a recovered reviewer to normal ranking while stale failures still hold
+its recency-weighted rate under threshold.
 """
 
 from __future__ import annotations
@@ -203,3 +208,152 @@ def test_assign_models_deprioritizes_low_completion_reviewer_end_to_end():
     completion = decision.routing_decision["code_review"]["completion_check"]
     assert completion["fired"] is True
     assert "rev-a" in completion["deprioritized"]
+
+
+# ── Re-inclusion: the registered inverse (#1880) ───────────────────────────
+
+
+def _recovered_entry(provider: str, model: str, stale_failures: int, clean_tail: int) -> dict:
+    """A reviewer whose lifetime record is poor but whose newest attempts are clean.
+
+    The recency half-life is ~50 runs, so a short clean tail on a long failure
+    history does NOT lift the weighted rate over the threshold — passive decay
+    alone would leave this reviewer deprioritized. That is exactly the case the
+    K-consecutive-clean-attempts re-inclusion rule exists to handle.
+    """
+    attempted = stale_failures + clean_tail
+    return {
+        "_identity": {"provider": provider, "model": model, "transport": "api"},
+        "review": {
+            "_attempted_count": attempted,
+            "_completed_count": clean_tail,
+            "completion_rate": round(clean_tail / attempted, 4),
+            "_completion_recent": [0] * stale_failures + [1] * clean_tail,
+        },
+    }
+
+
+def test_recovered_reviewer_still_scores_below_threshold():
+    # Guards the premise of the re-inclusion tests: if passive recency decay had
+    # already lifted this reviewer over the threshold there would be nothing for
+    # the recovery rule to do, and the tests below would pass vacuously.
+    from theforge.model_profiles import get_review_signal
+
+    profiles = _profiles(
+        **{"anthropic/sonnet/api": _recovered_entry("anthropic", "sonnet", 20, 5)}
+    )
+    signal = get_review_signal(profiles, "rev-a", 5, actual_model="sonnet", provider="anthropic")
+    assert signal["floor"] == "pass"
+    assert signal["rate"] < 0.5
+    assert signal["recovery"]["clean_streak"] == 5
+    assert signal["recovery"]["clean_attempts_required"] == 5
+    assert signal["recovery"]["recovered"] is True
+
+
+def test_reviewer_reincluded_after_k_clean_attempts():
+    # Same reviewer shape as test_full_vs_zero_completion_sorts_full_first, but
+    # rev-a's newest 5 attempts are clean → restored to its normal (input) rank
+    # ahead of rev-b instead of being sorted after it.
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _recovered_entry("anthropic", "sonnet", 20, 5),
+            "openai/gpt/api": _review_entry("openai", "gpt", 6, 6),
+        }
+    )
+    audit: dict = {}
+    selected = _select_reviewers(
+        _two_reviewers(),
+        tier="strong",
+        n=1,
+        prefer_cross_provider=False,
+        model_profiles=profiles,
+        completion_threshold=0.5,
+        completion_min_runs=5,
+        completion_audit=audit,
+    )
+    assert [a.name for a in selected] == ["rev-a"]
+    assert audit["applied"] is False
+    assert audit["deprioritized"] == []
+    assert audit["reincluded"] == ["rev-a"]
+    assert audit["reinclusion_clean_attempts_required"] == 5
+    assert audit["reinclusion_checked"]["rev-a"]["below_threshold"] is True
+    assert audit["reinclusion_checked"]["rev-a"]["clean_streak"] == 5
+
+
+def test_partial_clean_streak_does_not_reinclude():
+    # 4 clean attempts is one short of K=5 → still deprioritized. The streak is
+    # strictly consecutive: an older clean run interrupted by a failure does not
+    # count toward it.
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _recovered_entry("anthropic", "sonnet", 20, 4),
+            "openai/gpt/api": _review_entry("openai", "gpt", 6, 6),
+        }
+    )
+    audit: dict = {}
+    selected = _select_reviewers(
+        _two_reviewers(),
+        tier="strong",
+        n=1,
+        prefer_cross_provider=False,
+        model_profiles=profiles,
+        completion_threshold=0.5,
+        completion_min_runs=5,
+        completion_audit=audit,
+    )
+    assert [a.name for a in selected] == ["rev-b"]
+    assert audit["deprioritized"] == ["rev-a"]
+    assert audit["reincluded"] == []
+    assert audit["reinclusion_checked"]["rev-a"]["clean_streak"] == 4
+
+
+def test_assign_models_reincludes_recovered_reviewer_end_to_end():
+    agents = [
+        AgentDef("dev-cheap", "deepseek", "ds", 1.0, 300, "cheap"),
+        AgentDef("rev-a", "anthropic", "sonnet", 5.0, 600, "strong"),
+        AgentDef("rev-b", "openai", "gpt", 5.0, 600, "strong"),
+    ]
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _recovered_entry("anthropic", "sonnet", 20, 5),
+            "openai/gpt/api": _review_entry("openai", "gpt", 6, 6),
+        }
+    )
+    decision = assign_models(agents, _assign_cfg(), complexity="LOW", model_profiles=profiles)
+    assert [p.name for p in decision.code_reviewers] == ["rev-a"]
+    completion = decision.routing_decision["code_review"]["completion_check"]
+    assert completion["deprioritized"] == []
+    reinclusion = completion["reinclusion_check"]
+    assert reinclusion["mechanism"] == "reviewer_completion_reinclusion"
+    assert reinclusion["fired"] is True
+    assert reinclusion["clean_attempts_required"] == 5
+    assert reinclusion["reincluded"] == ["rev-a"]
+    assert "rev-a" in reinclusion["checked"]
+    assert reinclusion["reason"].startswith("clean_attempt_streak_met")
+    # The consulted per-candidate signal carries the recovery evidence too.
+    assert completion["signals"]["rev-a"]["recovery"]["clean_streak"] == 5
+
+
+def test_assign_models_records_reinclusion_checked_but_not_fired():
+    # Still-low reviewer with no clean streak: the re-inclusion path must be
+    # recorded as checked-and-didn't-fire, never omitted (ADR-0006 clause 7).
+    agents = [
+        AgentDef("dev-cheap", "deepseek", "ds", 1.0, 300, "cheap"),
+        AgentDef("rev-a", "anthropic", "sonnet", 5.0, 600, "strong"),
+        AgentDef("rev-b", "openai", "gpt", 5.0, 600, "strong"),
+    ]
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _review_entry("anthropic", "sonnet", 6, 0),
+            "openai/gpt/api": _review_entry("openai", "gpt", 6, 6),
+        }
+    )
+    decision = assign_models(agents, _assign_cfg(), complexity="LOW", model_profiles=profiles)
+    completion = decision.routing_decision["code_review"]["completion_check"]
+    assert completion["deprioritized"] == ["rev-a"]
+    reinclusion = completion["reinclusion_check"]
+    assert reinclusion["fired"] is False
+    assert reinclusion["reincluded"] == []
+    assert "rev-a" in reinclusion["checked"]
+    assert reinclusion["checked_detail"]["rev-a"]["clean_streak"] == 0
+    assert reinclusion["reason"] == "no_below_threshold_reviewer_met_clean_attempt_streak"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The implementation satisfies the reviewer re-inclusion criteria and the targeted reviewer completion and routing-symmetry tests pass. | [google-gemini-3.5-flash] The reviewer re-inclusion mechanism is fully implemented, thoroughly tested, and perfectly integrated with the routing-symmetry registry and audit logs.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $3.82
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Reviewer re-inclusion — restore a deprioritized reviewer after clean attempts (inverse of #1388) (GitHub Issue #1880)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1880