### PR TITLE
Adaptive code-review panel size is discarded and the roster is seated instead

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -997,7 +997,10 @@ def run_task(
 
         # ── PREFLIGHT ──────────────────────────────────────────────────
         if cached_preflight_state is not None:
-            from .preflight import _apply_preflight_config  # noqa: PLC0415
+            from .preflight import (  # noqa: PLC0415
+                _apply_preflight_config,
+                persist_routing_decision,
+            )
 
             cache_valid, cache_validation = validate_preflight_cache(
                 cached_preflight_state,
@@ -1009,6 +1012,15 @@ def run_task(
             if cache_valid:
                 apply_cached_preflight_state(state, cached_preflight_state)
                 config = _apply_preflight_config(config, state, task_slug=task.slug)
+                # Routing resolved from a cached verdict is still this run's
+                # decision — persist it so a later resume can recover it (#2154).
+                persist_routing_decision(
+                    config,
+                    state,
+                    task_slug=task.slug,
+                    story_content=story_content,
+                    run_id=_run_id,
+                )
                 from .preflight_flow import _handle_preflight_verdict  # noqa: PLC0415
 
                 config, _pf_result, _pf_already_done_loop = _handle_preflight_verdict(
@@ -1370,7 +1382,10 @@ def _run_resume_coordinator(
             state.timeout_escalation_used = True
 
     if cached_preflight_state is not None:
-        from .preflight import _apply_preflight_config  # noqa: PLC0415
+        from .preflight import (  # noqa: PLC0415
+            _apply_preflight_config,
+            persist_routing_decision,
+        )
 
         cache_valid, cache_validation = validate_preflight_cache(
             cached_preflight_state,
@@ -1382,6 +1397,13 @@ def _run_resume_coordinator(
         if cache_valid:
             apply_cached_preflight_state(state, cached_preflight_state)
             config = _apply_preflight_config(config, state, task_slug=task.slug)
+            persist_routing_decision(
+                config,
+                state,
+                task_slug=task.slug,
+                story_content=story_content,
+                run_id=logger._run_id,
+            )
             # Dispatch the cached verdict just like run_task's cache-valid
             # branch. Without this, a terminal ALREADY_DONE verdict served from
             # cache is applied to state but never acted on, so the resume path
@@ -1433,6 +1455,24 @@ def _run_resume_coordinator(
                 return _pf_result
             if _pf_already_done_loop:
                 skip_dev_first_iter = True
+    else:
+        # No cached preflight state: the scheduler's in-memory map lost this
+        # story (a mid-sprint re-exec drops it for stories already in flight).
+        # Without this branch the resumed phases run against config exactly as
+        # loaded from forge.yaml — the static roster — silently discarding the
+        # panel size routing already decided for this story (#2154). Recover the
+        # persisted decision; when none is usable, say so rather than passing off
+        # the roster as a routed panel.
+        from .preflight import restore_routing_decision  # noqa: PLC0415
+
+        config, _routing_recovery = restore_routing_decision(
+            config,
+            state,
+            task_slug=task.slug,
+            story_content=story_content,
+            log=_log,
+        )
+        logger._safe_emit("routing_recovery", phase="RESUME", **_routing_recovery)
 
     with _run_log_context(config, logger, task, state, _task_start):
         base_branch = config.workspace.base_branch

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -23,6 +23,8 @@ from theforge.review import ReviewFinding
 from theforge.routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from .state import CoordinatorState
 
 _VALID_PREFLIGHT_VERDICTS = frozenset({"PROCEED", "ALREADY_DONE", "BLOCKED"})
@@ -1395,3 +1397,167 @@ def _apply_preflight_config(
         _log_verbose(f"[adaptive] {_phase}: {_rsn}")
 
     return config
+
+
+def persist_routing_decision(
+    config: ForgeConfig,
+    state: "CoordinatorState",
+    *,
+    task_slug: str,
+    story_content: str | None = None,
+    run_id: str | None = None,
+    log_verbose: Callable[[str], None] | None = None,
+) -> "Path | None":
+    """Write this story's resolved routing decision to disk.
+
+    Called immediately after :func:`_apply_preflight_config` installs the
+    decision onto ``config``, so what is recorded is exactly what the phases
+    will execute. The record is the only copy that survives a mid-sprint
+    process re-exec, which drops the scheduler's in-memory preflight cache
+    (#2154).
+    """
+    from .routing_persistence import (  # noqa: PLC0415
+        build_routing_record,
+        save_routing_record,
+    )
+
+    _log_verbose = log_verbose or (lambda _msg: None)
+    record = build_routing_record(
+        slug=task_slug,
+        state=state,
+        review_pool_models=[p.model for p in config.review_pool],
+        dev_model=config.dev_profile.model,
+        plan_model=config.plan.model,
+        story_content=story_content,
+        run_id=run_id,
+    )
+    path = save_routing_record(config.project_root, record)
+    if path is not None:
+        _log_verbose(
+            f"[adaptive] routing decision persisted: {record['code_reviewer_count']} "
+            f"reviewer(s) {record['code_reviewers']} → {path}"
+        )
+    return path
+
+
+def _pin_pool_to_recorded(
+    pool: list[ModelProfile], recorded: list[str]
+) -> list[ModelProfile] | None:
+    """Return ``pool`` narrowed to the recorded models, or None if impossible.
+
+    Profiles are taken from ``pool`` — the freshly re-derived, router-sized
+    pool — never from the static roster, so each seat keeps the budget the
+    router sized for it. If any recorded model is absent the caller is told it
+    cannot honour the recorded panel rather than being handed a substitute.
+    """
+    remaining = list(pool)
+    pinned: list[ModelProfile] = []
+    for model in recorded:
+        match = next((p for p in remaining if p.model == model), None)
+        if match is None:
+            return None
+        remaining.remove(match)
+        pinned.append(match)
+    return pinned
+
+
+def restore_routing_decision(
+    config: ForgeConfig,
+    state: "CoordinatorState",
+    *,
+    task_slug: str,
+    story_content: str | None,
+    log: Callable[[str], None] | None = None,
+    log_verbose: Callable[[str], None] | None = None,
+) -> tuple[ForgeConfig, dict]:
+    """Recover a persisted routing decision for a story resumed without a cache.
+
+    Returns ``(config, recovery)``. ``recovery`` is also stitched into
+    ``state.complexity_routing_audit["routing_recovery"]`` so the audit trail
+    always states which panel the phase actually seated and why (convention 6);
+    when the routed panel cannot be honoured, that is said out loud rather than
+    silently substituted with the ``forge.yaml`` roster.
+    """
+    from .routing_persistence import (  # noqa: PLC0415
+        apply_routing_record_to_state,
+        load_routing_record,
+        validate_routing_record,
+    )
+
+    _log_fn = log or (lambda _msg: None)
+    _log_verbose = log_verbose or (lambda _msg: None)
+
+    def _finish(recovery: dict) -> tuple[ForgeConfig, dict]:
+        recovery["seated_review_pool"] = [p.model for p in config.review_pool]
+        recovery["seated_count"] = len(config.review_pool)
+        _audit = dict(state.complexity_routing_audit or {})
+        _audit["routing_recovery"] = recovery
+        state.complexity_routing_audit = _audit
+        return config, recovery
+
+    record = load_routing_record(config.project_root, task_slug)
+    if record is None:
+        _log_fn(
+            f"  ⚠ ROUTING     no persisted routing decision for {task_slug} — "
+            f"REVIEW will seat the configured roster "
+            f"({len(config.review_pool)} reviewer(s)), not a routed panel"
+        )
+        return _finish({"status": "unavailable", "reason": "no_record"})
+
+    usable, reason = validate_routing_record(record, story_content=story_content)
+    if not usable:
+        _log_fn(
+            f"  ⚠ ROUTING     persisted routing decision for {task_slug} rejected "
+            f"({reason}) — REVIEW will seat the configured roster "
+            f"({len(config.review_pool)} reviewer(s))"
+        )
+        return _finish({"status": "rejected", "reason": reason})
+
+    recorded = [str(m) for m in record.get("code_reviewers") or []]
+    apply_routing_record_to_state(state, record)
+    config = _apply_preflight_config(
+        config, state, log=log, log_verbose=log_verbose, task_slug=task_slug
+    )
+    derived = [p.model for p in config.review_pool]
+
+    recovery: dict = {
+        "status": "recovered",
+        "reason": reason,
+        "source_run_id": record.get("run_id"),
+        "recorded_review_pool": recorded,
+        "recorded_count": len(recorded),
+        "rederived_review_pool": derived,
+        "complexity": record.get("complexity"),
+        "complexity_score": record.get("complexity_score"),
+    }
+
+    if derived == recorded:
+        recovery["reconciliation"] = "rederived_match"
+        _log_fn(
+            f"  ✓ ROUTING     recovered routed panel for {task_slug}: "
+            f"{len(recorded)} reviewer(s) {recorded}"
+        )
+        return _finish(recovery)
+
+    pinned = _pin_pool_to_recorded(list(config.review_pool), recorded)
+    if pinned is not None:
+        config = _dc_replace(config, review_pool=pinned)
+        recovery["reconciliation"] = "pinned_to_record"
+        _log_fn(
+            f"  ✓ ROUTING     recovered routed panel for {task_slug}: "
+            f"{len(recorded)} reviewer(s) {recorded} "
+            f"(re-derivation proposed {len(derived)}: {derived})"
+        )
+        return _finish(recovery)
+
+    recovery["reconciliation"] = "unhonoured"
+    _log_fn(
+        f"  ⚠ ROUTING     routed panel for {task_slug} cannot be honoured: "
+        f"recorded {len(recorded)} reviewer(s) {recorded} include models absent "
+        f"from the re-derived pool {derived} — seating {len(derived)}"
+    )
+    _log_verbose(
+        "[adaptive] routing recovery could not reproduce the recorded panel; "
+        "quantities derived from the seat count describe the seated pool"
+    )
+    return _finish(recovery)

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -58,6 +58,7 @@ from .preflight import (
     _parse_preflight_verdict,
     _parse_preflight_warnings,
     _parse_preflight_work_type,
+    persist_routing_decision,
     score_to_band,
 )
 from .preflight_cache import capture_preflight_cache_snapshot
@@ -896,6 +897,17 @@ def _run_preflight_phase(
 
     config = _apply_preflight_config(
         config, state, log=_log, log_verbose=_log_verbose, task_slug=task.slug
+    )
+    # Durable copy of the decision just installed: the in-memory preflight state
+    # this run holds does not survive a mid-sprint process re-exec, and a resume
+    # without it would seat the static roster instead of this panel (#2154).
+    persist_routing_decision(
+        config,
+        state,
+        task_slug=task.slug,
+        story_content=story_content,
+        run_id=getattr(logger, "_run_id", None),
+        log_verbose=_log_verbose,
     )
 
     _log(f"  {'✗' if verdict == NO_JUDGMENT else '✓'} PREFLIGHT   {verdict}")

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -861,7 +861,14 @@ def _run_review_pool(
         for r in failed_results
     }
 
-    quorum_threshold = min(config.retry.review_quorum_threshold, pool_size)
+    # Quorum is measured against the reviewers that could actually answer this
+    # cycle, not the nominal pool: a budget-excluded reviewer was withdrawn as a
+    # spend decision, so counting it in the denominator can make the threshold
+    # unreachable before any verdict is weighed (#2154). Same collapse rule the
+    # nominal pool already gets — a threshold of 2 over a single eligible seat
+    # is a demand no run could satisfy, not a stricter standard.
+    eligible_pool_size = pool_size - len(_budget_excluded)
+    quorum_threshold = min(config.retry.review_quorum_threshold, eligible_pool_size)
     if quorum_threshold < 1:
         quorum_threshold = 1
     meta.quorum_threshold = quorum_threshold
@@ -886,7 +893,7 @@ def _run_review_pool(
         )
         if can_degrade:
             warning = (
-                f"Degraded quorum: {len(successful)}/{pool_size} reviewer(s) "
+                f"Degraded quorum: {len(successful)}/{eligible_pool_size} reviewer(s) "
                 f"delivered a verdict (threshold {quorum_threshold}); proceeding "
                 f"on surviving verdict(s) after non-verdict reviewer failure(s): "
                 f"{failed_desc}"
@@ -903,6 +910,7 @@ def _run_review_pool(
                     failed_detail=meta.failed_detail,
                     quorum_threshold=quorum_threshold,
                     pool_size=pool_size,
+                    eligible_pool_size=eligible_pool_size,
                     warning=warning,
                 )
         else:
@@ -919,14 +927,14 @@ def _run_review_pool(
             )
             state.phase = Phase.ESCALATE
             state.error = (
-                f"Quorum unmet: {len(successful)}/{pool_size} succeeded "
+                f"Quorum unmet: {len(successful)}/{eligible_pool_size} succeeded "
                 f"< threshold {quorum_threshold}; failed: {failed_desc}"
             )
             return successful, failed_results, None, [], []
 
     if failed_results and meta.quorum_met:
         _log(
-            f"Panel quorum met ({len(successful)}/{pool_size} reviewers succeeded "
+            f"Panel quorum met ({len(successful)}/{eligible_pool_size} reviewers succeeded "
             f"≥ quorum threshold {quorum_threshold}) — proceeding to synthesis"
         )
 

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -898,6 +898,13 @@ def _run_review_pool(
                 f"on surviving verdict(s) after non-verdict reviewer failure(s): "
                 f"{failed_desc}"
             )
+            if _budget_excluded:
+                # Same attribution rule as the escalation path: an excluded
+                # reviewer is a spend decision, not a failure to degrade past.
+                warning += (
+                    "; budget-excluded (ran, verdict not counted): "
+                    f"{', '.join(sorted(_budget_excluded))}"
+                )
             meta.degraded_quorum = True
             meta.degraded_quorum_warning = warning
             _log(f"  ⚠ {warning}")
@@ -911,6 +918,7 @@ def _run_review_pool(
                     quorum_threshold=quorum_threshold,
                     pool_size=pool_size,
                     eligible_pool_size=eligible_pool_size,
+                    budget_excluded=sorted(_budget_excluded),
                     warning=warning,
                 )
         else:
@@ -926,9 +934,20 @@ def _run_review_pool(
                 budget_excluded=_budget_excluded,
             )
             state.phase = Phase.ESCALATE
+            # A reviewer withdrawn over budget did not fail — its verdict was
+            # dropped as a spend decision. Naming the two causes separately is
+            # what makes the shortfall diagnosable; the original #2154 report
+            # read "Quorum unmet: 1/5 succeeded < threshold 2; failed:" with an
+            # empty list, because the missing four had been excluded, not failed.
+            _shortfall = f"failed: {failed_desc}"
+            if _budget_excluded:
+                _shortfall += (
+                    "; budget-excluded (ran, verdict not counted): "
+                    f"{', '.join(sorted(_budget_excluded))}"
+                )
             state.error = (
                 f"Quorum unmet: {len(successful)}/{eligible_pool_size} succeeded "
-                f"< threshold {quorum_threshold}; failed: {failed_desc}"
+                f"< threshold {quorum_threshold}; {_shortfall}"
             )
             return successful, failed_results, None, [], []
 

--- a/src/theforge/coordinator/routing_persistence.py
+++ b/src/theforge/coordinator/routing_persistence.py
@@ -1,0 +1,193 @@
+"""Durable per-story record of the routing decision preflight resolved.
+
+Adaptive routing decides, once per story, how many reviewers the code-review
+panel seats and which models fill it.  That decision lives only on the
+in-memory ``CoordinatorState`` produced by preflight, and the sprint scheduler
+hands it to a resumed story as ``cached_preflight_state``.  When that in-memory
+cache is lost — a mid-sprint ``os.execv`` re-exec drops the scheduler's
+``preflight_states`` map for stories already in flight — a resumed REVIEW phase
+has no routed decision to execute and falls back to the static ``forge.yaml``
+roster.  Seating the roster instead of the routed panel mis-sizes every
+quantity derived from the seat count (per-reviewer budget share, quorum
+threshold), which is how a story can escalate on a quorum that was unreachable
+before any reviewer ran (#2154).
+
+This module writes the routing decision next to the run so it survives the
+process, and reads it back on resume.  It deliberately records only what
+routing consumed and produced:
+
+* the complexity signal preflight measured (the *input* to routing), and
+* the models routing selected (the *output*), so a re-derivation that diverges
+  is detectable rather than silent.
+
+Validity is keyed on the story text alone.  Routing is a function of the
+story's complexity, not of the worktree's git state — a resumed story has
+commits its preflight never saw, so reusing ``preflight_cache``'s git-state
+fingerprint here would reject every record at exactly the moment it is needed.
+
+Stdlib-only imports (project convention 4: pure-data types live in
+low-dependency modules).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .state import CoordinatorState
+
+RECORD_VERSION = 1
+
+_SAFE_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_slug(slug: str) -> str:
+    """Filesystem-safe filename stem for a story slug."""
+    cleaned = _SAFE_SLUG_RE.sub("-", (slug or "").strip()).strip("-.")
+    return cleaned or "story"
+
+
+def routing_records_dir(project_root: Path) -> Path:
+    return Path(project_root) / ".forge" / "routing"
+
+
+def routing_record_path(project_root: Path, slug: str) -> Path:
+    return routing_records_dir(project_root) / f"{_safe_slug(slug)}.json"
+
+
+def story_content_hash(story_content: str) -> str:
+    return hashlib.sha256((story_content or "").encode("utf-8")).hexdigest()
+
+
+def build_routing_record(
+    *,
+    slug: str,
+    state: "CoordinatorState",
+    review_pool_models: list[str],
+    dev_model: str | None,
+    plan_model: str | None,
+    story_content: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Build the persisted routing record for a story.
+
+    ``review_pool_models`` is the *seated* panel — the models REVIEW will run —
+    and ``code_reviewer_count`` is stated explicitly so a reader never has to
+    infer the panel size from a list that some later stage may have rewritten.
+    """
+    return {
+        "version": RECORD_VERSION,
+        "slug": slug,
+        "run_id": run_id,
+        "story_content_hash": story_content_hash(story_content) if story_content else None,
+        "complexity": state.preflight_complexity,
+        "complexity_score": state.preflight_complexity_score,
+        "implementation_complexity_score": state.preflight_implementation_complexity_score,
+        "validation_complexity_score": state.preflight_validation_complexity_score,
+        "complexity_projection": state.preflight_complexity_projection,
+        "work_type": state.preflight_work_type,
+        "sufficiency": state.preflight_sufficiency,
+        "domains": list(state.preflight_domains or []),
+        "contract_change": bool(state.preflight_contract_change),
+        "dev_model": dev_model,
+        "plan_model": plan_model,
+        "code_reviewers": list(review_pool_models),
+        "code_reviewer_count": len(review_pool_models),
+    }
+
+
+def save_routing_record(
+    project_root: Path,
+    record: dict[str, Any],
+) -> Path | None:
+    """Persist ``record``; return the path written, or None if it could not be.
+
+    Best-effort by design: a routing record is a recovery aid, so failing to
+    write one — unwritable path, or a config value that will not serialize —
+    must never take down the run that produced it.
+    """
+    slug = str(record.get("slug") or "")
+    try:
+        path = routing_record_path(project_root, slug)
+        payload = json.dumps(record, indent=2, sort_keys=True)
+    except (TypeError, ValueError):
+        return None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(payload, encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        return None
+    return path
+
+
+def load_routing_record(project_root: Path, slug: str) -> dict[str, Any] | None:
+    """Read a story's persisted routing record, or None when unusable."""
+    try:
+        raw = routing_record_path(project_root, slug).read_text(encoding="utf-8")
+    except (OSError, TypeError, ValueError):
+        return None
+    try:
+        record = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(record, dict):
+        return None
+    if record.get("version") != RECORD_VERSION:
+        return None
+    return record
+
+
+def validate_routing_record(
+    record: dict[str, Any],
+    *,
+    story_content: str | None,
+) -> tuple[bool, str]:
+    """Return (usable, reason) for a loaded routing record.
+
+    A record with no recorded story hash is accepted as ``unverified_story``:
+    it still carries a real routing decision, and rejecting it would put the
+    run back on the static roster this module exists to prevent.
+    """
+    if not record.get("code_reviewers"):
+        return False, "no_routed_review_pool"
+    recorded_hash = record.get("story_content_hash")
+    if not recorded_hash:
+        return True, "unverified_story"
+    if story_content is None:
+        return True, "unverified_story"
+    if recorded_hash != story_content_hash(story_content):
+        return False, "story_content_changed"
+    return True, "story_content_match"
+
+
+def apply_routing_record_to_state(state: "CoordinatorState", record: dict[str, Any]) -> None:
+    """Restore the routing *inputs* from ``record`` onto a live state.
+
+    Only the complexity signal is restored — never the verdict.  A recovered
+    routing decision says how to size the panel; it says nothing about whether
+    the story should run, and synthesizing a PROCEED verdict from it would
+    fabricate a judgement no preflight made.
+    """
+    state.preflight_complexity = record.get("complexity") or state.preflight_complexity
+    if record.get("complexity_score") is not None:
+        state.preflight_complexity_score = record["complexity_score"]
+    if record.get("implementation_complexity_score") is not None:
+        state.preflight_implementation_complexity_score = record["implementation_complexity_score"]
+    if record.get("validation_complexity_score") is not None:
+        state.preflight_validation_complexity_score = record["validation_complexity_score"]
+    if record.get("complexity_projection"):
+        state.preflight_complexity_projection = record["complexity_projection"]
+    if record.get("work_type"):
+        state.preflight_work_type = record["work_type"]
+    if record.get("sufficiency"):
+        state.preflight_sufficiency = record["sufficiency"]
+    if record.get("domains") and not state.preflight_domains:
+        state.preflight_domains = list(record["domains"])
+    if record.get("contract_change"):
+        state.preflight_contract_change = True

--- a/tests/test_coord_routing_recovery.py
+++ b/tests/test_coord_routing_recovery.py
@@ -1,0 +1,418 @@
+"""The routed code-review panel survives a resume that lost the preflight cache.
+
+Adaptive routing sizes the code-review panel once, during preflight. That
+decision lived only in the sprint scheduler's in-memory ``preflight_states``
+map, so a mid-sprint process re-exec dropped it for stories already in flight
+and the resumed REVIEW phase re-derived its panel from the ``forge.yaml``
+roster instead — seating five reviewers where routing had chosen three, which
+mis-sized the per-reviewer budget share and the quorum threshold derived from
+the seat count (#2154).
+
+These tests cover the seam in both directions: preflight persists the decision
+it installed, and a resume with ``cached_preflight_state=None`` recovers it
+before REVIEW runs. When no usable record exists the resume must say so rather
+than pass the roster off as a routed panel.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import _make_agent_result, _make_config, patch_gate_shell
+
+from theforge.config import ModelProfile, RetryPolicy
+from theforge.coordinator.engine import run_from_review
+from theforge.coordinator.preflight import (
+    persist_routing_decision,
+    restore_routing_decision,
+)
+from theforge.coordinator.review_pool import _run_review_pool
+from theforge.coordinator.routing_persistence import (
+    RECORD_VERSION,
+    build_routing_record,
+    load_routing_record,
+    routing_record_path,
+    save_routing_record,
+    story_content_hash,
+    validate_routing_record,
+)
+from theforge.coordinator.state import CoordinatorState, Phase, ReviewCycleMetadata
+from theforge.task import TaskStory
+
+STORY_CONTENT = "# Test\n\nDo the thing."
+
+APPROVE_YAML = (
+    "```yaml\nverdict: APPROVE\nsummary: ok\nfindings: []\n"
+    "story_compliance:\n  matches_spec: true\n"
+    "test_coverage:\n  adequate: true\n"
+    "ac_verification:\n  - criterion: c\n    status: VERIFIED\n"
+    "    evidence: e\n```\n"
+)
+
+ROSTER_MODELS = ["sonnet", "gemini-3.5-flash", "gpt-5.4", "opus", "gpt-5.5"]
+ROUTED_MODELS = ["gpt-5.4", "gemini-3.5-flash", "opus"]
+
+
+def _profile(model: str, budget_usd: float = 1.0) -> ModelProfile:
+    return ModelProfile(
+        name=model,
+        cli="claude",
+        model=model,
+        budget_usd=budget_usd,
+        timeout_seconds=300,
+        allowed_tools=("Read", "Bash"),
+    )
+
+
+def _roster_config(tmp_path: Path):
+    """Config whose review_pool is the full static roster (the wrong panel)."""
+    config = _make_config(tmp_path)
+    return dataclasses.replace(config, review_pool=[_profile(m) for m in ROSTER_MODELS])
+
+
+def _state_with_complexity() -> CoordinatorState:
+    state = CoordinatorState()
+    state.preflight_complexity = "large"
+    state.preflight_complexity_score = 9
+    state.preflight_work_type = "bug"
+    state.preflight_sufficiency = "implementation_ready"
+    return state
+
+
+def _write_routed_record(tmp_path: Path, slug: str = "test-story", **overrides) -> dict:
+    record = build_routing_record(
+        slug=slug,
+        state=_state_with_complexity(),
+        review_pool_models=list(ROUTED_MODELS),
+        dev_model="opus",
+        plan_model="opus",
+        story_content=STORY_CONTENT,
+        run_id="prior-run-id",
+    )
+    record.update(overrides)
+    save_routing_record(tmp_path, record)
+    return record
+
+
+class TestRoutingRecordPersistence:
+    """The record round-trips and refuses to be read when it cannot be trusted."""
+
+    def test_round_trip_preserves_routed_panel(self, tmp_path: Path) -> None:
+        record = _write_routed_record(tmp_path)
+        loaded = load_routing_record(tmp_path, "test-story")
+
+        assert loaded is not None
+        assert loaded["code_reviewers"] == ROUTED_MODELS
+        assert loaded["code_reviewer_count"] == 3
+        assert loaded["complexity_score"] == 9
+        assert loaded == record
+
+    def test_missing_record_reads_as_none(self, tmp_path: Path) -> None:
+        assert load_routing_record(tmp_path, "never-ran") is None
+
+    def test_unknown_version_is_rejected(self, tmp_path: Path) -> None:
+        _write_routed_record(tmp_path, version=RECORD_VERSION + 1)
+        assert load_routing_record(tmp_path, "test-story") is None
+
+    def test_corrupt_record_is_rejected(self, tmp_path: Path) -> None:
+        path = routing_record_path(tmp_path, "test-story")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert load_routing_record(tmp_path, "test-story") is None
+
+    def test_changed_story_invalidates_record(self, tmp_path: Path) -> None:
+        record = _write_routed_record(tmp_path)
+        usable, reason = validate_routing_record(record, story_content="# Test\n\nDo it later.")
+        assert usable is False
+        assert reason == "story_content_changed"
+
+    def test_matching_story_validates(self, tmp_path: Path) -> None:
+        record = _write_routed_record(tmp_path)
+        usable, reason = validate_routing_record(record, story_content=STORY_CONTENT)
+        assert usable is True
+        assert reason == "story_content_match"
+
+    def test_record_without_story_hash_is_usable_but_unverified(self, tmp_path: Path) -> None:
+        """A hash-less record still carries a real decision; rejecting it would
+        put the run back on the roster this module exists to prevent."""
+        record = _write_routed_record(tmp_path, story_content_hash=None)
+        usable, reason = validate_routing_record(record, story_content=STORY_CONTENT)
+        assert usable is True
+        assert reason == "unverified_story"
+
+    def test_persist_writes_the_installed_panel(self, tmp_path: Path) -> None:
+        config = dataclasses.replace(
+            _make_config(tmp_path), review_pool=[_profile(m) for m in ROUTED_MODELS]
+        )
+        state = _state_with_complexity()
+
+        path = persist_routing_decision(
+            config,
+            state,
+            task_slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-1",
+        )
+
+        assert path is not None
+        written = json.loads(path.read_text(encoding="utf-8"))
+        assert written["code_reviewers"] == ROUTED_MODELS
+        assert written["story_content_hash"] == story_content_hash(STORY_CONTENT)
+        assert written["run_id"] == "run-1"
+
+    def test_persist_is_best_effort(self, tmp_path: Path) -> None:
+        """A record that cannot be written must not take down the run producing it."""
+        config = dataclasses.replace(
+            _make_config(tmp_path), review_pool=[_profile(m) for m in ROUTED_MODELS]
+        )
+        with patch(
+            "theforge.coordinator.routing_persistence.Path.mkdir",
+            side_effect=OSError("read-only"),
+        ):
+            assert (
+                persist_routing_decision(config, _state_with_complexity(), task_slug="test-story")
+                is None
+            )
+
+
+class TestRestoreRoutingDecision:
+    """Recovery narrows the roster back to the routed panel — or says it cannot."""
+
+    def test_recovered_panel_replaces_the_roster(self, tmp_path: Path) -> None:
+        _write_routed_record(tmp_path)
+        config = _roster_config(tmp_path)
+        state = CoordinatorState()
+
+        config, recovery = restore_routing_decision(
+            config, state, task_slug="test-story", story_content=STORY_CONTENT
+        )
+
+        assert [p.model for p in config.review_pool] == ROUTED_MODELS
+        assert recovery["status"] == "recovered"
+        assert recovery["recorded_count"] == 3
+        assert recovery["seated_count"] == 3
+        # The complexity signal routing consumed is restored too, so every other
+        # complexity-derived limit stops falling back to the static default.
+        assert state.preflight_complexity == "large"
+        assert state.preflight_complexity_score == 9
+
+    def test_recovery_is_recorded_in_the_audit_trail(self, tmp_path: Path) -> None:
+        _write_routed_record(tmp_path)
+        config = _roster_config(tmp_path)
+        state = CoordinatorState()
+
+        restore_routing_decision(
+            config, state, task_slug="test-story", story_content=STORY_CONTENT
+        )
+
+        recovery = (state.complexity_routing_audit or {}).get("routing_recovery")
+        assert recovery is not None
+        assert recovery["source_run_id"] == "prior-run-id"
+        assert recovery["recorded_review_pool"] == ROUTED_MODELS
+        assert recovery["seated_review_pool"] == ROUTED_MODELS
+
+    def test_no_record_leaves_roster_and_says_so(self, tmp_path: Path) -> None:
+        config = _roster_config(tmp_path)
+        state = CoordinatorState()
+        lines: list[str] = []
+
+        config, recovery = restore_routing_decision(
+            config,
+            state,
+            task_slug="test-story",
+            story_content=STORY_CONTENT,
+            log=lines.append,
+        )
+
+        assert [p.model for p in config.review_pool] == ROSTER_MODELS
+        assert recovery["status"] == "unavailable"
+        assert recovery["reason"] == "no_record"
+        assert recovery["seated_count"] == 5
+        assert any("no persisted routing decision" in line for line in lines)
+
+    def test_stale_record_is_refused_out_loud(self, tmp_path: Path) -> None:
+        _write_routed_record(tmp_path)
+        config = _roster_config(tmp_path)
+        state = CoordinatorState()
+        lines: list[str] = []
+
+        config, recovery = restore_routing_decision(
+            config,
+            state,
+            task_slug="test-story",
+            story_content="# Test\n\nSomething else entirely.",
+            log=lines.append,
+        )
+
+        assert [p.model for p in config.review_pool] == ROSTER_MODELS
+        assert recovery["status"] == "rejected"
+        assert recovery["reason"] == "story_content_changed"
+        assert any("rejected" in line for line in lines)
+        # A refused record must not leak its complexity signal into the run.
+        assert state.preflight_complexity is None
+
+    def test_unhonourable_panel_is_reported_not_substituted(self, tmp_path: Path) -> None:
+        """A recorded model absent from the current pool cannot be seated. The
+        run says so instead of quietly seating a differently-sized panel."""
+        _write_routed_record(tmp_path)
+        config = dataclasses.replace(
+            _roster_config(tmp_path),
+            review_pool=[_profile("sonnet"), _profile("opus")],
+        )
+        state = CoordinatorState()
+        lines: list[str] = []
+
+        config, recovery = restore_routing_decision(
+            config,
+            state,
+            task_slug="test-story",
+            story_content=STORY_CONTENT,
+            log=lines.append,
+        )
+
+        assert recovery["status"] == "recovered"
+        assert recovery["reconciliation"] == "unhonoured"
+        assert recovery["recorded_count"] == 3
+        assert recovery["seated_count"] == 2
+        assert any("cannot be honoured" in line for line in lines)
+
+    def test_preflight_record_is_what_resume_recovers(self, tmp_path: Path) -> None:
+        """End-to-end of the persistence seam: what preflight installs is what a
+        later resume seats, across two independent config objects."""
+        routed_config = dataclasses.replace(
+            _make_config(tmp_path), review_pool=[_profile(m) for m in ROUTED_MODELS]
+        )
+        persist_routing_decision(
+            routed_config,
+            _state_with_complexity(),
+            task_slug="test-story",
+            story_content=STORY_CONTENT,
+        )
+
+        resumed_config, recovery = restore_routing_decision(
+            _roster_config(tmp_path),
+            CoordinatorState(),
+            task_slug="test-story",
+            story_content=STORY_CONTENT,
+        )
+
+        assert [p.model for p in resumed_config.review_pool] == ROUTED_MODELS
+        assert recovery["status"] == "recovered"
+
+
+class TestResumeSeatsRoutedPanel:
+    """Seam test across the resume boundary: run_from_review with no cache."""
+
+    @staticmethod
+    def _shell(cmd: str, cwd, **kwargs):
+        if "--oneline" in cmd and "git log" in cmd:
+            return (True, "abc1234 feat: work", 0, False)
+        if "git status --porcelain" in cmd:
+            return (True, "", 0, False)
+        return (True, "OK", 0, False)
+
+    def _run(self, tmp_path: Path, mock_pool):
+        spec = tmp_path / "spec.md"
+        spec.write_text(STORY_CONTENT, encoding="utf-8")
+        config = _roster_config(tmp_path)
+        task = TaskStory(name="Test Story", story_path=spec, slug="test-story")
+        workspace = tmp_path / "test-story"
+        workspace.mkdir()
+
+        mock_pool.side_effect = lambda **kwargs: [
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name=p.name)
+            for p in kwargs["profiles"]
+        ]
+        return run_from_review(config, task, workspace, cached_preflight_state=None)
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell(side_effect=_shell.__func__)
+    def test_review_seats_the_routed_panel(
+        self, _mock_shell, _mock_dev, mock_pool, tmp_path: Path
+    ) -> None:
+        _write_routed_record(tmp_path)
+
+        self._run(tmp_path, mock_pool)
+
+        assert mock_pool.called
+        seated = [p.model for p in mock_pool.call_args.kwargs["profiles"]]
+        assert seated == ROUTED_MODELS, "resumed REVIEW re-derived the panel from the roster"
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell(side_effect=_shell.__func__)
+    def test_review_falls_back_to_roster_when_nothing_was_recorded(
+        self, _mock_shell, _mock_dev, mock_pool, tmp_path: Path
+    ) -> None:
+        """No record to recover: the roster is seated, but the run records that
+        it is a fallback rather than a routed decision."""
+        result = self._run(tmp_path, mock_pool)
+
+        seated = [p.model for p in mock_pool.call_args.kwargs["profiles"]]
+        assert seated == ROSTER_MODELS
+        recovery = (result.state.complexity_routing_audit or {}).get("routing_recovery")
+        assert recovery is not None
+        assert recovery["status"] == "unavailable"
+
+
+class TestQuorumCountsEligibleSeats:
+    """Quorum describes the seats that can answer, not the nominal pool."""
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_budget_excluded_reviewers_leave_the_denominator(
+        self, mock_pool, _mock_log, tmp_path: Path
+    ) -> None:
+        profiles = [_profile("a"), _profile("b"), _profile("c")]
+        config = dataclasses.replace(
+            _make_config(tmp_path),
+            review_pool=profiles,
+            synthesis_profile=None,
+            retry=RetryPolicy(
+                max_dev_iterations=2,
+                max_review_cycles=2,
+                review_quorum_threshold=2,
+                max_review_transport_retries=0,
+            ),
+        )
+        task = TaskStory(
+            name="Test Story",
+            story_path=tmp_path / "spec.md",
+            slug="test-story",
+        )
+        task.story_path.write_text(STORY_CONTENT, encoding="utf-8")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+
+        # Two of three reviewers blow their budget share this cycle: they are
+        # withdrawn as a spend decision, so only one seat can answer.
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name="a", cost_usd=0.10),
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name="b", cost_usd=5.00),
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name="c", cost_usd=5.00),
+        ]
+
+        meta = ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
+        _successful, _failed, merged, _, _ = _run_review_pool(
+            state,
+            config,
+            task,
+            STORY_CONTENT,
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=True,
+        )
+
+        # Threshold 2 against a nominal pool of 3 was unreachable with one
+        # eligible seat; measured against the eligible seat it is met.
+        assert meta.quorum_threshold == 1
+        assert meta.quorum_met is True
+        assert merged is not None
+        assert state.phase != Phase.ESCALATE

--- a/tests/test_coord_routing_recovery.py
+++ b/tests/test_coord_routing_recovery.py
@@ -359,6 +359,43 @@ class TestResumeSeatsRoutedPanel:
         assert recovery["status"] == "unavailable"
 
 
+def _three_reviewer_config(tmp_path: Path):
+    """Three-seat pool with a quorum threshold of 2 and no transient retries."""
+    return dataclasses.replace(
+        _make_config(tmp_path),
+        review_pool=[_profile("a"), _profile("b"), _profile("c")],
+        synthesis_profile=None,
+        retry=RetryPolicy(
+            max_dev_iterations=2,
+            max_review_cycles=2,
+            review_quorum_threshold=2,
+            max_review_transport_retries=0,
+        ),
+    )
+
+
+def _run_pool(tmp_path: Path, config) -> tuple[CoordinatorState, ReviewCycleMetadata, object]:
+    task = TaskStory(name="Test Story", story_path=tmp_path / "spec.md", slug="test-story")
+    task.story_path.write_text(STORY_CONTENT, encoding="utf-8")
+    workspace = tmp_path / "ws"
+    workspace.mkdir(exist_ok=True)
+    state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+    meta = ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
+
+    _successful, _failed, merged, _, _ = _run_review_pool(
+        state,
+        config,
+        task,
+        STORY_CONTENT,
+        workspace,
+        "branch",
+        meta,
+        notify=False,
+        enforce_budgets=True,
+    )
+    return state, meta, merged
+
+
 class TestQuorumCountsEligibleSeats:
     """Quorum describes the seats that can answer, not the nominal pool."""
 
@@ -367,28 +404,6 @@ class TestQuorumCountsEligibleSeats:
     def test_budget_excluded_reviewers_leave_the_denominator(
         self, mock_pool, _mock_log, tmp_path: Path
     ) -> None:
-        profiles = [_profile("a"), _profile("b"), _profile("c")]
-        config = dataclasses.replace(
-            _make_config(tmp_path),
-            review_pool=profiles,
-            synthesis_profile=None,
-            retry=RetryPolicy(
-                max_dev_iterations=2,
-                max_review_cycles=2,
-                review_quorum_threshold=2,
-                max_review_transport_retries=0,
-            ),
-        )
-        task = TaskStory(
-            name="Test Story",
-            story_path=tmp_path / "spec.md",
-            slug="test-story",
-        )
-        task.story_path.write_text(STORY_CONTENT, encoding="utf-8")
-        workspace = tmp_path / "ws"
-        workspace.mkdir()
-        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
-
         # Two of three reviewers blow their budget share this cycle: they are
         # withdrawn as a spend decision, so only one seat can answer.
         mock_pool.return_value = [
@@ -397,18 +412,7 @@ class TestQuorumCountsEligibleSeats:
             _make_agent_result(success=True, output=APPROVE_YAML, profile_name="c", cost_usd=5.00),
         ]
 
-        meta = ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
-        _successful, _failed, merged, _, _ = _run_review_pool(
-            state,
-            config,
-            task,
-            STORY_CONTENT,
-            workspace,
-            "branch",
-            meta,
-            notify=False,
-            enforce_budgets=True,
-        )
+        state, meta, merged = _run_pool(tmp_path, _three_reviewer_config(tmp_path))
 
         # Threshold 2 against a nominal pool of 3 was unreachable with one
         # eligible seat; measured against the eligible seat it is met.
@@ -416,3 +420,26 @@ class TestQuorumCountsEligibleSeats:
         assert meta.quorum_met is True
         assert merged is not None
         assert state.phase != Phase.ESCALATE
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_shortfall_names_exclusions_apart_from_failures(
+        self, mock_pool, _mock_log, tmp_path: Path
+    ) -> None:
+        """A reviewer withdrawn over budget did not fail. The escalation reason
+        has to say which reviewers ran and lost, and which were withheld — the
+        #2154 report's 'failed:' list was empty because the missing reviewers
+        were excluded, and the message gave the operator no way to see that."""
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name="a", cost_usd=5.00),
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name="b", cost_usd=5.00),
+            _make_agent_result(success=False, output="boom", profile_name="c", cost_usd=0.10),
+        ]
+
+        state, _meta, merged = _run_pool(tmp_path, _three_reviewer_config(tmp_path))
+
+        assert merged is None
+        assert state.phase == Phase.ESCALATE
+        assert "Quorum unmet: 0/1 succeeded < threshold 1" in state.error
+        assert "failed: c (exit=1)" in state.error
+        assert "budget-excluded (ran, verdict not counted): a, b" in state.error


### PR DESCRIPTION
## Summary

[openai-gpt-5.5] No P1 regressions found; focused routing-recovery and review-pool tests pass. | [google-gemini-3.5-flash] The implementation successfully persists and restores the routed review panel on resume, correctly handles quorum calculations for eligible seats, and distinguishes budget exclusions from failures.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** claude-sonnet, google-gemini-3.5-flash, openai-gpt-5.4, claude-opus, openai-gpt-5.5
- **Cost:** $15.60
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Adaptive code-review panel size is discarded and the roster is seated instead (GitHub Issue #2154)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2154