### PR TITLE
A broken-baseline abort discards the gate's failure evidence and deletes the worktree that produced it

### DIFF
--- a/src/theforge/coordinator/gate.py
+++ b/src/theforge/coordinator/gate.py
@@ -74,6 +74,7 @@ def run_gate_full(
     iter_num: int | None = None,
     *,
     output_digest: list[str] | None = None,
+    full_output: list[str] | None = None,
     label: GateLabel | None = None,
 ) -> tuple[str | None, str | None, str, str, int | None]:
     """Run the gate command and determine pass/fail from exit code.
@@ -93,6 +94,16 @@ def run_gate_full(
     returning a record — would churn all of them to carry one scalar that only
     one caller reads. A caller-supplied list keeps it explicit and per-call, so
     parallel story workers cannot share it.
+
+    ``full_output``, when given, receives the **full** raw output as a single
+    element. It exists for callers whose gate runs in a workspace that will not
+    survive the call — the baseline gate runs in a temporary worktree, so the
+    ``iter_num`` trace above (written *into* that workspace) is destroyed with
+    it. Such a caller needs the bytes in hand to persist them somewhere durable;
+    only the caller knows where that is. Same out-parameter shape, and for the
+    same reason, as ``output_digest``. It is populated on every path the gate
+    command actually ran, including timeout and infrastructure error, since
+    those are exactly the outcomes whose evidence is hardest to recover.
 
     ``label``, when given, names the gate's purpose and target in the "Running
     gate" log line so semantically different gates that resolve to the same
@@ -131,6 +142,9 @@ def run_gate_full(
 
     if output_digest is not None:
         output_digest.append(hashlib.sha256(output.encode("utf-8", errors="replace")).hexdigest())
+
+    if full_output is not None:
+        full_output.append(output)
 
     tail_chars = config.validation.gate_output_tail_chars
     output_tail = output[-tail_chars:]

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1102,8 +1102,145 @@ def _baseline_failure_diagnostic(output_tail: object) -> str:
     return f"{header}\n{excerpt}"
 
 
-def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[str, object]:
-    """Run the configured gate on the sprint merge base before any agent work starts."""
+#: How many preserved baseline worktrees may exist at once. A halting baseline
+#: gate keeps the worktree that produced it, because that worktree is the only
+#: place the failure can be re-run in the environment that produced it. Each one
+#: is a full checkout plus whatever the setup command installed into it, so the
+#: set is bounded: the newest are kept, older ones are reclaimed on the next
+#: baseline run. The durable evidence file outlives all of them.
+BASELINE_WORKTREE_KEEP = 2
+
+#: Directory prefix for the baseline gate's temporary worktree parent.
+BASELINE_TEMP_PREFIX = "forge-baseline-"
+
+
+def _remove_baseline_temp_root(project_root: Path, temp_root: Path) -> None:
+    """Unregister and delete one ``forge-baseline-*`` temp root, best-effort.
+
+    The prune covers the leftovers of a run that died before its own cleanup:
+    ``git worktree remove`` declines a path it no longer knows about, which
+    would leave the admin entry behind after the directory goes.
+    """
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(temp_root / "worktree")],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    shutil.rmtree(temp_root, ignore_errors=True)
+    subprocess.run(
+        ["git", "worktree", "prune"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _prune_preserved_baseline_worktrees(project_root: Path, keep: int) -> None:
+    """Reclaim all but the *keep* newest preserved baseline worktrees.
+
+    Called before a new baseline run creates its own temp root, so that a run
+    which goes on to preserve leaves at most ``BASELINE_WORKTREE_KEEP`` behind.
+    Only ``forge-baseline-*`` directories are touched, and only ones a previous
+    run left: a passing run removes its own.
+
+    Best-effort — pruning old evidence must never be the reason a sprint fails
+    to start.
+    """
+    forge_root = project_root / ".forge"
+    try:
+        candidates = [
+            path
+            for path in forge_root.iterdir()
+            if path.is_dir() and path.name.startswith(BASELINE_TEMP_PREFIX)
+        ]
+    except OSError:
+        return
+    try:
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    except OSError:
+        return
+    for stale in candidates[max(keep, 0) :]:
+        try:
+            _remove_baseline_temp_root(project_root, stale)
+        except Exception as exc:  # noqa: BLE001
+            _log(f"Warning: could not reclaim preserved baseline worktree {stale}: {exc}")
+
+
+def _write_baseline_gate_evidence(
+    *,
+    log_dir: Path,
+    filename: str,
+    header_lines: list[str],
+    full_output: str | None,
+) -> tuple[str | None, str | None]:
+    """Persist the halting baseline gate's raw output outside the temp worktree.
+
+    Returns ``(path, unavailable_reason)`` — exactly one is set. An absent
+    account is written *as* an absent account: when the gate produced no output
+    record the file is still written, saying so, so a reader can tell "nothing
+    was captured" from "nothing went wrong". A reason is returned only when the
+    file itself could not be written, which is the one case no file can state.
+    """
+    if full_output:
+        body = full_output
+    else:
+        body = (
+            "Gate output was not captured: the gate command produced no output "
+            "record for this run.\n"
+        )
+    content = "\n".join([*header_lines, "", body])
+    path = log_dir / filename
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        return None, f"could not write {path}: {exc}"
+    return str(path), None
+
+
+def _baseline_evidence_footer(
+    *,
+    worktree: str | None,
+    evidence_path: str | None,
+    evidence_unavailable: str | None,
+) -> str:
+    """Name, on the verdict itself, where the evidence for it now lives.
+
+    The verdict travels further than the run log — it becomes the RuntimeError
+    text and the audit record's message — so the pointers travel with it rather
+    than sitting in a file the verdict never references. When the full output
+    could not be persisted the message says that, so a missing pointer is never
+    read as "there was nothing to point at".
+    """
+    parts: list[str] = []
+    if evidence_path:
+        parts.append(f"Full gate output: {evidence_path}")
+    elif evidence_unavailable:
+        parts.append(f"Full gate output unavailable: {evidence_unavailable}")
+    if worktree:
+        parts.append(f"Baseline worktree preserved for reproduction: {worktree}")
+    return "\n" + "\n".join(parts) if parts else ""
+
+
+def _run_baseline_gate(
+    config: ForgeConfig,
+    resolved: ResolvedSprint,
+    *,
+    run_id: str | None = None,
+) -> dict[str, object]:
+    """Run the configured gate on the sprint merge base before any agent work starts.
+
+    A halting outcome (the gate failed, or the workspace setup that precedes it
+    failed) keeps two things the run would otherwise destroy at the moment it
+    produces them: the gate's full raw output, written under
+    ``.forge/logs/<sprint>/`` where it outlives the run, and the temporary
+    worktree the gate ran in, which is the only environment the failure can be
+    reproduced in. Cleanup of the worktree happens after that capture, never
+    before, and only on outcomes that did not halt the sprint (#2160).
+    """
 
     base_branch = config.workspace.base_branch
     if not _project_root_is_git_checkout(config.project_root):
@@ -1198,8 +1335,25 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
 
     forge_temp_root = config.project_root / ".forge"
     forge_temp_root.mkdir(parents=True, exist_ok=True)
-    temp_root = Path(tempfile.mkdtemp(prefix="forge-baseline-", dir=forge_temp_root))
+    # Reclaim older preserved worktrees *before* claiming disk for this run's, so
+    # the bound holds across a streak of failing runs.
+    _prune_preserved_baseline_worktrees(config.project_root, BASELINE_WORKTREE_KEEP - 1)
+    temp_root = Path(tempfile.mkdtemp(prefix=BASELINE_TEMP_PREFIX, dir=forge_temp_root))
     baseline_worktree = temp_root / "worktree"
+    sprint_log_dir = config.project_root / ".forge" / "logs" / resolved.name
+    # Run-id-keyed where there is one, matching the rest of the sprint log
+    # directory. Headless invocations have no run id, so the temp root's own
+    # unique suffix names the file instead — a wall-clock stamp would collide
+    # between two runs in the same second and silently overwrite the first
+    # run's evidence with the second's.
+    evidence_filename = (
+        f"run-{run_id}-baseline-gate.txt"
+        if run_id
+        else f"baseline-gate-{temp_root.name.removeprefix(BASELINE_TEMP_PREFIX)}.txt"
+    )
+    # Set to the worktree path by any outcome that halts the sprint; the finally
+    # block reclaims the worktree only while this is None.
+    preserved_worktree: str | None = None
     try:
         add_worktree = subprocess.run(
             ["git", "worktree", "add", "--detach", str(baseline_worktree), merge_base_ref],
@@ -1235,6 +1389,26 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
             )
             if not setup_ok:
                 duration = time.monotonic() - started_monotonic
+                preserved_worktree = str(baseline_worktree)
+                setup_message = (
+                    "Broken baseline: workspace setup command failed in the temporary "
+                    f"baseline worktree for merge base {merge_base_ref}: {setup_out}"
+                )
+                evidence_path, evidence_unavailable = _write_baseline_gate_evidence(
+                    log_dir=sprint_log_dir,
+                    filename=evidence_filename,
+                    header_lines=[
+                        f"# baseline workspace setup failed on merge base {merge_base_ref}",
+                        f"# setup command: {config.workspace.setup_command}",
+                        f"# worktree: {baseline_worktree}",
+                    ],
+                    full_output=setup_out,
+                )
+                setup_message += _baseline_evidence_footer(
+                    worktree=preserved_worktree,
+                    evidence_path=evidence_path,
+                    evidence_unavailable=evidence_unavailable,
+                )
                 return {
                     "status": "error",
                     "passed": False,
@@ -1244,15 +1418,20 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
                     "finished_at": datetime.datetime.now(datetime.timezone.utc),
                     "merge_base": merge_base_ref,
                     "command": config.validation.gate_command,
-                    "message": (
-                        "Broken baseline: workspace setup command failed in the temporary "
-                        f"baseline worktree for merge base {merge_base_ref}: {setup_out}"
-                    ),
+                    "worktree": preserved_worktree,
+                    "evidence_path": evidence_path,
+                    "evidence_unavailable": evidence_unavailable,
+                    "message": setup_message,
                 }
 
+        # The gate runs in a worktree that does not survive this function, so
+        # ``run_gate_full``'s own trace (written into that worktree) cannot be the
+        # durable record. The full output is taken out by value instead.
+        gate_full_output: list[str] = []
         decision, error, output_tail, resolved_gate_cmd, gate_exit_code = run_gate_full(
             config,
             baseline_worktree,
+            full_output=gate_full_output,
             label=GateLabel(
                 purpose=BASELINE_GATE_PURPOSE,
                 target="merge base",
@@ -1304,12 +1483,34 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
                 f" (local {base_branch} is at {local_sha[:12]}, origin is at {origin_sha[:12]}; "
                 f"local branch may be stale; run `git pull` on {base_branch} or omit --no-pull)"
             )
+        # Capture before the finally block would have reclaimed the workspace,
+        # and preserve the workspace itself: the excerpt below names which check
+        # failed, the file and the worktree are what let the operator find out
+        # why (#2160).
+        preserved_worktree = str(baseline_worktree)
+        evidence_path, evidence_unavailable = _write_baseline_gate_evidence(
+            log_dir=sprint_log_dir,
+            filename=evidence_filename,
+            header_lines=[
+                f"# baseline gate {decision or 'ERROR'} on merge base {merge_base_ref}",
+                f"# gate command: {resolved_gate_cmd}",
+                f"# exit code: {exit_code}",
+                f"# worktree: {baseline_worktree}",
+            ],
+            full_output=gate_full_output[0] if gate_full_output else None,
+        )
+        message += _baseline_evidence_footer(
+            worktree=preserved_worktree,
+            evidence_path=evidence_path,
+            evidence_unavailable=evidence_unavailable,
+        )
         # The sha names where the gate ran; only the gate's own output names what
         # must change. ``run_gate_full`` leaves ``error`` None for a plain nonzero
         # exit, so without this the operator is handed a commit to investigate
         # when the remedy is one key in one file (#1980). Appended last, after the
-        # sha and the stale-branch hint, and bounded so the same string stays
-        # usable as a log line and as the raised RuntimeError text.
+        # sha, the stale-branch hint and the evidence pointers, and bounded so the
+        # same string stays usable as a log line and as the raised RuntimeError
+        # text — the unbounded record is the evidence file the pointers name.
         _diagnostic = _baseline_failure_diagnostic(output_tail)
         if _diagnostic:
             message += f"\n{_diagnostic}"
@@ -1324,17 +1525,14 @@ def _run_baseline_gate(config: ForgeConfig, resolved: ResolvedSprint) -> dict[st
             "command": resolved_gate_cmd,
             "decision": decision,
             "output_tail": output_tail,
+            "worktree": preserved_worktree,
+            "evidence_path": evidence_path,
+            "evidence_unavailable": evidence_unavailable,
             "message": message,
         }
     finally:
-        subprocess.run(
-            ["git", "worktree", "remove", "--force", str(baseline_worktree)],
-            cwd=config.project_root,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        shutil.rmtree(temp_root, ignore_errors=True)
+        if preserved_worktree is None:
+            _remove_baseline_temp_root(config.project_root, temp_root)
 
 
 def _continuation_evidence(
@@ -3237,7 +3435,7 @@ def run_sprint(
             started_at=baseline_started_at.isoformat(),
         )
         try:
-            baseline_gate = _run_baseline_gate(config, resolved)
+            baseline_gate = _run_baseline_gate(config, resolved, run_id=run_id)
         finally:
             _publish_sprint_phase(SPRINT_PHASE_STARTING)
     resolved.baseline_gate = baseline_gate

--- a/tests/test_sprint_baseline_gate.py
+++ b/tests/test_sprint_baseline_gate.py
@@ -18,7 +18,12 @@ from theforge.config import (
     WorkspaceConfig,
 )
 from theforge.sprint.manifest import ResolvedSprint
-from theforge.sprint.runner import _run_baseline_gate, run_sprint
+from theforge.sprint.runner import (
+    BASELINE_TEMP_PREFIX,
+    BASELINE_WORKTREE_KEEP,
+    _run_baseline_gate,
+    run_sprint,
+)
 from theforge.sprint.sources import FileSource
 
 
@@ -141,6 +146,182 @@ def test_baseline_gate_preserves_actual_gate_exit_code(tmp_path: Path) -> None:
     assert baseline["merge_base"] == base_commit
     assert baseline["exit_code"] == 2
     assert "boom" in str(baseline.get("output_tail", ""))
+
+
+def _evidence_files(project_root: Path, sprint_name: str = "Test Sprint") -> list[Path]:
+    log_dir = project_root / ".forge" / "logs" / sprint_name
+    return sorted(log_dir.glob("*baseline-gate*.txt")) if log_dir.exists() else []
+
+
+def _preserved_temp_roots(project_root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in (project_root / ".forge").iterdir()
+        if path.is_dir() and path.name.startswith(BASELINE_TEMP_PREFIX)
+    )
+
+
+#: Emitted before ~5000 characters of filler, so it cannot survive in the
+#: 2000-character output tail — only a full-output record can carry it.
+_EARLY_MARKER = "EARLY-MARKER-9d2f"
+
+_LONG_FAILING_GATE = (
+    f"python -c \"import sys; print('{_EARLY_MARKER}'); print('x' * 5000); sys.exit(1)\""
+)
+
+
+def test_baseline_gate_failure_persists_full_output_beyond_the_tail(tmp_path: Path) -> None:
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(config.validation, gate_command=_LONG_FAILING_GATE),
+    )
+
+    baseline = _run_baseline_gate(config, resolved, run_id="abc123")
+
+    assert baseline["passed"] is False
+    # The tail alone cannot answer why: the failure's own first line is outside it.
+    assert _EARLY_MARKER not in str(baseline.get("output_tail", ""))
+
+    evidence_path = baseline["evidence_path"]
+    assert evidence_path is not None
+    assert baseline["evidence_unavailable"] is None
+    assert Path(evidence_path).name == "run-abc123-baseline-gate.txt"
+    evidence = Path(evidence_path).read_text(encoding="utf-8")
+    assert _EARLY_MARKER in evidence
+    assert str(baseline["merge_base"]) in evidence
+    # The verdict itself names where the evidence lives.
+    assert evidence_path in str(baseline["message"])
+
+
+def test_baseline_gate_failure_preserves_the_worktree_that_produced_it(
+    tmp_path: Path,
+) -> None:
+    config, resolved, base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(config.validation, gate_command=_LONG_FAILING_GATE),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    worktree = baseline["worktree"]
+    assert worktree is not None
+    worktree_path = Path(str(worktree))
+    assert worktree_path.is_dir()
+    # Still a usable checkout of the merge base, not a husk: the failure can be
+    # re-run in the environment that produced it.
+    assert _git(worktree_path, "rev-parse", "HEAD") == base_commit
+    assert str(worktree) in _git(tmp_path, "worktree", "list")
+    assert str(worktree) in str(baseline["message"])
+
+
+def test_baseline_gate_evidence_and_worktree_survive_the_sprint_abort(
+    tmp_path: Path,
+) -> None:
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(config.validation, gate_command=_LONG_FAILING_GATE),
+    )
+
+    with (
+        patch("theforge.sprint.runner.run_batch_preflight") as mock_preflight,
+        patch("theforge.sprint.runner.run_task") as mock_run_task,
+    ):
+        try:
+            run_sprint(config, resolved, no_pull=True, run_id="abc123")
+            raise AssertionError("expected baseline failure")
+        except RuntimeError as exc:
+            message = str(exc)
+
+    assert not mock_preflight.called
+    assert not mock_run_task.called
+    assert "Broken baseline" in message
+
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    audit = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+    baseline_check = audit["baseline_check"]
+    evidence_path = baseline_check["evidence_path"]
+    assert evidence_path is not None
+    # Both artifacts outlive the run that produced them.
+    assert _EARLY_MARKER in Path(evidence_path).read_text(encoding="utf-8")
+    assert Path(str(baseline_check["worktree"])).is_dir()
+    assert evidence_path in message
+
+
+def test_baseline_gate_records_that_output_was_unavailable(tmp_path: Path) -> None:
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(config.validation, gate_command="exit 4"),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is False
+    evidence = Path(str(baseline["evidence_path"])).read_text(encoding="utf-8")
+    # An absent account, stated as absent — distinguishable from "nothing went wrong".
+    assert "not captured" in evidence
+    assert "exit 4" in evidence
+
+
+def test_preserved_baseline_worktrees_stay_bounded_across_failing_runs(
+    tmp_path: Path,
+) -> None:
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(config.validation, gate_command=_LONG_FAILING_GATE),
+    )
+
+    evidence_paths = []
+    for _ in range(BASELINE_WORKTREE_KEEP + 2):
+        baseline = _run_baseline_gate(config, resolved)
+        evidence_paths.append(Path(str(baseline["evidence_path"])))
+
+    preserved = _preserved_temp_roots(tmp_path)
+    assert len(preserved) <= BASELINE_WORKTREE_KEEP
+    # Reclaimed worktrees are unregistered too, not left as missing entries.
+    registered = [
+        line
+        for line in _git(tmp_path, "worktree", "list").splitlines()
+        if BASELINE_TEMP_PREFIX in line
+    ]
+    assert len(registered) == len(preserved)
+    # Reclaiming worktrees never reclaims the durable record.
+    assert all(path.exists() for path in evidence_paths)
+    assert len(_evidence_files(tmp_path)) == len(evidence_paths)
+
+
+def test_baseline_gate_pass_leaves_no_preserved_worktree_or_evidence(
+    tmp_path: Path,
+) -> None:
+    config, resolved, _base_commit = _init_repo(tmp_path)
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is True
+    assert baseline.get("worktree") is None
+    assert _preserved_temp_roots(tmp_path) == []
+    assert _evidence_files(tmp_path) == []
+
+
+def test_baseline_gate_setup_failure_preserves_evidence_and_worktree(
+    tmp_path: Path,
+) -> None:
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        workspace=replace(config.workspace, setup_command="echo SETUP-BOOM; exit 3"),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["status"] == "error"
+    assert Path(str(baseline["worktree"])).is_dir()
+    evidence = Path(str(baseline["evidence_path"])).read_text(encoding="utf-8")
+    assert "SETUP-BOOM" in evidence
 
 
 def test_baseline_gate_substitutes_test_target_placeholder(tmp_path: Path) -> None:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -327,7 +327,9 @@ def test_run_sprint_pulls_base_branch_before_baseline_by_default(tmp_path: Path)
     def _fake_pull(_config: ForgeConfig, *, lands_locally: bool | None = None) -> None:
         call_order.append("pull")
 
-    def _fake_baseline(_config: ForgeConfig, _resolved: ResolvedSprint) -> dict[str, object]:
+    def _fake_baseline(
+        _config: ForgeConfig, _resolved: ResolvedSprint, **_kwargs: object
+    ) -> dict[str, object]:
         call_order.append("baseline")
         return {"passed": True, "message": "ok"}
 
@@ -363,7 +365,9 @@ def test_run_sprint_no_pull_skips_prebaseline_pull(tmp_path: Path) -> None:
     resolved = _make_empty_resolved()
     call_order: list[str] = []
 
-    def _fake_baseline(_config: ForgeConfig, _resolved: ResolvedSprint) -> dict[str, object]:
+    def _fake_baseline(
+        _config: ForgeConfig, _resolved: ResolvedSprint, **_kwargs: object
+    ) -> dict[str, object]:
         call_order.append("baseline")
         return {"passed": True, "message": "ok"}
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change preserves full baseline-gate evidence and the producing worktree across broken-baseline aborts, with focused tests passing. | [google-gemini-3.5-flash-api] The implementation successfully preserves baseline gate failure evidence and the temporary worktree on halting outcomes, with comprehensive test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $1.22
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

A broken-baseline abort discards the gate's failure evidence and deletes the worktree that produced it (GitHub Issue #2160)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2160