### PR TITLE
forge shape cannot classify a bug body written in the format the authoring guide mandates

### DIFF
--- a/src/theforge/intake/shape_classify.py
+++ b/src/theforge/intake/shape_classify.py
@@ -20,7 +20,9 @@ from theforge.intake.clarification import ClarificationQuestion, for_situation
 from theforge.shape_check.parsing import (
     extract_ac_section,
     extract_section,
+    has_bug_body_headings,
     has_heading,
+    iter_headings,
 )
 
 # Back-compat alias so existing call sites that imported AmbiguityQuestion
@@ -109,9 +111,9 @@ def _looks_like_bug(title: str, body: str, labels: set[str]) -> bool:
         return True
     if _has_any(title, _BUG_TITLE_TOKENS):
         return True
-    if has_heading(body, r"observed|actual behaviou?r|steps to reproduce"):
-        return True
-    return False
+    # Same heading definition the shape gate uses, so a body cannot be shaped
+    # as unclassifiable here and accepted as a bug there (#2139).
+    return has_bug_body_headings(body)
 
 
 def _looks_like_enhancement(title: str, body: str, labels: set[str]) -> bool:
@@ -176,6 +178,28 @@ def _looks_like_duplicate_or_stale(title: str, body: str, labels: set[str]) -> b
     return False
 
 
+_THIN_BODY_CHARS = 200
+
+
+def _no_signal_rationale(body: str) -> str:
+    """Rationale for the no-match branch, phrased for the draft actually seen.
+
+    "Too thin to shape" is a claim about substance. Applied to a sectioned,
+    evidenced body it misdirects the author toward adding material when what
+    is missing is a type signal, so a substantive draft gets told what would
+    resolve it instead (#2139).
+    """
+    substantive = bool(iter_headings(body)) or len(body.strip()) >= _THIN_BODY_CHARS
+    if substantive:
+        return (
+            "No classifying signal in title, body, or labels — the draft has substance "
+            "but nothing identifies its work type. Add a type label, a marker word in "
+            "the title, or the section headings for its type (see "
+            "docs/guides/authoring.md)."
+        )
+    return "No classifying signal in title, body, or labels — the draft is too thin to shape."
+
+
 def _slugify(text: str, max_len: int = 60) -> str:
     text = text.strip().lower()
     text = re.sub(r"[^a-z0-9]+", "-", text)
@@ -229,9 +253,7 @@ def classify(title: str, body: str, labels: list[str]) -> ShapeProposal:
             classification=Classification.UNRESOLVED,
             confidence=Confidence.LOW,
             ambiguity_questions=for_situation("no_signal"),
-            rationale=(
-                "No classifying signal in title, body, or labels — the draft is too thin to shape."
-            ),
+            rationale=_no_signal_rationale(body),
         )
 
     # Disambiguation rules: enhancement vs operator-action is the most common

--- a/src/theforge/shape_check/heuristics.py
+++ b/src/theforge/shape_check/heuristics.py
@@ -21,6 +21,7 @@ from theforge.shape_check.parsing import (
     extract_section,
     extract_top_level_bullet_blocks,
     fenced_code_blocks,
+    has_bug_body_headings,
     has_heading,
 )
 from theforge.shape_check.placeholders import is_placeholder_only, strip_placeholder_content
@@ -463,10 +464,14 @@ def derive_fix_ready(
 
 
 def is_bug_format_issue(body: str, labels: Iterable[str]) -> bool:
-    """Return true for bug reports, which use observed/expected sections instead of AC."""
+    """Return true for bug reports, which use observed/expected sections instead of AC.
+
+    Heading detection is delegated to :func:`has_bug_body_headings` so this gate
+    and the shape classifier cannot drift apart on what a bug body looks like.
+    """
     if _lower_labels(labels) & _BUG_LABELS:
         return True
-    return has_heading(body, r"what happened") and has_heading(body, r"what was expected")
+    return has_bug_body_headings(body)
 
 
 def check_missing_type(title: str, body: str, labels: Iterable[str]) -> Reason | None:

--- a/src/theforge/shape_check/parsing.py
+++ b/src/theforge/shape_check/parsing.py
@@ -173,6 +173,28 @@ def extract_ac_section(body: str) -> str | None:
     return extract_section(body, r"acceptance criteria|done criteria|checklist")
 
 
+# The bug-report shape is a symptom heading paired with an expectation heading.
+# `docs/guides/authoring.md` mandates the spelling "What happened" / "What was
+# expected"; the corpus overwhelmingly writes "Observed" / "Expected". Both are
+# the same contract, so both are recognised here — and recognised in exactly one
+# place, because intake decides "is this a bug body?" in more than one gate and
+# a body admitted by one gate must not be refused by another (#2139).
+_BUG_SYMPTOM_HEADING = r"what happened|observed|actual behaviou?r"
+_BUG_EXPECTATION_HEADING = r"what was expected|expected"
+_BUG_REPRODUCTION_HEADING = r"steps to reproduce"
+
+
+def has_bug_body_headings(body: str) -> bool:
+    """True when ``body`` carries the heading structure of a bug report.
+
+    Either a symptom/expectation heading pair (in any of its accepted
+    spellings), or a reproduction-steps heading, which only a bug report has.
+    """
+    if has_heading(body, _BUG_REPRODUCTION_HEADING):
+        return True
+    return has_heading(body, _BUG_SYMPTOM_HEADING) and has_heading(body, _BUG_EXPECTATION_HEADING)
+
+
 def is_example_heading(title: str) -> bool:
     normalized = re.sub(r"\s+", " ", title.strip().rstrip(":")).lower()
     return _EXAMPLE_HEADING_RE.fullmatch(normalized) is not None

--- a/tests/test_intake/test_shape_classify.py
+++ b/tests/test_intake/test_shape_classify.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import textwrap
+
+import pytest
+
 from theforge.intake.shape_classify import (
     Classification,
     Confidence,
     DiagnosisState,
+    _looks_like_bug,
     classify,
 )
+from theforge.shape_check.heuristics import is_bug_format_issue
 
 
 def test_classifies_bug_by_label():
@@ -80,6 +86,81 @@ def test_no_signal_returns_unresolved():
     assert proposal.classification is Classification.UNRESOLVED
     assert proposal.confidence is Confidence.LOW
     assert proposal.ambiguity_questions
+    assert "too thin to shape" in proposal.rationale
+
+
+# A bug brief written strictly to docs/guides/authoring.md: no bug label
+# (`--from-brief` supplies none), and a title that names the misbehavior
+# rather than opening with a marker word (#2139).
+DOCUMENTED_FORMAT_BRIEF = textwrap.dedent(
+    """\
+    ## What happened
+
+    Ran `forge sprint --resume` on a sprint where two of three stories had
+    already been merged. The resume run re-entered both at the dev phase.
+
+    ## What was expected
+
+    Resuming a sprint should never repeat work that has already reached a
+    terminal merged state, regardless of the last phase in the audit log.
+    """
+)
+
+
+def test_documented_bug_format_classifies_as_bug_without_label_or_title_token():
+    proposal = classify(
+        title="sprint resume re-runs already-merged stories",
+        body=DOCUMENTED_FORMAT_BRIEF,
+        labels=[],
+    )
+    assert proposal.classification is Classification.BUG
+    assert proposal.confidence is Confidence.HIGH
+    assert proposal.proposed_labels == ("bug",)
+
+
+def test_documented_bug_format_never_reports_no_signal():
+    proposal = classify(
+        title="sprint resume re-runs already-merged stories",
+        body=DOCUMENTED_FORMAT_BRIEF,
+        labels=[],
+    )
+    assert "too thin to shape" not in proposal.rationale
+
+
+def test_substantive_unclassifiable_draft_is_not_called_thin():
+    body = textwrap.dedent(
+        """\
+        ## Background
+
+        A long description of some situation, with measured evidence and a
+        quoted artifact, that nonetheless names no work type anywhere.
+        """
+    )
+    proposal = classify("something about the release process", body, [])
+    assert proposal.classification is Classification.UNRESOLVED
+    assert "too thin to shape" not in proposal.rationale
+    assert "authoring.md" in proposal.rationale
+
+
+BUG_BODY_CASES = [
+    pytest.param(DOCUMENTED_FORMAT_BRIEF, True, id="documented-what-happened-pair"),
+    pytest.param("## Observed\nfoo\n\n## Expected\nbar\n", True, id="corpus-observed-pair"),
+    pytest.param(
+        "## Observed behavior\nfoo\n\n## Expected behavior\nbar\n",
+        True,
+        id="observed-behavior-pair",
+    ),
+    pytest.param("## Steps to reproduce\n1. run it\n", True, id="reproduction-steps"),
+    pytest.param("## Acceptance criteria\n- a thing happens\n", False, id="feature-body"),
+    pytest.param("", False, id="empty"),
+]
+
+
+@pytest.mark.parametrize("body,expected", BUG_BODY_CASES)
+def test_classifier_and_shape_gate_agree_on_bug_bodies(body: str, expected: bool):
+    """The two intake gates must not disagree about what a bug body looks like."""
+    assert _looks_like_bug("", body, set()) is expected
+    assert is_bug_format_issue(body, []) is expected
 
 
 def test_duplicate_detected_by_label():


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change satisfies the documented-format bug classification issue and keeps the classifier and shape gate on the same shared heading helper. | [google-gemini-3.5-flash-api] Unified intake's bug-body detectors behind a shared definition, resolving classification failures for documented bug formats.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $3.26
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

forge shape cannot classify a bug body written in the format the authoring guide mandates (GitHub Issue #2139)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2139