### PR TITLE
Stories that land work within the reporting invocation are reported ALREADY_DONE, disowning the run that produced them

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -3411,6 +3411,47 @@ def run_sprint(
                 f"  {triage.slug:<20} {triage.action.upper().replace('_', ' ')} ({triage.reason})"
             )
 
+    def _recorded_prior_done(slug: str, canonical_ref: str | None = None) -> bool:
+        """True when this sprint already recorded the story as run-to-DONE.
+
+        Two records can hold that evidence and either one settles it: the
+        canonical story state (seeded above from the accumulated file) and the
+        accumulated entry itself. DONE is the only succeeded outcome that means
+        "a generation of this sprint ran the story"; ALREADY_DONE means the
+        opposite, so it is deliberately not accepted here.
+        """
+        entry = _story_state.get(slug)
+        if entry is not None and entry.outcome is StoryOutcome.DONE:
+            return True
+        ref = canonical_ref or slug_to_context.get(slug, (None, None, None))[2]
+        prior = recovered_prior_entries_by_ref.get(ref) if ref else None
+        return isinstance(prior, dict) and str(prior.get("outcome") or "").upper() == "DONE"
+
+    def _skip_merged_outcome(slug: str, canonical_ref: str) -> tuple[StoryOutcome, str | None]:
+        """Outcome and ``outcome_source`` to record for a ``skip_merged`` triage.
+
+        ``_triage_spec`` answers a question about git alone — "is this branch
+        merged into the base branch right now?" — and has no notion of *which*
+        run produced the merge. Reading that answer as "the work pre-dated this
+        run" is only sound when nothing in this sprint recorded having done it.
+        A mid-sprint re-exec breaks exactly that assumption: the story finished
+        DEV+REVIEW, queued its auto-merge, the process re-exec'd, and the new
+        generation's triage then observes the merge its own predecessor landed
+        moments earlier. Stamping ALREADY_DONE / ``resume_skip_merged`` there
+        tells the operator that a story which ran, spent budget and landed a
+        commit did nothing — while the same row still reports that spend
+        (#2150).
+
+        The recorded execution is the authoritative account of what happened,
+        so a prior DONE wins over the triage label and carries no
+        ``outcome_source``. ALREADY_DONE / ``resume_skip_merged`` remains for
+        the case it actually describes: merged work with no record of this
+        sprint having produced it.
+        """
+        if _recorded_prior_done(slug, canonical_ref):
+            return StoryOutcome.DONE, None
+        return StoryOutcome.ALREADY_DONE, "resume_skip_merged"
+
     # Build satisfied set: closed dep slugs detected at manifest build time,
     # resume-mode skip states, plus any cross-sprint depends_on slugs whose
     # branch is already merged to the base branch.
@@ -3985,9 +4026,10 @@ def run_sprint(
                     dag.mark_complete(slug)
                     _prior_entry = recovered_prior_entries_by_ref.get(canonical_ref)
                     if _prior_entry is not None:
+                        _skip_outcome, _skip_source = _skip_merged_outcome(slug, canonical_ref)
                         _already_done_entry = dict(_prior_entry)
-                        _already_done_entry["outcome"] = "ALREADY_DONE"
-                        _already_done_entry["outcome_source"] = "resume_skip_merged"
+                        _already_done_entry["outcome"] = _skip_outcome.name
+                        _already_done_entry["outcome_source"] = _skip_source
                         current_story_entries_by_ref[canonical_ref] = {
                             k: v for k, v in _already_done_entry.items() if k != "canonical_ref"
                         }
@@ -4093,12 +4135,7 @@ def run_sprint(
         it legitimately describes: a reconciled story with no surviving record of
         having run.
         """
-        entry = _story_state.get(slug)
-        if entry is not None and entry.outcome is StoryOutcome.DONE:
-            return StoryOutcome.DONE
-        ref = slug_to_context.get(slug, (None, None, None))[2]
-        prior = recovered_prior_entries_by_ref.get(ref) if ref else None
-        if isinstance(prior, dict) and str(prior.get("outcome") or "").upper() == "DONE":
+        if _recorded_prior_done(slug):
             return StoryOutcome.DONE
         return StoryOutcome.ALREADY_DONE
 
@@ -4264,6 +4301,10 @@ def run_sprint(
             depends_on: list[str],
         ) -> dict:
             prior_entry = recovered_prior_entries_by_ref.get(canonical_ref, {})
+            # A story this sprint already ran to DONE keeps that outcome even
+            # though its branch now reads as merged (#2150) — see
+            # ``_skip_merged_outcome``.
+            entry_outcome, entry_outcome_source = _skip_merged_outcome(slug, canonical_ref)
             display_key = (
                 f"Issue #{canonical_ref.split(':')[1]}"
                 if canonical_ref.startswith("issue:")
@@ -4273,8 +4314,8 @@ def run_sprint(
                 "canonical_ref": canonical_ref,
                 "path": display_key,
                 "slug": slug,
-                "outcome": "ALREADY_DONE",
-                "outcome_source": "resume_skip_merged",
+                "outcome": entry_outcome.name,
+                "outcome_source": entry_outcome_source,
                 "verdict": prior_entry.get("verdict"),
                 "cost_usd": _optional_cost(prior_entry.get("cost_usd")),
                 "story_run_id": prior_entry.get("story_run_id", run_id),
@@ -4388,11 +4429,15 @@ def run_sprint(
                         **_work.as_state_fields(),
                     }
             elif _triage and _triage.action == "skip_merged":
+                # Preserve *which* terminal this sprint reached: a story this
+                # run already carried to DONE must not be relabelled as
+                # pre-existing work just because its own landing completed
+                # around the re-exec boundary (#2150).
                 _status = "done"
-                _detail = {
-                    "final_outcome": "ALREADY_DONE",
-                    "outcome_source": "resume_skip_merged",
-                }
+                _skip_outcome, _skip_source = _skip_merged_outcome(_slug, _canonical_ref)
+                _detail = {"final_outcome": _skip_outcome.name}
+                if _skip_source:
+                    _detail["outcome_source"] = _skip_source
             elif _triage and _triage.action == "skip":
                 _status = "skipped"
                 _detail = {"final_outcome": "SKIPPED"}

--- a/tests/test_sprint_reexec_reconcile.py
+++ b/tests/test_sprint_reexec_reconcile.py
@@ -898,3 +898,226 @@ def test_reexec_landed_story_with_open_issue_is_not_redispatched(
     assert result.specs_succeeded == 2
     assert result.specs_failed == 0
     assert result.total_cost_usd == pytest.approx(1.33)
+
+
+def _accumulated_by_slug(tmp_path: Path, sprint_id: str) -> dict[str, dict]:
+    """Read ``.forge/sprints/<id>/state.yaml`` — the durable per-story record."""
+    state_path = tmp_path / ".forge" / "sprints" / sprint_id / "state.yaml"
+    data = yaml.safe_load(state_path.read_text(encoding="utf-8")) or {}
+    return {s["slug"]: s for s in data.get("stories", [])}
+
+
+def _persist_prior_story(
+    tmp_path: Path,
+    sprint_id: str,
+    *,
+    outcome: str,
+    cost_usd: float,
+    outcome_source: str | None = None,
+    story_run_id: str = "run-prev",
+) -> dict:
+    entry: dict = {
+        "canonical_ref": "feature-a.md",
+        "slug": "feature-a",
+        "path": "feature-a.md",
+        "outcome": outcome,
+        "cost_usd": cost_usd,
+        "story_run_id": story_run_id,
+        "started_at": "2026-08-02T02:32:00Z",
+        "finished_at": "2026-08-02T02:51:46Z",
+        "depends_on": [],
+    }
+    if outcome_source is not None:
+        entry["outcome_source"] = outcome_source
+    persist_accumulated_story_state(sprint_id, "Test Sprint", tmp_path, [entry])
+    return entry
+
+
+def _skip_merged_triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
+    if "feature-a" in spec_path:
+        return StoryTriage(
+            story_path="feature-a.md",
+            action="skip_merged",
+            reason="already merged in PR #2146, skipping",
+            worktree_path=None,
+            slug="feature-a",
+        )
+    return StoryTriage(
+        story_path="feature-b.md",
+        action="full",
+        reason="no worktree found",
+        worktree_path=None,
+        slug="feature-b",
+    )
+
+
+def test_reexec_skip_merged_keeps_prior_done_in_accumulated_state(
+    tmp_path: Path,
+) -> None:
+    """Issue #2150: a story this run carried to DONE, whose queued PR merged
+    around the re-exec boundary, must keep DONE in the durable sprint state.
+
+    The post-re-exec triage sees the branch as merged and returns
+    ``skip_merged``. That is a factually correct statement about git *now* — it
+    is not evidence that the work pre-dated this run. The prior generation's own
+    record (DONE, $11.93, this run's story_run_id) is, so the row must survive
+    intact rather than being restamped ALREADY_DONE / resume_skip_merged while
+    still reporting the spend that contradicts it.
+    """
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+    config = _make_config(tmp_path)
+
+    sprint_id = _set_sprint_id(tmp_path)
+    _write_prior_sprint_audit(tmp_path, sprint_id, 11.93)
+    prior = _persist_prior_story(tmp_path, sprint_id, outcome="DONE", cost_usd=11.93)
+
+    fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_skip_merged_triage_side_effect),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=fresh_result),
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        result = run_sprint(config, manifest_path, reexec=True)
+
+    accumulated = _accumulated_by_slug(tmp_path, sprint_id)["feature-a"]
+    assert accumulated["outcome"] == "DONE"
+    assert accumulated.get("outcome_source") is None
+    # Outcome, cost and elapsed agree: the same run owns all three.
+    assert accumulated["cost_usd"] == pytest.approx(11.93)
+    assert accumulated["story_run_id"] == prior["story_run_id"]
+    assert accumulated["started_at"] == prior["started_at"]
+    assert accumulated["finished_at"] == prior["finished_at"]
+
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
+    )
+    by_slug = {s["slug"]: s for s in summary["stories"]}
+    assert by_slug["feature-a"]["outcome"] == "DONE"
+    assert by_slug["feature-a"].get("outcome_source") is None
+    assert result.specs_succeeded == 2
+    assert result.specs_failed == 0
+
+
+def test_reexec_skip_merged_renders_done_in_live_status(tmp_path: Path) -> None:
+    """Issue #2150, operator surface: ``forge status`` mid-sprint.
+
+    The symptom was read from the live status file — five stories showing
+    ``ALREADY_DONE (merged)`` alongside the non-zero cost the same run had just
+    spent on them. This samples that row during the next story's dispatch,
+    which is exactly when the operator consults it.
+    """
+    from theforge.sprint.status_reader import read_live_status
+
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+    config = _make_config(tmp_path)
+
+    sprint_id = _set_sprint_id(tmp_path)
+    _write_prior_sprint_audit(tmp_path, sprint_id, 11.93)
+    _persist_prior_story(tmp_path, sprint_id, outcome="DONE", cost_usd=11.93)
+
+    observed: dict = {}
+
+    def run_task_side_effect(*args, **kwargs):
+        for entry in read_live_status("run-live", tmp_path) or []:
+            if entry.slug == "feature-a":
+                observed["status"] = entry.status
+                observed["detail"] = entry.detail
+                observed["cost_usd"] = entry.cost_usd
+        return _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_skip_merged_triage_side_effect),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", side_effect=run_task_side_effect),
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        run_sprint(config, manifest_path, reexec=True, run_id="run-live")
+
+    assert observed, "run_task never ran; live status was not sampled mid-sprint"
+    assert observed["status"] == "done"
+    assert observed["detail"] == "DONE"
+    assert "ALREADY_DONE" not in observed["detail"]
+    # The row that reports the spend must be the row that claims the work.
+    assert observed["cost_usd"] == pytest.approx(11.93)
+
+
+def test_reexec_skip_merged_preserves_prior_already_done_as_noop(
+    tmp_path: Path,
+) -> None:
+    """The other half of the #2150 rule: a prior generation that really was a
+    no-op keeps ALREADY_DONE and its ``resume_skip_merged`` source tag.
+
+    The fix lets the recorded execution decide the label, so this pins that it
+    only ever *preserves* a record — a prior entry with no run behind it (a
+    preflight short-circuit, $0, no elapsed) is still classified as
+    pre-existing merged work.
+    """
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+    config = _make_config(tmp_path)
+
+    sprint_id = _set_sprint_id(tmp_path)
+    _write_prior_sprint_audit(tmp_path, sprint_id, 0.0)
+    _persist_prior_story(
+        tmp_path,
+        sprint_id,
+        outcome="ALREADY_DONE",
+        cost_usd=0.0,
+        outcome_source="preflight_verdict",
+    )
+
+    fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_skip_merged_triage_side_effect),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=fresh_result),
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        result = run_sprint(config, manifest_path, reexec=True)
+
+    accumulated = _accumulated_by_slug(tmp_path, sprint_id)["feature-a"]
+    assert accumulated["outcome"] == "ALREADY_DONE"
+    assert accumulated["outcome_source"] == "resume_skip_merged"
+    assert result.specs_failed == 0
+
+
+def test_resume_skip_merged_keeps_prior_done_in_accumulated_state(
+    tmp_path: Path,
+) -> None:
+    """The same rule on the explicit ``--resume`` path, not just re-exec.
+
+    ``resume=True`` takes a second, distinct write of the accumulated state
+    (the resume-time persistence block), so the DONE-preserving rule is pinned
+    on both entry points rather than only the one the incident happened to hit.
+    """
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+    config = _make_config(tmp_path)
+
+    sprint_id = _set_sprint_id(tmp_path)
+    _write_prior_sprint_audit(tmp_path, sprint_id, 11.93)
+    _persist_prior_story(tmp_path, sprint_id, outcome="DONE", cost_usd=11.93)
+
+    fresh_result = _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_skip_merged_triage_side_effect),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=fresh_result),
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        run_sprint(config, manifest_path, resume=True)
+
+    accumulated = _accumulated_by_slug(tmp_path, sprint_id)["feature-a"]
+    assert accumulated["outcome"] == "DONE"
+    assert accumulated.get("outcome_source") is None
+    assert accumulated["cost_usd"] == pytest.approx(11.93)

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -1085,7 +1085,12 @@ class TestResumeSprintIntegration:
         assert by_slug["feature-a"]["cost_usd"] == pytest.approx(3.5)
         assert by_slug["feature-a"]["started_at"] == expected_started_at
         assert by_slug["feature-a"]["finished_at"] == expected_finished_at
-        assert by_slug["feature-a"]["outcome_source"] == "resume_skip_merged"
+        # #2150: the prior generation of *this* sprint ran feature-a to DONE and
+        # paid $3.50 for it. A post-re-exec triage observing the branch as merged
+        # must not relabel that as pre-existing work — the recorded execution is
+        # the authoritative account, so the row keeps DONE and no source tag.
+        assert by_slug["feature-a"]["outcome"] == "DONE"
+        assert by_slug["feature-a"]["outcome_source"] is None
 
     def test_fresh_sprint_persists_progressive_story_state_for_later_reexec(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] The change preserves prior in-sprint DONE records across skip_merged re-triage in persisted state, live status, and resume paths, with focused regression coverage passing. | [google-gemini-3.5-flash] The implementation successfully preserves in-run DONE outcomes across mid-sprint re-exec boundaries, preventing them from being incorrectly overwritten as ALREADY_DONE.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $4.71
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Stories that land work within the reporting invocation are reported ALREADY_DONE, disowning the run that produced them (GitHub Issue #2150)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2150