### PR TITLE
Extend mechanical reviewer-value signals to code-review selection

### DIFF
--- a/docs/routing-symmetry-followups.md
+++ b/docs/routing-symmetry-followups.md
@@ -58,6 +58,34 @@ names this as its `demotion` (audit label `reinclusion_check`) instead of
 `open_followup="reviewer-reinclusion"`. **Tests:** both directions in
 `tests/test_assignment_reviewer_completion.py`.
 
+### Reviewer-value recovery path (inverse of the #1443/#2156 value deprioritization) — RESOLVED (#2156)
+
+The mechanical reviewer-value deprioritization
+(`assignment.py:_rerank_reviewers_by_value`, surfaced by `_reviewer_value_check`)
+landed for plan review in #1443 and was extended to code-review reviewer selection
+in #2156. Its paired return path is the **passive recency recovery** (ADR-0006
+clause 2.4/5, `MECHANISM_REVIEWER_VALUE_RECOVERY =
+"reviewer_value_recency_recovery"`): the rate the router consults *is* the
+recency-weighted uniqueness rate, so a reviewer whose lifetime uniqueness sits
+below `assignment.{code_,}review_value_uniqueness_threshold` climbs back above it
+as fresh unique blocking findings enter the `_uniqueness_recent` ring, and the
+deprioritization simply stops firing. No new config surface, no operator action,
+and no permanent lock-out — the deprioritization is a sort-after, so a
+deprioritized reviewer is still seated whenever no better candidate exists and
+therefore keeps accumulating the samples its own recovery depends on.
+
+**Audit attribution.** Every `routing_decision[<reviewer role>].value_check`
+carries a nested `recovery_check` block whenever reviewer value profiles were
+consulted — `mechanism`, `fired`, `uniqueness_threshold`, `recovered`, `checked`,
+`checked_detail` (per-reviewer raw vs recency-weighted rate, sample count and
+below-lifetime-threshold state) and a `reason` distinguishing fired from
+checked-but-didn't-fire (ADR-0006 clause 7). The block's `phase` field records
+which value history was consulted, so the plan-review and code-review checks are
+never confusable. **Registry:** the reviewer-value pair in
+`ROUTING_SYMMETRY_REGISTRY` names this as its `demotion` (audit label
+`recovery_check`). **Tests:** both directions in
+`tests/test_assignment_code_review_value.py`.
+
 ### Escalation-history decay for dev-tier promotion — RESOLVED (#158)
 
 The dev-tier promotion no longer counts `ESCALATE` outcomes over a fixed last-10

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -94,6 +94,10 @@ MECHANISM_DEV_RECENCY_RECOVERY = "dev_recency_recovery"
 MECHANISM_POST_PLAN_DEMOTION = "post_plan_checkpoint"
 MECHANISM_REVIEWER_COMPLETION_DEPRIORITIZE = "reviewer_completion_rate"
 MECHANISM_REVIEWER_COMPLETION_REINCLUSION = "reviewer_completion_reinclusion"
+# Reviewer mechanical-value deprioritization (#1443 plan review, #2156 code
+# review) and its paired passive return path.
+MECHANISM_REVIEWER_VALUE_DEPRIORITIZE = "reviewer_value"
+MECHANISM_REVIEWER_VALUE_RECOVERY = "reviewer_value_recency_recovery"
 MECHANISM_PERSISTENT_P1_DEV_ESCALATION = "persistent_p1_dev_escalation"
 MECHANISM_PLAN_MODEL_ESCALATION = "plan_model_escalation"
 MECHANISM_RUN_SCOPED_RESET = "fresh_run_state_reset"
@@ -196,6 +200,34 @@ ROUTING_SYMMETRY_REGISTRY: tuple[RoutingSymmetryPair, ...] = (
         # audit-block builder directly, so grep for the mechanism token.
         promotion_test_token="completion",
         demotion_test_token="reinclusion_check",
+    ),
+    # Code-review reviewer mechanical-value deprioritization (#2156): a reviewer
+    # whose recency-weighted blocking-finding uniqueness at the story's complexity
+    # band is below threshold — over at least the sample floor of admissible,
+    # non-tainted, P1-bearing code-review samples — is reranked down. Its PAIRED
+    # return path is the passive recency recovery (ADR-0006 clause 2.4/5): the
+    # consulted rate IS the recency-weighted one, so as fresh unique blocking
+    # findings enter the ring a deprioritized reviewer climbs back above threshold
+    # and the deprioritization stops firing — no operator action, no separate
+    # config surface. Recorded — fired or merely checked — in the nested
+    # value_check.recovery_check block (clause 7).
+    RoutingSymmetryPair(
+        promotion=RoutingMechanism(
+            name=MECHANISM_REVIEWER_VALUE_DEPRIORITIZE,
+            symbol="theforge.assignment._reviewer_value_check",
+            audit_label="value_check",
+        ),
+        demotion=RoutingMechanism(
+            name=MECHANISM_REVIEWER_VALUE_RECOVERY,
+            symbol="theforge.assignment._reviewer_value_recovery_check",
+            audit_label="recovery_check",
+        ),
+        promotion_tests=("tests/test_assignment_code_review_value.py",),
+        demotion_tests=("tests/test_assignment_code_review_value.py",),
+        # Exercised via assign_models/_select_reviewers, not by calling the
+        # audit-block builder directly, so grep for the mechanism token.
+        promotion_test_token="value_check",
+        demotion_test_token="recovery_check",
     ),
     # In-run persistent-P1 dev escalation (#296): a repeated P1 across
     # consecutive review cycles upgrades the dev model for the current run only.
@@ -720,6 +752,41 @@ def _promote_tier(tier: str) -> str:
     return _TIER_ORDER[min(idx + 1, len(_TIER_ORDER) - 1)]
 
 
+def _reviewer_value_rationale(
+    enabled: bool,
+    signals: dict[str, dict],
+    audit: dict[str, object],
+) -> str:
+    """Return a rationale suffix describing how the value check shaped selection.
+
+    Three outcomes must be distinguishable at a glance in the human-readable
+    rationale, not only in the structured audit block (#2156): the mechanism was
+    off, it was evaluated but every candidate was below its sample floor (so
+    ordering fell through untouched), or it fired and deprioritized reviewers.
+    """
+    if not enabled:
+        return ""
+    if not signals:
+        return " [value check: enabled, no reviewer value history consulted]"
+    above_floor = [
+        name
+        for name, sig in signals.items()
+        if ((sig.get("uniqueness_rate") or {}).get("floor")) == "pass"
+    ]
+    if not above_floor:
+        return (
+            f" [value check: evaluated {len(signals)} reviewer(s), all below the "
+            f"{audit.get('min_runs')}-sample floor — ordering unchanged]"
+        )
+    depri = list(audit.get("deprioritized") or [])
+    if depri:
+        return f" [value check: deprioritized {', '.join(depri)} on P1-uniqueness]"
+    return (
+        f" [value check: evaluated {len(above_floor)} reviewer(s) above the sample "
+        f"floor, none below the uniqueness threshold]"
+    )
+
+
 def _reviewer_health_rationale(
     agents: list[AgentDef],
     selected: list[AgentDef],
@@ -892,21 +959,34 @@ def _rerank_reviewers_by_value(
     recency: object | None = None,
     signals_out: dict[str, dict] | None = None,
     audit: dict[str, object] | None = None,
+    phase: str = "plan_review",
 ) -> list[AgentDef]:
-    """Stable sort-after plan reviewers below the P1-uniqueness floor (#1443).
+    """Stable sort-after reviewers below the P1-uniqueness floor (#1443, #2156).
 
-    The value analog of :func:`_rerank_reviewers_by_completion`. A plan reviewer
-    whose recency-weighted P1-uniqueness rate at the story's complexity band is
-    below ``uniqueness_threshold`` — *and only once it has accumulated ``min_runs``
-    admissible (non-tainted, P1-bearing) samples* — is sorted **after** every
-    higher-uniqueness candidate. This is a sort-after, not a filter-out: a
-    redundant reviewer stays in the pool and is still selected when no better
-    candidate is available, so it is never permanently locked out.
+    The value analog of :func:`_rerank_reviewers_by_completion`. A reviewer whose
+    recency-weighted blocking-finding uniqueness rate at the story's complexity
+    band is below ``uniqueness_threshold`` — *and only once it has accumulated
+    ``min_runs`` admissible (non-tainted, P1-bearing) samples* — is sorted
+    **after** every higher-uniqueness candidate. This is a sort-after, not a
+    filter-out: a redundant reviewer stays in the pool and is still selected when
+    no better candidate is available, so it is never permanently locked out.
+
+    ``phase`` selects which persisted value history is consulted
+    (``plan_review`` / ``code_review``), so a reviewer's plan-review record never
+    deprioritizes it for code review or vice versa.
 
     Below the sample floor a reviewer's signal is ``floor="fail"`` (cold start), so
     it is not deprioritized and ordering falls through unchanged. The sort is
     stable on the incoming index, so every non-deprioritized reviewer keeps the
     ordering it arrived with (i.e. the completion/tier/health order).
+
+    Recovery (ADR-0006 clause 2.4/5, the registered inverse): the rate consulted is
+    the *recency-weighted* one, so as fresh unique blocking findings enter the ring
+    a previously deprioritized reviewer climbs back above threshold and the
+    deprioritization stops firing — with no new config surface and no operator
+    action. That passive return path is recorded for every consulted reviewer
+    (fired or merely checked) in ``recovery_checked``, per the routing-symmetry
+    audit-attribution requirement (ADR-0006 clause 7).
     """
     if not model_profiles or not candidates:
         return candidates
@@ -914,6 +994,8 @@ def _rerank_reviewers_by_value(
 
     rows: list[tuple[int, int, AgentDef]] = []
     deprioritized: list[str] = []
+    recovered_names: list[str] = []
+    recovery_checked: dict[str, dict[str, object]] = {}
     for idx, agent in enumerate(candidates):
         signal = get_reviewer_value_signal(
             model_profiles,
@@ -924,12 +1006,30 @@ def _rerank_reviewers_by_value(
             provider=agent.provider,
             cli=agent.cli,
             recency=recency,
+            phase=phase,
         )
         if signals_out is not None:
             signals_out[agent.name] = signal
         uniq = signal["uniqueness_rate"]
         rate = uniq["rate"]
-        is_low = uniq["floor"] == "pass" and rate is not None and rate < uniqueness_threshold
+        raw = uniq["raw"]
+        floor_ok = uniq["floor"] == "pass"
+        is_low = floor_ok and rate is not None and rate < uniqueness_threshold
+        # Recovery: the lifetime-average uniqueness is still below threshold, but
+        # the recency-weighted rate the router actually consults is not — this
+        # reviewer's recent contribution has come back, so the deprioritization it
+        # would otherwise attract does not fire.
+        lifetime_low = floor_ok and raw is not None and raw < uniqueness_threshold
+        recovered = lifetime_low and not is_low
+        recovery_checked[agent.name] = {
+            "raw": raw,
+            "weighted": uniq["weighted"],
+            "runs": uniq["runs"],
+            "below_threshold_lifetime": lifetime_low,
+            "recovered": recovered,
+        }
+        if recovered:
+            recovered_names.append(agent.name)
         if is_low:
             deprioritized.append(agent.name)
         rows.append((1 if is_low else 0, idx, agent))
@@ -938,7 +1038,8 @@ def _rerank_reviewers_by_value(
     if audit is not None:
         original_order = [a.name for a in candidates]
         final_order = [a.name for a in reranked]
-        audit["mechanism"] = "reviewer_value"
+        audit["mechanism"] = MECHANISM_REVIEWER_VALUE_DEPRIORITIZE
+        audit["phase"] = phase
         audit["uniqueness_threshold"] = uniqueness_threshold
         audit["min_runs"] = min_runs
         audit["complexity"] = complexity
@@ -946,6 +1047,9 @@ def _rerank_reviewers_by_value(
         audit["deprioritized"] = deprioritized
         audit["original_order"] = original_order
         audit["final_order"] = final_order
+        audit["recovery_mechanism"] = MECHANISM_REVIEWER_VALUE_RECOVERY
+        audit["recovered"] = recovered_names
+        audit["recovery_checked"] = recovery_checked
     return reranked
 
 
@@ -970,6 +1074,7 @@ def _select_reviewers(
     value_complexity: str | None = None,
     value_signals_out: dict[str, dict] | None = None,
     value_audit: dict[str, object] | None = None,
+    value_phase: str = "plan_review",
 ) -> list[AgentDef]:
     """Select n reviewer agents from the pool.
 
@@ -1056,10 +1161,11 @@ def _select_reviewers(
         audit=completion_audit,
     )
 
-    # Plan-reviewer value rerank (#1443): opt-in, runs on top of the completion
-    # rerank. A reviewer whose admissible P1-uniqueness is below the floor is
-    # sorted after higher-value candidates within the same eligible pool. Only
-    # fires when the operator enabled it; explicit profile pins never reach here.
+    # Reviewer value rerank (#1443 plan review, #2156 code review): opt-in, runs
+    # on top of the completion rerank. A reviewer whose admissible
+    # blocking-finding uniqueness is below the floor is sorted after higher-value
+    # candidates within the same eligible pool. Only fires when the operator
+    # enabled it for THIS phase; explicit profile pins never reach here.
     if value_enabled:
         candidates = _rerank_reviewers_by_value(
             candidates,
@@ -1070,6 +1176,7 @@ def _select_reviewers(
             recency=recency,
             signals_out=value_signals_out,
             audit=value_audit,
+            phase=value_phase,
         )
 
     if not prefer_cross_provider:
@@ -1853,10 +1960,10 @@ def _reviewer_value_check(
     audit: dict[str, object] | None,
     selected_names: set[str],
 ) -> dict[str, object]:
-    """Build the plan-reviewer value_check block (#1443, ADR-0006 clause 7).
+    """Build the reviewer value_check block (#1443/#2156, ADR-0006 clause 7).
 
     Records the P1-uniqueness rerank so the routing_decision explains when (and
-    how) mechanical reviewer-value history shaped the plan-reviewer ordering. For
+    how) mechanical reviewer-value history shaped this role's reviewer ordering. For
     every reviewer weighed it surfaces the consulted uniqueness rate and
     latency-per-P1 (raw + recency-weighted), the sample count, the sample-floor
     status, and the taint-excluded count — enough for an operator to answer "is
@@ -1889,18 +1996,59 @@ def _reviewer_value_check(
             "selected": name in selected_names,
         }
     block: dict[str, object] = {
-        "mechanism": "reviewer_value",
+        "mechanism": MECHANISM_REVIEWER_VALUE_DEPRIORITIZE,
+        # Which reviewer phase's value history was consulted (#2156), so the two
+        # value_check blocks in one routing_decision are never confusable.
+        "phase": (audit.get("phase") if audit else None) or "plan_review",
         "fired": fired,
         "uniqueness_threshold": audit.get("uniqueness_threshold") if audit else None,
         "min_runs": audit.get("min_runs") if audit else None,
         "complexity": audit.get("complexity") if audit else None,
         "deprioritized": (audit.get("deprioritized") if audit else None) or [],
         "signals": per_candidate,
+        "recovery_check": _reviewer_value_recovery_check(signals, audit),
     }
     if fired and audit:
         block["original_order"] = audit.get("original_order")
         block["final_order"] = audit.get("final_order")
     return block
+
+
+def _reviewer_value_recovery_check(
+    signals: dict[str, dict] | None,
+    audit: dict[str, object] | None,
+) -> dict[str, object]:
+    """Build the reviewer-value recovery sub-block (#2156, ADR-0006 c7).
+
+    The registered inverse of the value deprioritization: the passive recency
+    recovery (ADR-0006 clause 2.4/5). Because the rate the router consults is the
+    recency-weighted one, a reviewer whose lifetime uniqueness sits below threshold
+    climbs back out as fresh unique blocking findings enter the ring — the
+    deprioritization simply stops firing, with no operator action and no separate
+    config surface. Present on every ``value_check`` (i.e. whenever reviewer value
+    profiles were consulted), so an operator can always answer "did a deprioritized
+    reviewer recover this run, and if not, how close was it?" without grepping logs.
+    """
+    checked_meta = (audit or {}).get("recovery_checked") or {}
+    if not isinstance(checked_meta, dict):
+        checked_meta = {}
+    recovered = list((audit or {}).get("recovered") or [])
+    checked = sorted(checked_meta) if checked_meta else sorted(signals or {})
+    if recovered:
+        reason = f"recency_weighted_uniqueness_recovered: {', '.join(sorted(recovered))}"
+    elif not checked:
+        reason = "no_reviewer_value_signal_consulted"
+    else:
+        reason = "no_below_threshold_reviewer_recovered_on_recent_uniqueness"
+    return {
+        "mechanism": MECHANISM_REVIEWER_VALUE_RECOVERY,
+        "fired": bool(recovered),
+        "uniqueness_threshold": (audit or {}).get("uniqueness_threshold"),
+        "recovered": sorted(recovered),
+        "checked": checked,
+        "checked_detail": checked_meta,
+        "reason": reason,
+    }
 
 
 def _role_reliability_check(
@@ -2002,6 +2150,8 @@ def _build_routing_decision(
     cr_completion_audit: dict[str, object] | None = None,
     pr_value_signals: dict[str, dict] | None = None,
     pr_value_audit: dict[str, object] | None = None,
+    cr_value_signals: dict[str, dict] | None = None,
+    cr_value_audit: dict[str, object] | None = None,
     preflight_reliability_signals: dict[str, dict] | None = None,
     preflight_reliability_audit: dict[str, object] | None = None,
     planner_reliability_signals: dict[str, dict] | None = None,
@@ -2086,9 +2236,12 @@ def _build_routing_decision(
     cr_completion_block = _reviewer_completion_check(
         cr_completion_signals, cr_completion_audit, cr_selected
     )
-    # Plan-reviewer value rerank (#1443) explanation. Only the plan-review role has
-    # a value signal (this story is plan-review-specific).
+    # Reviewer value rerank explanation, per reviewer role: plan review (#1443)
+    # and code review (#2156). Each reads its own persisted value section, so the
+    # two blocks are independently populated and independently omitted when their
+    # phase's mechanism was not consulted.
     pr_value_block = _reviewer_value_check(pr_value_signals, pr_value_audit, pr_selected)
+    cr_value_block = _reviewer_value_check(cr_value_signals, cr_value_audit, cr_selected)
 
     # Non-dev single-model reliability rerank (#1489) explanation for the preflight
     # and planner roles. Empty (and omitted) when the mechanism was not consulted
@@ -2254,6 +2407,7 @@ def _build_routing_decision(
                 cr_fired, cr_depri, cr_fellback, unhealthy_models
             ),
             **({"completion_check": cr_completion_block} if cr_completion_block else {}),
+            **({"value_check": cr_value_block} if cr_value_block else {}),
             "exploration": dict(exploration),
             "final": {
                 "models": [p.model for p in decision.code_reviewers],
@@ -2732,6 +2886,10 @@ def assign_models(
     # uniqueness / latency-per-P1 signals and the ranking effect.
     _pr_value_signals: dict[str, dict] = {}
     _pr_value_audit: dict[str, object] = {}
+    # Code-review counterparts (#2156), read from the separate code_review_value
+    # profile section so the two phases' value histories never mix.
+    _cr_value_signals: dict[str, dict] = {}
+    _cr_value_audit: dict[str, object] = {}
     # Non-dev single-model reliability rerank accumulators (#1489), per role.
     # Populated by _pick_agent when preflight/planner selection consults role
     # reliability history and consumed by _build_routing_decision so the block
@@ -3141,6 +3299,13 @@ def assign_models(
             recency=effective_recency,
             completion_signals_out=_cr_completion_signals,
             completion_audit=_cr_completion_audit,
+            value_enabled=assignment_config.code_review_value_enabled,
+            value_uniqueness_threshold=(assignment_config.code_review_value_uniqueness_threshold),
+            value_min_runs=assignment_config.code_review_value_min_runs,
+            value_complexity=norm_complexity,
+            value_signals_out=_cr_value_signals,
+            value_audit=_cr_value_audit,
+            value_phase="code_review",
         )
         code_reviewers = [_agent_to_profile(a, role="review") for a in selected]
         providers = [a.effective_provider for a in selected]
@@ -3154,9 +3319,12 @@ def assign_models(
         health_note = _reviewer_health_rationale(
             agents, selected, tier, exclude_model=dev_model, unhealthy_models=unhealthy_models
         )
+        value_note = _reviewer_value_rationale(
+            assignment_config.code_review_value_enabled, _cr_value_signals, _cr_value_audit
+        )
         rationale["code_review"] = (
             f"{len(code_reviewers)} reviewer(s), tier {tier}, "
-            f"providers {providers}{score_note}{shortfall_note}{health_note}"
+            f"providers {providers}{score_note}{shortfall_note}{health_note}{value_note}"
         )
 
     decision = AssignmentDecision(
@@ -3205,6 +3373,8 @@ def assign_models(
             cr_completion_audit=_cr_completion_audit,
             pr_value_signals=_pr_value_signals,
             pr_value_audit=_pr_value_audit,
+            cr_value_signals=_cr_value_signals,
+            cr_value_audit=_cr_value_audit,
             preflight_reliability_signals=_preflight_reliability_signals,
             preflight_reliability_audit=_preflight_reliability_audit,
             planner_reliability_signals=_planner_reliability_signals,

--- a/src/theforge/cli/explain.py
+++ b/src/theforge/cli/explain.py
@@ -281,18 +281,23 @@ def _fmt_value_signal(signal: dict) -> str:
 
 
 def _render_reviewer_value_check(value: dict, lines: list[str]) -> None:
-    """Render the plan-reviewer value_check (#1443): P1-uniqueness + wall-clock cost.
+    """Render a reviewer value_check (#1443/#2156): P1-uniqueness + wall-clock cost.
 
     Surfaces, per consulted reviewer, the uniqueness rate and latency-per-P1 so an
     operator can answer "is this reviewer earning its wall-clock cost?" directly
     from the explain view. Absent block → mechanism not checked (opt-in/disabled).
+    Rendered per reviewer role, so a plan-review and a code-review value check both
+    appear under their own role, each labelled with the phase it consulted.
     """
     if not value:
         # Omitted when the mechanism was not consulted (opt-in disabled / no
         # profiles), mirroring how completion_check is only added when present.
         return
     depri = value.get("deprioritized") or []
-    detail = f"threshold={value.get('uniqueness_threshold')} band={value.get('complexity')}"
+    detail = (
+        f"phase={value.get('phase', '?')} threshold={value.get('uniqueness_threshold')} "
+        f"band={value.get('complexity')}"
+    )
     if depri:
         detail += f" — deprioritized: {', '.join(depri)}"
     _render_mechanism(
@@ -301,6 +306,16 @@ def _render_reviewer_value_check(value: dict, lines: list[str]) -> None:
         detail,
         lines,
     )
+    # The registered inverse (ADR-0006 clause 7): always present when the value
+    # mechanism was consulted, so the return path is never a silent gap.
+    recovery = value.get("recovery_check") or {}
+    if recovery:
+        _render_mechanism(
+            f"value recovery ({recovery.get('mechanism', '?')})",
+            _mechanism_state(checked=True, fired=bool(recovery.get("fired"))),
+            str(recovery.get("reason", "")),
+            lines,
+        )
     for name, sig in (value.get("signals") or {}).items():
         if not isinstance(sig, dict):
             continue

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -1067,6 +1067,21 @@ def _parse_unit_float(value: Any, *, key: str, default: float) -> float:
     return coerced
 
 
+def _parse_strict_bool(value: Any, *, key: str, default: bool) -> bool:
+    """Validate an opt-in flag at the config integrity boundary.
+
+    Bare ``bool()`` coercion makes every non-empty scalar truthy, so a typo like
+    ``enabled: flase`` or ``enabled: "no"`` silently turns a routing mechanism ON.
+    Config loading is an integrity boundary (ADR-0006 clause 1): a value that is
+    not an actual boolean is a hard error, not a truthiness question.
+    """
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean, got {value!r}")
+    return value
+
+
 def _parse_positive_int(value: Any, *, key: str, minimum: int, default: int) -> int:
     """Coerce/validate a bounded integer at the config integrity boundary.
 
@@ -1152,20 +1167,42 @@ def _parse_assignment(assignment_raw: dict[str, Any]) -> AssignmentConfig:
             assignment_raw.get("reviewer_completion_threshold", 0.5)
         ),
         reviewer_completion_min_runs=int(assignment_raw.get("reviewer_completion_min_runs", 5)),
-        reviewer_value_enabled=bool(assignment_raw.get("reviewer_value_enabled", False)),
+        # Both reviewer-value phases validate strictly: these three fields decide
+        # whether a mechanical signal is allowed to reorder reviewers and how much
+        # evidence it needs first, so a malformed scalar must fail loudly rather
+        # than coerce into an active routing setting.
+        reviewer_value_enabled=_parse_strict_bool(
+            assignment_raw.get("reviewer_value_enabled"),
+            key="assignment.reviewer_value_enabled",
+            default=False,
+        ),
         reviewer_value_uniqueness_threshold=_parse_unit_float(
             assignment_raw.get("reviewer_value_uniqueness_threshold"),
             key="assignment.reviewer_value_uniqueness_threshold",
             default=0.34,
         ),
-        reviewer_value_min_runs=int(assignment_raw.get("reviewer_value_min_runs", 5)),
-        code_review_value_enabled=bool(assignment_raw.get("code_review_value_enabled", False)),
+        reviewer_value_min_runs=_parse_positive_int(
+            assignment_raw.get("reviewer_value_min_runs"),
+            key="assignment.reviewer_value_min_runs",
+            minimum=1,
+            default=5,
+        ),
+        code_review_value_enabled=_parse_strict_bool(
+            assignment_raw.get("code_review_value_enabled"),
+            key="assignment.code_review_value_enabled",
+            default=False,
+        ),
         code_review_value_uniqueness_threshold=_parse_unit_float(
             assignment_raw.get("code_review_value_uniqueness_threshold"),
             key="assignment.code_review_value_uniqueness_threshold",
             default=0.34,
         ),
-        code_review_value_min_runs=int(assignment_raw.get("code_review_value_min_runs", 5)),
+        code_review_value_min_runs=_parse_positive_int(
+            assignment_raw.get("code_review_value_min_runs"),
+            key="assignment.code_review_value_min_runs",
+            minimum=1,
+            default=5,
+        ),
         dev_promotion_threshold=_parse_unit_float(
             assignment_raw.get("dev_promotion_threshold"),
             key="assignment.dev_promotion_threshold",

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -1159,6 +1159,13 @@ def _parse_assignment(assignment_raw: dict[str, Any]) -> AssignmentConfig:
             default=0.34,
         ),
         reviewer_value_min_runs=int(assignment_raw.get("reviewer_value_min_runs", 5)),
+        code_review_value_enabled=bool(assignment_raw.get("code_review_value_enabled", False)),
+        code_review_value_uniqueness_threshold=_parse_unit_float(
+            assignment_raw.get("code_review_value_uniqueness_threshold"),
+            key="assignment.code_review_value_uniqueness_threshold",
+            default=0.34,
+        ),
+        code_review_value_min_runs=int(assignment_raw.get("code_review_value_min_runs", 5)),
         dev_promotion_threshold=_parse_unit_float(
             assignment_raw.get("dev_promotion_threshold"),
             key="assignment.dev_promotion_threshold",

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -144,6 +144,16 @@ class AssignmentConfig:
     reviewer_value_enabled: bool = False
     reviewer_value_uniqueness_threshold: float = 0.34
     reviewer_value_min_runs: int = 5
+    # Code-reviewer mechanical value routing (#2156). The same mechanism as the
+    # plan-review fields above, over the independently accumulated
+    # ``code_review_value`` profile section, with its OWN enablement/threshold/
+    # floor so the two phases can be tuned (and turned on) separately: code review
+    # is where reviewer spend concentrates and where blocking findings are raised,
+    # so its uniqueness distribution is not the plan-review one. Same defaults as
+    # the plan-review fields — opt-in, and no reordering below the sample floor.
+    code_review_value_enabled: bool = False
+    code_review_value_uniqueness_threshold: float = 0.34
+    code_review_value_min_runs: int = 5
     # Dev pre-promotion from cross-run capability profiles (#158, ADR-0006
     # clauses 1/2.3/2.4/4/5/7). Before the first iteration the router reads the
     # selected dev model's **recency-weighted** success rate at the story's

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -199,18 +199,23 @@ def _build_plan_review_per_reviewer(state: CoordinatorState, config: ForgeConfig
     return per_reviewer
 
 
-def _build_plan_reviewer_value(state: CoordinatorState) -> list[dict]:
-    """Per-plan-reviewer mechanical value telemetry for the audit record (#1443).
+def _build_reviewer_value(entries: list[dict] | None, *, index_key: str) -> list[dict]:
+    """Per-reviewer mechanical value telemetry for the audit record (#1443/#2156).
 
-    Surfaces the deterministic signals captured at plan-review pool completion —
+    Surfaces the deterministic signals captured at reviewer-pool completion —
     unique P1 count, total P1 count, latency, and parse-error count — plus the
     derived ``latency_per_p1_s`` so an operator can answer "is this reviewer
     earning its wall-clock cost?" from structured telemetry without grepping logs.
     Parse-error count is carried straight from the per-reviewer capture, which
     derives it from the existing parse step (no parallel parse-failure writer).
+
+    ``index_key`` names the per-phase pool index the capture is keyed on: plan
+    review records one row per pool ``attempt``, code review one per review
+    ``cycle``. Both are echoed under the same key they were captured with, so the
+    audit row and the native capture stay trivially cross-referenceable.
     """
     out: list[dict] = []
-    for v in state.plan_reviewer_value or []:
+    for v in entries or []:
         if not isinstance(v, dict):
             continue
         total_p1 = int(v.get("total_p1_count", 0))
@@ -220,7 +225,7 @@ def _build_plan_reviewer_value(state: CoordinatorState) -> list[dict]:
         )
         out.append(
             {
-                "attempt": v.get("attempt"),
+                index_key: v.get(index_key),
                 "reviewer": v.get("reviewer"),
                 "complexity": v.get("complexity"),
                 "unique_p1_count": int(v.get("unique_p1_count", 0)),
@@ -393,6 +398,18 @@ def _build_phases_block(state: CoordinatorState, config: ForgeConfig) -> dict:
             "cycles": state.reviewer_cycles_run,
             "outcome": _final_verdict,
             "per_reviewer": per_reviewer,
+            # Code-review mechanical value telemetry (#2156): the same
+            # uniqueness / latency-per-P1 rows the plan_review block carries,
+            # captured at code-review pool completion.
+            **(
+                {
+                    "per_reviewer_value": _build_reviewer_value(
+                        state.code_reviewer_value, index_key="cycle"
+                    )
+                }
+                if state.code_reviewer_value
+                else {}
+            ),
         }
 
     # ── totals ────────────────────────────────────────────────────────────────
@@ -865,7 +882,11 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "cost_usd": _round_cost(state.total_plan_review_cost_measured),
                 **({"per_reviewer": plan_review_per_reviewer} if plan_review_per_reviewer else {}),
                 **(
-                    {"per_reviewer_value": _build_plan_reviewer_value(state)}
+                    {
+                        "per_reviewer_value": _build_reviewer_value(
+                            state.plan_reviewer_value, index_key="attempt"
+                        )
+                    }
                     if state.plan_reviewer_value
                     else {}
                 ),

--- a/src/theforge/coordinator/model_profiles_bridge.py
+++ b/src/theforge/coordinator/model_profiles_bridge.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from theforge.config import ForgeConfig
 from theforge.model_profiles import ReviewerAttempt, RoleAttempt, RunOutcome, update_from_run
-from theforge.reviewer_value import PlanReviewerValueSample
+from theforge.reviewer_value import PlanReviewerValueSample, ReviewerValueSample
 
 from .state import CoordinatorState
 from .trust_status import derive_trust_status, is_tainted
@@ -94,6 +94,34 @@ def _extract_plan_reviewer_values(state: CoordinatorState) -> list[PlanReviewerV
             continue
         samples.append(
             PlanReviewerValueSample(
+                name=str(v["reviewer"]),
+                complexity=str(v.get("complexity") or "medium"),
+                unique_p1=int(v.get("unique_p1_count", 0)),
+                total_p1=int(v.get("total_p1_count", 0)),
+                latency_s=v.get("latency_s"),
+                actual_model=v.get("actual_model"),
+                provider=v.get("provider"),
+                cli=v.get("cli"),
+            )
+        )
+    return samples
+
+
+def _extract_code_reviewer_values(state: CoordinatorState) -> list[ReviewerValueSample]:
+    """Convert per-code-reviewer value telemetry dicts into typed samples (#2156).
+
+    The code-review counterpart of :func:`_extract_plan_reviewer_values`, over
+    ``state.code_reviewer_value`` — the native per-(reviewer, review-cycle) capture
+    written at code-review pool completion. Same pure-adapter shape, keyed by each
+    reviewer's canonical identity, so the value signal lands under the same model
+    entry the router looks it up by.
+    """
+    samples: list[ReviewerValueSample] = []
+    for v in state.code_reviewer_value or []:
+        if not isinstance(v, dict) or not v.get("reviewer"):
+            continue
+        samples.append(
+            ReviewerValueSample(
                 name=str(v["reviewer"]),
                 complexity=str(v.get("complexity") or "medium"),
                 unique_p1=int(v.get("unique_p1_count", 0)),
@@ -289,6 +317,7 @@ def build_run_outcome(config: ForgeConfig, state: CoordinatorState, success: boo
         reviewers=_extract_reviewers(state),
         reviewer_attempts=_extract_reviewer_attempts(state),
         plan_reviewer_values=_extract_plan_reviewer_values(state),
+        code_reviewer_values=_extract_code_reviewer_values(state),
         # Domain tags (#155) recorded by preflight, folded into per-domain dev
         # slices so future routing can prefer models strong in the story's domains.
         domains=list(state.preflight_domains or []),

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -28,6 +28,7 @@ from theforge.review import (
     parse_review_json,
     parse_review_output,
 )
+from theforge.reviewer_value import code_review_anchor_text, compute_reviewer_uniqueness
 from theforge.sessions import save_sessions
 from theforge.task import ContextAssembler, TaskStory, build_review_prompt
 from theforge.traces import write_trace
@@ -1091,6 +1092,37 @@ def _run_review_pool(
     # data was extracted; callers that use this for PR review attribution will
     # post a COMMENT with potentially empty findings/summary for those reviewers.
     named_parsed: list[tuple[str, ReviewResult]] = list(zip(names, parsed_results))
+
+    # ── Per-code-reviewer mechanical value telemetry (#2156) ──────────────
+    # The code-review counterpart of the plan-review capture in plan_flow.py:
+    # deterministic, coordinator-computed, over the structured findings from THIS
+    # completed pool (no LLM judgment). Uniqueness compares each reviewer's
+    # blocking findings against every peer's via anchor overlap over the
+    # observed+evidence text; latency is the per-reviewer pool wall-clock measured
+    # above. Recorded for every reviewer regardless of outcome so the audit can
+    # answer "is this reviewer earning its wall-clock cost?" — reviewers whose
+    # output failed to parse are excluded from the uniqueness *comparison* (their
+    # findings list is not what they judged), matching plan_flow.
+    _profiles_by_name = {p.name: p for p in pool}
+    _uniq_inputs = [(n, p.findings) for n, p in named_parsed if not p.parse_errors]
+    _uniqueness = compute_reviewer_uniqueness(_uniq_inputs, anchor_text=code_review_anchor_text)
+    for _name, _parsed_r in named_parsed:
+        _unique_p1, _total_p1 = _uniqueness.get(_name, (0, 0))
+        _prof = _profiles_by_name.get(_name)
+        state.code_reviewer_value.append(
+            {
+                "cycle": _cycle_num,
+                "reviewer": _name,
+                "complexity": state.preflight_complexity or "medium",
+                "unique_p1_count": _unique_p1,
+                "total_p1_count": _total_p1,
+                "latency_s": round(_per_agent_dur, 2),
+                "parse_error_count": len(_parsed_r.parse_errors),
+                "actual_model": getattr(_prof, "model", None),
+                "provider": getattr(_prof, "provider", None),
+                "cli": getattr(_prof, "cli", None),
+            }
+        )
 
     # Attempt-completion telemetry (#1388): record the INITIAL (pool /
     # transient-final) invocation for every reviewer, classified on its own first

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -686,6 +686,14 @@ class CoordinatorState:
     # derived from the same parse step that feeds plan_review_failures (no parallel
     # parse-failure writer). Consumed by audit.py and the reviewer_value fold.
     plan_reviewer_value: list[dict] = field(default_factory=list)
+    # Per-code-reviewer mechanical value telemetry (#2156). Same shape and same
+    # deterministic anchor-overlap computation as ``plan_reviewer_value`` above,
+    # captured at code-review pool completion instead: one dict per (reviewer,
+    # review cycle) {cycle, reviewer, complexity, unique_p1_count, total_p1_count,
+    # latency_s, parse_error_count, actual_model, provider, cli}. Folded into the
+    # separate ``code_review_value`` profile section so code-review reviewer value
+    # stays independently queryable from plan-review value.
+    code_reviewer_value: list[dict] = field(default_factory=list)
     plan_regen_disposition: str | None = None  # "patch" | "backtrack" | "escalate"
     plan_backtrack_used: bool = False  # True once the backtrack regen has been dispatched
     log_dir: Path | None = None  # per-story log directory under <project_root>/.forge/logs/

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -221,6 +221,12 @@ class RunOutcome:
     # gate as every other capability aggregate. Typed as ``list`` to avoid an
     # import cycle; :func:`apply_run` reads each sample's attributes.
     plan_reviewer_values: list = field(default_factory=list)
+    # Per-code-reviewer mechanical value samples for this run (#2156): one
+    # :class:`theforge.reviewer_value.ReviewerValueSample` per (reviewer, review
+    # cycle) that raised ≥1 blocking finding. Folded into the SEPARATE
+    # ``code_review_value`` profile section, under the same taint gate, so the two
+    # reviewer phases never share a history.
+    code_reviewer_values: list = field(default_factory=list)
     # Domain tags for this run (issue #155), from the fixed taxonomy recorded by
     # preflight. The dev outcome is folded into a per-domain slice for each tag so
     # per-domain success rate can be aggregated deterministically. Empty = the run
@@ -1084,6 +1090,20 @@ def apply_run(data: dict, outcome: RunOutcome) -> dict:
                 cli=sample.cli,
             )
             fold_plan_reviewer_value(rev_entry, sample, tainted=outcome.dev_tainted)
+    # Code-reviewer mechanical value telemetry (#2156): identical fold, into the
+    # ``code_review_value`` section, under the same run-level taint marker.
+    if outcome.code_reviewer_values:
+        from theforge.reviewer_value import CODE_PHASE, fold_reviewer_value  # noqa: PLC0415
+
+        for sample in outcome.code_reviewer_values:
+            rev_entry = _ensure_model(
+                data,
+                sample.name,
+                actual_model=sample.actual_model,
+                provider=sample.provider,
+                cli=sample.cli,
+            )
+            fold_reviewer_value(rev_entry, sample, phase=CODE_PHASE, tainted=outcome.dev_tainted)
     return data
 
 

--- a/src/theforge/reviewer_value.py
+++ b/src/theforge/reviewer_value.py
@@ -1,11 +1,17 @@
-"""Mechanical reviewer-value signals for adaptive plan-review routing (#1443).
+"""Mechanical reviewer-value signals for adaptive reviewer routing (#1443, #2156).
 
-Records and aggregates *coordinator-computable* per-plan-reviewer value signals —
+Records and aggregates *coordinator-computable* per-reviewer value signals —
 P1 uniqueness (did this reviewer surface blocking findings no peer did?) and
 latency-per-P1 (wall-clock cost per blocking finding raised) — then exposes them
 as routing-safe aggregate signals only after ADR-0006 clause-2 admissibility
 gating: a sample floor, recency weighting via the shared #1392 mechanism, and
 taint exclusion via #1852.
+
+The same machinery serves both reviewer phases. ``phase`` selects which persisted
+section a fold writes and a signal read consults — ``plan_review_value`` for the
+plan-review pool (#1443) and ``code_review_value`` for the code-review pool
+(#2156) — so the two histories stay separately queryable and a reviewer that is
+redundant in one phase is not penalised in the other.
 
 This module stays on the routing-safe side of the ADR-0006 boundary: it never
 judges review "quality", "goodness", or "helpfulness". Uniqueness is computed by
@@ -15,12 +21,12 @@ prose scoring. Latency and P1 counts are mechanical.
 
 Data flow:
 
-- Per-run signals are computed at plan-review pool completion
-  (``coordinator/plan_flow.py``) via :func:`compute_plan_reviewer_uniqueness`,
-  persisted in the native audit record, and folded into ``model_profiles.yaml``'s
-  ``plan_review_value`` section by :func:`fold_plan_reviewer_value` — reusing the
-  exact taint gate and recency-ring mechanism the #1388 reviewer-completion
-  signal uses.
+- Per-run signals are computed at reviewer-pool completion —
+  ``coordinator/plan_flow.py`` for plan review, ``coordinator/review_pool.py``
+  for code review — via :func:`compute_reviewer_uniqueness`, persisted in the
+  native audit record, and folded into the matching ``model_profiles.yaml``
+  section by :func:`fold_reviewer_value` — reusing the exact taint gate and
+  recency-ring mechanism the #1388 reviewer-completion signal uses.
 - At routing time :func:`get_reviewer_value_signal` reads that folded section and
   returns raw / recency-weighted / sample-floor-gated values, mirroring
   :func:`model_profiles.get_review_signal`.
@@ -33,16 +39,29 @@ functions that need them so this module composes without an import cycle.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from theforge.review import PlanReviewFinding
+    from theforge.review import PlanReviewFinding, ReviewFinding
+
+# ── Reviewer phases ─────────────────────────────────────────────────────────
+# The two reviewer pools that produce structured blocking findings. Each folds
+# into its OWN persisted section so plan-review and code-review value histories
+# stay separately queryable (#2156) — a reviewer that is redundant when judging
+# plans is not thereby judged redundant when judging diffs.
+PLAN_PHASE = "plan_review"
+CODE_PHASE = "code_review"
 
 # ── Persisted section / ring key names ──────────────────────────────────────
-# One place owns the ``plan_review_value`` schema; the fold writer and the signal
-# reader both key off these constants so they can never drift apart.
+# One place owns the value-section schema; the fold writer and the signal reader
+# both key off these constants so they can never drift apart. ``SECTION`` stays
+# the literal plan-review key so profile data written before #2156 continues to
+# resolve without migration.
 SECTION = "plan_review_value"
+CODE_SECTION = "code_review_value"
+_SECTION_BY_PHASE = {PLAN_PHASE: SECTION, CODE_PHASE: CODE_SECTION}
 BY_COMPLEXITY = "by_complexity"
 UNIQUENESS_RING = "_uniqueness_recent"
 LATENCY_RING = "_latency_per_p1_recent"
@@ -56,17 +75,33 @@ VALUE_RECENCY_WINDOW = 200
 # samples the aggregate is not routing-safe and falls through to tier ordering.
 DEFAULT_VALUE_MIN_RUNS = 5
 
-# Severities that count as a blocking ("P1") plan finding — the same set the plan
-# review pool treats as blocking (review.py / plan_flow.py use ``in ("P0","P1")``).
+# Severities that count as a blocking ("P1") finding — the same set both reviewer
+# pools treat as blocking (review.py / plan_flow.py / review_phase.py all use
+# ``in ("P0", "P1")``). Deliberately excludes the plan-review ``P1-impl``
+# severity, which is the *downgraded*, non-blocking outcome of corroboration.
 _P1_SEVERITIES = frozenset({"P0", "P1"})
+
+
+def section_for_phase(phase: str = PLAN_PHASE) -> str:
+    """Return the persisted profile section a reviewer phase folds into.
+
+    Raises on an unknown phase rather than silently defaulting: a typo must not
+    quietly route one phase's value history into the other's section.
+    """
+    try:
+        return _SECTION_BY_PHASE[phase]
+    except KeyError:
+        raise ValueError(
+            f"unknown reviewer value phase {phase!r}; expected one of {sorted(_SECTION_BY_PHASE)}"
+        ) from None
 
 
 # ── Per-run sample carrier ──────────────────────────────────────────────────
 
 
 @dataclass(frozen=True)
-class PlanReviewerValueSample:
-    """One plan reviewer's mechanical value signals for one pool attempt.
+class ReviewerValueSample:
+    """One reviewer's mechanical value signals for one pool attempt.
 
     ``unique_p1`` / ``total_p1`` and ``latency_s`` are the raw mechanical
     measurements recorded verbatim in the audit trail. The aggregate routing
@@ -97,6 +132,11 @@ class PlanReviewerValueSample:
         return self.latency_s / self.total_p1
 
 
+# Historical name, kept so the plan-review producer chain reads unchanged. The
+# carrier was never plan-specific in content — only in naming.
+PlanReviewerValueSample = ReviewerValueSample
+
+
 # ── Deterministic uniqueness computation (Step 2) ───────────────────────────
 
 
@@ -121,8 +161,29 @@ class _UnionFind:
             self._parent[max(ra, rb)] = min(ra, rb)
 
 
-def compute_plan_reviewer_uniqueness(
-    named_findings: list[tuple[str, list["PlanReviewFinding"]]],
+def plan_review_anchor_text(finding: "PlanReviewFinding") -> str:
+    """Anchor text for a plan-review finding: its issue description."""
+    return finding.description
+
+
+def code_review_anchor_text(finding: "ReviewFinding") -> str:
+    """Anchor text for a code-review finding: observed behaviour plus evidence.
+
+    A :class:`review.ReviewFinding` splits what a plan finding carries in one
+    prose blob across ``observed`` (behaviour-only, by construction free of
+    symbol detail) and ``evidence`` (the file/line/symbol anchor). Corroboration
+    between two reviewers who spotted the same defect lives mostly in the latter,
+    so both feed the anchor extractor. ``file`` is deliberately NOT concatenated:
+    file-path anchors are dropped below anyway (two reviewers naming the same
+    file have not thereby raised the same issue).
+    """
+    return " ".join(part for part in (finding.observed, finding.evidence) if part)
+
+
+def compute_reviewer_uniqueness(
+    named_findings: list[tuple[str, list[Any]]],
+    *,
+    anchor_text: Callable[[Any], str] | None = None,
 ) -> dict[str, tuple[int, int]]:
     """Compute each reviewer's (unique_p1_count, total_p1_count) over a pool.
 
@@ -137,11 +198,19 @@ def compute_plan_reviewer_uniqueness(
     its own singleton group and counts as unique (novel-by-default), matching how
     corroboration treats an uncorroborated single-reviewer finding.
 
+    ``anchor_text`` maps one finding to the prose the anchor extractor reads,
+    which is the only phase-specific part of this computation: plan findings carry
+    a single description, code-review findings split behaviour and evidence across
+    two fields (see :func:`code_review_anchor_text`). Defaults to the plan-review
+    extractor.
+
     Returns a mapping for every reviewer name passed in (including reviewers that
     raised zero P1s, which map to ``(0, 0)``), so the caller can record a row per
     reviewer regardless of outcome.
     """
     from theforge.plan_finding_classifier import extract_anchors, strip_reviewer_prefix
+
+    to_text = anchor_text or plan_review_anchor_text
 
     # Collect one item per P1 finding: (reviewer_name, non_file_anchor_values).
     item_reviewer: list[str] = []
@@ -153,7 +222,7 @@ def compute_plan_reviewer_uniqueness(
             if f.severity not in _P1_SEVERITIES:
                 continue
             totals[name] = totals.get(name, 0) + 1
-            anchors = extract_anchors(strip_reviewer_prefix(f.description))
+            anchors = extract_anchors(strip_reviewer_prefix(to_text(f)))
             non_file = frozenset(a.value for a in anchors if a.kind != "file_path")
             item_reviewer.append(name)
             item_anchors.append(non_file)
@@ -181,6 +250,13 @@ def compute_plan_reviewer_uniqueness(
             uniques[item_reviewer[i]] = uniques.get(item_reviewer[i], 0) + 1
 
     return {name: (uniques.get(name, 0), totals.get(name, 0)) for name, _ in named_findings}
+
+
+def compute_plan_reviewer_uniqueness(
+    named_findings: list[tuple[str, list["PlanReviewFinding"]]],
+) -> dict[str, tuple[int, int]]:
+    """Plan-review-phase alias for :func:`compute_reviewer_uniqueness` (#1443)."""
+    return compute_reviewer_uniqueness(named_findings, anchor_text=plan_review_anchor_text)
 
 
 # ── Fold (Step 3, write side) ───────────────────────────────────────────────
@@ -230,13 +306,17 @@ def _fold_bucket(bucket: dict[str, Any], uniq: float, latency_per_p1: float | No
             bucket["avg_latency_per_p1"] = round(l_sum / measured, 4)
 
 
-def fold_plan_reviewer_value(
+def fold_reviewer_value(
     entry: dict[str, Any],
-    sample: PlanReviewerValueSample,
+    sample: ReviewerValueSample,
     *,
+    phase: str = PLAN_PHASE,
     tainted: bool = False,
 ) -> None:
-    """Fold one plan-reviewer value sample into a model profile entry.
+    """Fold one reviewer value sample into a model profile entry.
+
+    ``phase`` selects the persisted section (``plan_review_value`` /
+    ``code_review_value``) so the two reviewer phases accumulate independently.
 
     Mirrors :func:`model_profiles._update_review_completion`: keeps running
     counters and a bounded recency ring so the routing-admissible signal is
@@ -253,7 +333,7 @@ def fold_plan_reviewer_value(
     from theforge.model_profiles import _normalize_band  # noqa: PLC0415
 
     band = _normalize_band(sample.complexity)
-    section = entry.setdefault(SECTION, {})
+    section = entry.setdefault(section_for_phase(phase), {})
     section.setdefault("runs", 0)
     section.setdefault("tainted_runs", 0)
     band_bucket = section.setdefault(BY_COMPLEXITY, {}).setdefault(band, _empty_value_bucket())
@@ -268,6 +348,16 @@ def fold_plan_reviewer_value(
     lpp = sample.latency_per_p1()
     for bucket in (section, band_bucket):
         _fold_bucket(bucket, uniq, lpp)
+
+
+def fold_plan_reviewer_value(
+    entry: dict[str, Any],
+    sample: ReviewerValueSample,
+    *,
+    tainted: bool = False,
+) -> None:
+    """Plan-review-phase alias for :func:`fold_reviewer_value` (#1443)."""
+    fold_reviewer_value(entry, sample, phase=PLAN_PHASE, tainted=tainted)
 
 
 # ── Signal reader (Step 3, read side) ───────────────────────────────────────
@@ -323,13 +413,15 @@ def get_reviewer_value_signal(
     provider: str | None = None,
     cli: str | None = None,
     recency: Any | None = None,
+    phase: str = PLAN_PHASE,
 ) -> dict:
-    """Return a structured plan-reviewer *value* routing signal (#1443).
+    """Return a structured reviewer *value* routing signal (#1443, #2156).
 
-    The plan-review analog of :func:`model_profiles.get_review_signal`, over the
-    ``plan_review_value`` section this module folds. Reads only the in-memory
-    ``profiles`` dict (no disk, no LLM). Both sub-signals share the raw / weighted
-    / floor / rate contract so the explain renderer surfaces them uniformly:
+    The reviewer analog of :func:`model_profiles.get_review_signal`, over the
+    section this module folds for ``phase`` (``plan_review_value`` /
+    ``code_review_value``). Reads only the in-memory ``profiles`` dict (no disk,
+    no LLM). Both sub-signals share the raw / weighted / floor / rate contract so
+    the explain renderer surfaces them uniformly:
 
     - ``uniqueness_rate``: the ``min_runs``-gated recency-weighted fraction of this
       reviewer's P1s that no peer corroborated. ``rate`` is ``None`` below the
@@ -342,6 +434,7 @@ def get_reviewer_value_signal(
     """
     from theforge.model_profiles import _matching_profile_entries, _normalize_band  # noqa: PLC0415
 
+    section_key = section_for_phase(phase)
     matching = _matching_profile_entries(
         profiles, model, actual_model=actual_model, provider=provider, cli=cli
     )
@@ -358,7 +451,7 @@ def get_reviewer_value_signal(
         LATENCY_RING: [],
     }
     for _, entry in matching:
-        section = entry.get(SECTION)
+        section = entry.get(section_key)
         if not isinstance(section, dict):
             continue
         if band is None:

--- a/tests/test_assignment_code_review_value.py
+++ b/tests/test_assignment_code_review_value.py
@@ -1,0 +1,475 @@
+"""Code-review reviewer-value routing (#2156).
+
+Extends the plan-review mechanical value signal (#1443) to the code-review
+reviewer selection: a reviewer whose blocking-finding uniqueness at the story's
+complexity band is below threshold — over at least the sample floor of
+admissible code-review samples — is sorted after higher-value candidates, while a
+reviewer that merely *answers* reliably no longer rides its completion rate into
+the pool.
+
+Both directions of the routing-symmetry pairing are exercised here: the
+``value_check`` deprioritization and its registered inverse, the passive
+``recovery_check`` recency recovery that stops the deprioritization firing once a
+reviewer's recent contribution comes back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from theforge.assignment import (
+    MECHANISM_REVIEWER_VALUE_DEPRIORITIZE,
+    MECHANISM_REVIEWER_VALUE_RECOVERY,
+    ROUTING_SYMMETRY_REGISTRY,
+    AssignmentConfig,
+    assign_models,
+)
+from theforge.config import AgentDef
+from theforge.model_profiles import RunOutcome, apply_run
+from theforge.reviewer_value import (
+    CODE_PHASE,
+    CODE_SECTION,
+    PLAN_PHASE,
+    SECTION,
+    ReviewerValueSample,
+    code_review_anchor_text,
+    compute_reviewer_uniqueness,
+    fold_reviewer_value,
+    get_reviewer_value_signal,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_api_keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("GOOGLE_API_KEY", "k")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+def _agents() -> list[AgentDef]:
+    # A cheap dev model keeps both strong reviewers out of the anti-self-review
+    # exclusion, so ordering is driven purely by the value signal.
+    return [
+        AgentDef("dev-cheap", "deepseek", "ds", 1.0, 300, "cheap"),
+        AgentDef("rev-a", "anthropic", "sonnet", 5.0, 600, "strong"),
+        AgentDef("rev-b", "openai", "gpt", 5.0, 600, "strong"),
+    ]
+
+
+def _completion(attempted: int, completed: int) -> dict:
+    """A reviewer-completion record: this is the signal that governs today."""
+    return {
+        "_attempted_count": attempted,
+        "_completed_count": completed,
+        "completion_rate": round(completed / attempted, 4) if attempted else 0.0,
+        "_completion_recent": [1] * completed + [0] * (attempted - completed),
+    }
+
+
+def _value_bucket(ring: list[float], latency_per_p1: float = 60.0) -> dict:
+    runs = len(ring)
+    return {
+        "runs": runs,
+        "tainted_runs": 0,
+        "_uniqueness_sum": sum(ring),
+        "_latency_per_p1_sum": latency_per_p1 * runs,
+        "avg_uniqueness_rate": round(sum(ring) / runs, 4) if runs else 0.0,
+        "avg_latency_per_p1": latency_per_p1,
+        "_uniqueness_recent": list(ring),
+        "_latency_per_p1_recent": [latency_per_p1] * runs,
+    }
+
+
+def _entry(
+    provider: str,
+    model: str,
+    *,
+    attempted: int,
+    completed: int,
+    code_ring: list[float] | None = None,
+    plan_ring: list[float] | None = None,
+    band: str = "small",
+) -> dict:
+    """A profile entry stamped the way the real fold path (_ensure_model) does."""
+    entry: dict = {
+        "_identity": {"provider": provider, "model": model, "transport": "api"},
+        "review": _completion(attempted, completed),
+    }
+    for section, ring in ((CODE_SECTION, code_ring), (SECTION, plan_ring)):
+        if ring is None:
+            continue
+        bucket = _value_bucket(ring)
+        entry[section] = {**bucket, "by_complexity": {band: _value_bucket(ring)}}
+    return entry
+
+
+def _profiles(**by_key: dict) -> dict:
+    return {"models": dict(by_key)}
+
+
+def _cfg(**overrides) -> AssignmentConfig:
+    base = dict(
+        enabled=True,
+        min_reviewers=1,
+        max_reviewers=1,
+        prefer_cross_provider=False,
+        max_cost_per_story_usd=100.0,
+        escalation_memory=False,
+        code_review_value_enabled=True,
+        code_review_value_uniqueness_threshold=0.34,
+        code_review_value_min_runs=5,
+    )
+    base.update(overrides)
+    return AssignmentConfig(**base)
+
+
+# ── The story's headline case ──────────────────────────────────────────────
+
+
+def test_reliable_completer_with_no_unique_findings_is_deprioritized():
+    """The spec's example: answers reliably, contributes nothing unique.
+
+    rev-a completes 9 of 10 code reviews (it always *responds*) but over 8
+    admissible samples raised no blocking finding a peer had not already raised.
+    rev-b answers less often but its blocking findings are its own. Today only
+    completion is consulted and rev-a is seated; with the value signal wired in,
+    rev-b is.
+    """
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _entry(
+                "anthropic", "sonnet", attempted=10, completed=9, code_ring=[0.0] * 8
+            ),
+            "openai/gpt/api": _entry(
+                "openai", "gpt", attempted=10, completed=7, code_ring=[1.0] * 8
+            ),
+        }
+    )
+    decision = assign_models(_agents(), _cfg(), complexity="LOW", model_profiles=profiles)
+
+    assert [p.name for p in decision.code_reviewers] == ["rev-b"]
+    value = decision.routing_decision["code_review"]["value_check"]
+    assert value["mechanism"] == MECHANISM_REVIEWER_VALUE_DEPRIORITIZE
+    assert value["phase"] == "code_review"
+    assert value["fired"] is True
+    assert value["deprioritized"] == ["rev-a"]
+    # The uniqueness figures and the sample count that justified it are recorded
+    # per reviewer, per complexity band.
+    assert value["complexity"] == "LOW"  # normalised to the "small" band on read
+    assert value["min_runs"] == 5
+    assert value["signals"]["rev-a"]["runs"] == 8
+    assert value["signals"]["rev-a"]["uniqueness_rate"]["floor"] == "pass"
+    assert value["signals"]["rev-a"]["uniqueness_rate"]["rate"] == 0.0
+    assert value["signals"]["rev-b"]["uniqueness_rate"]["rate"] == 1.0
+    assert value["signals"]["rev-a"]["latency_per_p1"]["rate"] == 60.0
+    # And the human-readable rationale says the check fired, not just the audit.
+    assert "value check: deprioritized rev-a" in decision.rationale["code_review"]
+
+
+def test_evaluated_but_not_fired_is_recorded():
+    """Both reviewers clear the threshold → checked, did not fire, order intact."""
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _entry(
+                "anthropic", "sonnet", attempted=10, completed=9, code_ring=[1.0] * 8
+            ),
+            "openai/gpt/api": _entry(
+                "openai", "gpt", attempted=10, completed=9, code_ring=[1.0] * 8
+            ),
+        }
+    )
+    decision = assign_models(_agents(), _cfg(), complexity="LOW", model_profiles=profiles)
+
+    assert [p.name for p in decision.code_reviewers] == ["rev-a"]
+    value = decision.routing_decision["code_review"]["value_check"]
+    assert value["fired"] is False
+    assert value["deprioritized"] == []
+    assert set(value["signals"]) == {"rev-a", "rev-b"}
+    assert "none below the uniqueness threshold" in decision.rationale["code_review"]
+
+
+# ── Sample floor: cold start falls through ─────────────────────────────────
+
+
+def test_below_sample_floor_falls_through_to_completion_behaviour():
+    """A newly enabled reviewer is not deprioritized for absence of history.
+
+    rev-a has zero unique findings but only 3 code-review samples (< the floor of
+    5), so the value check must not fire and selection falls through to the
+    existing completion-rate behaviour — which seats rev-a.
+    """
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _entry(
+                "anthropic", "sonnet", attempted=10, completed=10, code_ring=[0.0] * 3
+            ),
+            "openai/gpt/api": _entry(
+                "openai", "gpt", attempted=10, completed=10, code_ring=[1.0] * 3
+            ),
+        }
+    )
+    decision = assign_models(_agents(), _cfg(), complexity="LOW", model_profiles=profiles)
+
+    assert [p.name for p in decision.code_reviewers] == ["rev-a"]
+    value = decision.routing_decision["code_review"]["value_check"]
+    assert value["fired"] is False
+    assert value["deprioritized"] == []
+    assert value["signals"]["rev-a"]["uniqueness_rate"]["floor"] == "fail"
+    assert value["signals"]["rev-a"]["uniqueness_rate"]["rate"] is None
+    assert "below the 5-sample floor" in decision.rationale["code_review"]
+
+
+def test_disabled_by_default_omits_the_block_entirely():
+    """Opt-in: with the flag off, code-review selection is exactly as before."""
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _entry(
+                "anthropic", "sonnet", attempted=10, completed=10, code_ring=[0.0] * 8
+            ),
+            "openai/gpt/api": _entry(
+                "openai", "gpt", attempted=10, completed=10, code_ring=[1.0] * 8
+            ),
+        }
+    )
+    cfg = _cfg(code_review_value_enabled=False)
+    decision = assign_models(_agents(), cfg, complexity="LOW", model_profiles=profiles)
+
+    assert [p.name for p in decision.code_reviewers] == ["rev-a"]
+    assert "value_check" not in decision.routing_decision["code_review"]
+    assert "value check" not in decision.rationale["code_review"]
+
+
+def test_plan_review_value_does_not_deprioritize_for_code_review():
+    """The two sections are independent: a poor plan-review record is not carried over.
+
+    rev-a has an all-zero *plan-review* uniqueness history over the floor and no
+    code-review history at all. Code-review selection must ignore it entirely.
+    """
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _entry(
+                "anthropic", "sonnet", attempted=10, completed=10, plan_ring=[0.0] * 8
+            ),
+            "openai/gpt/api": _entry(
+                "openai", "gpt", attempted=10, completed=10, plan_ring=[1.0] * 8
+            ),
+        }
+    )
+    decision = assign_models(_agents(), _cfg(), complexity="LOW", model_profiles=profiles)
+
+    assert [p.name for p in decision.code_reviewers] == ["rev-a"]
+    value = decision.routing_decision["code_review"]["value_check"]
+    assert value["fired"] is False
+    assert value["signals"]["rev-a"]["runs"] == 0
+    assert value["signals"]["rev-a"]["uniqueness_rate"]["floor"] == "fail"
+
+
+# ── Recovery: the registered inverse ───────────────────────────────────────
+
+
+def test_recovered_reviewer_is_not_deprioritized_and_recovery_is_recorded():
+    """A reviewer whose contribution comes back stops being deprioritized.
+
+    rev-a's lifetime uniqueness is 0.25 (below the 0.34 threshold) but its recent
+    samples are all unique, so the recency-weighted rate the router consults is
+    back above threshold. The deprioritization does not fire and the passive
+    recovery is recorded as the registered inverse.
+    """
+    # 50 stale zero-uniqueness samples, then 20 fresh fully-unique ones: lifetime
+    # 0.2857, recency-weighted (half-life ~50 runs) back above the 0.34 threshold.
+    ring = [0.0] * 50 + [1.0] * 20
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _entry(
+                "anthropic", "sonnet", attempted=10, completed=10, code_ring=ring
+            ),
+            "openai/gpt/api": _entry(
+                "openai", "gpt", attempted=10, completed=10, code_ring=[1.0] * 8
+            ),
+        }
+    )
+    decision = assign_models(_agents(), _cfg(), complexity="LOW", model_profiles=profiles)
+
+    value = decision.routing_decision["code_review"]["value_check"]
+    signal = value["signals"]["rev-a"]["uniqueness_rate"]
+    assert signal["raw"] == 0.2857  # lifetime: below threshold
+    assert signal["rate"] > 0.34  # recency-weighted: recovered
+    assert value["deprioritized"] == []
+    assert [p.name for p in decision.code_reviewers] == ["rev-a"]
+
+    recovery = value["recovery_check"]
+    assert recovery["mechanism"] == MECHANISM_REVIEWER_VALUE_RECOVERY
+    assert recovery["fired"] is True
+    assert recovery["recovered"] == ["rev-a"]
+    assert recovery["checked_detail"]["rev-a"]["below_threshold_lifetime"] is True
+    assert "recovered" in recovery["reason"]
+
+
+def test_recovery_block_is_present_even_when_it_did_not_fire():
+    """The return path is never a silent gap (ADR-0006 clause 7)."""
+    profiles = _profiles(
+        **{
+            "anthropic/sonnet/api": _entry(
+                "anthropic", "sonnet", attempted=10, completed=9, code_ring=[0.0] * 8
+            ),
+            "openai/gpt/api": _entry(
+                "openai", "gpt", attempted=10, completed=9, code_ring=[1.0] * 8
+            ),
+        }
+    )
+    decision = assign_models(_agents(), _cfg(), complexity="LOW", model_profiles=profiles)
+
+    recovery = decision.routing_decision["code_review"]["value_check"]["recovery_check"]
+    assert recovery["fired"] is False
+    assert recovery["recovered"] == []
+    assert sorted(recovery["checked"]) == ["rev-a", "rev-b"]
+    assert recovery["reason"] == "no_below_threshold_reviewer_recovered_on_recent_uniqueness"
+
+
+def test_symmetry_registry_pairs_value_deprioritization_with_recovery():
+    """Both directions are registered: exclusion ↔ recovery, neither alone."""
+    pair = next(
+        p
+        for p in ROUTING_SYMMETRY_REGISTRY
+        if p.promotion.name == MECHANISM_REVIEWER_VALUE_DEPRIORITIZE
+    )
+    assert pair.promotion.audit_label == "value_check"
+    assert pair.demotion is not None
+    assert pair.demotion.name == MECHANISM_REVIEWER_VALUE_RECOVERY
+    assert pair.demotion.audit_label == "recovery_check"
+    # And a recovery cannot exist without the exclusion side: the recovery
+    # mechanism appears in the registry only as this promotion's inverse.
+    recovery_pairs = [
+        p
+        for p in ROUTING_SYMMETRY_REGISTRY
+        if p.demotion is not None and p.demotion.name == MECHANISM_REVIEWER_VALUE_RECOVERY
+    ]
+    assert len(recovery_pairs) == 1
+    assert recovery_pairs[0].promotion.name == MECHANISM_REVIEWER_VALUE_DEPRIORITIZE
+    assert not any(
+        p.promotion.name == MECHANISM_REVIEWER_VALUE_RECOVERY for p in ROUTING_SYMMETRY_REGISTRY
+    )
+
+
+# ── Persistence: separate sections, per reviewer, per complexity band ──────
+
+
+def test_fold_writes_code_section_and_leaves_plan_section_untouched():
+    entry: dict = {}
+    fold_reviewer_value(
+        entry,
+        ReviewerValueSample("rev-a", "high", unique_p1=1, total_p1=4, latency_s=200.0),
+        phase=CODE_PHASE,
+    )
+    assert SECTION not in entry
+    section = entry[CODE_SECTION]
+    assert section["runs"] == 1
+    assert section["by_complexity"]["large"]["avg_uniqueness_rate"] == 0.25
+    assert section["by_complexity"]["large"]["avg_latency_per_p1"] == 50.0
+
+    fold_reviewer_value(
+        entry,
+        ReviewerValueSample("rev-a", "high", unique_p1=4, total_p1=4, latency_s=200.0),
+        phase=PLAN_PHASE,
+    )
+    # The plan fold lands in its own section and does not disturb the code one.
+    assert entry[SECTION]["by_complexity"]["large"]["avg_uniqueness_rate"] == 1.0
+    assert entry[CODE_SECTION]["by_complexity"]["large"]["avg_uniqueness_rate"] == 0.25
+
+
+def test_taint_gate_keeps_code_review_samples_out_of_the_aggregate():
+    entry: dict = {}
+    fold_reviewer_value(
+        entry,
+        ReviewerValueSample("rev-a", "low", unique_p1=0, total_p1=3, latency_s=90.0),
+        phase=CODE_PHASE,
+        tainted=True,
+    )
+    section = entry[CODE_SECTION]
+    assert section["runs"] == 0
+    assert section["tainted_runs"] == 1
+    # "low" normalises to the "small" band, as everywhere else in the profiles.
+    assert section["by_complexity"]["small"]["tainted_runs"] == 1
+
+
+def test_run_outcome_folds_code_reviewer_values_separately_from_plan():
+    """Seam test: RunOutcome → apply_run writes the two sections independently."""
+    data = apply_run(
+        {"models": {}},
+        RunOutcome(
+            dev_model="dev-cheap",
+            complexity="medium",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=0.0,
+            plan_reviewer_values=[
+                ReviewerValueSample("rev-a", "medium", unique_p1=2, total_p1=2, latency_s=100.0)
+            ],
+            code_reviewer_values=[
+                ReviewerValueSample("rev-a", "medium", unique_p1=0, total_p1=4, latency_s=200.0)
+            ],
+        ),
+    )
+    entry = data["models"]["rev-a"]
+    assert entry[SECTION]["by_complexity"]["medium"]["avg_uniqueness_rate"] == 1.0
+    assert entry[CODE_SECTION]["by_complexity"]["medium"]["avg_uniqueness_rate"] == 0.0
+    # And the signal reader resolves each phase to its own section.
+    assert (
+        get_reviewer_value_signal(data, "rev-a", "medium", 1, phase=CODE_PHASE)["uniqueness_rate"][
+            "rate"
+        ]
+        == 0.0
+    )
+    assert (
+        get_reviewer_value_signal(data, "rev-a", "medium", 1, phase=PLAN_PHASE)["uniqueness_rate"][
+            "rate"
+        ]
+        == 1.0
+    )
+
+
+# ── Uniqueness over code-review findings ───────────────────────────────────
+
+
+def test_uniqueness_over_code_review_findings_uses_observed_and_evidence():
+    """ReviewFinding carries its anchors across observed + evidence, not one blob."""
+    from theforge.review import ReviewFinding
+
+    def _f(observed: str, evidence: str, severity: str = "P1") -> ReviewFinding:
+        return ReviewFinding(
+            severity=severity,
+            file="src/theforge/assignment.py",
+            line=10,
+            observed=observed,
+            suggestion=None,
+            expected="",
+            evidence=evidence,
+        )
+
+    shared = _f(
+        "The selection helper drops candidates silently.",
+        "select_reviewers at assignment.py:3128 ignores the value arguments.",
+    )
+    peer_shared = _f(
+        "Candidates disappear without explanation.",
+        "See select_reviewers, which never receives the value flag.",
+    )
+    solo = _f(
+        "The band normaliser mangles an unknown complexity.",
+        "normalize_band coerces anything unrecognised to medium.",
+    )
+    # P2s never participate in the blocking-finding computation.
+    noise = _f("Naming could be clearer.", "select_reviewers is terse.", severity="P2")
+
+    result = compute_reviewer_uniqueness(
+        [("rev-a", [shared, solo, noise]), ("rev-b", [peer_shared])],
+        anchor_text=code_review_anchor_text,
+    )
+    # rev-a raised 2 blocking findings, one of which rev-b corroborated.
+    assert result["rev-a"] == (1, 2)
+    # rev-b's single finding was corroborated by rev-a, so nothing unique.
+    assert result["rev-b"] == (0, 1)

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -941,3 +941,72 @@ class TestAssignmentDevPromotion:
 
         with pytest.raises(ValueError, match="dev_promotion_min_runs"):
             _parse_assignment({"enabled": True, "dev_promotion_min_runs": 0})
+
+
+class TestAssignmentReviewerValue:
+    """assignment reviewer-value field parsing (#1443 plan review, #2156 code review).
+
+    These three fields per phase decide whether a mechanical signal may reorder
+    reviewers and how much evidence it needs first, so config loading validates
+    them strictly rather than coercing whatever scalar it was handed.
+    """
+
+    def test_omitted_uses_defaults(self):
+        from theforge.config.models import _parse_assignment
+
+        cfg = _parse_assignment({"enabled": True})
+        assert cfg.reviewer_value_enabled is False
+        assert cfg.reviewer_value_uniqueness_threshold == 0.34
+        assert cfg.reviewer_value_min_runs == 5
+        assert cfg.code_review_value_enabled is False
+        assert cfg.code_review_value_uniqueness_threshold == 0.34
+        assert cfg.code_review_value_min_runs == 5
+
+    def test_explicit_values_parsed_per_phase(self):
+        from theforge.config.models import _parse_assignment
+
+        cfg = _parse_assignment(
+            {
+                "enabled": True,
+                "reviewer_value_enabled": True,
+                "reviewer_value_uniqueness_threshold": 0.5,
+                "reviewer_value_min_runs": 9,
+                "code_review_value_enabled": True,
+                "code_review_value_uniqueness_threshold": 0.2,
+                "code_review_value_min_runs": 12,
+            }
+        )
+        # The two phases are tuned independently.
+        assert cfg.reviewer_value_uniqueness_threshold == 0.5
+        assert cfg.reviewer_value_min_runs == 9
+        assert cfg.code_review_value_uniqueness_threshold == 0.2
+        assert cfg.code_review_value_min_runs == 12
+
+    @pytest.mark.parametrize("key", ["reviewer_value_enabled", "code_review_value_enabled"])
+    @pytest.mark.parametrize("bad", ["flase", "no", 1, ""])
+    def test_non_boolean_enablement_is_rejected(self, key, bad):
+        # Bare bool() coercion would turn "flase" into an ON switch silently.
+        from theforge.config.models import _parse_assignment
+
+        with pytest.raises(ValueError, match=key):
+            _parse_assignment({"enabled": True, key: bad})
+
+    @pytest.mark.parametrize(
+        "key",
+        ["reviewer_value_uniqueness_threshold", "code_review_value_uniqueness_threshold"],
+    )
+    def test_out_of_range_threshold_is_rejected(self, key):
+        from theforge.config.models import _parse_assignment
+
+        with pytest.raises(ValueError, match=key):
+            _parse_assignment({"enabled": True, key: 1.5})
+
+    @pytest.mark.parametrize("key", ["reviewer_value_min_runs", "code_review_value_min_runs"])
+    @pytest.mark.parametrize("bad", ["5", 0, True, 2.5])
+    def test_invalid_min_runs_is_rejected(self, key, bad):
+        # A zero floor would let a single sample gate routing; a string or a bool
+        # is not a sample count at all.
+        from theforge.config.models import _parse_assignment
+
+        with pytest.raises(ValueError, match=key):
+            _parse_assignment({"enabled": True, key: bad})

--- a/tests/test_coord_code_reviewer_value_capture.py
+++ b/tests/test_coord_code_reviewer_value_capture.py
@@ -1,0 +1,201 @@
+"""Code-reviewer value capture at review-pool completion (#2156).
+
+Seam test for the producer half of the code-review value signal: the coordinator
+computes per-reviewer blocking-finding uniqueness at code-review pool completion,
+writes it to ``state.code_reviewer_value``, and the model-profiles bridge folds it
+into the ``code_review_value`` profile section — separately from the plan-review
+section — so the router has something to read at the next story's selection.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import patch
+
+from tests.coord_test_helpers import (
+    DEFAULT_REVIEW_PROFILE,
+    _make_agent_result,
+    _make_pool_config,
+    _make_task,
+)
+from theforge.coordinator.model_profiles_bridge import _extract_code_reviewer_values
+from theforge.coordinator.review_pool import _run_review_pool
+from theforge.coordinator.state import CoordinatorState, ReviewCycleMetadata
+from theforge.model_profiles import RunOutcome, apply_run
+from theforge.reviewer_value import CODE_SECTION, SECTION
+
+
+def _review(observed: str, evidence: str) -> str:
+    return (
+        "```yaml\n"
+        "verdict: REQUEST_CHANGES\n"
+        'summary: "Problems found."\n'
+        "findings:\n"
+        "  - severity: P1\n"
+        "    file: src/foo.py\n"
+        "    line: 10\n"
+        f'    observed: "{observed}"\n'
+        '    expected: "Behaviour conforms to the project contract."\n'
+        f'    evidence: "{evidence}"\n'
+        '    suggestion: "Fix it"\n'
+        "story_compliance:\n"
+        "  matches_spec: false\n"
+        "  mismatches:\n"
+        '    - "does not match"\n'
+        "test_coverage:\n"
+        "  adequate: false\n"
+        "  gaps:\n"
+        '    - "no test"\n'
+        "ac_verification:\n"
+        '  - criterion: "Implementation satisfies the spec"\n'
+        "    status: NOT_VERIFIED\n"
+        '    evidence: "see findings"\n'
+        "```\n"
+    )
+
+
+def _meta() -> ReviewCycleMetadata:
+    return ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
+
+
+def _profiles():
+    a = dataclasses.replace(DEFAULT_REVIEW_PROFILE, name="rev-a")
+    b = dataclasses.replace(DEFAULT_REVIEW_PROFILE, name="rev-b")
+    return a, b
+
+
+@patch("theforge.coordinator.review_pool.log_agent_result")
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+def test_completed_code_review_pool_populates_code_reviewer_value(mock_pool, _log, tmp_path):
+    prof_a, prof_b = _profiles()
+    config = _make_pool_config(tmp_path, [prof_a, prof_b], synthesis=None)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+    state.preflight_complexity = "medium"
+
+    # rev-a raises a blocking finding anchored on ``retry_budget``; rev-b raises a
+    # different one anchored on ``session_cache``. Neither corroborates the other,
+    # so both are unique — the deterministic anchor-overlap the router consumes.
+    mock_pool.return_value = [
+        _make_agent_result(
+            success=True,
+            output=_review("The retry budget is ignored.", "retry_budget is never read."),
+            profile_name="rev-a",
+        ),
+        _make_agent_result(
+            success=True,
+            output=_review("The session cache never expires.", "session_cache grows forever."),
+            profile_name="rev-b",
+        ),
+    ]
+
+    _run_review_pool(
+        state,
+        config,
+        task,
+        "story",
+        workspace,
+        "branch",
+        _meta(),
+        notify=False,
+        enforce_budgets=False,
+    )
+
+    rows = {v["reviewer"]: v for v in state.code_reviewer_value}
+    assert set(rows) == {"rev-a", "rev-b"}
+    for row in rows.values():
+        assert row["cycle"] == 1
+        assert row["complexity"] == "medium"
+        assert row["total_p1_count"] == 1
+        assert row["unique_p1_count"] == 1
+        assert row["parse_error_count"] == 0
+        assert row["latency_s"] is not None
+
+
+@patch("theforge.coordinator.review_pool.log_agent_result")
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+def test_corroborated_finding_is_not_counted_unique(mock_pool, _log, tmp_path):
+    prof_a, prof_b = _profiles()
+    config = _make_pool_config(tmp_path, [prof_a, prof_b], synthesis=None)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+    state.preflight_complexity = "medium"
+
+    # Both reviewers anchor on ``retry_budget`` — the same issue, independently
+    # surfaced, so neither reviewer's finding is unique.
+    mock_pool.return_value = [
+        _make_agent_result(
+            success=True,
+            output=_review("The retry budget is ignored.", "retry_budget is never read."),
+            profile_name="rev-a",
+        ),
+        _make_agent_result(
+            success=True,
+            output=_review("Retries run unbounded.", "retry_budget has no effect."),
+            profile_name="rev-b",
+        ),
+    ]
+
+    _run_review_pool(
+        state,
+        config,
+        task,
+        "story",
+        workspace,
+        "branch",
+        _meta(),
+        notify=False,
+        enforce_budgets=False,
+    )
+
+    rows = {v["reviewer"]: v for v in state.code_reviewer_value}
+    assert rows["rev-a"]["total_p1_count"] == 1
+    assert rows["rev-a"]["unique_p1_count"] == 0
+    assert rows["rev-b"]["unique_p1_count"] == 0
+
+
+def test_captured_rows_fold_into_the_code_review_section_only():
+    """The capture → bridge → profile-fold seam lands in code_review_value."""
+    state = CoordinatorState(review_cycle=0)
+    state.code_reviewer_value = [
+        {
+            "cycle": 1,
+            "reviewer": "rev-a",
+            "complexity": "medium",
+            "unique_p1_count": 0,
+            "total_p1_count": 2,
+            "latency_s": 120.0,
+            "parse_error_count": 0,
+            "actual_model": "sonnet",
+            "provider": "anthropic",
+            "cli": None,
+        }
+    ]
+
+    samples = _extract_code_reviewer_values(state)
+    assert [s.name for s in samples] == ["rev-a"]
+    assert samples[0].uniqueness_rate() == 0.0
+    assert samples[0].latency_per_p1() == 60.0
+
+    data = apply_run(
+        {"models": {}},
+        RunOutcome(
+            dev_model="dev",
+            complexity="medium",
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=0.0,
+            code_reviewer_values=samples,
+        ),
+    )
+    # _ensure_model keys the entry by canonical identity, not the profile name;
+    # the dev model has its own entry, which must carry no reviewer value section.
+    (entry,) = [e for e in data["models"].values() if CODE_SECTION in e]
+    assert SECTION not in entry
+    assert entry[CODE_SECTION]["runs"] == 1
+    assert entry[CODE_SECTION]["by_complexity"]["medium"]["avg_uniqueness_rate"] == 0.0
+    assert entry[CODE_SECTION]["by_complexity"]["medium"]["avg_latency_per_p1"] == 60.0


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No P1 regressions found; focused routing, capture, and config tests pass with 107 passed. | [google-gemini-3.5-flash-api] The implementation of extending mechanical reviewer-value signals to code-review selection is clean, robust, and fully verified.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $20.14
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Extend mechanical reviewer-value signals to code-review selection (GitHub Issue #2156)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2156