### PR TITLE
Preserved escalated worktree goes stale across a merge and resume fails with raw git conflict output

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -93,6 +93,7 @@ from .workspace import (
     pull_base_branch,
 )
 from .workspace_scrub import _scrub_forge_history
+from .worktree_drift import is_drift_classification
 
 # ── Lazy runner symbols ───────────────────────────────────────────────
 # Populated by _ensure_runners() at entry points.
@@ -951,7 +952,12 @@ def run_task(
                 success=False,
                 phase=state.phase,
                 state=state,
-                message=f"Workspace creation failed: {err}",
+                # A classified condition already says what happened and what to
+                # do about it; wrapping it in "Workspace creation failed" would
+                # re-frame it as a mechanism failure (#1993).
+                message=(
+                    err if is_drift_classification(err) else f"Workspace creation failed: {err}"
+                ),
             )
 
         assert workspace_path is not None

--- a/src/theforge/coordinator/workspace.py
+++ b/src/theforge/coordinator/workspace.py
@@ -22,6 +22,7 @@ from .config_snapshot import sync_forge_yaml_into_worktree
 from .gate import _run_gate
 from .git_lock import FETCH_LOCK
 from .run_setup import _rebase_onto_main
+from .worktree_drift import DRIFT_HEADER, classify_rebase_conflict
 
 # Populated lazily on first call to _resolve_merge_conflicts.
 run_agent = None
@@ -1060,11 +1061,24 @@ def _sync_base_before_worktree_use(
 
 
 def _rebase_reused_worktree(workspace_path: Path, base_branch: str) -> str | None:
-    """Rebase a reused worktree onto current base. Returns error message on failure."""
+    """Rebase a reused worktree onto current base. Returns error message on failure.
+
+    A failure here is usually not "git broke" but "the work in this worktree
+    predates commits that changed the same files" — the recurring cost of
+    preserving an escalated story's worktree across an intervening merge
+    (#1993). Classify that condition explicitly; only fall back to relaying the
+    tool failure when drift cannot be established.
+    """
     rebase_ok, rebase_err = _rebase_onto_main(str(workspace_path), base_branch, None)
     if rebase_ok:
         _cu._log(f"  rebased reused worktree onto origin/{base_branch}")
         return None
+    classified = classify_rebase_conflict(workspace_path, base_branch, rebase_err)
+    if classified is not None:
+        _cu._log(f"⚠ WORKSPACE  {DRIFT_HEADER} on {base_branch}")
+        for line in classified.splitlines()[1:]:
+            _cu._log(f"  {line}" if line else "")
+        return classified
     return (
         f"pre-dev rebase onto {base_branch} failed — conflicts must be resolved manually: "
         f"{rebase_err}"

--- a/src/theforge/coordinator/worktree_drift.py
+++ b/src/theforge/coordinator/worktree_drift.py
@@ -1,0 +1,219 @@
+"""Classification for reused worktrees whose base branch moved underneath them.
+
+Forge deliberately preserves a story worktree when the story escalates (the
+escalate marker in ``artifacts``), because the work in it may still be wanted.
+Nothing reconciles that worktree against the base branch afterwards, so a later
+resume rebases it onto a base that may have advanced over the same files. When
+that rebase conflicts, the condition is not "a git command failed" — it is
+"preserved work predates commits that changed the same files", a recurring and
+expected consequence of escalating stories and keeping their output (#1993).
+
+This module turns that condition into a named classification: which files both
+sides touched, which base-branch commits are responsible, and which resolutions
+are actually available to the operator. It reads git state only; it never
+mutates the repository.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from theforge.artifacts import ESCALATED_MARKER_PATH
+
+from . import util as _cu
+
+# First line of every message this module produces. ``engine`` matches on it to
+# avoid burying the classification under a generic "Workspace creation failed:"
+# prefix, so keep the two in sync through ``is_drift_classification``.
+DRIFT_HEADER = "preserved work predates conflicting commits"
+
+# Cap the evidence quoted back so a wide merge does not produce an unreadable wall.
+_MAX_FILES = 20
+_MAX_COMMITS = 10
+
+# git's own remediation advice ("git add/rm", "git rebase --continue") tells the
+# operator to hand-resolve conflicts inside a story worktree, which the
+# surrounding workflow does not support. Drop it; keep the factual first line.
+_HINT_RE = re.compile(r"^\s*hint:", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class WorktreeDrift:
+    """What a failed rebase of a reused worktree tells us about the two sides."""
+
+    base_branch: str
+    base_ref: str
+    escalated: bool
+    worktree_commits: int | None = None
+    base_commits: int | None = None
+    overlapping_files: list[str] = field(default_factory=list)
+    responsible_commits: list[str] = field(default_factory=list)
+    files_truncated: int = 0
+    commits_truncated: int = 0
+
+
+def is_drift_classification(message: str) -> bool:
+    """True when ``message`` was produced by :func:`classify_rebase_conflict`."""
+    return message.startswith(DRIFT_HEADER)
+
+
+def _git_lines(command: str, cwd: Path) -> list[str] | None:
+    ok, out = _cu._run_shell(command, cwd)
+    if not ok:
+        return None
+    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+
+
+def _git_count(command: str, cwd: Path) -> int | None:
+    lines = _git_lines(command, cwd)
+    if not lines:
+        return None
+    try:
+        return int(lines[0])
+    except ValueError:
+        return None
+
+
+def _resolve_base_ref(workspace_path: Path, base_branch: str) -> str:
+    """Prefer the remote-tracking ref the rebase used; fall back to the local branch."""
+    ok, _ = _cu._run_shell(
+        f"git rev-parse --verify --quiet origin/{base_branch}^{{commit}}", workspace_path
+    )
+    return f"origin/{base_branch}" if ok else base_branch
+
+
+def collect_drift(workspace_path: Path, base_branch: str) -> WorktreeDrift:
+    """Gather the two-sided divergence evidence for a worktree that failed to rebase.
+
+    Every probe degrades independently: a git command that cannot answer leaves
+    its field empty rather than aborting the classification, because a partial
+    explanation still beats forwarding raw rebase output.
+    """
+    base_ref = _resolve_base_ref(workspace_path, base_branch)
+    escalated = (workspace_path / ESCALATED_MARKER_PATH).exists()
+
+    merge_base_lines = _git_lines(f"git merge-base {base_ref} HEAD", workspace_path)
+    if not merge_base_lines:
+        return WorktreeDrift(base_branch=base_branch, base_ref=base_ref, escalated=escalated)
+    merge_base = merge_base_lines[0]
+
+    ours = _git_lines(f"git diff --name-only {merge_base}..HEAD", workspace_path) or []
+    theirs = _git_lines(f"git diff --name-only {merge_base}..{base_ref}", workspace_path) or []
+    overlap = sorted(set(ours) & set(theirs))
+
+    responsible: list[str] = []
+    commits_truncated = 0
+    if overlap:
+        paths = " ".join(shlex.quote(p) for p in overlap)
+        log = (
+            _git_lines(
+                f"git log --oneline --no-decorate {merge_base}..{base_ref} -- {paths}",
+                workspace_path,
+            )
+            or []
+        )
+        if len(log) > _MAX_COMMITS:
+            commits_truncated = len(log) - _MAX_COMMITS
+        responsible = log[:_MAX_COMMITS]
+
+    files_truncated = max(0, len(overlap) - _MAX_FILES)
+
+    return WorktreeDrift(
+        base_branch=base_branch,
+        base_ref=base_ref,
+        escalated=escalated,
+        worktree_commits=_git_count(f"git rev-list --count {merge_base}..HEAD", workspace_path),
+        base_commits=_git_count(f"git rev-list --count {merge_base}..{base_ref}", workspace_path),
+        overlapping_files=overlap[:_MAX_FILES],
+        responsible_commits=responsible,
+        files_truncated=files_truncated,
+        commits_truncated=commits_truncated,
+    )
+
+
+def _summarize_git_error(rebase_error: str) -> str:
+    """Keep git's factual first line, drop its manual-resolution advice."""
+    lines = [ln.rstrip() for ln in (rebase_error or "").splitlines() if ln.strip()]
+    kept = [ln for ln in lines if not _HINT_RE.match(ln)]
+    if not kept:
+        return ""
+    first = kept[0]
+    return first if len(first) <= 200 else first[:197] + "..."
+
+
+def render_drift(drift: WorktreeDrift, workspace_path: Path, rebase_error: str) -> str:
+    """Render the operator-facing classification for a drifted worktree."""
+    origin = "escalated" if drift.escalated else "reused"
+    held = (
+        f"{drift.worktree_commits} commit{'s' if drift.worktree_commits != 1 else ''}"
+        if drift.worktree_commits is not None
+        else "work"
+    )
+    landed = (
+        f"{drift.base_commits} commit{'s' if drift.base_commits != 1 else ''}"
+        if drift.base_commits is not None
+        else "commits"
+    )
+
+    lines = [
+        f"{DRIFT_HEADER} on {drift.base_branch}",
+        "",
+        f"The preserved {origin} worktree at {workspace_path} holds {held} made before"
+        f" {landed} landed on {drift.base_branch}. Replaying the preserved work on"
+        f" top of {drift.base_ref} conflicts, so this story cannot resume from it as-is."
+        " The worktree itself is intact — the rebase was aborted and nothing was lost.",
+    ]
+
+    lines += ["", "Files changed on both sides:"]
+    lines += [f"  - {p}" for p in drift.overlapping_files]
+    if drift.files_truncated:
+        lines.append(f"  - ... and {drift.files_truncated} more")
+
+    if drift.responsible_commits:
+        lines += ["", f"{drift.base_branch} commits that changed those files:"]
+        lines += [f"  - {c}" for c in drift.responsible_commits]
+        if drift.commits_truncated:
+            lines.append(f"  - ... and {drift.commits_truncated} more")
+
+    lines += [
+        "",
+        "Available resolutions:",
+        f"  - Bring the work forward yourself: rebase {workspace_path} onto"
+        f" {drift.base_ref} (git rebase {drift.base_ref}) outside forge, resolve the"
+        " conflicts there, commit, then resume the sprint — the resume will find the"
+        " worktree already current.",
+        "  - Discard the preserved work and re-run the story from current"
+        f" {drift.base_branch}: git worktree remove --force {workspace_path} (and delete"
+        " its branch), then resume — the run recreates the worktree from"
+        f" {drift.base_ref}. Any work in it is lost.",
+        f"  - Leave it and drop the story from the sprint if the {drift.base_branch}"
+        " commits above already supersede the preserved work.",
+        "",
+        "Resolving the conflicts in place with git rebase --continue is not a supported"
+        " operator action here: the run does not resume a worktree left mid-rebase.",
+    ]
+
+    summary = _summarize_git_error(rebase_error)
+    if summary:
+        lines += ["", f"git reported: {summary}"]
+
+    return "\n".join(lines)
+
+
+def classify_rebase_conflict(
+    workspace_path: Path, base_branch: str, rebase_error: str
+) -> str | None:
+    """Classify a failed pre-dev rebase of a reused worktree as base-branch drift.
+
+    Returns ``None`` when drift cannot be established — a rebase can also fail
+    for reasons that have nothing to do with the base moving (an unreachable
+    remote, an unreadable repository), and claiming drift for those would
+    mislabel the failure. Callers fall back to reporting the tool failure.
+    """
+    drift = collect_drift(workspace_path, base_branch)
+    if not drift.overlapping_files:
+        return None
+    return render_drift(drift, workspace_path, rebase_error)

--- a/src/theforge/sprint/collision.py
+++ b/src/theforge/sprint/collision.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from ..config import ForgeConfig, SprintBatchConfig
 from ..coordinator.engine import run_task
 from ..coordinator.state import CoordinatorState, Phase
+from ..coordinator.worktree_drift import is_drift_classification
 from ..log_util import _log_line
 from ..task import TaskStory
 
@@ -393,10 +394,23 @@ def run_batch_preflight(
                 continue
 
             if not result.success:
-                _log(
-                    "WARNING: batch preflight returned failure for "
-                    f"{task.slug}: {result.message}; excluding from collision detection"
-                )
+                message = result.message or ""
+                if is_drift_classification(message):
+                    # A classified condition is multi-line and names the files,
+                    # commits, and resolutions — squeezing it into the trailing
+                    # clause of one WARNING line is where it stopped being
+                    # readable (#1993).
+                    _log(
+                        f"WARNING: {task.slug} excluded from collision detection — "
+                        "its preserved worktree cannot be brought current:"
+                    )
+                    for line in message.splitlines():
+                        _log(f"  {line}" if line else "")
+                else:
+                    _log(
+                        "WARNING: batch preflight returned failure for "
+                        f"{task.slug}: {message}; excluding from collision detection"
+                    )
                 states[task.slug] = CoordinatorState(preflight_likely_files=None)
                 continue
 

--- a/tests/test_coord_worktree_drift.py
+++ b/tests/test_coord_worktree_drift.py
@@ -1,0 +1,354 @@
+"""Tests for issue #1993: preserved worktrees that go stale across a merge.
+
+Forge preserves an escalated story's worktree on purpose. Nothing reconciles it
+against a base branch that advances afterwards, so the next resume rebases it
+onto a base that may have rewritten the same files. That condition used to
+surface as raw ``git rebase`` stderr — including git's own "resolve manually /
+git rebase --continue" hints, which are not a supported operator action inside a
+story worktree.
+
+These tests pin the classification at each surface it crosses:
+
+- ``classify_rebase_conflict`` / ``collect_drift``: the classification itself,
+  against real git repositories — names the overlapping files and the
+  base-branch commits responsible, and drops git's hints
+- ``_create_workspace``: the reuse path returns the classification instead of
+  the relayed tool failure, and still returns the relayed failure when drift
+  cannot be established
+- ``run_task``: the WORKSPACE→ESCALATE seam forwards a classification verbatim
+  rather than re-framing it as "Workspace creation failed"
+- ``run_batch_preflight``: the operator-facing sprint log renders it line by
+  line instead of burying it inside one WARNING line
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.artifacts import ESCALATED_MARKER_PATH
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.engine import run_task
+from theforge.coordinator.state import Phase
+from theforge.coordinator.workspace import _create_workspace
+from theforge.coordinator.worktree_drift import (
+    DRIFT_HEADER,
+    classify_rebase_conflict,
+    collect_drift,
+    is_drift_classification,
+)
+from theforge.task import TaskStory
+
+REBASE_STDERR = (
+    "error: could not apply 231964a... fix(gate): align story gate with ci python matrix\n"
+    "hint: Resolve all conflicts manually, mark them as resolved with\n"
+    'hint: "git add/rm <conflicted_files>", then run "git rebase --continue".\n'
+    'hint: You can instead skip this commit: run "git rebase --skip".\n'
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _drifted_repo(tmp_path: Path, slug: str, *, escalated: bool) -> tuple[Path, Path, str]:
+    """Origin + clone + a story worktree whose commits conflict with later base commits.
+
+    Mirrors #1945: the story worktree holds commits touching several files, then
+    base-branch commits land that rewrite the same files.
+    """
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "--bare", "--initial-branch=main")
+
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    _git(project_root, "init", "--initial-branch=main")
+    _git(project_root, "config", "user.email", "test@example.com")
+    _git(project_root, "config", "user.name", "Test")
+    _git(project_root, "remote", "add", "origin", str(origin))
+
+    for name in ("gate.py", "types.py", "untouched.py"):
+        _write(project_root / "src" / name, f"# base {name}\n")
+    _git(project_root, "add", "src")
+    _git(project_root, "commit", "-m", "initial")
+    _git(project_root, "push", "-u", "origin", "main")
+
+    branch = f"feat/{slug}"
+    workspace_path = project_root / slug
+    _git(project_root, "worktree", "add", "-b", branch, str(workspace_path), "main")
+    _git(workspace_path, "config", "user.email", "test@example.com")
+    _git(workspace_path, "config", "user.name", "Test")
+
+    # Story work: two commits over gate.py and types.py.
+    _write(workspace_path / "src" / "gate.py", "# story gate change\n")
+    _git(workspace_path, "add", "src/gate.py")
+    _git(workspace_path, "commit", "-m", "story: rework gate")
+    _write(workspace_path / "src" / "types.py", "# story types change\n")
+    _git(workspace_path, "add", "src/types.py")
+    _git(workspace_path, "commit", "-m", "story: rework types")
+
+    if escalated:
+        marker = workspace_path / ESCALATED_MARKER_PATH
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("escalated\n", encoding="utf-8")
+
+    # Intervening merge on the base: one commit rewrites the same two files,
+    # another touches a file the story never saw.
+    _write(project_root / "src" / "gate.py", "# base gate rewrite\n")
+    _write(project_root / "src" / "types.py", "# base types rewrite\n")
+    _git(project_root, "add", "src")
+    _git(project_root, "commit", "-m", "fix(gate): align story gate with ci python matrix")
+    _write(project_root / "src" / "untouched.py", "# unrelated base change\n")
+    _git(project_root, "add", "src")
+    _git(project_root, "commit", "-m", "chore: unrelated change")
+    _git(project_root, "push", "origin", "main")
+
+    return project_root, workspace_path, branch
+
+
+def _real_config(project_root: Path, slug: str) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=project_root,
+        workspace=WorkspaceConfig(
+            create_command="git worktree add {slug} {base_branch}",
+            path_pattern="{slug}",
+            branch_pattern=f"feat/{slug}",
+            base_branch="main",
+            setup_command=None,
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        preflight_fallback_profile=None,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _real_task(slug: str, project_root: Path) -> TaskStory:
+    spec = project_root / f"{slug}.md"
+    spec.write_text("# task\n", encoding="utf-8")
+    return TaskStory(name="task", story_path=spec, slug=slug)
+
+
+# ── The classification itself ─────────────────────────────────────────
+
+
+class TestCollectDrift:
+    def test_names_overlapping_files_and_responsible_commits(self, tmp_path):
+        _root, workspace_path, _branch = _drifted_repo(tmp_path, "drift", escalated=True)
+        _git(workspace_path, "fetch", "origin", "main")
+
+        drift = collect_drift(workspace_path, "main")
+
+        assert drift.overlapping_files == ["src/gate.py", "src/types.py"]
+        assert drift.worktree_commits == 2
+        assert drift.base_commits == 2
+        assert drift.escalated is True
+        assert drift.base_ref == "origin/main"
+        subjects = " ".join(drift.responsible_commits)
+        assert "align story gate with ci python matrix" in subjects
+        # The base commit that touched only untouched.py is not responsible.
+        assert "unrelated change" not in subjects
+
+    def test_file_the_story_never_touched_is_not_reported(self, tmp_path):
+        _root, workspace_path, _branch = _drifted_repo(tmp_path, "drift2", escalated=True)
+        _git(workspace_path, "fetch", "origin", "main")
+
+        drift = collect_drift(workspace_path, "main")
+
+        assert "src/untouched.py" not in drift.overlapping_files
+
+    def test_marker_absence_is_recorded(self, tmp_path):
+        _root, workspace_path, _branch = _drifted_repo(tmp_path, "drift3", escalated=False)
+        _git(workspace_path, "fetch", "origin", "main")
+
+        assert collect_drift(workspace_path, "main").escalated is False
+
+
+class TestClassifyRebaseConflict:
+    def test_message_states_condition_files_commits_and_resolutions(self, tmp_path):
+        _root, workspace_path, _branch = _drifted_repo(tmp_path, "classify", escalated=True)
+        _git(workspace_path, "fetch", "origin", "main")
+
+        message = classify_rebase_conflict(workspace_path, "main", REBASE_STDERR)
+
+        assert message is not None
+        assert is_drift_classification(message)
+        assert message.startswith(DRIFT_HEADER)
+        assert "src/gate.py" in message
+        assert "src/types.py" in message
+        assert "align story gate with ci python matrix" in message
+        assert "Available resolutions:" in message
+        assert str(workspace_path) in message
+
+    def test_git_hint_lines_are_dropped(self, tmp_path):
+        _root, workspace_path, _branch = _drifted_repo(tmp_path, "hints", escalated=True)
+        _git(workspace_path, "fetch", "origin", "main")
+
+        message = classify_rebase_conflict(workspace_path, "main", REBASE_STDERR)
+
+        assert message is not None
+        assert "hint:" not in message
+        assert "git add/rm" not in message
+        # git's factual first line may still be quoted for reference, but it is
+        # no longer the entirety of what the operator is shown.
+        assert message.splitlines()[-1].startswith("git reported:")
+        assert len(message.splitlines()) > 10
+
+    def test_returns_none_when_no_overlap_can_be_established(self, tmp_path):
+        """A rebase can fail for reasons unrelated to drift — do not mislabel those."""
+        project_root = tmp_path / "repo"
+        project_root.mkdir()
+        _git(project_root, "init", "--initial-branch=main")
+        _git(project_root, "config", "user.email", "test@example.com")
+        _git(project_root, "config", "user.name", "Test")
+        _write(project_root / "a.txt", "a\n")
+        _git(project_root, "add", "a.txt")
+        _git(project_root, "commit", "-m", "initial")
+
+        assert classify_rebase_conflict(project_root, "main", "fatal: unable to access") is None
+
+    def test_no_git_repository_degrades_to_none(self, tmp_path):
+        assert classify_rebase_conflict(tmp_path, "main", "boom") is None
+
+
+# ── The workspace reuse path ──────────────────────────────────────────
+
+
+class TestCreateWorkspaceReuse:
+    def test_preserved_worktree_reports_classification_not_git_output(self, tmp_path):
+        slug = "reuse-drift"
+        project_root, workspace_path, _branch = _drifted_repo(tmp_path, slug, escalated=True)
+        config = _real_config(project_root, slug)
+        task = _real_task(slug, project_root)
+
+        path, branch_name, error = _create_workspace(config, task, no_pull=True)
+
+        assert path is None
+        assert branch_name is None
+        assert error is not None
+        assert is_drift_classification(error)
+        assert "src/gate.py" in error
+        assert "src/types.py" in error
+        assert "align story gate with ci python matrix" in error
+        assert "hint:" not in error
+        # The worktree survives the diagnosis — nothing is left mid-rebase.
+        assert workspace_path.exists()
+        assert not (workspace_path / ".git" / "rebase-merge").exists()
+        assert not (workspace_path / ".git" / "rebase-apply").exists()
+        assert (workspace_path / ESCALATED_MARKER_PATH).exists()
+
+    def test_unclassifiable_rebase_failure_still_relays_the_tool_error(self, tmp_path):
+        slug = "reuse-opaque"
+        project_root, _workspace_path, _branch = _drifted_repo(tmp_path, slug, escalated=True)
+        config = _real_config(project_root, slug)
+        task = _real_task(slug, project_root)
+
+        with patch("theforge.coordinator.workspace.classify_rebase_conflict", return_value=None):
+            _path, _branch_name, error = _create_workspace(config, task, no_pull=True)
+
+        assert error is not None
+        assert not is_drift_classification(error)
+        assert "pre-dev rebase onto main failed" in error
+
+
+# ── The WORKSPACE → ESCALATE seam ─────────────────────────────────────
+
+
+class TestRunTaskSeam:
+    @patch("theforge.coordinator.engine._create_workspace")
+    def test_classification_reaches_the_result_unwrapped(self, mock_create, tmp_path):
+        classification = f"{DRIFT_HEADER} on release/v0.13\n\nsrc/foo.py"
+        mock_create.return_value = (None, None, classification)
+        config = _make_config(tmp_path)
+        (tmp_path / ".git").mkdir(exist_ok=True)
+
+        result = run_task(config, _make_task(tmp_path))
+
+        assert result.success is False
+        assert result.phase is Phase.ESCALATE
+        assert result.message == classification
+        assert "Workspace creation failed" not in result.message
+        assert result.state.error == classification
+
+    @patch("theforge.coordinator.engine._create_workspace")
+    def test_unclassified_workspace_error_keeps_its_prefix(self, mock_create, tmp_path):
+        mock_create.return_value = (None, None, "Failed to create workspace: boom")
+        config = _make_config(tmp_path)
+        (tmp_path / ".git").mkdir(exist_ok=True)
+
+        result = run_task(config, _make_task(tmp_path))
+
+        assert result.message.startswith("Workspace creation failed:")
+
+
+# ── The sprint-log surface ────────────────────────────────────────────
+
+
+class TestBatchPreflightLogging:
+    def _run_batch(self, message: str, tmp_path: Path) -> list[str]:
+        from theforge.sprint import collision
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        result = type("R", (), {"success": False, "message": message, "state": None})()
+        logged: list[str] = []
+        with (
+            patch.object(collision, "run_task", return_value=result),
+            patch.object(collision, "_log", side_effect=logged.append),
+        ):
+            collision.run_batch_preflight(
+                [task], config, sprint_name="s", no_pull=True, max_parallel=1
+            )
+        return logged
+
+    def test_classification_is_logged_line_by_line(self, tmp_path):
+        message = "\n".join(
+            [
+                f"{DRIFT_HEADER} on release/v0.13",
+                "",
+                "Files changed on both sides:",
+                "  - src/theforge/coordinator/gate.py",
+                "",
+                "Available resolutions:",
+                "  - Discard the preserved work",
+            ]
+        )
+
+        logged = self._run_batch(message, tmp_path)
+
+        assert any("excluded from collision detection" in ln for ln in logged)
+        assert any("src/theforge/coordinator/gate.py" in ln for ln in logged)
+        assert any("Available resolutions:" in ln for ln in logged)
+        # Not squeezed into a single trailing clause.
+        assert not any(ln.count("\n") for ln in logged)
+
+    def test_unclassified_failure_keeps_the_single_warning_line(self, tmp_path):
+        logged = self._run_batch("Workspace setup command failed: boom", tmp_path)
+
+        assert any("batch preflight returned failure" in ln for ln in logged)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The reviewed commit satisfies the stale preserved-worktree classification behavior and the targeted drift tests pass locally. | [google-gemini-3.5-flash-api] Successfully classified stale preserved worktrees with clear operator-facing diagnostics and resolutions instead of raw git rebase errors.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $3.88
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Preserved escalated worktree goes stale across a merge and resume fails with raw git conflict output (GitHub Issue #1993)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1993