### PR TITLE
Missing sandbox capability profile is never surfaced, even when the agent reports the exact toolchain failure it causes

### DIFF
--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 import yaml
 
-from theforge.config.sandbox_capabilities import get_preset
+from theforge.config.sandbox_capabilities import SandboxCapabilityError, get_preset
 
 SCHEMA_VERSION = 1
 # Version of the classifier RULES themselves. Bump whenever a rule change can
@@ -43,7 +43,7 @@ SCHEMA_VERSION = 1
 # (schema_version stays 1) rather than a silent rewrite of historical judgement:
 # an operator can tell whether two RCA files for one sprint were produced by the
 # same rule set by comparing this field.
-RULESET_VERSION = 8
+RULESET_VERSION = 9
 RCA_FILENAME = "sprint-rca.yaml"
 
 # Outcomes that mean the story landed / succeeded. These stay accounted for in
@@ -691,6 +691,7 @@ def _classify_story(
         contributing,
         story,
         capability_preset=capability_gap.preset if capability_gap else None,
+        capability_profile_note=capability_gap.profile_note if capability_gap else None,
     )
 
     return {
@@ -989,7 +990,7 @@ def _capability_payload_grants_preset(payload: dict, preset_name: str) -> bool:
     """True when one recorded capability payload fully grants a preset."""
     try:
         preset = get_preset(preset_name)
-    except Exception:
+    except SandboxCapabilityError:
         return False
 
     write_roots = payload.get("write_roots")
@@ -1035,7 +1036,7 @@ def _capability_symptom_hit(sources: list[_TextSource]) -> tuple[str, str, str, 
     for preset in sorted(_CAPABILITY_PRESET_SYMPTOMS):
         symptoms = _CAPABILITY_PRESET_SYMPTOMS[preset]
         for src in sources:
-            if src.kind in {"authored", "structured"}:
+            if src.kind == "authored":
                 continue
             for line in src.text.splitlines():
                 lowered = line.lower()
@@ -1406,27 +1407,17 @@ def _select_primary(
 ) -> str | None:
     """Choose the winning primary failure class by declared priority.
 
-    Structured fields from the current run outrank broad text scans. Text scans
-    remain valuable fallback evidence, but they must not override the run's own
-    recorded terminal state.
+    Structured fields and text scans are both eligible evidence; the declared
+    priority list decides which class is most actionable overall.
     """
-    present = set(structured_primary_classes)
-    for cls in _PRIMARY_PRIORITY:
-        # Capability-gap evidence may be carried as text when the denial lives in
-        # a log line, but it still needs to outrank the generic iteration-limit
-        # symptom it usually presents as.
-        if cls == "iteration_exhaustion" and "capability_profile_gap" in text_primary_classes:
-            return "capability_profile_gap"
-        if cls in present:
-            return cls
-    if structured_primary_classes:
-        return structured_primary_classes[0]
-    present = set(text_primary_classes)
+    present = set(structured_primary_classes) | set(text_primary_classes)
     for cls in _PRIMARY_PRIORITY:
         if cls in present:
             return cls
     # A primary rule fired but its class is not in the priority list — return
     # the first seen so we never lose a real classification.
+    if structured_primary_classes:
+        return structured_primary_classes[0]
     return text_primary_classes[0] if text_primary_classes else None
 
 
@@ -1521,7 +1512,9 @@ def _launch_collision_action(story: dict, ref: str) -> str:
     )
 
 
-def _capability_gap_action(preset: str | None, ref: str) -> str:
+def _capability_gap_action(
+    preset: str | None, ref: str, profile_note: str | None = None
+) -> str:
     """Next step for a capability-profile gap: name the setting and the preset.
 
     Deliberately does not mention the iteration budget. The budget was spent on
@@ -1529,10 +1522,11 @@ def _capability_gap_action(preset: str | None, ref: str) -> str:
     same failure (#2029).
     """
     named = f"'{preset}'" if preset else "the preset matching the failing toolchain"
+    profile_clause = f"{profile_note}; " if profile_note else ""
     return (
         f"set sandbox.capability_profile: {preset or '<preset>'} in the project's forge.yaml "
-        f"and re-sprint {ref} — the run resolved no capability profile while the agent "
-        f"reported exactly the toolchain/service denial the {named} preset removes, so the "
+        f"and re-sprint {ref} — {profile_clause}recorded capability payloads did not "
+        f"grant the {named} preset's required write roots or mach services, so the "
         "dev agent could not build or verify its own work"
     )
 
@@ -1543,6 +1537,7 @@ def _recommend_actions(
     story: dict,
     *,
     capability_preset: str | None = None,
+    capability_profile_note: str | None = None,
 ) -> list[str]:
     """Map primary class + contributing factors to actionable next steps."""
     ref = _story_ref(story)
@@ -1595,7 +1590,9 @@ def _recommend_actions(
             "discard partial work"
         ),
         "dependency_skip": _dependency_action(story, ref),
-        "capability_profile_gap": _capability_gap_action(capability_preset, ref),
+        "capability_profile_gap": _capability_gap_action(
+            capability_preset, ref, capability_profile_note
+        ),
         "iteration_exhaustion": (
             f"raise the iteration budget for {ref} or narrow its scope, then re-run"
         ),

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+from theforge.config.sandbox_capabilities import get_preset
 
 SCHEMA_VERSION = 1
 # Version of the classifier RULES themselves. Bump whenever a rule change can
@@ -41,7 +42,7 @@ SCHEMA_VERSION = 1
 # (schema_version stays 1) rather than a silent rewrite of historical judgement:
 # an operator can tell whether two RCA files for one sprint were produced by the
 # same rule set by comparing this field.
-RULESET_VERSION = 7
+RULESET_VERSION = 8
 RCA_FILENAME = "sprint-rca.yaml"
 
 # Outcomes that mean the story landed / succeeded. These stay accounted for in
@@ -922,30 +923,28 @@ _CAPABILITY_PRESET_SYMPTOMS: dict[str, tuple[str, ...]] = {
 
 # A symptom token alone is just the name of a tool the story legitimately uses.
 # It only evidences a *capability* gap when the same line also states that the
-# resource was refused — so both must co-occur on one line. That pairing is also
-# what keeps a pure outbound-network failure (no toolchain subject on the line)
-# from being classified as a toolchain capability gap.
+# resource was refused — so both must co-occur on one line.
 _CAPABILITY_DENIAL_MARKERS: tuple[str, ...] = (
     "operation not permitted",
     "permission denied",
     "not permitted",
-    "denied",
     "unreachable",
     "connection invalid",
     "connection interrupted",
     "connection refused",
     "could not connect",
-    "unavailable",
-    "sandbox",
+    "sandbox denied",
 )
 
 
 @dataclass(frozen=True)
 class _CapabilityGap:
-    """A resolved-no-profile run whose text reported a preset's failure mode."""
+    """A run whose capability payloads missed the matched preset's grants."""
 
     preset: str
     source: str
+    source_kind: str
+    profile_note: str
     excerpt: str
 
 
@@ -969,24 +968,63 @@ def _sandbox_capability_payloads(audit: dict) -> list[dict]:
     return payloads
 
 
-def _capability_grant_absent(audit: dict) -> bool:
-    """True when the run's own record says no capability was granted at all.
+def _capability_root_suffix(template: str) -> tuple[str, ...]:
+    """Return the path suffix a preset template must match in an audit payload."""
+    if template.startswith("~/"):
+        template = template[2:]
+    return Path(template).parts
 
-    Returns False when the audit carries no capability record: the class asserts
-    what forge *resolved*, so a record it never wrote cannot evidence it.
-    """
-    payloads = _sandbox_capability_payloads(audit)
-    if not payloads:
+
+def _capability_root_matches(actual: str, template: str) -> bool:
+    """True when a resolved write root satisfies a preset template."""
+    actual_parts = Path(actual).parts
+    template_parts = _capability_root_suffix(template)
+    if len(actual_parts) < len(template_parts):
         return False
-    for payload in payloads:
-        if _nonempty(payload.get("profile")):
+    return actual_parts[-len(template_parts) :] == template_parts
+
+
+def _capability_payload_grants_preset(payload: dict, preset_name: str) -> bool:
+    """True when one recorded capability payload fully grants a preset."""
+    try:
+        preset = get_preset(preset_name)
+    except Exception:
+        return False
+
+    write_roots = payload.get("write_roots")
+    mach_services = payload.get("mach_services")
+    if not isinstance(write_roots, list) or not isinstance(mach_services, list):
+        return False
+
+    actual_roots = [str(root) for root in write_roots if _nonempty(root)]
+    actual_services = {str(service) for service in mach_services if _nonempty(service)}
+
+    for template in preset.write_roots:
+        if not any(_capability_root_matches(actual, template) for actual in actual_roots):
             return False
-        if payload.get("write_roots") or payload.get("mach_services"):
+    for service in preset.mach_services:
+        if service not in actual_services:
             return False
     return True
 
 
-def _capability_symptom_hit(sources: list[_TextSource]) -> tuple[str, str, str] | None:
+def _capability_profile_note(payloads: list[dict]) -> str:
+    """Summarise the recorded profile state for capability-gap evidence."""
+    profiles = [
+        _nonempty(payload.get("profile"))
+        for payload in payloads
+        if isinstance(payload, dict) and _nonempty(payload.get("profile"))
+    ]
+    if not profiles:
+        return "sandbox.capability_profile unset"
+    profile = profiles[0]
+    if len({p for p in profiles}) == 1:
+        return f"sandbox.capability_profile={profile!r}"
+    unique = ", ".join(repr(p) for p in sorted(set(profiles)))
+    return f"sandbox.capability_profile values {unique}"
+
+
+def _capability_symptom_hit(sources: list[_TextSource]) -> tuple[str, str, str, str] | None:
     """Find the first line naming a preset's toolchain *and* its refusal.
 
     Agent-authored prose is out of scope for the same reason as #2031: it
@@ -1004,27 +1042,36 @@ def _capability_symptom_hit(sources: list[_TextSource]) -> tuple[str, str, str] 
                     continue
                 if not any(marker in lowered for marker in _CAPABILITY_DENIAL_MARKERS):
                     continue
-                return preset, src.source, _truncate(line.strip())
+                return preset, src.source, src.kind, _truncate(line.strip())
     return None
 
 
 def _capability_profile_gap_evidence(
     audit: dict, sources: list[_TextSource]
 ) -> _CapabilityGap | None:
-    """Correlate "no profile resolved" with "the toolchain that needs one failed".
+    """Correlate a missing/incomplete capability payload with the matching denial.
 
     Neither half classifies alone: most runs legitimately resolve no profile, and
-    a toolchain error under a *granted* profile is a different problem with a
+    a toolchain error under a fully granted preset is a different problem with a
     different fix. Together they are the configuration gap forge already held
     both halves of and reported as an iteration-budget problem (#2029).
     """
-    if not _capability_grant_absent(audit):
+    payloads = _sandbox_capability_payloads(audit)
+    if not payloads:
         return None
     hit = _capability_symptom_hit(sources)
     if hit is None:
         return None
-    preset, source, excerpt = hit
-    return _CapabilityGap(preset=preset, source=source, excerpt=excerpt)
+    preset, source, source_kind, excerpt = hit
+    if any(_capability_payload_grants_preset(payload, preset) for payload in payloads):
+        return None
+    return _CapabilityGap(
+        preset=preset,
+        source=source,
+        source_kind=source_kind,
+        profile_note=_capability_profile_note(payloads),
+        excerpt=excerpt,
+    )
 
 
 def _provider_quota_evidence(audit: dict, audit_source: str) -> tuple[str, str, str] | None:
@@ -1169,7 +1216,7 @@ def _signal_rule_hits(
     Signal hits carry ``None`` as the matched pattern — they are field-derived,
     not pattern-derived, so the ambiguity-precedence check never applies to them.
     """
-    hits: list[tuple[str, str, str]] = []
+    hits: list[tuple[str, str, str, str]] = []
     summary_source = _rel(summary_path, logs_root)
     audit_source = _rel(sprint_log_dir / str(story.get("slug") or "") / "audit.yaml", logs_root)
     outcome = str(story.get("outcome") or "").upper()
@@ -1187,7 +1234,7 @@ def _signal_rule_hits(
         audit, outcome, error, summary_source, audit_source
     )
     if config_change is not None:
-        hits.append(config_change)
+        hits.append((*config_change, "structured"))
 
     # Shared-infrastructure abort (#2107) — field-derived from the run's own
     # recorded error_type/outcome_code and the structured cause the runner or
@@ -1196,20 +1243,21 @@ def _signal_rule_hits(
     # assign this class.
     infra_hit = _infrastructure_abort_evidence(story, audit, summary_source, audit_source)
     if infra_hit is not None:
-        hits.append(infra_hit)
+        hits.append((*infra_hit, "structured"))
 
     # Provider quota / fallback classification from the run's own transport
     # telemetry rather than scanned for in prose (#2031).
     quota_hit = _provider_quota_evidence(audit, audit_source)
     if quota_hit is not None:
-        hits.append(quota_hit)
+        hits.append((*quota_hit, "structured"))
     fallback_hit = _fallback_not_applied_evidence(audit, audit_source)
     if fallback_hit is not None:
-        hits.append(fallback_hit)
+        hits.append((*fallback_hit, "structured"))
 
     # Sandbox capability-profile gap (#2029) — the run's own resolved capability
-    # record (null profile, no grants) correlated with a reported denial of a
-    # resource a forge-owned preset grants. Detected in
+    # record, whether absent or missing the matched preset's required grants,
+    # correlated with a reported denial of a resource a forge-owned preset
+    # grants. Detected in
     # ``_capability_profile_gap_evidence`` so the matched preset can also name
     # itself in the recommended action.
     if capability_gap is not None:
@@ -1218,19 +1266,21 @@ def _signal_rule_hits(
                 "sandbox_capability_profile_missing",
                 capability_gap.source,
                 _truncate(
-                    f"sandbox.capability_profile unset (no write roots or mach services "
-                    f"granted); reported denial the '{capability_gap.preset}' preset "
+                    f"{capability_gap.profile_note}; recorded capability payloads did not "
+                    f"grant the '{capability_gap.preset}' preset's required write roots or "
+                    f"mach services; reported denial the '{capability_gap.preset}' preset "
                     f"grants: {capability_gap.excerpt}"
                 ),
+                capability_gap.source_kind,
             )
         )
 
     if outcome == "MERGE_FAILED":
-        hits.append(("merge_failed", summary_source, _outcome_excerpt()))
+        hits.append(("merge_failed", summary_source, _outcome_excerpt(), "structured"))
     if outcome == "MERGE_ARMING_FAILED":
-        hits.append(("merge_arming_failed", summary_source, _outcome_excerpt()))
+        hits.append(("merge_arming_failed", summary_source, _outcome_excerpt(), "structured"))
     if outcome == "OPERATOR_ACTION":
-        hits.append(("operator_action_required", summary_source, _outcome_excerpt()))
+        hits.append(("operator_action_required", summary_source, _outcome_excerpt(), "structured"))
     drop_reason = _nonempty(story.get("drop_reason"))
     if drop_reason == _STRANDED_WORKTREE_REASON:
         # A prior-generation worktree left unfinished sprint state — a distinct,
@@ -1240,12 +1290,18 @@ def _signal_rule_hits(
                 "sprint_state_stranded",
                 summary_source,
                 _truncate(f"outcome={outcome}; stranded prior-generation sprint state"),
+                "structured",
             )
         )
     elif outcome in {"DROPPED", "PRESERVED"} or drop_reason:
         drop = drop_reason or error or "launch-guard drop"
         hits.append(
-            ("launch_guard_dropped", summary_source, _truncate(f"outcome={outcome}; {drop}"))
+            (
+                "launch_guard_dropped",
+                summary_source,
+                _truncate(f"outcome={outcome}; {drop}"),
+                "structured",
+            )
         )
     if outcome == "SKIPPED":
         deps = list(story.get("depends_on") or [])
@@ -1255,6 +1311,7 @@ def _signal_rule_hits(
                     "dependency_blocked",
                     summary_source,
                     _truncate(f"skipped; unmet dependencies: {', '.join(str(d) for d in deps)}"),
+                    "structured",
                 )
             )
 
@@ -1287,6 +1344,7 @@ def _signal_rule_hits(
                     "(HANDOFF_NO_GATE_EVIDENCE); latest commit was not reviewed"
                     f"{stale}; outcome={outcome}"
                 ),
+                "structured",
             )
         )
     elif verdict == "REQUEST_CHANGES" and outcome in {"ESCALATE", "ESCALATED", "FAILED"}:
@@ -1295,6 +1353,7 @@ def _signal_rule_hits(
                 "review_changes_requested",
                 audit_source if audit else summary_source,
                 _truncate(f"final review verdict REQUEST_CHANGES; outcome={outcome}"),
+                "structured",
             )
         )
 
@@ -1307,7 +1366,12 @@ def _signal_rule_hits(
     review_hit = _hit_limit(usage, "review")
     if dev_hit:
         hits.append(
-            ("dev_iteration_limit_hit", summary_source, _truncate("dev iteration limit reached"))
+            (
+                "dev_iteration_limit_hit",
+                summary_source,
+                _truncate("dev iteration limit reached"),
+                "structured",
+            )
         )
     if review_hit:
         hits.append(
@@ -1315,6 +1379,7 @@ def _signal_rule_hits(
                 "review_iteration_limit_hit",
                 summary_source,
                 _truncate("review iteration limit reached"),
+                "structured",
             )
         )
     # Elevate iteration exhaustion to a primary cause only when the story failed
@@ -1325,10 +1390,14 @@ def _signal_rule_hits(
                 "iteration_budget_exhausted",
                 summary_source,
                 _truncate("iteration budget exhausted before completion"),
+                "structured",
             )
         )
 
-    return [(rule_id, source, excerpt, None, "structured") for rule_id, source, excerpt in hits]
+    return [
+        (rule_id, source, excerpt, None, source_kind)
+        for rule_id, source, excerpt, source_kind in hits
+    ]
 
 
 def _select_primary(
@@ -1342,6 +1411,11 @@ def _select_primary(
     """
     present = set(structured_primary_classes)
     for cls in _PRIMARY_PRIORITY:
+        # Capability-gap evidence may be carried as text when the denial lives in
+        # a log line, but it still needs to outrank the generic iteration-limit
+        # symptom it usually presents as.
+        if cls == "iteration_exhaustion" and "capability_profile_gap" in text_primary_classes:
+            return "capability_profile_gap"
         if cls in present:
             return cls
     if structured_primary_classes:

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -1512,9 +1512,7 @@ def _launch_collision_action(story: dict, ref: str) -> str:
     )
 
 
-def _capability_gap_action(
-    preset: str | None, ref: str, profile_note: str | None = None
-) -> str:
+def _capability_gap_action(preset: str | None, ref: str, profile_note: str | None = None) -> str:
     """Next step for a capability-profile gap: name the setting and the preset.
 
     Deliberately does not mention the iteration budget. The budget was spent on

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+
 from theforge.config.sandbox_capabilities import get_preset
 
 SCHEMA_VERSION = 1
@@ -1034,7 +1035,7 @@ def _capability_symptom_hit(sources: list[_TextSource]) -> tuple[str, str, str, 
     for preset in sorted(_CAPABILITY_PRESET_SYMPTOMS):
         symptoms = _CAPABILITY_PRESET_SYMPTOMS[preset]
         for src in sources:
-            if src.kind == "authored":
+            if src.kind in {"authored", "structured"}:
                 continue
             for line in src.text.splitlines():
                 lowered = line.lower()

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -1407,17 +1407,31 @@ def _select_primary(
 ) -> str | None:
     """Choose the winning primary failure class by declared priority.
 
-    Structured fields and text scans are both eligible evidence; the declared
-    priority list decides which class is most actionable overall.
+    Structured fields from the current run outrank broad text scans. Text scans
+    remain valuable fallback evidence, but they must not override the run's own
+    recorded terminal state.
+
+    ``capability_profile_gap`` is the single exception: its structured half (the
+    run's own resolved, empty capability payload) is always present, and only
+    the denial half is carried as a log line, so a text-sourced hit still
+    represents structured run state. It is promoted into the structured pool and
+    then competes on the declared priority list like any other class — it does
+    not jump ahead of a higher-priority class such as ``merge_failed``.
     """
-    present = set(structured_primary_classes) | set(text_primary_classes)
+    present = set(structured_primary_classes)
+    if "capability_profile_gap" in text_primary_classes:
+        present.add("capability_profile_gap")
+    for cls in _PRIMARY_PRIORITY:
+        if cls in present:
+            return cls
+    if structured_primary_classes:
+        return structured_primary_classes[0]
+    present = set(text_primary_classes)
     for cls in _PRIMARY_PRIORITY:
         if cls in present:
             return cls
     # A primary rule fired but its class is not in the priority list — return
     # the first seen so we never lose a real classification.
-    if structured_primary_classes:
-        return structured_primary_classes[0]
     return text_primary_classes[0] if text_primary_classes else None
 
 

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -41,7 +41,7 @@ SCHEMA_VERSION = 1
 # (schema_version stays 1) rather than a silent rewrite of historical judgement:
 # an operator can tell whether two RCA files for one sprint were produced by the
 # same rule set by comparing this field.
-RULESET_VERSION = 6
+RULESET_VERSION = 7
 RCA_FILENAME = "sprint-rca.yaml"
 
 # Outcomes that mean the story landed / succeeded. These stay accounted for in
@@ -294,6 +294,16 @@ RULES: tuple[RcaRule, ...] = (
         description="Story skipped because an unmet dependency blocked launch.",
     ),
     RcaRule(
+        rule_id="sandbox_capability_profile_missing",
+        failure_class="capability_profile_gap",
+        role="primary",
+        description=(
+            "The run resolved no sandbox capability profile while the story "
+            "reported a toolchain/service denial a forge-owned preset grants — "
+            "the project never opted into the capability the failure needed."
+        ),
+    ),
+    RcaRule(
         rule_id="iteration_budget_exhausted",
         failure_class="iteration_exhaustion",
         role="primary",
@@ -377,6 +387,12 @@ _PRIMARY_PRIORITY: tuple[str, ...] = (
     "sprint_state_stranded",
     "launch_collision",
     "dependency_skip",
+    # A story whose dev agent could not run its toolchain because the project
+    # declared no capability profile outranks the iteration exhaustion it
+    # presents as (#2029): the budget was spent on iterations that could never
+    # succeed, so "raise the budget" funds a repeat of the same failure. The
+    # configuration gap is the cause; the exhausted budget is its symptom.
+    "capability_profile_gap",
     "iteration_exhaustion",
 )
 
@@ -575,9 +591,17 @@ def _classify_story(
 
     # (rule_id, source, excerpt, matched_pattern, source_kind) tuples in
     # deterministic order.
+    # Correlated once here (not inside the signal pass) so the matched preset is
+    # available to both the evidence and the recommended action.
+    capability_gap = _capability_profile_gap_evidence(audit, text_sources)
+
     hits: list[tuple[str, str, str, str | None, str]] = []
     hits.extend(_text_rule_hits(text_sources))
-    hits.extend(_signal_rule_hits(story, audit, summary_path, sprint_log_dir, logs_root))
+    hits.extend(
+        _signal_rule_hits(
+            story, audit, summary_path, sprint_log_dir, logs_root, capability_gap=capability_gap
+        )
+    )
 
     # The story's explicitly-captured terminal error (summary + audit). A concrete
     # captured cause takes precedence over an *ambiguous* pattern hit (e.g. a bare
@@ -660,7 +684,12 @@ def _classify_story(
     )
 
     partial_value = _detect_partial_value(story, audit)
-    actions = _recommend_actions(primary, contributing, story)
+    actions = _recommend_actions(
+        primary,
+        contributing,
+        story,
+        capability_preset=capability_gap.preset if capability_gap else None,
+    )
 
     return {
         "primary_failure_class": primary,
@@ -861,6 +890,143 @@ def _dev_loop_entries(audit: dict) -> list[dict]:
     return [entry for entry in dev_loop if isinstance(entry, dict)]
 
 
+# ── Sandbox capability-profile gap (#2029) ────────────────────────────────────
+#
+# Forge owns the capability presets (``config.sandbox_capabilities``) and records
+# the resolved capability set in every story's audit. When a project selects no
+# preset, that record reads ``profile: null`` with empty grants — and if the dev
+# agent then reports the exact toolchain denial a preset exists to remove, forge
+# is holding the symptom and the configuration that explains it at the same time.
+#
+# The symptom vocabulary lives here rather than in the preset table: a preset
+# declares what it *grants* (paths, mach services), which is not the text a
+# failing toolchain prints. Keys must name real forge-owned presets — asserted by
+# the test suite against ``sandbox_capabilities.preset_names()``.
+_CAPABILITY_PRESET_SYMPTOMS: dict[str, tuple[str, ...]] = {
+    "xcode": (
+        "coresimulator",
+        "core simulator",
+        "simulator service",
+        "simulator runtime",
+        "simctl",
+        "xcodebuild",
+        "xcodegen",
+        "swift build",
+        "swiftpm",
+        "deriveddata",
+        "library/developer",
+        "com.apple.dt.xcode",
+        "org.swift.swiftpm",
+    ),
+}
+
+# A symptom token alone is just the name of a tool the story legitimately uses.
+# It only evidences a *capability* gap when the same line also states that the
+# resource was refused — so both must co-occur on one line. That pairing is also
+# what keeps a pure outbound-network failure (no toolchain subject on the line)
+# from being classified as a toolchain capability gap.
+_CAPABILITY_DENIAL_MARKERS: tuple[str, ...] = (
+    "operation not permitted",
+    "permission denied",
+    "not permitted",
+    "denied",
+    "unreachable",
+    "connection invalid",
+    "connection interrupted",
+    "connection refused",
+    "could not connect",
+    "unavailable",
+    "sandbox",
+)
+
+
+@dataclass(frozen=True)
+class _CapabilityGap:
+    """A resolved-no-profile run whose text reported a preset's failure mode."""
+
+    preset: str
+    source: str
+    excerpt: str
+
+
+def _sandbox_capability_payloads(audit: dict) -> list[dict]:
+    """Every resolved capability record the story's audit carries.
+
+    Both the run-level ``workspace.sandbox_capabilities`` and the per-iteration
+    ``iterations.dev_loop[*].sandbox_capabilities`` payloads written by
+    ``coordinator.audit`` — a story is only treated as ungranted when *every*
+    record agrees, so a run that widened containment for even one iteration is
+    never reported as having had none.
+    """
+    payloads: list[dict] = []
+    workspace = audit.get("workspace") if isinstance(audit, dict) else None
+    if isinstance(workspace, dict) and isinstance(workspace.get("sandbox_capabilities"), dict):
+        payloads.append(workspace["sandbox_capabilities"])
+    for entry in _dev_loop_entries(audit):
+        payload = entry.get("sandbox_capabilities")
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads
+
+
+def _capability_grant_absent(audit: dict) -> bool:
+    """True when the run's own record says no capability was granted at all.
+
+    Returns False when the audit carries no capability record: the class asserts
+    what forge *resolved*, so a record it never wrote cannot evidence it.
+    """
+    payloads = _sandbox_capability_payloads(audit)
+    if not payloads:
+        return False
+    for payload in payloads:
+        if _nonempty(payload.get("profile")):
+            return False
+        if payload.get("write_roots") or payload.get("mach_services"):
+            return False
+    return True
+
+
+def _capability_symptom_hit(sources: list[_TextSource]) -> tuple[str, str, str] | None:
+    """Find the first line naming a preset's toolchain *and* its refusal.
+
+    Agent-authored prose is out of scope for the same reason as #2031: it
+    describes the project under development, not the run developing it, so it
+    can never assign a runtime cause code.
+    """
+    for preset in sorted(_CAPABILITY_PRESET_SYMPTOMS):
+        symptoms = _CAPABILITY_PRESET_SYMPTOMS[preset]
+        for src in sources:
+            if src.kind == "authored":
+                continue
+            for line in src.text.splitlines():
+                lowered = line.lower()
+                if not any(symptom in lowered for symptom in symptoms):
+                    continue
+                if not any(marker in lowered for marker in _CAPABILITY_DENIAL_MARKERS):
+                    continue
+                return preset, src.source, _truncate(line.strip())
+    return None
+
+
+def _capability_profile_gap_evidence(
+    audit: dict, sources: list[_TextSource]
+) -> _CapabilityGap | None:
+    """Correlate "no profile resolved" with "the toolchain that needs one failed".
+
+    Neither half classifies alone: most runs legitimately resolve no profile, and
+    a toolchain error under a *granted* profile is a different problem with a
+    different fix. Together they are the configuration gap forge already held
+    both halves of and reported as an iteration-budget problem (#2029).
+    """
+    if not _capability_grant_absent(audit):
+        return None
+    hit = _capability_symptom_hit(sources)
+    if hit is None:
+        return None
+    preset, source, excerpt = hit
+    return _CapabilityGap(preset=preset, source=source, excerpt=excerpt)
+
+
 def _provider_quota_evidence(audit: dict, audit_source: str) -> tuple[str, str, str] | None:
     """Return a ``provider_usage_limit`` hit from the run's own quota observation.
 
@@ -996,6 +1162,7 @@ def _signal_rule_hits(
     summary_path: Path,
     sprint_log_dir: Path,
     logs_root: Path,
+    capability_gap: _CapabilityGap | None = None,
 ) -> list[tuple[str, str, str, str | None, str]]:
     """Fire field-derived (signal) rules from summary/audit structured fields.
 
@@ -1039,6 +1206,24 @@ def _signal_rule_hits(
     fallback_hit = _fallback_not_applied_evidence(audit, audit_source)
     if fallback_hit is not None:
         hits.append(fallback_hit)
+
+    # Sandbox capability-profile gap (#2029) — the run's own resolved capability
+    # record (null profile, no grants) correlated with a reported denial of a
+    # resource a forge-owned preset grants. Detected in
+    # ``_capability_profile_gap_evidence`` so the matched preset can also name
+    # itself in the recommended action.
+    if capability_gap is not None:
+        hits.append(
+            (
+                "sandbox_capability_profile_missing",
+                capability_gap.source,
+                _truncate(
+                    f"sandbox.capability_profile unset (no write roots or mach services "
+                    f"granted); reported denial the '{capability_gap.preset}' preset "
+                    f"grants: {capability_gap.excerpt}"
+                ),
+            )
+        )
 
     if outcome == "MERGE_FAILED":
         hits.append(("merge_failed", summary_source, _outcome_excerpt()))
@@ -1261,7 +1446,29 @@ def _launch_collision_action(story: dict, ref: str) -> str:
     )
 
 
-def _recommend_actions(primary: str, contributing: list[str], story: dict) -> list[str]:
+def _capability_gap_action(preset: str | None, ref: str) -> str:
+    """Next step for a capability-profile gap: name the setting and the preset.
+
+    Deliberately does not mention the iteration budget. The budget was spent on
+    iterations that could not have succeeded, so raising it funds a repeat of the
+    same failure (#2029).
+    """
+    named = f"'{preset}'" if preset else "the preset matching the failing toolchain"
+    return (
+        f"set sandbox.capability_profile: {preset or '<preset>'} in the project's forge.yaml "
+        f"and re-sprint {ref} — the run resolved no capability profile while the agent "
+        f"reported exactly the toolchain/service denial the {named} preset removes, so the "
+        "dev agent could not build or verify its own work"
+    )
+
+
+def _recommend_actions(
+    primary: str,
+    contributing: list[str],
+    story: dict,
+    *,
+    capability_preset: str | None = None,
+) -> list[str]:
     """Map primary class + contributing factors to actionable next steps."""
     ref = _story_ref(story)
     actions: list[str] = []
@@ -1313,6 +1520,7 @@ def _recommend_actions(primary: str, contributing: list[str], story: dict) -> li
             "discard partial work"
         ),
         "dependency_skip": _dependency_action(story, ref),
+        "capability_profile_gap": _capability_gap_action(capability_preset, ref),
         "iteration_exhaustion": (
             f"raise the iteration budget for {ref} or narrow its scope, then re-run"
         ),
@@ -1331,6 +1539,10 @@ def _recommend_actions(primary: str, contributing: list[str], story: dict) -> li
     # names a cause the evidence contradicts (issue #1946).
     iteration_advice_applies = primary not in {
         "iteration_exhaustion",
+        # The iteration limit is how a capability gap *presents*; the budget was
+        # never the constraint, so budget advice here would restate the wrong
+        # cause the class exists to replace (#2029).
+        "capability_profile_gap",
         "merge_failed",
         # Same reasoning as merge_failed: the story produced a landable commit and
         # failed for a reason the iteration budget did not cause (#2056).

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -797,6 +797,7 @@ def test_ruleset_version_stamped(tmp_path: Path) -> None:
     payload = _build(d)
     assert payload["schema_version"] == rca_mod.SCHEMA_VERSION
     assert payload["ruleset_version"] == rca_mod.RULESET_VERSION
+    assert payload["ruleset_version"] == 9
 
 
 def test_improved_ruleset_regenerates_versioned(tmp_path: Path, monkeypatch) -> None:
@@ -1291,9 +1292,68 @@ def test_missing_capability_profile_outranks_iteration_exhaustion(tmp_path: Path
 
     actions = entry["recommended_next_actions"]
     assert any("sandbox.capability_profile" in a and "xcode" in a for a in actions)
+    assert any("sandbox.capability_profile unset" in a for a in actions)
     # The budget was spent on iterations that could not have succeeded; naming it
     # is the misdirection this class exists to remove.
     assert not any("iteration budget" in a for a in actions)
+
+
+def test_capability_gap_from_structured_audit_text(tmp_path: Path) -> None:
+    """Run-authored structured audit text can carry the same capability symptom."""
+    d = _sprint_dir(tmp_path, name="capability-structured-audit")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-248b",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    audit = _no_capability_audit(
+        {
+            "error": "Failed to get the connection to the CoreSimulator service: Operation not permitted",
+        }
+    )
+    _write(d / "issue-248b" / "audit.yaml", audit)
+
+    entry = _build(d)["stories"]["issue-248b"]
+    assert entry["primary_failure_class"] == "capability_profile_gap"
+    actions = entry["recommended_next_actions"]
+    assert any("sandbox.capability_profile" in a and "xcode" in a for a in actions)
+    assert any("sandbox.capability_profile unset" in a for a in actions)
+
+
+def test_capability_gap_does_not_override_worker_timeout_text(tmp_path: Path) -> None:
+    """Higher-priority text classes still win over the capability-gap class."""
+    d = _sprint_dir(tmp_path, name="capability-worker-timeout")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-248c",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    _write(d / "issue-248c" / "audit.yaml", _no_capability_audit())
+    story_dir = d / "issue-248c"
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "dev-iteration-1.log").write_text(
+        "Worker thread timed out after 3600s\n", encoding="utf-8"
+    )
+    (story_dir / "dev-iteration-2.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
+
+    entry = _build(d)["stories"]["issue-248c"]
+    assert entry["primary_failure_class"] == "worker_timeout"
 
 
 def test_exhausted_story_without_capability_symptom_stays_iteration_exhaustion(
@@ -1377,10 +1437,7 @@ def test_incomplete_capability_profile_outranks_iteration_exhaustion(tmp_path: P
 
     entry = _build(d)["stories"]["issue-248a"]
     assert entry["primary_failure_class"] == "capability_profile_gap"
-    assert any(
-        "sandbox.capability_profile" in a and "xcode" in a
-        for a in entry["recommended_next_actions"]
-    )
+    assert any("sandbox.capability_profile='xcode'" in a for a in entry["recommended_next_actions"])
 
 
 def test_outbound_network_denial_alone_is_not_a_capability_gap(tmp_path: Path) -> None:

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -796,7 +796,7 @@ def test_ruleset_version_stamped(tmp_path: Path) -> None:
     payload = _build(d)
     assert payload["schema_version"] == rca_mod.SCHEMA_VERSION
     assert payload["ruleset_version"] == rca_mod.RULESET_VERSION
-    assert payload["ruleset_version"] == 6
+    assert payload["ruleset_version"] == 7
 
 
 def test_improved_ruleset_regenerates_versioned(tmp_path: Path, monkeypatch) -> None:
@@ -1221,6 +1221,254 @@ def test_dev_gate_evidence_seam_coordinator_audit_to_rca(tmp_path: Path) -> None
 
     entry = _build(d)["stories"]["issue-220"]
     assert entry["primary_failure_class"] == "dev_gate_evidence_missing"
+
+
+# ── Sandbox capability-profile gap (#2029) ────────────────────────────────────
+
+
+def _exhausted_usage() -> dict:
+    return {
+        "dev": {"used": 3, "max": 3, "hit_limit": True},
+        "review": {"used": 0, "max": 2, "hit_limit": False},
+    }
+
+
+def _no_capability_audit(extra: dict | None = None) -> dict:
+    """A per-story audit shaped like the one the coordinator writes with no preset."""
+    audit = {
+        "workspace": {
+            "path": "/tmp/wt/issue-246",
+            "branch": "feat/issue-246",
+            "sandbox_capabilities": {
+                "profile": None,
+                "write_roots": [],
+                "mach_services": [],
+            },
+        },
+        "iterations": {"usage_summary": _exhausted_usage()},
+    }
+    if extra:
+        audit.update(extra)
+    return audit
+
+
+_SIMULATOR_DENIAL = (
+    "dev iteration 1: xcodebuild failed — Failed to get the connection to the "
+    "CoreSimulator service: Operation not permitted\n"
+)
+
+
+def test_missing_capability_profile_outranks_iteration_exhaustion(tmp_path: Path) -> None:
+    """The configuration gap forge already recorded beats the budget it presents as."""
+    d = _sprint_dir(tmp_path, name="capability-gap")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-246",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    _write(d / "issue-246" / "audit.yaml", _no_capability_audit())
+    (d / "issue-246" / "dev-iteration-1.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
+
+    entry = _build(d)["stories"]["issue-246"]
+    assert entry["primary_failure_class"] == "capability_profile_gap"
+    hit = next(
+        ev for ev in entry["evidence"] if ev["rule_id"] == "sandbox_capability_profile_missing"
+    )
+    assert "sandbox.capability_profile" in hit["excerpt"]
+    assert "CoreSimulator" in hit["excerpt"]
+
+    actions = entry["recommended_next_actions"]
+    assert any("sandbox.capability_profile" in a and "xcode" in a for a in actions)
+    # The budget was spent on iterations that could not have succeeded; naming it
+    # is the misdirection this class exists to remove.
+    assert not any("iteration budget" in a for a in actions)
+
+
+def test_exhausted_story_without_capability_symptom_stays_iteration_exhaustion(
+    tmp_path: Path,
+) -> None:
+    """No capability-shaped failure text ⇒ the existing classification is untouched."""
+    d = _sprint_dir(tmp_path, name="capability-none")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-247",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    _write(d / "issue-247" / "audit.yaml", _no_capability_audit())
+    (d / "issue-247" / "dev-iteration-1.log").write_text(
+        "dev iteration 1: 3 unit tests still failing after the refactor\n", encoding="utf-8"
+    )
+
+    entry = _build(d)["stories"]["issue-247"]
+    assert entry["primary_failure_class"] == "iteration_exhaustion"
+    assert any("raise the iteration budget" in a for a in entry["recommended_next_actions"])
+
+
+def test_granted_capability_profile_is_not_reported_as_a_gap(tmp_path: Path) -> None:
+    """A toolchain failure *under* a granted preset is a different problem."""
+    d = _sprint_dir(tmp_path, name="capability-granted")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-248",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    audit = _no_capability_audit()
+    audit["workspace"]["sandbox_capabilities"] = {
+        "profile": "xcode",
+        "write_roots": ["/Users/dev/Library/Developer"],
+        "mach_services": ["com.apple.CoreSimulator.CoreSimulatorService"],
+    }
+    _write(d / "issue-248" / "audit.yaml", audit)
+    (d / "issue-248" / "dev-iteration-1.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
+
+    entry = _build(d)["stories"]["issue-248"]
+    assert entry["primary_failure_class"] == "iteration_exhaustion"
+
+
+def test_outbound_network_denial_alone_is_not_a_capability_gap(tmp_path: Path) -> None:
+    """No existing preset grants network egress, so egress text must not claim one."""
+    d = _sprint_dir(tmp_path, name="capability-network")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-249",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    _write(d / "issue-249" / "audit.yaml", _no_capability_audit())
+    (d / "issue-249" / "dev-iteration-1.log").write_text(
+        "dev iteration 1: could not fetch the cached package — outbound network denied\n",
+        encoding="utf-8",
+    )
+
+    entry = _build(d)["stories"]["issue-249"]
+    assert entry["primary_failure_class"] == "iteration_exhaustion"
+
+
+def test_capability_symptom_in_agent_authored_prose_is_not_a_cause(tmp_path: Path) -> None:
+    """Agent prose describes the project, not the run — it cannot assign this class."""
+    d = _sprint_dir(tmp_path, name="capability-prose")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-250",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    _write(d / "issue-250" / "audit.yaml", _no_capability_audit())
+    (d / "issue-250" / "dev-notes.md").write_text(
+        "The app should surface a clear error when the CoreSimulator connection is "
+        "unavailable or permission is denied.\n",
+        encoding="utf-8",
+    )
+
+    entry = _build(d)["stories"]["issue-250"]
+    assert entry["primary_failure_class"] == "iteration_exhaustion"
+
+
+def test_capability_preset_symptom_keys_name_real_presets() -> None:
+    """The symptom table may only reference presets forge actually owns."""
+    from theforge.config.sandbox_capabilities import preset_names
+    from theforge.sprint.rca import _CAPABILITY_PRESET_SYMPTOMS
+
+    assert set(_CAPABILITY_PRESET_SYMPTOMS) <= set(preset_names())
+    assert _CAPABILITY_PRESET_SYMPTOMS
+
+
+def test_capability_gap_seam_coordinator_audit_to_rca(tmp_path: Path) -> None:
+    """Seam: real coordinator audit (no preset selected) → RCA capability class.
+
+    Anchors the cause code to the fields ``generate_audit_log`` actually writes
+    (``workspace.sandbox_capabilities`` and the per-iteration payload), not to a
+    shape this test invented.
+    """
+    from coord_test_helpers import _make_config, _make_task
+
+    from theforge.coordinator.audit import generate_audit_log
+    from theforge.coordinator.state import (
+        CoordinatorResult,
+        CoordinatorState,
+        DevIterationTelemetry,
+        Phase,
+    )
+
+    config = _make_config(tmp_path)
+    task = _make_task(tmp_path)
+    state = CoordinatorState(dev_iteration=2, review_cycle=0)
+    state.phase = Phase.ESCALATE
+    state.error = "dev exhausted iterations"
+    state.dev_iteration_telemetry = [
+        DevIterationTelemetry(
+            iteration=i,
+            max_iterations=2,
+            cost_usd=1.0,
+            duration_s=5.0,
+            cycle=0,
+            gate_result="FAIL",
+        )
+        for i in (1, 2)
+    ]
+
+    audit = generate_audit_log(
+        config,
+        task,
+        CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message=state.error),
+    )
+    # The coordinator records "default containment" explicitly — that record is
+    # the half of the correlation forge already held.
+    assert audit["workspace"]["sandbox_capabilities"]["profile"] is None
+    assert audit["iterations"]["usage_summary"]["dev"]["hit_limit"] is True
+
+    d = _sprint_dir(tmp_path, name="seam-capability")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-251", "outcome": "FAILED", "error": state.error}]),
+    )
+    _write(d / "issue-251" / "audit.yaml", audit)
+    (d / "issue-251" / "dev-iteration-1.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
+
+    entry = _build(d)["stories"]["issue-251"]
+    assert entry["primary_failure_class"] == "capability_profile_gap"
+    assert any(
+        "sandbox.capability_profile" in a and "xcode" in a
+        for a in entry["recommended_next_actions"]
+    )
 
 
 # ── Rule set discoverability ──────────────────────────────────────────────────

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -1316,7 +1316,10 @@ def test_capability_gap_from_structured_audit_text(tmp_path: Path) -> None:
     )
     audit = _no_capability_audit(
         {
-            "error": "Failed to get the connection to the CoreSimulator service: Operation not permitted",
+            "error": (
+                "Failed to get the connection to the CoreSimulator service: "
+                "Operation not permitted"
+            ),
         }
     )
     _write(d / "issue-248b" / "audit.yaml", audit)
@@ -1437,7 +1440,9 @@ def test_incomplete_capability_profile_outranks_iteration_exhaustion(tmp_path: P
 
     entry = _build(d)["stories"]["issue-248a"]
     assert entry["primary_failure_class"] == "capability_profile_gap"
-    assert any("sandbox.capability_profile='xcode'" in a for a in entry["recommended_next_actions"])
+    assert any(
+        "sandbox.capability_profile='xcode'" in a for a in entry["recommended_next_actions"]
+    )
 
 
 def test_outbound_network_denial_alone_is_not_a_capability_gap(tmp_path: Path) -> None:

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 
 import yaml
 
+from theforge.config.sandbox_capabilities import resolve_capabilities
 from theforge.sprint.rca import (
     RULES,
     RULES_BY_ID,
@@ -23,7 +24,6 @@ from theforge.sprint.rca import (
     read_sprint_rca,
     write_sprint_rca,
 )
-from theforge.config.sandbox_capabilities import resolve_capabilities
 
 
 def _write(path: Path, data: object) -> None:

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -1331,17 +1331,22 @@ def test_capability_gap_from_structured_audit_text(tmp_path: Path) -> None:
     assert any("sandbox.capability_profile unset" in a for a in actions)
 
 
-def test_capability_gap_does_not_override_worker_timeout_text(tmp_path: Path) -> None:
-    """Higher-priority text classes still win over the capability-gap class."""
-    d = _sprint_dir(tmp_path, name="capability-worker-timeout")
+def test_text_evidence_does_not_override_structured_terminal_outcome(tmp_path: Path) -> None:
+    """Unrelated higher-priority *text* must not displace the run's own terminal state.
+
+    The capability-gap class is the only text-carried promotion into the
+    structured pool; a worker-timeout line scraped from a log stays fallback
+    evidence behind a recorded MERGE_FAILED.
+    """
+    d = _sprint_dir(tmp_path, name="capability-structured-precedence")
     _write(
         d / "sprint-summary.yaml",
         _summary(
             [
                 {
                     "slug": "issue-248c",
-                    "outcome": "FAILED",
-                    "error": "dev exhausted iterations",
+                    "outcome": "MERGE_FAILED",
+                    "error": "merge failed",
                     "iteration_usage": _exhausted_usage(),
                 }
             ]
@@ -1353,10 +1358,38 @@ def test_capability_gap_does_not_override_worker_timeout_text(tmp_path: Path) ->
     (story_dir / "dev-iteration-1.log").write_text(
         "Worker thread timed out after 3600s\n", encoding="utf-8"
     )
-    (story_dir / "dev-iteration-2.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
 
     entry = _build(d)["stories"]["issue-248c"]
-    assert entry["primary_failure_class"] == "worker_timeout"
+    assert entry["primary_failure_class"] == "merge_failed"
+
+
+def test_capability_gap_does_not_outrank_structured_merge_failure(tmp_path: Path) -> None:
+    """The promoted capability class still competes on the declared priority list."""
+    d = _sprint_dir(tmp_path, name="capability-vs-merge")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-248d",
+                    "outcome": "MERGE_FAILED",
+                    "error": "merge failed",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    _write(d / "issue-248d" / "audit.yaml", _no_capability_audit())
+    story_dir = d / "issue-248d"
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "dev-iteration-1.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
+
+    entry = _build(d)["stories"]["issue-248d"]
+    # merge_failed sits above capability_profile_gap in _PRIMARY_PRIORITY, so the
+    # promotion must not let the capability class jump the queue.
+    assert entry["primary_failure_class"] == "merge_failed"
+    # The capability evidence is still recorded as a contributing factor.
+    assert any(ev["rule_id"] == "sandbox_capability_profile_missing" for ev in entry["evidence"])
 
 
 def test_exhausted_story_without_capability_symptom_stays_iteration_exhaustion(

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -23,6 +23,7 @@ from theforge.sprint.rca import (
     read_sprint_rca,
     write_sprint_rca,
 )
+from theforge.config.sandbox_capabilities import resolve_capabilities
 
 
 def _write(path: Path, data: object) -> None:
@@ -796,7 +797,6 @@ def test_ruleset_version_stamped(tmp_path: Path) -> None:
     payload = _build(d)
     assert payload["schema_version"] == rca_mod.SCHEMA_VERSION
     assert payload["ruleset_version"] == rca_mod.RULESET_VERSION
-    assert payload["ruleset_version"] == 7
 
 
 def test_improved_ruleset_regenerates_versioned(tmp_path: Path, monkeypatch) -> None:
@@ -1252,6 +1252,10 @@ def _no_capability_audit(extra: dict | None = None) -> dict:
     return audit
 
 
+def _xcode_capability_payload() -> dict:
+    return resolve_capabilities("xcode", home=Path("/Users/dev")).audit_payload()
+
+
 _SIMULATOR_DENIAL = (
     "dev iteration 1: xcodebuild failed — Failed to get the connection to the "
     "CoreSimulator service: Operation not permitted\n"
@@ -1283,7 +1287,7 @@ def test_missing_capability_profile_outranks_iteration_exhaustion(tmp_path: Path
         ev for ev in entry["evidence"] if ev["rule_id"] == "sandbox_capability_profile_missing"
     )
     assert "sandbox.capability_profile" in hit["excerpt"]
-    assert "CoreSimulator" in hit["excerpt"]
+    assert "xcodebuild" in hit["excerpt"]
 
     actions = entry["recommended_next_actions"]
     assert any("sandbox.capability_profile" in a and "xcode" in a for a in actions)
@@ -1337,16 +1341,46 @@ def test_granted_capability_profile_is_not_reported_as_a_gap(tmp_path: Path) -> 
         ),
     )
     audit = _no_capability_audit()
-    audit["workspace"]["sandbox_capabilities"] = {
-        "profile": "xcode",
-        "write_roots": ["/Users/dev/Library/Developer"],
-        "mach_services": ["com.apple.CoreSimulator.CoreSimulatorService"],
-    }
+    audit["workspace"]["sandbox_capabilities"] = _xcode_capability_payload()
     _write(d / "issue-248" / "audit.yaml", audit)
     (d / "issue-248" / "dev-iteration-1.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
 
     entry = _build(d)["stories"]["issue-248"]
     assert entry["primary_failure_class"] == "iteration_exhaustion"
+
+
+def test_incomplete_capability_profile_outranks_iteration_exhaustion(tmp_path: Path) -> None:
+    """A resolved xcode profile missing required grants stays a capability gap."""
+    d = _sprint_dir(tmp_path, name="capability-incomplete")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-248a",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    audit = _no_capability_audit()
+    xcode = _xcode_capability_payload()
+    audit["workspace"]["sandbox_capabilities"] = {
+        "profile": "xcode",
+        "write_roots": xcode["write_roots"][:-1],
+        "mach_services": xcode["mach_services"][:-1],
+    }
+    _write(d / "issue-248a" / "audit.yaml", audit)
+    (d / "issue-248a" / "dev-iteration-1.log").write_text(_SIMULATOR_DENIAL, encoding="utf-8")
+
+    entry = _build(d)["stories"]["issue-248a"]
+    assert entry["primary_failure_class"] == "capability_profile_gap"
+    assert any(
+        "sandbox.capability_profile" in a and "xcode" in a
+        for a in entry["recommended_next_actions"]
+    )
 
 
 def test_outbound_network_denial_alone_is_not_a_capability_gap(tmp_path: Path) -> None:
@@ -1372,6 +1406,32 @@ def test_outbound_network_denial_alone_is_not_a_capability_gap(tmp_path: Path) -
     )
 
     entry = _build(d)["stories"]["issue-249"]
+    assert entry["primary_failure_class"] == "iteration_exhaustion"
+
+
+def test_benign_sandbox_reference_does_not_trigger_capability_gap(tmp_path: Path) -> None:
+    """A toolchain mention plus the word sandbox is not enough without a refusal."""
+    d = _sprint_dir(tmp_path, name="capability-sandbox-noise")
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-249a",
+                    "outcome": "FAILED",
+                    "error": "dev exhausted iterations",
+                    "iteration_usage": _exhausted_usage(),
+                }
+            ]
+        ),
+    )
+    _write(d / "issue-249a" / "audit.yaml", _no_capability_audit())
+    (d / "issue-249a" / "dev-iteration-1.log").write_text(
+        "dev iteration 1: xcodebuild is running under the forge sandbox for this test\n",
+        encoding="utf-8",
+    )
+
+    entry = _build(d)["stories"]["issue-249a"]
     assert entry["primary_failure_class"] == "iteration_exhaustion"
 
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The prior P1 precedence regression is fixed, and the capability-profile gap path now classifies and recommends the sandbox setting instead of iteration budget advice. | [google-gemini-3.5-flash] Approved. The capability-profile gap is correctly surfaced and prioritized, and the Cycle 1 precedence regression is fully resolved.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $8.37
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Missing sandbox capability profile is never surfaced, even when the agent reports the exact toolchain failure it causes (GitHub Issue #2029)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2029