### PR TITLE
fix(gate): resolve forge from .venv, not the ambient PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,19 @@ test-parallel:
 
 # Gate: run lint, format check, and tests. Exit 0 = PASS, non-zero = FAIL.
 # The coordinator reads the exit code; no handoff file is written.
+#
+# Both forge invocations use .venv/bin/forge — the checkout under test — never
+# the ambient PATH, which resolves to whichever released orchestrator is
+# installed. SCRUBBED_GATE_CMD already pins PATH=".venv/bin:$$PATH" for the same
+# reason; these two calls were the remaining hole. A bare `forge` here validates
+# the checkout's config with the previous release's schema, so any change to a
+# config contract fails its own gate after merge even though the change is
+# correct (observed cutting v0.13.0rc17 against the #1415 model-identity
+# migration: `Unknown model 'anthropic/sonnet/cli'` from the rc16 registry).
 gate:
 	@mkdir -p .forge/index .forge && \
-	forge index && \
-	forge check-story-config && \
+	.venv/bin/forge index && \
+	.venv/bin/forge check-story-config && \
 	$(SCRUBBED_GATE_CMD)
 
 # Transitional alias retained for one release while the scrubbed gate rolls out.


### PR DESCRIPTION
## What

`make gate` invoked bare `forge index` and `forge check-story-config`. Both
resolve through the ambient `PATH` to whichever released orchestrator is
installed (`~/.local/bin/forge` → `.forge/rc-envs/<version>/`), not to the
checkout under test.

`SCRUBBED_GATE_CMD` on the very next line already pins `PATH=".venv/bin:$PATH"`
and scrubs the environment for exactly this reason. The test half of the gate was
isolated to the patient; the validation half was not.

## Why it matters

A change to a config contract fails its own gate *after* merge, because the gate
validates the new config using the previous release's schema.

Observed cutting `v0.13.0rc17` against the #1415 model-identity migration:

```
forge.yaml story-mutation guard failed: Unknown model 'anthropic/sonnet/cli':
not in AGENT_REGISTRY. Known models: ['claude/opus', 'claude/sonnet', ...]
```

The merged code is correct — post-#1415 `AGENT_REGISTRY` holds 20 canonical
`<provider>/<model>/<transport>` keys including `anthropic/sonnet/cli`. The
"known models" list in that error is rc16's registry. Controlled directly:

| runtime | `forge check-story-config` |
|---|---|
| `.venv/bin/forge` (checkout) | passes |
| `forge` (rc16 orchestrator) | fails, as above |

The story's own gate could not have caught this. At the time it ran, the
orchestrator and the branch still agreed about model spellings; the disagreement
only exists after the merge.

## Scope

Affects `make gate` only — `forge.yaml`'s `validation.gate_command`, plus
`cut-rc.sh`, `promote-rc.sh` and `release.sh`. CI is unaffected: it runs
`make lint` and `make test` directly, never `make gate`. Every worktree is
provisioned with a `.venv` by `workspace.setup_command`, so `.venv/bin/forge`
resolves everywhere the gate runs.

Distinct from #1945, which covers story-gate vs CI divergence. This axis is
story-gate vs orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)