### PR TITLE
Story gate and required merge check enforce different standards: different command, extras, environment, and platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,24 @@ jobs:
         # the provider SDKs absent, so config load raised on any profile naming
         # an API provider and CI rejected work the story gate had passed — the
         # extras half of #1945.
-        run: pip install -e ".[all,dev]"
+        #
+        # Install into ./.venv rather than the runner interpreter: `make gate`
+        # invokes .venv/bin/forge and pins PATH=".venv/bin:$PATH", so the
+        # checkout under test — not an ambient release — is what gets gated.
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -e ".[all,dev]"
 
-      - name: Lint
-        run: make lint
-
-      - name: Test
-        run: make test
+      - name: Gate
+        # Run the *same* target the story gate runs (forge.yaml
+        # validation.gate_command -> `make gate`), not an independently
+        # composed lint+test pair. `make gate` adds `forge index` and
+        # `forge check-story-config` ahead of ruff/pytest and runs the suite
+        # under a scrubbed `env -i`. Splitting these two standards let a commit
+        # that breaks the project's own config contract pass CI while every
+        # sprint's baseline gate failed — the command half of #1945. The only
+        # deliberate remaining difference between the two is platform
+        # (macOS development host vs ubuntu-latest here), which is kept on
+        # purpose to catch host-specific assumptions.
+        run: make gate

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -498,8 +498,17 @@ Key modules:
 make fmt        # ruff format + ruff check --fix (auto-fix)
 make lint       # ruff check + ruff format --check (no auto-fix)
 make test       # pytest tests/ -v
-make gate       # lint + format check + tests (exit code only, no file written)
+make gate       # forge index + check-story-config + lint + format check +
+                # tests, under a scrubbed env (exit code only, no file written)
 ```
+
+`make gate` is the single standard: it is what `validation.gate_command` runs
+for a story and what the required merge check runs in CI
+(`.github/workflows/ci.yml`). The one deliberate difference between the two is
+platform — stories are gated on the macOS development host, CI on
+`ubuntu-latest` — kept on purpose to catch host-specific assumptions. Do not
+add a second, independently composed command list to either side; a merge check
+that is not a superset of the story gate is not a gate (#1945).
 
 ### Language and toolchain agnosticism
 TheForge is a generic orchestrator — it must work for Python, Node, Go, Java, Rust,

--- a/tests/test_ci_gate_parity.py
+++ b/tests/test_ci_gate_parity.py
@@ -1,0 +1,62 @@
+"""The required merge check must enforce the same standard as the story gate.
+
+Regression guard for #1945: CI ran an independently composed `make lint` +
+`make test` pair while the story gate ran `make gate`, which additionally runs
+`forge index` and `forge check-story-config` and scrubs the environment. Neither
+was a superset of the other, so a commit that broke the project's own config
+contract passed CI while every sprint's baseline gate failed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ci_gate_job() -> dict:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text())
+    return workflow["jobs"]["gate"]
+
+
+def _run_commands() -> list[str]:
+    return [step["run"] for step in _ci_gate_job()["steps"] if "run" in step]
+
+
+def _run_lines() -> list[str]:
+    return [line.strip() for command in _run_commands() for line in command.splitlines()]
+
+
+def _story_gate_command() -> str:
+    config = yaml.safe_load((REPO_ROOT / "forge.yaml").read_text())
+    return config["validation"]["gate_command"]
+
+
+def test_ci_runs_the_story_gate_command() -> None:
+    """CI invokes exactly the command forge.yaml names as the story gate."""
+    assert _story_gate_command() in _run_lines()
+
+
+def test_ci_does_not_substitute_a_narrower_command_pair() -> None:
+    """`make lint` / `make test` omit the forge preconditions and env scrubbing."""
+    lines = _run_lines()
+    assert "make lint" not in lines
+    assert "make test" not in lines
+
+
+def test_ci_installs_into_the_venv_the_gate_resolves_from() -> None:
+    """`make gate` calls .venv/bin/forge and pins PATH=".venv/bin:$PATH"."""
+    commands = "\n".join(_run_commands())
+    assert "python -m venv .venv" in commands
+    assert '.venv/bin/pip install -e ".[all,dev]"' in commands
+
+
+def test_gate_target_carries_the_forge_preconditions() -> None:
+    """The target CI now runs is the one that enforces the config contract."""
+    makefile = (REPO_ROOT / "Makefile").read_text()
+    gate_block = makefile[makefile.index("gate:\n") : makefile.index("gate-strict:")]
+    assert "forge index" in gate_block
+    assert "forge check-story-config" in gate_block
+    assert "$(SCRUBBED_GATE_CMD)" in gate_block


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] CI now invokes the same gate target as the story gate, with a regression test covering the prior independently composed workflow. | [google-gemini-3.5-flash-api] Successfully unified the CI required merge check and the local story gate by running `make gate` in CI, closing the command-composition and environment-scrubbing gaps while preserving the already-fixed extras and interpreter axes.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $2.08
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Story gate and required merge check enforce different standards: different command, extras, environment, and platform (GitHub Issue #1945)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1945