### PR TITLE
Config-contract change landing mid-sprint invalidates the running sprint's config and reports as a broken baseline

### DIFF
--- a/src/theforge/coordinator/config_snapshot.py
+++ b/src/theforge/coordinator/config_snapshot.py
@@ -287,3 +287,65 @@ def pinned_forge_yaml() -> Path | None:
     except OSError:
         return None
     return path
+
+
+def sync_forge_yaml_into_worktree(
+    project_root: Path,
+    workspace_path: Path,
+    *,
+    label: str,
+) -> None:
+    """Place the run's operative forge.yaml in ``workspace_path``.
+
+    The source is the sprint's pinned snapshot when one is active and the
+    project root otherwise, so every story of a sprint is prepared from one
+    configuration while a standalone run keeps reading the operator's live
+    file. Every path that hands a worktree to setup, dev, or a gate goes
+    through here — a worktree prepared without it runs against whatever
+    forge.yaml its base branch happened to carry, which is the divergence this
+    pin exists to remove (#1980).
+
+    Either source may hold uncommitted operator edits, so the synced file is
+    flagged ``skip-worktree``: the content is available to the run, the
+    worktree never reads as dirty, and operator config cannot be swept into a
+    story commit (#1627). When that flag cannot be set on a worktree that does
+    not track forge.yaml, the copy is withdrawn rather than left behind as an
+    untracked file a dev-phase commit could absorb.
+
+    Best effort throughout: a run that cannot be given its config still runs
+    against the worktree's own file, exactly as it did before this existed.
+    """
+    from . import util as _cu  # noqa: PLC0415 - avoids an import cycle at module load
+
+    source = pinned_forge_yaml() or (Path(project_root) / "forge.yaml")
+    destination = Path(workspace_path) / "forge.yaml"
+    if not source.exists():
+        return
+
+    origin = "sprint-pinned snapshot" if pinned_forge_yaml() else "project root"
+    existed = destination.exists()
+    try:
+        shutil.copy2(source, destination)
+    except OSError as exc:
+        _cu._log(f"  ⚠ {label}   could not sync forge.yaml from {source}: {exc}")
+        return
+
+    skip_ok, skip_out = _cu._run_shell(
+        "git update-index --skip-worktree forge.yaml", workspace_path
+    )
+    if not skip_ok:
+        tracked_ok, _tracked_out = _cu._run_shell(
+            "git ls-files --error-unmatch forge.yaml", workspace_path
+        )
+        if not tracked_ok and not existed:
+            try:
+                destination.unlink()
+            except OSError:
+                pass
+            _cu._log(
+                f"  ⚠ {label}   worktree does not track forge.yaml — left unsynced so no "
+                "story commit can absorb operator config"
+            )
+            return
+        _cu._log(f"  ⚠ {label}   could not skip-worktree forge.yaml: {skip_out.strip()}")
+    _cu._log(f"  ↺ {label}   synced forge.yaml from {origin} {source}")

--- a/src/theforge/coordinator/config_snapshot.py
+++ b/src/theforge/coordinator/config_snapshot.py
@@ -1,0 +1,289 @@
+"""Sprint-scoped pinning of the operative ``forge.yaml``.
+
+A sprint used to re-resolve its configuration from the project root on every
+run/resume invocation (``run_setup._setup_resume_entry``). Any change to that
+file mid-sprint — landed by a story that changes what a valid configuration is,
+or made by the operator in the working tree — silently partitioned the sprint
+into stories that ran under different contracts, with no artifact recording the
+boundary (#1980).
+
+This module holds the sprint's configuration identity: the content is copied
+once, at sprint entry, into ``.forge/sprints/<sprint_id>/forge.yaml`` and every
+story in that sprint is prepared from that copy. Re-entry (``--resume``, or the
+``os.execv`` re-exec after a source update) reloads the existing snapshot rather
+than recapturing, so the pin survives exactly the event that motivated it. When
+the project-root file no longer matches the pin, the divergence is recorded as a
+drift event on the snapshot record and surfaced in the sprint log and audit —
+the story still runs under the pinned copy.
+
+Stdlib + yaml only, so both the sprint runner and the coordinator's run-setup
+path can import it without a dependency cycle.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import os
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+#: Points child processes (and the re-exec'd sprint process) at the pinned copy.
+#: An environment variable rather than a call argument because the value has to
+#: cross ``os.execv`` and the in-process story dispatch alike.
+SNAPSHOT_ENV_VAR = "FORGE_SPRINT_CONFIG_SNAPSHOT"
+
+_SNAPSHOT_FILENAME = "forge.yaml"
+_RECORD_FILENAME = "config_snapshot.yaml"
+
+# The process-wide active snapshot, set by the sprint runner at startup. One
+# sprint per process, so a module global is the whole scope.
+_ACTIVE: "SprintConfigSnapshot | None" = None
+
+
+def _now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def digest_text(text: str) -> str:
+    """Return the sha256 digest of ``text`` as used for config identity."""
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def snapshot_dir(project_root: Path, sprint_id: str) -> Path:
+    return Path(project_root) / ".forge" / "sprints" / sprint_id
+
+
+def snapshot_config_path(project_root: Path, sprint_id: str) -> Path:
+    return snapshot_dir(project_root, sprint_id) / _SNAPSHOT_FILENAME
+
+
+def snapshot_record_path(project_root: Path, sprint_id: str) -> Path:
+    return snapshot_dir(project_root, sprint_id) / _RECORD_FILENAME
+
+
+def project_config_path(project_root: Path) -> Path:
+    return Path(project_root) / "forge.yaml"
+
+
+def project_config_digest(project_root: Path) -> str | None:
+    """Digest of the live project-root forge.yaml, or None when absent/unreadable."""
+    text = _read_text(project_config_path(project_root))
+    return None if text is None else digest_text(text)
+
+
+@dataclass
+class SprintConfigSnapshot:
+    """The configuration identity a sprint runs under, and its drift history."""
+
+    sprint_id: str
+    project_root: Path
+    digest: str | None
+    captured_at: str
+    source: str
+    pinned_path: Path | None
+    present: bool
+    reused: bool = False
+    drift_events: list[dict] = field(default_factory=list)
+
+    def as_record(self) -> dict:
+        return {
+            "sprint_id": self.sprint_id,
+            "digest": self.digest,
+            "captured_at": self.captured_at,
+            "source": self.source,
+            "pinned_path": str(self.pinned_path) if self.pinned_path else None,
+            "present": self.present,
+            "drift_events": list(self.drift_events),
+        }
+
+    def save(self) -> None:
+        """Persist the record next to the pinned copy. Best effort."""
+        path = snapshot_record_path(self.project_root, self.sprint_id)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                yaml.dump(self.as_record(), fh, default_flow_style=False, sort_keys=False)
+        except OSError:
+            pass
+
+
+def _load_record(project_root: Path, sprint_id: str) -> dict | None:
+    path = snapshot_record_path(project_root, sprint_id)
+    text = _read_text(path)
+    if text is None:
+        return None
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_audit_record(project_root: Path, sprint_id: str | None) -> dict | None:
+    """Return the persisted snapshot record for the sprint audit, if any."""
+    if not sprint_id:
+        return None
+    return _load_record(Path(project_root), sprint_id)
+
+
+def capture_or_load(project_root: Path, sprint_id: str) -> SprintConfigSnapshot:
+    """Return this sprint's pinned configuration, capturing it on first entry.
+
+    Capture happens once per logical sprint. On re-entry — ``--resume`` or the
+    re-exec that follows a source update — the existing snapshot is reloaded
+    even if the project root has since changed, which is precisely the case the
+    pin exists for; the difference is reported by :func:`check_drift`, not
+    absorbed by a fresh capture.
+
+    A missing or unreadable project-root ``forge.yaml`` yields a snapshot with
+    ``present=False`` rather than an error: callers fall back to their previous
+    behaviour of reading the project root directly.
+    """
+    project_root = Path(project_root)
+    pinned = snapshot_config_path(project_root, sprint_id)
+    record = _load_record(project_root, sprint_id)
+
+    if record is not None and pinned.exists():
+        return SprintConfigSnapshot(
+            sprint_id=sprint_id,
+            project_root=project_root,
+            digest=record.get("digest"),
+            captured_at=str(record.get("captured_at") or ""),
+            source=str(record.get("source") or str(project_config_path(project_root))),
+            pinned_path=pinned,
+            present=True,
+            reused=True,
+            drift_events=list(record.get("drift_events") or []),
+        )
+
+    src = project_config_path(project_root)
+    text = _read_text(src)
+    if text is None:
+        return SprintConfigSnapshot(
+            sprint_id=sprint_id,
+            project_root=project_root,
+            digest=None,
+            captured_at=_now(),
+            source=str(src),
+            pinned_path=None,
+            present=False,
+        )
+
+    snapshot = SprintConfigSnapshot(
+        sprint_id=sprint_id,
+        project_root=project_root,
+        digest=digest_text(text),
+        captured_at=_now(),
+        source=str(src),
+        pinned_path=pinned,
+        present=True,
+    )
+    try:
+        pinned.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, pinned)
+    except OSError:
+        # Disk full, permissions, a read-only .forge — the sprint still runs, it
+        # just runs unpinned, exactly as it did before this mechanism existed.
+        snapshot.pinned_path = None
+        snapshot.present = False
+        return snapshot
+    snapshot.save()
+    return snapshot
+
+
+def check_drift(
+    snapshot: "SprintConfigSnapshot | None",
+    *,
+    story: str | None = None,
+) -> dict | None:
+    """Record and return a drift event when the project root has moved off the pin.
+
+    Returns None when there is nothing to report (no snapshot, no pin, or the
+    live file still matches). A repeat of an already-recorded digest for the
+    same story is not re-recorded, so a parallel sprint does not fill the record
+    with duplicates of one edit.
+    """
+    if snapshot is None or not snapshot.present or snapshot.digest is None:
+        return None
+    current = project_config_digest(snapshot.project_root)
+    if current == snapshot.digest:
+        return None
+    for prior in snapshot.drift_events:
+        if prior.get("project_root_digest") == current and prior.get("story") == story:
+            return None
+    event = {
+        "detected_at": _now(),
+        "story": story,
+        "pinned_digest": snapshot.digest,
+        "project_root_digest": current,
+        "project_root_config_present": current is not None,
+        "pinned_config_in_effect": True,
+    }
+    snapshot.drift_events.append(event)
+    snapshot.save()
+    return event
+
+
+def describe_drift(event: dict) -> str:
+    """One operator-facing line for a drift event."""
+    where = f" before story {event['story']}" if event.get("story") else ""
+    if not event.get("project_root_config_present", True):
+        current = "removed"
+    else:
+        current = f"now {str(event.get('project_root_digest'))[:12]}"
+    return (
+        f"forge.yaml in the project root changed after this sprint pinned its config{where} "
+        f"(pinned {str(event.get('pinned_digest'))[:12]}, {current}); "
+        "stories keep running under the pinned snapshot"
+    )
+
+
+def activate(snapshot: "SprintConfigSnapshot | None") -> None:
+    """Make ``snapshot`` the config source for stories dispatched by this process."""
+    global _ACTIVE
+    _ACTIVE = snapshot
+    if snapshot is not None and snapshot.present and snapshot.pinned_path is not None:
+        os.environ[SNAPSHOT_ENV_VAR] = str(snapshot.pinned_path)
+    else:
+        os.environ.pop(SNAPSHOT_ENV_VAR, None)
+
+
+def deactivate() -> None:
+    """Drop the active pin (end of sprint, or tests)."""
+    global _ACTIVE
+    _ACTIVE = None
+    os.environ.pop(SNAPSHOT_ENV_VAR, None)
+
+
+def active_snapshot() -> "SprintConfigSnapshot | None":
+    return _ACTIVE
+
+
+def pinned_forge_yaml() -> Path | None:
+    """The pinned forge.yaml to prepare worktrees from, or None for standalone runs.
+
+    Read from the environment so it survives ``os.execv`` and reaches child
+    processes; a pin whose file has disappeared is treated as absent, which
+    returns the caller to the project-root source.
+    """
+    raw = os.environ.get(SNAPSHOT_ENV_VAR)
+    if not raw:
+        return None
+    path = Path(raw)
+    try:
+        if not path.is_file():
+            return None
+    except OSError:
+        return None
+    return path

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -21,6 +21,7 @@ from theforge.sessions import load_sessions
 from theforge.task import TaskStory, load_story
 
 from . import util as _cu
+from .config_snapshot import pinned_forge_yaml
 from .git_lock import FETCH_LOCK
 from .logging import StructuredLogger
 from .notify import _escalate_notify
@@ -515,26 +516,36 @@ def _setup_resume_entry(
     # plan-derived policy signal degrades to a zero/empty default (issue #1135).
     load_plan_state(workspace_path, state)
 
-    # Sync forge.yaml from project root into the worktree so the run executes
-    # with current settings. The source is the operator's live working-tree
-    # file, which may carry uncommitted edits; syncing it onto the worktree's
-    # tracked forge.yaml would otherwise make the worktree dirty and let the
-    # dev-phase auto-commit sweep that operator state into the story's commits
-    # and PR (issue #1627). Flag the synced file skip-worktree so git ignores
-    # its working-tree modifications: the content stays available to the run,
-    # but it never appears as dirty and never lands in a story commit. An
+    # Sync forge.yaml into the worktree so the run executes with the sprint's
+    # settings. Under a sprint the source is the snapshot pinned at sprint entry
+    # (issue #1980) so every story in one sprint runs under one configuration
+    # even when the project-root file changes mid-sprint; a standalone run has
+    # no pin and reads the operator's live working-tree file as before.
+    #
+    # Either source may carry uncommitted operator edits; syncing them onto the
+    # worktree's tracked forge.yaml would otherwise make the worktree dirty and
+    # let the dev-phase auto-commit sweep that operator state into the story's
+    # commits and PR (issue #1627). Flag the synced file skip-worktree so git
+    # ignores its working-tree modifications: the content stays available to the
+    # run, but it never appears as dirty and never lands in a story commit. An
     # operator config change reaches main only when the operator commits it
     # deliberately from the project root.
-    _forge_yaml_src = config.project_root / "forge.yaml"
+    _pinned_forge_yaml = pinned_forge_yaml()
+    _forge_yaml_src = _pinned_forge_yaml or (config.project_root / "forge.yaml")
     _forge_yaml_dst = workspace_path / "forge.yaml"
     if _forge_yaml_src.exists():
-        shutil.copy2(_forge_yaml_src, _forge_yaml_dst)
-        _skip_ok, _skip_out = _cu._run_shell(
-            "git update-index --skip-worktree forge.yaml", workspace_path
-        )
-        if not _skip_ok:
-            _cu._log(f"  ⚠ RESUME   could not skip-worktree forge.yaml: {_skip_out.strip()}")
-        _cu._log(f"  ↺ RESUME   synced forge.yaml from {_forge_yaml_src}")
+        try:
+            shutil.copy2(_forge_yaml_src, _forge_yaml_dst)
+        except OSError as exc:
+            _cu._log(f"  ⚠ RESUME   could not sync forge.yaml from {_forge_yaml_src}: {exc}")
+        else:
+            _skip_ok, _skip_out = _cu._run_shell(
+                "git update-index --skip-worktree forge.yaml", workspace_path
+            )
+            if not _skip_ok:
+                _cu._log(f"  ⚠ RESUME   could not skip-worktree forge.yaml: {_skip_out.strip()}")
+            _origin = "sprint-pinned snapshot" if _pinned_forge_yaml else "project root"
+            _cu._log(f"  ↺ RESUME   synced forge.yaml from {_origin} {_forge_yaml_src}")
 
     # Restore session IDs from prior run if available
     _sessions = load_sessions(workspace_path)

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -21,7 +20,7 @@ from theforge.sessions import load_sessions
 from theforge.task import TaskStory, load_story
 
 from . import util as _cu
-from .config_snapshot import pinned_forge_yaml
+from .config_snapshot import sync_forge_yaml_into_worktree
 from .git_lock import FETCH_LOCK
 from .logging import StructuredLogger
 from .notify import _escalate_notify
@@ -516,36 +515,9 @@ def _setup_resume_entry(
     # plan-derived policy signal degrades to a zero/empty default (issue #1135).
     load_plan_state(workspace_path, state)
 
-    # Sync forge.yaml into the worktree so the run executes with the sprint's
-    # settings. Under a sprint the source is the snapshot pinned at sprint entry
-    # (issue #1980) so every story in one sprint runs under one configuration
-    # even when the project-root file changes mid-sprint; a standalone run has
-    # no pin and reads the operator's live working-tree file as before.
-    #
-    # Either source may carry uncommitted operator edits; syncing them onto the
-    # worktree's tracked forge.yaml would otherwise make the worktree dirty and
-    # let the dev-phase auto-commit sweep that operator state into the story's
-    # commits and PR (issue #1627). Flag the synced file skip-worktree so git
-    # ignores its working-tree modifications: the content stays available to the
-    # run, but it never appears as dirty and never lands in a story commit. An
-    # operator config change reaches main only when the operator commits it
-    # deliberately from the project root.
-    _pinned_forge_yaml = pinned_forge_yaml()
-    _forge_yaml_src = _pinned_forge_yaml or (config.project_root / "forge.yaml")
-    _forge_yaml_dst = workspace_path / "forge.yaml"
-    if _forge_yaml_src.exists():
-        try:
-            shutil.copy2(_forge_yaml_src, _forge_yaml_dst)
-        except OSError as exc:
-            _cu._log(f"  ⚠ RESUME   could not sync forge.yaml from {_forge_yaml_src}: {exc}")
-        else:
-            _skip_ok, _skip_out = _cu._run_shell(
-                "git update-index --skip-worktree forge.yaml", workspace_path
-            )
-            if not _skip_ok:
-                _cu._log(f"  ⚠ RESUME   could not skip-worktree forge.yaml: {_skip_out.strip()}")
-            _origin = "sprint-pinned snapshot" if _pinned_forge_yaml else "project root"
-            _cu._log(f"  ↺ RESUME   synced forge.yaml from {_origin} {_forge_yaml_src}")
+    # Give the resumed run its operative forge.yaml: the sprint's pinned
+    # snapshot when one is active, the project root otherwise (#1980, #1627).
+    sync_forge_yaml_into_worktree(config.project_root, workspace_path, label="RESUME")
 
     # Restore session IDs from prior run if available
     _sessions = load_sessions(workspace_path)

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -18,6 +18,7 @@ from theforge.task import TaskStory
 from theforge.workspace_env import read_venv_base_executable, venv_matches_interpreter
 
 from . import util as _cu
+from .config_snapshot import sync_forge_yaml_into_worktree
 from .gate import _run_gate
 from .git_lock import FETCH_LOCK
 from .run_setup import _rebase_onto_main
@@ -1070,6 +1071,20 @@ def _rebase_reused_worktree(workspace_path: Path, base_branch: str) -> str | Non
     )
 
 
+def _sync_run_forge_yaml(config: ForgeConfig, workspace_path: Path) -> None:
+    """Give a freshly created or reused worktree the run's operative forge.yaml.
+
+    Called on every path out of ``_create_workspace``, before the workspace
+    setup command runs and therefore before any agent or gate reads the
+    worktree. A fresh worktree otherwise carries whatever forge.yaml its base
+    branch happened to hold, so a story dispatched after a config change landed
+    mid-sprint ran against that change while the sprint record still reported
+    the pinned snapshot (#1980). Under a sprint the source is that snapshot;
+    a standalone run reads the project root, as before.
+    """
+    sync_forge_yaml_into_worktree(config.project_root, workspace_path, label="WORKSPACE")
+
+
 def _create_workspace(
     config: ForgeConfig,
     task: TaskStory,
@@ -1130,6 +1145,7 @@ def _create_workspace(
             rebase_err = _rebase_reused_worktree(workspace_path, config.workspace.base_branch)
             if rebase_err is not None:
                 return None, None, rebase_err
+            _sync_run_forge_yaml(config, workspace_path)
             if config.workspace.setup_command:
                 _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
                 ok_s, out_s = _run_setup_split(
@@ -1171,6 +1187,7 @@ def _create_workspace(
                 rebase_err = _rebase_reused_worktree(existing_wt, config.workspace.base_branch)
                 if rebase_err is not None:
                     return None, None, rebase_err
+                _sync_run_forge_yaml(config, existing_wt)
                 if config.workspace.setup_command:
                     _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
                     ok_s, out_s = _run_setup_split(
@@ -1208,6 +1225,7 @@ def _create_workspace(
             rebase_err = _rebase_reused_worktree(workspace_path, config.workspace.base_branch)
             if rebase_err is not None:
                 return None, None, rebase_err
+            _sync_run_forge_yaml(config, workspace_path)
             if config.workspace.setup_command:
                 _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
                 ok_s, out_s = _run_setup_split(
@@ -1239,6 +1257,7 @@ def _create_workspace(
     if not workspace_path.exists():
         return None, None, f"Workspace path does not exist after creation: {workspace_path}"
 
+    _sync_run_forge_yaml(config, workspace_path)
     if config.workspace.setup_command:
         _cu._log(f"Running workspace setup: {config.workspace.setup_command}")
         ok, output = _run_setup_split(

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import yaml
 
 from ..advisory_conventions import noteworthy_advisory_entries
+from ..coordinator.config_snapshot import load_audit_record as load_config_snapshot_record
 from ..coordinator.iteration_usage import dev_usage as _dev_usage
 from ..coordinator.landing_record import build_landing_record
 from ..log_util import _log_line
@@ -766,6 +767,11 @@ def _write_sprint_audit(
             if isinstance(getattr(manifest, "baseline_gate", None), dict)
             else None
         ),
+        # Which forge.yaml this sprint ran under, and every point at which the
+        # project-root file moved off it (#1980). Without this, two issues filed
+        # from one sprint can describe its configuration contradictorily and
+        # both be right about the runs their authors read.
+        "config_snapshot": load_config_snapshot_record(project_root, sprint_id),
         # TODO(issue-817): Distinguishing externally closed dependencies from
         # earlier-resume completion would require finer provenance on ResolvedSprint.
         "closed_dependency_slugs": [

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -23,6 +23,7 @@ import yaml
 from ..advisory_conventions import AdvisoryArtifactError
 from ..config import ForgeConfig, ModelProfile
 from ..config.auth import check_agent_auth
+from ..coordinator import config_snapshot as config_snapshot_mod
 from ..coordinator import workspace as coordinator_workspace
 from ..coordinator.agent_failure import (
     CATEGORY_AUTH,
@@ -31,6 +32,7 @@ from ..coordinator.agent_failure import (
     is_infrastructure_abort,
     mark_infrastructure_abort,
 )
+from ..coordinator.config_snapshot import SprintConfigSnapshot, capture_or_load
 from ..coordinator.engine import run_from_dev, run_from_review, run_review_only, run_task
 from ..coordinator.gate import run_gate_full
 from ..coordinator.log_tee import _make_story_log_dir, set_worker_slug
@@ -1074,6 +1076,32 @@ def _publish_reuse_gate_end(run_id: str | None, project_root: Path, label: GateL
     )
 
 
+#: Bound on the gate excerpt carried inside the broken-baseline message. The
+#: full tail stays available under the result's ``output_tail`` and in the run
+#: log; this is only what has to travel with the verdict itself.
+BASELINE_DIAGNOSTIC_MAX_LINES = 12
+BASELINE_DIAGNOSTIC_MAX_CHARS = 1200
+
+
+def _baseline_failure_diagnostic(output_tail: object) -> str:
+    """Render the gate's own output as a bounded excerpt for the failure message.
+
+    Returns "" when the gate captured nothing, so the caller's message is
+    unchanged rather than gaining an empty section.
+    """
+    tail = (output_tail or "").strip() if isinstance(output_tail, str) else ""
+    if not tail:
+        return ""
+    lines = tail.splitlines()
+    truncated = len(lines) > BASELINE_DIAGNOSTIC_MAX_LINES
+    excerpt = "\n".join(lines[-BASELINE_DIAGNOSTIC_MAX_LINES:])
+    if len(excerpt) > BASELINE_DIAGNOSTIC_MAX_CHARS:
+        excerpt = excerpt[-BASELINE_DIAGNOSTIC_MAX_CHARS:]
+        truncated = True
+    header = "Gate output (last lines, truncated):" if truncated else "Gate output:"
+    return f"{header}\n{excerpt}"
+
+
 def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[str, object]:
     """Run the configured gate on the sprint merge base before any agent work starts."""
 
@@ -1276,6 +1304,15 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
                 f" (local {base_branch} is at {local_sha[:12]}, origin is at {origin_sha[:12]}; "
                 f"local branch may be stale; run `git pull` on {base_branch} or omit --no-pull)"
             )
+        # The sha names where the gate ran; only the gate's own output names what
+        # must change. ``run_gate_full`` leaves ``error`` None for a plain nonzero
+        # exit, so without this the operator is handed a commit to investigate
+        # when the remedy is one key in one file (#1980). Appended last, after the
+        # sha and the stale-branch hint, and bounded so the same string stays
+        # usable as a log line and as the raised RuntimeError text.
+        _diagnostic = _baseline_failure_diagnostic(output_tail)
+        if _diagnostic:
+            message += f"\n{_diagnostic}"
         return {
             "status": "fail",
             "passed": False,
@@ -1767,6 +1804,17 @@ def _run_single_story(
     started_at = datetime.datetime.now(datetime.timezone.utc)
     set_worker_slug(task.slug)
     workspace_path = config.project_root / config.workspace.path_pattern.format(slug=task.slug)
+
+    # Whether the project-root forge.yaml still matches what this sprint pinned.
+    # The story runs under the pin either way; what changes is that the boundary
+    # between stories that ran under different project-root content is recorded
+    # instead of being reconstructed later from what the runs happened to log
+    # (#1980).
+    _drift = config_snapshot_mod.check_drift(
+        config_snapshot_mod.active_snapshot(), story=task.slug
+    )
+    if _drift is not None:
+        _log(f"⚠ {config_snapshot_mod.describe_drift(_drift)}")
 
     if state_update_fn is not None:
         state_update_fn({"spec": task.slug, "phase": "STARTING"})
@@ -3073,6 +3121,37 @@ def run_sprint(
         _sprint_id = _get_or_create_sprint_id(resolved.name, config.project_root)
     except Exception:
         pass
+
+    # Pin the configuration this sprint runs under (#1980). Captured once, on
+    # first entry, and reloaded on every re-entry — --resume, and the re-exec
+    # that follows a source update, which is the path that first exposed this:
+    # a story landing a config-contract change made the sprint's own forge.yaml
+    # invalid, and the next re-entry read the changed file. A project root that
+    # has since moved off the pin is reported as drift, never silently adopted.
+    _config_snapshot: "SprintConfigSnapshot | None" = None
+    if _sprint_id:
+        try:
+            _config_snapshot = capture_or_load(config.project_root, _sprint_id)
+        except Exception:  # pragma: no cover - snapshotting must never abort a sprint
+            _config_snapshot = None
+    config_snapshot_mod.activate(_config_snapshot)
+    if _config_snapshot is not None and _config_snapshot.present:
+        _log(
+            f"Sprint config pinned: forge.yaml {(_config_snapshot.digest or '')[:12]} "
+            f"captured {_config_snapshot.captured_at}"
+            + (" (reused from earlier entry)" if _config_snapshot.reused else "")
+        )
+        _sprint_logger.emit(
+            "sprint_config_pinned",
+            digest=_config_snapshot.digest,
+            captured_at=_config_snapshot.captured_at,
+            source=_config_snapshot.source,
+            reused=_config_snapshot.reused,
+        )
+        _entry_drift = config_snapshot_mod.check_drift(_config_snapshot, story=None)
+        if _entry_drift is not None:
+            _log(f"⚠ {config_snapshot_mod.describe_drift(_entry_drift)}")
+            _sprint_logger.emit("sprint_config_drift", **_entry_drift)
 
     # Failure causes already on disk for this sprint, by canonical ref. Read
     # unconditionally — not just when resuming — because every generation

--- a/tests/test_sprint_config_snapshot.py
+++ b/tests/test_sprint_config_snapshot.py
@@ -1,0 +1,300 @@
+"""Sprint configuration pinning and baseline-gate diagnostics (issue #1980).
+
+Two failures of the same kind: a config problem reported as something else. The
+baseline gate discarded the output that named the missing key, and the sprint
+re-resolved forge.yaml per invocation so a mid-sprint change silently split the
+sprint across two configurations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from coord_test_helpers import _make_config as _make_coord_config
+from coord_test_helpers import _make_task
+
+# Reuse the baseline-gate repo harness rather than restating it.
+from test_sprint_baseline_gate import _init_repo  # noqa: E402
+
+from theforge.coordinator import config_snapshot as cs
+from theforge.coordinator.run_setup import _setup_resume_entry
+from theforge.coordinator.state import Phase
+from theforge.sprint.runner import (
+    BASELINE_DIAGNOSTIC_MAX_LINES,
+    _baseline_failure_diagnostic,
+    _run_baseline_gate,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_active_pin():
+    cs.deactivate()
+    yield
+    cs.deactivate()
+
+
+# --------------------------------------------------------------------------
+# 1. The broken-baseline message names what must change
+# --------------------------------------------------------------------------
+
+GUARD_STDERR = (
+    "forge.yaml story-mutation guard failed: workspace.setup_command uses "
+    "{forge_python} but workspace.python_interpreter is not set."
+)
+
+
+def test_broken_baseline_message_carries_the_gate_output(tmp_path: Path) -> None:
+    """The operator is handed the missing key, not only the merge-base sha."""
+    config, resolved, base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command=f'python -c "import sys; print({GUARD_STDERR!r}); sys.exit(1)"',
+        ),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is False
+    message = str(baseline["message"])
+    # The sha still names where the gate ran...
+    assert base_commit in message
+    # ...and the message now also names the file and the key that must change.
+    assert "workspace.python_interpreter" in message
+    assert "forge.yaml" in message
+
+
+def test_broken_baseline_message_is_bounded(tmp_path: Path) -> None:
+    """A chatty gate cannot turn the raised error into an unbounded dump."""
+    config, resolved, _base = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command=(
+                'python -c "import sys;'
+                "[print('noise line %d' % i) for i in range(500)];"
+                'sys.exit(1)"'
+            ),
+        ),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    message = str(baseline["message"])
+    assert "truncated" in message
+    body = message.split("Gate output", 1)[1]
+    assert len(body.splitlines()) <= BASELINE_DIAGNOSTIC_MAX_LINES + 1
+    # The full tail is still available on the record for anyone who wants it.
+    assert len(str(baseline["output_tail"])) > len(body)
+
+
+def test_baseline_diagnostic_empty_when_gate_captured_nothing() -> None:
+    assert _baseline_failure_diagnostic("") == ""
+    assert _baseline_failure_diagnostic(None) == ""
+    assert _baseline_failure_diagnostic(123) == ""
+
+
+# --------------------------------------------------------------------------
+# 2. The sprint's config identity
+# --------------------------------------------------------------------------
+
+
+def _write_root_config(root: Path, text: str) -> None:
+    (root / "forge.yaml").write_text(text, encoding="utf-8")
+
+
+def test_capture_pins_project_config(tmp_path: Path) -> None:
+    _write_root_config(tmp_path, "project: one\n")
+
+    snap = cs.capture_or_load(tmp_path, "sprint-a")
+
+    assert snap.present is True
+    assert snap.reused is False
+    assert snap.digest == cs.digest_text("project: one\n")
+    assert snap.pinned_path is not None
+    assert snap.pinned_path.read_text(encoding="utf-8") == "project: one\n"
+    record = yaml.safe_load(cs.snapshot_record_path(tmp_path, "sprint-a").read_text())
+    assert record["digest"] == snap.digest
+    assert record["drift_events"] == []
+
+
+def test_reentry_reuses_the_pin_and_reports_drift(tmp_path: Path) -> None:
+    """A re-exec / --resume must not recapture the config it exists to pin."""
+    _write_root_config(tmp_path, "project: one\n")
+    first = cs.capture_or_load(tmp_path, "sprint-a")
+
+    # A story lands a config-contract change (or the operator edits the file).
+    _write_root_config(tmp_path, "project: two\n")
+    second = cs.capture_or_load(tmp_path, "sprint-a")
+
+    assert second.reused is True
+    assert second.digest == first.digest
+    assert second.pinned_path.read_text(encoding="utf-8") == "project: one\n"
+
+    event = cs.check_drift(second, story="issue-1945")
+    assert event is not None
+    assert event["pinned_digest"] == first.digest
+    assert event["project_root_digest"] == cs.digest_text("project: two\n")
+    assert event["story"] == "issue-1945"
+    assert event["pinned_config_in_effect"] is True
+    assert "forge.yaml" in cs.describe_drift(event)
+
+    record = yaml.safe_load(cs.snapshot_record_path(tmp_path, "sprint-a").read_text())
+    assert len(record["drift_events"]) == 1
+    # Re-checking the same state for the same story does not duplicate the event.
+    assert cs.check_drift(second, story="issue-1945") is None
+
+
+def test_no_drift_reported_while_the_root_matches(tmp_path: Path) -> None:
+    _write_root_config(tmp_path, "project: one\n")
+    snap = cs.capture_or_load(tmp_path, "sprint-a")
+    assert cs.check_drift(snap, story="issue-1") is None
+
+
+def test_missing_project_config_is_not_an_error(tmp_path: Path) -> None:
+    snap = cs.capture_or_load(tmp_path, "sprint-a")
+
+    assert snap.present is False
+    assert snap.digest is None
+    assert snap.pinned_path is None
+    assert cs.check_drift(snap, story="issue-1") is None
+    cs.activate(snap)
+    assert cs.pinned_forge_yaml() is None
+
+
+def test_activate_exposes_the_pin_and_survives_a_vanished_file(tmp_path: Path) -> None:
+    _write_root_config(tmp_path, "project: one\n")
+    snap = cs.capture_or_load(tmp_path, "sprint-a")
+
+    cs.activate(snap)
+    assert cs.pinned_forge_yaml() == snap.pinned_path
+    assert cs.active_snapshot() is snap
+
+    snap.pinned_path.unlink()
+    assert cs.pinned_forge_yaml() is None  # falls back to the project root
+
+    cs.deactivate()
+    assert cs.pinned_forge_yaml() is None
+    assert cs.active_snapshot() is None
+
+
+def test_audit_record_is_loadable_by_sprint_id(tmp_path: Path) -> None:
+    _write_root_config(tmp_path, "project: one\n")
+    snap = cs.capture_or_load(tmp_path, "sprint-a")
+    _write_root_config(tmp_path, "project: two\n")
+    cs.check_drift(snap, story="issue-2")
+
+    record = cs.load_audit_record(tmp_path, "sprint-a")
+
+    assert record is not None
+    assert record["digest"] == snap.digest
+    assert [e["story"] for e in record["drift_events"]] == ["issue-2"]
+    assert cs.load_audit_record(tmp_path, None) is None
+
+
+# --------------------------------------------------------------------------
+# 3. Seam: story worktree preparation uses the pin, not the live project root
+# --------------------------------------------------------------------------
+
+
+def _prepare_story(config, task, workspace: Path):
+    with patch(
+        "theforge.coordinator.run_setup._cu._run_shell", return_value=(True, "forge/test-task")
+    ):
+        return _setup_resume_entry(
+            config,
+            task,
+            workspace,
+            initial_phase=Phase.DEV,
+            notify=False,
+            run_id="test-run-id",
+        )
+
+
+def test_two_stories_in_one_sprint_get_the_same_config(tmp_path: Path) -> None:
+    """The whole point: a mid-sprint edit does not partition the sprint."""
+    _write_root_config(tmp_path, "project: sprint-entry\n")
+    snap = cs.capture_or_load(tmp_path, "sprint-a")
+    cs.activate(snap)
+
+    config = _make_coord_config(tmp_path)
+    task = _make_task(tmp_path)
+
+    story_a = tmp_path / "story-a"
+    story_a.mkdir()
+    _prepare_story(config, task, story_a)
+
+    # A story lands a config change / the operator edits forge.yaml mid-sprint.
+    _write_root_config(tmp_path, "project: changed-mid-sprint\n")
+    drift = cs.check_drift(snap, story="story-b")
+
+    story_b = tmp_path / "story-b"
+    story_b.mkdir()
+    _prepare_story(config, task, story_b)
+
+    assert (story_a / "forge.yaml").read_text(encoding="utf-8") == "project: sprint-entry\n"
+    assert (story_b / "forge.yaml").read_text(encoding="utf-8") == "project: sprint-entry\n"
+    # And the divergence is recorded rather than absorbed.
+    assert drift is not None
+    record = cs.load_audit_record(tmp_path, "sprint-a")
+    assert [e["story"] for e in record["drift_events"]] == ["story-b"]
+
+
+def test_standalone_run_without_a_pin_still_reads_the_project_root(tmp_path: Path) -> None:
+    """No sprint, no pin: the pre-existing behaviour is unchanged."""
+    _write_root_config(tmp_path, "project: live\n")
+    config = _make_coord_config(tmp_path)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    _prepare_story(config, task, workspace)
+
+    assert (workspace / "forge.yaml").read_text(encoding="utf-8") == "project: live\n"
+
+
+def test_sprint_audit_records_the_config_snapshot(tmp_path: Path) -> None:
+    """The sprint audit carries the config identity the sprint ran under."""
+    from theforge.sprint.audit import _write_sprint_audit
+    from theforge.sprint.manifest import ResolvedSprint, SprintResult
+
+    _write_root_config(tmp_path, "project: pinned\n")
+    snap = cs.capture_or_load(tmp_path, "sprint-a")
+    _write_root_config(tmp_path, "project: drifted\n")
+    cs.check_drift(snap, story="issue-9")
+
+    import datetime
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    _write_sprint_audit(
+        manifest=ResolvedSprint(name="Sprint A", budget_usd=1.0, stories=[], max_parallel=1),
+        result=SprintResult(
+            name="Sprint A",
+            specs_total=0,
+            specs_succeeded=0,
+            specs_failed=0,
+            specs_skipped=0,
+            total_cost_usd=0.0,
+            budget_usd=1.0,
+            results=[],
+        ),
+        canonical_refs=[],
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        project_root=tmp_path,
+        sprint_id="sprint-a",
+    )
+
+    audit = yaml.safe_load(
+        (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+    )
+    block = audit["config_snapshot"]
+    assert block["digest"] == snap.digest
+    assert [e["story"] for e in block["drift_events"]] == ["issue-9"]

--- a/tests/test_sprint_config_snapshot.py
+++ b/tests/test_sprint_config_snapshot.py
@@ -8,6 +8,7 @@ sprint across two configurations.
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
@@ -23,6 +24,7 @@ from test_sprint_baseline_gate import _init_repo  # noqa: E402
 from theforge.coordinator import config_snapshot as cs
 from theforge.coordinator.run_setup import _setup_resume_entry
 from theforge.coordinator.state import Phase
+from theforge.coordinator.workspace import _create_workspace
 from theforge.sprint.runner import (
     BASELINE_DIAGNOSTIC_MAX_LINES,
     _baseline_failure_diagnostic,
@@ -257,6 +259,176 @@ def test_standalone_run_without_a_pin_still_reads_the_project_root(tmp_path: Pat
     _prepare_story(config, task, workspace)
 
     assert (workspace / "forge.yaml").read_text(encoding="utf-8") == "project: live\n"
+
+
+# --------------------------------------------------------------------------
+# 4. Seam: fresh workspace creation, over real git
+#
+# A resumed story is only half the sprint. A story dispatched fresh gets its
+# worktree from the base branch, so once a config-contract change has *landed*
+# the checkout itself carries it — the case the sprint pin exists for.
+# --------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    ).stdout
+
+
+def _init_project(tmp_path: Path, forge_yaml: str) -> Path:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    _git(project_root, "init", "--initial-branch=main")
+    _git(project_root, "config", "user.email", "test@example.com")
+    _git(project_root, "config", "user.name", "Test")
+    (project_root / "forge.yaml").write_text(forge_yaml, encoding="utf-8")
+    (project_root / "shared.txt").write_text("base\n", encoding="utf-8")
+    _git(project_root, "add", ".")
+    _git(project_root, "commit", "-m", "initial")
+    return project_root
+
+
+def _real_config(project_root: Path, slug: str):
+    from theforge.config import (
+        DEFAULT_DEV_PROFILE,
+        DEFAULT_PREFLIGHT_PROFILE,
+        DEFAULT_REVIEW_PROFILE,
+        DEFAULT_VALIDATION,
+        ForgeConfig,
+        LogConfig,
+        RetryPolicy,
+        WorkspaceConfig,
+    )
+
+    return ForgeConfig(
+        project="test",
+        project_root=project_root,
+        workspace=WorkspaceConfig(
+            create_command="git worktree add {slug} -b feat/{slug} {base_branch}",
+            path_pattern="{slug}",
+            branch_pattern=f"feat/{slug}",
+            base_branch="main",
+            setup_command=None,
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        preflight_fallback_profile=None,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _real_task(project_root: Path, slug: str):
+    from theforge.task import TaskStory
+
+    spec = project_root / f"{slug}.md"
+    spec.write_text("# task\n", encoding="utf-8")
+    return TaskStory(name="task", story_path=spec, slug=slug)
+
+
+def test_fresh_story_worktree_uses_the_pin_after_a_config_change_lands(tmp_path: Path) -> None:
+    """A story dispatched after the change merged still runs under the pin.
+
+    This is the reported failure shape: the checkout the worktree is created
+    from already carries the new forge.yaml, so nothing about the story's own
+    setup would have noticed the sprint had moved off its recorded config.
+    """
+    project_root = _init_project(tmp_path, "project: sprint-entry\n")
+    snap = cs.capture_or_load(project_root, "sprint-a")
+    cs.activate(snap)
+
+    # Story A is dispatched fresh at sprint entry.
+    path_a, _branch_a, err_a = _create_workspace(
+        _real_config(project_root, "story-a"), _real_task(project_root, "story-a"), no_pull=True
+    )
+    assert err_a is None
+
+    # Story A lands a config-contract change: it is now committed on main *and*
+    # present in the project-root working tree.
+    (project_root / "forge.yaml").write_text("project: changed-by-landing\n", encoding="utf-8")
+    _git(project_root, "commit", "-am", "land config change")
+    drift = cs.check_drift(snap, story="story-b")
+
+    # Story B is dispatched fresh afterwards.
+    path_b, _branch_b, err_b = _create_workspace(
+        _real_config(project_root, "story-b"), _real_task(project_root, "story-b"), no_pull=True
+    )
+    assert err_b is None
+
+    assert (path_a / "forge.yaml").read_text(encoding="utf-8") == "project: sprint-entry\n"
+    assert (path_b / "forge.yaml").read_text(encoding="utf-8") == "project: sprint-entry\n"
+    # The pinned content is invisible to git, so it cannot land in a story
+    # commit (#1627) — even though it now differs from the branch's version.
+    assert _git(path_b, "status", "--porcelain").strip() == ""
+    # And the boundary is on the record.
+    assert drift is not None
+    assert cs.load_audit_record(project_root, "sprint-a")["drift_events"][0]["story"] == "story-b"
+
+
+def test_reused_story_worktree_is_resynced_to_the_pin(tmp_path: Path) -> None:
+    """A reused worktree is rebased onto the changed base, then put back on the pin."""
+    project_root = _init_project(tmp_path, "project: sprint-entry\n")
+    snap = cs.capture_or_load(project_root, "sprint-a")
+    cs.activate(snap)
+
+    config = _real_config(project_root, "story-a")
+    task = _real_task(project_root, "story-a")
+    path, _branch, err = _create_workspace(config, task, no_pull=True)
+    assert err is None
+
+    (project_root / "forge.yaml").write_text("project: changed-by-landing\n", encoding="utf-8")
+    _git(project_root, "commit", "-am", "land config change")
+
+    # Same story dispatched again (resume / second sprint generation): the
+    # worktree is reused and rebased onto a base that now carries the change.
+    path_again, _branch_again, err_again = _create_workspace(config, task, no_pull=True)
+
+    assert err_again is None
+    assert path_again == path
+    assert (path_again / "forge.yaml").read_text(encoding="utf-8") == "project: sprint-entry\n"
+
+
+def test_fresh_worktree_without_a_pin_takes_the_live_project_root(tmp_path: Path) -> None:
+    """Standalone runs keep reading the operator's working-tree forge.yaml."""
+    project_root = _init_project(tmp_path, "project: committed\n")
+    (project_root / "forge.yaml").write_text("project: uncommitted-edit\n", encoding="utf-8")
+
+    path, _branch, err = _create_workspace(
+        _real_config(project_root, "story-a"), _real_task(project_root, "story-a"), no_pull=True
+    )
+
+    assert err is None
+    assert (path / "forge.yaml").read_text(encoding="utf-8") == "project: uncommitted-edit\n"
+    assert _git(path, "status", "--porcelain").strip() == ""
+
+
+def test_untracked_forge_yaml_is_not_left_in_the_worktree(tmp_path: Path) -> None:
+    """A repo that does not track forge.yaml keeps its worktree free of it.
+
+    skip-worktree cannot be set on an untracked path, and leaving the copy
+    behind would let a dev-phase commit sweep operator config into the story.
+    """
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    _git(project_root, "init", "--initial-branch=main")
+    _git(project_root, "config", "user.email", "test@example.com")
+    _git(project_root, "config", "user.name", "Test")
+    (project_root / "shared.txt").write_text("base\n", encoding="utf-8")
+    _git(project_root, "add", ".")
+    _git(project_root, "commit", "-m", "initial")
+    (project_root / "forge.yaml").write_text("project: untracked\n", encoding="utf-8")
+
+    path, _branch, err = _create_workspace(
+        _real_config(project_root, "story-a"), _real_task(project_root, "story-a"), no_pull=True
+    )
+
+    assert err is None
+    assert not (path / "forge.yaml").exists()
+    assert _git(path, "status", "--porcelain").strip() == ""
 
 
 def test_sprint_audit_records_the_config_snapshot(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior fresh/reused dispatch P1 is fixed; baseline failures now carry the gate output, sprint worktrees use the pinned forge.yaml across fresh, reused, and resume paths, and the focused test file passes. | [google-gemini-3.5-flash-api] The implementation successfully pins the sprint configuration, detects mid-sprint drift, and includes gate output in baseline failures with comprehensive test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $12.53
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Config-contract change landing mid-sprint invalidates the running sprint's config and reports as a broken baseline (GitHub Issue #1980)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1980