### PR TITLE
forge groom resolves a missing-example finding with placeholder text that passes the check

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -620,6 +620,17 @@ state present in the body:
 `forge groom` will never propose adding the `ready` label to a bug whose
 cause is unknown — this is a hard invariant of the lifecycle.
 
+**Groom restructures; it does not write content.** For a feature/task/docs
+issue missing acceptance criteria or an example, groom inserts the section
+heading with a `TODO(forge-groom)` placeholder — and the corresponding
+shape-gate finding *stays*. Those findings are listed under `UNRESOLVED:` in
+the output and recorded as `unsupplied_findings` in the audit event, so the
+gap is carried by the issue instead of erased from it. Fill the placeholder
+sections in yourself before labeling `ready`; a groomed-but-unfilled issue
+will not reach the `runnable` verdict. This is enforced mechanically: any
+proposal that resolves `missing_acceptance_criteria` or `missing_example` is
+discarded and the body falls back to whitespace normalization.
+
 **`--next` is operator hint, not protocol.** Output is human-readable; the
 v0.11 contract does not promise a stable machine-readable shape. A `--json`
 extension may follow when auto-routing in v0.12+ needs it.

--- a/src/theforge/cli/groom.py
+++ b/src/theforge/cli/groom.py
@@ -107,6 +107,16 @@ def cmd_groom(args: argparse.Namespace) -> int:
                 file=sys.stdout,
             )
 
+    if result.unsupplied_findings:
+        codes = ", ".join(result.unsupplied_findings)
+        print(
+            f"\nUNRESOLVED: {codes}\n"
+            "      groom scaffolds sections but does not invent their content, so\n"
+            "      these findings still stand. Fill the placeholder sections in\n"
+            "      before labeling this issue ready.",
+            file=sys.stdout,
+        )
+
     if result.needs_change:
         if apply_changes:
             print(

--- a/src/theforge/intake/groom_flow.py
+++ b/src/theforge/intake/groom_flow.py
@@ -30,6 +30,7 @@ from ..shape_check.heuristics import (
     is_bug_format_issue,
 )
 from ..shape_check.parsing import find_heading
+from ..shape_check.placeholders import PLACEHOLDER_MARKER
 from .diagnosis_staleness import StalenessReport, evaluate_staleness
 
 # ── Types ─────────────────────────────────────────────────────────────────
@@ -74,6 +75,9 @@ class GroomResult:
     staleness: StalenessReport | None = None
     confirm_diagnosis_current: bool = False
     staleness_notice: bool = False
+    #: Finding codes groom deliberately left standing because resolving them
+    #: requires content it cannot supply. Reported, never silently dropped.
+    unsupplied_findings: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def needs_change(self) -> bool:
@@ -91,6 +95,7 @@ class GroomResult:
             "bug_diagnosis_state": self.bug_state.value,
             "applied": self.applied,
             "refusal_reason": self.refusal_reason,
+            "unsupplied_findings": list(self.unsupplied_findings),
         }
         if self.staleness is not None:
             payload["staleness_verdict"] = self.staleness.state.value
@@ -243,17 +248,25 @@ def _normalize_body(body: str) -> str:
     return out
 
 
+# Findings whose resolution requires *content* groom cannot invent. Groom
+# may scaffold the section, but it must never emit text that resolves these
+# — an unresolved finding keeps the issue out of a sprint, while a finding
+# satisfied by placeholder text admits it.
+UNSUPPLIABLE_FINDING_CODES: frozenset[str] = frozenset(
+    {"missing_acceptance_criteria", "missing_example"}
+)
+
 _AC_STUB = (
     "\n## Acceptance criteria\n\n"
-    "- TODO: replace with verifiable observable-behavior bullets "
+    f"- {PLACEHOLDER_MARKER}: replace with verifiable observable-behavior bullets "
     "(returns/emits/writes/...)\n"
 )
 
 _EXAMPLE_STUB = (
     "\n## Example\n\n"
     "```\n"
-    "TODO: replace with a concrete example — sample output, target sketch,\n"
-    "or before/after snippet that lets a reviewer eyeball the behavior.\n"
+    f"{PLACEHOLDER_MARKER}: replace with a concrete example — sample output, "
+    "target sketch, or before/after snippet.\n"
     "```\n"
 )
 
@@ -262,11 +275,11 @@ def _restructure_feature_body(body: str) -> str:
     """Insert placeholder sections when AC or Example heading is missing.
 
     Conservative — only adds stub sections; does not rewrite or remove
-    existing content. The stubs are deliberately shape-gate-clean (the AC
-    bullet contains observable-verb tokens; the Example stub is wrapped in
-    a fenced block) so the post-groom verdict can reach ``runnable`` even
-    while operator-readable TODO markers make it clear that substantive
-    content still needs to be filled in by a human or a future LLM pass.
+    existing content. The stubs are deliberately *not* shape-gate-clean:
+    they carry :data:`PLACEHOLDER_MARKER`, which the heuristics strip before
+    measuring substance, so the corresponding finding stands until a human
+    or a later content-supplying pass fills the section in. Groom scaffolds
+    the gap into the issue; it does not erase it.
     """
     out = body or ""
     if not find_heading(out, r"acceptance criteria|done criteria|checklist"):
@@ -276,6 +289,18 @@ def _restructure_feature_body(body: str) -> str:
     ):
         out = out.rstrip() + "\n" + _EXAMPLE_STUB
     return _normalize_body(out)
+
+
+def _fabricated_resolutions(pre: ShapeResult, post: ShapeResult) -> tuple[str, ...]:
+    """Return unsuppliable finding codes present in ``pre`` but gone in ``post``.
+
+    Mechanical guard, not a convention: if a body edit ever makes one of
+    these findings disappear, the content was fabricated by definition —
+    groom supplies no substance. Callers discard such a proposal.
+    """
+    pre_codes = {r.code for r in pre.reasons}
+    post_codes = {r.code for r in post.reasons}
+    return tuple(sorted((pre_codes - post_codes) & UNSUPPLIABLE_FINDING_CODES))
 
 
 # ── Issue loading ─────────────────────────────────────────────────────────
@@ -534,6 +559,9 @@ def run_groom(
                 and staleness.is_stale
                 and bug_state is BugDiagnosisState.CAUSE_UNKNOWN
             ),
+            unsupplied_findings=tuple(
+                sorted({r.code for r in pre_result.reasons} & UNSUPPLIABLE_FINDING_CODES)
+            ),
         )
 
     # Body restructure / normalization
@@ -549,6 +577,16 @@ def run_groom(
             proposed = _restructure_feature_body(body)
 
     post_result = shape_check(title, proposed, shape_labels)
+
+    # Mechanical guard: if the proposal resolved a finding whose resolution
+    # needs content groom cannot supply, the content was fabricated. Discard
+    # the restructure and fall back to normalization, so the gap is carried
+    # by the issue rather than erased from it.
+    fabricated = _fabricated_resolutions(pre_result, post_result)
+    if fabricated:
+        proposed = _normalize_body(body)
+        post_result = shape_check(title, proposed, shape_labels)
+
     post_verdict = post_result.verdict
 
     applied = False
@@ -565,8 +603,8 @@ def run_groom(
             refetched = fetch(loaded.number, project_root)
             if refetched is not None:
                 confirmed_body = refetched.get("body", "") or ""
-                confirmed_result = shape_check(title, confirmed_body, shape_labels)
-                post_verdict = confirmed_result.verdict
+                post_result = shape_check(title, confirmed_body, shape_labels)
+                post_verdict = post_result.verdict
         elif loaded.file_path is not None:
             try:
                 loaded.file_path.write_text(proposed, encoding="utf-8")
@@ -580,8 +618,10 @@ def run_groom(
                 raise GroomError(
                     f"could not re-read {loaded.file_path} after apply: {exc}"
                 ) from exc
-            confirmed_result = shape_check(title, confirmed_body, shape_labels)
-            post_verdict = confirmed_result.verdict
+            post_result = shape_check(title, confirmed_body, shape_labels)
+            post_verdict = post_result.verdict
+
+    unsupplied = tuple(sorted({r.code for r in post_result.reasons} & UNSUPPLIABLE_FINDING_CODES))
 
     next_cmd = _next_command(
         issue_ref=issue_ref,
@@ -613,4 +653,5 @@ def run_groom(
             and staleness.is_stale
             and bug_state is BugDiagnosisState.CAUSE_UNKNOWN
         ),
+        unsupplied_findings=unsupplied,
     )

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -23,6 +23,7 @@ from theforge.shape_check.parsing import (
     fenced_code_blocks,
     has_heading,
 )
+from theforge.shape_check.placeholders import is_placeholder_only, strip_placeholder_content
 from theforge.shape_check.types import Reason, Severity
 
 DEFAULT_CLUSTER_THRESHOLD = 4
@@ -629,14 +630,24 @@ def check_missing_acceptance_criteria(
 ) -> Reason | None:
     if is_bug_format_issue(body, labels):
         return None
+    placeholder_only = False
     if has_heading(body, r"acceptance criteria|done criteria|checklist"):
         section = extract_ac_section(body) or ""
-        if extract_bullets(section):
+        # Placeholder bullets are shaped like criteria but assert nothing;
+        # measure substance on what remains once they are stripped.
+        if extract_bullets(strip_placeholder_content(section)):
             return None
+        placeholder_only = bool(extract_bullets(section))
+    detail = (
+        "Acceptance criteria section contains only placeholder/TODO text — "
+        "no verifiable criteria supplied."
+        if placeholder_only
+        else "No acceptance criteria section with a bullet/checklist found."
+    )
     return Reason(
         code="missing_acceptance_criteria",
         severity=Severity.BLOCKING,
-        detail="No acceptance criteria section with a bullet/checklist found.",
+        detail=detail,
     )
 
 
@@ -678,15 +689,26 @@ def check_missing_example(title: str, body: str, labels: Iterable[str]) -> Reaso
             detail="No recognizable example section found for this feature-format issue.",
         )
 
-    content_chars = len(re.sub(r"\s+", "", section))
-    if content_chars < _EXAMPLE_MIN_CONTENT_CHARS or not _has_structured_example_content(section):
+    # A section that only says an example is missing is not an example.
+    # Strip placeholder scaffolding before measuring substance, so a producer
+    # cannot resolve this finding with text merely shaped like the answer.
+    substantive = strip_placeholder_content(section)
+    content_chars = len(re.sub(r"\s+", "", substantive))
+    if content_chars < _EXAMPLE_MIN_CONTENT_CHARS or not _has_structured_example_content(
+        substantive
+    ):
+        detail = (
+            "Example section contains only placeholder/TODO text — no concrete example supplied."
+            if is_placeholder_only(section)
+            else (
+                "Example section is present but not substantive; include a concrete list, "
+                "table, or fenced example."
+            )
+        )
         return Reason(
             code="missing_example",
             severity=Severity.ADVISORY,
-            detail=(
-                "Example section is present but not substantive; include a concrete list, "
-                "table, or fenced example."
-            ),
+            detail=detail,
         )
     return None
 

--- a/src/theforge/shape_check/placeholders.py
+++ b/src/theforge/shape_check/placeholders.py
@@ -1,0 +1,133 @@
+"""Placeholder-content detection. Stdlib only.
+
+The shape gate tests *structure* as a proxy for *substance*: a section that
+exists, is long enough, and contains a fence/list/table is accepted as a
+concrete example. That proxy holds for hand-written bodies and breaks for
+machine-written ones — a producer can emit text shaped like the missing
+thing and satisfy a check nothing actually resolved.
+
+This module is the shared contract that closes the gap. Producers mark
+content they could not supply with :data:`PLACEHOLDER_MARKER`; the
+heuristics strip marked lines before measuring substance, so a
+placeholder-only section keeps its finding instead of erasing it. The
+generic markers (``TBD``, ``FIXME``, ``XXX``, bare ``TODO``) are recognised
+too, so a hand-copied stub is caught the same way.
+"""
+
+from __future__ import annotations
+
+import re
+
+from theforge.shape_check.parsing import FenceTracker
+
+#: Marker a producer writes when it cannot supply the content a section
+#: needs. Written by ``forge groom``; recognised by the heuristics below.
+PLACEHOLDER_MARKER = "TODO(forge-groom)"
+
+# Leading bullet / checkbox / blockquote / comment scaffolding that may
+# precede the marker word on a placeholder line.
+_PLACEHOLDER_LINE_RE = re.compile(
+    r"^\s*(?:>\s*)*(?:(?:[-*+]|\d+[.)])\s+)?(?:\[[ xX]\]\s+)?(?:<!--\s*)?"
+    r"(?:TODO|TBD|FIXME|XXX)\b",
+    re.IGNORECASE,
+)
+
+
+# A placeholder's instructions may wrap onto following lines. Anything that
+# opens new structure (blank line, bullet, heading, fence, table row) ends
+# the wrap.
+_NEW_BLOCK_RE = re.compile(r"^\s*(?:$|(?:[-*+]|\d+[.)])\s|#{1,6}\s|`{3,}|~{3,}|\|)")
+
+# Only a line that is visibly mid-sentence pulls the next line in with it.
+# A self-contained "TODO: ..." followed by real sample output must not
+# swallow that output — the wrap rule has to be narrower than "next line".
+_WRAPS_RE = re.compile(r"[,;:—–\-(\[]$")
+
+
+def is_placeholder_line(line: str) -> bool:
+    """True when ``line`` is an unfilled-template marker rather than content."""
+    return _PLACEHOLDER_LINE_RE.match(line) is not None
+
+
+def _wraps_onto_next_line(line: str) -> bool:
+    return _WRAPS_RE.search(line.rstrip()) is not None
+
+
+def _is_continuation(line: str) -> bool:
+    """True when ``line`` continues the preceding placeholder's prose."""
+    return _NEW_BLOCK_RE.match(line) is None
+
+
+def has_placeholder_marker(text: str) -> bool:
+    """True when ``text`` contains the producer-written placeholder marker."""
+    return PLACEHOLDER_MARKER.lower() in text.lower()
+
+
+def strip_placeholder_content(text: str) -> str:
+    """Return ``text`` with placeholder lines removed.
+
+    Fenced blocks left with no substantive content are dropped whole, so a
+    fence wrapping nothing but a TODO does not read as structured content
+    to :mod:`theforge.shape_check.heuristics`.
+    """
+    if not text:
+        return text
+
+    out: list[str] = []
+    block: list[str] | None = None  # buffered fenced block, incl. delimiters
+    block_has_content = False
+    dropping = False  # inside a placeholder's wrapped prose
+    tracker = FenceTracker()
+
+    for line in text.splitlines():
+        role = tracker.feed(line)
+        if role == "open":
+            block = [line]
+            block_has_content = False
+            dropping = False
+            continue
+        if role == "inside":
+            if block is None:  # defensive: fence state without an opener
+                out.append(line)
+                continue
+            if is_placeholder_line(line):
+                dropping = _wraps_onto_next_line(line)
+                continue
+            if dropping and _is_continuation(line):
+                dropping = _wraps_onto_next_line(line)
+                continue
+            dropping = False
+            block.append(line)
+            if line.strip():
+                block_has_content = True
+            continue
+        if role == "close":
+            dropping = False
+            if block is not None:
+                if block_has_content:
+                    block.append(line)
+                    out.extend(block)
+                block = None
+                block_has_content = False
+            continue
+        if is_placeholder_line(line):
+            dropping = _wraps_onto_next_line(line)
+            continue
+        if dropping and _is_continuation(line):
+            dropping = _wraps_onto_next_line(line)
+            continue
+        dropping = False
+        out.append(line)
+
+    # Unclosed fence at end of text: keep it only if it held real content.
+    if block is not None and block_has_content:
+        out.extend(block)
+
+    return "\n".join(out)
+
+
+def is_placeholder_only(text: str) -> bool:
+    """True when nothing but placeholder scaffolding remains in ``text``."""
+    if not text.strip():
+        return False
+    return not strip_placeholder_content(text).strip()

--- a/tests/test_cli_groom.py
+++ b/tests/test_cli_groom.py
@@ -167,3 +167,37 @@ def test_cli_groom_appears_in_help():
         if isinstance(action, argparse._SubParsersAction)
     )
     assert "groom" in subparsers_action.choices
+
+
+# ── Unsupplied content is reported, not erased (#2129) ───────────────────
+
+_FEATURE_BODY = """\
+## What
+
+Users can export their data.
+"""
+
+
+def test_cli_reports_findings_groom_could_not_resolve(tmp_path, monkeypatch, capsys):
+    _patch_fetch(monkeypatch, {"title": "Add export", "body": _FEATURE_BODY, "labels": ["task"]})
+    rc = cli_groom.cmd_groom(_build_args("2129", tmp_path, want_next=True))
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "UNRESOLVED" in captured.out
+    assert "missing_example" in captured.out
+    assert "missing_acceptance_criteria" in captured.out
+    assert "--add-label ready" not in captured.out
+
+
+def test_cli_event_records_unsupplied_findings(tmp_path, monkeypatch, capsys):
+    _patch_fetch(monkeypatch, {"title": "Add export", "body": _FEATURE_BODY, "labels": ["task"]})
+    _patch_edit(monkeypatch, ok=True)
+    cli_groom.cmd_groom(_build_args("2129", tmp_path, apply=True))
+
+    conn = sqlite3.connect(str(substrate_path(tmp_path)))
+    rows = conn.execute("SELECT post_verdict, raw_json FROM readiness_events").fetchall()
+    conn.close()
+    assert len(rows) == 1
+    post, raw = rows[0]
+    assert post != "runnable"
+    assert "missing_example" in raw

--- a/tests/test_intake/test_groom_flow.py
+++ b/tests/test_intake/test_groom_flow.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from theforge.intake import groom_flow
 from theforge.intake.groom_flow import (
     BugDiagnosisState,
     GroomAction,
@@ -18,6 +19,8 @@ from theforge.intake.groom_flow import (
     run_groom,
 )
 from theforge.shape_check import ShapeVerdict
+from theforge.shape_check import check as shape_check
+from theforge.shape_check.placeholders import has_placeholder_marker
 
 # ── Bug fixtures ──────────────────────────────────────────────────────────
 
@@ -201,15 +204,24 @@ def test_groom_feature_inserts_missing_ac_and_example():
     assert "## Acceptance criteria" in result.proposed_body
     assert "## Example" in result.proposed_body
     assert result.needs_change
-    # P1: the groomed feature body must be shape-gate-clean.
-    assert result.post_verdict is ShapeVerdict.RUNNABLE
+    # Groom scaffolds the missing sections but does not invent their content,
+    # so the findings it could not resolve must still stand (#2129).
+    assert result.post_verdict is not ShapeVerdict.RUNNABLE
+    assert result.unsupplied_findings == ("missing_acceptance_criteria", "missing_example")
 
 
 def test_groom_docs_reaches_runnable():
     """Docs-typed issues are first-class per ADR-0001; normalize them onto
     the shape gate's recognized type vocabulary so the post-groom verdict
-    can reach runnable rather than tripping on missing_type."""
-    body = "## What\n\nDocument the new endpoint.\n"
+    can reach runnable rather than tripping on missing_type.
+
+    Body already carries real AC and example content — groom supplies
+    neither (#2129), so type normalization is what's under test here."""
+    body = (
+        "## What\n\nDocument the new endpoint.\n\n"
+        "## Acceptance criteria\n\n- Docs build produces a page for the export endpoint\n\n"
+        "## Example\n\n```\nGET /api/export -> 200 text/csv\n```\n"
+    )
     fetch = _fake_fetch(
         {
             "title": "Document export endpoint",
@@ -225,8 +237,15 @@ def test_groom_docs_reaches_runnable():
 
 def test_groom_story_reaches_runnable():
     """Story-typed issues are supported per the lifecycle spec; normalize
-    them to a shape-gate-recognized label so they reach a real verdict."""
-    body = "## What\n\nUsers can filter by date.\n"
+    them to a shape-gate-recognized label so they reach a real verdict.
+
+    Body already carries real AC and example content — groom supplies
+    neither (#2129), so type normalization is what's under test here."""
+    body = (
+        "## What\n\nUsers can filter by date.\n\n"
+        "## Acceptance criteria\n\n- Filter emits only rows within the date range\n\n"
+        "## Example\n\n```\nfilter --from 2026-01-01 --to 2026-02-01\n```\n"
+    )
     fetch = _fake_fetch(
         {
             "title": "Filter by date",
@@ -364,8 +383,10 @@ def test_apply_rechecks_persisted_file_after_local_write(tmp_path: Path):
     )
     result = run_groom(str(f), apply_changes=True)
     assert result.applied is True
-    # File on disk has the canonical groomed body, so re-read verdict is runnable.
-    assert result.post_verdict is ShapeVerdict.RUNNABLE
+    # Re-read verdict is derived from disk. Groom scaffolded the missing
+    # sections but supplied no content, so the findings still stand.
+    assert result.post_verdict is not ShapeVerdict.RUNNABLE
+    assert result.unsupplied_findings == ("missing_acceptance_criteria", "missing_example")
     on_disk = f.read_text(encoding="utf-8")
     assert "## Acceptance criteria" in on_disk
     assert "## Example" in on_disk
@@ -419,3 +440,78 @@ def test_event_payload_for_restructured():
     ev = result.as_event()
     assert ev["action"] == "restructured"
     assert ev["bug_diagnosis_state"] == "confirmed-cause"
+
+
+# ── Content groom cannot supply (#2129) ───────────────────────────────────
+
+
+def _feature_fetch():
+    return _fake_fetch(
+        {
+            "title": "Add export",
+            "body": "## What\n\nUsers can export.\n",
+            "labels": ["enhancement"],
+        }
+    )
+
+
+def test_groom_stub_body_still_fails_the_checks_it_did_not_resolve():
+    """The proposed body must not pass a check groom did not actually
+    resolve — re-running the shape gate on it keeps both findings."""
+    result = run_groom("42", fetch_issue=_feature_fetch(), edit_issue_body=_no_op_edit)
+    codes = {
+        r.code for r in shape_check("Add export", result.proposed_body, ["enhancement"]).reasons
+    }
+    assert "missing_example" in codes
+    assert "missing_acceptance_criteria" in codes
+
+
+def test_groom_marks_stub_sections_as_placeholders():
+    result = run_groom("42", fetch_issue=_feature_fetch(), edit_issue_body=_no_op_edit)
+    assert has_placeholder_marker(result.proposed_body)
+
+
+def test_unsupplied_findings_are_reported_in_the_event_payload():
+    result = run_groom("42", fetch_issue=_feature_fetch(), edit_issue_body=_no_op_edit)
+    ev = result.as_event()
+    assert ev["unsupplied_findings"] == ["missing_acceptance_criteria", "missing_example"]
+
+
+def test_next_command_is_not_ready_when_content_is_unsupplied():
+    result = run_groom("42", fetch_issue=_feature_fetch(), edit_issue_body=_no_op_edit)
+    assert "--add-label ready" not in (result.next_command or "")
+
+
+def test_fabricated_resolution_is_discarded_and_body_falls_back_to_normalization(monkeypatch):
+    """Mechanical guard: any restructure that resolves an unsuppliable
+    finding is discarded, whatever text produced it."""
+
+    def fabricate(body: str) -> str:
+        return (
+            body.rstrip()
+            + "\n\n## Acceptance criteria\n\n- Export writes a CSV file\n"
+            + "\n## Example\n\n```\nexport --format csv > out.csv\n```\n"
+        )
+
+    monkeypatch.setattr(groom_flow, "_restructure_feature_body", fabricate)
+    result = run_groom("42", fetch_issue=_feature_fetch(), edit_issue_body=_no_op_edit)
+    assert "## Acceptance criteria" not in result.proposed_body
+    assert result.post_verdict is not ShapeVerdict.RUNNABLE
+    assert result.unsupplied_findings == ("missing_acceptance_criteria", "missing_example")
+
+
+def test_body_with_real_content_keeps_no_unsupplied_findings():
+    fetch = _fake_fetch(
+        {
+            "title": "Add export",
+            "body": (
+                "## What\n\nUsers can export.\n\n"
+                "## Acceptance criteria\n\n- Export writes a CSV to the download directory\n\n"
+                "## Example\n\n```\nexport --format csv > out.csv\n```\n"
+            ),
+            "labels": ["enhancement"],
+        }
+    )
+    result = run_groom("42", fetch_issue=fetch, edit_issue_body=_no_op_edit)
+    assert result.unsupplied_findings == ()
+    assert result.post_verdict is ShapeVerdict.RUNNABLE

--- a/tests/test_shape_check_placeholders.py
+++ b/tests/test_shape_check_placeholders.py
@@ -1,0 +1,170 @@
+"""Placeholder content must not satisfy a check it does not resolve (#2129).
+
+The shape gate tests structure as a proxy for substance. These tests pin the
+boundary: text merely *shaped* like an example or a criterion — a fenced TODO,
+a placeholder bullet — keeps its finding standing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from theforge.shape_check.heuristics import (
+    check_missing_acceptance_criteria,
+    check_missing_example,
+)
+from theforge.shape_check.placeholders import (
+    PLACEHOLDER_MARKER,
+    is_placeholder_line,
+    is_placeholder_only,
+    strip_placeholder_content,
+)
+
+# The body `forge groom 1108` actually proposed — verbatim from the story.
+_ISSUE_1108_STUB = """## Example
+
+```
+TODO: replace with a concrete example — sample output, target sketch,
+or before/after snippet that lets a reviewer eyeball the behavior.
+```
+"""
+
+_REAL_EXAMPLE = """## Example
+
+```
+$ forge groom 1108
+Post-groom verdict: needs_grooming_missing_example
+```
+"""
+
+
+# ── strip / detect primitives ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        f"{PLACEHOLDER_MARKER}: replace with a concrete example",
+        "TODO: fill this in",
+        "- TODO(forge-groom): replace with criteria",
+        "  * TBD",
+        "1. FIXME: needs content",
+        "- [ ] TODO: decide",
+        "> XXX placeholder",
+    ],
+)
+def test_placeholder_lines_are_recognized(line):
+    assert is_placeholder_line(line)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "- Export emits a downloadable file",
+        "the todo list renders newest-first",
+        "```",
+        "",
+    ],
+)
+def test_content_lines_are_not_placeholders(line):
+    assert not is_placeholder_line(line)
+
+
+def test_strip_drops_fenced_block_left_empty():
+    stripped = strip_placeholder_content(_ISSUE_1108_STUB)
+    assert "```" not in stripped
+    assert "TODO" not in stripped
+
+
+def test_strip_keeps_fenced_block_with_real_content():
+    stripped = strip_placeholder_content(_REAL_EXAMPLE)
+    assert "forge groom 1108" in stripped
+    assert stripped.count("```") == 2
+
+
+def test_strip_keeps_real_lines_alongside_placeholders():
+    section = "- Export emits a file\n- TODO: decide the format\n"
+    stripped = strip_placeholder_content(section)
+    assert "Export emits a file" in stripped
+    assert "TODO" not in stripped
+
+
+def test_is_placeholder_only_distinguishes_mixed_content():
+    assert is_placeholder_only(_ISSUE_1108_STUB.split("\n", 2)[2])
+    assert not is_placeholder_only(_REAL_EXAMPLE)
+    assert not is_placeholder_only("")
+
+
+def test_strip_keeps_unclosed_fence_with_content():
+    section = "```\nreal sample output\n"
+    assert "real sample output" in strip_placeholder_content(section)
+
+
+# ── check_missing_example ─────────────────────────────────────────────────
+
+
+def test_groom_1108_placeholder_body_still_reports_missing_example():
+    """The exact regression: a fenced TODO passed all three structural tests."""
+    reason = check_missing_example("Add export", _ISSUE_1108_STUB, ["enhancement"])
+    assert reason is not None
+    assert reason.code == "missing_example"
+    assert "placeholder" in reason.detail.lower()
+
+
+def test_marked_placeholder_example_still_reports_missing_example():
+    body = f"## Example\n\n```\n{PLACEHOLDER_MARKER}: replace with a concrete example.\n```\n"
+    reason = check_missing_example("Add export", body, ["enhancement"])
+    assert reason is not None
+    assert reason.code == "missing_example"
+
+
+def test_real_example_still_passes():
+    assert check_missing_example("Add export", _REAL_EXAMPLE, ["enhancement"]) is None
+
+
+def test_example_with_placeholder_plus_real_content_passes():
+    body = (
+        "## Example\n\n"
+        "```\n"
+        "TODO: add the error case too\n"
+        "$ forge groom 1108 --apply\n"
+        "Applied body restructure to #1108.\n"
+        "```\n"
+    )
+    assert check_missing_example("Add export", body, ["enhancement"]) is None
+
+
+# ── check_missing_acceptance_criteria ─────────────────────────────────────
+
+
+def test_placeholder_only_acceptance_criteria_still_reports_finding():
+    body = (
+        "## Acceptance criteria\n\n"
+        f"- {PLACEHOLDER_MARKER}: replace with verifiable observable-behavior bullets "
+        "(returns/emits/writes/...)\n"
+    )
+    reason = check_missing_acceptance_criteria("Add export", body, ["enhancement"])
+    assert reason is not None
+    assert reason.code == "missing_acceptance_criteria"
+    assert "placeholder" in reason.detail.lower()
+
+
+def test_real_acceptance_criteria_still_passes():
+    body = "## Acceptance criteria\n\n- Export writes a CSV to the download directory\n"
+    assert check_missing_acceptance_criteria("Add export", body, ["enhancement"]) is None
+
+
+def test_mixed_acceptance_criteria_passes_on_the_real_bullet():
+    body = (
+        "## Acceptance criteria\n\n"
+        "- TODO: confirm the filename convention\n"
+        "- Export writes a CSV to the download directory\n"
+    )
+    assert check_missing_acceptance_criteria("Add export", body, ["enhancement"]) is None
+
+
+def test_missing_section_detail_unchanged():
+    body = "## What\n\nStuff.\n"
+    reason = check_missing_acceptance_criteria("Add export", body, ["enhancement"])
+    assert reason is not None
+    assert "No acceptance criteria section" in reason.detail


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change keeps groom placeholder sections from satisfying the shape gate and reports the unresolved content gap. | [google-gemini-3.5-flash] Approved. Successfully fixed groom resolving missing-content findings with placeholder text by introducing a shared placeholder contract and mechanical guard.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $6.46
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge groom resolves a missing-example finding with placeholder text that passes the check (GitHub Issue #2129)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2129